### PR TITLE
Prevent pyreadline from bugging out in --pdb mode with capture

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Eduardo Schettino
 Elizaveta Shashkova
 Eric Hunsberger
 Eric Siegerman
+Erik M. Bray
 Florian Bruhin
 Floris Bruynooghe
 Gabriel Reis

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,9 @@
   this was a regression failing plugins combinations
   like pytest-pep8 + pytest-flakes
 
+- Workaround for exception that occurs in pyreadline when using
+  ``--pdb`` with standard I/O capture enabled.
+
 2.8.5
 -----
 

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -308,6 +308,14 @@ class FDCapture:
     """ Capture IO to/from a given os-level filedescriptor. """
 
     def __init__(self, targetfd, tmpfile=None):
+        # ensure readline is imported so that it attaches to the correct
+        # stdio handles on Windows
+        if targetfd in (0, 1, 2):
+            try:
+                import readline
+            except ImportError:
+                pass
+
         self.targetfd = targetfd
         try:
             self.targetfd_save = os.dup(self.targetfd)


### PR DESCRIPTION
This implements a workaround to a bug that's been dogging me for a long time.  When using py.test with the `--pdb` option on Windows, file descriptor capture enabled, and pyreadline installed, as soon as the pdb prompt is dropped into pyreadline starts bugging out.

Part of the problem is pyreadline, which doesn't work well when standard I/O handles have been redirected.  It does some import-time setup that attaches itself to whatever handles standard I/O have been redirected to, and blows up if stdout is no longer a TTY.  I'm working on addressing this issue in pyreadline.

A simple workaround, that should work for the vast majority of cases in the context of pytest, is to just make sure to `import readline` before any redirection is done.  This way pyreadline still connects correctly to the console, and functions correctly when pytest suspends capturing.