### PR TITLE
Close #138

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -71,6 +71,7 @@ Piotr Banaszkiewicz
 Punyashloka Biswal
 Ralf Schmitt
 Raphael Pierzina
+Roman Bolshakov
 Ronny Pfannschmidt
 Ross Lawley
 Ryan Wooden

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,11 +37,13 @@
 
 * Fix (`#649`_): parametrized test nodes cannot be specified to run on the command line.
 
+* Fix (`#138`_): better reporting for python 3.3+ chained exceptions
 
 .. _#1437: https://github.com/pytest-dev/pytest/issues/1437
 .. _#469: https://github.com/pytest-dev/pytest/issues/469
 .. _#1431: https://github.com/pytest-dev/pytest/pull/1431
 .. _#649: https://github.com/pytest-dev/pytest/issues/649
+.. _#138: https://github.com/pytest-dev/pytest/issues/138
 
 .. _@asottile: https://github.com/asottile
 

--- a/_pytest/runner.py
+++ b/_pytest/runner.py
@@ -498,6 +498,7 @@ def importorskip(modname, minversion=None):
     try:
         __import__(modname)
     except ImportError:
+        # Do not raise chained exception here(#1485)
         should_skip = True
     if should_skip:
         skip("could not import %r" %(modname,))

--- a/_pytest/runner.py
+++ b/_pytest/runner.py
@@ -491,9 +491,12 @@ def importorskip(modname, minversion=None):
     """
     __tracebackhide__ = True
     compile(modname, '', 'eval') # to catch syntaxerrors
+    should_skip = False
     try:
         __import__(modname)
     except ImportError:
+        should_skip = True
+    if should_skip:
         skip("could not import %r" %(modname,))
     mod = sys.modules[modname]
     if minversion is None:


### PR DESCRIPTION
The change fixes #138. Exception chain is printed according to [PEP-3134](https://www.python.org/dev/peps/pep-3134/).  
The tracebacks of each exception in the chain are the same as tracebacks of non-chained exceptions in py.test. The tracebacks are delimited by `The above exception was the direct cause of the following exception:` or `During handling of the above exception, another exception occurred:` messages, depending on `__cause__` or `__context__` respectively.  If an exception has both `__cause__` and `__context__`, `__cause__` takes priority. The messages are yellow-colored as it looks better than cyan delimiters:
![yellow-exc-sep](https://cloud.githubusercontent.com/assets/189619/13901585/45b2bd6e-ee42-11e5-9c0f-78b312a8c49a.png)
![cyan-exc-sep](https://cloud.githubusercontent.com/assets/189619/13901586/47ef63d4-ee42-11e5-9756-6df39ff95012.png)

