### PR TITLE
Use getfullargspec if available

### DIFF
--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -34,23 +34,15 @@ REGEX_TYPE = type(re.compile(''))
 
 
 if hasattr(inspect, 'signature'):
-    def _has_positional_arg(func):
-        sig = inspect.signature(func)
-        params = list(sig.parameters.values())
-        if params:
-            return params[0].kind in (params[0].POSITIONAL_ONLY,
-                                      params[0].POSITIONAL_OR_KEYWORD)
-        else:
-            return False
-
     def _format_args(func):
         return str(inspect.signature(func))
 else:
-    def _has_positional_arg(func):
-        return bool(inspect.getargspec(func).args)
-
     def _format_args(func):
         return inspect.formatargspec(*inspect.getargspec(func))
+
+
+def _has_positional_arg(func):
+    return func.__code__.co_argcount
 
 
 def filter_traceback(entry):

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -32,6 +32,26 @@ exc_clear = getattr(sys, 'exc_clear', lambda: None)
 # The type of re.compile objects is not exposed in Python.
 REGEX_TYPE = type(re.compile(''))
 
+
+if hasattr(inspect, 'signature'):
+    def _has_positional_arg(func):
+        sig = inspect.signature(func)
+        params = list(sig.parameters.values())
+        if len(params):
+            return params[0].kind in (sig.POSITIONAL_ONLY, sig.POSITIONAL_OR_KEYWORD)
+        else:
+            return False
+
+    def _format_args(func):
+        return str(inspect.signature(func))
+else:
+    def _has_positional_arg(func):
+        return inspect.getargspec(func)[0] is not None
+
+    def _format_args(func):
+        return inspect.formatargspec(*inspect.getargspec(func))
+
+
 def filter_traceback(entry):
     return entry.path != cutdir1 and not entry.path.relto(cutdir2)
 
@@ -586,7 +606,7 @@ class Module(pytest.File, PyCollector):
             #XXX: nose compat hack, move to nose plugin
             # if it takes a positional arg, its probably a pytest style one
             # so we pass the current module object
-            if inspect.getargspec(setup_module)[0]:
+            if _has_positional_arg(setup_module):
                 setup_module(self.obj)
             else:
                 setup_module()
@@ -597,7 +617,7 @@ class Module(pytest.File, PyCollector):
             #XXX: nose compat hack, move to nose plugin
             # if it takes a positional arg, it's probably a pytest style one
             # so we pass the current module object
-            if inspect.getargspec(fin)[0]:
+            if _has_positional_arg(fin):
                 finalizer = lambda: fin(self.obj)
             else:
                 finalizer = fin
@@ -1580,7 +1600,7 @@ class FixtureRequest(FuncargnamesCompatAttr):
             factory = fixturedef.func
             fs, lineno = getfslineno(factory)
             p = self._pyfuncitem.session.fspath.bestrelpath(fs)
-            args = inspect.formatargspec(*inspect.getargspec(factory))
+            args = _format_args(factory)
             lines.append("%s:%d:  def %s%s" %(
                 p, lineno, factory.__name__, args))
         return lines

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -37,7 +37,7 @@ if hasattr(inspect, 'signature'):
     def _has_positional_arg(func):
         sig = inspect.signature(func)
         params = list(sig.parameters.values())
-        if len(params):
+        if params:
             return params[0].kind in (sig.POSITIONAL_ONLY, sig.POSITIONAL_OR_KEYWORD)
         else:
             return False

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -46,7 +46,7 @@ if hasattr(inspect, 'signature'):
         return str(inspect.signature(func))
 else:
     def _has_positional_arg(func):
-        return inspect.getargspec(func)[0] is not None
+        return bool(inspect.getargspec(func).args)
 
     def _format_args(func):
         return inspect.formatargspec(*inspect.getargspec(func))

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -38,7 +38,8 @@ if hasattr(inspect, 'signature'):
         sig = inspect.signature(func)
         params = list(sig.parameters.values())
         if params:
-            return params[0].kind in (sig.POSITIONAL_ONLY, sig.POSITIONAL_OR_KEYWORD)
+            return params[0].kind in (params[0].POSITIONAL_ONLY,
+                                      params[0].POSITIONAL_OR_KEYWORD)
         else:
             return False
 

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -21,7 +21,6 @@ class TestMetafunc:
         metafunc = self.Metafunc(function)
         assert not metafunc.fixturenames
         repr(metafunc._calls)
