### PR TITLE
Catch and raise OutcomeException's instead of catching all exceptions

### DIFF
--- a/_pytest/skipping.py
+++ b/_pytest/skipping.py
@@ -6,6 +6,7 @@ import traceback
 import py
 import pytest
 from _pytest.mark import MarkInfo
+from _pytest.runner import OutcomeException
 
 
 def pytest_addoption(parser):
@@ -88,6 +89,8 @@ class MarkEvaluator:
     def istrue(self):
         try:
             return self._istrue()
+        except OutcomeException:
+            raise
         except Exception:
             self.exc = sys.exc_info()
             if isinstance(self.exc[1], SyntaxError):

--- a/_pytest/skipping.py
+++ b/_pytest/skipping.py
@@ -6,7 +6,7 @@ import traceback
 import py
 import pytest
 from _pytest.mark import MarkInfo
-from _pytest.runner import OutcomeException
+from _pytest.runner import Skipped
 
 
 def pytest_addoption(parser):
@@ -89,7 +89,7 @@ class MarkEvaluator:
     def istrue(self):
         try:
             return self._istrue()
-        except OutcomeException:
+        except Skipped:
             raise
         except Exception:
             self.exc = sys.exc_info()

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -154,7 +154,7 @@ class TestCustomMarkEvaluator:
                 return evaluation_globals
 
             def istrue(self):
-                result = super(FixtureMarkEvaluator, self).istrue()
+                result = _pytest.skipping.MarkEvaluator.istrue(self)
                 if self.holder:
                     try:
                         # We're evaluating against a dictionary which changes


### PR DESCRIPTION
Recently I needed to create my own custom `MarkEvaluator`, I called it `FixtureMarkEvaluator`.

It looks up at fixture results and decides to skip a test based on that:
```python

@pytest.mark.skipiffixture("auth_config['auth_config'] == 'internal'",
                           # Only run this against external authers which are the
                           # only ones which thrown unmanaged resource exceptions
                           fixtures=('auth_config',),
                           reason='Test not applicable to the internal auth config')
def test_create_unmanaged_user_removes_cached(self, client, auth_config):
    pass
```
The alternative would be to skip the test on the test function body, but by then, our DB prep routines(which are extensive) would have been executed only for the test to be skipped.
This way, we skip before those prep routines are even executed.

I ended up with something like:

```python
class FixtureMarkEvaluator(_pytest.skipping.MarkEvaluator):
    def _getglobals(self):
        evaluation_globals = super(FixtureMarkEvaluator, self)._getglobals()
        for fixture_name in self.holder.kwargs.get('fixtures', ()):
            # Looking up fixture results will add some finalizers which, once/if tests are skipped
            # by this marker, it will make pytest fail because of the added finalizer.
            # We have 2 options, run the finalizer ourselves, or, just restore the previously
            # existing finalizers ignoring any actions those added finalizers would do(for our
            # current needs, we can ignore the finalizers)

            # Store the finalizers before getting the fixture value and restore it afterwards
            original_finalizers = self.item._request.session._setupstate._finalizers.copy()

            # Inject the fixture value into the globals that should be passed on to evaluate the marker
            try:
                evaluation_globals[fixture_name] = self.item._request.getfuncargvalue(fixture_name)
            finally:
                # Restore previous finalizers state
                self.item._request.session._setupstate._finalizers = original_finalizers
        return evaluation_globals

    def istrue(self):
        result = super(FixtureMarkEvaluator, self).istrue()
        if self.holder:
            try:
                # In our specific use case, we're evaluating against a dictionary which changes
                # Remove the evaluated expr from the cache since the cache is
                # not aware of the arguments used to get the result
                self.item.config._evalcache.pop(self.expr)
            except KeyError:
                pass
        return result
```

This would just work, however, again, for our specific use case, we depend on an external library on one of the fixtures for which we use this custom marker, and calling `pytest.skip` on it would just make the exception get caught by [this](https://github.com/pytest-dev/pytest/blob/master/_pytest/skipping.py#L91) catch all exception and we would end up with a not so helpful error message:
```
self = <tests.conftest.FixtureMarkEvaluator object at 0x7fdc62db0240>

    def istrue(self):
>       result = super(FixtureMarkEvaluator, self).istrue()
E       AttributeError: 'FixtureMarkEvaluator' object has no attribute 'expr'

tests/conftest.py:101: AttributeError
```

~~The approach in this PR is to just catch `OutcomeExceptions` and raise them as opposed to just let them get "caught" by the catch all exception.~~
The approach in this PR is to just catch `Skipped` and raise it as opposed to just let it get "caught" by the catch all exception(we don't catch `OutcomeException` because while evaluating `_istrue()` a `Failed` exception can be raised and catching `OutcomeException` would change the way `Failed` is handled.

~~Please consider this PR as is, catching and re-raisng the `OutcomeExceptions` should not trigger any regression, if fact, the skipping code should know how to handle outcome exceptions and not treat them as any other unknown kind of exception.~~
Please consider this PR as is, catching and re-raisng the `Skipped` should not trigger any regression, if fact, the skipping code should know how to handle `Skipped` exceptions and not treat them as any other unknown kind of exception.

If a test case is mandatory, I'd have to recreate our use case in a single test(possible, but probably very specific and not that much helpful as an example), still, I could try to create such test to get this code in since it's breaking our pytest usage experience...