### PR TITLE
doc: Use ascii chars for file tree

### DIFF
--- a/doc/en/example/pythoncollection.rst
+++ b/doc/en/example/pythoncollection.rst
@@ -9,19 +9,19 @@ by passing the ``--ignore=path`` option on the cli. ``pytest`` allows multiple
 ``--ignore`` options. Example::
 
     tests/
-    ├── example
-    │   ├── test_example_01.py
-    │   ├── test_example_02.py
-    │   └── test_example_03.py
-    ├── foobar
-    │   ├── test_foobar_01.py
-    │   ├── test_foobar_02.py
-    │   └── test_foobar_03.py
-    └── hello
-        └── world
-            ├── test_world_01.py
-            ├── test_world_02.py
-            └── test_world_03.py
+    |-- example
+    |   |-- test_example_01.py
+    |   |-- test_example_02.py
+    |   '-- test_example_03.py
+    |-- foobar
+    |   |-- test_foobar_01.py
+    |   |-- test_foobar_02.py
+    |   '-- test_foobar_03.py
+    '-- hello
+        '-- world
+            |-- test_world_01.py
+            |-- test_world_02.py
+            '-- test_world_03.py
 
 Now if you invoke ``pytest`` with ``--ignore=tests/foobar/test_foobar_03.py --ignore=tests/hello/``,
 you will see that ``pytest`` only collects test-modules, which do not match the patterns specified::


### PR DESCRIPTION
LaTeX doesn't like those particular unicode chars, so let's avoid them so the
PDF builds easily.