### PR TITLE
Goodpractises docs reorganization/review

### DIFF
--- a/doc/en/customize.rst
+++ b/doc/en/customize.rst
@@ -162,7 +162,7 @@ Builtin configuration file options
    .. versionadded:: 2.8
 
    Sets list of directories that should be searched for tests when
-   no specific directories or files are given in the command line when
+   no specific directories, files or test ids are given in the command line when
    executing pytest from the :ref:`rootdir <rootdir>` directory.
    Useful when all project tests are in a known location to speed up
    test collection and to avoid picking up undesired tests by accident.

--- a/doc/en/faq.rst
+++ b/doc/en/faq.rst
@@ -76,7 +76,7 @@ be the same, confusing the reinterpreter and obfuscating the initial
 error (this is also explained at the command line if it happens).
 
 You can also turn off all assertion interaction using the
-``--assertmode=off`` option.
+``--assert=plain`` option.
 
 .. _`py namespaces`: index.html
 .. _`py/__init__.py`: http://bitbucket.org/hpk42/py-trunk/src/trunk/py/__init__.py

--- a/doc/en/goodpractises.rst
+++ b/doc/en/goodpractises.rst
@@ -4,6 +4,30 @@
 Good Integration Practices
 =================================================
 
+
+.. _`test discovery`:
+.. _`Python test discovery`:
+
+Conventions for Python test discovery
+-------------------------------------------------
+
+``pytest`` implements the following standard test discovery:
+
+* collection starts from paths specified in :confval:`testpaths` if configured,
+  otherwise from initial command line arguments which may be directories,
+  filenames or test ids. If :confval:`testpaths` is not configured and no
+  directories or files were given in the command line, start collection from
+  the current directory.
+* recurse into directories, unless they match :confval:`norecursedirs`
+* ``test_*.py`` or ``*_test.py`` files, imported by their `test package name`_.
+* ``Test`` prefixed test classes (without an ``__init__`` method)
+* ``test_`` prefixed test functions or methods are test items
+
+For examples of how to customize your test discovery :doc:`example/pythoncollection`.
+
+Within Python modules, ``pytest`` also discovers tests using the standard
+:ref:`unittest.TestCase <unittest.TestCase>` subclassing technique.
+
 Work with virtual environments
 -----------------------------------------------------------
 
@@ -306,27 +330,5 @@ is equivalent to running ``py.test --durations=5``.
     For a more powerful solution, take a look at the
     `pytest-runner <https://pypi.python.org/pypi/pytest-runner>`_ plugin.
 
-.. _`test discovery`:
-.. _`Python test discovery`:
-
-Conventions for Python test discovery
--------------------------------------------------
-
-``pytest`` implements the following standard test discovery:
-
-* collection starts from paths specified in :confval:`testpaths` if configured,
-  otherwise from initial command line arguments which may be directories,
-  filenames or test ids. If :confval:`testpaths` is not configured and no
-  directories or files were given in the command line, start collection from
-  the current directory.
-* recurse into directories, unless they match :confval:`norecursedirs`
-* ``test_*.py`` or ``*_test.py`` files, imported by their `test package name`_.
-* ``Test`` prefixed test classes (without an ``__init__`` method)
-* ``test_`` prefixed test functions or methods are test items
-
-For examples of how to customize your test discovery :doc:`example/pythoncollection`.
-
-Within Python modules, ``pytest`` also discovers tests using the standard
-:ref:`unittest.TestCase <unittest.TestCase>` subclassing technique.
 
 .. include:: links.inc

--- a/doc/en/goodpractises.rst
+++ b/doc/en/goodpractises.rst
@@ -276,11 +276,6 @@ get started with setuptools integration::
             TestCommand.initialize_options(self)
             self.pytest_args = []
 
-        def finalize_options(self):
-            TestCommand.finalize_options(self)
-            self.test_args = []
-            self.test_suite = True
-
         def run_tests(self):
             #import here, cause outside the eggs aren't loaded
             import pytest

--- a/doc/en/goodpractises.rst
+++ b/doc/en/goodpractises.rst
@@ -209,52 +209,6 @@ required for calling the test command. You can also pass additional
 arguments to py.test such as your test directory or other
 options using ``--addopts``.
 
