### PR TITLE
Fix practise -> practice typo in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Features
 - Detailed info on failing `assert statements <http://pytest.org/latest/assert.html>`_ (no need to remember ``self.assert*`` names);
 
 - `Auto-discovery
-  <http://pytest.org/latest/goodpractises.html#python-test-discovery>`_
+  <http://pytest.org/latest/goodpractices.html#python-test-discovery>`_
   of test modules and functions;
 
 - `Modular fixtures <http://pytest.org/latest/fixture.html>`_  for

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -193,7 +193,7 @@ Where to go next
 Here are a few suggestions where to go next:
 
 * :ref:`cmdline` for command line invocation examples
-* :ref:`good practises <goodpractises>` for virtualenv, test layout, genscript support
+* :ref:`good practices <goodpractices>` for virtualenv, test layout, genscript support
 * :ref:`fixtures` for providing a functional baseline to your tests
 * :ref:`apiref` for documentation and examples on using ``pytest``
 * :ref:`plugins` managing and writing plugins

--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -1,5 +1,5 @@
 .. highlightlang:: python
-.. _`goodpractises`:
+.. _`goodpractices`:
 
 Good Integration Practices
 =================================================

--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -40,7 +40,7 @@ pytest: helps you write better programs
  - multi-paradigm: pytest can run ``nose``, ``unittest`` and
    ``doctest`` style test suites, including running testcases made for
    Django and trial
- - supports :ref:`good integration practises <goodpractises>`
+ - supports :ref:`good integration practices <goodpractices>`
  - supports extended :ref:`xUnit style setup <xunitsetup>`
  - supports domain-specific :ref:`non-python tests`
  - supports generating `test coverage reports

--- a/doc/en/overview.rst
+++ b/doc/en/overview.rst
@@ -7,7 +7,7 @@ Getting started basics
 
    getting-started
    usage
-   goodpractises
+   goodpractices
    projects
    faq
 

--- a/doc/en/writing_plugins.rst
+++ b/doc/en/writing_plugins.rst
@@ -95,7 +95,7 @@ Here is how you might run it::
     python package directory (i.e. one containing an ``__init__.py``) then
     "import conftest" can be ambiguous because there might be other
     ``conftest.py`` files as well on your PYTHONPATH or ``sys.path``.
-    It is thus good practise for projects to either put ``conftest.py``
+    It is thus good practice for projects to either put ``conftest.py``
     under a package scope or to never import anything from a
     conftest.py file.
 


### PR DESCRIPTION
From the "Usage" section of http://www.oxforddictionaries.com/definition/english/practice:

> Practice is the correct spelling for the noun in both British and US English and it is also the spelling of the verb in US English. However, in British English the verb should be spelled practise.

I generated the doc locally and it looks fine AFAICT. Not sure what your workflow is for checking documentation changes. If needed I can upload it to my github.io.