### PR TITLE
Fix autouse fixtures and doctest modules

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,10 @@
   Thanks Daniel Hahler, Ashley C Straw, Philippe Gauthier and Pavel Savchenko
   for contributing and Bruno Oliveira for the PR.
 
+- fix #1100 and #1057: errors when using autouse fixtures and doctest modules.
+  Thanks Sergey B Kirpichev and Vital Kudzelka for contributing and Bruno
+  Oliveira for the PR.
+
 2.8.1
 -----
 


### PR DESCRIPTION
The problem was that `DoctestModule` was setting up fixtures before forwarding a `getfixture` function to the doc-tests; the correct approach is to actually let each `DoctestItem` configure its own fixtures during its `setup` phase.

Took the opportunity to add a lot of tests with all possible scopes to ensure all of them work properly.

Fix #1100 
Fix #1057 

Probably also fixes #943