### PR TITLE
parametrize: allow Ellipsis to avoid repeating argument list

### DIFF
--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -850,7 +850,15 @@ class Metafunc(FuncargnamesCompatAttr):
         argvalues = unwrapped_argvalues
 
         if not isinstance(argnames, (tuple, list)):
-            argnames = [x.strip() for x in argnames.split(",") if x.strip()]
+            if argnames is Ellipsis:
+                try:
+                    autoargs = len(argval)
+                except TypeError:
+                    autoargs = 1
+                argnames = inspect.getargspec(self.function)[0][:autoargs]
+            else:
+                argnames = [x.strip() for x in argnames.split(",")
+                            if x.strip()]
             if len(argnames) == 1:
                 argvalues = [(val,) for val in argvalues]
         if not argvalues:


### PR DESCRIPTION
This is an implementation for #518.

This is an example for the usage of `parametrize` before this PR:

```Python
import pytest

testparams = [
    (1, 2, 3, 4, 5, 6, 7, 8),
    (8, 7, 6, 5, 4, 3, 2, 1),
]


@pytest.mark.parametrize("a, b, c, d, e, f, g, h", testparams)
def test_many_args(a, b, c, d, e, f, g, h):
    assert False
```

The argument list has to be repeated, which is annoying.
After this PR, the argument list can be replaced by `...` (or `Ellipsis`, which also works in Python 2.x):

```Python
import pytest

testparams = [
    (1, 2, 3, 4, 5, 6, 7, 8),
    (8, 7, 6, 5, 4, 3, 2, 1),
]


@pytest.mark.parametrize(..., testparams)
def test_many_args(a, b, c, d, e, f, g, h):
    assert False
```

The auto-deduced parameters must be in the beginning of the parameter list, but any other parameters can be used afterwards, e.g. a fixture:

```Python
import pytest

testparams = [
    (1, 2, 3, 4, 5, 6, 7, 8),
    (8, 7, 6, 5, 4, 3, 2, 1),
]


@pytest.fixture
def myfixture():
    pass


@pytest.mark.parametrize(..., testparams)
def test_many_args_and_fixture(a, b, c, d, e, f, g, h, myfixture):
    assert False
```