### PR TITLE
Always show full comparison output if on CI.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,10 @@
   including removal of the obsolete ``_pytest.assertion.oldinterpret`` module.
   Thanks `@nicoddemus`_ for the PR (`#1226`_).
 
+* Comparisons now always show up in full when ``CI`` or ``BUILD_NUMBER`` is
+  found in the environment, even when -vv isn't used.
+  Thanks `@The-Compiler`_ for the PR.
+
 
 **Bug Fixes**
 
@@ -44,6 +48,7 @@
 .. _@jab: https://github.com/jab
 .. _@codewarrior0: https://github.com/codewarrior0
 .. _@jaraco: https://github.com/jaraco
+.. _@The-Compiler: https://github.com/The-Compiler
 
 
 2.8.6.dev1

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -405,7 +405,7 @@ def test_sequence_comparison_uses_repr(testdir):
     ])
 
 
-def test_assert_compare_truncate_longmessage(testdir):
+def test_assert_compare_truncate_longmessage(monkeypatch, testdir):
     testdir.makepyfile(r"""
         def test_long():
             a = list(range(200))
@@ -414,6 +414,7 @@ def test_assert_compare_truncate_longmessage(testdir):
             b = '\n'.join(map(str, b))
             assert a == b
     """)
+    monkeypatch.delenv('CI', raising=False)
 
     result = testdir.runpytest()
     # without -vv, truncate the message showing a few diff lines only
@@ -427,6 +428,12 @@ def test_assert_compare_truncate_longmessage(testdir):
 
 
     result = testdir.runpytest('-vv')
+    result.stdout.fnmatch_lines([
+        "*- 197",
+    ])
+
+    monkeypatch.setenv('CI', '1')
+    result = testdir.runpytest()
     result.stdout.fnmatch_lines([
         "*- 197",
     ])


### PR DESCRIPTION
When you don't get enough information with a test running on a CI, it's quite
frustrating, for various reasons:

- It's more likely to be a flaky test, so you might not be able to reproduce
  the failure.
- Passing -vv is quite bothersome (creating a temporary commit and reverting
  it)

For those reasons, if something goes wrong on CI, it's good to have as much
information as possible.