### PR TITLE
Separate 2.9.0 CHANGELOG into sections

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,18 +1,29 @@
 2.9.0.dev
----------
+=========
+
+New Features
+------------
 
 * New `pytest.mark.skip` mark, which unconditional skips marked tests.
   Thanks Michael Aquilina for the complete PR.
 
-* fix issue #680: the -s and -c options should now work under xdist;
-  `Config.fromdictargs` now represents its input much more faithfully.
-  Thanks to Buck Evan for the complete PR.
+* New `-rp` and `-rP` reporting options give the summary and full output
+  of passing tests, respectively. Thanks to David Vierra for the PR.
+
+
+Changes
+-------
 
 * `pytest_enter_pdb` now optionally receives the pytest config object.
   Thanks Bruno Oliveira for the PR.
 
-* New `-rp` and `-rP` reporting options give the summary and full output
-  of passing tests, respectively. Thanks to David Vierra for the PR.
+
+Bug Fixes/Adjustments
+---------------------
+
+* fix issue #680: the -s and -c options should now work under xdist;
+  `Config.fromdictargs` now represents its input much more faithfully.
+  Thanks to Buck Evan for the complete PR.
 
 * fix #1226: Removed code and documentation for Python 2.5 or lower versions,
   including removal of the obsolete ``_pytest.assertion.oldinterpret`` module.
@@ -20,11 +31,11 @@
 
 
 2.8.6.dev1
-----------
+==========
 
 
 2.8.5
------
+=====
 
 - fix #1243: fixed issue where class attributes injected during collection could break pytest.
   PR by Alexei Kozlenok, thanks Ronny Pfannschmidt and Bruno Oliveira for the review and help.
@@ -38,7 +49,7 @@
 
 
 2.8.4
------
+=====
 
 - fix #1190: ``deprecated_call()`` now works when the deprecated
   function has been already called by another test in the same
@@ -62,7 +73,7 @@
   Thanks Bruno Oliveira for the PR.
 
 2.8.3
------
+=====
 
 - fix #1169: add __name__ attribute to testcases in TestCaseFunction to
   support the @unittest.skip decorator on functions and methods.
@@ -90,7 +101,7 @@
 
 
 2.8.2
------
+=====
 
 - fix #1085: proper handling of encoding errors when passing encoded byte
   strings to pytest.parametrize in Python 2.
@@ -110,7 +121,7 @@
   Oliveira for the PR.
 
 2.8.1
------
+=====
 
 - fix #1034: Add missing nodeid on pytest_logwarning call in
   addhook.  Thanks Simon Gomizelj for the PR.
@@ -157,7 +168,7 @@
 - fix issue 1029: transform errors when writing cache values into pytest-warnings
 
 2.8.0
------------------------------
+=============================
 
 - new ``--lf`` and ``-ff`` options to run only the last failing tests or
   "failing tests first" from the last run.  This functionality is provided
@@ -347,7 +358,7 @@
   Thanks Peter Lauri for the report and Bruno Oliveira for the PR.
 
 2.7.3 (compared to 2.7.2)
------------------------------
+=============================
 
 - Allow 'dev', 'rc', or other non-integer version strings in `importorskip`.
   Thanks to Eric Hunsberger for the PR.
@@ -390,7 +401,7 @@
   Thanks Bruno Oliveira for the PR.
 
 2.7.2 (compared to 2.7.1)
------------------------------
+=============================
 
 - fix issue767: pytest.raises value attribute does not contain the exception
   instance on Python 2.6. Thanks Eric Siegerman for providing the test
@@ -419,7 +430,7 @@
 
 
 2.7.1 (compared to 2.7.0)
------------------------------
+=============================
 
 - fix issue731: do not get confused by the braces which may be present
   and unbalanced in an object's repr while collapsing False
@@ -452,7 +463,7 @@
   at least by pytest-xdist.
 
 2.7.0 (compared to 2.6.4)
------------------------------
+=============================
 
 - fix issue435: make reload() work when assert rewriting is active.
   Thanks Daniel Hahler.
@@ -522,7 +533,7 @@
   via postmortem debugging (almarklein).
 
 2.6.4
-----------
+==========
 
 - Improve assertion failure reporting on iterables, by using ndiff and
   pprint.
