### PR TITLE
typo fix, changed position of context manager notes

### DIFF
--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1194,6 +1194,28 @@ def raises(expected_exception, *args, **kwargs):
         >>> with raises(ZeroDivisionError):
         ...    1/0
 
+    .. note::
+
+       When using ``pytest.raises`` as a context manager, it's worthwhile to
+       note that normal context manager rules apply and that the exception
+       raised *must* be the final line in the scope of the context manager.
+       Lines of code after that, within the scope of the context manager will
+       not be executed. For example::
+
+           >>> with raises(OSError) as err:
+                   assert 1 == 1  # this will execute as expected
+                   raise OSError(errno.EEXISTS, 'directory exists')
+                   assert err.errno == errno.EEXISTS  # this will not execute
+
+       Instead, the following approach must be taken (note the difference in
+       scope)::
+
+           >>> with raises(OSError) as err:
+                   assert 1 == 1  # this will execute as expected
+                   raise OSError(errno.EEXISTS, 'directory exists')
+
+               assert err.errno == errno.EEXISTS  # this will now execute
+
     Or you can specify a callable by passing a to-be-called lambda::
 
         >>> raises(ZeroDivisionError, lambda: 1/0)
@@ -1212,28 +1234,6 @@ def raises(expected_exception, *args, **kwargs):
 
         >>> raises(ZeroDivisionError, "f(0)")
         <ExceptionInfo ...>
-
-    .. note::
-
-       When using ``pytest.raises`` as a context manager, it's worthwhile to
-       note that normal context manager rules apply and that the exception
-       raised *must* be the final line in the scope of the context manager.
-       Lines of code after that, within the scope of the context manager will
-       not be executed. For example::
-
-           >>> with raises(OSError) as err:
-                   assert 1 == 1  # this will execute as expected
-                   raise OSError(errno.EEXISTS, 'directory exists')
-                   assert err.errno = errno.EEXISTS  # this will not execute
-
-       Instead, the following approach must be taken (note the difference in
-       scope)::
-
-           >>> with raises(OSError) as err:
-                   assert 1 == 1  # this will execute as expected
-                   raise OSError(errno.EEXISTS, 'directory exists')
-
-               assert err.errno = errno.EEXISTS  # this will now execute
 
     Performance note:
     -----------------


### PR DESCRIPTION
This addresses two issues:

1. A typo I just noticed in my original submission (assignment instead of comparison).
2. I also noticed that the note was moved from where originally placed in #1106. I think that it serves the users much better where originally placed. By moving it below, you miss the context (hah!) of the section in the docs that it addresses. Also in moving it out-of-band, should someone find the section on context managers, they will generally not continue reading once the docs move into other usages (at least that's what I'd do ;)) and so the change of missing this note entirely is increase.

I realize that point 2 is subjective, so won't be put off (too much ;)) if rejected.