### PR TITLE
Paths after normal options are now properly used to discover rootdir and ini files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -150,6 +150,10 @@
 - issue951: add new record_xml_property fixture, that supports logging
   additional information on xml output. Thanks David Diaz for the PR.
 
+- issue949: paths after normal options (for example `-s`, `-v`, etc) are now
+  properly used to discover `rootdir` and `ini` files.
+  Thanks Peter Lauri for the report and Bruno Oliveira for the PR.
+
 2.7.3 (compared to 2.7.2)
 -----------------------------
 

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -479,7 +479,7 @@ class Parser:
     def parse_known_args(self, args):
         optparser = self._getparser()
         args = [str(x) for x in args]
-        return optparser.parse_known_args(args)[0]
+        return optparser.parse_known_args(args)
 
     def addini(self, name, help, type=None, default=None):
         """ register an ini-file option.
@@ -879,8 +879,9 @@ class Config(object):
         self.pluginmanager._set_initial_conftests(early_config.known_args_namespace)
 
     def _initini(self, args):
-        parsed_args = self._parser.parse_known_args(args)
-        r = determine_setup(parsed_args.inifilename, parsed_args.file_or_dir)
+        parsed_args, extra_args = self._parser.parse_known_args(args)
+        r = determine_setup(parsed_args.inifilename,
+                            parsed_args.file_or_dir + extra_args)
         self.rootdir, self.inifile, self.inicfg = r
         self._parser.extra_info['rootdir'] = self.rootdir
         self._parser.extra_info['inifile'] = self.inifile
@@ -900,7 +901,8 @@ class Config(object):
         except ImportError as e:
             self.warn("I2", "could not load setuptools entry import: %s" % (e,))
         self.pluginmanager.consider_env()
-        self.known_args_namespace = ns = self._parser.parse_known_args(args)
+        ns, _ = self._parser.parse_known_args(args)
+        self.known_args_namespace = ns
         if self.known_args_namespace.confcutdir is None and self.inifile:
             confcutdir = py.path.local(self.inifile).dirname
             self.known_args_namespace.confcutdir = confcutdir

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -341,6 +341,31 @@ def test_invalid_options_show_extra_information(testdir):
         "*  rootdir: %s*" % testdir.tmpdir,
     ])
 
+
+@pytest.mark.parametrize('args', [
+    ['dir1', 'dir2', '-v'],
+    ['dir1', '-v', 'dir2'],
+    ['dir2', '-v', 'dir1'],
+    ['-v', 'dir2', 'dir1'],
+])
+def test_consider_args_after_options_for_rootdir_and_inifile(testdir, args):
+    """
+    Consider all arguments in the command-line for rootdir and inifile
+    discovery, even if they happen to occur after an option. #949
+    """
+    # replace "dir1" and "dir2" from "args" into their real directory
+    root = testdir.tmpdir.mkdir('myroot')
+    d1 = root.mkdir('dir1')
+    d2 = root.mkdir('dir2')
+    for i, arg in enumerate(args):
+        if arg == 'dir1':
+            args[i] = d1
+        elif arg == 'dir2':
+            args[i] = d2
+    result = testdir.runpytest(*args)
+    result.stdout.fnmatch_lines(['*rootdir: *myroot, inifile: '])
+
+
 @pytest.mark.skipif("sys.platform == 'win32'")
 def test_toolongargs_issue224(testdir):
     result = testdir.runpytest("-m", "hello" * 500)

--- a/testing/test_parseopt.py
+++ b/testing/test_parseopt.py
@@ -105,8 +105,10 @@ class TestParser:
     def test_parse_known_args(self, parser):
         parser.parse_known_args([py.path.local()])
         parser.addoption("--hello", action="store_true")
-        ns = parser.parse_known_args(["x", "--y", "--hello", "this"])
+        ns, extra_args = parser.parse_known_args(["x", "--y", "--hello", "this"])
         assert ns.hello
+        assert ns.file_or_dir == ['x']
+        assert extra_args == ['--y', 'this']
 
     def test_parse_will_set_default(self, parser):
         parser.addoption("--hello", dest="hello", default="x", action="store")


### PR DESCRIPTION
Fix #949