### PR TITLE
Fix #1290: Py3.5's @ operator/assertion rewriting.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 2.8.8.dev1
 ----------
 
+- fix #1290: support Python 3.5's @ operator in assertion rewriting.
+  Thanks Shinkenjoe for report with test case and Tom Viner for the PR.
+
 2.8.7
 -----
 

--- a/_pytest/assertion/rewrite.py
+++ b/_pytest/assertion/rewrite.py
@@ -453,6 +453,11 @@ binop_map = {
     ast.In: "in",
     ast.NotIn: "not in"
 }
+# Python 3.5+ compatibility
+try:
+    binop_map[ast.MatMult] = "@"
+except AttributeError:
+    pass
 
 # Python 3.4+ compatibility
 if hasattr(ast, "NameConstant"):

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -279,6 +279,19 @@ class TestAssertionRewrite:
             assert False or 4 % 2
         assert getmsg(f) == "assert (False or (4 % 2))"
 
+    @pytest.mark.skipif("sys.version_info < (3,5)")
+    def test_at_operator_issue1290(self, testdir):
+        testdir.makepyfile("""
+            class Matrix:
+                def __init__(self, num):
+                    self.num = num
+                def __matmul__(self, other):
+                    return self.num * other.num
+
+            def test_multmat_operator():
+                assert Matrix(2) @ Matrix(3) == 6""")
+        testdir.runpytest().assert_outcomes(passed=1)
+
     def test_call(self):
         def g(a=42, *args, **kwargs):
             return False


### PR DESCRIPTION
Fix for https://github.com/pytest-dev/pytest/issues/1290

Support `ast.MatMult` when it's present. And add a test that runs on Python 3.5+. See [PEP 465](http://legacy.python.org/dev/peps/pep-0465/) -- A dedicated infix operator for matrix multiplication