### PR TITLE
Pinning mock module to < 1.1 fo py26

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,12 @@ deps=
     nose
     mock
 
+[testenv:py26]
+commands= py.test --lsof -rfsxX {posargs:testing}
+deps=
+    nose
+    mock<1.1  # last supported version for py26
+
 [testenv:py27-subprocess]
 changedir=.
 basepython=python2.7


### PR DESCRIPTION
It has been announced that mock>=1.1 will be supported for python 2.7+ only.