### PR TITLE
Allow @unittest.skip decorators in Python 2.7

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -46,6 +46,7 @@ Jason R. Coombs
 Jurko Gospodnetić
 Katarzyna Jachim
 Kevin Cox
+Lee Kamentsky
 Maciek Fijalkowski
 Maho
 Marc Schlaich

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 2.8.3.dev
 ---------
 
+- fix #1169: add __name__ attribute to testcases in TestCaseFunction to
+  support the @unittest.skip decorator on functions and methods.
+
 - fix #1035: collecting tests if test module level obj has __getattr__().
   Thanks Suor for the report and Bruno Oliveira / Tom Viner for the PR.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 
 - fix #1169: add __name__ attribute to testcases in TestCaseFunction to
   support the @unittest.skip decorator on functions and methods.
+  Thanks Lee Kamentsky for the PR.
 
 - fix #1035: collecting tests if test module level obj has __getattr__().
   Thanks Suor for the report and Bruno Oliveira / Tom Viner for the PR.

--- a/_pytest/unittest.py
+++ b/_pytest/unittest.py
@@ -69,6 +69,16 @@ class TestCaseFunction(pytest.Function):
 
     def setup(self):
         self._testcase = self.parent.obj(self.name)
+        #
+        # See issue #1169
+        #
+        # The @unittest.skip decorator calls functools.wraps(self._testcase)
+        # The call to functools.wraps() fails unless self._testcase
+        # has a __name__ attribute. This is usually automatically supplied
+        # if the test is a function or method, but we need to add manually
+        # here.
+        #
+        setattr(self._testcase, "__name__", self.name)
         self._obj = getattr(self._testcase, self.name)
         if hasattr(self._testcase, 'setup_method'):
             self._testcase.setup_method(self._obj)
@@ -134,7 +144,6 @@ class TestCaseFunction(pytest.Function):
         pass
 
     def runtest(self):
-        setattr(self._testcase, "__name__", self.name)
         self._testcase(result=self)
 
     def _prunetraceback(self, excinfo):

--- a/_pytest/unittest.py
+++ b/_pytest/unittest.py
@@ -69,21 +69,25 @@ class TestCaseFunction(pytest.Function):
 
     def setup(self):
         self._testcase = self.parent.obj(self.name)
-        #
-        # See issue #1169
-        #
-        # The @unittest.skip decorator calls functools.wraps(self._testcase)
-        # The call to functools.wraps() fails unless self._testcase
-        # has a __name__ attribute. This is usually automatically supplied
-        # if the test is a function or method, but we need to add manually
-        # here.
-        #
-        setattr(self._testcase, "__name__", self.name)
+        self._fix_unittest_skip_decorator()
         self._obj = getattr(self._testcase, self.name)
         if hasattr(self._testcase, 'setup_method'):
             self._testcase.setup_method(self._obj)
         if hasattr(self, "_request"):
             self._request._fillfixtures()
+
+    def _fix_unittest_skip_decorator(self):
+        """
+        The @unittest.skip decorator calls functools.wraps(self._testcase)
+        The call to functools.wraps() fails unless self._testcase
+        has a __name__ attribute. This is usually automatically supplied
+        if the test is a function or method, but we need to add manually
+        here.
+
+        See issue #1169
+        """
+        if sys.version_info[0] == 2:
+            setattr(self._testcase, "__name__", self.name)
 
     def teardown(self):
         if hasattr(self._testcase, 'teardown_method'):

--- a/_pytest/unittest.py
+++ b/_pytest/unittest.py
@@ -134,6 +134,7 @@ class TestCaseFunction(pytest.Function):
         pass
 
     def runtest(self):
+        setattr(self._testcase, "__name__", self.name)
         self._testcase(result=self)
 
     def _prunetraceback(self, excinfo):

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -719,6 +719,7 @@ def test_unittest_raise_skip_issue748(testdir):
         *1 skipped*
     """)
 
+@pytest.mark.skipif("sys.version_info < (2,7)")
 def test_unittest_skip_issue1169(testdir):
     testpath = testdir.makepyfile(test_foo="""
         import unittest

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -718,3 +718,16 @@ def test_unittest_raise_skip_issue748(testdir):
         *SKIP*[1]*test_foo.py*skipping due to reasons*
         *1 skipped*
     """)
+
+def test_unittest_skip_issue1169(testdir):
+    testpath = testdir.makepyfile(test_foo="""
+        import unittest
+        
+        class MyTestCase(unittest.TestCase):
+            @unittest.skip
+            def test_skip(self):
+                 self.fail()
+        """)
+    reprec = testdir.inline_run(testpath)
+    reprec.assertoutcome(passed=1)
+    

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -721,14 +721,16 @@ def test_unittest_raise_skip_issue748(testdir):
 
 @pytest.mark.skipif("sys.version_info < (2,7)")
 def test_unittest_skip_issue1169(testdir):
-    testpath = testdir.makepyfile(test_foo="""
+    testdir.makepyfile(test_foo="""
         import unittest
         
         class MyTestCase(unittest.TestCase):
-            @unittest.skip
+            @unittest.skip("skipping due to reasons")
             def test_skip(self):
                  self.fail()
         """)
-    reprec = testdir.inline_run(testpath)
-    reprec.assertoutcome(passed=1)
-    
+    result = testdir.runpytest("-v", '-rs')
+    result.stdout.fnmatch_lines("""
+        *SKIP*[1]*skipping due to reasons*
+        *1 skipped*
+    """)


### PR DESCRIPTION
Supersedes #1170

CC @LeeKamentsky 