### PR TITLE
Raise CollectError if pytest.skip() is called during collection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,24 @@
+3.0.0.dev1
+==========
+
+**Changes**
+
+*
+
+*
+
+*
+
+* Fix (`#607`_): pytest.skip() is no longer allowed at module level to
+  prevent misleading use as test function decorator. When used at a module
+  level an error will be raised during collection.
+  Thanks `@omarkohl`_ for the complete PR (`#1519`_).
+
+*
+
+.. _#607: https://github.com/pytest-dev/pytest/issues/607
+.. _#1519: https://github.com/pytest-dev/pytest/pull/1519
+
 2.10.0.dev1
 ===========
 

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -656,6 +656,12 @@ class Module(pytest.File, PyCollector):
                 "Make sure your test modules/packages have valid Python names."
                 % (self.fspath, exc or exc_class)
             )
+        except _pytest.runner.Skipped:
+            raise self.CollectError(
+                "Using @pytest.skip outside a test (e.g. as a test function "
+                "decorator) is not allowed. Use @pytest.mark.skip or "
+                "@pytest.mark.skipif instead."
+            )
         #print "imported test module", mod
         self.config.pluginmanager.consider_module(mod)
         return mod

--- a/testing/test_resultlog.py
+++ b/testing/test_resultlog.py
@@ -83,18 +83,9 @@ class TestWithFunctionIntegration:
 
     def test_collection_report(self, testdir):
         ok = testdir.makepyfile(test_collection_ok="")
-        skip = testdir.makepyfile(test_collection_skip=
-            "import pytest ; pytest.skip('hello')")
         fail = testdir.makepyfile(test_collection_fail="XXX")
         lines = self.getresultlog(testdir, ok)
         assert not lines
-
-        lines = self.getresultlog(testdir, skip)
-        assert len(lines) == 2
-        assert lines[0].startswith("S ")
-        assert lines[0].endswith("test_collection_skip.py")
-        assert lines[1].startswith(" ")
-        assert lines[1].endswith("test_collection_skip.py:1: Skipped: hello")
 
         lines = self.getresultlog(testdir, fail)
         assert lines

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -365,18 +365,6 @@ class TestSessionReports:
         assert res[0].name == "test_func1"
         assert res[1].name == "TestClass"
 
-    def test_skip_at_module_scope(self, testdir):
-        col = testdir.getmodulecol("""
-            import pytest
-            pytest.skip("hello")
-            def test_func():
-                pass
-        """)
-        rep = main.collect_one_node(col)
-        assert not rep.failed
-        assert not rep.passed
-        assert rep.skipped
-
 
 reporttypes = [
     runner.BaseReport,

--- a/testing/test_session.py
+++ b/testing/test_session.py
@@ -174,10 +174,6 @@ class TestNewSession(SessionTests):
                 class TestY(TestX):
                     pass
             """,
-            test_two="""
-                import pytest
-                pytest.skip('xxx')
-            """,
             test_three="xxxdsadsadsadsa",
             __init__=""
         )
@@ -189,11 +185,9 @@ class TestNewSession(SessionTests):
         started = reprec.getcalls("pytest_collectstart")
         finished = reprec.getreports("pytest_collectreport")
         assert len(started) == len(finished)
-        assert len(started) == 8 # XXX extra TopCollector
+        assert len(started) == 7 # XXX extra TopCollector
         colfail = [x for x in finished if x.failed]
-        colskipped = [x for x in finished if x.skipped]
         assert len(colfail) == 1
-        assert len(colskipped) == 1
 
     def test_minus_x_import_error(self, testdir):
         testdir.makepyfile(__init__="")

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -682,10 +682,6 @@ def test_skipped_reasons_functional(testdir):
                 def test_method(self):
                     doskip()
        """,
-       test_two = """
-            from conftest import doskip
-            doskip()
-       """,
        conftest = """
             import pytest
             def doskip():
@@ -694,7 +690,7 @@ def test_skipped_reasons_functional(testdir):
     )
     result = testdir.runpytest('--report=skipped')
     result.stdout.fnmatch_lines([
-        "*SKIP*3*conftest.py:3: test",
+        "*SKIP*2*conftest.py:3: test",
     ])
     assert result.ret == 0
 
@@ -941,3 +937,19 @@ def test_xfail_item(testdir):
     assert not failed
     xfailed = [r for r in skipped if hasattr(r, 'wasxfail')]
     assert xfailed
+
+
+def test_module_level_skip_error(testdir):
+    """
+    Verify that using pytest.skip at module level causes a collection error
+    """
+    testdir.makepyfile("""
+        import pytest
+        @pytest.skip
+        def test_func():
+            assert True
+    """)
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(
+        "*Using @pytest.skip outside a test * is not allowed*"
+    )

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -223,8 +223,7 @@ class TestCollectonly:
         """)
         result = testdir.runpytest("--collect-only", "-rs")
         result.stdout.fnmatch_lines([
-            "SKIP*hello*",
-            "*1 skip*",
+            "*ERROR collecting*",
         ])
 
     def test_collectonly_failed_module(self, testdir):


### PR DESCRIPTION
I'll add the `CHANGELOG` and documentation once I get some feedback if this is correct.

This change effectively disables using `pytest.skip` at module level (even as a normal function not only as a decorator) because that is how I understand issue #607 .

@nicoddemus:

>> @nicoddemus @hpk should we issue a pytest_warning if pytest.skip happens outside of the runtestprotocol?

> Sounds good, but as we commented before, the current warnings system could use some improvements.

@nicoddemus:

> On second thought I think this should actually fail the collection of that module.


This earlier comment by @hpk42 is also an option:

> What about making pytest.skip fail when a function object is passed and point to "pytest.mark.skipif" and the docs?

I tried checking the type of the `msg` parameter in `pytest.skip` and it achieves the desired result.

Here's a quick checklist that should be present in PRs:

- [X] Target: for bug or doc fixes, target `master`; for new features, target `features`
- [X] Make sure to include one or more tests for your change
- [X] Add yourself to `AUTHORS`
- [x] Add a new entry to the `CHANGELOG` (choose any open position to avoid merge conflicts with other PRs) 

pytest.skip() must not be used at module level because it can easily be
misunderstood and used as a decorator instead of pytest.mark.skip, causing the
whole module to be skipped instead of just the test being decorated.

This is unexpected for users used to the @unittest.skip decorator and therefore
it is best to bail out with a clean error when it happens.

The pytest equivalent of @unittest.skip is @pytest.mark.skip .

Adapt existing tests that were actually relying on this behaviour and add a
test that explicitly test that collection fails.

fix #607