-Integrating with setuptools / ``python setup.py test`` / ``genscript``
-----------------------------------------------------------------------
-
-You can integrate test runs into your
-setuptools based project.  Use the `genscript method`_
-to generate a standalone ``pytest`` script::
-
-    py.test --genscript=runtests.py
-
-and make this script part of your distribution and then add
-this to your ``setup.py`` file::
-
-    from distutils.core import setup, Command
-    # you can also import from setuptools
-
-    class PyTest(Command):
-        user_options = []
-        def initialize_options(self):
-            pass
-
-        def finalize_options(self):
-            pass
-
-        def run(self):
-            import subprocess
-            import sys
-            errno = subprocess.call([sys.executable, 'runtests.py'])
-            raise SystemExit(errno)
-
-
-    setup(
-        #...,
-        cmdclass = {'test': PyTest},
-        #...,
-    )
-
-If you now type::
-
-    python setup.py test
-
-this will execute your tests using ``runtests.py``. As this is a
-standalone version of ``pytest`` no prior installation whatsoever is
-required for calling the test command. You can also pass additional
-arguments to the subprocess-calls such as your test directory or other
-options.
-
 
 Integration with setuptools test commands
 ----------------------------------------------------
@@ -310,6 +264,8 @@ is equivalent to running ``py.test --durations=5``.
 
 (deprecated) Create a pytest standalone script
 -----------------------------------------------
+
+.. deprecated:: 2.7
 
 If you are a maintainer or application developer and want people
 who don't deal with python much to easily run tests you may generate

--- a/doc/en/goodpractises.rst
+++ b/doc/en/goodpractises.rst
@@ -258,8 +258,7 @@ is equivalent to running ``py.test --durations=5``.
     * It cannot support plugins, rendering its usefulness extremely limited;
     * Tooling has become much better since ``genscript`` was introduced;
     * It is possible to build a zipped ``pytest`` application without the
-      shortcomings above (this will be documented in more detail in a later
-      version of this documentation).
+      shortcomings above.
 
     There's no planned version in which this command will be removed
     at the moment of this writing, but its use is discouraged for new

--- a/doc/en/goodpractises.rst
+++ b/doc/en/goodpractises.rst
@@ -140,7 +140,7 @@ Tox
 ------
 
 For development, we recommend to use virtualenv_ environments and pip_
- for installing your application and any dependencies
+for installing your application and any dependencies
 as well as the ``pytest`` package itself. This ensures your code and
 dependencies are isolated from the system Python installation.
 
@@ -178,7 +178,8 @@ Add this to ``setup.py`` file:
         #...,
     )
 
-And create an alias into ``setup.cfg``file:
+
+And create an alias into ``setup.cfg`` file:
 
 
 .. code-block:: ini

