### PR TITLE
Cut a dead test helper function

### DIFF
--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -8,15 +8,10 @@ import _pytest._pluggy as pluggy
 import _pytest._code
 import py
 import pytest
-from _pytest import runner
 from _pytest.main import EXIT_NOTESTSCOLLECTED
 from _pytest.terminal import TerminalReporter, repr_pythonversion, getreportopt
 from _pytest.terminal import build_summary_stats_line, _plugin_nameversions
 
-
-def basic_run_report(item):
-    runner.call_and_report(item, "setup", log=False)
-    return runner.call_and_report(item, "call", log=False)
 
 DistInfo = collections.namedtuple('DistInfo', ['project_name', 'version'])
 


### PR DESCRIPTION
This appears to have been unused since commit
320835d "split out pytest-xdist related reporting to the plugin"
in July 2010.  It's the only caller outside of _pytest/runner.py
of the `call_and_report` helper function there, so cutting it out
makes that more of a pure helper function and makes it slightly
easier to understand the code in _pytest/runner.py .