### PR TITLE
Using standard python build in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 python:
-    - 'nightly'
+  - 3.5
 # command to install dependencies
 install: "pip install -U tox"
 # # command to run tests


### PR DESCRIPTION
"nightly" is now getting Python 3.6.0a0 instead of 3.5:

https://travis-ci.org/pytest-dev/pytest/jobs/71538501