### PR TITLE
Add docs on how to disable cache provider

### DIFF
--- a/_pytest/helpconfig.py
+++ b/_pytest/helpconfig.py
@@ -86,7 +86,7 @@ def showhelp(config):
     tw.line("to see available fixtures type: py.test --fixtures")
     tw.line("(shown according to specified file_or_dir or current dir "
             "if not specified)")
-    tw.line(str(reporter.stats))
+
     for warningreport in reporter.stats.get('warnings', []):
         tw.line("warning : " + warningreport.message, red=True)
     return

--- a/_pytest/helpconfig.py
+++ b/_pytest/helpconfig.py
@@ -80,8 +80,18 @@ def showhelp(config):
         line = "  %-24s %s" %(spec, help)
         tw.line(line[:tw.fullwidth])
 
-    tw.line() ; tw.line()
-    #tw.sep("=")
+    tw.line()
+    tw.line("environment variables:")
+    vars = [
+        ("PYTEST_ADDOPTS", "extra command line options"),
+        ("PYTEST_PLUGINS", "comma-separated plugins to load during startup"),
+        ("PYTEST_DEBUG", "set to enable debug tracing of pytest's internals")
+    ]
+    for name, help in vars:
+        tw.line("  %-24s %s" % (name, help))
+    tw.line()
+    tw.line()
+
     tw.line("to see available markers type: py.test --markers")
     tw.line("to see available fixtures type: py.test --fixtures")
     tw.line("(shown according to specified file_or_dir or current dir "

--- a/doc/en/cache.rst
+++ b/doc/en/cache.rst
@@ -10,6 +10,16 @@ cache: working with cross-testrun state
   is compatible regarding command line options and API usage except that you
   can only store/receive data between test runs that is json-serializable.
 
+  If for any reason you want to disable this plugin, you can do so by
+  adding ``-p no:cacheprovider`` to the command-line, or more permanently
+  to your ``pytest.ini`` file:
+
+  .. code-block:: ini
+
+      [pytest]
+      addopts = -p no:cacheprovider
+
+
 Usage
 ---------
 

--- a/doc/en/cache.rst
+++ b/doc/en/cache.rst
@@ -10,15 +10,6 @@ cache: working with cross-testrun state
   is compatible regarding command line options and API usage except that you
   can only store/receive data between test runs that is json-serializable.
 
-  If for any reason you want to disable this plugin, you can do so by
-  adding ``-p no:cacheprovider`` to the command-line, or more permanently
-  to your ``pytest.ini`` file:
-
-  .. code-block:: ini
-
-      [pytest]
-      addopts = -p no:cacheprovider
-
 
 Usage
 ---------
@@ -35,6 +26,12 @@ all cross-session cache contents ahead of a test run.
 
 Other plugins may access the `config.cache`_ object to set/get 
 **json encodable** values between ``py.test`` invocations.
+
+.. note::
+
+    This plugin is enabled by default, but can be disabled if needed: see
+    :ref:`cmdunregister` (the internal name for this plugin is
+    ``cacheprovider``).
 
 
 Rerunning only failures or failures first

--- a/doc/en/plugins.rst
+++ b/doc/en/plugins.rst
@@ -108,8 +108,21 @@ You can prevent plugins from loading or unregister them::
     py.test -p no:NAME
 
 This means that any subsequent try to activate/load the named
-plugin will it already existing.  See :ref:`findpluginname` for
-how to obtain the name of a plugin.
+plugin will not work.
+
+If you want to unconditionally disable a plugin for a project, you can add
+this option to your ``pytest.ini`` file:
+
+.. code-block:: ini
+
+      [pytest]
+      addopts = -p no:NAME
+
+Alternatively to disable it only in certain environments (for example in a
+CI server), you can set ``PYTEST_ADDOPTS`` environment variable to
+``-p no:name``.
+
+See :ref:`findpluginname` for how to obtain the name of a plugin.
 
 .. _`builtin plugins`:
 
@@ -123,6 +136,7 @@ in the `pytest repository <https://github.com/pytest-dev/pytest>`_.
 .. autosummary::
 
     _pytest.assertion
+    _pytest.cacheprovider
     _pytest.capture
     _pytest.config
     _pytest.doctest


### PR DESCRIPTION
After discussion in #1029

I suggest we start to advise people who are having problems related to `cache` to use this trick so it doesn't affect their use of `pytest-2.8` and force them to pin down to `pytest-2.7.X`.