### PR TITLE
Issue 1544: norecursedirs build & dist dirs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,11 @@
 
 *
 
+* Add ``build/`` and ``dist/`` to the default ``--norecursedirs`` list. Thanks
+  `@mikofski`_ for the report and `@tomviner`_ for the PR (`#1544`_).
+
+*
+
 .. _@milliams: https://github.com/milliams
 .. _@novas0x2a: https://github.com/novas0x2a
 .. _@kalekundert: https://github.com/kalekundert
@@ -48,6 +53,7 @@
 .. _@ceridwen: https://github.com/ceridwen
 .. _@palaviv: https://github.com/palaviv
 .. _@omarkohl: https://github.com/omarkohl
+.. _@mikofski: https://github.com/mikofski
 
 .. _#1428: https://github.com/pytest-dev/pytest/pull/1428
 .. _#1444: https://github.com/pytest-dev/pytest/pull/1444
@@ -58,6 +64,7 @@
 .. _#1474: https://github.com/pytest-dev/pytest/pull/1474
 .. _#1502: https://github.com/pytest-dev/pytest/pull/1502
 .. _#372: https://github.com/pytest-dev/pytest/issues/372
+.. _#1544: https://github.com/pytest-dev/pytest/issues/1544
 
 2.9.2.dev1
 ==========

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -29,7 +29,7 @@ name_re = re.compile("^[a-zA-Z_]\w*$")
 
 def pytest_addoption(parser):
     parser.addini("norecursedirs", "directory patterns to avoid for recursion",
-        type="args", default=['.*', 'CVS', '_darcs', '{arch}', '*.egg'])
+        type="args", default=['.*', 'build', 'dist', 'CVS', '_darcs', '{arch}', '*.egg'])
     parser.addini("testpaths", "directories to search for tests when no files or directories are given in the command line.",
         type="args", default=[])
     #parser.addini("dirpatterns",

--- a/doc/en/customize.rst
+++ b/doc/en/customize.rst
@@ -144,7 +144,7 @@ Builtin configuration file options
         [seq]   matches any character in seq
         [!seq]  matches any char not in seq
 
-   Default patterns are ``'.*', 'CVS', '_darcs', '{arch}', '*.egg'``.
+   Default patterns are ``'.*', 'build', 'dist', 'CVS', '_darcs', '{arch}', '*.egg'``.
    Setting a ``norecursedirs`` replaces the default.  Here is an example of
    how to avoid certain directories:
 

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -88,6 +88,8 @@ class TestCollector:
 class TestCollectFS:
     def test_ignored_certain_directories(self, testdir):
         tmpdir = testdir.tmpdir
+        tmpdir.ensure("build", 'test_notfound.py')
+        tmpdir.ensure("dist", 'test_notfound.py')
         tmpdir.ensure("_darcs", 'test_notfound.py')
         tmpdir.ensure("CVS", 'test_notfound.py')
         tmpdir.ensure("{arch}", 'test_notfound.py')


### PR DESCRIPTION
Fix for https://github.com/pytest-dev/pytest/issues/1544

I've put the new `dist` and `build` strings near the front of the list as I figure these are more common than directory names like `CVS` and `_darcs`.