### PR TITLE
Automatically create directories for junit-xml and resultlog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,30 @@
 sudo: false
 language: python
 # command to install dependencies
-install: "pip install -U detox"
+install: "pip install -U tox"
 # # command to run tests
-script: detox --recreate -i ALL=https://devpi.net/hpk/dev/
+env:
+  matrix:
+    - TESTENV=flakes
+    - TESTENV=py26
+    - TESTENV=py27
+    - TESTENV=py34
+    - TESTENV=pypy
+    - TESTENV=py27-pexpect
+    - TESTENV=py33-pexpect
+    - TESTENV=py27-nobyte
+    - TESTENV=py33
+    - TESTENV=py27-xdist
+    - TESTENV=py33-xdist
+    - TESTENV=py27
+    - TESTENV=py27-trial
+    - TESTENV=py33
+    - TESTENV=py33-trial
+    - TESTENV=py27-subprocess
+    - TESTENV=doctesting
+    - TESTENV=py27-cxfreeze
+    - TESTENV=coveralls
+script: tox --recreate -i ALL=https://devpi.net/hpk/dev/ -e $TESTENV
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 # command to install dependencies
 install: "pip install -U detox"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ env:
     - TESTENV=py27-trial
     - TESTENV=py33
     - TESTENV=py33-trial
-    - TESTENV=py27-subprocess
+    # inprocess tests by default were introduced in 2.8 only;
+    # this TESTENV should be enabled when merged back to master
+    #- TESTENV=py27-subprocess
     - TESTENV=doctesting
     - TESTENV=py27-cxfreeze
     - TESTENV=coveralls

--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Andreas Zeidler
 Andy Freeland
 Anthon van der Neut
 Armin Rigo
+Aron Curzon
 Benjamin Peterson
 Bob Ippolito
 Brian Dorsey
@@ -21,6 +22,7 @@ Christian Tismer
 Christopher Gilling
 Daniel Grana
 Daniel Nuri
+Dave Hunt
 Dave Hunt
 David Mohr
 Floris Bruynooghe

--- a/AUTHORS
+++ b/AUTHORS
@@ -23,7 +23,6 @@ Christopher Gilling
 Daniel Grana
 Daniel Nuri
 Dave Hunt
-Dave Hunt
 David Mohr
 Floris Bruynooghe
 Graham Horler

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 2.7.2 (compared to 2.7.1)
 -----------------------------
 
+- Automatically create directory for junitxml and results log.
+  Thanks Aron Curzon.
+
 - fix issue713: JUnit XML reports for doctest failures.
   Thanks Punyashloka Biswal.
 

--- a/_pytest/junitxml.py
+++ b/_pytest/junitxml.py
@@ -205,6 +205,9 @@ class LogXML(object):
         self.suite_start_time = time.time()
 
     def pytest_sessionfinish(self):
+        dirname = os.path.dirname(os.path.abspath(self.logfile))
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
         logfile = open(self.logfile, 'w', encoding='utf-8')
         suite_stop_time = time.time()
         suite_time_delta = suite_stop_time - self.suite_start_time

--- a/_pytest/junitxml.py
+++ b/_pytest/junitxml.py
@@ -206,7 +206,7 @@ class LogXML(object):
 
     def pytest_sessionfinish(self):
         dirname = os.path.dirname(os.path.abspath(self.logfile))
-        if not os.path.exists(dirname):
+        if not os.path.isdir(dirname):
             os.makedirs(dirname)
         logfile = open(self.logfile, 'w', encoding='utf-8')
         suite_stop_time = time.time()

--- a/_pytest/resultlog.py
+++ b/_pytest/resultlog.py
@@ -16,7 +16,7 @@ def pytest_configure(config):
     # prevent opening resultlog on slave nodes (xdist)
     if resultlog and not hasattr(config, 'slaveinput'):
         dirname = os.path.dirname(os.path.abspath(resultlog))
-        if not os.path.exists(dirname):
+        if not os.path.isdir(dirname):
             os.makedirs(dirname)
         logfile = open(resultlog, 'w', 1) # line buffered
         config._resultlog = ResultLog(config, logfile)

