### PR TITLE
Alert user about other parametrize spellings.

### DIFF
--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -160,10 +160,13 @@ def pytest_cmdline_main(config):
 
 
 def pytest_generate_tests(metafunc):
-    # this misspelling is common - raise a specific error to alert the user
-    if hasattr(metafunc.function, 'parameterize'):
-        msg = "{0} has 'parameterize', spelling should be 'parametrize'"
-        raise MarkerError(msg.format(metafunc.function.__name__))
+    # those alternative spellings are common - raise a specific error to alert
+    # the user
+    alt_spellings = ['parameterize', 'parametrise', 'parameterise']
+    for attr in alt_spellings:
+        if hasattr(metafunc.function, attr):
+            msg = "{0} has '{1}', spelling should be 'parametrize'"
+            raise MarkerError(msg.format(metafunc.function.__name__, attr))
     try:
         markers = metafunc.function.parametrize
     except AttributeError:

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -683,18 +683,20 @@ class TestMetafuncFunctional:
         reprec.assert_outcomes(passed=4)
 
     @pytest.mark.issue463
-    def test_parameterize_misspelling(self, testdir):
+    @pytest.mark.parametrize('attr', ['parametrise', 'parameterize',
+                                     'parameterise'])
+    def test_parametrize_misspelling(self, testdir, attr):
         testdir.makepyfile("""
             import pytest
 
-            @pytest.mark.parameterize("x", range(2))
+            @pytest.mark.{0}("x", range(2))
             def test_foo(x):
                 pass
-        """)
+        """.format(attr))
         reprec = testdir.inline_run('--collectonly')
         failures = reprec.getfailures()
         assert len(failures) == 1
-        expectederror = "MarkerError: test_foo has 'parameterize', spelling should be 'parametrize'"
+        expectederror = "MarkerError: test_foo has '{0}', spelling should be 'parametrize'".format(attr)
         assert expectederror in failures[0].longrepr.reprcrash.message
 
 


### PR DESCRIPTION
> One day I'll fork py.test and call it "parametrise".
-- @flub ([on Twitter](https://twitter.com/flubdevork/status/626019628741996545))

I saw the "misspelling" check for "parameterize", so I thought why not add "parametrise" and "parameterise" as well to make it a bit easier for `en_GB` users :wink:

(All of them seem to be valid spellings, depending on whom you ask)