### PR TITLE
unittest.UnitTestCase: Allow __test__ for methods

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@ merlinux GmbH, Germany, office at merlinux eu
 
 Contributors include::
 
+Abdeali JK
 Abhijeet Kasurde
 Anatoly Bubenkoff
 Andreas Zeidler

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,10 @@
 
 **New Features**
 
+* Support nose-style ``__test__`` attribute on methods of classes,
+  including unittest-style Classes. If set to False, the test will not be
+  collected.
+
 * New ``doctest_namespace`` fixture for injecting names into the
   namespace in which your doctests run.
   Thanks `@milliams`_ for the complete PR (`#1428`_).

--- a/_pytest/unittest.py
+++ b/_pytest/unittest.py
@@ -50,6 +50,8 @@ class UnitTestCase(pytest.Class):
         foundsomething = False
         for name in loader.getTestCaseNames(self.obj):
             x = getattr(self.obj, name)
+            if not getattr(x, '__test__', True):
+                continue
             funcobj = getattr(x, 'im_func', x)
             transfer_markers(funcobj, cls, module)
             yield TestCaseFunction(name, parent=self)

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -735,3 +735,17 @@ def test_unittest_skip_issue1169(testdir):
         *SKIP*[1]*skipping due to reasons*
         *1 skipped*
     """)
+
+def test_class_method_containing_test_issue1558(testdir):
+    testdir.makepyfile(test_foo="""
+        import unittest
+
+        class MyTestCase(unittest.TestCase):
+            def test_should_run(self):
+                pass
+            def test_should_not_run(self):
+                pass
+            test_should_not_run.__test__ = False
+    """)
+    reprec = testdir.inline_run()
+    reprec.assertoutcome(passed=1)


### PR DESCRIPTION
__test__ needs to be checked for methods of a class too. Earlier,
this was not done, and all methods in a class was assumed to be
a test. This commit adds the appropriate condition to ensure that
if the __test__ is set to False, it does not collect that method.

Fixes https://github.com/pytest-dev/pytest/issues/1558