### PR TITLE
Use SVGs for all README badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,9 @@ pytest
 The ``pytest`` testing tool makes it easy to write small tests, yet
 scales to support complex functional testing.
 
-.. image:: http://img.shields.io/pypi/v/pytest.png
+.. image:: http://img.shields.io/pypi/v/pytest.svg
    :target: https://pypi.python.org/pypi/pytest
-.. image:: http://img.shields.io/coveralls/pytest-dev/pytest.png?branch=master
+.. image:: http://img.shields.io/coveralls/pytest-dev/pytest/master.svg
    :target: https://coveralls.io/r/pytest-dev/pytest
 .. image:: https://travis-ci.org/pytest-dev/pytest.svg?branch=master
     :target: https://travis-ci.org/pytest-dev/pytest


### PR DESCRIPTION
Using SVGs improves the appearance of badges on high resolution displays (see diff below). In addition, both of the build status badges are already SVGs, so this standardizes all of the badges.

![svg badges](https://cloud.githubusercontent.com/assets/2434728/8268473/0396908c-173c-11e5-8060-e34318e3694d.png)
