### PR TITLE
Fix `repr_traceback` to work with unicode errors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,6 +61,7 @@ Marc Schlaich
 Mark Abramowitz
 Markus Unterwaditzer
 Martijn Faassen
+Martin Prusse
 Matt Bachmann
 Michael Aquilina
 Michael Birtwell

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,12 +7,21 @@
 
 *
 
+* Fix maximum recursion depth detection when raised error class is not aware
+  of unicode/encoded bytes.
+  Thanks `@prusse-martin`_ for the PR (`#1506`_).
+
 * Fix ``pytest.mark.skip`` mark when used in strict mode.
   Thanks `@pquentin`_ for the PR and `@RonnyPfannschmidt`_ for
   showing how to fix the bug.
 
 * Minor improvements and fixes to the documentation.
   Thanks `@omarkohl`_ for the PR.
+
+
+.. _#1506: https://github.com/pytest-dev/pytest/pull/1506
+
+.. _@prusse-martin: https://github.com/prusse-martin
 
 
 2.9.1

--- a/_pytest/_code/code.py
+++ b/_pytest/_code/code.py
@@ -579,9 +579,8 @@ class FormattedExcinfo(object):
         if self.tbfilter:
             traceback = traceback.filter()
         recursionindex = None
-        if excinfo.errisinstance(RuntimeError):
-            if "maximum recursion depth exceeded" in str(excinfo.value):
-                recursionindex = traceback.recursionindex()
+        if is_recursion_error(excinfo):
+            recursionindex = traceback.recursionindex()
         last = traceback[-1]
         entries = []
         extraline = None
@@ -793,3 +792,14 @@ def getrawcode(obj, trycall=True):
                     return x
         return obj
 
+if sys.version_info[:2] >= (3, 5):  # RecursionError introduced in 3.5
+    def is_recursion_error(excinfo):
+        return excinfo.errisinstance(RecursionError)  # noqa
+else:
+    def is_recursion_error(excinfo):
+        if not excinfo.errisinstance(RuntimeError):
+            return False
+        try:
+            return "maximum recursion depth exceeded" in str(excinfo.value)
+        except UnicodeError:
+            return False

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -3,7 +3,7 @@
 import _pytest
 import py
 import pytest
-from _pytest._code.code import FormattedExcinfo, ReprExceptionInfo
+from _pytest._code.code import ExceptionInfo, FormattedExcinfo, ReprExceptionInfo
 
 queue = py.builtin._tryimport('queue', 'Queue')
 
@@ -909,3 +909,19 @@ raise ValueError()
         assert tw.lines[14] == "E       ValueError"
         assert tw.lines[15] == ""
         assert tw.lines[16].endswith("mod.py:9: ValueError")
+
+
+@pytest.mark.parametrize("style", ["short", "long"])
+@pytest.mark.parametrize("encoding", [None, "utf8", "utf16"])
+def test_repr_traceback_with_unicode(style, encoding):
+    msg = u'☹'
+    if encoding is not None:
+        msg = msg.encode(encoding)
+    try:
+        raise RuntimeError(msg)
+    except RuntimeError:
+        e_info = ExceptionInfo()
+    formatter = FormattedExcinfo(style=style)
+    repr_traceback = formatter.repr_traceback(e_info)
+    assert repr_traceback is not None
+


### PR DESCRIPTION
Properly handle errors with unicode messages (could cause unicode decode errors when converting to `str`).
Added test to check if different encodings in raised error will not cause the code to fail.
