### PR TITLE
Add logo and some readme changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
-======
-pytest
-======
+.. image:: doc/en/img/pytest1.png
+   :target: http://pytest.org
+   :align: center
+   :alt: pytest
 
-The ``pytest`` testing tool makes it easy to write small tests, yet
-scales to support complex functional testing.
+------
 
 .. image:: https://img.shields.io/pypi/v/pytest.svg
    :target: https://pypi.python.org/pypi/pytest
@@ -14,53 +14,84 @@ scales to support complex functional testing.
 .. image:: https://ci.appveyor.com/api/projects/status/mrgbjaua7t33pg6b?svg=true
     :target: https://ci.appveyor.com/project/pytestbot/pytest
 
-Documentation: http://pytest.org/latest/
+The ``pytest`` framework makes it easy to write small tests, yet
+scales to support complex functional testing for applications and libraries.    
 
-Changelog: http://pytest.org/latest/changelog.html
+An example of a simple test:
 
-Issues: https://github.com/pytest-dev/pytest/issues
+.. code-block:: python
+
+    # content of test_sample.py
+    def func(x):
+        return x + 1
+
+    def test_answer():
+        assert func(3) == 5
+
+
+To execute it::
+
+    $ py.test
+    ======= test session starts ========
+    platform linux -- Python 3.4.3, pytest-2.8.5, py-1.4.31, pluggy-0.3.1    
+    collected 1 items
+
+    test_sample.py F
+
+    ======= FAILURES ========
+    _______ test_answer ________
+
+        def test_answer():
+    >       assert func(3) == 5
+    E       assert 4 == 5
+    E        +  where 4 = func(3)
+
+    test_sample.py:5: AssertionError
+    ======= 1 failed in 0.12 seconds ========
+
+Due to ``py.test``'s detailed assertion introspection, only plain ``assert`` statements are used. See `getting-started <http://pytest.org/latest/getting-started.html#our-first-test-run>`_ for more examples.
+        
 
 Features
 --------
 
-- `auto-discovery
+- Detailed info on failing `assert statements <http://pytest.org/latest/assert.html>`_ (no need to remember ``self.assert*`` names);
+
+- `Auto-discovery
   <http://pytest.org/latest/goodpractises.html#python-test-discovery>`_
-  of test modules and functions,
-- detailed info on failing `assert statements <http://pytest.org/latest/assert.html>`_ (no need to remember ``self.assert*`` names)
-- `modular fixtures <http://pytest.org/latest/fixture.html>`_  for
-  managing small or parametrized long-lived test resources.
-- multi-paradigm support: you can use ``pytest`` to run test suites based
-  on `unittest <http://pytest.org/latest/unittest.html>`_ (or trial),
-  `nose <http://pytest.org/latest/nose.html>`_
-- single-source compatibility from Python2.6 all the way up to
-  Python3.5, PyPy-2.3, (jython-2.5 untested)
+  of test modules and functions;
+
+- `Modular fixtures <http://pytest.org/latest/fixture.html>`_  for
+  managing small or parametrized long-lived test resources;
+
+- Can run `unittest <http://pytest.org/latest/unittest.html>`_ (or trial),
+  `nose <http://pytest.org/latest/nose.html>`_ test suites out of the box;
+
+- Python2.6+, Python3.2+, PyPy-2.3, Jython-2.5 (untested);
+
+- Rich plugin architecture, with over 150+ `external plugins <http://pytest.org/latest/plugins.html#installing-external-plugins-searching>`_ and thriving comminity;
 
 
-- many `external plugins <http://pytest.org/latest/plugins.html#installing-external-plugins-searching>`_.
+Documentation
+-------------
 
-A simple example for a test:
-
-.. code-block:: python
-
-    # content of test_module.py
-    def test_function():
-        i = 4
-        assert i == 3
-
-which can be run with ``py.test test_module.py``.  See `getting-started <http://pytest.org/latest/getting-started.html#our-first-test-run>`_ for more examples.
-
-For much more info, including PDF docs, see
-
-    http://pytest.org
-
-and report bugs at:
-
-    https://github.com/pytest-dev/pytest/issues
-
-and checkout or fork repo at:
-
-    https://github.com/pytest-dev/pytest
+For full documentation, including installation, tutorials and PDF documents, please see http://pytest.org.
 
 
-Copyright Holger Krekel and others, 2004-2015
+Bugs/Requests
+-------------
+
+Please use the `GitHub issue tracker <https://github.com/pytest-dev/pytest/issues>`_ to submit bugs or feature requests.
+
+
+Changelog
+---------
+
+Consult the `Changelog <http://pytest.org/latest/changelog.html>`_ page for fixes and enhancements for each version.
+
+
+License
+-------
+
+Copyright Holger Krekel and others, 2004-2015.
 Licensed under the MIT license.


### PR DESCRIPTION
* Show pytest logo
* Show assertion introspection in the example
* Use separate sections for change-log, docs, license, etc.

Borrowed some ideas from [awesome-readme](https://github.com/matiassingers/awesome-readme).

Please see [my fork](https://github.com/nicoddemus/pytest/tree/readme-changes-logo) to checkout how it looks.