### PR TITLE
Add -rp and -rP options to report passing tests.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,6 +26,7 @@ Daniel Grana
 Daniel Nuri
 Dave Hunt
 David Mohr
+David Vierra
 Edison Gustavo Muenz
 Eduardo Schettino
 Endre Galaczi

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,9 @@
 * `pytest_enter_pdb` now optionally receives the pytest config object.
   Thanks Bruno Oliveira for the PR.
 
+* New `-rp` and `-rP` reporting options give the summary and full output
+  of passing tests, respectively. Thanks to David Vierra for the PR.
+
 2.8.2.dev
 ---------
 

--- a/_pytest/runner.py
+++ b/_pytest/runner.py
@@ -177,9 +177,13 @@ class BaseReport(object):
         self.__dict__.update(kw)
 
     def toterminal(self, out):
-        longrepr = self.longrepr
         if hasattr(self, 'node'):
             out.line(getslaveinfoline(self.node))
+
+        longrepr = self.longrepr
+        if longrepr is None:
+            return
+
         if hasattr(longrepr, 'toterminal'):
             longrepr.toterminal(out)
         else:

--- a/_pytest/skipping.py
+++ b/_pytest/skipping.py
@@ -252,6 +252,9 @@ def pytest_terminal_summary(terminalreporter):
             show_skipped(terminalreporter, lines)
         elif char == "E":
             show_simple(terminalreporter, lines, 'error', "ERROR %s")
+        elif char == 'p':
+            show_simple(terminalreporter, lines, 'passed', "PASSED %s")
+
     if lines:
         tr._tw.sep("=", "short test summary info")
         for line in lines:

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -22,7 +22,8 @@ def pytest_addoption(parser):
     group._addoption('-r',
          action="store", dest="reportchars", default=None, metavar="chars",
          help="show extra test summary info as specified by chars (f)ailed, "
-              "(E)error, (s)skipped, (x)failed, (X)passed (w)pytest-warnings (a)all.")
+              "(E)error, (s)skipped, (x)failed, (X)passed (w)pytest-warnings "
+              "(p)passed, (P)passed with output, (a)all except pP.")
     group._addoption('-l', '--showlocals',
          action="store_true", dest="showlocals", default=False,
          help="show locals in tracebacks (disabled by default).")
@@ -367,10 +368,12 @@ class TerminalReporter:
             self.summary_errors()
             self.summary_failures()
             self.summary_warnings()
+            self.summary_passes()
             self.config.hook.pytest_terminal_summary(terminalreporter=self)
         if exitstatus == EXIT_INTERRUPTED:
             self._report_keyboardinterrupt()
             del self._keyboardinterrupt_memo
+
         self.summary_deselected()
         self.summary_stats()
 
@@ -445,6 +448,18 @@ class TerminalReporter:
             for w in warnings:
                 self._tw.line("W%s %s %s" % (w.code,
                               w.fslocation, w.message))
+
+    def summary_passes(self):
+        if self.config.option.tbstyle != "no":
+            if self.hasopt("P"):
+                reports = self.getreports('passed')
+                if not reports:
+                    return
+                self.write_sep("=", "PASSES")
+                for rep in reports:
+                    msg = self._getfailureheadline(rep)
+                    self.write_sep("_", msg)
+                    self._outrep_summary(rep)
 
     def summary_failures(self):
         if self.config.option.tbstyle != "no":

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -542,6 +542,8 @@ def test_pass_output_reporting(testdir):
         def test_pass_output():
             print("Four score and seven years ago...")
     """)
+    result = testdir.runpytest()
+    assert 'Four score and seven years ago...' not in result.stdout.str()
     result = testdir.runpytest('-rP')
     result.stdout.fnmatch_lines([
         "Four score and seven years ago...",

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -522,6 +522,31 @@ def test_fail_reporting_on_pass(testdir):
     result = testdir.runpytest('-rf')
     assert 'short test summary' not in result.stdout.str()
 
+def test_pass_extra_reporting(testdir):
+    testdir.makepyfile("def test_this(): assert 1")
+    result = testdir.runpytest()
+    assert 'short test summary' not in result.stdout.str()
+    result = testdir.runpytest('-rp')
+    result.stdout.fnmatch_lines([
+        "*test summary*",
+        "PASS*test_pass_extra_reporting*",
+    ])
+
+def test_pass_reporting_on_fail(testdir):
+    testdir.makepyfile("def test_this(): assert 0")
+    result = testdir.runpytest('-rp')
+    assert 'short test summary' not in result.stdout.str()
+
+def test_pass_output_reporting(testdir):
+    testdir.makepyfile("""
+        def test_pass_output():
+            print("Four score and seven years ago...")
+    """)
+    result = testdir.runpytest('-rP')
+    result.stdout.fnmatch_lines([
+        "Four score and seven years ago...",
+    ])
+
 def test_color_yes(testdir):
     testdir.makepyfile("def test_this(): assert 1")
     result = testdir.runpytest('--color=yes')


### PR DESCRIPTION
`-rP` is an alternative to `-s` for viewing the output of passing tests.
This causes the captured stdout/stderr of passing tests to be output in
the same way as that of failing tests.

`-rp` adds a simple one-line-per-test summary for passing tests.

Neither option is included by `-ra`.

~~Additional changes to `pytest_capturelog` and `pytest_catchlog` are
needed for this option to also output captured logs: They must be
changed to use `rep.sections.add` instead of `rep.longrepr.addsection`,
and to add these additional sections even if the test passes, since
passing tests don't seem to have a `longrepr` at report time.~~