### PR TITLE
Add notes to docstring of `monkeypatch.undo()`

### DIFF
--- a/_pytest/monkeypatch.py
+++ b/_pytest/monkeypatch.py
@@ -197,7 +197,7 @@ class monkeypatch:
         called automatically during tear-down.
         
         Note that the same `monkeypatch` fixture is used across a
-        single test invocation. If `monkeypatch` is used both by
+        single test function invocation. If `monkeypatch` is used both by
         the test function itself and one of the test fixtures, 
         calling `undo()` will undo all of the changes made in
         both functions.

--- a/_pytest/monkeypatch.py
+++ b/_pytest/monkeypatch.py
@@ -191,7 +191,17 @@ class monkeypatch:
     def undo(self):
         """ Undo previous changes.  This call consumes the
         undo stack. Calling it a second time has no effect unless
-        you do more monkeypatching after the undo call."""
+        you do more monkeypatching after the undo call.
+        
+        There is generally no need to call `undo()`, since it is 
+        called automatically during tear-down.
+        
+        Note that the same `monkeypatch` fixture is used across a
+        single test invocation. If `monkeypatch` is used both by
+        the test function itself and one of the test fixtures, 
+        calling `undo()` will undo all of the changes made in
+        both functions.
+        """
         for obj, name, value in self._setattr:
             if value is not notset:
                 setattr(obj, name, value)


### PR DESCRIPTION
Note that calling `undo()` is generally not needed, and describe the "gotcha" discovered in #981.