### PR TITLE
Add a new doctest_namespace fixture

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ Marc Schlaich
 Mark Abramowitz
 Markus Unterwaditzer
 Martijn Faassen
+Matt Williams
 Michael Aquilina
 Michael Birtwell
 Michael Droettboom

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,8 @@
 
 **New Features**
 
-*
+* New ``doctest_namespace`` fixture for injecting names into the
+  namespace in which your doctests run.
 
 * 
 

--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -71,6 +71,8 @@ class DoctestItem(pytest.Item):
         if self.dtest is not None:
             self.fixture_request = _setup_fixtures(self)
             globs = dict(getfixture=self.fixture_request.getfuncargvalue)
+            for name, value in self.fixture_request.getfuncargvalue('doctest_namespace').items():
+                globs[name] = value
             self.dtest.globs.update(globs)
 
     def runtest(self):
@@ -158,6 +160,9 @@ class DoctestTextfile(DoctestItem, pytest.Module):
         globs = dict(getfixture=fixture_request.getfuncargvalue)
         if '__name__' not in globs:
             globs['__name__'] = '__main__'
+
+        for name, value in fixture_request.getfuncargvalue('doctest_namespace').items():
+            globs[name] = value
 
         optionflags = get_optionflags(self)
         runner = doctest.DebugRunner(verbose=0, optionflags=optionflags,
@@ -288,3 +293,11 @@ def _get_allow_bytes_flag():
     """
     import doctest
     return doctest.register_optionflag('ALLOW_BYTES')
+
+
+@pytest.fixture(scope='session')
+def doctest_namespace():
+    """
+    Inject names into the doctest namespace.
+    """
+    return dict()

--- a/doc/en/doctest.rst
+++ b/doc/en/doctest.rst
@@ -102,4 +102,29 @@ itself::
     >>> get_unicode_greeting()  # doctest: +ALLOW_UNICODE
     'Hello'
 
+The 'doctest_namespace' fixture
+-------------------------------
 
+The ``doctest_namespace`` fixture can be used to inject items into the
+namespace in which your doctests run. It is intended to be used within
+your own fixtures to provide the tests that use them with context.
+
+``doctest_namespace`` is a standard ``dict`` object into which you
+place the objects you want to appear in the doctest namespace::
+
+    # content of conftest.py
+    import numpy
+    @pytest.fixture(autouse=True)
+        def add_np(doctest_namespace):
+            doctest_namespace['np'] = numpy
+
+which can then be used in your doctests directly::
+
+    # content of numpy.py
+    def arange():
+        """
+        >>> a = np.arange(10)
+        >>> len(a)
+        10
+        """
+        pass

--- a/doc/en/doctest.rst
+++ b/doc/en/doctest.rst
@@ -115,8 +115,8 @@ place the objects you want to appear in the doctest namespace::
     # content of conftest.py
     import numpy
     @pytest.fixture(autouse=True)
-        def add_np(doctest_namespace):
-            doctest_namespace['np'] = numpy
+    def add_np(doctest_namespace):
+        doctest_namespace['np'] = numpy
 
 which can then be used in your doctests directly::
 


### PR DESCRIPTION
This resolves #1047 by introducing a new fixture `doctest_namespace`. This fixture can be used to inject names into the namespace in which your doctests run. The basic usage is described in `doctest.rst` but it works like:

```python
# content of conftest.py
import numpy
@pytest.fixture(autouse=True)
def add_np(doctest_namespace):
    doctest_namespace['np'] = numpy
```
which can then be used in your doctests directly::
```python
# content of numpy.py
def arange():
    """
    >>> a = np.arange(10)
    >>> len(a)
    10
    """
    pass
```

This is my first contribution to pytest so I welcome any feedback on style etc.