### PR TITLE
Fix regression caused by changing the signature for parse_known_args

### DIFF
--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -477,6 +477,15 @@ class Parser:
         return getattr(parsedoption, FILE_OR_DIR)
 
     def parse_known_args(self, args):
+        """parses and returns a namespace object with known arguments at this
+        point.
+        """
+        return self.parse_known_and_unknown_args(args)[0]
+
+    def parse_known_and_unknown_args(self, args):
+        """parses and returns a namespace object with known arguments, and
+        the remaining arguments unknown at this point.
+        """
         optparser = self._getparser()
         args = [str(x) for x in args]
         return optparser.parse_known_args(args)
@@ -879,9 +888,8 @@ class Config(object):
         self.pluginmanager._set_initial_conftests(early_config.known_args_namespace)
 
     def _initini(self, args):
-        parsed_args, extra_args = self._parser.parse_known_args(args)
-        r = determine_setup(parsed_args.inifilename,
-                            parsed_args.file_or_dir + extra_args)
+        ns, unknown_args = self._parser.parse_known_and_unknown_args(args)
+        r = determine_setup(ns.inifilename, ns.file_or_dir + unknown_args)
         self.rootdir, self.inifile, self.inicfg = r
         self._parser.extra_info['rootdir'] = self.rootdir
         self._parser.extra_info['inifile'] = self.inifile
@@ -901,8 +909,7 @@ class Config(object):
         except ImportError as e:
             self.warn("I2", "could not load setuptools entry import: %s" % (e,))
         self.pluginmanager.consider_env()
-        ns, _ = self._parser.parse_known_args(args)
-        self.known_args_namespace = ns
+        self.known_args_namespace = ns = self._parser.parse_known_args(args)
         if self.known_args_namespace.confcutdir is None and self.inifile:
             confcutdir = py.path.local(self.inifile).dirname
             self.known_args_namespace.confcutdir = confcutdir

--- a/testing/test_parseopt.py
+++ b/testing/test_parseopt.py
@@ -105,10 +105,17 @@ class TestParser:
     def test_parse_known_args(self, parser):
         parser.parse_known_args([py.path.local()])
         parser.addoption("--hello", action="store_true")
-        ns, extra_args = parser.parse_known_args(["x", "--y", "--hello", "this"])
+        ns = parser.parse_known_args(["x", "--y", "--hello", "this"])
         assert ns.hello
         assert ns.file_or_dir == ['x']
-        assert extra_args == ['--y', 'this']
+
+    def test_parse_known_and_unknown_args(self, parser):
+        parser.addoption("--hello", action="store_true")
+        ns, unknown = parser.parse_known_and_unknown_args(["x", "--y",
+                                                           "--hello", "this"])
+        assert ns.hello
+        assert ns.file_or_dir == ['x']
+        assert unknown == ['--y', 'this']
 
     def test_parse_will_set_default(self, parser):
         parser.addoption("--hello", dest="hello", default="x", action="store")


### PR DESCRIPTION
Sorry about that, for some reason it didn't occur to me that `parse_known_args` was part of the public API. :sweat_smile: 

Fix #973