### PR TITLE
fixes #1259 - take finalized nodes out of the mapping

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,9 @@
 2.8.6.dev1
 ----------
 
-- fix #1259: allow for double nodeids in junitxml
+- fix #1259: allow for double nodeids in junitxml,
+  this was a regression failing plugins combinations
+  like pytest-pep8 + pytest-flakes
 
 2.8.5
 -----

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 2.8.6.dev1
 ----------
 
+- fix #1259: allow for double nodeids in junitxml
 
 2.8.5
 -----

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -706,6 +706,7 @@ def test_fancy_items_regression(testdir):
                 return [
                     FunItem('a', self),
                     NoFunItem('a', self),
+                    NoFunItem('b', self),
                 ]
 
         def pytest_collect_file(path, parent):
@@ -731,8 +732,10 @@ def test_fancy_items_regression(testdir):
     assert items == [
         u'conftest a conftest.py',
         u'conftest a conftest.py',
+        u'conftest b conftest.py',
         u'test_fancy_items_regression a test_fancy_items_regression.py',
         u'test_fancy_items_regression a test_fancy_items_regression.py',
+        u'test_fancy_items_regression b test_fancy_items_regression.py',
         u'test_fancy_items_regression test_pass'
         u' test_fancy_items_regression.py',
     ]


### PR DESCRIPTION
this allows double node id usage for file based items