### PR TITLE
Fix a small issue about shlex.split not working well with win32 path

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -87,3 +87,4 @@ Russel Winder
 Ben Webb
 Alexei Kozlenok
 Cal Leeming
+Feng Ma

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,8 @@
 
 *
 
-*
+* Fix win32 path issue when puttinging custom config file with absolute path 
+  in ``pytest.main("-c your_absolute_path")``.
 
 * Fix maximum recursion depth detection when raised error class is not aware
   of unicode/encoded bytes.

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -104,7 +104,10 @@ def _prepareconfig(args=None, plugins=None):
     elif not isinstance(args, (tuple, list)):
         if not isinstance(args, str):
             raise ValueError("not a string or argument list: %r" % (args,))
-        args = shlex.split(args)
+        if sys.platform == "win32":
+            args = shlex.split(args, posix=False)
+        else:
+            args = shlex.split(args)
     config = get_config()
     pluginmanager = config.pluginmanager
     try:

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -104,10 +104,7 @@ def _prepareconfig(args=None, plugins=None):
     elif not isinstance(args, (tuple, list)):
         if not isinstance(args, str):
             raise ValueError("not a string or argument list: %r" % (args,))
-        if sys.platform == "win32":
-            args = shlex.split(args, posix=False)
-        else:
-            args = shlex.split(args)
+        args = shlex.split(args, posix=sys.platform == "win32")
     config = get_config()
     pluginmanager = config.pluginmanager
     try:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -79,7 +79,7 @@ class TestParseIni:
         """)
         result = testdir.inline_run("--confcutdir=.")
         assert result.ret == 0
-
+        
 class TestConfigCmdlineParsing:
     def test_parsing_again_fails(self, testdir):
         config = testdir.parseconfig()
@@ -100,6 +100,16 @@ class TestConfigCmdlineParsing:
         """)
         config = testdir.parseconfig("-c", "custom.cfg")
         assert config.getini("custom") == "1"
+
+    def test_absolute_win32_path(self, testdir):
+        temp_cfg_file = testdir.makefile(".cfg", custom="""
+            [pytest]
+            addopts = --version
+        """)
+        from os.path import normpath
+        temp_cfg_file = normpath(str(temp_cfg_file))
+        ret = pytest.main("-c " + temp_cfg_file)
+        assert ret == _pytest.main.EXIT_OK
 
 class TestConfigAPI:
     def test_config_trace(self, testdir):


### PR DESCRIPTION
Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Target: **Fix a win32 path issue, so I target master branch**
- [x] Tests: **added**
- [x] Add yourself to `AUTHORS` (**done**)
- [x] Add a new entry to the `CHANGELOG` (**done**) 

Issue description:

Under `win32` machine:

```
import pytest
get_ini_path = from_some_other_func
pytest.main("-c " + get_ini_path)
```

Look at the ``shlex.split`` signature:
```
shlex.split(str, posix=True)
```
the ``posix`` default value is ``True``, once I passed a `win32` path (e.x. `D:\tests\pytest.ini`) into `shlex.split`, it will output as `Dtestspytest.ini`. This PR will check the platform firstly before applying the `win32` path into `shlex.split`.