### PR TITLE
fix #510 by adding a describing skip marker on empty parameterize

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@
 * Minor improvements and fixes to the documentation.
   Thanks `@omarkohl`_ for the PR.
 
-
+.. _#510: https://github.com/pytest-dev/pytest/issues/510
 .. _#1506: https://github.com/pytest-dev/pytest/pull/1506
 
 .. _@prusse-martin: https://github.com/prusse-martin

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,9 +3,10 @@
 
 **Bug Fixes**
 
-*
+* fix `#510`_: skip tests where one parameterize dimension was empty
+  thanks Alex Stapleton for the Report and `@RonnyPfannschmidt`_ for the PR
 
-* Fix win32 path issue when puttinging custom config file with absolute path 
+* Fix win32 path issue when puttinging custom config file with absolute path
   in ``pytest.main("-c your_absolute_path")``.
 
 * Fix maximum recursion depth detection when raised error class is not aware
@@ -78,7 +79,7 @@
   ``xfail_strict`` ini option that can be used to configure it project-wise.
   Thanks `@rabbbit`_ for the request and `@nicoddemus`_ for the PR (`#1355`_).
 
-* ``Parser.addini`` now supports options of type ``bool``. 
+* ``Parser.addini`` now supports options of type ``bool``.
   Thanks `@nicoddemus`_ for the PR.
 
 * New ``ALLOW_BYTES`` doctest option. This strips ``b`` prefixes from byte strings
@@ -89,25 +90,25 @@
   Fixes `#1366`_.
   Thanks to `@hpk42`_ for the report and `@RonnyPfannschmidt`_ for the PR.
 
-* Catch ``IndexError`` exceptions when getting exception source location. 
+* Catch ``IndexError`` exceptions when getting exception source location.
   Fixes a pytest internal error for dynamically generated code (fixtures and tests)
   where source lines are fake by intention.
 
 **Changes**
 
 * **Important**: `py.code <https://pylib.readthedocs.io/en/latest/code.html>`_ has been
-  merged into the ``pytest`` repository as ``pytest._code``. This decision 
-  was made because ``py.code`` had very few uses outside ``pytest`` and the 
-  fact that it was in a different repository made it difficult to fix bugs on 
+  merged into the ``pytest`` repository as ``pytest._code``. This decision
+  was made because ``py.code`` had very few uses outside ``pytest`` and the
+  fact that it was in a different repository made it difficult to fix bugs on
   its code in a timely manner. The team hopes with this to be able to better
   refactor out and improve that code.
   This change shouldn't affect users, but it is useful to let users aware
   if they encounter any strange behavior.
-  
-  Keep in mind that the code for ``pytest._code`` is **private** and 
+
+  Keep in mind that the code for ``pytest._code`` is **private** and
   **experimental**, so you definitely should not import it explicitly!
 
-  Please note that the original ``py.code`` is still available in 
+  Please note that the original ``py.code`` is still available in
   `pylib <https://pylib.readthedocs.io>`_.
 
 * ``pytest_enter_pdb`` now optionally receives the pytest config object.
@@ -201,7 +202,7 @@
 - fix #1292: monkeypatch calls (setattr, setenv, etc.) are now O(1).
   Thanks David R. MacIver for the report and Bruno Oliveira for the PR.
 
-- fix #1223: captured stdout and stderr are now properly displayed before 
+- fix #1223: captured stdout and stderr are now properly displayed before
   entering pdb when ``--pdb`` is used instead of being thrown away.
   Thanks Cal Leeming for the PR.
 
@@ -276,8 +277,8 @@
   Thanks Gabriel Reis for the PR.
 
 - add more talks to the documentation
-- extend documentation on the --ignore cli option 
-- use pytest-runner for setuptools integration 
+- extend documentation on the --ignore cli option
+- use pytest-runner for setuptools integration
 - minor fixes for interaction with OS X El Capitan
   system integrity protection (thanks Florian)
 

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -871,8 +871,6 @@ class CallSpec2(object):
             getattr(self, valtype_for_arg)[arg] = val
             self.indices[arg] = param_index
             self._arg2scopenum[arg] = scopenum
-            if val is _notexists:
-                self._emptyparamspecified = True
         self._idlist.append(id)
         self.keywords.update(keywords)
 
@@ -992,8 +990,10 @@ class Metafunc(FuncargnamesCompatAttr):
             argvalues = [(_notexists,) * len(argnames)]
             # we passed a empty list to parameterize, skip that test
             #
+            fs, lineno = getfslineno(self.function)
             newmark = pytest.mark.skip(
-                reason='argument listing for %r was empty' % argnames)
+                reason="got empty parameter set, function %s at %s:%d" % (
+                    self.function.__name__, fs, lineno))
             newmarks = newkeywords.setdefault(0, {})
             newmarks[newmark.markname] = newmark
 
@@ -1415,15 +1415,6 @@ class Function(FunctionMixin, pytest.Item, FuncargnamesCompatAttr):
         self.ihook.pytest_pyfunc_call(pyfuncitem=self)
 
     def setup(self):
-        # check if parametrization happend with an empty list
-        try:
-            self.callspec._emptyparamspecified
-        except AttributeError:
-            pass
-        else:
-            fs, lineno = self._getfslineno()
-            pytest.skip("got empty parameter set, function %s at %s:%d" %(
-                self.function.__name__, fs, lineno))
         super(Function, self).setup()
         fillfixtures(self)
 

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -990,6 +990,13 @@ class Metafunc(FuncargnamesCompatAttr):
                 argvalues = [(val,) for val in argvalues]
         if not argvalues:
             argvalues = [(_notexists,) * len(argnames)]
+            # we passed a empty list to parameterize, skip that test
+            #
+            newmark = pytest.mark.skip(
+                reason='argument listing for %r was empty' % argnames)
+            newmarks = newkeywords.setdefault(0, {})
+            newmarks[newmark.markname] = newmark
+
 
         if scope is None:
             scope = "function"

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -992,8 +992,8 @@ class Metafunc(FuncargnamesCompatAttr):
             #
             fs, lineno = getfslineno(self.function)
             newmark = pytest.mark.skip(
-                reason="got empty parameter set, function %s at %s:%d" % (
-                    self.function.__name__, fs, lineno))
+                reason="got empty parameter set %r, function %s at %s:%d" % (
+                    argnames, self.function.__name__, fs, lineno))
             newmarks = newkeywords.setdefault(0, {})
             newmarks[newmark.markname] = newmark
 

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -109,6 +109,13 @@ class TestMetafunc:
             metafunc.parametrize(("x","y"), [("abc", "def"),
                                              ("ghi", "jkl")], ids=["one"]))
 
+    @pytest.mark.issue510
+    def test_parametrize_empty_list(self):
+        def func( y): pass
+        metafunc = self.Metafunc(func)
+        metafunc.parametrize("y", [])
+        assert 'skip' in metafunc._calls[0].keywords
+
     def test_parametrize_with_userobjects(self):
         def func(x, y): pass
         metafunc = self.Metafunc(func)


### PR DESCRIPTION
this might need to go to features

also we might want to consider using a xfail marker with run=False instead of skip
