### PR TITLE
Automatically create directory for results

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Andreas Zeidler
 Andy Freeland
 Anthon van der Neut
 Armin Rigo
+Aron Curzon
 Benjamin Peterson
 Bob Ippolito
 Brian Dorsey

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 2.8.0.dev (compared to 2.7.X)
 -----------------------------
 
+- Automatically create directory for junitxml and results log.
+  Thanks Aron Curzon.
+
 - Include setup and teardown in junitxml test durations.
   Thanks Janne Vanhala.
 

--- a/_pytest/junitxml.py
+++ b/_pytest/junitxml.py
@@ -203,6 +203,9 @@ class LogXML(object):
         self.suite_start_time = time.time()
 
     def pytest_sessionfinish(self):
+        dirname = os.path.dirname(os.path.abspath(self.logfile))
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
         logfile = open(self.logfile, 'w', encoding='utf-8')
         suite_stop_time = time.time()
         suite_time_delta = suite_stop_time - self.suite_start_time

--- a/_pytest/resultlog.py
+++ b/_pytest/resultlog.py
@@ -3,6 +3,7 @@ text file.
 """
 
 import py
+import os
 
 def pytest_addoption(parser):
     group = parser.getgroup("terminal reporting", "resultlog plugin options")
@@ -14,6 +15,9 @@ def pytest_configure(config):
     resultlog = config.option.resultlog
     # prevent opening resultlog on slave nodes (xdist)
     if resultlog and not hasattr(config, 'slaveinput'):
+        dirname = os.path.dirname(os.path.abspath(resultlog))
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
         logfile = open(resultlog, 'w', 1) # line buffered
         config._resultlog = ResultLog(config, logfile)
         config.pluginmanager.register(config._resultlog)

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -478,6 +478,15 @@ def test_logxml_changingdir(testdir):
     assert result.ret == 0
     assert testdir.tmpdir.join("a/x.xml").check()
 
+def test_logxml_makedir(testdir):
+    testdir.makepyfile("""
+        def test_pass():
+            pass
+    """)
+    result = testdir.runpytest("--junitxml=path/to/results.xml")
+    assert result.ret == 0
+    assert testdir.tmpdir.join("path/to/results.xml").check()
+
 def test_escaped_parametrized_names_xml(testdir):
     testdir.makepyfile("""
         import pytest

--- a/testing/test_resultlog.py
+++ b/testing/test_resultlog.py
@@ -180,6 +180,20 @@ def test_generic(testdir, LineMatcher):
         "x *:test_xfail_norun",
     ])
 
+def test_makedir_for_resultlog(testdir, LineMatcher):
+    testdir.plugins.append("resultlog")
+    testdir.makepyfile("""
+        import pytest
+        def test_pass():
+            pass
+    """)
+    testdir.runpytest("--resultlog=path/to/result.log")
+    lines = testdir.tmpdir.join("path/to/result.log").readlines(cr=0)
+    LineMatcher(lines).fnmatch_lines([
+        ". *:test_pass",
+    ])
+
+
 def test_no_resultlog_on_slaves(testdir):
     config = testdir.parseconfig("-p", "resultlog", "--resultlog=resultlog")
 


### PR DESCRIPTION
py.test --junit-xml=results/results.xml fails if results directory has not already been created.