### PR TITLE
Don't ignore ImportError when importing setuptools plugins

### DIFF
--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -923,10 +923,7 @@ class Config(object):
             args[:] = self.getini("addopts") + args
         self._checkversion()
         self.pluginmanager.consider_preparse(args)
-        try:
-            self.pluginmanager.load_setuptools_entrypoints("pytest11")
-        except ImportError as e:
-            self.warn("I2", "could not load setuptools entry import: %s" % (e,))
+        self.pluginmanager.load_setuptools_entrypoints("pytest11")
         self.pluginmanager.consider_env()
         self.known_args_namespace = ns = self._parser.parse_known_args(args, namespace=self.option.copy())
         if self.known_args_namespace.confcutdir is None and self.inifile:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -391,6 +391,23 @@ def test_preparse_ordering_with_setuptools(testdir, monkeypatch):
     plugin = config.pluginmanager.getplugin("mytestplugin")
     assert plugin.x == 42
 
+
+def test_setuptools_importerror_issue1479(testdir, monkeypatch):
+    pkg_resources = pytest.importorskip("pkg_resources")
+    def my_iter(name):
+        assert name == "pytest11"
+        class EntryPoint:
+            name = "mytestplugin"
+            dist = None
+            def load(self):
+                raise ImportError("Don't hide me!")
+        return iter([EntryPoint()])
+
+    monkeypatch.setattr(pkg_resources, 'iter_entry_points', my_iter)
+    with pytest.raises(ImportError):
+        testdir.parseconfig()
+
+
 def test_plugin_preparse_prevents_setuptools_loading(testdir, monkeypatch):
     pkg_resources = pytest.importorskip("pkg_resources")
     def my_iter(name):


### PR DESCRIPTION
This was added in b2d66b9 but is a bad idea. When a plugin can't be imported, commandline options (optionally set in pytest.ini) could be undefined, which means pytest bails out much earlier before showing the warning, which is hard to debug.

Fixes #1479, also see #1307 and #1497