### PR TITLE
Fix flaky test_timing_function in Windows

### DIFF
--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -55,7 +55,7 @@ class TestPython:
         node = dom.getElementsByTagName("testsuite")[0]
         tnode = node.getElementsByTagName("testcase")[0]
         val = tnode.getAttributeNode("time").value
-        assert float(val) >= 0.03
+        assert round(float(val), 2) >= 0.03
 
     def test_setup_error(self, testdir):
         testdir.makepyfile("""


### PR DESCRIPTION
This tests fails consistently on Windows due to a small time
difference:

```
>       assert float(val) >= 0.03
E       assert 0.0299999713898 >= 0.03
E        +  where 0.0299999713898 = float('0.0299999713898')
```

Windows time.time() function is not as accurate as linux's,
so relaxed the test a bit.