### PR TITLE
Fix issue where pytest.raises() doesn't always return Exception instance in py26

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 2.7.2 (compared to 2.7.1)
 -----------------------------
 
+- fix issue767: pytest.raises value attribute does not contain the exception
+  instance on Python 2.6. Thanks Eric Siegerman for providing the test
+  case and Bruno Oliveira for PR.
+
 - Automatically create directory for junitxml and results log.
   Thanks Aron Curzon.
 

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1099,6 +1099,13 @@ class RaisesContext(object):
         __tracebackhide__ = True
         if tp[0] is None:
             pytest.fail("DID NOT RAISE")
+        if sys.version_info < (2, 7):
+            # py26: on __exit__() exc_value often does not contain the
+            # exception value.
+            # http://bugs.python.org/issue7853
+            if not isinstance(tp[1], BaseException):
+                exc_type, value, traceback = tp
+                tp = exc_type, exc_type(value), traceback
         self.excinfo.__init__(tp)
         return issubclass(self.excinfo.type, self.ExpectedException)
 

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -46,6 +46,7 @@ class TestRaises:
                     1/0
                 print (excinfo)
                 assert excinfo.type == ZeroDivisionError
+                assert isinstance(excinfo.value, ZeroDivisionError)
 
             def test_noraise():
                 with pytest.raises(pytest.raises.Exception):


### PR DESCRIPTION
Fixes #767