### PR TITLE
junit: allow multiple properties with same name

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,6 +52,7 @@ Jurko Gospodnetić
 Katarzyna Jachim
 Kevin Cox
 Lee Kamentsky
+Lukas Bednar
 Maciek Fijalkowski
 Maho
 Marc Schlaich

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -98,7 +98,8 @@
   (auto/long/short/line/native/no), with `auto` being the default since v2.6.
   Thanks `@hackebrot`_ for the PR.
 
-*
+* Fix (`#1422`_): junit record_xml_property doesn't allow multiple records
+  with same name.
 
 *
 
@@ -106,6 +107,7 @@
 
 .. _`traceback style docs`: https://pytest.org/latest/usage.html#modifying-python-traceback-printing
 
+.. _#1422: https://github.com/pytest-dev/pytest/issues/1422
 .. _#1379: https://github.com/pytest-dev/pytest/issues/1379
 .. _#1366: https://github.com/pytest-dev/pytest/issues/1366
 .. _#1040: https://github.com/pytest-dev/pytest/pull/1040

--- a/_pytest/junitxml.py
+++ b/_pytest/junitxml.py
@@ -65,8 +65,7 @@ class _NodeReporter(object):
         self.xml = xml
         self.add_stats = self.xml.add_stats
         self.duration = 0
-        self.properties = {}
-        self.property_insert_order = []
+        self.properties = []
         self.nodes = []
         self.testcase = None
         self.attrs = {}
@@ -76,18 +75,15 @@ class _NodeReporter(object):
         self.nodes.append(node)
 
     def add_property(self, name, value):
-        name = str(name)
-        if name not in self.property_insert_order:
-            self.property_insert_order.append(name)
-        self.properties[name] = bin_xml_escape(value)
+        self.properties.append((str(name), bin_xml_escape(value)))
 
     def make_properties_node(self):
         """Return a Junit node containing custom properties, if any.
         """
         if self.properties:
             return Junit.properties([
-                Junit.property(name=name, value=self.properties[name])
-                for name in self.property_insert_order
+                Junit.property(name=name, value=value)
+                for name, value in self.properties
             ])
         return ''
 

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -669,6 +669,21 @@ def test_record_property(testdir):
     result.stdout.fnmatch_lines('*C3*test_record_property.py*experimental*')
 
 
+def test_record_property_same_name(testdir):
+    testdir.makepyfile("""
+        def test_record_with_same_name(record_xml_property):
+            record_xml_property("foo", "bar")
+            record_xml_property("foo", "baz")
+    """)
+    result, dom = runandparse(testdir, '-rw')
+    node = dom.find_first_by_tag("testsuite")
+    tnode = node.find_first_by_tag("testcase")
+    psnode = tnode.find_first_by_tag('properties')
+    pnodes = psnode.find_by_tag('property')
+    pnodes[0].assert_attr(name="foo", value="bar")
+    pnodes[1].assert_attr(name="foo", value="baz")
+
+
 def test_random_report_log_xdist(testdir):
     """xdist calls pytest_runtest_logreport as they are executed by the slaves,
     with nodes from several nodes overlapping, so junitxml must cope with that


### PR DESCRIPTION
It might happen that test can be affected by two or more bugs.
I need to be able to track them all.

Fix #1422 