### PR TITLE
Fix a typo in the docstring for mark.MarkGenerator

### DIFF
--- a/_pytest/mark.py
+++ b/_pytest/mark.py
@@ -169,7 +169,7 @@ class MarkGenerator:
     """ Factory for :class:`MarkDecorator` objects - exposed as
     a ``pytest.mark`` singleton instance.  Example::
 
-         import py
+         import pytest
          @pytest.mark.slowtest
          def test_function():
             pass


### PR DESCRIPTION
The docstring for `mark.MarkGenerator` imports `py` and then uses `pytest.mark`, this PR changes the import to `pytest`.