### PR TITLE
Improve idmaker name selection in case of duplicate ids in parametrize

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,9 +25,11 @@
 
 * parametrize ids can accept None as specific test id. The
   automatically generated id for that argument will be used.
+  Thanks `@palaviv`_ for the complete PR (`#1468`_).
 
 * improved idmaker name selection in case of duplicate ids in
   parametrize.
+  Thanks `@palaviv`_ for the complete PR (`#1474`_).
 
 *
 
@@ -35,11 +37,14 @@
 .. _@novas0x2a: https://github.com/novas0x2a
 .. _@kalekundert: https://github.com/kalekundert
 .. _@tareqalayan: https://github.com/tareqalayan
+.. _@palaviv: https://github.com/palaviv
 
 .. _#1428: https://github.com/pytest-dev/pytest/pull/1428
 .. _#1444: https://github.com/pytest-dev/pytest/pull/1444
 .. _#1441: https://github.com/pytest-dev/pytest/pull/1441
 .. _#1454: https://github.com/pytest-dev/pytest/pull/1454
+.. _#1468: https://github.com/pytest-dev/pytest/pull/1468
+.. _#1474: https://github.com/pytest-dev/pytest/pull/1474
 
 
 2.9.2.dev1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,8 @@
 * parametrize ids can accept None as specific test id. The
   automatically generated id for that argument will be used.
 
-*
+* improved idmaker name selection in case of duplicate ids in
+  parametrize.
 
 *
 

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -7,6 +7,7 @@ import re
 import types
 import sys
 import math
+import collections
 
 import py
 import pytest
@@ -1152,9 +1153,14 @@ def _idvalset(idx, valset, argnames, idfn, ids):
 def idmaker(argnames, argvalues, idfn=None, ids=None):
     ids = [_idvalset(valindex, valset, argnames, idfn, ids)
            for valindex, valset in enumerate(argvalues)]
-    if len(set(ids)) < len(ids):
-        # user may have provided a bad idfn which means the ids are not unique
-        ids = [str(i) + testid for i, testid in enumerate(ids)]
+    duplicates = [testid for testid in ids if ids.count(testid) > 1]
+    if duplicates:
+        # The ids are not unique
+        counters = collections.defaultdict(lambda: 0)
+        for index, testid in enumerate(ids):
+            if testid in duplicates:
+                ids[index] = testid + str(counters[testid])
+                counters[testid] += 1
     return ids
 
 def showfixtures(config):

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1153,9 +1153,9 @@ def _idvalset(idx, valset, argnames, idfn, ids):
 def idmaker(argnames, argvalues, idfn=None, ids=None):
     ids = [_idvalset(valindex, valset, argnames, idfn, ids)
            for valindex, valset in enumerate(argvalues)]
-    duplicates = [testid for testid in ids if ids.count(testid) > 1]
-    if duplicates:
+    if len(set(ids)) != len(ids):
         # The ids are not unique
+        duplicates = [testid for testid in ids if ids.count(testid) > 1]
         counters = collections.defaultdict(lambda: 0)
         for index, testid in enumerate(ids):
             if testid in duplicates:

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -238,9 +238,9 @@ class TestMetafunc:
                                       (20, KeyError()),
                                       ("three", [1, 2, 3]),
         ], idfn=ids)
-        assert result == ["0a-a",
-                          "1a-a",
-                          "2a-a",
+        assert result == ["a-a0",
+                          "a-a1",
+                          "a-a2",
                          ]
 
     @pytest.mark.issue351
@@ -267,10 +267,9 @@ class TestMetafunc:
 
     def test_idmaker_with_ids_unique_names(self):
         from _pytest.python import idmaker
-        result = idmaker(("a", "b"), [(1, 2),
-                                      (3, 4)],
-                         ids=["a", "a"])
-        assert result == ["0a", "1a"]
+        result = idmaker(("a"), [1,2,3,4,5],
+                         ids=["a", "a", "b", "c", "b"])
+        assert result == ["a0", "a1", "b0", "c", "b1"]
 
     def test_addcall_and_parametrize(self):
         def func(x, y): pass
@@ -834,8 +833,8 @@ class TestMetafuncFunctional:
         result = testdir.runpytest("-v")
         assert result.ret == 1
         result.stdout.fnmatch_lines_random([
-            "*test_function*0a*PASSED",
-            "*test_function*1a*FAILED"
+            "*test_function*a0*PASSED",
+            "*test_function*a1*FAILED"
         ])
 
     @pytest.mark.parametrize(("scope", "length"),


### PR DESCRIPTION
As @RonnyPfannschmidt mentioned in pull request #1468 the name selection in case of duplicate ids had some problems.
Let's take for example:

    import pytest
    @pytest.mark.parametrize("a", [1,2,3,4,5,6], ids=["a", "a", "b", "c", "b", "l"])
    def test_a(a,b):
        pass

Before this change the tests names would be:

- test_a[0a]
- test_a[1a]
- test_a[2b]
- test_a[3c]
- test_a[4b]
- test_a[5l]

After this change:

- test_a[a0]
- test_a[a1]
- test_a[b0]
- test_a[c]
- test_a[b1]
- test_a[l]

 