### PR TITLE
Make a good faith effort to display a bytestring when one is provided…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ Marc Schlaich
 Mark Abramowitz
 Markus Unterwaditzer
 Martijn Faassen
+Matt Bachmann
 Michael Aquilina
 Michael Birtwell
 Michael Droettboom

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,17 +8,19 @@
 * Fix (`#469`_): junit parses report.nodeid incorrectly, when params IDs
   contain ``::``. Thanks `@tomviner`_ for the PR (`#1431`_).
 
-*
 
 * Fix (`#578 <https://github.com/pytest-dev/pytest/issues/578>`_): SyntaxErrors
   containing non-ascii lines at the point of failure generated an internal
   py.test error.
   Thanks `@asottile`_ for the report and `@nicoddemus`_ for the PR.
 
-*
+* Fix (`#1437`_): When passing in a bytestring regex pattern to parameterize
+  attempt to decode it as utf-8 ignoring errors.
 
 *
 
+
+.. _#1437: https://github.com/pytest-dev/pytest/issues/1437
 .. _#469: https://github.com/pytest-dev/pytest/issues/469
 .. _#1431: https://github.com/pytest-dev/pytest/pull/1431
 

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1115,7 +1115,7 @@ def _idval(val, argname, idx, idfn):
     elif isinstance(val, (float, int, str, bool, NoneType)):
         return str(val)
     elif isinstance(val, REGEX_TYPE):
-        return val.pattern
+        return _escape_bytes(val.pattern) if isinstance(val.pattern, bytes) else val.pattern
     elif enum is not None and isinstance(val, enum.Enum):
         return str(val)
     elif isclass(val) and hasattr(val, '__name__'):

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -392,6 +392,20 @@ class TestGeneralUsage:
         monkeypatch.setitem(sys.modules, 'myplugin', mod)
         assert pytest.main(args=[str(tmpdir)], plugins=['myplugin']) == 0
 
+    def test_parameterized_with_bytes_regex(self, testdir):
+        p = testdir.makepyfile("""
+            import re
+            import pytest
+            @pytest.mark.parametrize('r', [re.compile(b'foo')])
+            def test_stuff(r):
+                pass
+        """
+        )
+        res = testdir.runpytest(p)
+        res.stdout.fnmatch_lines([
+            '*1 passed*'
+        ])
+
 
 class TestInvocationVariants:
     def test_earlyinit(self, testdir):

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -170,6 +170,11 @@ class TestMetafunc:
         result = idmaker((py.builtin._totext("a"), "b"), [({}, b'\xc3\xb4')])
         assert result == ['a0-\\xc3\\xb4']
 
+    def test_idmaker_with_bytes_regex(self):
+        from _pytest.python import idmaker
+        result = idmaker(("a"), [(re.compile(b'foo'), 1.0)])
+        assert result == ["foo"]
+
     def test_idmaker_native_strings(self):
         from _pytest.python import idmaker
         totext = py.builtin._totext


### PR DESCRIPTION
Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

[ X] Target: for bug or doc fixes, target `master`; for new features, target `features`
[ X] Make sure to include one or more tests for your change
[ X] Add yourself to `AUTHORS`
[ X] Add a new entry to the `CHANGELOG` (choose any open position to avoid merge conflicts with other PRs) 

… as a regex patterm
Attempting to fix https://github.com/pytest-dev/pytest/issues/1437
This will display odd behavior when the text in the bytestring is not encoded in ascii or utf-8. It wont crash but it will be wrong.

However, as I dont see a way to know the encoding for sure this seemed reasonable

Open to other ideas. Saw this on twitter and thought I would take a stab at it