### PR TITLE
Handle reports that don't have a reprcrash

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,6 +43,7 @@ Mark Abramowitz
 Martijn Faassen
 Nicolas Delaby
 Piotr Banaszkiewicz
+Punyashloka Biswal
 Ralf Schmitt
 Ronny Pfannschmidt
 Ross Lawley

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 2.8.0.dev (compared to 2.7.X)
 -----------------------------
 
+- fix issue713: JUnit XML reports for doctest failures.
+  Thanks Punyashloka Biswal.
+
 - Include setup and teardown in junitxml test durations.
   Thanks Janne Vanhala.
 

--- a/_pytest/junitxml.py
+++ b/_pytest/junitxml.py
@@ -123,10 +123,12 @@ class LogXML(object):
                 Junit.skipped(message="xfail-marked test passes unexpectedly"))
             self.skipped += 1
         else:
-            if isinstance(report.longrepr, (unicode, str)):
+            if hasattr(report.longrepr, "reprcrash"):
+                message = report.longrepr.reprcrash.message
+            elif isinstance(report.longrepr, (unicode, str)):
                 message = report.longrepr
             else:
-                message = report.longrepr.reprcrash.message
+                message = str(report.longrepr)
             message = bin_xml_escape(message)
             fail = Junit.failure(message=message)
             fail.append(bin_xml_escape(report.longrepr))

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -352,3 +352,16 @@ class TestDoctests:
         reprec = testdir.inline_run(p, "--doctest-modules",
                                     "--doctest-ignore-import-errors")
         reprec.assertoutcome(skipped=1, failed=1, passed=0)
+
+    def test_junit_report_for_doctest(self, testdir):
+        p = testdir.makepyfile("""
+            def foo():
+                '''
+                >>> 1 + 1
+                3
+                '''
+                pass
+        """)
+        reprec = testdir.inline_run(p, "--doctest-modules",
+                                    "--junit-xml=junit.xml")
+        reprec.assertoutcome(failed=1)


### PR DESCRIPTION
Closes #713 (which happens because `ReprFailDoctest` doesn't have a reprcrash)