### PR TITLE
Use pytest-of-$user as base directory for tmpdir_factory

### DIFF
--- a/_pytest/tmpdir.py
+++ b/_pytest/tmpdir.py
@@ -56,7 +56,7 @@ class TempdirFactory:
                 # make_numbered_dir() call
                 import getpass
                 temproot = py.path.local.get_temproot()
-                rootdir = temproot.join('pytest-%s' % getpass.getuser())
+                rootdir = temproot.join('pytest-of-%s' % getpass.getuser())
                 rootdir.ensure(dir=1)
                 basetemp = py.path.local.make_numbered_dir(prefix='pytest-',
                                                            rootdir=rootdir)

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -95,12 +95,26 @@ def test_tmpdir_always_is_realpath(testdir):
     result = testdir.runpytest("-s", p, '--basetemp=%s/bt' % linktemp)
     assert not result.ret
 
+
 def test_tmpdir_too_long_on_parametrization(testdir):
     testdir.makepyfile("""
         import pytest
         @pytest.mark.parametrize("arg", ["1"*1000])
         def test_some(arg, tmpdir):
             tmpdir.ensure("hello")
+    """)
+    reprec = testdir.inline_run()
+    reprec.assertoutcome(passed=1)
+
+
+def test_tmpdir_factory(testdir):
+    testdir.makepyfile("""
+        import pytest
+        @pytest.fixture(scope='session')
+        def session_dir(tmpdir_factory):
+            return tmpdir_factory.mktemp('data', numbered=False)
+        def test_some(session_dir):
+            session_dir.isdir()
     """)
     reprec = testdir.inline_run()
     reprec.assertoutcome(passed=1)


### PR DESCRIPTION
Before tmpdir_factory, pytest used to create a link named "pytest-$user" to the current numbered directory. Use
 a different name so there's no conflict when running different pytest versions.

Fix #894