### PR TITLE
Re-enable Python 3.5 testing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 python:
-    - 'nightly'
+    - '3.5.0b3'
 # command to install dependencies
 install: "pip install -U tox"
 # # command to run tests
@@ -27,10 +27,6 @@ env:
     - TESTENV=py34-xdist
     - TESTENV=py35
     - TESTENV=pypy
-matrix:
-  allow_failures:
-    # py35 is currently broken on travis, see #744
-    - env: TESTENV=py35
 script: tox --recreate -i ALL=https://devpi.net/hpk/dev/ -e $TESTENV
 
 notifications:


### PR DESCRIPTION
According to the docs, it looks like this should work:
http://docs.travis-ci.com/user/languages/python/

I've explicitly specified beta 3, so it will need updating when future betas come out. You could instead specify '3.5-dev', which would give less need to update, but then it's less clear whether a change in status is due to a change in pytest or in Python itself.