### PR TITLE
Show fixtures per test

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,11 @@
 * New ``pytest_make_parametrize_id`` hook.
   Thanks `@palaviv`_ for the PR.
 
+* New cli flag ``--fixtures-per-test`` that shows which fixtures are being used
+  for each selected test item. Features doc strings of fixtures by default.
+  Can also show where fixtures are defined if combined with ``-v``.
+  Thanks `@hackebrot`_ for the PR.
+
 **Changes**
 
 * Fix (`#1351`_):

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1229,12 +1229,12 @@ def _show_fixtures_per_test(config, session):
             return
         if verbose > 0:
             bestrel = get_best_rel(fixture_def.func)
-            funcargspec = "{} -- {}".format(argname, bestrel)
+            funcargspec = "{0} -- {1}".format(argname, bestrel)
         else:
             funcargspec = argname
         tw.line(funcargspec, green=True)
 
-        INDENT = '    {}'
+        INDENT = '    {0}'
         fixture_doc = fixture_def.func.__doc__
 
         if fixture_doc:
@@ -1252,8 +1252,8 @@ def _show_fixtures_per_test(config, session):
         bestrel = get_best_rel(item.function)
 
         tw.line()
-        tw.sep('-', 'fixtures used by {}'.format(item.name))
-        tw.sep('-', 'from {}'.format(bestrel))
+        tw.sep('-', 'fixtures used by {0}'.format(item.name))
+        tw.sep('-', 'from {0}'.format(bestrel))
         for argname, fixture_defs in sorted(name2fixturedefs.items()):
             assert fixture_defs is not None
             if not fixture_defs:

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1253,7 +1253,7 @@ def _show_fixtures_per_test(config, session):
 
         tw.line()
         tw.sep('-', 'fixtures used by {0}'.format(item.name))
-        tw.sep('-', 'from {0}'.format(bestrel))
+        tw.sep('-', '({0})'.format(bestrel))
         for argname, fixture_defs in sorted(name2fixturedefs.items()):
             assert fixture_defs is not None
             if not fixture_defs:

--- a/testing/python/show_fixtures_per_test.py
+++ b/testing/python/show_fixtures_per_test.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+
+
+def test_no_items_should_not_show_output(testdir):
+    result = testdir.runpytest('--fixtures-per-test')
+    assert 'fixtures used by' not in result.stdout.str()
+    assert result.ret == 0
+
+
+def test_fixtures_in_module(testdir):
+    p = testdir.makepyfile('''
+        import pytest
+        @pytest.fixture
+        def _arg0():
+            """hidden arg0 fixture"""
+        @pytest.fixture
+        def arg1():
+            """arg1 docstring"""
+        def test_arg1(arg1):
+            pass
+    ''')
+
+    result = testdir.runpytest("--fixtures-per-test", p)
+    assert result.ret == 0
+
+    result.stdout.fnmatch_lines([
+        '*fixtures used by test_arg1*',
+        '*from test_fixtures_in_module.py:9*',
+        'arg1',
+        '    arg1 docstring',
+    ])
+    assert "_arg0" not in result.stdout.str()
+
+
+def test_fixtures_in_conftest(testdir):
+    testdir.makeconftest('''
+        import pytest
+        @pytest.fixture
+        def arg1():
+            """arg1 docstring"""
+        @pytest.fixture
+        def arg2():
+            """arg2 docstring"""
+        @pytest.fixture
+        def arg3(arg1, arg2):
+            """arg3
+            docstring
+            """
+    ''')
+    p = testdir.makepyfile('''
+        def test_arg2(arg2):
+            pass
+        def test_arg3(arg3):
+            pass
+    ''')
+    result = testdir.runpytest("--fixtures-per-test", p)
+    assert result.ret == 0
+
+    result.stdout.fnmatch_lines([
+        '*fixtures used by test_arg2*',
+        '*from test_fixtures_in_conftest.py:2*',
+        'arg2',
+        '    arg2 docstring',
+        '*fixtures used by test_arg3*',
+        '*from test_fixtures_in_conftest.py:4*',
+        'arg1',
+        '    arg1 docstring',
+        'arg2',
+        '    arg2 docstring',
+        'arg3',
+        '    arg3',
+        '    docstring',
+    ])
+
+
+def test_should_show_fixtures_used_by_test(testdir):
+    testdir.makeconftest('''
+        import pytest
+        @pytest.fixture
+        def arg1():
+            """arg1 from conftest"""
+        @pytest.fixture
+        def arg2():
+            """arg2 from conftest"""
+    ''')
+    p = testdir.makepyfile('''
+        import pytest
+        @pytest.fixture
+        def arg1():
+            """arg1 from testmodule"""
+        def test_args(arg1, arg2):
+            pass
+    ''')
+    result = testdir.runpytest("--fixtures-per-test", p)
+    assert result.ret == 0
+
+    result.stdout.fnmatch_lines([
+        '*fixtures used by test_args*',
+        '*from test_should_show_fixtures_used_by_test.py:6*',
+        'arg1',
+        '    arg1 from testmodule',
+        'arg2',
+        '    arg2 from conftest',
+    ])
+
+
+def test_verbose_include_private_fixtures_and_loc(testdir):
+    testdir.makeconftest('''
+        import pytest
+        @pytest.fixture
+        def _arg1():
+            """_arg1 from conftest"""
+        @pytest.fixture
+        def arg2(_arg1):
+            """arg2 from conftest"""
+    ''')
+    p = testdir.makepyfile('''
+        import pytest
+        @pytest.fixture
+        def arg3():
+            """arg3 from testmodule"""
+        def test_args(arg2, arg3):
+            pass
+    ''')
+    result = testdir.runpytest("--fixtures-per-test", "-v", p)
+    assert result.ret == 0
+
+    result.stdout.fnmatch_lines([
+        '*fixtures used by test_args*',
+        '*from test_verbose_include_private_fixtures_and_loc.py:6*',
+        '_arg1 -- conftest.py:3',
+        '    _arg1 from conftest',
+        'arg2 -- conftest.py:6',
+        '    arg2 from conftest',
+        'arg3 -- test_verbose_include_private_fixtures_and_loc.py:3',
+        '    arg3 from testmodule',
+    ])

