### PR TITLE
Remove "index" entry from overview.rst

### DIFF
--- a/doc/en/overview.rst
+++ b/doc/en/overview.rst
@@ -5,7 +5,6 @@ Getting started basics
 .. toctree::
    :maxdepth: 2
 
-   index
    getting-started
    usage
    goodpractises


### PR DESCRIPTION
"index" is already displayed in the main docs, repeating it here breaks the reading flow.

From [contents](http://pytest.org/latest/contents.html):

* Getting started basics
  * pytest: helps you write better programs  <-- this link will be removed
  * Installation and Getting Started
  * Usage and Invocations
  * Good Integration Practices
  * Project examples
  * Some Issues and Questions