### PR TITLE
Make tmpdir more resilient in case environment variables required by getpass are missing

### DIFF
--- a/_pytest/tmpdir.py
+++ b/_pytest/tmpdir.py
@@ -52,10 +52,14 @@ class TempdirFactory:
                     basetemp.remove()
                 basetemp.mkdir()
             else:
-                # use a sub-directory in the temproot to speed-up
-                # make_numbered_dir() call
                 temproot = py.path.local.get_temproot()
-                rootdir = temproot.join('pytest-of-%s' % get_user())
+                user = get_user()
+                if user:
+                    # use a sub-directory in the temproot to speed-up
+                    # make_numbered_dir() call
+                    rootdir = temproot.join('pytest-of-%s' % user)
+                else:
+                    rootdir = temproot
                 rootdir.ensure(dir=1)
                 basetemp = py.path.local.make_numbered_dir(prefix='pytest-',
                                                            rootdir=rootdir)
@@ -68,15 +72,14 @@ class TempdirFactory:
 
 
 def get_user():
-    """Return the current user name, falling back to using "tox" as user name
-    because getpass relies on environment variables which might not be
-    available in a tox environment (see #1010).
+    """Return the current user name, or None if getuser() does not work
+    in the current environment (see #1010).
     """
     import getpass
     try:
         return getpass.getuser()
     except ImportError:
-        return 'tox'
+        return None
 
 # backward compatibility
 TempdirHandler = TempdirFactory

--- a/_pytest/tmpdir.py
+++ b/_pytest/tmpdir.py
@@ -54,13 +54,8 @@ class TempdirFactory:
             else:
                 # use a sub-directory in the temproot to speed-up
                 # make_numbered_dir() call
-                import getpass
                 temproot = py.path.local.get_temproot()
-                try:
-                    rootdir = temproot.join('pytest-of-%s' % getpass.getuser())
-                except ImportError:
-                    # see issue #1010
-                    rootdir = temproot.join('pytest-tox')
+                rootdir = temproot.join('pytest-of-%s' % get_user())
                 rootdir.ensure(dir=1)
                 basetemp = py.path.local.make_numbered_dir(prefix='pytest-',
                                                            rootdir=rootdir)
@@ -70,6 +65,18 @@ class TempdirFactory:
 
     def finish(self):
         self.trace("finish")
+
+
+def get_user():
+    """Return the current user name, falling back to using "tox" as user name
+    because getpass relies on environment variables which might not be
+    available in a tox environment (see #1010).
+    """
+    import getpass
+    try:
+        return getpass.getuser()
+    except ImportError:
+        return 'tox'
 
 # backward compatibility
 TempdirHandler = TempdirFactory

--- a/_pytest/tmpdir.py
+++ b/_pytest/tmpdir.py
@@ -56,7 +56,11 @@ class TempdirFactory:
                 # make_numbered_dir() call
                 import getpass
                 temproot = py.path.local.get_temproot()
-                rootdir = temproot.join('pytest-of-%s' % getpass.getuser())
+                try:
+                    rootdir = temproot.join('pytest-of-%s' % getpass.getuser())
+                except ImportError:
+                    # see issue #1010
+                    rootdir = temproot.join('pytest-tox')
                 rootdir.ensure(dir=1)
                 basetemp = py.path.local.make_numbered_dir(prefix='pytest-',
                                                            rootdir=rootdir)

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -118,3 +118,18 @@ def test_tmpdir_factory(testdir):
     """)
     reprec = testdir.inline_run()
     reprec.assertoutcome(passed=1)
+
+
+def test_tmpdir_fallback_tox_env(testdir, monkeypatch):
+    """Test that tmpdir works even if environment variables required by getpass
+    module are missing (#1010).
+    """
+    monkeypatch.delenv('USER', raising=False)
+    monkeypatch.delenv('USERNAME', raising=False)
+    testdir.makepyfile("""
+        import pytest
+        def test_some(tmpdir):
+            assert tmpdir.isdir()
+    """)
+    reprec = testdir.inline_run()
+    reprec.assertoutcome(passed=1)

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -1,3 +1,4 @@
+import sys
 import py
 import pytest
 
@@ -135,9 +136,11 @@ def test_tmpdir_fallback_tox_env(testdir, monkeypatch):
     reprec.assertoutcome(passed=1)
 
 
+@pytest.mark.skipif(not sys.platform.startswith('win'), reason='win only')
 def test_get_user(monkeypatch):
     """Test that get_user() function works even if environment variables
-    required by getpass module are missing from the environment (#1010).
+    required by getpass module are missing from the environment on Windows
+    (#1010).
     """
     from _pytest.tmpdir import get_user
     monkeypatch.delenv('USER', raising=False)

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -133,3 +133,13 @@ def test_tmpdir_fallback_tox_env(testdir, monkeypatch):
     """)
     reprec = testdir.inline_run()
     reprec.assertoutcome(passed=1)
+
+
+def test_get_user(monkeypatch):
+    """Test that get_user() function works even if environment variables
+    required by getpass module are missing from the environment (#1010).
+    """
+    from _pytest.tmpdir import get_user
+    monkeypatch.delenv('USER', raising=False)
+    monkeypatch.delenv('USERNAME', raising=False)
+    assert get_user() == 'tox'

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -145,4 +145,4 @@ def test_get_user(monkeypatch):
     from _pytest.tmpdir import get_user
     monkeypatch.delenv('USER', raising=False)
     monkeypatch.delenv('USERNAME', raising=False)
-    assert get_user() == 'tox'
+    assert get_user() is None


### PR DESCRIPTION
Fix #1010