### PR TITLE
Don't skip fixtures that are substrings of params

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,11 +25,11 @@ Daniel Grana
 Daniel Nuri
 Dave Hunt
 David Mohr
+Edison Gustavo Muenz
 Eduardo Schettino
+Eric Hunsberger
 Eric Siegerman
 Florian Bruhin
-Edison Gustavo Muenz
-Eric Hunsberger
 Floris Bruynooghe
 Graham Horler
 Grig Gheorghiu
@@ -47,6 +47,7 @@ Maciek Fijalkowski
 Maho
 Marc Schlaich
 Mark Abramowitz
+Markus Unterwaditzer
 Martijn Faassen
 Nicolas Delaby
 Pieter Mulder

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,10 @@
 
 - Fix #562: @nose.tools.istest now fully respected.
 
+- Fix issue736: Fix a bug where fixture params would be discarded when combined
+  with parametrization markers.
+  Thanks to Markus Unterwaditzer for the PR.
+
 - parametrize now also generates meaningful test IDs for enum, regex and class
   objects (as opposed to class instances).
   Thanks to Florian Bruhin for the PR.
@@ -10,7 +14,7 @@
 - Add 'warns' to assert that warnings are thrown (like 'raises').
   Thanks to Eric Hunsberger for the PR.
 
-- Fix #683: Do not apply an already applied mark.  Thanks ojake for the PR.
+- Fix issue683: Do not apply an already applied mark.  Thanks ojake for the PR.
 
 - Deal with capturing failures better so fewer exceptions get lost to
   /dev/null.  Thanks David Szotten for the PR.
@@ -36,7 +40,7 @@
   deprecated.
   Thanks Bruno Oliveira for the PR.
 
-- fix issue 808: pytest's internal assertion rewrite hook now implements the
+- fix issue808: pytest's internal assertion rewrite hook now implements the
   optional PEP302 get_data API so tests can access data files next to them.
   Thanks xmo-odoo for request and example and Bruno Oliveira for
   the PR.

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1818,7 +1818,7 @@ class FixtureManager:
                 if fixturedef.params is not None:
                     func_params = getattr(getattr(metafunc.function, 'parametrize', None), 'args', [[None]])
                     # skip directly parametrized arguments
-                    if argname not in func_params and argname not in func_params[0]:
+                    if argname not in func_params:
                         metafunc.parametrize(argname, fixturedef.params,
                                              indirect=True, scope=fixturedef.scope,
                                              ids=fixturedef.ids)

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -412,9 +412,19 @@ class TestFunction:
                                      ['overridden'])
             def test_overridden_via_param(value):
                 assert value == 'overridden'
+
+            @pytest.mark.parametrize('somevalue', ['overridden'])
+            def test_not_overridden(value, somevalue):
+                assert value == 'value'
+                assert somevalue == 'overridden'
+
+            @pytest.mark.parametrize('other,value', [('foo', 'overridden')])
+            def test_overridden_via_multiparam(other, value):
+                assert other == 'foo'
+                assert value == 'overridden'
         """)
         rec = testdir.inline_run()
-        rec.assertoutcome(passed=1)
+        rec.assertoutcome(passed=3)
 
 
     def test_parametrize_overrides_parametrized_fixture(self, testdir):

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -1598,6 +1598,22 @@ class TestFixtureMarker:
         reprec = testdir.inline_run()
         reprec.assertoutcome(passed=4)
 
+    def test_multiple_parametrization_issue_736(self, testdir):
+        testdir.makepyfile("""
+            import pytest
+
+            @pytest.fixture(params=[1,2,3])
+            def foo(request):
+                return request.param
+
+            @pytest.mark.parametrize('foobar', [4,5,6])
+            def test_issue(foo, foobar):
+                assert foo in [1,2,3]
+                assert foobar in [4,5,6]
+        """)
+        reprec = testdir.inline_run()
+        reprec.assertoutcome(passed=9)
+
     def test_scope_session(self, testdir):
         testdir.makepyfile("""
             import pytest


### PR DESCRIPTION
Fix #736