### PR TITLE
Fix #1017 - add option remember the last failed set if its not completely resolved

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,9 @@
 * fix issue #680: the -s and -c options should now work under xdist;
   `Config.fromdictargs` now represents its input much more faithfully.
   Thanks to Buck Evan for the complete PR.
+* fix issue #1017: add a --lf-keep option to remember the failure set
+  in case of of only a part of the failed set passing.
+  Thanks to Ronny Pfannschmidt for the issue and the PR.
 
 2.8.2.dev
 ---------

--- a/doc/en/cache.rst
+++ b/doc/en/cache.rst
@@ -13,17 +13,21 @@ Cache: working with cross-testrun state
 Usage
 ---------
 
-The plugin provides two command line options to rerun failures from the
+The plugin provides command line options to rerun failures from the
 last ``py.test`` invocation:
 
 * ``--lf`` (last failures) - to only re-run the failures.
 * ``--ff`` (failures first) - to run the failures first and then the rest of
   the tests.
+* ``--lf-keep`` (last full failure set) - will prevent partial clearning
+  of the set of the last failed set, so all once failed tests stay in the set
+  until all tests pass, this works in particular well in the combination
+  ``--ff --lf-keep -x``
 
 For cleanup (usually not needed), a ``--cache-clear`` option allows to remove
 all cross-session cache contents ahead of a test run.
 
-Other plugins may access the `config.cache`_ object to set/get 
+Other plugins may access the `config.cache`_ object to set/get
 **json encodable** values between ``py.test`` invocations.
 
 
@@ -46,26 +50,26 @@ If you run this for the first time you will see two failures::
     .................F.......F........................
     ======= FAILURES ========
     _______ test_num[17] ________
-    
+
     i = 17
-    
+
         @pytest.mark.parametrize("i", range(50))
         def test_num(i):
             if i in (17, 25):
     >          pytest.fail("bad luck")
     E          Failed: bad luck
-    
+
     test_50.py:6: Failed
     _______ test_num[25] ________
-    
+
     i = 25
-    
+
         @pytest.mark.parametrize("i", range(50))
         def test_num(i):
             if i in (17, 25):
     >          pytest.fail("bad luck")
     E          Failed: bad luck
-    
+
     test_50.py:6: Failed
     2 failed, 48 passed in 0.12 seconds
 
@@ -75,33 +79,33 @@ If you then run it with ``--lf``::
     ======= test session starts ========
     platform linux -- Python 3.4.3, pytest-2.8.1, py-1.4.30, pluggy-0.3.1
     run-last-failure: rerun last 2 failures
-    rootdir: $REGENDOC_TMPDIR, inifile: 
+    rootdir: $REGENDOC_TMPDIR, inifile:
     collected 50 items
-    
+
     test_50.py FF
-    
+
     ======= FAILURES ========
     _______ test_num[17] ________
-    
+
     i = 17
-    
+
         @pytest.mark.parametrize("i", range(50))
         def test_num(i):
             if i in (17, 25):
     >          pytest.fail("bad luck")
     E          Failed: bad luck
-    
+
     test_50.py:6: Failed
     _______ test_num[25] ________
-    
+
     i = 25
-    
+
         @pytest.mark.parametrize("i", range(50))
         def test_num(i):
             if i in (17, 25):
     >          pytest.fail("bad luck")
     E          Failed: bad luck
-    
+
     test_50.py:6: Failed
     ======= 2 failed, 48 deselected in 0.12 seconds ========
 
@@ -116,33 +120,33 @@ of ``FF`` and dots)::
     ======= test session starts ========
     platform linux -- Python 3.4.3, pytest-2.8.1, py-1.4.30, pluggy-0.3.1
     run-last-failure: rerun last 2 failures first
-    rootdir: $REGENDOC_TMPDIR, inifile: 
+    rootdir: $REGENDOC_TMPDIR, inifile:
     collected 50 items
-    
+
     test_50.py FF................................................
