### PR TITLE
Fix usage of backticks in ReStructured Text files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,7 +65,7 @@
   ``Config.fromdictargs`` now represents its input much more faithfully.
   Thanks to `@bukzor`_ for the complete PR (`#680`_).
 
-* Fix (`#1290`_): support Python 3.5's `@` operator in assertion rewriting.
+* Fix (`#1290`_): support Python 3.5's ``@`` operator in assertion rewriting.
   Thanks `@Shinkenjoe`_ for report with test case and `@tomviner`_ for the PR.
 
 * Fix formatting utf-8 explanation messages (`#1379`_).
@@ -321,10 +321,10 @@
 - fix issue768: docstrings found in python modules were not setting up session
   fixtures. Thanks Jason R. Coombs for reporting and Bruno Oliveira for the PR.
 
-- added `tmpdir_factory`, a session-scoped fixture that can be used to create
+- added ``tmpdir_factory``, a session-scoped fixture that can be used to create
   directories under the base temporary directory. Previously this object was
-  installed as a `_tmpdirhandler` attribute of the `config` object, but now it
-  is part of the official API and using `config._tmpdirhandler` is
+  installed as a ``_tmpdirhandler`` attribute of the ``config`` object, but now it
+  is part of the official API and using ``config._tmpdirhandler`` is
   deprecated.
   Thanks Bruno Oliveira for the PR.
 
@@ -353,7 +353,7 @@
   or no tests were run at all (related to issue500).
   Thanks Eric Siegerman.
 
-- New `testpaths` ini option: list of directories to search for tests
+- New ``testpaths`` ini option: list of directories to search for tests
   when executing pytest from the root directory. This can be used
   to speed up test collection when a project has well specified directories
   for tests, being usually more practical than configuring norecursedirs for
@@ -449,20 +449,20 @@
 - issue951: add new record_xml_property fixture, that supports logging
   additional information on xml output. Thanks David Diaz for the PR.
 
-- issue949: paths after normal options (for example `-s`, `-v`, etc) are now
-  properly used to discover `rootdir` and `ini` files.
+- issue949: paths after normal options (for example ``-s``, ``-v``, etc) are now
+  properly used to discover ``rootdir`` and ``ini`` files.
   Thanks Peter Lauri for the report and Bruno Oliveira for the PR.
 
 2.7.3 (compared to 2.7.2)
 =============================
 
-- Allow 'dev', 'rc', or other non-integer version strings in `importorskip`.
+- Allow 'dev', 'rc', or other non-integer version strings in ``importorskip``.
   Thanks to Eric Hunsberger for the PR.
 
 - fix issue856: consider --color parameter in all outputs (for example
   --fixtures). Thanks Barney Gale for the report and Bruno Oliveira for the PR.
 
-- fix issue855: passing str objects as `plugins` argument to pytest.main
+- fix issue855: passing str objects as ``plugins`` argument to pytest.main
   is now interpreted as a module name to be imported and registered as a
   plugin, instead of silently having no effect.
   Thanks xmo-odoo for the report and Bruno Oliveira for the PR.
@@ -2097,7 +2097,7 @@ v1.1.1
 - new funcarg: "pytestconfig" is the pytest config object for access
   to command line args and can now be easily used in a test.
 
-- install 'py.test' and `py.which` with a ``-$VERSION`` suffix to
+- install ``py.test`` and ``py.which`` with a ``-$VERSION`` suffix to
   disambiguate between Python3, python2.X, Jython and PyPy installed versions.
 
 - new "pytestconfig" funcarg allows access to test config object

--- a/doc/en/cache.rst
+++ b/doc/en/cache.rst
@@ -262,7 +262,7 @@ than speed.
 config.cache API
 ------------------
 
-The `config.cache`` object allows other plugins,
+The ``config.cache`` object allows other plugins,
 including ``conftest.py`` files,
 to safely and flexibly store and retrieve values across
 test runs because the ``config`` object is available

--- a/doc/en/parametrize.rst
+++ b/doc/en/parametrize.rst
@@ -142,7 +142,7 @@ Sometimes you may want to implement your own parametrization scheme
 or implement some dynamism for determining the parameters or scope
 of a fixture.   For this, you can use the ``pytest_generate_tests`` hook
 which is called when collecting a test function.  Through the passed in
-`metafunc` object you can inspect the requesting test context and, most
+``metafunc`` object you can inspect the requesting test context and, most
 importantly, you can call ``metafunc.parametrize()`` to cause
 parametrization.
 

--- a/doc/en/skipping.rst
+++ b/doc/en/skipping.rst
@@ -31,7 +31,7 @@ Marking a test function to be skipped
 
 .. versionadded:: 2.9
 
-The simplest way to skip a test function is to mark it with the `skip` decorator
+The simplest way to skip a test function is to mark it with the ``skip`` decorator
 which may be passed an optional ``reason``:
 
 .. code-block:: python
@@ -45,7 +45,7 @@ which may be passed an optional ``reason``:
 
 .. versionadded:: 2.0, 2.4
 
-If you wish to skip something conditionally then you can use `skipif` instead.
+If you wish to skip something conditionally then you can use ``skipif`` instead.
 Here is an example of marking a test function to be skipped
 when run on a Python3.3 interpreter::
 

--- a/doc/en/writing_plugins.rst
+++ b/doc/en/writing_plugins.rst
@@ -109,7 +109,7 @@ If you want to write a plugin, there are many real-life examples
 you can copy from:
 
 * a custom collection example plugin: :ref:`yaml plugin`
-* around 20 doc:`builtin plugins` which provide pytest's own functionality
+* around 20 :ref:`builtin plugins` which provide pytest's own functionality
 * many `external plugins <http://plugincompat.herokuapp.com>`_ providing additional features
 
 All of these plugins implement the documented `well specified hooks`_


### PR DESCRIPTION
Noticed [this docs typo](https://pytest.org/latest/writing_plugins.html#writing-your-own-plugin) (you get italics because \`single backticks\` are rendered as \<cite\> tags):
![image](https://cloud.githubusercontent.com/assets/167319/13062666/399ba884-d438-11e5-90e9-fb56e8a10792.png)
Fixed ([links here](https://pytest.org/latest/plugins.html#builtin-plugins)):
![image](https://cloud.githubusercontent.com/assets/167319/13062679/48d2e04c-d438-11e5-8475-f89f5d088087.png)

Had a look for other accidental \<cite\> tags, which make up the rest of this PR.

For convenience in reviewing this, here's the diff of the generated docs https://github.com/tomviner/pytest/commit/5c79745c2f28a3f39001e505ad1436fe97c702b2 (I made a new branch off master, committed the doc/en/_build directory, cherry-picked this PR, and committed doc/en/_build again - this final commit is linked.)

Wasn't sure if this warranted a changelog entry?