### PR TITLE
Make normal fixtures work with "yield"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,12 @@
 
 **Changes**
 
+* Fixtures marked with ``@pytest.fixture`` can now use ``yield`` statements exactly like
+  those marked with the ``@pytest.yield_fixture`` decorator. This change renders
+  ``@pytest.yield_fixture`` deprecated and makes ``@pytest.fixture`` with ``yield`` statements
+  the preferred way to write teardown code (`#1461`_).
+  Thanks `@csaftoiu`_ for bringing this to attention and `@nicoddemus`_ for the PR.
+
 * Fix (`#1351`_):
   explicitly passed parametrize ids do not get escaped to ascii.
   Thanks `@ceridwen`_ for the PR.
@@ -58,6 +64,7 @@
 *
 
 .. _@milliams: https://github.com/milliams
+.. _@csaftoiu: https://github.com/csaftoiu
 .. _@novas0x2a: https://github.com/novas0x2a
 .. _@kalekundert: https://github.com/kalekundert
 .. _@tareqalayan: https://github.com/tareqalayan
@@ -72,6 +79,7 @@
 .. _#1441: https://github.com/pytest-dev/pytest/pull/1441
 .. _#1454: https://github.com/pytest-dev/pytest/pull/1454
 .. _#1351: https://github.com/pytest-dev/pytest/issues/1351
+.. _#1461: https://github.com/pytest-dev/pytest/pull/1461
 .. _#1468: https://github.com/pytest-dev/pytest/pull/1468
 .. _#1474: https://github.com/pytest-dev/pytest/pull/1474
 .. _#1502: https://github.com/pytest-dev/pytest/pull/1502

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -175,7 +175,7 @@ def fixture(scope="function", params=None, autouse=False, ids=None, name=None):
         params = list(params)
     return FixtureFunctionMarker(scope, params, autouse, ids=ids, name=name)
 
-def yield_fixture(scope="function", params=None, autouse=False, ids=None):
+def yield_fixture(scope="function", params=None, autouse=False, ids=None, name=None):
     """ (return a) decorator to mark a yield-fixture factory function
     (EXPERIMENTAL).
 
@@ -184,12 +184,12 @@ def yield_fixture(scope="function", params=None, autouse=False, ids=None):
     statement to provide a fixture.  See
     http://pytest.org/en/latest/yieldfixture.html for more info.
     """
-    if callable(scope) and params is None and autouse == False:
+    if callable(scope) and params is None and not autouse:
         # direct decoration
         return FixtureFunctionMarker(
-                "function", params, autouse, yieldctx=True)(scope)
+                "function", params, autouse, name=name, yieldctx=True, ids=ids)(scope)
     else:
-        return FixtureFunctionMarker(scope, params, autouse,
+        return FixtureFunctionMarker(scope, params, autouse, name=name,
                                      yieldctx=True, ids=ids)
 
 defaultfuncargprefixmarker = fixture()

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -2326,6 +2326,7 @@ def fail_fixturefunc(fixturefunc, msg):
                 pytrace=False)
 
 def call_fixture_func(fixturefunc, request, kwargs, yieldctx):
