### PR TITLE
Handle EPERM when writing rewritten bytecode.

### DIFF
--- a/_pytest/assertion/rewrite.py
+++ b/_pytest/assertion/rewrite.py
@@ -128,7 +128,7 @@ class AssertionRewritingHook(object):
                     # One of the path components was not a directory, likely
                     # because we're in a zip file.
                     write = False
-                elif e in [errno.EACCES, errno.EROFS]:
+                elif e in [errno.EACCES, errno.EROFS, errno.EPERM]:
                     state.trace("read only directory: %r" % fn_pypath.dirname)
                     write = False
                 else:


### PR DESCRIPTION
Fixes #1143.

I'm afraid I have no idea how to write a test for this, but I'd guess the existing tests already fail on OS X El Capitan.

@hannes-ucsc any chance you could test it, by doing something like this (or putting this URL in your `tox.ini`)?

`pip install git+https://github.com/The-Compiler/pytest.git@elcapitan-sip`
