### PR TITLE
Make fnmatch_lines case-sensitive.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@
 - fix #331: don't collect tests if their failure cannot be reported correctly
   e.g. they are a callable instance of a class.
 
+- ``fnmatch_lines`` is now case-sensitive on all platforms, it used to be
+  case-insensitive on Windows. Thanks Bruno Oliveira for discovering this and
+  Florian Bruhin for the PR.
+
 2.8.2
 -----
 

--- a/_pytest/pytester.py
+++ b/_pytest/pytester.py
@@ -7,7 +7,7 @@ import codecs
 import re
 import time
 import platform
-from fnmatch import fnmatch
+from fnmatch import fnmatchcase
 import subprocess
 
 import py
@@ -1056,7 +1056,7 @@ class LineMatcher:
         lines2 = self._getlines(lines2)
         for line in lines2:
             for x in self.lines:
-                if line == x or fnmatch(x, line):
+                if line == x or fnmatchcase(x, line):
                     print_("matched: ", repr(line))
                     break
             else:
@@ -1068,7 +1068,7 @@ class LineMatcher:
         The given line can contain glob wildcards.
         """
         for i, line in enumerate(self.lines):
-            if fnline == line or fnmatch(line, fnline):
+            if fnline == line or fnmatchcase(line, fnline):
                 return self.lines[i+1:]
         raise ValueError("line %r not found in output" % fnline)
 
@@ -1095,7 +1095,7 @@ class LineMatcher:
                 if line == nextline:
                     show("exact match:", repr(line))
                     break
-                elif fnmatch(nextline, line):
+                elif fnmatchcase(nextline, line):
                     show("fnmatch:", repr(line))
                     show("   with:", repr(nextline))
                     break

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -1,6 +1,6 @@
 import pytest
 import os
-from _pytest.pytester import HookRecorder
+from _pytest.pytester import HookRecorder, LineMatcher
 from _pytest.config import PytestPluginManager
 from _pytest.main import EXIT_OK, EXIT_TESTSFAILED
 
@@ -120,3 +120,9 @@ def test_inline_run_clean_modules(testdir):
     test_mod.write("def test_foo(): assert False")
     result2 = testdir.inline_run(str(test_mod))
     assert result2.ret == EXIT_TESTSFAILED
+
+def test_linematcher_case_sensitive(testdir):
+    matcher = LineMatcher(['spamfilter'])
+    matcher.fnmatch_lines(['*spam*'])
+    with pytest.raises(pytest.fail.Exception):
+        matcher.fnmatch_lines(['*Spam*'])


### PR DESCRIPTION
`fnmatch` uses the file system case-sensitivity, which means it's
case-insensitive on Windows. `fnmatchcase` is case-sensitive on any OS.

See https://github.com/pytest-dev/pytest-qt/issues/70#issuecomment-148233602

Strictly speaking this is backwards-incompatible - but if any tests using `testdir` break due to this change, they were broken on non-Windows OS' to begin with.