--- a/doc/en/goodpractises.rst
+++ b/doc/en/goodpractises.rst
@@ -28,29 +28,6 @@ For examples of how to customize your test discovery :doc:`example/pythoncollect
 Within Python modules, ``pytest`` also discovers tests using the standard
 :ref:`unittest.TestCase <unittest.TestCase>` subclassing technique.
 
-Work with virtual environments
------------------------------------------------------------
-
-We recommend to use virtualenv_ environments and pip_
- for installing your application and any dependencies
-as well as the ``pytest`` package itself.  This way you will get an isolated
-and reproducible environment.    Given you have installed virtualenv_
-and execute it from the command line, here is an example session for unix
-or windows::
-
-    virtualenv .   # create a virtualenv directory in the current directory
-
-    source bin/activate  # on unix
-
-    scripts/activate     # on Windows
-
-We can now install pytest::
-
-    pip install pytest
-
-Due to the ``activate`` step above the ``pip`` will come from
-the virtualenv directory and install any package into the isolated
-virtual environment.
 
 Choosing a test layout / import rules
 ------------------------------------------
@@ -160,7 +137,12 @@ required configurations.
 .. _`use tox`:
 
 Tox
----
+------
+
+For development, we recommend to use virtualenv_ environments and pip_
+ for installing your application and any dependencies
+as well as the ``pytest`` package itself. This ensures your code and
+dependencies are isolated from the system Python installation.
 
 If you frequently release code and want to make sure that your actual
 package passes all tests you may want to look into `tox`_, the
@@ -172,8 +154,8 @@ options.  It will run tests against the installed package and not
 against your source code checkout, helping to detect packaging
 glitches.
 
-If you want to use Jenkins_ you can use the ``--junitxml=PATH`` option
-to create a JUnitXML file that Jenkins_ can pick up and generate reports.
+Continuous integration services such as Jenkins_ can make use of the
+``--junitxml=PATH`` option to create a JUnitXML file and generate reports.
 
 
 Integrating with setuptools / ``python setup.py test`` / ``pytest-runner``

--- a/doc/en/goodpractises.rst
+++ b/doc/en/goodpractises.rst
@@ -13,11 +13,9 @@ Conventions for Python test discovery
 
 ``pytest`` implements the following standard test discovery:
 
-* collection starts from paths specified in :confval:`testpaths` if configured,
-  otherwise from initial command line arguments which may be directories,
-  filenames or test ids. If :confval:`testpaths` is not configured and no
-  directories or files were given in the command line, start collection from
-  the current directory.
+* If no arguments are specified then collection starts from :confval:`testpaths`
+  (if configured) or the current directory. Alternatively, command line arguments
+  can be used in any combination of directories, file names or node ids.
 * recurse into directories, unless they match :confval:`norecursedirs`
 * ``test_*.py`` or ``*_test.py`` files, imported by their `test package name`_.
 * ``Test`` prefixed test classes (without an ``__init__`` method)

--- a/doc/en/goodpractises.rst
+++ b/doc/en/goodpractises.rst
@@ -175,31 +175,6 @@ glitches.
 If you want to use Jenkins_ you can use the ``--junitxml=PATH`` option
 to create a JUnitXML file that Jenkins_ can pick up and generate reports.
 
-.. _standalone:
-.. _`genscript method`:
-
-(deprecated) Create a pytest standalone script
------------------------------------------------
-
-If you are a maintainer or application developer and want people
-who don't deal with python much to easily run tests you may generate
-a standalone ``pytest`` script::
-
-    py.test --genscript=runtests.py
-
-This generates a ``runtests.py`` script which is a fully functional basic
-``pytest`` script, running unchanged under Python2 and Python3.
-You can tell people to download the script and then e.g.  run it like this::
-
-    python runtests.py
-
-.. note::
-
-   You must have pytest and its dependencies installed as an sdist, not
-   as wheels because genscript need the source code for generating a
-   standalone script.
-
-
 
 Integrating with setuptools / ``python setup.py test`` / ``pytest-runner``
 --------------------------------------------------------------------------
@@ -329,6 +304,30 @@ is equivalent to running ``py.test --durations=5``.
 
     For a more powerful solution, take a look at the
     `pytest-runner <https://pypi.python.org/pypi/pytest-runner>`_ plugin.
+
+.. _standalone:
+.. _`genscript method`:
+
+(deprecated) Create a pytest standalone script
+-----------------------------------------------
+
+If you are a maintainer or application developer and want people
+who don't deal with python much to easily run tests you may generate
+a standalone ``pytest`` script::
+
+    py.test --genscript=runtests.py
+
+This generates a ``runtests.py`` script which is a fully functional basic
+``pytest`` script, running unchanged under Python2 and Python3.
+You can tell people to download the script and then e.g.  run it like this::
+
+    python runtests.py
+
+.. note::
+
+   You must have pytest and its dependencies installed as an sdist, not
+   as wheels because genscript need the source code for generating a
+   standalone script.
 
 
 .. include:: links.inc

--- a/doc/en/goodpractises.rst
+++ b/doc/en/goodpractises.rst
@@ -277,11 +277,5 @@ You can tell people to download the script and then e.g.  run it like this::
 
     python runtests.py
 
-.. note::
-
-   You must have pytest and its dependencies installed as an sdist, not
-   as wheels because genscript need the source code for generating a
-   standalone script.
-
 
 .. include:: links.inc

--- a/doc/en/goodpractises.rst
+++ b/doc/en/goodpractises.rst
@@ -31,8 +31,8 @@ Within Python modules, ``pytest`` also discovers tests using the standard
 Work with virtual environments
 -----------------------------------------------------------
 
