### PR TITLE
Fixed issue shadowing error when missing argument on teardown_method

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -91,3 +91,4 @@ Thomas Grainger
 Tom Viner
 Trevor Bekolay
 Wouter van Ackooy
+Bernard Pratz

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@
 * Text documents without any doctests no longer appear as "skipped".
   Thanks `@graingert`_ for reporting and providing a full PR (`#1580`_).
 
-*
+* Fix internal error issue when ``method`` argument is missing for 
+  ``teardown_method()``. Fixes (`#1605`_).
 
 *
 
@@ -15,6 +16,7 @@
   `@marscher`. Thanks `@nicoddemus` for his help.
 
 .. _#1580: https://github.com/pytest-dev/pytest/issues/1580
+.. _#1605: https://github.com/pytest-dev/pytest/issues/1605
 
 .. _@graingert: https://github.com/graingert
 

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -392,7 +392,10 @@ class Node(object):
         if self.config.option.fulltrace:
             style="long"
         else:
+            tb = _pytest._code.Traceback([excinfo.traceback[-1]])
             self._prunetraceback(excinfo)
+            if len(excinfo.traceback) == 0:
+                excinfo.traceback = tb
             tbfilter = False  # prunetraceback already does it
             if style == "auto":
                 style = "long"


### PR DESCRIPTION
When the method argument is missing on teardown_method, the traceback is
100% internal to pytest, which with default options get pruned. Then
that traceback is empty, leading to a new exception as a traceback shall
not be empty.

This PR fixes that issue by pushing back the last stack on the
traceback, when the stacktrace is empty after pruning. Then the output
is still pruned, but gives meaningful information with the item where it
failed on the stack.

* fixes issue #1604