### PR TITLE
Add __eq__ method to assertion comparison example

### DIFF
--- a/doc/en/assert.rst
+++ b/doc/en/assert.rst
@@ -200,7 +200,10 @@ now, given this test module::
    # content of test_foocompare.py
    class Foo:
        def __init__(self, val):
-            self.val = val
+           self.val = val
+
+       def __eq__(self, other):
+           return self.val == other.val
 
    def test_compare():
        f1 = Foo(1)


### PR DESCRIPTION
This makes the example make more sense, because now Foo(1) == Foo(1) is
true. Fixes #411