### PR TITLE
Skip reports refer to pytest code instead of original test functions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,9 @@
 - fix issue114: skipif marker reports to internal skipping plugin;
   Thanks Floris Bruynooghe for reporting and Bruno Oliveira for the PR.
 
+- fix issue748: unittest.SkipTest reports to internal pytest unittest plugin.
+  Thanks Thomas De Schampheleire for reporting and Bruno Oliveira for the PR.
+
 2.7.1 (compared to 2.7.0)
 -----------------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,9 @@
 - fix issue735: assertion failures on debug versions of Python 3.4+
   Thanks Benjamin Peterson.
 
+- fix issue114: skipif marker reports to internal skipping plugin;
+  Thanks Floris Bruynooghe for reporting and Bruno Oliveira for the PR.
+
 2.7.1 (compared to 2.7.0)
 -----------------------------
 

--- a/_pytest/unittest.py
+++ b/_pytest/unittest.py
@@ -9,6 +9,7 @@ import py
 
 # for transfering markers
 from _pytest.python import transfer_markers
+from _pytest.skipping import MarkEvaluator
 
 
 def pytest_pycollect_makeitem(collector, name, obj):
@@ -113,6 +114,8 @@ class TestCaseFunction(pytest.Function):
         try:
             pytest.skip(reason)
         except pytest.skip.Exception:
+            self._evalskip = MarkEvaluator(self, 'SkipTest')
+            self._evalskip.result = True
             self._addexcinfo(sys.exc_info())
 
     def addExpectedFailure(self, testcase, rawexcinfo, reason=""):

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -396,7 +396,7 @@ class TestSkipif:
 
 
     def test_skipif_reporting(self, testdir):
-        p = testdir.makepyfile("""
+        p = testdir.makepyfile(test_foo="""
             import pytest
             @pytest.mark.skipif("hasattr(sys, 'platform')")
             def test_that():
@@ -404,7 +404,7 @@ class TestSkipif:
         """)
         result = testdir.runpytest(p, '-s', '-rs')
         result.stdout.fnmatch_lines([
-            "*SKIP*1*platform*",
+            "*SKIP*1*test_foo.py*platform*",
             "*1 skipped*"
         ])
         assert result.ret == 0

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -700,4 +700,17 @@ def test_issue333_result_clearing(testdir):
     reprec = testdir.inline_run()
     reprec.assertoutcome(failed=1)
 
+@pytest.mark.skipif("sys.version_info < (2,7)")
+def test_unittest_raise_skip_issue748(testdir):
+    testdir.makepyfile(test_foo="""
+        import unittest
 
+        class MyTestCase(unittest.TestCase):
+            def test_one(self):
+                raise unittest.SkipTest('skipping due to reasons')
+    """)
+    result = testdir.runpytest("-v", '-rs')
+    result.stdout.fnmatch_lines("""
+        *SKIP*[1]*test_foo.py*skipping due to reasons*
+        *1 skipped*
+    """)


### PR DESCRIPTION
Fix #114: when using `pytest.mark.skipif`
Fix #748: when using `unittest.SkipTest`