### PR TITLE
Use a subdirectory in the TEMP directory to speed up tmpdir creation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,12 @@
   fixtures declared on the first one.
   Thanks Florian Bruhin for reporting and Bruno Oliveira for the PR.
 
+- optimized tmpdir fixture initialization, which should make test sessions
+  faster (specially when using pytest-xdist). The only visible effect
+  is that now pytest uses a subdirectory in the $TEMP directory for all
+  directories created by this fixture (defaults to $TEMP/pytest-$USER).
+  Thanks Bruno Oliveira for the PR.
+
 
 2.7.2 (compared to 2.7.1)
 -----------------------------

--- a/_pytest/tmpdir.py
+++ b/_pytest/tmpdir.py
@@ -43,7 +43,14 @@ class TempdirHandler:
                     basetemp.remove()
                 basetemp.mkdir()
             else:
-                basetemp = py.path.local.make_numbered_dir(prefix='pytest-')
+                # use a sub-directory in the temproot to speed-up
+                # make_numbered_dir() call
+                import getpass
+                temproot = py.path.local.get_temproot()
+                rootdir = temproot.join('pytest-%s' % getpass.getuser())
+                rootdir.ensure(dir=1)
+                basetemp = py.path.local.make_numbered_dir(prefix='pytest-',
+                                                           rootdir=rootdir)
             self._basetemp = t = basetemp.realpath()
             self.trace("new basetemp", t)
             return t

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist=
 
 [testenv]
 commands= py.test --lsof -rfsxX {posargs:testing}
+passenv = USER USERNAME
 deps=
     nose
     mock


### PR DESCRIPTION
Fix for #105 

Using a sub-directory as root in the `TEMP` directory speeds up `make_numbered_dir` calls, because it will loop over all files to find an unused directory name.

```python
import pytest

pytest_plugins = 'pytester'
@pytest.mark.parametrize('i', range(10))
def test_foo(i, testdir):
    print(str(testdir.tmpdir))  
```

**before**:

```
========================== slowest 3 test durations ===========================
0.46s setup    test_foo.py::test_foo[0]
0.00s setup    test_foo.py::test_foo[7]
0.00s teardown test_foo.py::test_foo[5]
```

**after**:

```
========================== slowest 3 test durations ===========================
0.00s setup    test_foo.py::test_foo[0]
0.00s setup    test_foo.py::test_foo[7]
0.00s teardown test_foo.py::test_foo[5]
```

The speed-up depends on the number of files in the user's `$TEMP` directory.