### PR TITLE
Fix typo in doc

### DIFF
--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1451,7 +1451,7 @@ class FixtureRequest(FuncargnamesCompatAttr):
         self._pyfuncitem = pyfuncitem
         #: fixture for which this request is being performed
         self.fixturename = None
-        #: Scope string, one of "function", "cls", "module", "session"
+        #: Scope string, one of "function", "class", "module", "session"
         self.scope = "function"
         self._funcargs  = {}
         self._fixturedefs = {}


### PR DESCRIPTION
Documentation for FixtureRequest.scope should say "class" instead of "cls".