+    yieldctx = is_generator(fixturefunc)
     if yieldctx:
         if not is_generator(fixturefunc):
             fail_fixturefunc(fixturefunc,

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -2326,29 +2326,20 @@ def fail_fixturefunc(fixturefunc, msg):
 def call_fixture_func(fixturefunc, request, kwargs):
     yieldctx = is_generator(fixturefunc)
     if yieldctx:
-        if not is_generator(fixturefunc):
-            fail_fixturefunc(fixturefunc,
-                msg="yield_fixture requires yield statement in function")
-        iter = fixturefunc(**kwargs)
-        next = getattr(iter, "__next__", None)
-        if next is None:
-            next = getattr(iter, "next")
-        res = next()
+        it = fixturefunc(**kwargs)
+        res = next(it)
+
         def teardown():
             try:
-                next()
+                next(it)
             except StopIteration:
                 pass
             else:
                 fail_fixturefunc(fixturefunc,
                     "yield_fixture function has more than one 'yield'")
+
         request.addfinalizer(teardown)
     else:
-        if is_generator(fixturefunc):
-            fail_fixturefunc(fixturefunc,
-                msg="pytest.fixture functions cannot use ``yield``. "
-                    "Instead write and return an inner function/generator "
-                    "and let the consumer call and iterate over it.")
         res = fixturefunc(**kwargs)
     return res
 

--- a/doc/en/example/costlysetup/conftest.py
+++ b/doc/en/example/costlysetup/conftest.py
@@ -4,8 +4,8 @@ import pytest
 @pytest.fixture("session")
 def setup(request):
     setup = CostlySetup()
-    request.addfinalizer(setup.finalize)
-    return setup
+    yield setup
+    setup.finalize()
 
 class CostlySetup:
     def __init__(self):

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -648,15 +648,14 @@ here is a little example implemented via a local plugin::
 
     @pytest.fixture
     def something(request):
-        def fin():
-            # request.node is an "item" because we use the default
-            # "function" scope
-            if request.node.rep_setup.failed:
-                print ("setting up a test failed!", request.node.nodeid)
-            elif request.node.rep_setup.passed:
-                if request.node.rep_call.failed:
-                    print ("executing test failed", request.node.nodeid)
-        request.addfinalizer(fin)
+        yield
+        # request.node is an "item" because we use the default
+        # "function" scope
+        if request.node.rep_setup.failed:
+            print ("setting up a test failed!", request.node.nodeid)
+        elif request.node.rep_setup.passed:
+            if request.node.rep_call.failed:
+                print ("executing test failed", request.node.nodeid)
 
 
 if you then have failing tests::

--- a/doc/en/yieldfixture.rst
+++ b/doc/en/yieldfixture.rst
@@ -1,6 +1,6 @@
 .. _yieldfixture:
 
-Fixture functions using "yield" / context manager integration
+"yield_fixture" functions
 ---------------------------------------------------------------
 
 .. deprecated:: 2.10
@@ -10,98 +10,8 @@ Fixture functions using "yield" / context manager integration
 .. important::
     Since pytest-2.10, fixtures using the normal ``fixture`` decorator can use a ``yield``
     statement to provide fixture values and execute teardown code, exactly like ``yield_fixture``
-    described in this session.
+    in previous versions.
 
-.. regendoc:wipe
+    Marking functions as ``yield_fixture`` is still supported, but deprecated and should not
+    be used in new code.
 
-pytest-2.4 allows fixture functions to seamlessly use a ``yield`` instead 
-of a ``return`` statement to provide a fixture value while otherwise
-fully supporting all other fixture features.
-
-Let's look at a simple standalone-example using the ``yield`` syntax::
-
-    # content of test_yield.py
-    
-    import pytest
-
-    @pytest.yield_fixture
-    def passwd():
-        print ("\nsetup before yield")
-        f = open("/etc/passwd")
-        yield f.readlines()
-        print ("teardown after yield")
-        f.close()
-
-    def test_has_lines(passwd):
-        print ("test called")
-        assert passwd
-
-In contrast to :ref:`finalization through registering callbacks
-<finalization>`, our fixture function used a ``yield``
-statement to provide the lines of the ``/etc/passwd`` file.  
-The code after the ``yield`` statement serves as the teardown code, 
-avoiding the indirection of registering a teardown callback function.   
-
-Let's run it with output capturing disabled::
-
-    $ py.test -q -s test_yield.py
-    
-    setup before yield
-    test called
-    .teardown after yield
-    
-    1 passed in 0.12 seconds
-
-We can also seamlessly use the new syntax with ``with`` statements.
-Let's simplify the above ``passwd`` fixture::
-
-    # content of test_yield2.py
-    
-    import pytest
-
-    @pytest.yield_fixture
-    def passwd():
-        with open("/etc/passwd") as f:
-            yield f.readlines()
-
-    def test_has_lines(passwd):
-        assert len(passwd) >= 1
-
-The file ``f`` will be closed after the test finished execution
-because the Python ``file`` object supports finalization when
-the ``with`` statement ends. 
-
-Note that the yield fixture form supports all other fixture
-features such as ``scope``, ``params``, etc., thus changing existing
-fixture functions to use ``yield`` is straightforward.
-
-.. note::
-
-    While the ``yield`` syntax is similar to what
-    :py:func:`contextlib.contextmanager` decorated functions
-    provide, with pytest fixture functions the part after the
-    "yield" will always be invoked, independently from the
-    exception status of the test function which uses the fixture.
-    This behaviour makes sense if you consider that many different
-    test functions might use a module or session scoped fixture.
-
-
-Discussion and future considerations / feedback
-++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-There are some topics that are worth mentioning:
-
-- usually ``yield`` is used for producing multiple values.
-  But fixture functions can only yield exactly one value.
-  Yielding a second fixture value will get you an error.
-  It's possible we can evolve pytest to allow for producing
-  multiple values as an alternative to current parametrization.
-  For now, you can just use the normal
-  :ref:`fixture parametrization <fixture-parametrize>`
-  mechanisms together with ``yield``-style fixtures.
-
-- lastly ``yield`` introduces more than one way to write
-  fixture functions, so what's the obvious way to a newcomer?
-
-If you want to feedback or participate in discussion of the above
-topics, please join our :ref:`contact channels`, you are most welcome.

--- a/doc/en/yieldfixture.rst
+++ b/doc/en/yieldfixture.rst
@@ -3,7 +3,14 @@
 Fixture functions using "yield" / context manager integration
 ---------------------------------------------------------------
 
+.. deprecated:: 2.10
+
 .. versionadded:: 2.4
+
+.. important::
+    Since pytest-2.10, fixtures using the normal ``fixture`` decorator can use a ``yield``
+    statement to provide fixture values and execute teardown code, exactly like ``yield_fixture``
+    described in this session.
 
 .. regendoc:wipe
 

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -2693,15 +2693,14 @@ class TestContextManagerFixtureFuncs:
             *test_yields*:2*
         """)
 
-# TODO: yield_fixture should work as well (this is bugged right now)
-def test_custom_name(testdir):
-    testdir.makepyfile("""
-        import pytest
-        @pytest.fixture(name='meow')
-        def arg1():
-            return 'mew'
-        def test_1(meow):
-            print(meow)
-    """)
-    result = testdir.runpytest("-s")
-    result.stdout.fnmatch_lines("*mew*")
+    def test_custom_name(self, testdir, flavor):
+        testdir.makepyfile("""
+            import pytest
+            @pytest.{flavor}(name='meow')
+            def arg1():
+                return 'mew'
+            def test_1(meow):
+                print(meow)
+        """.format(flavor=flavor))
+        result = testdir.runpytest("-s")
+        result.stdout.fnmatch_lines("*mew*")


### PR DESCRIPTION
Did a quick experiment to see how hard would it be to implement #1461 to suggest working on it during the sprint... astonished to find out it was way too easy. :astonished: 

Just ignore the `yieldctx` parameter and decide on the spot if we are a "yield fixture" based on whether or not the function is a generator does the trick nicely.

Almost all of the changes are related only to change the tests of `yield_fixture` to also test with plain `fixture` to prove this is working.

Missing:

* Clean up the code (remove the need to pass `yieldctx` around);
* Update docs and CHANGELOG;

Opening the PR to discuss if we should move this forward or not. @RonnyPfannschmidt, @hpk42, @The-Compiler what you guys think?