### PR TITLE
Workaround for cmdexec bug on Windows

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -15,7 +15,13 @@ class LsofFdLeakChecker(object):
     def _exec_lsof(self):
         pid = os.getpid()
         #return py.process.cmdexec("lsof -Ffn0 -p %d" % pid)
-        return py.process.cmdexec("lsof -p %d" % pid)
+        try:
+            return py.process.cmdexec("lsof -p %d" % pid)
+        except UnicodeDecodeError:
+            # cmdexec may raise UnicodeDecodeError on Windows systems
+            # with locale other than english:
+            # https://bitbucket.org/pytest-dev/py/issues/66
+            return ''
 
     def _parse_lsof_output(self, out):
         def isopen(line):

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -651,7 +651,8 @@ def lsof_check():
     pid = os.getpid()
     try:
         out = py.process.cmdexec("lsof -p %d" % pid)
-    except py.process.cmdexec.Error:
+    except (py.process.cmdexec.Error, UnicodeDecodeError):
+        # about UnicodeDecodeError, see note on conftest.py 
         pytest.skip("could not run 'lsof'")
     yield
     out2 = py.process.cmdexec("lsof -p %d" % pid)


### PR DESCRIPTION
This bug fails the entire pytest suite when executed with the
`--lsof` option in Python 2 on Windows.

Related to this bug: https://bitbucket.org/pytest-dev/py/issues/66