### PR TITLE
pytest.mark in classes marks methods defined in the class body only

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,11 @@
   all directories that do not contain tests.
   Thanks to Adrian for idea (#694) and Bruno Oliveira for the PR.
 
+- fix issue725: pytest.mark in class decorators will mark methods defined
+  in the class body only, instead of propagating marks to the superclass'
+  test methods.
+  Thanks to foobarbazquux for the report and Bruno Oliveira for the PR.
+
 - fix issue713: JUnit XML reports for doctest failures.
   Thanks Punyashloka Biswal.
 

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -483,16 +483,23 @@ class FuncFixtureInfo:
 def transfer_markers(funcobj, cls, mod):
     # XXX this should rather be code in the mark plugin or the mark
     # plugin should merge with the python plugin.
-    for holder in (cls, mod):
+    def transfer(holder):
         try:
             pytestmark = holder.pytestmark
         except AttributeError:
-            continue
-        if isinstance(pytestmark, list):
-            for mark in pytestmark:
-                mark(funcobj)
+            pass
         else:
-            pytestmark(funcobj)
+            if isinstance(pytestmark, list):
+                for mark in pytestmark:
+                    mark(funcobj)
+            else:
+                pytestmark(funcobj)
+
+    # transfer markers from class decorators only if the method is defined
+    # in the class itself
+    if cls is not None and funcobj.__name__ in cls.__dict__:
+        transfer(cls)
+    transfer(mod)
 
 class Module(pytest.File, PyCollector):
     """ Collector for test classes and functions. """

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -300,20 +300,19 @@ def test_apiwrapper_problem_issue260(testdir):
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)
 
-@pytest.mark.skipif("sys.version_info < (2,6)")
+
 def test_setup_teardown_linking_issue265(testdir):
     # we accidentally didnt integrate nose setupstate with normal setupstate
     # this test ensures that won't happen again
     testdir.makepyfile('''
         import pytest
 
-        class TestGeneric(object):
-            def test_nothing(self):
-                """Tests the API of the implementation (for generic and specialized)."""
-
         @pytest.mark.skipif("True", reason=
                     "Skip tests to check if teardown is skipped as well.")
-        class TestSkipTeardown(TestGeneric):
+        class TestSkipTeardown(object):
+
+            def test_nothing(self):
+                pass
 
             def setup(self):
                 """Sets up my specialized implementation for $COOL_PLATFORM."""
@@ -324,7 +323,7 @@ def test_setup_teardown_linking_issue265(testdir):
                 raise Exception("should not call teardown for skipped tests")
         ''')
     reprec = testdir.runpytest()
-    reprec.assert_outcomes(passed=1, skipped=1)
+    reprec.assert_outcomes(passed=0, skipped=1)
 
 
 def test_SkipTest_during_collection(testdir):


### PR DESCRIPTION
Fix #725 