### PR TITLE
Make tmpdir resiliant to user ids that do not exist

### DIFF
--- a/_pytest/tmpdir.py
+++ b/_pytest/tmpdir.py
@@ -78,7 +78,7 @@ def get_user():
     import getpass
     try:
         return getpass.getuser()
-    except ImportError:
+    except (ImportError, KeyError):
         return None
 
 # backward compatibility


### PR DESCRIPTION
Previously, the tmpdir fixture would fail if the current process's user id does not correspond to a valid user (e.g. running pytest in a Docker container with 'docker run -u').