### PR TITLE
Rename "warnings" to "pytest-warnings" in terminal output

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -79,6 +79,11 @@
 - fix issue713: JUnit XML reports for doctest failures.
   Thanks Punyashloka Biswal.
 
+- fix issue970: internal pytest warnings now appear as "pytest-warnings" in
+  the terminal instead of "warnings", so it is clear for users that those
+  warnings are from pytest and not from the builtin "warnings" module.
+  Thanks Bruno Oliveira.
+
 - Include setup and teardown in junitxml test durations.
   Thanks Janne Vanhala.
 

--- a/_pytest/pytester.py
+++ b/_pytest/pytester.py
@@ -326,7 +326,7 @@ def testdir(request, tmpdir_factory):
     return Testdir(request, tmpdir_factory)
 
 
-rex_outcome = re.compile("(\d+) (\w+)")
+rex_outcome = re.compile("(\d+) ([\w-]+)")
 class RunResult:
     """The result of running a command.
 

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -438,7 +438,7 @@ class TerminalReporter:
             warnings = self.stats.get("warnings")
             if not warnings:
                 return
-            self.write_sep("=", "warning summary")
+            self.write_sep("=", "pytest-warning summary")
             for w in warnings:
                 self._tw.line("W%s %s %s" % (w.code,
                               w.fslocation, w.message))
@@ -527,6 +527,7 @@ def flatten(l):
 def build_summary_stats_line(stats):
     keys = ("failed passed skipped deselected "
            "xfailed xpassed warnings error").split()
+    key_translation = {'warnings': 'pytest-warnings'}
     unknown_key_seen = False
     for key in stats.keys():
         if key not in keys:
@@ -537,7 +538,8 @@ def build_summary_stats_line(stats):
     for key in keys:
         val = stats.get(key, None)
         if val:
-            parts.append("%d %s" % (len(val), key))
+            key_name = key_translation.get(key, key)
+            parts.append("%d %s" % (len(val), key_name))
     line = ", ".join(parts)
 
     if 'failed' in stats or 'error' in stats:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -429,12 +429,12 @@ class TestWarning:
                 pass
         """)
         result = testdir.runpytest()
-        assert result.parseoutcomes()["warnings"] > 0
+        assert result.parseoutcomes()["pytest-warnings"] > 0
         assert "hello" not in result.stdout.str()
 
         result = testdir.runpytest("-rw")
         result.stdout.fnmatch_lines("""
-            ===*warning summary*===
+            ===*pytest-warning summary*===
             *WT1*test_warn_on_test_item*:5*hello*
         """)
 

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -756,8 +756,9 @@ def test_terminal_summary(testdir):
     ("yellow", "1 weird", {"weird": (1,)}),
     ("yellow", "1 passed, 1 weird", {"weird": (1,), "passed": (1,)}),
 
-    ("yellow", "1 warnings", {"warnings": (1,)}),
-    ("yellow", "1 passed, 1 warnings", {"warnings": (1,), "passed": (1,)}),
+    ("yellow", "1 pytest-warnings", {"warnings": (1,)}),
+    ("yellow", "1 passed, 1 pytest-warnings", {"warnings": (1,),
+                                               "passed": (1,)}),
 
     ("green", "5 passed", {"passed": (1,2,3,4,5)}),
 


### PR DESCRIPTION
Fix #970