### PR TITLE
Simplify default pytest_runtestloop

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,6 +47,7 @@ Floris Bruynooghe
 Gabriel Reis
 Georgy Dyuldin
 Graham Horler
+Greg Price
 Grig Gheorghiu
 Guido Wesdorp
 Harald Armin Massa

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -136,17 +136,8 @@ def pytest_runtestloop(session):
     if session.config.option.collectonly:
         return True
 
-    def getnextitem(i):
-        # this is a function to avoid python2
-        # keeping sys.exc_info set when calling into a test
-        # python2 keeps sys.exc_info till the frame is left
-        try:
-            return session.items[i+1]
-        except IndexError:
-            return None
-
     for i, item in enumerate(session.items):
-        nextitem = getnextitem(i)
+        nextitem = session.items[i+1] if i+1 < len(session.items) else None
         item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
         if session.shouldstop:
             raise session.Interrupted(session.shouldstop)


### PR DESCRIPTION
The inner function and the explanatory comment it makes necessary can
all be removed if we switch to an if/else rather than try/except for
this condition.

Perhaps this bit comes from my fondness for C, but I think I would
find this style clearer and easier to understand even if it weren't
for the Python 2 quirk that makes the other style require us to add an
unnecessary-looking function abstraction.  In any case, given that the
alternative does require that abstraction this is definitely simpler.

-----

In the handy PR checklist:

> - [ ] Add yourself to `AUTHORS`
> - [ ] Add a new entry to the `CHANGELOG` (choose any open position to avoid merge conflicts with other PRs) 

I've skipped these as this small refactor isn't user-visible (so I imagine doesn't belong in `CHANGELOG`) and seems awfully small for putting myself in an `AUTHORS` file. But this is obviously up to your judgement as maintainers of the project -- I'm happy to adjust either or both of those as desired.
