### PR TITLE
Color highlight on the name of the failed tests

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,6 +33,7 @@ Eric Hunsberger
 Eric Siegerman
 Florian Bruhin
 Floris Bruynooghe
+Gabriel Reis
 Graham Horler
 Grig Gheorghiu
 Guido Wesdorp

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,10 @@
   belongs to a file which is no longer available.
   Thanks Bruno Oliveira for the PR.
 
+- enhancement made to highlight in red the name of the failing tests so
+  they stand out in the output.
+  Thanks Gabriel Reis for the PR.
+
 2.8.2
 -----
 

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -458,7 +458,8 @@ class TerminalReporter:
                     self.write_line(line)
                 else:
                     msg = self._getfailureheadline(rep)
-                    self.write_sep("_", msg)
+                    markup = {'red': True, 'bold': True}
+                    self.write_sep("_", msg, **markup)
                     self._outrep_summary(rep)
 
     def summary_errors(self):


### PR DESCRIPTION
I'm proposing this small enhancement because it is sometimes difficult, especially when using verbose tests output, to immediately spot which tests are failing in the middle of all the tracebacks and other output messages. I believe by highlighting the separator line containing the test name which is failing in red would allow developers to quickly spot the failed test and target where his next action should be.

![image](https://cloud.githubusercontent.com/assets/209902/10786315/6cd3c75a-7d61-11e5-8991-edb789463b0e.png)
