### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -95,7 +95,7 @@
 
 **Changes**
 
-* **Important**: `py.code <http://pylib.readthedocs.org/en/latest/code.html>`_ has been
+* **Important**: `py.code <https://pylib.readthedocs.io/en/latest/code.html>`_ has been
   merged into the ``pytest`` repository as ``pytest._code``. This decision 
   was made because ``py.code`` had very few uses outside ``pytest`` and the 
   fact that it was in a different repository made it difficult to fix bugs on 
@@ -108,7 +108,7 @@
   **experimental**, so you definitely should not import it explicitly!
 
   Please note that the original ``py.code`` is still available in 
-  `pylib <http://pylib.readthedocs.org>`_.
+  `pylib <https://pylib.readthedocs.io>`_.
 
 * ``pytest_enter_pdb`` now optionally receives the pytest config object.
   Thanks `@nicoddemus`_ for the PR.

--- a/doc/en/announce/release-2.9.0.rst
+++ b/doc/en/announce/release-2.9.0.rst
@@ -75,7 +75,7 @@ The py.test Development Team
 
 **Changes**
 
-* **Important**: `py.code <http://pylib.readthedocs.org/en/latest/code.html>`_ has been
+* **Important**: `py.code <https://pylib.readthedocs.io/en/latest/code.html>`_ has been
   merged into the ``pytest`` repository as ``pytest._code``. This decision 
   was made because ``py.code`` had very few uses outside ``pytest`` and the 
   fact that it was in a different repository made it difficult to fix bugs on 
@@ -88,7 +88,7 @@ The py.test Development Team
   **experimental**, so you definitely should not import it explicitly!
 
   Please note that the original ``py.code`` is still available in 
-  `pylib <http://pylib.readthedocs.org>`_.
+  `pylib <https://pylib.readthedocs.io>`_.
 
 * ``pytest_enter_pdb`` now optionally receives the pytest config object.
   Thanks `@nicoddemus`_ for the PR.

--- a/doc/en/bash-completion.rst
+++ b/doc/en/bash-completion.rst
@@ -5,7 +5,7 @@ Setting up bash completion
 ==========================
 
 When using bash as your shell, ``pytest`` can use argcomplete
-(https://argcomplete.readthedocs.org/) for auto-completion.
+(https://argcomplete.readthedocs.io/) for auto-completion.
 For this ``argcomplete`` needs to be installed **and** enabled.
 
 Install argcomplete using::

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -703,7 +703,7 @@ Integrating pytest runner and cx_freeze
 -----------------------------------------------------------
 
 If you freeze your application using a tool like
-`cx_freeze <http://cx-freeze.readthedocs.org>`_ in order to distribute it
+`cx_freeze <https://cx-freeze.readthedocs.io>`_ in order to distribute it
 to your end-users, it is a good idea to also package your test runner and run
 your tests using the frozen application.
 

--- a/doc/en/links.inc
+++ b/doc/en/links.inc
@@ -6,7 +6,7 @@
 .. _`pytest_nose`: plugin/nose.html
 .. _`reStructured Text`: http://docutils.sourceforge.net
 .. _`Python debugger`: http://docs.python.org/lib/module-pdb.html
-.. _nose: https://nose.readthedocs.org/en/latest/
+.. _nose: https://nose.readthedocs.io/en/latest/
 .. _pytest: http://pypi.python.org/pypi/pytest
 .. _mercurial: http://mercurial.selenic.com/wiki/
 .. _`setuptools`: http://pypi.python.org/pypi/setuptools
@@ -18,4 +18,4 @@
 .. _hudson: http://hudson-ci.org/
 .. _jenkins: http://jenkins-ci.org/
 .. _tox: http://testrun.org/tox
-.. _pylib: http://py.readthedocs.org/en/latest/
+.. _pylib: https://py.readthedocs.io/en/latest/

--- a/doc/en/nose.rst
+++ b/doc/en/nose.rst
@@ -46,7 +46,7 @@ Unsupported idioms / known issues
   (e.g. ``tests/test_mode.py`` and ``other/tests/test_mode.py``)
   by extending sys.path/import semantics.   pytest does not do that
   but there is discussion in `issue268 <https://github.com/pytest-dev/pytest/issues/268>`_ for adding some support.  Note that
-  `nose2 choose to avoid this sys.path/import hackery <https://nose2.readthedocs.org/en/latest/differences.html#test-discovery-and-loading>`_.
+  `nose2 choose to avoid this sys.path/import hackery <https://nose2.readthedocs.io/en/latest/differences.html#test-discovery-and-loading>`_.
 
 - nose-style doctests are not collected and executed correctly,
   also doctest fixtures don't work.

--- a/doc/en/projects.rst
+++ b/doc/en/projects.rst
@@ -57,7 +57,7 @@ Here are some examples of projects using ``pytest`` (please send notes via :ref:
 * `bu <http://packages.python.org/bu/>`_ a microscopic build system
 * `katcp <https://bitbucket.org/hodgestar/katcp>`_ Telescope communication protocol over Twisted
 * `kss plugin timer <http://pypi.python.org/pypi/kss.plugin.timer>`_
-* `pyudev <http://pyudev.readthedocs.org/en/latest/tests/plugins.html>`_ a pure Python binding to the Linux library libudev
+* `pyudev <https://pyudev.readthedocs.io/en/latest/tests/plugins.html>`_ a pure Python binding to the Linux library libudev
 * `pytest-localserver <https://bitbucket.org/basti/pytest-localserver/>`_ a plugin for pytest that provides a httpserver and smtpserver
 * `pytest-monkeyplus <http://pypi.python.org/pypi/pytest-monkeyplus/>`_ a plugin that extends monkeypatch
 

--- a/doc/en/writing_plugins.rst
+++ b/doc/en/writing_plugins.rst
@@ -172,7 +172,7 @@ If a package is installed this way, ``pytest`` will load
 .. note::
 
     Make sure to include ``Framework :: Pytest`` in your list of
-    `PyPI classifiers <http://python-packaging-user-guide.readthedocs.org/en/latest/distributing/#classifiers>`_
+    `PyPI classifiers <https://python-packaging-user-guide.readthedocs.io/en/latest/distributing/#classifiers>`_
     to make it easy for users to find your plugin.
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def has_environment_marker_support():
 
     References:
 
-    * https://wheel.readthedocs.org/en/latest/index.html#defining-conditional-dependencies
+    * https://wheel.readthedocs.io/en/latest/index.html#defining-conditional-dependencies
     * https://www.python.org/dev/peps/pep-0426/#environment-markers
     """
     try:


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified. One was not modified - `http://media.readthedocs.org/epub/pytest/latest/pytest.epub` - since it doesn't work on `readthedocs.io`.