--- a/testing/python/show_fixtures_per_test.py
+++ b/testing/python/show_fixtures_per_test.py
@@ -25,7 +25,7 @@ def test_fixtures_in_module(testdir):
 
     result.stdout.fnmatch_lines([
         '*fixtures used by test_arg1*',
-        '*from test_fixtures_in_module.py:9*',
+        '*(test_fixtures_in_module.py:9)*',
         'arg1',
         '    arg1 docstring',
     ])
@@ -58,11 +58,11 @@ def test_fixtures_in_conftest(testdir):
 
     result.stdout.fnmatch_lines([
         '*fixtures used by test_arg2*',
-        '*from test_fixtures_in_conftest.py:2*',
+        '*(test_fixtures_in_conftest.py:2)*',
         'arg2',
         '    arg2 docstring',
         '*fixtures used by test_arg3*',
-        '*from test_fixtures_in_conftest.py:4*',
+        '*(test_fixtures_in_conftest.py:4)*',
         'arg1',
         '    arg1 docstring',
         'arg2',
@@ -96,7 +96,7 @@ def test_should_show_fixtures_used_by_test(testdir):
 
     result.stdout.fnmatch_lines([
         '*fixtures used by test_args*',
-        '*from test_should_show_fixtures_used_by_test.py:6*',
+        '*(test_should_show_fixtures_used_by_test.py:6)*',
         'arg1',
         '    arg1 from testmodule',
         'arg2',
@@ -127,7 +127,7 @@ def test_verbose_include_private_fixtures_and_loc(testdir):
 
     result.stdout.fnmatch_lines([
         '*fixtures used by test_args*',
-        '*from test_verbose_include_private_fixtures_and_loc.py:6*',
+        '*(test_verbose_include_private_fixtures_and_loc.py:6)*',
         '_arg1 -- conftest.py:3',
         '    _arg1 from conftest',
         'arg2 -- conftest.py:6',


### PR DESCRIPTION
New cli flag ``--fixtures-per-test`` that shows which fixtures are being used for each selected test item. Features doc strings of fixtures by default. Can also show where fixtures are defined if combined with ``-v``.

This feature is going to help understand how pytest fixture injection works as to where it gets the fixtures from. Sometimes users get confused if a test suite contains a number of conftest.py files that define fixtures but also test modules which have their own. This gets particularly complex if fixtures share a name.

Example output for ``--fixtures-per-test -v``:

```text
-------- fixtures used by test_value_error_if_key_missing_in_context --------
--------------------- from tests/replay/test_dump.py:50 ---------------------
remove_replay_dump -- tests/replay/test_dump.py:29
    Remove the replay file created by tests.
replay_file -- tests/replay/test_dump.py:22
    Fixture to return a actual file name of the dump.
replay_test_dir -- tests/replay/conftest.py:18
    no docstring available
template_name -- tests/replay/test_dump.py:16
    Fixture to return a valid template_name.
```

Please let me know your thoughts! 🙇 