@@ -551,7 +562,7 @@
 - fix issue614: fixed pastebin support.
 
 2.6.3
------------
+===========
 
 - fix issue575: xunit-xml was reporting collection errors as failures
   instead of errors, thanks Oleg Sinyavskiy.
@@ -578,7 +589,7 @@
   Floris Bruynooghe.
 
 2.6.2
------------
+===========
 
 - Added function pytest.freeze_includes(), which makes it easy to embed
   pytest into executables using tools like cx_freeze.
@@ -607,7 +618,7 @@
   to them.
 
 2.6.1
------------------------------------
+===================================
 
 - No longer show line numbers in the --verbose output, the output is now
   purely the nodeid.  The line number is still shown in failure reports.
@@ -639,7 +650,7 @@
   Thanks Bruno Oliveira.
 
 2.6
------------------------------------
+===================================
 
 - Cache exceptions from fixtures according to their scope (issue 467).
 
@@ -744,7 +755,7 @@
 
 
 2.5.2
------------------------------------
+===================================
 
 - fix issue409 -- better interoperate with cx_freeze by not
   trying to import from collections.abc which causes problems
@@ -772,7 +783,7 @@
 
 
 2.5.1
------------------------------------
+===================================
 
 - merge new documentation styling PR from Tobias Bieniek.
 
@@ -793,7 +804,7 @@
 
 
 2.5.0
------------------------------------
+===================================
 
 - dropped python2.5 from automated release testing of pytest itself
   which means it's probably going to break soon (but still works
@@ -929,7 +940,7 @@
 - fix verbose reporting for @mock'd test functions
 
 v2.4.2
------------------------------------
+===================================
 
 - on Windows require colorama and a newer py lib so that py.io.TerminalWriter()
   now uses colorama instead of its own ctypes hacks. (fixes issue365)
@@ -960,7 +971,7 @@ v2.4.2
   config.do_configure() for plugin-compatibility
 
 v2.4.1
------------------------------------
+===================================
 
 - When using parser.addoption() unicode arguments to the
   "type" keyword should also be converted to the respective types.
@@ -976,7 +987,7 @@ v2.4.1
 - merge doc typo fixes, thanks Andy Dirnberger
 
 v2.4
------------------------------------
+===================================
 
 known incompatibilities:
 
@@ -1145,7 +1156,7 @@ Bug fixes:
   information at the end of a test run.
 
 v2.3.5
------------------------------------
+===================================
 
 - fix issue169: respect --tb=style with setup/teardown errors as well.
 
@@ -1210,7 +1221,7 @@ v2.3.5
 - fix issue266 - accept unicode in MarkEvaluator expressions
 
 v2.3.4
------------------------------------
+===================================
 
 - yielded test functions will now have autouse-fixtures active but
   cannot accept fixtures as funcargs - it's anyway recommended to
@@ -1230,7 +1241,7 @@ v2.3.4
   method in a certain test class.
 
 v2.3.3
------------------------------------
+===================================
 
 - fix issue214 - parse modules that contain special objects like e. g.
   flask's request object which blows up on getattr access if no request
@@ -1262,7 +1273,7 @@ v2.3.3
   add a ``config.getoption(name)`` helper function for consistency.
 
 v2.3.2
------------------------------------
+===================================
 
 - fix issue208 and fix issue29 use new py version to avoid long pauses
   when printing tracebacks in long modules
@@ -1295,7 +1306,7 @@ v2.3.2
     bits are properly distributed for maintainers who run pytest-own tests
 
 v2.3.1