-We recommend to use virtualenv_ environments and use pip_
-(or easy_install_) for installing your application and any dependencies
+We recommend to use virtualenv_ environments and pip_
+ for installing your application and any dependencies
 as well as the ``pytest`` package itself.  This way you will get an isolated
 and reproducible environment.    Given you have installed virtualenv_
 and execute it from the command line, here is an example session for unix
@@ -159,8 +159,8 @@ required configurations.
 
 .. _`use tox`:
 
-Use tox and Continuous Integration servers
--------------------------------------------------
+Tox
+---
 
 If you frequently release code and want to make sure that your actual
 package passes all tests you may want to look into `tox`_, the
@@ -180,9 +180,11 @@ Integrating with setuptools / ``python setup.py test`` / ``pytest-runner``
 --------------------------------------------------------------------------
 
 You can integrate test runs into your setuptools based project
-with pytest-runner.
+with the `pytest-runner <https://pypi.python.org/pypi/pytest-runner>`_ plugin.
 
-Add this to ``setup.py`` file::
+Add this to ``setup.py`` file:
+
+.. code-block:: python
 
     from distutils.core import setup
     # you can also import from setuptools
@@ -194,7 +196,10 @@ Add this to ``setup.py`` file::
         #...,
     )
 
-And create an alias into ``setup.cfg``file::
+And create an alias into ``setup.cfg``file:
+
+
+.. code-block:: ini
 
     [aliases]
     test=pytest
@@ -210,12 +215,13 @@ arguments to py.test such as your test directory or other
 options using ``--addopts``.
 
 
-Integration with setuptools test commands
-----------------------------------------------------
+Manual Integration
+^^^^^^^^^^^^^^^^^^
 
-Setuptools supports writing our own Test command for invoking pytest.
-Most often it is better to use tox_ instead, but here is how you can
-get started with setuptools integration::
+If for some reason you don't want/can't use ``pytest-runner``, you can write
+your own setuptools Test command for invoking pytest.
+
+.. code-block:: python
 
     import sys
 
@@ -254,10 +260,6 @@ using the ``--pytest-args`` or ``-a`` command-line option. For example::
 
 is equivalent to running ``py.test --durations=5``.
 
-.. seealso::
-
-    For a more powerful solution, take a look at the
-    `pytest-runner <https://pypi.python.org/pypi/pytest-runner>`_ plugin.
 
 .. _standalone:
 .. _`genscript method`:

--- a/doc/en/goodpractises.rst
+++ b/doc/en/goodpractises.rst
@@ -250,7 +250,21 @@ is equivalent to running ``py.test --durations=5``.
 (deprecated) Create a pytest standalone script
 -----------------------------------------------
 
-.. deprecated:: 2.7
+.. deprecated:: 2.8
+
+.. note::
+
+    ``genscript`` has been deprecated because:
+
+    * It cannot support plugins, rendering its usefulness extremely limited;
+    * Tooling has become much better since ``genscript`` was introduced;
+    * It is possible to build a zipped ``pytest`` application without the
+      shortcomings above (this will be documented in more detail in a later
+      version of this documentation).
+
+    There's no planned version in which this command will be removed
+    at the moment of this writing, but its use is discouraged for new
+    applications.
 
 If you are a maintainer or application developer and want people
 who don't deal with python much to easily run tests you may generate

--- a/doc/en/goodpractises.rst
+++ b/doc/en/goodpractises.rst
@@ -168,8 +168,7 @@ Add this to ``setup.py`` file:
 
 .. code-block:: python
 
-    from distutils.core import setup
-    # you can also import from setuptools
+    from setuptools import setup
 
     setup(
         #...,


### PR DESCRIPTION
Fixed #1134 and took opportunity to review and reorganize `goodpractises` a little.

* Moved "Conventions for Python test discovery"  and "Choosing test layout" to the top
* Moved deprecated genscript method to the bottom and added a `.. deprecated:` directive;
* Removed detailed session about setuptools and `genscript` integration, since the latter is deprecated anyway;
* Merged `tox` and `virtualenv` sessions: Nowadays virtualenv's usage is pretty standard so we don't need to devote a how-to section in pytest's docs
