### PR TITLE
Pytest.raises custom error message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -66,7 +66,8 @@
 * Add ``build/`` and ``dist/`` to the default ``--norecursedirs`` list. Thanks
   `@mikofski`_ for the report and `@tomviner`_ for the PR (`#1544`_).
 
-*
+* pytest.raises accepts a custom message to raise when no exception accord.
+  Thanks `@palaviv`_ for the PR.
 
 .. _@milliams: https://github.com/milliams
 .. _@csaftoiu: https://github.com/csaftoiu

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -66,8 +66,8 @@
 * Add ``build/`` and ``dist/`` to the default ``--norecursedirs`` list. Thanks
   `@mikofski`_ for the report and `@tomviner`_ for the PR (`#1544`_).
 
-* pytest.raises accepts a custom message to raise when no exception accord.
-  Thanks `@palaviv`_ for the PR.
+* pytest.raises accepts a custom message to raise when no exception occurred.
+  Thanks `@palaviv`_ for the complete PR (`#1616`_).
 
 .. _@milliams: https://github.com/milliams
 .. _@csaftoiu: https://github.com/csaftoiu
@@ -92,6 +92,7 @@
 .. _#1520: https://github.com/pytest-dev/pytest/pull/1520
 .. _#372: https://github.com/pytest-dev/pytest/issues/372
 .. _#1544: https://github.com/pytest-dev/pytest/issues/1544
+.. _#1616: https://github.com/pytest-dev/pytest/pull/1616
 
 
 **Bug Fixes**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -66,7 +66,8 @@
 * Add ``build/`` and ``dist/`` to the default ``--norecursedirs`` list. Thanks
   `@mikofski`_ for the report and `@tomviner`_ for the PR (`#1544`_).
 
-* pytest.raises accepts a custom message to raise when no exception occurred.
+* pytest.raises in the context manager form accepts a custom
+  message to raise when no exception occurred.
   Thanks `@palaviv`_ for the complete PR (`#1616`_).
 
 .. _@milliams: https://github.com/milliams

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1337,6 +1337,14 @@ def raises(expected_exception, *args, **kwargs):
         >>> with raises(ZeroDivisionError):
         ...    1/0
 
+    In the context manager form you may use the keyword argument
+    ``message`` to specify a custom failure message::
+
+        >>> with raises(ZeroDivisionError, message="Expecting ZeroDivisionError"):
+        ...    pass
+        ... Failed: Expecting ZeroDivisionError
+
+
     .. note::
 
        When using ``pytest.raises`` as a context manager, it's worthwhile to

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1412,8 +1412,13 @@ def raises(expected_exception, *args, **kwargs):
     elif not isclass(expected_exception):
         raise TypeError(msg % type(expected_exception))
 
+    if "message" in kwargs:
+        message = kwargs.pop("message")
+    else:
+        message = "DID NOT RAISE {0}".format(expected_exception)
+
     if not args:
-        return RaisesContext(expected_exception)
+        return RaisesContext(expected_exception, message)
     elif isinstance(args[0], str):
         code, = args
         assert isinstance(code, str)
@@ -1434,11 +1439,12 @@ def raises(expected_exception, *args, **kwargs):
             func(*args[1:], **kwargs)
         except expected_exception:
             return _pytest._code.ExceptionInfo()
-    pytest.fail("DID NOT RAISE {0}".format(expected_exception))
+    pytest.fail(message)
 
 class RaisesContext(object):
-    def __init__(self, expected_exception):
+    def __init__(self, expected_exception, message):
         self.expected_exception = expected_exception
+        self.message = message
         self.excinfo = None
 
     def __enter__(self):
@@ -1448,7 +1454,7 @@ class RaisesContext(object):
     def __exit__(self, *tp):
         __tracebackhide__ = True
         if tp[0] is None:
-            pytest.fail("DID NOT RAISE")
+            pytest.fail(self.message)
         if sys.version_info < (2, 7):
             # py26: on __exit__() exc_value often does not contain the
             # exception value.

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1412,12 +1412,11 @@ def raises(expected_exception, *args, **kwargs):
     elif not isclass(expected_exception):
         raise TypeError(msg % type(expected_exception))
 
-    if "message" in kwargs:
-        message = kwargs.pop("message")
-    else:
-        message = "DID NOT RAISE {0}".format(expected_exception)
+    message = "DID NOT RAISE {0}".format(expected_exception)
 
     if not args:
