### PR TITLE
importorskip: Allow 'dev' at end of versions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 2.7.3 (compared to 2.7.2)
 -----------------------------
 
+- Allow 'dev' or other unused info at end of version strings in `importorskip`.
+  We now only parse as much of the version string as required for comparison.
+  Thanks to Eric Hunsberger for the PR.
+
 - fix issue856: consider --color parameter in all outputs (for example
   --fixtures). Thanks Barney Gale for the report and Bruno Oliveira for the PR.
 

--- a/_pytest/runner.py
+++ b/_pytest/runner.py
@@ -3,6 +3,8 @@ import bdb
 import sys
 from time import time
 
+from pkg_resources import parse_version
+
 import py
 import pytest
 from py._code.code import TerminalRepr
@@ -496,9 +498,7 @@ def importorskip(modname, minversion=None):
     if minversion is None:
         return mod
     verattr = getattr(mod, '__version__', None)
-    def intver(verstring):
-        return [int(x) for x in verstring.split(".")]
-    if verattr is None or intver(verattr) < intver(minversion):
+    if verattr is None or parse_version(verattr) < parse_version(minversion):
         skip("module %r has __version__ %r, required is: %r" %(
              modname, verattr, minversion))
     return mod

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -439,7 +439,7 @@ def test_exception_printing_skip():
         s = excinfo.exconly(tryshort=True)
         assert s.startswith("Skipped")
 
-def test_importorskip():
+def test_importorskip(monkeypatch):
     importorskip = pytest.importorskip
     def f():
         importorskip("asdlkj")
@@ -457,7 +457,7 @@ def test_importorskip():
         pytest.raises(SyntaxError, "pytest.importorskip('x=y')")
         mod = py.std.types.ModuleType("hello123")
         mod.__version__ = "1.3"
-        sys.modules["hello123"] = mod
+        monkeypatch.setitem(sys.modules, "hello123", mod)
         pytest.raises(pytest.skip.Exception, """
             pytest.importorskip("hello123", minversion="1.3.1")
         """)
@@ -471,11 +471,11 @@ def test_importorskip_imports_last_module_part():
     ospath = pytest.importorskip("os.path")
     assert os.path == ospath
 
-def test_importorskip_dev_module():
+def test_importorskip_dev_module(monkeypatch):
     try:
         mod = py.std.types.ModuleType("mockmodule")
         mod.__version__ = '0.13.0.dev-43290'
-        sys.modules['mockmodule'] = mod
+        monkeypatch.setitem(sys.modules, 'mockmodule', mod)
         mod2 = pytest.importorskip('mockmodule', minversion='0.12.0')
         assert mod2 == mod
         pytest.raises(pytest.skip.Exception, """

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -471,6 +471,19 @@ def test_importorskip_imports_last_module_part():
     ospath = pytest.importorskip("os.path")
     assert os.path == ospath
 
+def test_importorskip_dev_module():
+    try:
+        mod = py.std.types.ModuleType("mockmodule")
+        mod.__version__ = '0.13.0.dev-43290'
+        sys.modules['mockmodule'] = mod
+        mod2 = pytest.importorskip('mockmodule', minversion='0.12.0')
+        assert mod2 == mod
+        pytest.raises(pytest.skip.Exception, """
+            pytest.importorskip('mockmodule1', minversion='0.14.0')""")
+    except pytest.skip.Exception:
+        print(py.code.ExceptionInfo())
+        pytest.fail("spurious skip")
+
 
 def test_pytest_cmdline_main(testdir):
     p = testdir.makepyfile("""


### PR DESCRIPTION
In importorskip, only parse the length of the version needed
to compare with `minversion`. This means that version strings can
end in `.dev` (or other) and not cause an error.

I ran into this when I had Scipy version `0.14.0.dev-40896a5` installed, and wanted to do `pytest.importorskip('scipy', minversion='0.9')`.