### PR TITLE
Fix docs on traceback styles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -94,13 +94,17 @@
 * Fix formatting utf-8 explanation messages (`#1379`_).
   Thanks `@biern`_ for the PR.
 
-*
+* Fix `traceback style docs`_ to describe all of the available options
+  (auto/long/short/line/native/no), with `auto` being the default since v2.6.
+  Thanks `@hackebrot`_ for the PR.
 
 *
 
 *
 
 *
+
+.. _`traceback style docs`: https://pytest.org/latest/usage.html#modifying-python-traceback-printing
 
 .. _#1379: https://github.com/pytest-dev/pytest/issues/1379
 .. _#1366: https://github.com/pytest-dev/pytest/issues/1366
@@ -124,6 +128,7 @@
 .. _@tomviner: https://github.com/tomviner
 .. _@RonnyPfannschmidt: https://github.com/RonnyPfannschmidt
 .. _@rabbbit: https://github.com/rabbbit
+.. _@hackebrot: https://github.com/hackebrot
 
 2.8.7
 -----

--- a/doc/en/usage.rst
+++ b/doc/en/usage.rst
@@ -66,10 +66,13 @@ Examples for modifying traceback printing::
     py.test --showlocals # show local variables in tracebacks
     py.test -l           # show local variables (shortcut)
 
-    py.test --tb=long    # the default informative traceback formatting
-    py.test --tb=native  # the Python standard library formatting
-    py.test --tb=short   # a shorter traceback format
+    py.test --tb=auto    # (default) 'long' tracebacks for the first and last
+                         # entry, but 'short' style for the other entries
+    py.test --tb=long    # exhaustive, informative traceback formatting
+    py.test --tb=short   # shorter traceback format
     py.test --tb=line    # only one line per failure
+    py.test --tb=native  # Python standard library formatting
+    py.test --tb=no      # no traceback at all
 
 Dropping to PDB_ (Python Debugger) on failures
 -----------------------------------------------


### PR DESCRIPTION
Fix [traceback style docs](https://pytest.org/latest/usage.html#modifying-python-traceback-printing
) to describe all of the available options (auto/long/short/line/native/no), with `auto` being the default since [pytest v2.6](https://pytest.org/latest/announce/release-2.6.0.html#id1)

