### PR TITLE
Remove experimental status from pytest_exception_interact

### DIFF
--- a/_pytest/hookspec.py
+++ b/_pytest/hookspec.py
@@ -282,12 +282,11 @@ def pytest_keyboard_interrupt(excinfo):
     """ called for keyboard interrupt. """
 
 def pytest_exception_interact(node, call, report):
-    """ (experimental, new in 2.4) called when
-    an exception was raised which can potentially be
+    """called when an exception was raised which can potentially be
     interactively handled.
 
     This hook is only called if an exception was raised
-    that is not an internal exception like "skip.Exception".
+    that is not an internal exception like ``skip.Exception``.
     """
 
 def pytest_enter_pdb():


### PR DESCRIPTION
Noticed that this hook was still marked as experimental since 2.4 while working on pytest-dev/pytest-faulthandler#14