### PR TITLE
Issue 1619 conftest assert rewrite

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -84,6 +84,7 @@ Ronny Pfannschmidt
 Ross Lawley
 Ryan Wooden
 Samuele Pedroni
+Stephan Obermann
 Tareq Alayan
 Tom Viner
 Trevor Bekolay

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -74,8 +74,19 @@
   message to raise when no exception occurred.
   Thanks `@palaviv`_ for the complete PR (`#1616`_).
 
+* ``conftest.py`` files now benefit from assertion rewriting; previously it
+  was only available for test modules. Thanks `@flub`_, `@sober7`_ and
+  `@nicoddemus`_ for the PR (`#1619`_).
+
+*
+
+*
+
+*
+
 .. _@milliams: https://github.com/milliams
 .. _@csaftoiu: https://github.com/csaftoiu
+.. _@flub: https://github.com/flub
 .. _@novas0x2a: https://github.com/novas0x2a
 .. _@kalekundert: https://github.com/kalekundert
 .. _@tareqalayan: https://github.com/tareqalayan
@@ -83,6 +94,7 @@
 .. _@palaviv: https://github.com/palaviv
 .. _@omarkohl: https://github.com/omarkohl
 .. _@mikofski: https://github.com/mikofski
+.. _@sober7: https://github.com/sober7
 
 .. _#1426: https://github.com/pytest-dev/pytest/issues/1426
 .. _#1428: https://github.com/pytest-dev/pytest/pull/1428
@@ -95,6 +107,7 @@
 .. _#1474: https://github.com/pytest-dev/pytest/pull/1474
 .. _#1502: https://github.com/pytest-dev/pytest/pull/1502
 .. _#1520: https://github.com/pytest-dev/pytest/pull/1520
+.. _#1619: https://github.com/pytest-dev/pytest/issues/1619
 .. _#372: https://github.com/pytest-dev/pytest/issues/372
 .. _#1544: https://github.com/pytest-dev/pytest/issues/1544
 .. _#1616: https://github.com/pytest-dev/pytest/pull/1616

--- a/_pytest/assertion/__init__.py
+++ b/_pytest/assertion/__init__.py
@@ -165,7 +165,6 @@ def _load_modules(mode):
 
 
 def warn_about_missing_assertion(mode, pluginmanager):
-    print('got here')
     try:
         assert False
     except AssertionError:

--- a/_pytest/assertion/__init__.py
+++ b/_pytest/assertion/__init__.py
@@ -76,8 +76,7 @@ def pytest_load_initial_conftests(early_config, parser, args):
 
     hook = None
     if mode == "rewrite":
-        hook = rewrite.AssertionRewritingHook()  # noqa
-        hook.set_config(early_config)
+        hook = rewrite.AssertionRewritingHook(early_config)  # noqa
         sys.meta_path.insert(0, hook)
 
     early_config._assertstate.hook = hook

--- a/_pytest/assertion/rewrite.py
+++ b/_pytest/assertion/rewrite.py
@@ -87,7 +87,7 @@ class AssertionRewritingHook(object):
 
         fn_pypath = py.path.local(fn)
         if not self._should_rewrite(fn_pypath, state):
-            return
+            return None
 
         # The requested module looks like a test file, so rewrite it. This is
         # the most magical part of the process: load the source, rewrite the

--- a/_pytest/assertion/rewrite.py
+++ b/_pytest/assertion/rewrite.py
@@ -44,17 +44,15 @@ else:
 class AssertionRewritingHook(object):
     """PEP302 Import hook which rewrites asserts."""
 
-    def __init__(self):
+    def __init__(self, config):
+        self.config = config
+        self.fnpats = config.getini("python_files")
         self.session = None
         self.modules = {}
         self._register_with_pkg_resources()
 
     def set_session(self, session):
         self.session = session
-
-    def set_config(self, config):
-        self.config = config
-        self.fnpats = config.getini("python_files")
 
     def find_module(self, name, path=None):
         state = self.config._assertstate

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -694,6 +694,40 @@ class TestAssertionRewriteHookDetails(object):
         result = testdir.runpytest()
         result.stdout.fnmatch_lines('*1 passed*')
 
+    @pytest.mark.parametrize('initial_conftest', [True, False])
+    @pytest.mark.parametrize('mode', ['plain', 'rewrite', 'reinterp'])
+    def test_conftest_assertion_rewrite(self, testdir, initial_conftest, mode):
+        """Test that conftest files are using assertion rewrite on import.
+        (#1619)
+        """
+        testdir.tmpdir.join('foo/tests').ensure(dir=1)
+        conftest_path = 'conftest.py' if initial_conftest else 'foo/conftest.py'
+        contents = {
+            conftest_path: """
+                import pytest
+                @pytest.fixture
+                def check_first():
+                    def check(values, value):
+                        assert values.pop(0) == value
+                    return check
+            """,
+            'foo/tests/test_foo.py': """
+                def test(check_first):
+                    check_first([10, 30], 30)
+            """
+        }
+        testdir.makepyfile(**contents)
+        result = testdir.runpytest_subprocess('--assert=%s' % mode)
+        if mode == 'plain':
+            expected = 'E       AssertionError'
+        elif mode == 'rewrite':
+            expected = '*assert 10 == 30*'
+        elif mode == 'reinterp':
+            expected = '*AssertionError:*was re-run*'
+        else:
+            assert 0
+        result.stdout.fnmatch_lines([expected])
+
 
 def test_issue731(testdir):
     testdir.makepyfile("""

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -485,9 +485,14 @@ def test_load_initial_conftest_last_ordering(testdir):
     pm.register(m)
     hc = pm.hook.pytest_load_initial_conftests
     l = hc._nonwrappers + hc._wrappers
-    assert l[-1].function.__module__ == "_pytest.capture"
-    assert l[-2].function == m.pytest_load_initial_conftests
-    assert l[-3].function.__module__ == "_pytest.config"
+    expected = [
+        "_pytest.config",
+        'test_config',
+        '_pytest.assertion',
+        '_pytest.capture',
+    ]
+    assert [x.function.__module__ for x in l] == expected
+
 
 class TestWarning:
     def test_warn_config(self, testdir):


### PR DESCRIPTION
This change now makes rewrites assertions in `conftest.py` files so they can benefit from assertion rewriting. 

Fixes #1619
cc @flub @sober7