-    
+
     ======= FAILURES ========
     _______ test_num[17] ________
-    
+
     i = 17
-    
+
         @pytest.mark.parametrize("i", range(50))
         def test_num(i):
             if i in (17, 25):
     >          pytest.fail("bad luck")
     E          Failed: bad luck
-    
+
     test_50.py:6: Failed
     _______ test_num[25] ________
-    
+
     i = 25
-    
+
         @pytest.mark.parametrize("i", range(50))
         def test_num(i):
             if i in (17, 25):
     >          pytest.fail("bad luck")
     E          Failed: bad luck
-    
+
     test_50.py:6: Failed
     ======= 2 failed, 48 passed in 0.12 seconds ========
 
@@ -181,13 +185,13 @@ of the sleep::
     F
     ======= FAILURES ========
     _______ test_function ________
-    
+
     mydata = 42
-    
+
         def test_function(mydata):
     >       assert mydata == 23
     E       assert 42 == 23
-    
+
     test_caching.py:14: AssertionError
     1 failed in 0.12 seconds
 
@@ -198,13 +202,13 @@ the cache and this will be quick::
     F
     ======= FAILURES ========
     _______ test_function ________
-    
+
     mydata = 42
-    
+
         def test_function(mydata):
     >       assert mydata == 23
     E       assert 42 == 23
-    
+
     test_caching.py:14: AssertionError
     1 failed in 0.12 seconds
 
@@ -220,20 +224,20 @@ You can always peek at the content of the cache using the
     $ py.test --cache-clear
     ======= test session starts ========
     platform linux -- Python 3.4.3, pytest-2.8.1, py-1.4.30, pluggy-0.3.1
-    rootdir: $REGENDOC_TMPDIR, inifile: 
+    rootdir: $REGENDOC_TMPDIR, inifile:
     collected 1 items
-    
+
     test_caching.py F
-    
+
     ======= FAILURES ========
     _______ test_function ________
-    
+
     mydata = 42
-    
+
         def test_function(mydata):
     >       assert mydata == 23
     E       assert 42 == 23
-    
+
     test_caching.py:14: AssertionError
     ======= 1 failed in 0.12 seconds ========
 

--- a/testing/test_cache.py
+++ b/testing/test_cache.py
@@ -285,50 +285,43 @@ class TestLastFailed:
         result = testdir.runpytest()
         result.stdout.fnmatch_lines('*1 failed in*')
 
-    def test_lastfailed_collectfailure(self, testdir, monkeypatch):
 
+    @pytest.fixture()
+    def rlf(self, testdir, monkeypatch):
         testdir.makepyfile(test_maybe="""
-            import py
-            env = py.std.os.environ
+            from os import environ as env
             if '1' == env['FAILIMPORT']:
                 raise ImportError('fail')
             def test_hello():
                 assert '0' == env['FAILTEST']
         """)
 
-        def rlf(fail_import, fail_run):
+        def inner_rlf(fail_import=0, fail_run=0, args=()):
             monkeypatch.setenv('FAILIMPORT', fail_import)
             monkeypatch.setenv('FAILTEST', fail_run)
 
-            testdir.runpytest('-q')
+            result = testdir.runpytest('-q', '--lf', *args)
             config = testdir.parseconfigure()
             lastfailed = config.cache.get("cache/lastfailed", -1)
-            return lastfailed
+            return result, sorted(lastfailed)
+        return inner_rlf
 
-        lastfailed = rlf(fail_import=0, fail_run=0)
+    def test_lastfailed_collectfailure(self, rlf):
+
+
+        result, lastfailed = rlf()
         assert not lastfailed
 
-        lastfailed = rlf(fail_import=1, fail_run=0)
-        assert list(lastfailed) == ['test_maybe.py']
+        result, lastfailed = rlf(fail_import=1)
+        assert lastfailed == ['test_maybe.py']
 
