### PR TITLE
Ensure that a module within a namespace package can be found by --pyargs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -87,6 +87,7 @@ Russel Winder
 Ryan Wooden
 Samuele Pedroni
 Simon Gomizelj
+Stefano Taschini
 Thomas Grainger
 Tom Viner
 Trevor Bekolay

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,16 +9,22 @@
 * Fix internal error issue when ``method`` argument is missing for 
   ``teardown_method()``. Fixes (`#1605`_).
 
-*
-
 * Fix exception visualization in case the current working directory (CWD) gets
   deleted during testing. Fixes (`#1235`). Thanks `@bukzor` for reporting. PR by
   `@marscher`. Thanks `@nicoddemus` for his help.
 
-.. _#1580: https://github.com/pytest-dev/pytest/issues/1580
+* Ensure that a module within a namespace package can be found when it
+  is specified on the command line together with the ``--pyargs``
+  option.  Thanks to `@taschini`_ for the PR (`#1597`_).
+
+*
+
+.. _#1580: https://github.com/pytest-dev/pytest/pull/1580
 .. _#1605: https://github.com/pytest-dev/pytest/issues/1605
+.. _#1597: https://github.com/pytest-dev/pytest/pull/1597
 
 .. _@graingert: https://github.com/graingert
+.. _@taschini: https://github.com/taschini
 
 
 2.9.2

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -664,9 +664,12 @@ class Session(FSCollector):
             return x
         if loader is None:
             return x
+        # This method is sometimes invoked when AssertionRewritingHook, which
+        # does not define a get_filename method, is already in place:
         try:
             path = loader.get_filename()
-        except:
+        except AttributeError:
+            # Retrieve path from AssertionRewritingHook:
             path = loader.modules[x][0].co_filename
         if loader.is_package(x):
             path = os.path.dirname(path)

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -1,7 +1,5 @@
 """ core implementation of testing process: init, session, runtest loop. """
-import imp
 import os
-import re
 import sys
 
 import _pytest
@@ -24,8 +22,6 @@ EXIT_INTERRUPTED = 2
 EXIT_INTERNALERROR = 3
 EXIT_USAGEERROR = 4
 EXIT_NOTESTSCOLLECTED = 5
-
-name_re = re.compile("^[a-zA-Z_]\w*$")
 
 def pytest_addoption(parser):
     parser.addini("norecursedirs", "directory patterns to avoid for recursion",
@@ -658,36 +654,29 @@ class Session(FSCollector):
         return True
 
     def _tryconvertpyarg(self, x):
-        mod = None
-        path = [os.path.abspath('.')] + sys.path
-        for name in x.split('.'):
-            # ignore anything that's not a proper name here
-            # else something like --pyargs will mess up '.'
-            # since imp.find_module will actually sometimes work for it
-            # but it's supposed to be considered a filesystem path
-            # not a package
-            if name_re.match(name) is None:
-                return x
-            try:
-                fd, mod, type_ = imp.find_module(name, path)
-            except ImportError:
-                return x
-            else:
-                if fd is not None:
-                    fd.close()
+        """Convert a dotted module name to path.
 
-            if type_[2] != imp.PKG_DIRECTORY:
-                path = [os.path.dirname(mod)]
-            else:
-                path = [mod]
-        return mod
+        """
+        import pkgutil
+        try:
+            loader = pkgutil.find_loader(x)
+        except ImportError:
+            return x
+        if loader is None:
+            return x
+        try:
+            path = loader.get_filename()
+        except:
+            path = loader.modules[x][0].co_filename
+        if loader.is_package(x):
+            path = os.path.dirname(path)
+        return path
 
     def _parsearg(self, arg):
         """ return (fspath, names) tuple after checking the file exists. """
-        arg = str(arg)
-        if self.config.option.pyargs:
-            arg = self._tryconvertpyarg(arg)
         parts = str(arg).split("::")
+        if self.config.option.pyargs:
+            parts[0] = self._tryconvertpyarg(parts[0])
         relpath = parts[0].replace("/", os.sep)
         path = self.config.invocation_dir.join(relpath, abs=True)
         if not path.check():


### PR DESCRIPTION
This PR supersedes #1568 and addresses the problem highlighted in #1567 and in part #478.

See #1568 for the description of the test setup.

Unlike #1568, this PR does not attempt to emulate the import machinery to determine the filename of a  package or directory, delegating instead most of the work to the ``pkgutil`` module of the standard library.

**NB** In case of a non-top-level module or package, ``pkgutil.find_loader`` *will* import the parent package or packages.