### PR TITLE
Check conftest.py is not loaded with --confcutdir.

### DIFF
--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -171,6 +171,7 @@ def test_conftest_confcutdir(testdir):
     """))
     result = testdir.runpytest("-h", "--confcutdir=%s" % x, x)
     result.stdout.fnmatch_lines(["*--xyz*"])
+    assert 'warning: could not load initial' not in result.stdout.str()
 
 def test_conftest_existing_resultlog(testdir):
     x = testdir.mkdir("tests")


### PR DESCRIPTION
The test creates a conftest.py with "assert 0" which never should be loaded.
However, if it were loaded, the test would still pass as it never checks if it
was loaded or not.

See #799.