### PR TITLE
Fix terminal output if no tests were run.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,9 @@
 - fix #1204: another error when collecting with a nasty __getattr__().
   Thanks Florian Bruhin for the PR.
 
+- fix the summary printed when no tests did run.
+  Thanks Florian Bruhin for the PR.
+
 2.8.3
 -----
 

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -544,7 +544,11 @@ def build_summary_stats_line(stats):
         if val:
             key_name = key_translation.get(key, key)
             parts.append("%d %s" % (len(val), key_name))
-    line = ", ".join(parts)
+
+    if parts:
+        line = ", ".join(parts)
+    else:
+        line = "no tests run"
 
     if 'failed' in stats or 'error' in stats:
         color = 'red'

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -779,10 +779,10 @@ def test_terminal_summary(testdir):
     ("green", "1 passed, 1 xpassed", {"xpassed": (1,), "passed": (1,)}),
 
     # Likewise if no tests were found at all
-    ("yellow", "", {}),
+    ("yellow", "no tests run", {}),
 
     # Test the empty-key special case
-    ("yellow", "", {"": (1,)}),
+    ("yellow", "no tests run", {"": (1,)}),
     ("green", "1 passed", {"": (1,), "passed": (1,)}),
 
 


### PR DESCRIPTION
This finally annoyed me enough to open a PR after noticing it for dozen of times :wink:

Before:
```
====  in 0.00 seconds ====
```

After:
```
==== no tests run in 0.00 seconds ====
```