### PR TITLE
Add 'Improve your testing with Pytest and Mock' video from PyCon SG 2015

### DIFF
--- a/doc/en/talks.rst
+++ b/doc/en/talks.rst
@@ -14,6 +14,9 @@ Talks and blog postings
 .. _`tutorial1 repository`: http://bitbucket.org/pytest-dev/pytest-tutorial1/
 .. _`pycon 2010 tutorial PDF`: http://bitbucket.org/pytest-dev/pytest-tutorial1/raw/tip/pytest-basic.pdf
 
+- `Improve your testing with Pytest and Mock, Gabe Hollombe, PyCon SG 2015
+  <https://www.youtube.com/watch?v=RcN26hznmk4>`_.
+
 - `Introduction to pytest, Andreas Pelme, EuroPython 2014
   <https://www.youtube.com/watch?v=LdVJj65ikRY>`_.
 


### PR DESCRIPTION
Hi there!

Earlier this year, I shared the awesomeness that is Pytest at PyCon SG here in Singapore. The video is online and I thought it would be nice to add it to the list in Pytest's documentation.

This PR adds the talk video to the docs. I'm assuming the links are in reverse chronological order, so I added mine near the top.