--- a/_pytest/resultlog.py
+++ b/_pytest/resultlog.py
@@ -3,6 +3,7 @@ text file.
 """
 
 import py
+import os
 
 def pytest_addoption(parser):
     group = parser.getgroup("terminal reporting", "resultlog plugin options")
@@ -14,6 +15,9 @@ def pytest_configure(config):
     resultlog = config.option.resultlog
     # prevent opening resultlog on slave nodes (xdist)
     if resultlog and not hasattr(config, 'slaveinput'):
+        dirname = os.path.dirname(os.path.abspath(resultlog))
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
         logfile = open(resultlog, 'w', 1) # line buffered
         config._resultlog = ResultLog(config, logfile)
         config.pluginmanager.register(config._resultlog)

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -474,6 +474,15 @@ def test_logxml_changingdir(testdir):
     assert result.ret == 0
     assert testdir.tmpdir.join("a/x.xml").check()
 
+def test_logxml_makedir(testdir):
+    testdir.makepyfile("""
+        def test_pass():
+            pass
+    """)
+    result = testdir.runpytest("--junitxml=path/to/results.xml")
+    assert result.ret == 0
+    assert testdir.tmpdir.join("path/to/results.xml").check()
+
 def test_escaped_parametrized_names_xml(testdir):
     testdir.makepyfile("""
         import pytest

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -475,6 +475,7 @@ def test_logxml_changingdir(testdir):
     assert testdir.tmpdir.join("a/x.xml").check()
 
 def test_logxml_makedir(testdir):
+    """--junitxml should automatically create directories for the xml file"""
     testdir.makepyfile("""
         def test_pass():
             pass

--- a/testing/test_resultlog.py
+++ b/testing/test_resultlog.py
@@ -181,6 +181,7 @@ def test_generic(testdir, LineMatcher):
     ])
 
 def test_makedir_for_resultlog(testdir, LineMatcher):
+    """--resultlog should automatically create directories for the log file"""
     testdir.plugins.append("resultlog")
     testdir.makepyfile("""
         import pytest

--- a/testing/test_resultlog.py
+++ b/testing/test_resultlog.py
@@ -180,6 +180,20 @@ def test_generic(testdir, LineMatcher):
         "x *:test_xfail_norun",
     ])
 
+def test_makedir_for_resultlog(testdir, LineMatcher):
+    testdir.plugins.append("resultlog")
+    testdir.makepyfile("""
+        import pytest
+        def test_pass():
+            pass
+    """)
+    testdir.runpytest("--resultlog=path/to/result.log")
+    lines = testdir.tmpdir.join("path/to/result.log").readlines(cr=0)
+    LineMatcher(lines).fnmatch_lines([
+        ". *:test_pass",
+    ])
+
+
 def test_no_resultlog_on_slaves(testdir):
     config = testdir.parseconfig("-p", "resultlog", "--resultlog=resultlog")
 

--- a/tox.ini
+++ b/tox.ini
@@ -132,6 +132,18 @@ commands=
     {envpython} runtests_setup.py build --build-exe build
     {envpython} tox_run.py
 
+[testenv:coveralls]
+changedir=testing
+basepython=python3.4
+deps =
+    {[testenv]deps}
+    coveralls
+commands=
+    coverage run --source=_pytest {envdir}/bin/py.test
+    coverage report -m
+    coveralls
+passenv=COVERALLS_REPO_TOKEN
+
 [pytest]
 minversion=2.0
 plugins=pytester


### PR DESCRIPTION
Credits for the fix go to @curzona. :smile:

Only created this PR to solve some conflicts when #783 was rebased to `pytest-2.7`.

With this PR I noticed that `pytest-2.7` was actually broken on Travis since we moved to GitHub; in order to make it work again, I cherry-picked some of @bubenkoff's commits from `master`, but I also had to remove `py27-subprocess` from the test environments that run on Travis as the feature tested by it (inprocess tests by default) has been introduced in `master` only. 

We must be careful when merging this back into `master` to not merge the commented out environment.
