### PR TITLE
Filter selectively with __tracebackhide__

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,8 +23,9 @@
   Thanks `@omarkohl`_ for the complete PR (`#1502`_) and `@nicoddemus`_ for the
   implementation tips.
 
-* ``__tracebackhide__`` can now also be set to an exception type (or a list of
-  exception types) to only filter exceptions of that type.
+* ``__tracebackhide__`` can now also be set to a callable which then can decide
+  whether to filter the traceback based on the ``ExceptionInfo`` object passed
+  to it.
 
 *
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,9 @@
   Thanks `@omarkohl`_ for the complete PR (`#1502`_) and `@nicoddemus`_ for the
   implementation tips.
 
+* ``__tracebackhide__`` can now also be set to an exception type (or a list of
+  exception types) to only filter exceptions of that type.
+
 *
 
 **Changes**

--- a/_pytest/_code/code.py
+++ b/_pytest/_code/code.py
@@ -235,7 +235,7 @@ class TracebackEntry(object):
             except KeyError:
                 return False
 
-        if callable(tbh):
+        if py.builtin.callable(tbh):
             return tbh(self._excinfo)
         else:
             return tbh

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -216,16 +216,18 @@ Let's run our little function::
     test_checkconfig.py:8: Failed
     1 failed in 0.12 seconds
 
-If you only want to hide certain exception classes, you can also set
-``__tracebackhide__`` to an exception type or a list of exception types::
+If you only want to hide certain exceptions, you can set ``__tracebackhide__``
+to a callable which gets the ``ExceptionInfo`` object. You can for example use
+this to make sure unexpected exception types aren't hidden::
 
+    import operator
     import pytest
 
     class ConfigException(Exception):
         pass
 
     def checkconfig(x):
-        __tracebackhide__ = ConfigException
+        __tracebackhide__ = operator.methodcaller('errisinstance', ConfigException)
         if not hasattr(x, "config"):
             raise ConfigException("not configured: %s" %(x,))
 

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -216,6 +216,26 @@ Let's run our little function::
     test_checkconfig.py:8: Failed
     1 failed in 0.12 seconds
 
+If you only want to hide certain exception classes, you can also set
+``__tracebackhide__`` to an exception type or a list of exception types::
+
+    import pytest
+
+    class ConfigException(Exception):
+        pass
+
+    def checkconfig(x):
+        __tracebackhide__ = ConfigException
+        if not hasattr(x, "config"):
+            raise ConfigException("not configured: %s" %(x,))
+
+    def test_something():
+        checkconfig(42)
+
+This will avoid hiding the exception traceback on unrelated exceptions (i.e.
+bugs in assertion helpers).
+
+
 Detect if running from within a pytest run
 --------------------------------------------------------------
 

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import operator
 import _pytest
 import py
 import pytest
@@ -145,10 +146,10 @@ class TestTraceback_f_g_h:
         assert len(ntraceback) == len(traceback) - 1
 
     @pytest.mark.parametrize('tracebackhide, matching', [
-        (ValueError, True),
-        (IndexError, False),
-        ([ValueError, IndexError], True),
-        ((ValueError, IndexError), True),
+        (lambda info: True, True),
+        (lambda info: False, False),
+        (operator.methodcaller('errisinstance', ValueError), True),
+        (operator.methodcaller('errisinstance', IndexError), False),
     ])
     def test_traceback_filter_selective(self, tracebackhide, matching):
         def f():
@@ -475,7 +476,7 @@ raise ValueError()
             f_globals = {}
 
         class FakeTracebackEntry(_pytest._code.Traceback.Entry):
-            def __init__(self, tb, exctype=None):
+            def __init__(self, tb, excinfo=None):
                 self.lineno = 5+3
 
             @property

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -168,8 +168,8 @@ class TestTraceback_f_g_h:
         excinfo = pytest.raises(ValueError, h)
         traceback = excinfo.traceback
         ntraceback = traceback.filter()
-        print('old: {!r}'.format(traceback))
-        print('new: {!r}'.format(ntraceback))
+        print('old: {0!r}'.format(traceback))
+        print('new: {0!r}'.format(ntraceback))
 
         if matching:
             assert len(ntraceback) == len(traceback) - 2


### PR DESCRIPTION
When `__tracebackhide__` gets set to an exception type or list/tuple of exception types, only those exceptions get filtered, while the full traceback is shown if another exception (e.g. a bug in a assertion helper) happens.