### PR TITLE
Use py35 as preferred py3 interpreter for special test environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,9 @@ env:
     - TESTENV=py33
     - TESTENV=py33
     - TESTENV=py34
-    - TESTENV=py34-pexpect
-    - TESTENV=py34-trial
-    - TESTENV=py34-trial
-    - TESTENV=py34-xdist
+    - TESTENV=py35-pexpect
+    - TESTENV=py35-trial
+    - TESTENV=py35-xdist
     - TESTENV=py35
     - TESTENV=pypy
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,16 @@ environment:
       PYTHON_ARCH: "64"
       TESTENV: "py34"
 
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.x" # currently 3.5.0
+      PYTHON_ARCH: "32"
+      TESTENV: "py35"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x" # currently 3.5.0
+      PYTHON_ARCH: "64"
+      TESTENV: "py35"
+
     # Also test a Python version not pre-installed
     # See: https://github.com/ogrisel/python-appveyor-demo/issues/10
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,18 @@ environment:
       PYTHON_ARCH: "32"
       TESTENV: "py26"
 
+    # xdist testing
+
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x" # currently 2.7.9
+      PYTHON_ARCH: "32"
+      TESTENV: "py27-xdist"
+
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.x" # currently 3.5.0
+      PYTHON_ARCH: "32"
+      TESTENV: "py35-xdist"
+
 
 install:
   - ECHO "Filesystem root:"

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ minversion=2.0
 distshare={homedir}/.tox/distshare
 envlist=
      flakes,py26,py27,py33,py34,py35,pypy,
-     {py27,py34}-{pexpect,xdist,trial},
+     {py27,py35}-{pexpect,xdist,trial},
      py27-nobyte,doctesting,py27-cxfreeze
 
 [testenv]
@@ -43,7 +43,7 @@ deps=pytest-xdist>=1.13
 commands=
   py.test -n1 -rfsxX {posargs:testing}
 
-[testenv:py34-xdist]
+[testenv:py35-xdist]
 deps={[testenv:py27-xdist]deps}
 commands=
   py.test -n3 -rfsxX {posargs:testing}
@@ -55,7 +55,7 @@ deps=pexpect
 commands=
   py.test -rfsxX test_pdb.py test_terminal.py test_unittest.py
 
-[testenv:py34-pexpect]
+[testenv:py35-pexpect]
 changedir=testing
 platform=linux|darwin
 deps={[testenv:py27-pexpect]deps}
@@ -75,8 +75,7 @@ deps=twisted
 commands=
   py.test -rsxf {posargs:testing/test_unittest.py}
 
-[testenv:py34-trial]
-# py34-trial does not work
+[testenv:py35-trial]
 platform=linux|darwin
 deps={[testenv:py27-trial]deps}
 commands=


### PR DESCRIPTION
* Update `trial`, `pexpect` and `xdist` to use `py35`
* Test py35 on AppVeyor
* Test `py27-xdist` and `py35-xdist` on AppVeyor