### PR TITLE
Adjust IRC notifications to use #pytest.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ script: tox --recreate -i ALL=https://devpi.net/hpk/dev/ -e $TESTENV
 
 notifications:
   irc:
-    - "chat.freenode.net#pytest-dev"
+    channels:
+      - "chat.freenode.net#pytest"
+    on_success: change
+    on_failure: change
+    skip_join: true
   email:
     - pytest-commit@python.org


### PR DESCRIPTION
It seems #pytest-dev is quite dead. Also I set it to only send notifications on
changes (i.e. success -> failure and vice-versa).