### PR TITLE
Add a --noconftest option.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -65,6 +65,8 @@
 - fix issue741: make running output from testdir.run copy/pasteable
   Thanks Bruno Oliveira.
 
+- add a new ``--noconftest`` argument which ignores all ``conftest.py`` files.
+
 2.7.2 (compared to 2.7.1)
 -----------------------------
 

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -239,7 +239,7 @@ class PytestPluginManager(PluginManager):
 
     def _getconftestmodules(self, path):
         if self._noconftest:
-            self._path2confmods[path] = []
+            return []
         try:
             return self._path2confmods[path]
         except KeyError:

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -120,6 +120,7 @@ class PytestPluginManager(PluginManager):
         self._path2confmods = {}
         self._conftestpath2mod = {}
         self._confcutdir = None
+        self._noconftest = False
 
         self.add_hookspecs(_pytest.hookspec)
         self.register(self)
@@ -212,6 +213,7 @@ class PytestPluginManager(PluginManager):
         current = py.path.local()
         self._confcutdir = current.join(namespace.confcutdir, abs=True) \
                                 if namespace.confcutdir else None
+        self._noconftest = namespace.noconftest
         testpaths = namespace.file_or_dir
         foundanchor = False
         for path in testpaths:
@@ -236,6 +238,8 @@ class PytestPluginManager(PluginManager):
                     self._getconftestmodules(x)
 
     def _getconftestmodules(self, path):
+        if self._noconftest:
+            self._path2confmods[path] = []
         try:
             return self._path2confmods[path]
         except KeyError:

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -54,6 +54,9 @@ def pytest_addoption(parser):
     group.addoption('--confcutdir', dest="confcutdir", default=None,
         metavar="dir",
         help="only load conftest.py's relative to specified dir.")
+    group.addoption('--noconftest', action="store_true",
+        dest="noconftest", default=False,
+        help="Don't load any conftest.py files.")
 
     group = parser.getgroup("debugconfig",
         "test session debugging and configuration")

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -24,6 +24,7 @@ def conftest_setinitial(conftest, args, confcutdir=None):
         def __init__(self):
             self.file_or_dir = args
             self.confcutdir = str(confcutdir)
+            self.noconftest = False
     conftest._set_initial_conftests(Namespace())
 
 class TestConftestValueAccessGlobal:
@@ -160,6 +161,11 @@ def test_conftest_confcutdir(testdir):
     """))
     result = testdir.runpytest("-h", "--confcutdir=%s" % x, x)
     result.stdout.fnmatch_lines(["*--xyz*"])
+
+def test_no_conftest(testdir):
+    testdir.makeconftest("assert 0")
+    result = testdir.runpytest("--noconftest")
+    assert result.ret == 0
 
 def test_conftest_existing_resultlog(testdir):
     x = testdir.mkdir("tests")


### PR DESCRIPTION
~~Pushing this *work-in-progress* PR because I'd appreciate some help.~~

I want to add a `--noconftest` option to not load any `conftest.py` files (which is useful when using things like `pytest-{pep8,flakes,mccabe,...}` and not wanting the dependencies imported in the `conftest.py` file).

~~I now implemented the option and a test (`test_no_conftest`) but not the feature itself, i.e. I'd expect that test to fail. However, it passes! Why is that?~~

It's inspired by the test above (`test_conftest_confcutdir`) where a `conftest.py` with `assert 0` is created as well to ensure it shouldn't get loaded.