### PR TITLE
Add issue and PR GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,8 @@
+Thanks for submitting an issue!
+
+Here's a quick checklist in what to include:
+
+[ ] Include a detailed description of the bug or suggestion
+[ ] `pip list` of the virtual environment you are using
+[ ] py.test and operating system versions
+[ ] Minimal example if possible

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Thanks for submitting a PR, your contribution is really appreciated!
+
+Here's a quick checklist that should be present in PRs:
+
+[ ] Target: for bug or doc fixes, target `master`; for new features, target `features`
+[ ] Make sure to include one or more tests for your change
+[ ] Add yourself to `AUTHORS`
+[ ] Add a new entry to the `CHANGELOG` (choose any open position to avoid merge conflicts with other PRs) 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,14 @@
   this fixes `#1366`_.
   Thanks to `@hpk42`_ for the report and `@RonnyPfannschmidt`_ for the PR.
 
+*
+
+*
+
+*
+
+*
+
 **Changes**
 
 * **Important**: `py.code <http://pylib.readthedocs.org/en/latest/code.html>`_ has been
@@ -62,6 +70,14 @@
 
 * Added expected exceptions to pytest.raises fail message
 
+*
+
+*
+
+*
+
+*
+
 **Bug Fixes**
 
 * The ``-s`` and ``-c`` options should now work under ``xdist``;
@@ -73,6 +89,14 @@
 
 * Fix formatting utf-8 explanation messages (`#1379`_).
   Thanks `@biern`_ for the PR.
+
+*
+
+*
+
+*
+
+*
 
 .. _#1379: https://github.com/pytest-dev/pytest/issues/1379
 .. _#1366: https://github.com/pytest-dev/pytest/issues/1366


### PR DESCRIPTION
As discussed in the mailing list, making use of this new GH feature

Also added the blank entries on the `CHANGELOG` to avoid merge conflicts.