### PR TITLE
pytest warnings emitted during ``pytest_terminal_summary`` are now properly displayed.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,10 @@
 - fix #1292: monkeypatch calls (setattr, setenv, etc.) are now O(1).
   Thanks David R. MacIver for the report and Bruno Oliveira for the PR.
 
+- fix #1305: pytest warnings emitted during ``pytest_terminal_summary`` are now
+  properly displayed.
+  Thanks Ionel Maries Cristian for the report and Bruno Oliveira for the PR.
+
 
 2.8.5
 -----

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -364,10 +364,10 @@ class TerminalReporter:
             EXIT_OK, EXIT_TESTSFAILED, EXIT_INTERRUPTED, EXIT_USAGEERROR,
             EXIT_NOTESTSCOLLECTED)
         if exitstatus in summary_exit_codes:
+            self.config.hook.pytest_terminal_summary(terminalreporter=self)
             self.summary_errors()
             self.summary_failures()
             self.summary_warnings()
-            self.config.hook.pytest_terminal_summary(terminalreporter=self)
         if exitstatus == EXIT_INTERRUPTED:
             self._report_keyboardinterrupt()
             del self._keyboardinterrupt_memo

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -739,6 +739,23 @@ def test_terminal_summary(testdir):
         world
     """)
 
+
+def test_terminal_summary_warnings_are_displayed(testdir):
+    """Test that warnings emitted during pytest_terminal_summary are displayed.
+    (#1305).
+    """
+    testdir.makeconftest("""
+        def pytest_terminal_summary(terminalreporter):
+            config = terminalreporter.config
+            config.warn('C1', 'internal warning')
+    """)
+    result = testdir.runpytest('-rw')
+    result.stdout.fnmatch_lines([
+        '*C1*internal warning',
+        '*== 1 pytest-warnings in *',
+    ])
+
+
 @pytest.mark.parametrize("exp_color, exp_line, stats_arg", [
     # The method under test only cares about the length of each
     # dict value, not the actual contents, so tuples of anything


### PR DESCRIPTION
Fix #1305

cc @ionelmc 