### PR TITLE
None in paramtrized test id will use automatically generated id

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,8 @@
 
 **Changes**
 
-*
+* parametrize ids can accept None as specific test id. The
+  automatically generated id for that argument will be used.
 
 *
 
@@ -45,7 +46,7 @@
 
 **Bug Fixes**
 
-*
+* When receiving identical test ids in parametrize we generate unique test ids.
 
 *
 

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1017,8 +1017,7 @@ class Metafunc(FuncargnamesCompatAttr):
         if ids and len(ids) != len(argvalues):
             raise ValueError('%d tests specified with %d ids' %(
                              len(argvalues), len(ids)))
-        if not ids:
-            ids = idmaker(argnames, argvalues, idfn)
+        ids = idmaker(argnames, argvalues, idfn, ids)
         newcalls = []
         for callspec in self._calls or [CallSpec2(self)]:
             for param_index, valset in enumerate(argvalues):
@@ -1130,13 +1129,16 @@ def _idval(val, argname, idx, idfn):
             pass
     return str(argname)+str(idx)
 
-def _idvalset(idx, valset, argnames, idfn):
-    this_id = [_idval(val, argname, idx, idfn)
-               for val, argname in zip(valset, argnames)]
-    return "-".join(this_id)
+def _idvalset(idx, valset, argnames, idfn, ids):
+    if ids is None or ids[idx] is None:
+        this_id = [_idval(val, argname, idx, idfn)
+                   for val, argname in zip(valset, argnames)]
+        return "-".join(this_id)
+    else:
+        return ids[idx]
 
-def idmaker(argnames, argvalues, idfn=None):
-    ids = [_idvalset(valindex, valset, argnames, idfn)
+def idmaker(argnames, argvalues, idfn=None, ids=None):
+    ids = [_idvalset(valindex, valset, argnames, idfn, ids)
            for valindex, valset in enumerate(argvalues)]
     if len(set(ids)) < len(ids):
         # user may have provided a bad idfn which means the ids are not unique

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -956,7 +956,8 @@ class Metafunc(FuncargnamesCompatAttr):
 
         :arg ids: list of string ids, or a callable.
             If strings, each is corresponding to the argvalues so that they are
-            part of the test id.
+            part of the test id. If None is given as id of specific test, the
+            automatically generated id for that argument will be used.
             If callable, it should take one argument (a single argvalue) and return
             a string or return None. If None, the automatically generated id for that
             argument will be used.

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -796,6 +796,24 @@ class TestMetafuncFunctional:
             *test_function*1.3-b1*
         """)
 
+    def test_parametrize_with_None_in_ids(self, testdir):
+        testdir.makepyfile("""
+            import pytest
+            def pytest_generate_tests(metafunc):
+                metafunc.parametrize(("a", "b"), [(1,1), (1,1) , (1,2)],
+                                     ids=["basic", None, "advanced"])
+
+            def test_function(a, b):
+                assert a == b
+        """)
+        result = testdir.runpytest("-v")
+        assert result.ret == 1
+        result.stdout.fnmatch_lines_random([
+            "*test_function*basic*PASSED",
+            "*test_function*1-1*PASSED",
+            "*test_function*advanced*FAILED",
+        ])
+
     @pytest.mark.parametrize(("scope", "length"),
                              [("module", 2), ("function", 4)])
     def test_parametrize_scope_overrides(self, testdir, scope, length):

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -265,6 +265,13 @@ class TestMetafunc:
                          ids=["a", None])
         assert result == ["a", "3-4"]
 
+    def test_idmaker_with_ids_unique_names(self):
+        from _pytest.python import idmaker
+        result = idmaker(("a", "b"), [(1, 2),
+                                      (3, 4)],
+                         ids=["a", "a"])
+        assert result == ["0a", "1a"]
+
     def test_addcall_and_parametrize(self):
         def func(x, y): pass
         metafunc = self.Metafunc(func)
@@ -800,7 +807,7 @@ class TestMetafuncFunctional:
         testdir.makepyfile("""
             import pytest
             def pytest_generate_tests(metafunc):
-                metafunc.parametrize(("a", "b"), [(1,1), (1,1) , (1,2)],
+                metafunc.parametrize(("a", "b"), [(1,1), (1,1), (1,2)],
                                      ids=["basic", None, "advanced"])
 
             def test_function(a, b):
@@ -812,6 +819,23 @@ class TestMetafuncFunctional:
             "*test_function*basic*PASSED",
             "*test_function*1-1*PASSED",
             "*test_function*advanced*FAILED",
+        ])
+
+    def test_parametrize_with_identical_ids_get_unique_names(self, testdir):
+        testdir.makepyfile("""
+            import pytest
+            def pytest_generate_tests(metafunc):
+                metafunc.parametrize(("a", "b"), [(1,1), (1,2)],
+                                     ids=["a", "a"])
+
+            def test_function(a, b):
+                assert a == b
+        """)
+        result = testdir.runpytest("-v")
+        assert result.ret == 1
+        result.stdout.fnmatch_lines_random([
+            "*test_function*0a*PASSED",
+            "*test_function*1a*FAILED"
         ])
 
     @pytest.mark.parametrize(("scope", "length"),

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -258,6 +258,13 @@ class TestMetafunc:
                           "three-b2",
                          ]
 
+    def test_idmaker_with_ids(self):
+        from _pytest.python import idmaker
+        result = idmaker(("a", "b"), [(1, 2),
+                                      (3, 4)],
+                         ids=["a", None])
+        assert result == ["a", "3-4"]
+
     def test_addcall_and_parametrize(self):
         def func(x, y): pass
         metafunc = self.Metafunc(func)


### PR DESCRIPTION
This pull request is allowing the user to pass None as a specific test id of parametrize. If a test id is None the specific test id will be automatically calculated.

    import pytest
    @pytest.mark.parametrize(("a,b"), [(1,1), (1,1), (1,2)],
                             ids=["basic", None, "advanced"])  
    def test_function(a, b):
        assert a == b

This will result in the following tests:
  - test_function[basic]
  - test_function[1-1]
  - test_function[advanced]

As a side effect of this PR i noticed that when you pass the same test id we recieve a duplicate test:

    import pytest
    @pytest.mark.parametrize("a,b", [(1,2), (3,4)], ids=["a", "a"])
    def test_a(a,b):
        pass

Currently result in the test:
    - test_a[a]
    - test_a[a]

After this change the result will be:
    - test_a[0a]
    - test_a[1a]

Same as when a ids callable return the same value.







   
    