### PR TITLE
Raise CollectError if import test module fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,7 +39,9 @@
   parametrize.
   Thanks `@palaviv`_ for the complete PR (`#1474`_).
 
-*
+* Fix `#1426`_ Make ImportError during collection more explicit by reminding
+  the user to check the name of the test module/package(s).
+  Thanks `@omarkohl`_ for the complete PR (`#1520`_).
 
 .. _@milliams: https://github.com/milliams
 .. _@novas0x2a: https://github.com/novas0x2a
@@ -49,6 +51,7 @@
 .. _@palaviv: https://github.com/palaviv
 .. _@omarkohl: https://github.com/omarkohl
 
+.. _#1426: https://github.com/pytest-dev/pytest/issues/1426
 .. _#1428: https://github.com/pytest-dev/pytest/pull/1428
 .. _#1444: https://github.com/pytest-dev/pytest/pull/1444
 .. _#1441: https://github.com/pytest-dev/pytest/pull/1441
@@ -57,6 +60,7 @@
 .. _#1468: https://github.com/pytest-dev/pytest/pull/1468
 .. _#1474: https://github.com/pytest-dev/pytest/pull/1474
 .. _#1502: https://github.com/pytest-dev/pytest/pull/1502
+.. _#1520: https://github.com/pytest-dev/pytest/pull/1520
 .. _#372: https://github.com/pytest-dev/pytest/issues/372
 
 2.9.2.dev1

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -636,6 +636,14 @@ class Module(pytest.File, PyCollector):
                 "unique basename for your test file modules"
                  % e.args
             )
+        except ImportError:
+            exc_class, exc, _ = sys.exc_info()
+            raise self.CollectError(
+                "ImportError while importing test module '%s'.\n"
+                "Original error message:\n'%s'\n"
+                "Make sure your test modules/packages have valid Python names."
+                % (self.fspath, exc or exc_class)
+            )
         #print "imported test module", mod
         self.config.pluginmanager.consider_module(mod)
         return mod

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -117,7 +117,8 @@ class TestGeneralUsage:
         result = testdir.runpytest(p)
         result.stdout.fnmatch_lines([
             #XXX on jython this fails:  ">   import import_fails",
-            "E   ImportError: No module named *does_not_work*",
+            "ImportError while importing test module*",
+            "'No module named *does_not_work*",
         ])
         assert result.ret == 1
 

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -5,14 +5,16 @@ from textwrap import dedent
 import _pytest._code
 import py
 import pytest
-from _pytest.main import EXIT_NOTESTSCOLLECTED
+from _pytest.main import (
+    Collector,
+    EXIT_NOTESTSCOLLECTED
+)
 
 
 class TestModule:
     def test_failing_import(self, testdir):
         modcol = testdir.getmodulecol("import alksdjalskdjalkjals")
-        pytest.raises(ImportError, modcol.collect)
-        pytest.raises(ImportError, modcol.collect)
+        pytest.raises(Collector.CollectError, modcol.collect)
 
     def test_import_duplicate(self, testdir):
         a = testdir.mkdir("a")
@@ -59,6 +61,16 @@ class TestModule:
     def test_module_considers_pluginmanager_at_import(self, testdir):
         modcol = testdir.getmodulecol("pytest_plugins='xasdlkj',")
         pytest.raises(ImportError, lambda: modcol.obj)
+
+    def test_invalid_test_module_name(self, testdir):
+        a = testdir.mkdir('a')
+        a.ensure('test_one.part1.py')
+        result = testdir.runpytest("-rw")
+        result.stdout.fnmatch_lines([
+            "ImportError while importing test module*test_one.part1*",
+            "Make sure your test modules/packages have valid Python names.",
+        ])
+
 
 class TestClass:
     def test_class_with_init_warning(self, testdir):

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -176,7 +176,8 @@ class TestPrunetraceback:
         assert "__import__" not in result.stdout.str(), "too long traceback"
         result.stdout.fnmatch_lines([
             "*ERROR collecting*",
-            "*mport*not_exists*"
+            "ImportError while importing test module*",
+            "'No module named *not_exists*",
         ])
 
     def test_custom_repr_failure(self, testdir):

--- a/testing/test_session.py
+++ b/testing/test_session.py
@@ -42,7 +42,7 @@ class SessionTests:
         reprec = testdir.inline_run(tfile)
         l = reprec.getfailedcollections()
         assert len(l) == 1
-        out = l[0].longrepr.reprcrash.message
+        out = str(l[0].longrepr)
         assert out.find('does_not_work') != -1
 
     def test_raises_output(self, testdir):

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -276,8 +276,8 @@ class TestCollectonly:
         assert result.ret == 1
         result.stdout.fnmatch_lines(_pytest._code.Source("""
             *ERROR*
-            *import Errlk*
             *ImportError*
+            *No module named *Errlk*
             *1 error*
         """).strip())
 
@@ -665,8 +665,8 @@ class TestGenericReporting:
         testdir.makepyfile("import xyz\n")
         result = testdir.runpytest(*option.args)
         result.stdout.fnmatch_lines([
-            "?   import xyz",
-            "E   ImportError: No module named *xyz*",
+            "ImportError while importing*",
+            "'No module named *xyz*",
             "*1 error*",
         ])
 


### PR DESCRIPTION
A few tests are still failing and need to be fixed. I will do that and adapt the `CHANGELOG` if the change makes sense.

I honestly don't see much point in fixing #1426 (but did it because it looked simple enough).

Here's a quick checklist that should be present in PRs:

- [X] Target: for bug or doc fixes, target `master`; for new features, target `features`
- [X] Make sure to include one or more tests for your change
- [X] Add yourself to `AUTHORS`
- [x] Add a new entry to the `CHANGELOG` (choose any open position to avoid merge conflicts with other PRs) 

One of the reasons for failing to import the test module is invalid Python
identifiers in the full package path of the test module.

fix #1426