### PR TITLE
Fix TracebackItem documentation in pytest.code

### DIFF
--- a/_pytest/_code/code.py
+++ b/_pytest/_code/code.py
@@ -294,11 +294,11 @@ class Traceback(list):
     def filter(self, fn=lambda x: not x.ishidden()):
         """ return a Traceback instance with certain items removed
 
-            fn is a function that gets a single argument, a TracebackItem
+            fn is a function that gets a single argument, a TracebackEntry
             instance, and should return True when the item should be added
             to the Traceback, False when not
 
-            by default this removes all the TracebackItems which are hidden
+            by default this removes all the TracebackEntries which are hidden
             (see ishidden() above)
         """
         return Traceback(filter(fn, self))
@@ -314,7 +314,7 @@ class Traceback(list):
         return self[-1]
 
     def recursionindex(self):
-        """ return the index of the frame/TracebackItem where recursion
+        """ return the index of the frame/TracebackEntry where recursion
             originates if appropriate, None if no recursion occurred
         """
         cache = {}


### PR DESCRIPTION
The TracebackItem class does not exist, but it seems the docstrings refer to
TracebackEntry.