### PR TITLE
Update docs skip with cli option

### DIFF
--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -131,10 +131,6 @@ line option to control skipping of ``slow`` marked tests::
         parser.addoption("--runslow", action="store_true",
             help="run slow tests")
 
-    def pytest_runtest_setup(item):
-        if 'slow' in item.keywords and not item.config.getoption("--runslow"):
-            pytest.skip("need --runslow option to run")
-
 We can now write a test module like this::
 
     # content of test_module.py

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -137,13 +137,18 @@ We can now write a test module like this::
 
     import pytest
 
-    def test_func_fast():
-        pass
 
-    @pytest.mark.skipif(
+    slow = pytest.mark.skipif(
         not pytest.config.getoption("--runslow"),
         reason="need --runslow option to run"
     )
+
+
+    def test_func_fast():
+        pass
+
+
+    @slow
     def test_func_slow():
         pass
 

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -136,12 +136,14 @@ We can now write a test module like this::
     # content of test_module.py
 
     import pytest
-    slow = pytest.mark.slow
 
     def test_func_fast():
         pass
 
-    @slow
+    @pytest.mark.skipif(
+        not pytest.config.getoption("--runslow"),
+        reason="need --runslow option to run"
+    )
     def test_func_slow():
         pass
 


### PR DESCRIPTION
Change the code snippet in the documentation on [skipping tests based on cli options](http://pytest.org/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option).

The code now features a ``skipif`` marker that directly looks up whether the ``--runslow`` option has been set. If so, the test runs as usual otherwise it will be skipped.

*Please note that I did not recreate the tracebacks*.

Resolve #536 :bow: 