### PR TITLE
Add badge of supported python versions to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,8 @@ scales to support complex functional testing.
 
 .. image:: https://img.shields.io/pypi/v/pytest.svg
    :target: https://pypi.python.org/pypi/pytest
+.. image:: https://img.shields.io/pypi/pyversions/pytest.svg
+  :target: https://pypi.python.org/pypi/pytest
 .. image:: https://img.shields.io/coveralls/pytest-dev/pytest/master.svg
    :target: https://coveralls.io/r/pytest-dev/pytest
 .. image:: https://travis-ci.org/pytest-dev/pytest.svg?branch=master


### PR DESCRIPTION
Please take a look [at my fork](https://github.com/nicoddemus/pytest/tree/pyversions-badge) to see how it looks like.