------------------------------------
+===================================
 
 - fix issue202 - fix regression: using "self" from fixture functions now
   works as expected (it's the same "self" instance that a test method
@@ -1308,7 +1319,7 @@ v2.3.1
   pytest.mark.* usage.
 
 v2.3.0
------------------------------------
+===================================
 
 - fix issue202 - better automatic names for parametrized test functions
 - fix issue139 - introduce @pytest.fixture which allows direct scoping
@@ -1387,7 +1398,7 @@ v2.3.0
   - py.test -vv will show all of assert comparisations instead of truncating
 
 v2.2.4
------------------------------------
+===================================
 
 - fix error message for rewritten assertions involving the % operator
 - fix issue 126: correctly match all invalid xml characters for junitxml
@@ -1404,12 +1415,12 @@ v2.2.4
 - upgrade distribute_setup.py to 0.6.27
 
 v2.2.3
-----------------------------------------
+========================================
 
 - fix uploaded package to only include neccesary files
 
 v2.2.2
-----------------------------------------
+========================================
 
 - fix issue101: wrong args to unittest.TestCase test function now
   produce better output
@@ -1429,7 +1440,7 @@ v2.2.2
   with distributed testing (no upgrade of pytest-xdist needed)
 
 v2.2.1
-----------------------------------------
+========================================
 
 - fix issue99 (in pytest and py) internallerrors with resultlog now
   produce better output - fixed by normalizing pytest_internalerror
@@ -1446,7 +1457,7 @@ v2.2.1
   to Ralf Schmitt (fixed by depending on a more recent pylib)
 
 v2.2.0
-----------------------------------------
+========================================
 
 - fix issue90: introduce eager tearing down of test items so that
   teardown function are called earlier.
@@ -1481,7 +1492,7 @@ v2.2.0
 - add support for skip properties on unittest classes and functions
 
 v2.1.3
-----------------------------------------
+========================================
 
 - fix issue79: assertion rewriting failed on some comparisons in boolops
 - correctly handle zero length arguments (a la pytest '')
@@ -1490,7 +1501,7 @@ v2.1.3
 - fix issue77 / Allow assertrepr_compare hook to apply to a subset of tests
 
 v2.1.2
-----------------------------------------
+========================================
 
 - fix assertion rewriting on files with windows newlines on some Python versions
 - refine test discovery by package/module name (--pyargs), thanks Florian Mayer
@@ -1500,7 +1511,7 @@ v2.1.2
 - don't try assertion rewriting on Jython, use reinterp
 
 v2.1.1
-----------------------------------------------
+==============================================
 
 - fix issue64 / pytest.set_trace now works within pytest_generate_tests hooks
 - fix issue60 / fix error conditions involving the creation of __pycache__
@@ -1513,7 +1524,7 @@ v2.1.1
 - you can now build a man page with "cd doc ; make man"
 
 v2.1.0
-----------------------------------------------
+==============================================
 
 - fix issue53 call nosestyle setup functions with correct ordering
 - fix issue58 and issue59: new assertion code fixes
@@ -1533,7 +1544,7 @@ v2.1.0
 - fix issue 35 - provide PDF doc version and download link from index page
 
 v2.0.3
-----------------------------------------------
+==============================================
 
 - fix issue38: nicer tracebacks on calls to hooks, particularly early
   configure/sessionstart ones
@@ -1553,7 +1564,7 @@ v2.0.3
 - fix issue37: avoid invalid characters in junitxml's output
 
 v2.0.2
-----------------------------------------------
+==============================================
 
 - tackle issue32 - speed up test runs of very quick test functions
   by reducing the relative overhead
@@ -1605,7 +1616,7 @@ v2.0.2
 - avoid std unittest assertion helper code in tracebacks (thanks Ronny)
 
 v2.0.1
-----------------------------------------------
+==============================================
 
 - refine and unify initial capturing so that it works nicely
   even if the logging module is used on an early-loaded conftest.py
@@ -1654,7 +1665,7 @@ v2.0.1
   mechanism, see the docs.
 
 v2.0.0
-----------------------------------------------
+==============================================
 
 - pytest-2.0 is now its own package and depends on pylib-2.0
 - new ability: python -m pytest / python -m pytest.main ability
@@ -1699,7 +1710,7 @@ v2.0.0
 - fix strangeness: mark.* objects are now immutable, create new instances
 
 v1.3.4
-----------------------------------------------
+==============================================
 
 - fix issue111: improve install documentation for windows
 - fix issue119: fix custom collectability of __init__.py as a module
@@ -1708,7 +1719,7 @@ v1.3.4
 - fix issue118: new --tb=native for presenting cpython-standard exceptions
 
 v1.3.3
-----------------------------------------------
+==============================================
 
 - fix issue113: assertion representation problem with triple-quoted strings
   (and possibly other cases)
@@ -1723,7 +1734,7 @@ v1.3.3
 - remove trailing whitespace in all py/text distribution files
 
 v1.3.2
-----------------------------------------------
+==============================================
 
 New features
 ++++++++++++++++++
@@ -1798,7 +1809,7 @@ Bug fixes / Maintenance
 - ship distribute_setup.py version 0.6.13
 
 v1.3.1
----------------------------------------------
+=============================================
 
 New features
 ++++++++++++++++++
@@ -1870,7 +1881,7 @@ Fixes / Maintenance
 
 
 v1.3.0
----------------------------------------------
+=============================================
 
 - deprecate --report option in favour of a new shorter and easier to
   remember -r option: it takes a string argument consisting of any
@@ -1935,7 +1946,7 @@ v1.3.0
 
 
 v1.2.0
----------------------------------------------
+=============================================
 
 - refined usage and options for "py.cleanup"::
 
@@ -1974,7 +1985,7 @@ v1.2.0
 - fix plugin links
 
 v1.1.1
----------------------------------------------
+=============================================
 
 - moved dist/looponfailing from py.test core into a new
   separately released pytest-xdist plugin.
@@ -2058,7 +2069,7 @@ v1.1.1
 
 
 v1.1.0
----------------------------------------------
+=============================================
 
 - introduce automatic plugin registration via 'pytest11'
   entrypoints via setuptools' pkg_resources.iter_entry_points
@@ -2077,7 +2088,7 @@ v1.1.0
   report a correct location
 
 v1.0.2
----------------------------------------------
+=============================================
 
 * adjust and improve docs
 
@@ -2162,7 +2173,7 @@ v1.0.2
 * simplified internal localpath implementation
 
 v1.0.2
--------------------------------------------
+===========================================
 
 * fixing packaging issues, triggered by fedora redhat packaging,
   also added doc, examples and contrib dirs to the tarball.
@@ -2170,7 +2181,7 @@ v1.0.2
 * added a documentation link to the new django plugin.
 
 v1.0.1
--------------------------------------------
+===========================================
 
 * added a 'pytest_nose' plugin which handles nose.SkipTest,
   nose-style function/method/generator setup/teardown and
@@ -2204,13 +2215,13 @@ v1.0.1
   renamed some internal methods and argnames
 
 v1.0.0
--------------------------------------------
+===========================================
 
 * more terse reporting try to show filesystem path relatively to current dir
 * improve xfail output a bit
 
 v1.0.0b9
--------------------------------------------
+===========================================
 
 * cleanly handle and report final teardown of test setup
 
@@ -2244,7 +2255,7 @@ v1.0.0b9
 
 
 v1.0.0b8
--------------------------------------------
+===========================================
 
 * pytest_unittest-plugin is now enabled by default
 
@@ -2273,7 +2284,7 @@ v1.0.0b8
   thanks Radomir.
 
 v1.0.0b7
--------------------------------------------
+===========================================
 
 * renamed py.test.xfail back to py.test.mark.xfail to avoid
   two ways to decorate for xfail
@@ -2298,7 +2309,7 @@ v1.0.0b7
 * make __name__ == "__channelexec__" for remote_exec code
 
 v1.0.0b3
--------------------------------------------
+===========================================
 
 * plugin classes are removed: one now defines
   hooks directly in conftest.py or global pytest_*.py
@@ -2315,7 +2326,7 @@ v1.0.0b3
 
 
 v1.0.0b1
--------------------------------------------
+===========================================
 
 * introduced new "funcarg" setup method,
   see doc/test/funcarg.txt
@@ -2339,7 +2350,7 @@ v1.0.0b1
 XXX lots of things missing here XXX
 
 v0.9.2
--------------------------------------------
+===========================================
 
 * refined installation and metadata, created new setup.py,
   now based on setuptools/ez_setup (thanks to Ralf Schmitt
@@ -2372,7 +2383,7 @@ v0.9.2
 * there now is a py.__version__ attribute
 
 v0.9.1
--------------------------------------------
+===========================================
 
 This is a fairly complete list of v0.9.1, which can
 serve as a reference for developers.


### PR DESCRIPTION
Added an extra *Changes* section as suggested by @RonnyPfannschmidt.

Also replace section titles from `---` to `===`, and changed sections to then use `---`. With sections, this looks better IMO. 

Fix #1275