### PR TITLE
Generate parametrize IDs for enum/re/class objects.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 2.8.0.dev (compared to 2.7.X)
 -----------------------------
 
+- parametrize now also generates meaningful test IDs for enum, regex and class
+  objects.
+
 - Add 'warns' to assert that warnings are thrown (like 'raises').
   Thanks to Eric Hunsberger for the PR.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,8 @@
 -----------------------------
 
 - parametrize now also generates meaningful test IDs for enum, regex and class
-  objects.
+  objects (as opposed to class instances).
+  Thanks to Florian Bruhin for the PR.
 
 - Add 'warns' to assert that warnings are thrown (like 'raises').
   Thanks to Eric Hunsberger for the PR.

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1,4 +1,5 @@
 """ Python test discovery, setup and run of test functions. """
+import re
 import fnmatch
 import functools
 import py
@@ -976,8 +977,22 @@ def _idval(val, argname, idx, idfn):
                 return s
         except Exception:
             pass
+
+    try:
+        import enum
+    except ImportError:
+        # Only available in Python 3.4+
+        enum = None
+
     if isinstance(val, (float, int, str, bool, NoneType)):
         return str(val)
+    elif isinstance(val, type(re.compile(''))):
+        # The type of re.compile objects is not exposed in Python.
+        return val.pattern
+    elif enum is not None and isinstance(val, enum.Enum):
+        return str(val)
+    elif isinstance(val, type) and hasattr(val, '__name__'):
+        return val.__name__
     return str(argname)+str(idx)
 
 def _idvalset(idx, valset, argnames, idfn):

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -23,6 +23,8 @@ isclass = inspect.isclass
 callable = py.builtin.callable
 # used to work around a python2 exception info leak
 exc_clear = getattr(sys, 'exc_clear', lambda: None)
+# The type of re.compile objects is not exposed in Python.
+REGEX_TYPE = type(re.compile(''))
 
 def filter_traceback(entry):
     return entry.path != cutdir1 and not entry.path.relto(cutdir2)
@@ -983,16 +985,14 @@ def _idval(val, argname, idx, idfn):
     except ImportError:
         # Only available in Python 3.4+
         enum = None
-    # The type of re.compile objects is not exposed in Python.
-    RegexType = type(re.compile(''))
 
     if isinstance(val, (float, int, str, bool, NoneType)):
         return str(val)
-    elif isinstance(val, RegexType):
+    elif isinstance(val, REGEX_TYPE):
         return val.pattern
     elif enum is not None and isinstance(val, enum.Enum):
         return str(val)
-    elif inspect.isclass(val) and hasattr(val, '__name__'):
+    elif isclass(val) and hasattr(val, '__name__'):
         return val.__name__
     return str(argname)+str(idx)
 

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -983,15 +983,16 @@ def _idval(val, argname, idx, idfn):
     except ImportError:
         # Only available in Python 3.4+
         enum = None
+    # The type of re.compile objects is not exposed in Python.
+    RegexType = type(re.compile(''))
 
     if isinstance(val, (float, int, str, bool, NoneType)):
         return str(val)
-    elif isinstance(val, type(re.compile(''))):
-        # The type of re.compile objects is not exposed in Python.
+    elif isinstance(val, RegexType):
         return val.pattern
     elif enum is not None and isinstance(val, enum.Enum):
         return str(val)
-    elif isinstance(val, type) and hasattr(val, '__name__'):
+    elif inspect.isclass(val) and hasattr(val, '__name__'):
         return val.__name__
     return str(argname)+str(idx)
 

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -9,6 +9,12 @@ import pytest
 from _pytest.mark import MarkDecorator, MarkerError
 from py._code.code import TerminalRepr
 
+try:
+    import enum
+except ImportError:  # pragma: no cover
+    # Only available in Python 3.4+ or as a backport
+    enum = None
+
 import _pytest
 import pluggy
 
@@ -979,12 +985,6 @@ def _idval(val, argname, idx, idfn):
                 return s
         except Exception:
             pass
-
-    try:
-        import enum
-    except ImportError:
-        # Only available in Python 3.4+
-        enum = None
 
     if isinstance(val, (float, int, str, bool, NoneType)):
         return str(val)

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1,3 +1,4 @@
+import re
 
 import pytest, py
 from _pytest import python as funcargs
@@ -138,6 +139,8 @@ class TestMetafunc:
                                       ("three", "three hundred"),
                                       (True, False),
                                       (None, None),
+                                      (re.compile('foo'), re.compile('bar')),
+                                      (str, int),
                                       (list("six"), [66, 66]),
                                       (set([7]), set("seven")),
                                       (tuple("eight"), (8, -8, 8))
@@ -147,9 +150,18 @@ class TestMetafunc:
                           "three-three hundred",
                           "True-False",
                           "None-None",
-                          "a5-b5",
-                          "a6-b6",
-                          "a7-b7"]
+                          "foo-bar",
+                          "str-int",
+                          "a7-b7",
+                          "a8-b8",
+                          "a9-b9"]
+
+    def test_idmaker_enum(self):
+        from _pytest.python import idmaker
+        enum = pytest.importorskip("enum")
+        e = enum.Enum("Foo", "one, two")
+        result = idmaker(("a", "b"), [(e.one, e.two)])
+        assert result == ["Foo.one-Foo.two"]
 
     @pytest.mark.issue351
     def test_idmaker_idfn(self):


### PR DESCRIPTION
I noticed my tests were generating default IDs for those, so I thought why not make pytest a bit smarter :wink: