### PR TITLE
Add new capture option, "forget", to not print to stdout when test fails

### DIFF
--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev9'
+__version__ = '2.8.3.dev10'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev3'
+__version__ = '2.8.3.dev4'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev5'
+__version__ = '2.8.3.dev6'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev13'
+__version__ = '2.8.3.dev14'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev1'
+__version__ = '2.8.3.dev2'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev8'
+__version__ = '2.8.3.dev9'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev6'
+__version__ = '2.8.3.dev7'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev14'
+__version__ = '2.8.3.dev15'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev4'
+__version__ = '2.8.3.dev5'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev7'
+__version__ = '2.8.3.dev8'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev18'
+__version__ = '2.8.3.dev19'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev15'
+__version__ = '2.8.3.dev16'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev17'
+__version__ = '2.8.3.dev18'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev19'
+__version__ = '2.8.3.dev20'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev2'
+__version__ = '2.8.3.dev3'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev12'
+__version__ = '2.8.3.dev13'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev11'
+__version__ = '2.8.3.dev12'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev16'
+__version__ = '2.8.3.dev17'

--- a/_pytest/__init__.py
+++ b/_pytest/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = '2.8.3.dev10'
+__version__ = '2.8.3.dev11'

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -424,7 +424,7 @@ class ForgetCapture(FDCapture):
     """ Capture IO to/from a given os-level filedescriptor and forget it. """
 
     def __init__(self, targetfd, tmpfile=None):
-        super.__init__(targetfd, tmpfile=None)
+        super().__init__(targetfd, tmpfile=None)
         # self.targetfd = targetfd
         # try:
         #     self.targetfd_save = os.dup(self.targetfd)

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -364,7 +364,7 @@ class FDCapture:
         targetfd_save = self.__dict__.pop("targetfd_save")
         os.dup2(targetfd_save, self.targetfd)
         os.close(targetfd_save)
-        os.remove(targetfd_save)
+        os.remove(self.targetfd)
         self.syscapture.done()
         self.tmpfile.close()
 

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -364,7 +364,6 @@ class FDCapture:
         targetfd_save = self.__dict__.pop("targetfd_save")
         os.dup2(targetfd_save, self.targetfd)
         os.close(targetfd_save)
-        os.remove(self.targetfd)
         self.syscapture.done()
         self.tmpfile.close()
 
@@ -479,9 +478,9 @@ class ForgetCapture:
         targetfd_save = self.__dict__.pop("targetfd_save")
         os.dup2(targetfd_save, self.targetfd)
         os.close(targetfd_save)
+        os.remove(targetfd_save)
         self.syscapture.done()
         self.tmpfile.close()
-        os.remove(targetfd_save)
 
     def suspend(self):
         self.syscapture.suspend()

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -479,7 +479,7 @@ class ForgetCapture:
         os.dup2(targetfd_save, self.targetfd)
         os.close(targetfd_save)
         self.syscapture.done()
-        with open(self.tmpfile, 'r') as fh:
+        with open(self.tmpfile_fd, 'r') as fh:
             for line in fh.readlines():
                 print(line)
         self.tmpfile.close()

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -480,6 +480,7 @@ class ForgetCapture:
         os.close(targetfd_save)
         self.syscapture.done()
         self.tmpfile.close()
+        os.remove(self.tmpfile)
 
     def suspend(self):
         self.syscapture.suspend()
@@ -491,10 +492,9 @@ class ForgetCapture:
 
     def writeorg(self, data):
         """ write to original file descriptor. """
-        # if py.builtin._istext(data):
-        #     data = data.encode("utf8") # XXX use encoding of original stream
-        # os.write(self.targetfd_save, data)
-        pass
+        if py.builtin._istext(data):
+            data = data.encode("utf8") # XXX use encoding of original stream
+        os.write(self.targetfd_save, data)
 
 
 class DontReadFromInput:

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -366,6 +366,7 @@ class FDCapture:
         os.close(targetfd_save)
         self.syscapture.done()
         self.tmpfile.close()
+        os.remove(self.targetfd)
 
     def suspend(self):
         self.syscapture.suspend()

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -22,8 +22,8 @@ def pytest_addoption(parser):
     group._addoption(
         '--capture', action="store",
         default="fd" if hasattr(os, "dup") else "sys",
-        metavar="method", choices=['fd', 'sys', 'no'],
-        help="per-test capturing method: one of fd|sys|no.")
+        metavar="method", choices=['fd', 'sys', 'no', 'forget'],
+        help="per-test capturing method: one of fd|sys|no|forget.")
     group._addoption(
         '-s', action="store_const", const="no", dest="capture",
         help="shortcut for --capture=no.")
@@ -63,6 +63,8 @@ class CaptureManager:
             return MultiCapture(out=True, err=True, Capture=FDCapture)
         elif method == "sys":
             return MultiCapture(out=True, err=True, Capture=SysCapture)
+        elif method == "forget":
+            return MultiCapture(out=False, err=False, Capture=FDCapture)
         elif method == "no":
             return MultiCapture(out=False, err=False, in_=False)
         else:

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -480,7 +480,9 @@ class ForgetCapture:
         os.close(targetfd_save)
         self.syscapture.done()
         self.tmpfile.close()
-        os.remove(self.tmpfile)
+        with open(self.tmpfile, 'r') as fh:
+            for line in fh.readlines():
+                print(line)
 
     def suspend(self):
         self.syscapture.suspend()

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -478,7 +478,7 @@ class ForgetCapture:
         targetfd_save = self.__dict__.pop("targetfd_save")
         os.dup2(targetfd_save, self.targetfd)
         os.close(targetfd_save)
-        os.remove(targetfd_save)
+        os.remove(self.targetfd)
         self.syscapture.done()
         self.tmpfile.close()
 

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -364,9 +364,9 @@ class FDCapture:
         targetfd_save = self.__dict__.pop("targetfd_save")
         os.dup2(targetfd_save, self.targetfd)
         os.close(targetfd_save)
+        os.remove(targetfd_save)
         self.syscapture.done()
         self.tmpfile.close()
-        os.remove(self.targetfd)
 
     def suspend(self):
         self.syscapture.suspend()

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -479,10 +479,10 @@ class ForgetCapture:
         os.dup2(targetfd_save, self.targetfd)
         os.close(targetfd_save)
         self.syscapture.done()
-        self.tmpfile.close()
         with open(self.tmpfile, 'r') as fh:
             for line in fh.readlines():
                 print(line)
+        self.tmpfile.close()
 
     def suspend(self):
         self.syscapture.suspend()

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -112,9 +112,9 @@ class CaptureManager:
             outcome = yield
             out, err = self.suspendcapture()
             rep = outcome.get_result()
-            if out:
+            if out and self.method != "forget":
                 rep.sections.append(("Captured stdout", out))
-            if err:
+            if err and self.method != "forget":
                 rep.sections.append(("Captured stderr", err))
         else:
             yield

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -478,7 +478,6 @@ class ForgetCapture:
         targetfd_save = self.__dict__.pop("targetfd_save")
         os.dup2(targetfd_save, self.targetfd)
         os.close(targetfd_save)
-        os.remove(self.targetfd)
         self.syscapture.done()
         self.tmpfile.close()
 
@@ -492,9 +491,10 @@ class ForgetCapture:
 
     def writeorg(self, data):
         """ write to original file descriptor. """
-        if py.builtin._istext(data):
-            data = data.encode("utf8") # XXX use encoding of original stream
-        os.write(self.targetfd_save, data)
+        # if py.builtin._istext(data):
+        #     data = data.encode("utf8") # XXX use encoding of original stream
+        # os.write(self.targetfd_save, data)
+        pass
 
 
 class DontReadFromInput:

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -425,40 +425,9 @@ class ForgetCapture(FDCapture):
 
     def __init__(self, targetfd, tmpfile=None):
         super().__init__(targetfd, tmpfile=None)
-        # self.targetfd = targetfd
-        # try:
-        #     self.targetfd_save = os.dup(self.targetfd)
-        # except OSError:
-        #     self.start = lambda: None
-        #     self.done = lambda: None
-        # else:
-        #     if targetfd == 0:
-        #         assert not tmpfile, "cannot set tmpfile with stdin"
-        #         tmpfile = open(os.devnull, "r")
-        #         self.syscapture = SysCapture(targetfd)
-        #     else:
-        #         if tmpfile is None:
-        #             f = TemporaryFile()
-        #             with f:
-        #                 tmpfile = safe_text_dupfile(f, mode="wb+")
-        #         if targetfd in patchsysdict:
-        #             self.syscapture = SysCapture(targetfd, tmpfile)
-        #         else:
-        #             self.syscapture = NoCapture()
-        #     self.tmpfile = tmpfile
-        #     self.tmpfile_fd = tmpfile.fileno()
 
     def __repr__(self):
         return "<ForgetCapture %s oldfd=%s>" % (self.targetfd, self.targetfd_save)
-
-    # def start(self):
-    #     """ Start capturing on targetfd using memorized tmpfile. """
-    #     try:
-    #         os.fstat(self.targetfd_save)
-    #     except (AttributeError, OSError):
-    #         raise ValueError("saved filedescriptor not valid anymore")
-    #     os.dup2(self.tmpfile_fd, self.targetfd)
-    #     self.syscapture.start()
 
     def snap(self):
         f = self.tmpfile
@@ -470,31 +439,7 @@ class ForgetCapture(FDCapture):
                 res = py.builtin._totext(res, enc, "replace")
             f.truncate(0)
             f.seek(0)
-            # return res
         return ''
-
-    # def done(self):
-    #     """ stop capturing, restore streams, return original capture file,
-    #     seeked to position zero. """
-    #     targetfd_save = self.__dict__.pop("targetfd_save")
-    #     os.dup2(targetfd_save, self.targetfd)
-    #     os.close(targetfd_save)
-    #     self.syscapture.done()
-    #     self.tmpfile.close()
-    #
-    # def suspend(self):
-    #     self.syscapture.suspend()
-    #     os.dup2(self.targetfd_save, self.targetfd)
-    #
-    # def resume(self):
-    #     self.syscapture.resume()
-    #     os.dup2(self.tmpfile_fd, self.targetfd)
-    #
-    # def writeorg(self, data):
-    #     """ write to original file descriptor. """
-    #     if py.builtin._istext(data):
-    #         data = data.encode("utf8") # XXX use encoding of original stream
-    #     os.write(self.targetfd_save, data)
 
 
 class DontReadFromInput:

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -448,7 +448,7 @@ class ForgetCapture:
             self.tmpfile_fd = tmpfile.fileno()
 
     def __repr__(self):
-        return "<FDCapture %s oldfd=%s>" % (self.targetfd, self.targetfd_save)
+        return "<ForgetCapture %s oldfd=%s>" % (self.targetfd, self.targetfd_save)
 
     def start(self):
         """ Start capturing on targetfd using memorized tmpfile. """
@@ -457,7 +457,7 @@ class ForgetCapture:
         except (AttributeError, OSError):
             raise ValueError("saved filedescriptor not valid anymore")
         os.dup2(self.tmpfile_fd, self.targetfd)
-        # self.syscapture.start()
+        self.syscapture.start()
 
     def snap(self):
         f = self.tmpfile
@@ -480,6 +480,7 @@ class ForgetCapture:
         os.close(targetfd_save)
         self.syscapture.done()
         self.tmpfile.close()
+        os.remove(targetfd_save)
 
     def suspend(self):
         # self.syscapture.suspend()

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -440,11 +440,10 @@ class ForgetCapture:
                     f = TemporaryFile()
                     with f:
                         tmpfile = safe_text_dupfile(f, mode="wb+")
-                # if targetfd in patchsysdict:
-                #     self.syscapture = SysCapture(targetfd, tmpfile)
-                # else:
-                #     self.syscapture = NoCapture()
-                self.syscapture = NoCapture()
+                if targetfd in patchsysdict:
+                    self.syscapture = SysCapture(targetfd, tmpfile)
+                else:
+                    self.syscapture = NoCapture()
             self.tmpfile = tmpfile
             self.tmpfile_fd = tmpfile.fileno()
 
@@ -470,7 +469,7 @@ class ForgetCapture:
                 res = py.builtin._totext(res, enc, "replace")
             f.truncate(0)
             f.seek(0)
-            return res
+            # return res
         return ''
 
     def done(self):

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -440,10 +440,11 @@ class ForgetCapture:
                     f = TemporaryFile()
                     with f:
                         tmpfile = safe_text_dupfile(f, mode="wb+")
-                if targetfd in patchsysdict:
-                    self.syscapture = SysCapture(targetfd, tmpfile)
-                else:
-                    self.syscapture = NoCapture()
+                # if targetfd in patchsysdict:
+                #     self.syscapture = SysCapture(targetfd, tmpfile)
+                # else:
+                #     self.syscapture = NoCapture()
+                self.syscapture = NoCapture()
             self.tmpfile = tmpfile
             self.tmpfile_fd = tmpfile.fileno()
 
@@ -479,9 +480,6 @@ class ForgetCapture:
         os.dup2(targetfd_save, self.targetfd)
         os.close(targetfd_save)
         self.syscapture.done()
-        with open(self.tmpfile_fd, 'r') as fh:
-            for line in fh.readlines():
-                print(line)
         self.tmpfile.close()
 
     def suspend(self):

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -112,9 +112,9 @@ class CaptureManager:
             outcome = yield
             out, err = self.suspendcapture()
             rep = outcome.get_result()
-            if out and self.method != "forget":
+            if out:
                 rep.sections.append(("Captured stdout", out))
-            if err and self.method != "forget":
+            if err:
                 rep.sections.append(("Captured stderr", err))
         else:
             yield
@@ -483,11 +483,11 @@ class ForgetCapture:
         os.remove(targetfd_save)
 
     def suspend(self):
-        # self.syscapture.suspend()
+        self.syscapture.suspend()
         os.dup2(self.targetfd_save, self.targetfd)
 
     def resume(self):
-        # self.syscapture.resume()
+        self.syscapture.resume()
         os.dup2(self.tmpfile_fd, self.targetfd)
 
     def writeorg(self, data):


### PR DESCRIPTION
Capture and display of output (--capture=fd) when tests fail is problematic in cases meeting these conditions:

* Long test runs with many tests
* Debug logging enabled (using Python's logging module) in all tests

I run tests through Jenkins and PyTest captures all output that makes reading through PyTest's own pertinent output cumbersome. Plus, since debug logs are already captured in files this output is redundant. Hence the need to add an option to "forget" capture.

This is proof of concept PR provides support for clean output while retaining everything else in logs (if they're being used).

Disclaimers:

* I have tested this PoC with Python 3 only
* I am still learning PyTest and made a lot of exploratory commits in trying to understand the code; the commit history is atrocious for that reason
* My reasons for creating the PR are selfish: I'd rather this was supported in upstream instead of carrying my own patches
* I am willing to learn more and clean up the code with PR review feedback
