### PR TITLE
Ignore hidden files (.testmondata) in test_pytest_collect_file

### DIFF
--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -150,7 +150,9 @@ class TestCollectPluginHookRelay:
         wascalled = []
         class Plugin:
             def pytest_collect_file(self, path, parent):
-                wascalled.append(path)
+                if not path.basename.startswith("."):
+                    # Ignore hidden files, e.g. .testmondata.
+                    wascalled.append(path)
         testdir.makefile(".abc", "xyz")
         pytest.main([testdir.tmpdir], plugins=[Plugin()])
         assert len(wascalled) == 1


### PR DESCRIPTION
`test_pytest_collect_file` fails if you run the tests using `--testmon`,
because pytest-testmon will put its DB there as `.testmondata`.