### PR TITLE
Improve coverage score by tweaking options

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+omit = 
+    # standlonetemplate is read dynamically and tested by test_genscript
+    *standalonetemplate.py
+    # oldinterpret could be removed, as it is no longer used in py26+
+    *oldinterpret.py


### PR DESCRIPTION
Improving coverage score by removing files known to generate bogus reports.

**Note**: Can we remove `oldreinterpret.py` altogether? It seems to be used for python versions pre-2.6, but we no longer support those.