### PR TITLE
issue469: junit parsing nodeid, add method test

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,10 +5,14 @@
 
 *
 
-* Fix (`#469`_): junit parses report.nodeid incorrectly, when params contain
-  ``::``.
+* Fix (`#469`_): junit parses report.nodeid incorrectly, when params IDs
+  contain ``::``. Thanks `@tomviner`_ for the PR (`#1431`_).
 
 *
+
+.. _#469: https://github.com/pytest-dev/pytest/issues/469
+.. _#1431: https://github.com/pytest-dev/pytest/pull/1431
+
 
 2.9.0
 =====
@@ -103,7 +107,6 @@
 
 .. _`traceback style docs`: https://pytest.org/latest/usage.html#modifying-python-traceback-printing
 
-.. _#469: https://github.com/pytest-dev/pytest/issues/469
 .. _#1422: https://github.com/pytest-dev/pytest/issues/1422
 .. _#1379: https://github.com/pytest-dev/pytest/issues/1379
 .. _#1366: https://github.com/pytest-dev/pytest/issues/1366

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -620,7 +620,7 @@ def test_escaped_parametrized_names_xml(testdir):
     node.assert_attr(name="test_func[#x00]")
 
 
-def test_double_colon_split_issue469(testdir):
+def test_double_colon_split_function_issue469(testdir):
     testdir.makepyfile("""
         import pytest
         @pytest.mark.parametrize('param', ["double::colon"])
@@ -630,7 +630,23 @@ def test_double_colon_split_issue469(testdir):
     result, dom = runandparse(testdir)
     assert result.ret == 0
     node = dom.find_first_by_tag("testcase")
-    node.assert_attr(classname="test_double_colon_split_issue469")
+    node.assert_attr(classname="test_double_colon_split_function_issue469")
+    node.assert_attr(name='test_func[double::colon]')
+
+
+def test_double_colon_split_method_issue469(testdir):
+    testdir.makepyfile("""
+        import pytest
+        class TestClass:
+            @pytest.mark.parametrize('param', ["double::colon"])
+            def test_func(self, param):
+                pass
+    """)
+    result, dom = runandparse(testdir)
+    assert result.ret == 0
+    node = dom.find_first_by_tag("testcase")
+    node.assert_attr(
+        classname="test_double_colon_split_method_issue469.TestClass")
     node.assert_attr(name='test_func[double::colon]')
 
 


### PR DESCRIPTION
Additional test as recommend before https://github.com/pytest-dev/pytest/pull/1431 was merged :-)

Also added name to the changelog entry. And repositioned the rst link definition.

While I'm here couple comments on the changelog:
- ~~we're in risk of the `(#469_)` numbers referencing both issues and pull requests clashing (both are up to around 1400 now). Obviously all links are explicitly defined, but could be confusing. rst-lint will error on duplicate definitions, but if someone forgets the 2nd definition, it would silently reference the first. Maybe reference PRs as `(PR#469_)` and keep `(#469_)` for issues?~~
- minor point, but all the trailing whitespace makes editing the changelog difficult as my editor strips it. Would someone be happy stripping it? Or maybe my editor settings are overzealous :-)