### PR TITLE
Fix shell argument split in win32

### DIFF
--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -104,7 +104,7 @@ def _prepareconfig(args=None, plugins=None):
     elif not isinstance(args, (tuple, list)):
         if not isinstance(args, str):
             raise ValueError("not a string or argument list: %r" % (args,))
-        args = shlex.split(args, posix=sys.platform == "win32")
+        args = shlex.split(args, posix=sys.platform != "win32")
     config = get_config()
     pluginmanager = config.pluginmanager
     try:


### PR DESCRIPTION
This fixes the bug inserted by accident in #1523

@RonnyPfannschmidt this is why your #1554 is failing on Windows... not sure how that passed the first time on `master`, as the logic for the `posix` argument was wrong. :confused: 