### PR TITLE
deprecated_call does not revert warning functions back to original v2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,6 +42,7 @@ Marc Schlaich
 Mark Abramowitz
 Martijn Faassen
 Nicolas Delaby
+Pieter Mulder
 Piotr Banaszkiewicz
 Punyashloka Biswal
 Ralf Schmitt

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 2.7.2 (compared to 2.7.1)
 -----------------------------
 
+- preserve warning functions after call to pytest.deprecated_call
+
 - fix issue767: pytest.raises value attribute does not contain the exception
   instance on Python 2.6. Thanks Eric Siegerman for providing the test
   case and Bruno Oliveira for PR.

--- a/_pytest/recwarn.py
+++ b/_pytest/recwarn.py
@@ -45,8 +45,8 @@ def deprecated_call(func, *args, **kwargs):
     try:
         ret = func(*args, **kwargs)
     finally:
-        warnings.warn_explicit = warn_explicit
-        warnings.warn = warn
+        warnings.warn_explicit = oldwarn_explicit
+        warnings.warn = oldwarn
     if not l:
         __tracebackhide__ = True
         raise AssertionError("%r did not produce DeprecationWarning" %(func,))

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -64,12 +64,12 @@ def test_deprecated_call_ret():
     assert ret == 42
 
 def test_deprecated_call_preserves():
-    r = py.std.warnings.onceregistry.copy()
-    f = py.std.warnings.filters[:]
+    warn = py.std.warnings.warn
+    warn_explicit = py.std.warnings.warn_explicit
     test_deprecated_call_raises()
     test_deprecated_call()
-    assert r == py.std.warnings.onceregistry
-    assert f == py.std.warnings.filters
+    assert warn == py.std.warnings.warn
+    assert warn_explicit == py.std.warnings.warn_explicit
 
 def test_deprecated_explicit_call_raises():
     pytest.raises(AssertionError,


### PR DESCRIPTION
See https://github.com/pytest-dev/pytest/pull/802 Rebased on branch pytest-2.7
Added test and data in AUTHORS and CHANGELOG