### PR TITLE
Test with pypy and enable coveralls in AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,25 +7,25 @@ install: "pip install -U tox"
 # # command to run tests
 env:
   matrix:
+    # coveralls is not listed in tox's envlist, but should run in travis
     - TESTENV=coveralls
-    - TESTENV=doctesting
+    # note: please use "tox --listenvs" to populate the build matrix below
     - TESTENV=flakes
     - TESTENV=py26
     - TESTENV=py27
-    - TESTENV=py27-cxfreeze
-    - TESTENV=py27-nobyte
-    - TESTENV=py27-pexpect
-    - TESTENV=py27-subprocess
-    - TESTENV=py27-trial
-    - TESTENV=py27-xdist
-    - TESTENV=py33
     - TESTENV=py33
     - TESTENV=py34
-    - TESTENV=py35-pexpect
-    - TESTENV=py35-trial
-    - TESTENV=py35-xdist
     - TESTENV=py35
     - TESTENV=pypy
+    - TESTENV=py27-pexpect
+    - TESTENV=py27-xdist
+    - TESTENV=py27-trial
+    - TESTENV=py35-pexpect
+    - TESTENV=py35-xdist
+    - TESTENV=py35-trial
+    - TESTENV=py27-nobyte
+    - TESTENV=doctesting
+    - TESTENV=py27-cxfreeze
 
 script: tox --recreate -e $TESTENV
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,19 +1,28 @@
+environment:
+  COVERALLS_REPO_TOKEN:
+    secure: 2NJ5Ct55cHJ9WEg3xbSqCuv0rdgzzb6pnzOIG5OkMbTndw3wOBrXntWFoQrXiMFi
+    # this is pytest's token in coveralls.io, encrypted
+    # using pytestbot account as detailed here:
+    # https://www.appveyor.com/docs/build-configuration#secure-variables
+
 install:
   - echo Installed Pythons
   - dir c:\Python*
+
+  # install pypy using choco (redirect to a file and write to console in case
+  # choco install returns non-zero, because choco install python.pypy is too
+  # noisy)
+  - choco install python.pypy > pypy-inst.log 2>&1 || (type pypy-inst.log & exit /b 1)
+  - set PATH=C:\tools\pypy\pypy;%PATH% # so tox can find pypy
+  - echo PyPy installed
+  - pypy --version
 
   - C:\Python35\python -m pip install tox
 
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-  - 'set TESTENVS=
-          flakes,
-          py26,
-          py27,
-          py33,
-          py34,
-          py27-xdist,
-          py35-xdist
-    '
-  - C:\Python35\python -m tox -e "%TESTENVS%"
+  - C:\Python35\python -m tox  
+  # coveralls is not in tox's envlist, plus for PRs the secure variable
+  # is not defined so we have to check for it
+  - if defined COVERALLS_REPO_TOKEN C:\Python35\python -m tox -e coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -131,7 +131,7 @@ commands=
 
 
 [testenv:coveralls]
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH COVERALLS_REPO_TOKEN
 usedevelop=True
 basepython=python3.4
 changedir=.
@@ -139,7 +139,7 @@ deps =
     {[testenv]deps}
     coveralls
 commands=
-    coverage run --source=_pytest {envdir}/bin/py.test testing
+    coverage run --source=_pytest -m pytest testing
     coverage report -m
     coveralls
 


### PR DESCRIPTION
I don't know how I did not realize before that we can use [chocolatey](https://chocolatey.org/) to install PyPy... :sweat_smile: 

Also following the same logic as discussed in pytest-dev/pytest-xdist#43, run all tox environments in AppVeyor.

* Install pypy using chocolatey
* Running coveralls environment in AppVeyor
* Suggest maintaining build matrix in .travis.yml by using "tox --listenvs"

Note: I created the PR in a branch directly in pytest-dev instead of my fork because I'm using pytestbot's encryption key to encrypt the coveralls secret.

 Fix #1254 