### PR TITLE
Warnings always raised in WarningsRecorder

### DIFF
--- a/_pytest/recwarn.py
+++ b/_pytest/recwarn.py
@@ -143,10 +143,14 @@ class WarningsRecorder(object):
                 message, category, filename, lineno, file, line))
 
             # still perform old showwarning functionality
-            self._showwarning(message, category, filename, lineno,
-                              file=file, line=line)
+            self._showwarning(
+                message, category, filename, lineno, file=file, line=line)
 
         self._module.showwarning = showwarning
+
+        # allow the same warning to be raised more than once
+        self._module.simplefilter('always', append=True)
+
         return self
 
     def __exit__(self, *exc_info):

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -167,3 +167,9 @@ class TestWarns(object):
         assert len(record) == 2
         assert str(record[0].message) == "user"
         assert str(record[1].message) == "runtime"
+
+    @pytest.mark.parametrize('run', [1, 2])
+    def test_doubletest(self, run):
+        """If a test is run again, the warning should still be raised"""
+        with pytest.warns(RuntimeWarning):
+            warnings.warn("runtime", RuntimeWarning)


### PR DESCRIPTION
This ensures that if tests for warnings are run more than once,
the warning is still raised as expected.