### PR TITLE
issue 1496 - xfail with condition keyword

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,9 @@
 
 **Bug Fixes**
 
-*
+* Fix Xfail does not work with condition keyword argument.
+  Thanks `@astraw38`_ for reporting the issue (`#1496`_) and `@tomviner`_
+  for PR the (`#1524`_).
 
 *
 
@@ -20,8 +22,11 @@
 
 
 .. _#1506: https://github.com/pytest-dev/pytest/pull/1506
+.. _#1496: https://github.com/pytest-dev/pytest/issue/1496
+.. _#1524: https://github.com/pytest-dev/pytest/issue/1524
 
 .. _@prusse-martin: https://github.com/prusse-martin
+.. _@astraw38: https://github.com/astraw38
 
 
 2.9.1

--- a/_pytest/skipping.py
+++ b/_pytest/skipping.py
@@ -120,7 +120,7 @@ class MarkEvaluator:
             return self.result
         if self.holder:
             d = self._getglobals()
-            if self.holder.args:
+            if self.holder.args or 'condition' in self.holder.kwargs:
                 self.result = False
                 # "holder" might be a MarkInfo or a MarkDecorator; only
                 # MarkInfo keeps track of all parameters it received in an
@@ -130,6 +130,8 @@ class MarkEvaluator:
                 else:
                     arglist = [(self.holder.args, self.holder.kwargs)]
                 for args, kwargs in arglist:
+                    if 'condition' in kwargs:
+                        args = (kwargs['condition'],)
                     for expr in args:
                         self.expr = expr
                         if isinstance(expr, py.builtin._basestring):

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -405,6 +405,19 @@ class TestXFail:
         result.stdout.fnmatch_lines('*1 passed*')
         assert result.ret == 0
 
+    @pytest.mark.parametrize('strict', [True, False])
+    def test_xfail_condition_keyword(self, testdir, strict):
+        p = testdir.makepyfile("""
+            import pytest
+
+            @pytest.mark.xfail(condition=False, reason='unsupported feature', strict=%s)
+            def test_foo():
+                pass
+        """ % strict)
+        result = testdir.runpytest(p, '-rxX')
+        result.stdout.fnmatch_lines('*1 passed*')
+        assert result.ret == 0
+
     @pytest.mark.parametrize('strict_val', ['true', 'false'])
     def test_strict_xfail_default_from_file(self, testdir, strict_val):
         testdir.makeini('''


### PR DESCRIPTION
Fix for https://github.com/pytest-dev/pytest/issues/1496 Xfail does not work with condition keyword argument.

We were only looking at `args`, despite [the docs saying](https://pytest.org/latest/skipping.html#xfail-signature-summary):
> Here’s the signature of the xfail marker, using Python 3 keyword-only arguments syntax:
> `def xfail(condition=None, *, reason=None, raises=None, run=True, strict=False):`