### PR TITLE
New ALLOW_UNICODE doctest option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,11 @@
   with parametrization markers.
   Thanks to Markus Unterwaditzer for the PR.
 
+- fix issue710: introduce ALLOW_UNICODE doctest option: when enabled, the
+  ``u`` prefix is stripped from unicode strings in expected doctest output. This
+  allows doctests which use unicode to run in Python 2 and 3 unchanged.
+  Thanks Jason R. Coombs for the report and Bruno Oliveira for the PR.
+
 - parametrize now also generates meaningful test IDs for enum, regex and class
   objects (as opposed to class instances).
   Thanks to Florian Bruhin for the PR.

--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -202,21 +202,26 @@ def _get_unicode_checker():
 
         _literal_re = re.compile(r"(\W|^)[uU]([rR]?[\'\"])", re.UNICODE)
 
-        def _remove_u_prefixes(self, txt):
-            return re.sub(self._literal_re, r'\1\2', txt)
-
         def check_output(self, want, got, optionflags):
-            res = doctest.OutputChecker.check_output(self, want, got, optionflags)
+            res = doctest.OutputChecker.check_output(self, want, got,
+                                                     optionflags)
             if res:
                 return True
 
             if not (optionflags & _get_allow_unicode_flag()):
                 return False
 
-            cleaned_want = self._remove_u_prefixes(want)
-            cleaned_got = self._remove_u_prefixes(got)
-            res = doctest.OutputChecker.check_output(self, cleaned_want, cleaned_got, optionflags)
-            return res
+            else:  # pragma: no cover
+                # the code below will end up executed only in Python 2 in
+                # our tests, and our coverage check runs in Python 3 only
+                def remove_u_prefixes(txt):
+                    return re.sub(self._literal_re, r'\1\2', txt)
+
+                want = remove_u_prefixes(want)
+                got = remove_u_prefixes(got)
+                res = doctest.OutputChecker.check_output(self, want, got,
+                                                         optionflags)
+                return res
 
     _get_unicode_checker.UnicodeOutputChecker = UnicodeOutputChecker
     return _get_unicode_checker.UnicodeOutputChecker()

--- a/doc/en/doctest.rst
+++ b/doc/en/doctest.rst
@@ -72,3 +72,18 @@ ignore lengthy exception stack traces you can just write::
     # content of pytest.ini
     [pytest]
     doctest_optionflags= NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
+
+
+py.test also introduces a new ``ALLOW_UNICODE`` option flag: when enabled, the
+``u`` prefix is stripped from unicode strings in expected doctest output. This
+allows doctests which use unicode to run in Python 2 and 3 unchanged.
+
+As with any other option flag, this flag can be enabled in ``pytest.ini`` using
+the ``doctest_optionflags`` ini option or by an inline comment in the doc test
+itself::
+
+    # content of example.rst
+    >>> get_unicode_greeting()  # doctest: +ALLOW_UNICODE
+    'Hello'
+
+

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -1,5 +1,7 @@
+import sys
 from _pytest.doctest import DoctestItem, DoctestModule, DoctestTextfile
 import py
+import pytest
 
 class TestDoctests:
 
@@ -400,4 +402,46 @@ class TestDoctests:
         """)
         result = testdir.runpytest("--doctest-modules")
         result.stdout.fnmatch_lines('*2 passed*')
+
+    @pytest.mark.parametrize('config_mode', ['ini', 'comment'])
+    def test_allow_unicode(self, testdir, config_mode):
+        """Test that doctests which output unicode work in all python versions
+        tested by pytest when the ALLOW_UNICODE option is used (either in
+        the ini file or by an inline comment).
+        """
+        if config_mode == 'ini':
+            testdir.makeini('''
+            [pytest]
+            doctest_optionflags = ALLOW_UNICODE
+            ''')
+            comment = ''
+        else:
+            comment = '#doctest: +ALLOW_UNICODE'
+
+        testdir.maketxtfile(test_doc="""
+            >>> b'12'.decode('ascii') {comment}
+            '12'
+        """.format(comment=comment))
+        testdir.makepyfile(foo="""
+            def foo():
+              '''
+              >>> b'12'.decode('ascii') {comment}
+              '12'
+              '''
+        """.format(comment=comment))
+        reprec = testdir.inline_run("--doctest-modules")
+        reprec.assertoutcome(passed=2)
+
+    @pytest.mark.skipif(sys.version_info[0] >= 3, reason='Python 2 only')
+    def test_unicode_string_fails(self, testdir):
+        """Test that doctests which output unicode fail in Python 2 when
+        the ALLOW_UNICODE option is not used.
+        """
+        testdir.maketxtfile(test_doc="""
+            >>> b'12'.decode('ascii') {comment}
+            '12'
+        """)
+        reprec = testdir.inline_run()
+        reprec.assertoutcome(failed=1)
+
 

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -432,16 +432,17 @@ class TestDoctests:
         reprec = testdir.inline_run("--doctest-modules")
         reprec.assertoutcome(passed=2)
 
-    @pytest.mark.skipif(sys.version_info[0] >= 3, reason='Python 2 only')
-    def test_unicode_string_fails(self, testdir):
+    def test_unicode_string(self, testdir):
         """Test that doctests which output unicode fail in Python 2 when
-        the ALLOW_UNICODE option is not used.
+        the ALLOW_UNICODE option is not used. The same test should pass
+        in Python 3.
         """
         testdir.maketxtfile(test_doc="""
-            >>> b'12'.decode('ascii') {comment}
+            >>> b'12'.decode('ascii')
             '12'
         """)
         reprec = testdir.inline_run()
-        reprec.assertoutcome(failed=1)
+        passed = int(sys.version_info[0] >= 3)
+        reprec.assertoutcome(passed=passed, failed=int(not passed))
 
 


### PR DESCRIPTION
Code and option copied from the [nltk](https://github.com/nltk/nltk) project.

Fixes #710.

cc @jaraco 