### PR TITLE
Don't collect classes with truthy __getattr__.

### DIFF
--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -405,7 +405,10 @@ class PyCollector(PyobjMixin, pytest.Collector):
         """ Look for the __test__ attribute, which is applied by the
         @nose.tools.istest decorator
         """
-        return safe_getattr(obj, '__test__', False)
+        # We explicitly check for "is True" here to not mistakenly treat
+        # classes with a custom __getattr__ returning something truthy (like a
+        # function) as test classes.
+        return safe_getattr(obj, '__test__', False) is True
 
     def classnamefilter(self, name):
         return self._matches_prefix_or_glob_option('python_classes', name)


### PR DESCRIPTION
When we have a metaclass which returns something truthy (like a method) in its
`__getattr__`, we collected the class because pytest thought its `__test__`
attribute was set to True.

We can work around this to some degree by assuming `__test__` will always be set
to an explicit True if that's what the user has intended, and if it's something
other than that, this is probably a mistake.

Fixes #1204.