### PR TITLE
Collect functools.partial objects

### DIFF
--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1,5 +1,6 @@
 """ Python test discovery, setup and run of test functions. """
 import fnmatch
+import functools
 import py
 import inspect
 import sys
@@ -24,7 +25,7 @@ def get_real_func(obj):
     """
     while hasattr(obj, "__wrapped__"):
         obj = obj.__wrapped__
-    if isinstance(obj, py.std.functools.partial):
+    if isinstance(obj, functools.partial):
         obj = obj.func
     return obj
 
@@ -603,10 +604,7 @@ class FunctionMixin(PyobjMixin):
 
     def _prunetraceback(self, excinfo):
         if hasattr(self, '_obj') and not self.config.option.fulltrace:
-            if isinstance(self.obj, py.std.functools.partial):
-                code = py.code.Code(self.obj.func)
-            else:
-                code = py.code.Code(self.obj)
+            code = py.code.Code(get_real_func(self.obj))
             path, firstlineno = code.path, code.firstlineno
             traceback = excinfo.traceback
             ntraceback = traceback.cut(path=path, firstlineno=firstlineno)
@@ -1949,7 +1947,7 @@ def getfuncargnames(function, startindex=None):
     if realfunction != function:
         startindex += num_mock_patch_args(function)
         function = realfunction
-    if isinstance(function, py.std.functools.partial):
+    if isinstance(function, functools.partial):
         argnames = inspect.getargs(py.code.getrawcode(function.func))[0]
         partial = function
         argnames = argnames[len(partial.args):]

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -851,3 +851,47 @@ def test_unorderable_types(testdir):
     result = testdir.runpytest()
     assert "TypeError" not in result.stdout.str()
     assert result.ret == 0
+
+
+def test_collect_functools_partial(testdir):
+    """
+    Test that collection of functools.partial object works, and arguments
+    to the wrapped functions are dealt correctly (see #811).
+    """
+    testdir.makepyfile("""
+        import functools
+        import pytest
+
+        @pytest.fixture
+        def fix1():
+            return 'fix1'
+
+        @pytest.fixture
+        def fix2():
+            return 'fix2'
+
+        def check1(i, fix1):
+            assert i == 2
+            assert fix1 == 'fix1'
+
+        def check2(fix1, i):
+            assert i == 2
+            assert fix1 == 'fix1'
+
+        def check3(fix1, i, fix2):
+            assert i == 2
+            assert fix1 == 'fix1'
+            assert fix2 == 'fix2'
+
+        test_ok_1 = functools.partial(check1, i=2)
+        test_ok_2 = functools.partial(check1, i=2, fix1='fix1')
+        test_ok_3 = functools.partial(check1, 2)
+        test_ok_4 = functools.partial(check2, i=2)
+        test_ok_5 = functools.partial(check3, i=2)
+        test_ok_6 = functools.partial(check3, i=2, fix1='fix1')
+
+        test_fail_1 = functools.partial(check2, 2)
+        test_fail_2 = functools.partial(check3, 2)
+    """)
+    result = testdir.inline_run()
+    result.assertoutcome(passed=6, failed=2)


### PR DESCRIPTION
Fix for issue #811.

I feel the current implementation is hackish and might break in some corner-cases.

Perhaps it would be better to don't support tests created by `functools.partial` objects at all, and issue a warning during collection and add a note to the documentation?