### PR TITLE
Fix showfixtures for multiple fixturedefs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,10 @@
 * Minor improvements and fixes to the documentation.
   Thanks `@omarkohl`_ for the PR.
 
+* Fix ``--fixtures`` to show all fixture definitions as opposed to just
+  one per fixture name.
+  Thanks to `@hackebrot`_ for the PR.
+
 .. _#510: https://github.com/pytest-dev/pytest/issues/510
 .. _#1506: https://github.com/pytest-dev/pytest/pull/1506
 .. _#1496: https://github.com/pytest-dev/pytest/issue/1496

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1168,12 +1168,12 @@ def _showfixtures_main(config, session):
         assert fixturedefs is not None
         if not fixturedefs:
             continue
-        fixturedef = fixturedefs[-1]
-        loc = getlocation(fixturedef.func, curdir)
-        available.append((len(fixturedef.baseid),
-                          fixturedef.func.__module__,
-                          curdir.bestrelpath(loc),
-                          fixturedef.argname, fixturedef))
+        for fixturedef in fixturedefs:
+            loc = getlocation(fixturedef.func, curdir)
+            available.append((len(fixturedef.baseid),
+                              fixturedef.func.__module__,
+                              curdir.bestrelpath(loc),
+                              fixturedef.argname, fixturedef))
 
     available.sort()
     currentmodule = None

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -2564,6 +2564,38 @@ class TestShowFixtures:
                 Fixture B
         """)
 
+    def test_show_fixtures_with_same_name(self, testdir):
+        testdir.makeconftest('''
+            import pytest
+            @pytest.fixture
+            def arg1():
+                """Hello World in conftest.py"""
+                return "Hello World"
+        ''')
+        testdir.makepyfile('''
+            def test_foo(arg1):
+                assert arg1 == "Hello World"
+        ''')
+        testdir.makepyfile('''
+            import pytest
+            @pytest.fixture
+            def arg1():
+                """Hi from test module"""
+                return "Hi"
+            def test_bar(arg1):
+                assert arg1 == "Hi"
+        ''')
+        result = testdir.runpytest("--fixtures")
+        result.stdout.fnmatch_lines('''
+            * fixtures defined from conftest *
+            arg1
+                Hello World in conftest.py
+
+            * fixtures defined from test_show_fixtures_with_same_name *
+            arg1
+                Hi from test module
+        ''')
+
 
 class TestContextManagerFixtureFuncs:
     def test_simple(self, testdir):


### PR DESCRIPTION
Hi 😄 

When inspecting available fixtures in a test suite via ``--fixtures`` and there are multiple fixtures with the same name, currently only one will be shown on stdout.

The reason for this is ``fixturedef = fixturedefs[-1]`` in the current implementation (last touched by @hpk42 in 37965657 from 2012), which discards all but the last fixture def for a fixture name. I am not sure about why this is - I might not understand all the implications.

If there are no objections, I'd like to iterate over all of the found fixture defs. Tox is green for me and I've added a new test to cover the desired behaviour.

Please let me know your thoughts! 🙇 

Raphael

----

- [x] Target: for bug or doc fixes, target `master`; for new features, target `features`
- [x] Make sure to include one or more tests for your change
- [x] Add yourself to `AUTHORS`
- [x] Add a new entry to the `CHANGELOG` (choose any open position to avoid merge conflicts with other PRs) 