### PR TITLE
Make monkeypatch differentiate ImportError sources

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,10 @@
   ``--pdb`` with standard I/O capture enabled.
   Thanks Erik M. Bray for the PR.
 
+- fix #900: Better error message in case the target of a ``monkeypatch`` call
+  raises an ``ImportError``.
+
+
 2.8.5
 -----
 


### PR DESCRIPTION
Previously `monkeypatch` assumed that any `ImportError` was caused by
a mistake in the specified import path. However this assumption is false 
in case the import target itself causes an `ImportError`.

Fixes: #900