### PR TITLE
junitxml: align custom properties with junit format

### DIFF
--- a/_pytest/junitxml.py
+++ b/_pytest/junitxml.py
@@ -137,7 +137,15 @@ class LogXML(object):
         self.tests[-1].append(obj)
 
     def append_custom_properties(self):
-        self.tests[-1].attr.__dict__.update(self.custom_properties)
+        if self.custom_properties:
+            self.tests[-1].append(
+                Junit.properties(
+                    [
+                        Junit.property(name=name, value=value)
+                        for name, value in self.custom_properties.items()
+                    ]
+                )
+            )
         self.custom_properties.clear()
 
     def append_pass(self, report):

--- a/doc/en/usage.rst
+++ b/doc/en/usage.rst
@@ -174,7 +174,11 @@ This will add an extra property ``example_key="1"`` to the generated
 
 .. code-block:: xml
 
-    <testcase classname="test_function" example_key="1" file="test_function.py" line="0" name="test_function" time="0.0009">
+    <testcase classname="test_function" file="test_function.py" line="0" name="test_function" time="0.0009">
+      <properties>
+        <property name="example_key" value="1" />
+      </properties>
+    </testcase>
 
 .. warning::
 

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -561,5 +561,7 @@ def test_record_property(testdir):
     result, dom = runandparse(testdir, '-rw')
     node = dom.getElementsByTagName("testsuite")[0]
     tnode = node.getElementsByTagName("testcase")[0]
-    assert_attr(tnode, foo="<1")
+    psnode = tnode.getElementsByTagName('properties')[0]
+    pnode = psnode.getElementsByTagName('property')[0]
+    assert_attr(pnode, name="foo", value="<1")
     result.stdout.fnmatch_lines('*C3*test_record_property.py*experimental*')


### PR DESCRIPTION
According to [1], custom properties should be listed inside of
properties element instead of being testcase attributes.

[1] http://help.catchsoftware.com/display/ET/JUnit+Format