+        if "message" in kwargs:
+            message = kwargs.pop("message")
         return RaisesContext(expected_exception, message)
     elif isinstance(args[0], str):
         code, = args

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1337,6 +1337,8 @@ def raises(expected_exception, *args, **kwargs):
         >>> with raises(ZeroDivisionError):
         ...    1/0
 
+    .. versionchanged:: 2.10
+
     In the context manager form you may use the keyword argument
     ``message`` to specify a custom failure message::
 

--- a/doc/en/assert.rst
+++ b/doc/en/assert.rst
@@ -85,6 +85,8 @@ and if you need to have access to the actual exception info you may use::
 the actual exception raised.  The main attributes of interest are
 ``.type``, ``.value`` and ``.traceback``.
 
+.. versionchanged:: 2.10
+
 In the context manager form you may use the keyword argument
 ``message`` to specify a custom failure message::
 

--- a/doc/en/assert.rst
+++ b/doc/en/assert.rst
@@ -85,6 +85,13 @@ and if you need to have access to the actual exception info you may use::
 the actual exception raised.  The main attributes of interest are
 ``.type``, ``.value`` and ``.traceback``.
 
+In the context manager form you may use the keyword argument
+``message`` to specify a custom failure message::
+
+     >>> with raises(ZeroDivisionError, message="Expecting ZeroDivisionError"):
+     ...    pass
+     ... Failed: Expecting ZeroDivisionError
+
 If you want to write test code that works on Python 2.4 as well,
 you may also use two other ways to test for an expected exception::
 

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -76,3 +76,20 @@ class TestRaises:
             pytest.raises(ValueError, int, '0')
         except pytest.raises.Exception as e:
             assert e.msg == "DID NOT RAISE {0}".format(repr(ValueError))
+        try:
+            with pytest.raises(ValueError):
+                pass
+        except pytest.raises.Exception as e:
+            e.msg == "DID NOT RAISE {0}".format(repr(ValueError))
+
+    def test_costum_raise_message(self):
+        message = "TEST_MESSAGE"
+        try:
+            pytest.raises(ValueError, int, '0', message=message)
+        except pytest.raises.Exception as e:
+            assert e.msg == message
+        try:
+            with pytest.raises(ValueError, message=message):
+                pass
+        except pytest.raises.Exception as e:
+            e.msg == message

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -80,7 +80,7 @@ class TestRaises:
             with pytest.raises(ValueError):
                 pass
         except pytest.raises.Exception as e:
-            e.msg == "DID NOT RAISE {0}".format(repr(ValueError))
+            assert e.msg == "DID NOT RAISE {0}".format(repr(ValueError))
 
     def test_costum_raise_message(self):
         message = "TEST_MESSAGE"
@@ -92,4 +92,4 @@ class TestRaises:
             with pytest.raises(ValueError, message=message):
                 pass
         except pytest.raises.Exception as e:
-            e.msg == message
+            assert e.msg == message

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -76,20 +76,23 @@ class TestRaises:
             pytest.raises(ValueError, int, '0')
         except pytest.raises.Exception as e:
             assert e.msg == "DID NOT RAISE {0}".format(repr(ValueError))
+        else:
+            assert False, "Expected pytest.raises.Exception"
+
         try:
             with pytest.raises(ValueError):
                 pass
         except pytest.raises.Exception as e:
             assert e.msg == "DID NOT RAISE {0}".format(repr(ValueError))
+        else:
+            assert False, "Expected pytest.raises.Exception"
 
     def test_costum_raise_message(self):
         message = "TEST_MESSAGE"
-        try:
-            pytest.raises(ValueError, int, '0', message=message)
-        except pytest.raises.Exception as e:
-            assert e.msg == message
         try:
             with pytest.raises(ValueError, message=message):
                 pass
         except pytest.raises.Exception as e:
             assert e.msg == message
+        else:
+            assert False, "Expected pytest.raises.Exception"


### PR DESCRIPTION
This PR change pytest.raises to accept custom made message that will be raised if no exception was raised. For example:

```py
with pytest.raises(KeyError, message="I am expecting a KeyError to be raised"):
    pass
Failed: I am expecting a KeyError to be raised
```

The use case behind this feature is as follows:

```py
for i in random.shuffle(["a", "b", "c"]):
   with pytest.raises(KeyError):
        if i == "b":
            raise KeyError
```

As you can see in this example I can't know at which ``input`` I have failed from the result of the test. The new message will allow me to change the test as follows:

 ```py
for input in random.shuffle(["a", "b", "c"]):
   with pytest.raises(KeyError, message="Key error was not raised for input {}".format(i)):
        if input == "b":
            raise KeyError
```

Now I can know the exact ``input`` the test failed.