### PR TITLE
`deprecated_call` detects pending warnings again

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 2.8.1.dev
 ---------
 
+- 'deprecated_call' is now only satisfied with a DeprecationWarning or
+  PendingDeprecationWarning. Before 2.8.0, it accepted any warning, and 2.8.0
+  made it accept only DeprecationWarning (but not PendingDeprecationWarning).
+  Thanks Alex Gaynor for the issue and Eric Hunsberger for the PR.
+
 - fix issue #1073: avoid calling __getattr__ on potential plugin objects.
   This fixes an incompatibility with pytest-django.  Thanks Andreas Pelme,
   Bruno Oliveira and Ronny Pfannschmidt for contributing and Holger Krekel

--- a/_pytest/recwarn.py
+++ b/_pytest/recwarn.py
@@ -36,7 +36,8 @@ def deprecated_call(func, *args, **kwargs):
         warnings.simplefilter('always')  # ensure all warnings are triggered
         ret = func(*args, **kwargs)
 
-    if not any(r.category is DeprecationWarning for r in wrec):
+    depwarnings = (DeprecationWarning, PendingDeprecationWarning)
+    if not any(r.category in depwarnings for r in wrec):
         __tracebackhide__ = True
         raise AssertionError("%r did not produce DeprecationWarning" % (func,))
 

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -115,6 +115,14 @@ class TestDeprecatedCall(object):
         f = lambda: py.std.warnings.warn(PendingDeprecationWarning("hi"))
         pytest.deprecated_call(f)
 
+    def test_deprecated_call_specificity(self):
+        other_warnings = [Warning, UserWarning, SyntaxWarning, RuntimeWarning,
+                          FutureWarning, ImportWarning, UnicodeWarning]
+        for warning in other_warnings:
+            f = lambda: py.std.warnings.warn(warning("hi"))
+            with pytest.raises(AssertionError):
+                pytest.deprecated_call(f)
+
 
 class TestWarns(object):
     def test_strings(self):

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -81,7 +81,7 @@ def dep_explicit(i):
 class TestDeprecatedCall(object):
     def test_deprecated_call_raises(self):
         excinfo = pytest.raises(AssertionError,
-                       "pytest.deprecated_call(dep, 3)")
+                                "pytest.deprecated_call(dep, 3)")
         assert str(excinfo).find("did not produce") != -1
 
     def test_deprecated_call(self):
@@ -105,11 +105,15 @@ class TestDeprecatedCall(object):
 
     def test_deprecated_explicit_call_raises(self):
         pytest.raises(AssertionError,
-                       "pytest.deprecated_call(dep_explicit, 3)")
+                      "pytest.deprecated_call(dep_explicit, 3)")
 
     def test_deprecated_explicit_call(self):
         pytest.deprecated_call(dep_explicit, 0)
         pytest.deprecated_call(dep_explicit, 0)
+
+    def test_deprecated_call_pending(self):
+        f = lambda: py.std.warnings.warn(PendingDeprecationWarning("hi"))
+        pytest.deprecated_call(f)
 
 
 class TestWarns(object):
@@ -181,4 +185,3 @@ class TestWarns(object):
         ''')
         result = testdir.runpytest()
         result.stdout.fnmatch_lines(['*2 passed in*'])
-


### PR DESCRIPTION
The first commit ensures `deprecated_call` now looks for PendingDeprecationWarnings, as it did previously but was broken by #897. Fixes #1037. Also added a test so this does not happen again.

I realized that before 2.8.0, `deprecated_call` would be fine with any warning being raised, not just a DeprecationWarning or PendingDeprecationWarning. The second commit ensures that other warnings do not suffice.