### PR TITLE
Improve error message when a plugin fails to import

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,13 +5,17 @@
 
 *
 
+*
+
+* Improve error message when a plugin fails to load.
+  Thanks `@nicoddemus`_ for the PR.
+
 * Fix (`#1178 <https://github.com/pytest-dev/pytest/issues/1178>`_):
   ``pytest.fail`` with non-ascii characters raises an internal pytest error.
   Thanks `@nicoddemus`_ for the PR.
 
 * Fix (`#469`_): junit parses report.nodeid incorrectly, when params IDs
   contain ``::``. Thanks `@tomviner`_ for the PR (`#1431`_).
-
 
 * Fix (`#578 <https://github.com/pytest-dev/pytest/issues/578>`_): SyntaxErrors
   containing non-ascii lines at the point of failure generated an internal
@@ -20,6 +24,8 @@
 
 * Fix (`#1437`_): When passing in a bytestring regex pattern to parameterize
   attempt to decode it as utf-8 ignoring errors.
+
+*
 
 *
 

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -383,8 +383,8 @@ class PytestPluginManager(PluginManager):
             importspec = modname
         try:
             __import__(importspec)
-        except ImportError:
-            raise
+        except ImportError as e:
+            raise ImportError('Error importing plugin "%s": %s' % (modname, e))
         except Exception as e:
             import pytest
             if not hasattr(pytest, 'skip') or not isinstance(e, pytest.skip.Exception):

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -384,7 +384,12 @@ class PytestPluginManager(PluginManager):
         try:
             __import__(importspec)
         except ImportError as e:
-            raise ImportError('Error importing plugin "%s": %s' % (modname, e))
+            new_exc = ImportError('Error importing plugin "%s": %s' % (modname, e))
+            # copy over name and path attributes
+            for attr in ('name', 'path'):
+                if hasattr(e, attr):
+                    setattr(new_exc, attr, getattr(e, attr))
+            raise new_exc
         except Exception as e:
             import pytest
             if not hasattr(pytest, 'skip') or not isinstance(e, pytest.skip.Exception):

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -178,13 +178,17 @@ def test_default_markers(testdir):
         "*trylast*last*",
     ])
 
+
 def test_importplugin_issue375(testdir, pytestpm):
+    """Don't hide import errors when importing plugins and provide
+    an easy to debug message.
+    """
     testdir.syspathinsert(testdir.tmpdir)
     testdir.makepyfile(qwe="import aaaa")
     with pytest.raises(ImportError) as excinfo:
         pytestpm.import_plugin("qwe")
-    assert "qwe" not in str(excinfo.value)
-    assert "aaaa" in str(excinfo.value)
+    expected = '.*Error importing plugin "qwe": No module named \'?aaaa\'?'
+    assert py.std.re.match(expected, str(excinfo.value))
 
 
 class TestPytestPluginManager:


### PR DESCRIPTION
Currently when a plugin fails to load, pytest will display only the bare import error message, which might be difficult to diagnose the problem depending on the number of plugins installed  

For example, suppose we have a broken installation of `pytest_cov` which is missing the plugin module `pytest_cov.plugin`, the error message given by `py.test` is:

```
$ py.test -p pytestqt.plugin -p pytest_cov.plugin -p pytest_timeout ...
<... long traceback ...>
No module named 'plugin'
```

This PR just adds the full name of the plugin module which py.test is attempting to load to the exception message:

```
$ py.test -p pytestqt.plugin -p pytest_cov.plugin -p pytest_timeout ...
<... long traceback ...>
Error importing plugin "pytest_cov.plugin": No module named 'plugin'
```

I encountered this problem a few times when updating py.test and some plugins in a frozen py.test installation; in our case, we pass all the plugins explicitly in the command-line, and with the current message is hard to track the problem down.