### PR TITLE
Don't hardcode 'std' for captured stdout/stderr.

### DIFF
--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -147,8 +147,8 @@ class CaptureManager:
 
     def suspendcapture_item(self, item, when):
         out, err = self.suspendcapture()
-        item.add_report_section(when, "out", out)
-        item.add_report_section(when, "err", err)
+        item.add_report_section(when, "stdout", out)
+        item.add_report_section(when, "stderr", err)
 
 error_capsysfderror = "cannot use capsys and capfd at the same time"
 

--- a/_pytest/runner.py
+++ b/_pytest/runner.py
@@ -226,7 +226,7 @@ def pytest_runtest_makereport(item, call):
                 longrepr = item._repr_failure_py(excinfo,
                                             style=item.config.option.tbstyle)
     for rwhen, key, content in item._report_sections:
-        sections.append(("Captured std%s %s" %(key, rwhen), content))
+        sections.append(("Captured %s %s" %(key, rwhen), content))
     return TestReport(item.nodeid, item.location,
                       keywords, outcome, longrepr, when,
                       sections, duration)


### PR DESCRIPTION
This will make `Item.add_report_sect` more usable for plugins.
See https://github.com/eisensheng/pytest-catchlog/pull/7