### PR TITLE
doc: fix argument order for pytest_load_initial_conftests

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Christian Theunert
 Christian Tismer
 Christopher Gilling
 Daniel Grana
+Daniel Hahler
 Daniel Nuri
 Dave Hunt
 David Mohr

--- a/_pytest/hookspec.py
+++ b/_pytest/hookspec.py
@@ -81,7 +81,7 @@ def pytest_cmdline_main(config):
     """ called for performing the main command line action. The default
     implementation will invoke the configure hooks and runtest_mainloop. """
 
-def pytest_load_initial_conftests(args, early_config, parser):
+def pytest_load_initial_conftests(early_config, parser, args):
     """ implements the loading of initial conftest files ahead
     of command line option parsing. """
 


### PR DESCRIPTION
Pointed out in https://github.com/pytest-dev/pytest-django/issues/300#issuecomment-194565905.

Not adding a changelog entry for this; but/and it should get "backported" probably.