### PR TITLE
Avoid detecting conftest files upwards from setup.cfg/pytest.ini/tox.ini by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 2.8.0.dev (compared to 2.7.X)
 -----------------------------
 
+- fix issue82: avoid loading conftest files from setup.cfg/pytest.ini/tox.ini
+  files and upwards by default (--confcutdir can still be set to override this).
+  Thanks Bruno Oliveira for the PR.
+
 - fix issue768: docstrings found in python modules were not setting up session
   fixtures. Thanks Jason R. Coombs for reporting and Bruno Oliveira for the PR.
 

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -894,6 +894,9 @@ class Config(object):
             self.warn("I2", "could not load setuptools entry import: %s" % (e,))
         self.pluginmanager.consider_env()
         self.known_args_namespace = ns = self._parser.parse_known_args(args)
+        if self.known_args_namespace.confcutdir is None and self.inifile:
+            confcutdir = py.path.local(self.inifile).dirname
+            self.known_args_namespace.confcutdir = confcutdir
         try:
             self.hook.pytest_load_initial_conftests(early_config=self,
                     args=args, parser=self._parser)

--- a/doc/en/customize.txt
+++ b/doc/en/customize.txt
@@ -219,3 +219,10 @@ Builtin configuration file options
 
    One or more doctest flag names from the standard ``doctest`` module.
    :doc:`See how py.test handles doctests <doctest>`.
+
+.. confval:: confcutdir
+
+   Sets a directory where search upwards for ``conftest.py`` files stops.
+   By default, pytest will stop searching for ``conftest.py`` files upwards
+   from ``pytest.ini``/``tox.ini``/``setup.cfg`` of the project if any,
+   or up to the file-system root.


### PR DESCRIPTION
Fixes #82