### PR TITLE
Fix basepython for tox envs "doctesting" and "coveralls"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -89,6 +89,7 @@ commands=
     make html
 
 [testenv:doctesting]
+basepython = python3.4
 changedir=doc/en
 deps=PyYAML
 commands= py.test -rfsxX {posargs}
@@ -117,6 +118,7 @@ commands=
     
 
 [testenv:coveralls]
+basepython = python3.4
 changedir=testing
 deps =
     {[testenv]deps}


### PR DESCRIPTION
Because we are currently using "nighly" python for travis, which
uses python 3.6 as the default interpreter. This breaks the environments
listed above because "inspect.getargspec" has been removed in py36.