### PR TITLE
Always lstrip() keyword expression

### DIFF
--- a/_pytest/mark.py
+++ b/_pytest/mark.py
@@ -58,7 +58,7 @@ pytest_cmdline_main.tryfirst = True
 
 
 def pytest_collection_modifyitems(items, config):
-    keywordexpr = config.option.keyword
+    keywordexpr = config.option.keyword.lstrip()
     matchexpr = config.option.markexpr
     if not keywordexpr and not matchexpr:
         return

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -670,6 +670,11 @@ class TestDurations:
             "*call*test_1*",
         ])
 
+    def test_with_not(self, testdir):
+        testdir.makepyfile(self.source)
+        result = testdir.runpytest("-k not 1")
+        assert result.ret == 0
+
 
 class TestDurationWithFixture:
     source = """


### PR DESCRIPTION
This solves the following bug.
Given and example test mod `test_name_filter.py`:

```python
def test_4x4():                
    pass                       
                               
if __name__ == '__main__':     
    import pytest              
    pytest.main(["-k not 4x4"])
```
Running from an IPython shell:

```python
In [26]: run ./test_name_filter.py                                                                           
================================================= test session starts =======================================
platform linux2 -- Python 2.7.11, pytest-2.9.0, py-1.4.31, pluggy-0.3.1
rootdir: /home/tyler/pytest_bugs, inifile: 
plugins: interactive-0.1.1, ordering-0.4, instafail-0.3.0
collected 1 items 
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/tyler/repos/pytest/_pytest/main.py", line 94, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/home/tyler/repos/pytest/_pytest/main.py", line 124, in _main
INTERNALERROR>     config.hook.pytest_collection(session=session)
INTERNALERROR>   File "/home/tyler/repos/pytest/_pytest/vendored_packages/pluggy.py", line 724, in __call__
INTERNALERROR>     return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
INTERNALERROR>   File "/home/tyler/repos/pytest/_pytest/vendored_packages/pluggy.py", line 338, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/tyler/repos/pytest/_pytest/vendored_packages/pluggy.py", line 333, in <lambda>
INTERNALERROR>     _MultiCall(methods, kwargs, hook.spec_opts).execute()
INTERNALERROR>   File "/home/tyler/repos/pytest/_pytest/vendored_packages/pluggy.py", line 596, in execute
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/tyler/repos/pytest/_pytest/main.py", line 133, in pytest_collection
INTERNALERROR>     return session.perform_collect()
INTERNALERROR>   File "/home/tyler/repos/pytest/_pytest/main.py", line 567, in perform_collect
INTERNALERROR>     config=self.config, items=items)
INTERNALERROR>   File "/home/tyler/repos/pytest/_pytest/vendored_packages/pluggy.py", line 724, in __call__
INTERNALERROR>     return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
INTERNALERROR>   File "/home/tyler/repos/pytest/_pytest/vendored_packages/pluggy.py", line 338, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/tyler/repos/pytest/_pytest/vendored_packages/pluggy.py", line 333, in <lambda>
INTERNALERROR>     _MultiCall(methods, kwargs, hook.spec_opts).execute()
INTERNALERROR>   File "/home/tyler/repos/pytest/_pytest/vendored_packages/pluggy.py", line 596, in execute
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/tyler/repos/pytest/_pytest/mark.py", line 78, in pytest_collection_modifyitems
INTERNALERROR>     if keywordexpr and not matchkeyword(colitem, keywordexpr):
INTERNALERROR>   File "/home/tyler/repos/pytest/_pytest/mark.py", line 161, in matchkeyword
INTERNALERROR>     return eval(keywordexpr, {}, mapping)
INTERNALERROR>   File "<string>", line 1
INTERNALERROR>     not 4x4
INTERNALERROR>           ^
INTERNALERROR> SyntaxError: unexpected EOF while parsing

============================================ no tests ran in 0.00 seconds ===================================
```

It will also be triggered from the console if a user mistakenly prefixes the expression with a space:
```
$ py.test ./test_filter_name -k ' not 4x4'
```

I wasn't sure if the change warranted a test but I added quick one anyway. 
Also I figured this was too trivial to add to `AUTHORS` or `CHANGELOG`.