-        assert funcargs._format_args(function) == '()'
 
     def test_function_basic(self):
         def func(arg1, arg2="qwe"): pass
@@ -30,7 +29,6 @@ class TestMetafunc:
         assert 'arg1' in metafunc.fixturenames
         assert metafunc.function is func
         assert metafunc.cls is None
-        assert funcargs._format_args(func) == "(arg1, arg2='qwe')"
 
     def test_addcall_no_args(self):
         def func(arg1): pass
@@ -40,7 +38,6 @@ class TestMetafunc:
         call = metafunc._calls[0]
         assert call.id == "0"
         assert not hasattr(call, 'param')
-        assert funcargs._format_args(func) == "(arg1)"
 
     def test_addcall_id(self):
         def func(arg1): pass
@@ -88,7 +85,6 @@ class TestMetafunc:
         metafunc.parametrize("y", [1,2])
         pytest.raises(ValueError, lambda: metafunc.parametrize("y", [5,6]))
         pytest.raises(ValueError, lambda: metafunc.parametrize("y", [5,6]))
-        assert funcargs._format_args(func) == '(x, y)'
 
     def test_parametrize_and_id(self):
         def func(x, y): pass
@@ -476,6 +472,20 @@ class TestMetafunc:
             *test_3*2*
             *6 passed*
         """)
+
+    def test_format_args(self):
+        def function1(): pass
+        assert funcargs._format_args(function1) == '()'
+
+        def function2(arg1): pass
+        assert funcargs._format_args(function2) == "(arg1)"
+
+        def function3(arg1, arg2="qwe"): pass
+        assert funcargs._format_args(function3) == "(arg1, arg2='qwe')"
+
+        def function4(arg1, *args, **kwargs): pass
+        assert funcargs._format_args(function4) == "(arg1, *args, **kwargs)"
+
 
 class TestMetafuncFunctional:
     def test_attributes(self, testdir):

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -21,6 +21,7 @@ class TestMetafunc:
         metafunc = self.Metafunc(function)
         assert not metafunc.fixturenames
         repr(metafunc._calls)
+        assert funcargs._format_args(function) == '()'
 
     def test_function_basic(self):
         def func(arg1, arg2="qwe"): pass
@@ -29,6 +30,7 @@ class TestMetafunc:
         assert 'arg1' in metafunc.fixturenames
         assert metafunc.function is func
         assert metafunc.cls is None
+        assert funcargs._format_args(func) == "(arg1, arg2='qwe')"
 
     def test_addcall_no_args(self):
         def func(arg1): pass
@@ -38,6 +40,7 @@ class TestMetafunc:
         call = metafunc._calls[0]
         assert call.id == "0"
         assert not hasattr(call, 'param')
+        assert funcargs._format_args(func) == "(arg1)"
 
     def test_addcall_id(self):
         def func(arg1): pass
@@ -85,6 +88,7 @@ class TestMetafunc:
         metafunc.parametrize("y", [1,2])
         pytest.raises(ValueError, lambda: metafunc.parametrize("y", [5,6]))
         pytest.raises(ValueError, lambda: metafunc.parametrize("y", [5,6]))
+        assert funcargs._format_args(func) == '(x, y)'
 
     def test_parametrize_and_id(self):
         def func(x, y): pass

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -349,7 +349,10 @@ reporttypes = [
 
 @pytest.mark.parametrize('reporttype', reporttypes, ids=[x.__name__ for x in reporttypes])
 def test_report_extra_parameters(reporttype):
-    args = py.std.inspect.getargspec(reporttype.__init__)[0][1:]
+    if hasattr(py.std.inspect, 'signature'):
+        args = list(py.std.inspect.signature(reporttype.__init__).parameters.keys())[1:]
+    else:
+        args = py.std.inspect.getargspec(reporttype.__init__)[0][1:]
     basekw = dict.fromkeys(args, [])
     report = reporttype(newthing=1, **basekw)
     assert report.newthing == 1


### PR DESCRIPTION
`inspect.getargspec` raises `DeprecationWarning` on Python 3.5.  It turns out that all of the uses of `getargspec` in `py.test` can be safely replaced with `getfullargspec`, when available.

In `astropy`, we run our tests with `DeprecationWarnings` converted to exceptions to make sure we are on top of any API changes in Python or third-party dependencies.  Since `py.test` now raises `DeprecationWarnings` as a matter of course on Python 3.5, this is a bit of a problem.