### PR TITLE
Make doctest SKIP option register doctests as SKIPPED rather than PASSED

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -159,6 +159,10 @@
 - fix issue890: changed extension of all documentation files from ``txt`` to
   ``rst``. Thanks to Abhijeet for the PR.
 
+- fix issue957: "# doctest: SKIP" option will now register doctests as SKIPPED
+  rather than PASSED.
+  Thanks Thomas Grainger for the report and Bruno Oliveira for the PR.
+
 - issue951: add new record_xml_property fixture, that supports logging
   additional information on xml output. Thanks David Diaz for the PR.
 

--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -47,6 +47,7 @@ class DoctestItem(pytest.Item):
         self.dtest = dtest
 
     def runtest(self):
+        _check_all_skipped(self.dtest)
         self.runner.run(self.dtest)
 
     def repr_failure(self, excinfo):
@@ -133,7 +134,18 @@ class DoctestTextfile(DoctestItem, pytest.File):
 
         parser = doctest.DocTestParser()
         test = parser.get_doctest(text, globs, name, filename, 0)
+        _check_all_skipped(test)
         runner.run(test)
+
+
+def _check_all_skipped(test):
+    """raises pytest.skip() if all examples in the given DocTest have the SKIP
+    option set.
+    """
+    import doctest
+    all_skipped = all(x.options.get(doctest.SKIP, False) for x in test.examples)
+    if all_skipped:
+        pytest.skip('all tests skipped by +SKIP option')
 
 
 class DoctestModule(pytest.File):


### PR DESCRIPTION
Fix #957