### PR TITLE
issue469: add fix junit double colon split issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,8 @@
 
 *
 
-*
+* Fix (`#469`_): junit parses report.nodeid incorrectly, when params contain
+  ``::``.
 
 *
 
@@ -102,6 +103,7 @@
 
 .. _`traceback style docs`: https://pytest.org/latest/usage.html#modifying-python-traceback-printing
 
+.. _#469: https://github.com/pytest-dev/pytest/issues/469
 .. _#1422: https://github.com/pytest-dev/pytest/issues/1422
 .. _#1379: https://github.com/pytest-dev/pytest/issues/1379
 .. _#1366: https://github.com/pytest-dev/pytest/issues/1366

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -449,11 +449,12 @@ class TestPython:
         assert "hello-stderr" in systemout.toxml()
 
 
-def test_mangle_testnames():
-    from _pytest.junitxml import mangle_testnames
-    names = ["a/pything.py", "Class", "()", "method"]
-    newnames = mangle_testnames(names)
-    assert newnames == ["a.pything", "Class", "method"]
+def test_mangle_test_address():
+    from _pytest.junitxml import mangle_test_address
+    address = '::'.join(
+        ["a/my.py.thing.py", "Class", "()", "method", "[a-1-::]"])
+    newnames = mangle_test_address(address)
+    assert newnames == ["a.my.py.thing", "Class", "method", "[a-1-::]"]
 
 
 def test_dont_configure_on_slaves(tmpdir):
@@ -617,6 +618,20 @@ def test_escaped_parametrized_names_xml(testdir):
     assert result.ret == 0
     node = dom.find_first_by_tag("testcase")
     node.assert_attr(name="test_func[#x00]")
+
+
+def test_double_colon_split_issue469(testdir):
+    testdir.makepyfile("""
+        import pytest
+        @pytest.mark.parametrize('param', ["double::colon"])
+        def test_func(param):
+            pass
+    """)
+    result, dom = runandparse(testdir)
+    assert result.ret == 0
+    node = dom.find_first_by_tag("testcase")
+    node.assert_attr(classname="test_double_colon_split_issue469")
+    node.assert_attr(name='test_func[double::colon]')
 
 
 def test_unicode_issue368(testdir):


### PR DESCRIPTION
Fix for https://github.com/pytest-dev/pytest/issues/469

A Node ID with all the components looks like this:
`testing/test_skipping.py::TestSkipif::()::test_skipif_reporting_multiple[param-data-maybe-a-some-colons-::]`

This PR:
- Split the nodeid by `[`, before splitting by `::`
- remove `.py` only when at end of file path