-        lastfailed = rlf(fail_import=0, fail_run=1)
-        assert list(lastfailed) == ['test_maybe.py::test_hello']
+        result, lastfailed = rlf(fail_run=1)
+        assert lastfailed == ['test_maybe.py::test_hello']
 
 
-    def test_lastfailed_failure_subset(self, testdir, monkeypatch):
-
-        testdir.makepyfile(test_maybe="""
-            import py
-            env = py.std.os.environ
-            if '1' == env['FAILIMPORT']:
-                raise ImportError('fail')
-            def test_hello():
-                assert '0' == env['FAILTEST']
-        """)
-
+    def test_lastfailed_failure_subset(self, testdir, rlf):
         testdir.makepyfile(test_maybe2="""
-            import py
-            env = py.std.os.environ
+            from os import environ as env
             if '1' == env['FAILIMPORT']:
                 raise ImportError('fail')
             def test_hello():
@@ -338,36 +331,25 @@ class TestLastFailed:
                 pass
         """)
 
-        def rlf(fail_import, fail_run, args=()):
-            monkeypatch.setenv('FAILIMPORT', fail_import)
-            monkeypatch.setenv('FAILTEST', fail_run)
-
-            result = testdir.runpytest('-q', '--lf', *args)
-            config = testdir.parseconfigure()
-            lastfailed = config.cache.get("cache/lastfailed", -1)
-            return result, lastfailed
-
-        result, lastfailed = rlf(fail_import=0, fail_run=0)
+        result, lastfailed = rlf()
         assert not lastfailed
         result.stdout.fnmatch_lines([
             '*3 passed*',
         ])
 
-        result, lastfailed = rlf(fail_import=1, fail_run=0)
-        assert sorted(list(lastfailed)) == ['test_maybe.py', 'test_maybe2.py']
+        result, lastfailed = rlf(fail_import=1)
+        assert lastfailed == ['test_maybe.py', 'test_maybe2.py']
 
 
-        result, lastfailed = rlf(fail_import=0, fail_run=0,
-                                 args=('test_maybe2.py',))
-        assert list(lastfailed) == ['test_maybe.py']
+        result, lastfailed = rlf(args=('test_maybe2.py',))
+        assert lastfailed == ['test_maybe.py']
 
 
         # edge case of test selection - even if we remember failures
         # from other tests we still need to run all tests if no test
         # matches the failures
-        result, lastfailed = rlf(fail_import=0, fail_run=0,
-                                 args=('test_maybe2.py',))
-        assert list(lastfailed) == ['test_maybe.py']
+        result, lastfailed = rlf(args=('test_maybe2.py',))
+        assert lastfailed == ['test_maybe.py']
         result.stdout.fnmatch_lines([
             '*2 passed*',
         ])

--- a/testing/test_cache.py
+++ b/testing/test_cache.py
@@ -353,3 +353,32 @@ class TestLastFailed:
         result.stdout.fnmatch_lines([
             '*2 passed*',
         ])
+
+
+    def test_lastfailed_keepfailure(self, testdir, rlf, monkeypatch):
+        testdir.makepyfile(test_maybe2="""
+            from os import environ as env
+            def test_hello():
+                assert False
+
+            def test_pass():
+                pass
+        """)
+
+        result, lastfailed = rlf(fail_run=1)
+        assert lastfailed == [
+            'test_maybe.py::test_hello',
+            'test_maybe2.py::test_hello',
+        ]
+        result.stdout.fnmatch_lines([
+            '*2 failed, 1 passed*',
+        ])
+
+        result, lastfailed = rlf(args=['--lf-keep'])
+        assert lastfailed == [
+            'test_maybe.py::test_hello',
+            'test_maybe2.py::test_hello',
+        ]
+        result.stdout.fnmatch_lines([
+            '*1 failed, 1 passed, 1 deselected*',
+        ])


### PR DESCRIPTION
as noted in #1017 when doing a red-green rre-factoring
it is helpful to keep running a larger test set instead of loosing track of those that passed once