### PR TITLE
Allow py35 to fail on Travis until it is properly supported (fix2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ env:
     - TESTENV=doctesting
     - TESTENV=py27-cxfreeze
     - TESTENV=coveralls
+matrix:
+  allow_failures:
+    # py35 is currently broken on travis, see #744
+    - env: TESTENV=py35
 script: tox --recreate -i ALL=https://devpi.net/hpk/dev/ -e $TESTENV
 
 notifications:


### PR DESCRIPTION
Conflicts:
	.travis.yml