### PR TITLE
Reintroduce get_plugin_manager() for backward-compatibility

### DIFF
--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -82,6 +82,17 @@ def get_config():
         pluginmanager.import_plugin(spec)
     return config
 
+def get_plugin_manager():
+    """
+    Obtain a new instance of the
+    :py:class:`_pytest.config.PytestPluginManager`, with default plugins
+    already loaded.
+
+    This function can be used by integration with other tools, like hooking
+    into pytest to run tests into an IDE.
+    """
+    return get_config().pluginmanager
+
 def _prepareconfig(args=None, plugins=None):
     if args is None:
         args = sys.argv[1:]
@@ -111,6 +122,14 @@ def exclude_pytest_names(name):
 
 
 class PytestPluginManager(PluginManager):
+    """
+    Overwrites :py:class:`pluggy.PluginManager` to add pytest-specific
+    functionality:
+
+    * loading plugins from the command line, ``PYTEST_PLUGIN`` env variable and
+      ``pytest_plugins`` global variables found in plugins being loaded;
+    * ``conftest.py`` loading during start-up;
+    """
     def __init__(self):
         super(PytestPluginManager, self).__init__("pytest", implprefix="pytest_")
         self._warnings = []
@@ -135,6 +154,11 @@ class PytestPluginManager(PluginManager):
             self.enable_tracing()
 
     def addhooks(self, module_or_class):
+        """
+        .. deprecated:: 2.8
+
+        Use :py:meth:`pluggy.PluginManager.add_hookspecs` instead.
+        """
         warning = dict(code="I2",
                        fslocation=py.code.getfslineno(sys._getframe(1)),
                        message="use pluginmanager.add_hookspecs instead of "

--- a/doc/en/writing_plugins.txt
+++ b/doc/en/writing_plugins.txt
@@ -531,6 +531,16 @@ Reference of objects involved in hooks
 .. autoclass:: _pytest.core.CallOutcome()
     :members:
 
+.. autofunction:: _pytest.config.get_plugin_manager()
+
+.. autoclass:: _pytest.config.PytestPluginManager()
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: pluggy.PluginManager()
+    :members:
+
 .. currentmodule:: _pytest.pytester
 
 .. autoclass:: Testdir()

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -564,6 +564,12 @@ class TestInvocationVariants:
             "*1 failed*",
         ])
 
+    def test_core_backward_compatibility(self):
+        """Test backward compatibility for get_plugin_manager function. See #787."""
+        import _pytest.config
+        assert type(_pytest.config.get_plugin_manager()) is _pytest.config.PytestPluginManager
+
+
 class TestDurations:
     source = """
         import time


### PR DESCRIPTION
PyCharm depends on `get_plugin_manager()` for its pytest runner.

Using the pytest runner in PyCharm as of `2.8.0.dev4` raises this exception:

```
Traceback (most recent call last):
  File "D:\Programming\PyCharm\helpers\pycharm\pytestrunner.py", line 60, in <module>
    main()
  File "D:\Programming\PyCharm\helpers\pycharm\pytestrunner.py", line 30, in main
    _pluginmanager = get_plugin_manager()
  File "D:\Programming\PyCharm\helpers\pycharm\pytestrunner.py", line 20, in get_plugin_manager
    from _pytest.core import PluginManager
ImportError: No module named '_pytest.core'
```

The related code in `PyCharm\helpers\pycharm\pytestrunner.py` is:

```python
def get_plugin_manager():
  try:
    from _pytest.config import get_plugin_manager
    return get_plugin_manager()
  except ImportError:
    from _pytest.core import PluginManager
    return PluginManager(load=True)
```

`get_plugin_manager` was removed during the refactoring that lead to `pluggy`, I guess.

While it could be argued that PyCharm could fix it on their side, keeping backward compatibility in pytest is simple and would prevent a ton of PyCharm users not being able to run py.test tests when we release `2.8.0`, at least until a hotfix for PyCharm is released.