### PR TITLE
Add missing nodeid on pytest_logwarning call in addhook.

### DIFF
--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -159,6 +159,7 @@ class PytestPluginManager(PluginManager):
         """
         warning = dict(code="I2",
                        fslocation=py.code.getfslineno(sys._getframe(1)),
+                       nodeid=None,
                        message="use pluginmanager.add_hookspecs instead of "
                                "deprecated addhooks() method.")
         self._warn(warning)

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -145,6 +145,23 @@ class TestPytestPluginInteractions:
         assert len(warnings) == len(before) + 1
         assert "deprecated" in warnings[-1]
 
+    def test_warn_on_deprecated_addhooks(self, pytestpm):
+        warnings = []
+
+        class get_warnings:
+            def pytest_logwarning(self, code, fslocation, message, nodeid):
+                warnings.append(message)
+
+        class Plugin:
+            def pytest_testhook():
+                pass
+
+        pytestpm.register(get_warnings())
+        before = list(warnings)
+        pytestpm.addhooks(Plugin())
+        assert len(warnings) == len(before) + 1
+        assert "deprecated" in warnings[-1]
+
 
 def test_namespace_has_default_and_env_plugins(testdir):
     p = testdir.makepyfile("""


### PR DESCRIPTION
Otherwise KeyError: 'nodeid' gets thrown, killing pytest. This may fix issue #1034, but the details and it may be caused by something similar somewhere else.