### PR TITLE
setuptools not present issue deprecating gentest

### DIFF
--- a/_pytest/standalonetemplate.py
+++ b/_pytest/standalonetemplate.py
@@ -68,6 +68,11 @@ class DictImporter(object):
         return res
 
 if __name__ == "__main__":
+    try:
+        import pkg_resources  # noqa
+    except ImportError:
+        sys.stderr.write("ERROR: setuptools not installed\n")
+        sys.exit(2)
     if sys.version_info >= (3, 0):
         exec("def do_exec(co, loc): exec(co, loc)\n")
         import pickle
@@ -80,6 +85,5 @@ if __name__ == "__main__":
 
     importer = DictImporter(sources)
     sys.meta_path.insert(0, importer)
-
     entry = "@ENTRY@"
     do_exec(entry, locals()) # noqa

--- a/testing/test_genscript.py
+++ b/testing/test_genscript.py
@@ -27,13 +27,17 @@ def test_gen(testdir, anypython, standalone):
             pytest.skip("genscript called from python2.7 cannot work "
                         "earlier python versions")
     result = standalone.run(anypython, testdir, '--version')
-    assert result.ret == 0
-    result.stderr.fnmatch_lines([
-        "*imported from*mypytest*"
-    ])
-    p = testdir.makepyfile("def test_func(): assert 0")
-    result = standalone.run(anypython, testdir, p)
-    assert result.ret != 0
+    if result.ret == 2:
+        result.stderr.fnmatch_lines(["*ERROR: setuptools not installed*"])
+    elif result.ret == 0:
+        result.stderr.fnmatch_lines([
+            "*imported from*mypytest*"
+        ])
+        p = testdir.makepyfile("def test_func(): assert 0")
+        result = standalone.run(anypython, testdir, p)
+        assert result.ret != 0
+    else:
+        pytest.fail("Unexpected return code")
 
 
 def test_freeze_includes():


### PR DESCRIPTION
test_gen in testing/test_genscript.py failed because of its expects setuptools to be installed.
Made genscript fails cleanly when setuptools is not installed.