### PR TITLE
Reorganize "Contents" page

### DIFF
--- a/doc/en/cache.rst
+++ b/doc/en/cache.rst
@@ -1,4 +1,4 @@
-cache: working with cross-testrun state
+Cache: working with cross-testrun state
 =======================================
 
 .. versionadded:: 2.8
@@ -253,7 +253,7 @@ than speed.
 .. _`cache-api`:
 
 config.cache API
-========================================
+------------------
 
 The `config.cache`` object allows other plugins,
 including ``conftest.py`` files,

--- a/doc/en/contents.rst
+++ b/doc/en/contents.rst
@@ -12,12 +12,12 @@ Full pytest documentation
 
    overview
    apiref
-   cache
-   plugins
-   plugins_index/index
    example/index
-   talks
+   plugins
+   cache
    contributing
+   plugins_index/index
+   talks
    funcarg_compare
    announce/index
 

--- a/doc/en/plugins.rst
+++ b/doc/en/plugins.rst
@@ -113,8 +113,8 @@ how to obtain the name of a plugin.
 
 .. _`builtin plugins`:
 
-pytest default plugin reference
-===============================
+Pytest default plugin reference
+-------------------------------
 
 
 You can find the source code for the following plugins


### PR DESCRIPTION
Change the organization in a more logical way to a newcomer. 

Changed the order of the documents that are displayed in the page, plus small caps adjustment in one title or another for consistency Here's the top-level titles of the end result:

* Getting started basics
* Usages and Examples
* Installing and Using plugins
* Cache: working with cross-testrun state
* Contribution getting started
* List of Third-Party Plugins
* Talks and Tutorials
* pytest-2.3: reasoning for fixture/funcarg evolution
* Release announcements

I feel that *pytest-2.3: reasoning for fixture/funcarg evolution* should be placed somewhere else? It is mostly historic at this point, and it takes some space in the "Contents" page, which arguably gets a lot of traffic from new users.

