### PR TITLE
Show a few diff lines when truncating string diffs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,13 @@
 2.8.0.dev (compared to 2.7.X)
 -----------------------------
 
-- Fix #562: @nose.tools.istest now fully respected.
+- fix issue562: @nose.tools.istest now fully respected.
 
-- Fix issue736: Fix a bug where fixture params would be discarded when combined
+- fix issue934: when string comparison fails and a diff is too large to display
+  without passing -vv, still show a few lines of the diff.
+  Thanks Florian Bruhin for the report and Bruno Oliveira for the PR.
+
+- fix issue736: Fix a bug where fixture params would be discarded when combined
   with parametrization markers.
   Thanks to Markus Unterwaditzer for the PR.
 

--- a/_pytest/assertion/__init__.py
+++ b/_pytest/assertion/__init__.py
@@ -114,8 +114,11 @@ def pytest_runtest_setup(item):
             if new_expl:
                 if (sum(len(p) for p in new_expl[1:]) > 80*8
                         and item.config.option.verbose < 2):
-                    new_expl[1:] = [py.builtin._totext(
-                        'Detailed information truncated, use "-vv" to show')]
+                    show_max = 10
+                    truncated_lines = len(new_expl) - show_max
+                    new_expl[show_max:] = [py.builtin._totext(
+                        'Detailed information truncated (%d more lines)'
+                        ', use "-vv" to show' % truncated_lines)]
                 new_expl = [line.replace("\n", "\\n") for line in new_expl]
                 res = py.builtin._totext("\n~").join(new_expl)
                 if item.config.getvalue("assertmode") == "rewrite":

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -411,8 +411,13 @@ def test_assert_compare_truncate_longmessage(testdir):
     """)
 
     result = testdir.runpytest()
+    # without -vv, truncate the message showing a few diff lines only
     result.stdout.fnmatch_lines([
-        "*truncated*use*-vv*",
+        "*- 1",
+        "*- 3",
+        "*- 5",
+        "*- 7",
+        "*truncated (191 more lines)*use*-vv*",
     ])
 
 


### PR DESCRIPTION
Fix #934

cc @RonnyPfannschmidt 