### PR TITLE
add pytest.logs context manager

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -80,6 +80,7 @@ Ronny Pfannschmidt
 Ross Lawley
 Ryan Wooden
 Samuele Pedroni
+Stephen Fuhry
 Tareq Alayan
 Tom Viner
 Trevor Bekolay

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,8 @@
   Thanks `@omarkohl`_ for the complete PR (`#1502`_) and `@nicoddemus`_ for the
   implementation tips.
 
-*
+* New ``pytest.logs()``` context manager. Backport of stdlib assertLogs in
+  unittest library.
 
 **Changes**
 

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -8,6 +8,7 @@ import types
 import sys
 import math
 import collections
+import logging
 
 import py
 import pytest
@@ -273,6 +274,7 @@ def pytest_namespace():
         'fixture': fixture,
         'yield_fixture': yield_fixture,
         'raises': raises,
+        'logs': logs,
         'approx': approx,
         'collect': {
         'Module': Module, 'Class': Class, 'Instance': Instance,
@@ -1343,6 +1345,23 @@ def raises(expected_exception, *args, **kwargs):
             return _pytest._code.ExceptionInfo()
     pytest.fail("DID NOT RAISE {0}".format(expected_exception))
 
+
+# builtin pytest.logs helper
+
+def logs(logger=None, level=None):
+    """Fail unless a log message of level *level* or higher is emitted
+    on *logger_name* or its children.  If omitted, *level* defaults to
+    INFO and *logger* defaults to the root logger.
+    Example::
+        with pytest.logs('foo', level='INFO') as cm:
+            logging.getLogger('foo').info('first message')
+            logging.getLogger('foo.bar').error('second message')
+        assert cm.output == ['INFO:foo:first message',
+                             'ERROR:foo.bar:second message']
+    """
+    return LogsContext(logger, level)
+
+
 class RaisesContext(object):
     def __init__(self, expected_exception):
         self.expected_exception = expected_exception
@@ -1365,6 +1384,76 @@ class RaisesContext(object):
                 tp = exc_type, exc_type(value), traceback
         self.excinfo.__init__(tp)
         return issubclass(self.excinfo.type, self.expected_exception)
+
+
+class LogsContext(object):
+    """A context manager used to implement logs().
+    This is back-ported from stdlib python.unittest.case._AssertLogsContext
+    See: https://hg.python.org/cpython/rev/4f5815747f58
+    """
+
+    LOGGING_FORMAT = "%(levelname)s:%(name)s:%(message)s"
+
+    def __init__(self, logger_name, level):
+        self.logger_name = logger_name
+        if level:
+            self.level = logging._nameToLevel.get(level, level)
+        else:
+            self.level = logging.INFO
+        self.msg = None
+
+    def __enter__(self):
+        if isinstance(self.logger_name, logging.Logger):
+            logger = self.logger = self.logger_name
+        else:
+            logger = self.logger = logging.getLogger(self.logger_name)
+        formatter = logging.Formatter(self.LOGGING_FORMAT)
+        handler = _CapturingHandler()
+        handler.setFormatter(formatter)
+        self.watcher = handler.watcher
+        self.old_handlers = logger.handlers[:]
+        self.old_level = logger.level
+        self.old_propagate = logger.propagate
+        logger.handlers = [handler]
+        logger.setLevel(self.level)
+        logger.propagate = False
+        return handler.watcher
+
+    def __exit__(self, exc_type, exc_value, tb):
+        self.logger.handlers = self.old_handlers
+        self.logger.propagate = self.old_propagate
+        self.logger.setLevel(self.old_level)
+        if exc_type is not None:
+            # let unexpected exceptions pass through
+            return False
+        if len(self.watcher.records) == 0:
+            pytest.fail(
+                "no logs of level {} or higher triggered on {}"
+                .format(logging.getLevelName(self.level), self.logger.name))
+
+try:
+    from unittest.case import _CapturingHandler
+except ImportError:
+
+    _LoggingWatcher = collections.namedtuple("_LoggingWatcher",
+                                             ["records", "output"])
+    class _CapturingHandler(logging.Handler):
+        """
+        A logging handler capturing all (raw and formatted) logging output.
+        """
+
+        def __init__(self):
+            logging.Handler.__init__(self)
+            self.watcher = _LoggingWatcher([], [])
+
+        def flush(self):
+            pass
+
+        def emit(self, record):
+            self.watcher.records.append(record)
+            msg = self.format(record)
+            self.watcher.output.append(msg)
+
 
 # builtin pytest.approx helper
 

--- a/testing/python/logs.py
+++ b/testing/python/logs.py
@@ -1,0 +1,113 @@
+import io
+import sys
+import logging
+import contextlib
+
+import pytest
+
+
+@contextlib.contextmanager
+def captured_stderr():
+    """Return a context manager used by stderr
+    that temporarily replaces the sys stream stderr with a StringIO."""
+    orig_stdout = sys.stderr
+    sys.stderr = io.StringIO()
+    try:
+        yield sys.stderr
+    finally:
+        sys.stderr = orig_stdout
+
+
+log_foo = logging.getLogger('foo')
+log_foobar = logging.getLogger('foo.bar')
+log_quux = logging.getLogger('quux')
+
+
+class TestLogs:
+
+    @contextlib.contextmanager
+    def assertNoStderr(self):
+        with captured_stderr() as buf:
+            yield
+        assert buf.getvalue() == ""
+
+    def assertLogRecords(self, records, matches):
+        assert len(records) == len(matches)
+        for rec, match in zip(records, matches):
+            assert isinstance(rec, logging.LogRecord)
+            for k, v in match.items():
+                assert getattr(rec, k) == v
+
+    def test_logs_defaults(self):
+        with self.assertNoStderr():
+            with pytest.logs() as cm:
+                log_foo.info("1")
+                log_foobar.debug("2")
+            assert cm.output == ["INFO:foo:1"]
+            self.assertLogRecords(cm.records, [{'name': 'foo'}])
+
+    def testAssertLogsTwoMatchingMessages(self):
+        # Same, but with two matching log messages
+        with self.assertNoStderr():
+            with pytest.logs() as cm:
+                log_foo.info("1")
+                log_foobar.debug("2")
+                log_quux.warning("3")
+            assert cm.output == ["INFO:foo:1", "WARNING:quux:3"]
+            self.assertLogRecords(cm.records,
+                                  [{'name': 'foo'}, {'name': 'quux'}])
+
+    def checkAssertLogsPerLevel(self, level):
+        # Check level filtering
+        with self.assertNoStderr():
+            with pytest.logs(level=level) as cm:
+                log_foo.warning("1")
+                log_foobar.error("2")
+                log_quux.critical("3")
+            assert cm.output == ["ERROR:foo.bar:2", "CRITICAL:quux:3"]
+            self.assertLogRecords(cm.records,
+                                   [{'name': 'foo.bar'}, {'name': 'quux'}])
+
+    def testAssertLogsPerLevel(self):
+        self.checkAssertLogsPerLevel(logging.ERROR)
+        self.checkAssertLogsPerLevel('ERROR')
+
+    def checkAssertLogsPerLogger(self, logger):
+        # Check per-logger fitering
+        with self.assertNoStderr():
+            with pytest.logs(level='DEBUG') as outer_cm:
+                with pytest.logs(logger, level='DEBUG') as cm:
+                    log_foo.info("1")
+                    log_foobar.debug("2")
+                    log_quux.warning("3")
+                assert cm.output == ["INFO:foo:1", "DEBUG:foo.bar:2"]
+                self.assertLogRecords(cm.records,
+                                       [{'name': 'foo'}, {'name': 'foo.bar'}])
+            # The outer catchall caught the quux log
+            assert outer_cm.output == ["WARNING:quux:3"]
+
+    def testAssertLogsPerLogger(self):
+        self.checkAssertLogsPerLogger(logging.getLogger('foo'))
+        self.checkAssertLogsPerLogger('foo')
+
+    def testAssertLogsFailureNoLogs(self):
+        # Failure due to no logs
+        with self.assertNoStderr():
+            with pytest.raises(pytest.fail.Exception):
+                with pytest.logs():
+                    pass
+
+    def testAssertLogsFailureLevelTooHigh(self):
+        # Failure due to level too high
+        with self.assertNoStderr():
+            with pytest.raises(pytest.fail.Exception):
+                with pytest.logs(level='WARNING'):
+                    log_foo.info("1")
+
+    def testAssertLogsFailureMismatchingLogger(self):
+        # Failure due to mismatching logger (and the logged message is
+        # passed through)
+        with pytest.logs('quux', level='ERROR'):
+            with pytest.raises(pytest.fail.Exception):
+                with pytest.logs('foo'):
+                    log_quux.error("1")


### PR DESCRIPTION
Backport from python 3.4 https://hg.python.org/cpython/rev/4f5815747f58

Having an issue or two with some regressions in the test suite that may have something to do with the way I'm modifying `sys.stderr` temporarily, but I'm not sure yet.

Thanks in advance for the feedback!