### PR TITLE
issue1625, rename getfuncargvalue to getfixturevalue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,10 @@
   Thanks `@Vogtinator`_ for reporting. Thanks to `@RedBeardCode`_ and
   `@tomviner`_ for PR.
 
+* Rename ``getfuncargvalue`` to ``getfixturevalue``. ``getfuncargvalue`` is
+  deprecated but still present. Thanks to `@RedBeardCode`_ and `@tomviner`_
+  for PR (`#1626`_).
+
 *
 
 .. _#1580: https://github.com/pytest-dev/pytest/pull/1580
@@ -34,6 +38,7 @@
 .. _#1597: https://github.com/pytest-dev/pytest/pull/1597
 .. _#460: https://github.com/pytest-dev/pytest/pull/460
 .. _#1553: https://github.com/pytest-dev/pytest/issues/1553
+.. _#1626: https://github.com/pytest-dev/pytest/pull/1626
 
 .. _@graingert: https://github.com/graingert
 .. _@taschini: https://github.com/taschini

--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -70,7 +70,7 @@ class DoctestItem(pytest.Item):
     def setup(self):
         if self.dtest is not None:
             self.fixture_request = _setup_fixtures(self)
-            globs = dict(getfixture=self.fixture_request.getfuncargvalue)
+            globs = dict(getfixture=self.fixture_request.getfixturevalue)
             self.dtest.globs.update(globs)
 
     def runtest(self):

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -5,6 +5,7 @@ import inspect
 import re
 import types
 import sys
+import warnings
 
 import py
 import pytest
@@ -1469,7 +1470,7 @@ class FixtureRequest(FuncargnamesCompatAttr):
         fixturedefs = self._arg2fixturedefs.get(argname, None)
         if fixturedefs is None:
             # we arrive here because of a  a dynamic call to
-            # getfuncargvalue(argname) usage which was naturally
+            # getfixturevalue(argname) usage which was naturally
             # not known at parsing/collection time
             fixturedefs = self._fixturemanager.getfixturedefs(
                             argname, self._pyfuncitem.parent.nodeid)
@@ -1564,7 +1565,7 @@ class FixtureRequest(FuncargnamesCompatAttr):
         fixturenames = getattr(item, "fixturenames", self.fixturenames)
         for argname in fixturenames:
             if argname not in item.funcargs:
-                item.funcargs[argname] = self.getfuncargvalue(argname)
+                item.funcargs[argname] = self.getfixturevalue(argname)
 
     def cached_setup(self, setup, teardown=None, scope="module", extrakey=None):
         """ (deprecated) Return a testing resource managed by ``setup`` &
@@ -1598,16 +1599,22 @@ class FixtureRequest(FuncargnamesCompatAttr):
                 self._addfinalizer(finalizer, scope=scope)
         return val
 
-    def getfuncargvalue(self, argname):
-        """ Dynamically retrieve a named fixture function argument.
+    def getfixturevalue(self, argname):
+        """ Dynamically run a named fixture function.
 
-        As of pytest-2.3, it is easier and usually better to access other
-        fixture values by stating it as an input argument in the fixture
-        function.  If you only can decide about using another fixture at test
+        Declaring fixtures via function argument is recommended where possible.
+        But if you can only decide whether to use another fixture at test
         setup time, you may use this function to retrieve it inside a fixture
-        function body.
+        or test function body.
         """
         return self._get_active_fixturedef(argname).cached_result[0]
+
+    def getfuncargvalue(self, argname):
+        """ Deprecated, use getfixturevalue. """
+        warnings.warn(
+            "use of getfuncargvalue is deprecated, use getfixturevalue",
+            DeprecationWarning)
+        return self.getfixturevalue(argname)
 
     def _get_active_fixturedef(self, argname):
         try:
@@ -1624,7 +1631,7 @@ class FixtureRequest(FuncargnamesCompatAttr):
                 raise
         # remove indent to prevent the python3 exception
         # from leaking into the call
-        result = self._getfuncargvalue(fixturedef)
+        result = self._getfixturevalue(fixturedef)
         self._funcargs[argname] = result
         self._fixturedefs[argname] = fixturedef
         return fixturedef
@@ -1640,7 +1647,7 @@ class FixtureRequest(FuncargnamesCompatAttr):
             l.append(fixturedef)
             current = current._parent_request
 
-    def _getfuncargvalue(self, fixturedef):
+    def _getfixturevalue(self, fixturedef):
         # prepare a subrequest object before calling fixture function
         # (latter managed by fixturedef)
         argname = fixturedef.argname

--- a/doc/en/genapi.py
+++ b/doc/en/genapi.py
@@ -32,7 +32,7 @@ class Writer:
 
 def pytest_funcarg__a(request):
     with Writer("request") as writer:
-        writer.docmethod(request.getfuncargvalue)
+        writer.docmethod(request.getfixturevalue)
         writer.docmethod(request.cached_setup)
         writer.docmethod(request.addfinalizer)
         writer.docmethod(request.applymarker)

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -327,7 +327,7 @@ class TestFormattedExcinfo:
     def pytest_funcarg__importasmod(self, request):
         def importasmod(source):
             source = _pytest._code.Source(source)
-            tmpdir = request.getfuncargvalue("tmpdir")
+            tmpdir = request.getfixturevalue("tmpdir")
             modpath = tmpdir.join("mod.py")
             tmpdir.ensure("__init__.py")
             modpath.write(source)

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -93,12 +93,12 @@ class TestFillFixtures:
         sub1.join("conftest.py").write(_pytest._code.Source("""
             import pytest
             def pytest_funcarg__arg1(request):
-                pytest.raises(Exception, "request.getfuncargvalue('arg2')")
+                pytest.raises(Exception, "request.getfixturevalue('arg2')")
         """))
         sub2.join("conftest.py").write(_pytest._code.Source("""
             import pytest
             def pytest_funcarg__arg2(request):
-                pytest.raises(Exception, "request.getfuncargvalue('arg1')")
+                pytest.raises(Exception, "request.getfixturevalue('arg1')")
         """))
 
         sub1.join("test_in_sub1.py").write("def test_1(arg1): pass")
@@ -435,21 +435,23 @@ class TestRequestBasic:
         assert len(arg2fixturedefs) == 1
         assert arg2fixturedefs[0].__name__ == "pytest_funcarg__something"
 
-    def test_getfuncargvalue_recursive(self, testdir):
+    def test_getfixturevalue_recursive(self, testdir):
         testdir.makeconftest("""
             def pytest_funcarg__something(request):
                 return 1
         """)
         testdir.makepyfile("""
             def pytest_funcarg__something(request):
-                return request.getfuncargvalue("something") + 1
+                return request.getfixturevalue("something") + 1
             def test_func(something):
                 assert something == 2
         """)
         reprec = testdir.inline_run()
         reprec.assertoutcome(passed=1)
 
-    def test_getfuncargvalue(self, testdir):
+    @pytest.mark.parametrize(
+        'getfixmethod', ('getfixturevalue', 'getfuncargvalue'))
+    def test_getfixturevalue(self, testdir, getfixmethod):
         item = testdir.getitem("""
             l = [2]
             def pytest_funcarg__something(request): return 1
@@ -458,14 +460,15 @@ class TestRequestBasic:
             def test_func(something): pass
         """)
         req = item._request
-        pytest.raises(FixtureLookupError, req.getfuncargvalue, "notexists")
-        val = req.getfuncargvalue("something")
+        fixture_fetcher = getattr(req, getfixmethod)
+        pytest.raises(FixtureLookupError, fixture_fetcher, "notexists")
+        val = fixture_fetcher("something")
         assert val == 1
-        val = req.getfuncargvalue("something")
+        val = fixture_fetcher("something")
         assert val == 1
-        val2 = req.getfuncargvalue("other")
+        val2 = fixture_fetcher("other")
         assert val2 == 2
-        val2 = req.getfuncargvalue("other")  # see about caching
+        val2 = fixture_fetcher("other")  # see about caching
         assert val2 == 2
         pytest._fillfuncargs(item)
         assert item.funcargs["something"] == 1
@@ -812,10 +815,10 @@ class TestRequestCachedSetup:
             "*1 passed*"
         ])
 
-    def test_request_cached_setup_getfuncargvalue(self, testdir):
+    def test_request_cached_setup_getfixturevalue(self, testdir):
         testdir.makepyfile("""
             def pytest_funcarg__arg1(request):
-                arg1 = request.getfuncargvalue("arg2")
+                arg1 = request.getfixturevalue("arg2")
                 return request.cached_setup(lambda: arg1 + 1)
             def pytest_funcarg__arg2(request):
                 return request.cached_setup(lambda: 10)
@@ -1118,7 +1121,7 @@ class TestFixtureUsages:
 
 class TestFixtureManagerParseFactories:
     def pytest_funcarg__testdir(self, request):
-        testdir = request.getfuncargvalue("testdir")
+        testdir = request.getfixturevalue("testdir")
         testdir.makeconftest("""
             def pytest_funcarg__hello(request):
                 return "conftest"
@@ -1804,9 +1807,9 @@ class TestFixtureMarker:
         reprec.assertoutcome(passed=4)
 
     @pytest.mark.parametrize("method", [
-        'request.getfuncargvalue("arg")',
+        'request.getfixturevalue("arg")',
         'request.cached_setup(lambda: None, scope="function")',
-    ], ids=["getfuncargvalue", "cached_setup"])
+    ], ids=["getfixturevalue", "cached_setup"])
     def test_scope_mismatch_various(self, testdir, method):
         testdir.makeconftest("""
             import pytest
@@ -2737,6 +2740,7 @@ class TestContextManagerFixtureFuncs:
             *def arg1*
         """)
 
+
 class TestParameterizedSubRequest:
     def test_call_from_fixture(self, testdir):
         testfile = testdir.makepyfile("""
@@ -2748,7 +2752,7 @@ class TestParameterizedSubRequest:
 
             @pytest.fixture
             def get_named_fixture(request):
-                return request.getfuncargvalue('fix_with_param')
+                return request.getfixturevalue('fix_with_param')
 
             def test_foo(request, get_named_fixture):
                 pass
@@ -2773,7 +2777,7 @@ class TestParameterizedSubRequest:
                 return request.param
 
             def test_foo(request):
-                request.getfuncargvalue('fix_with_param')
+                request.getfixturevalue('fix_with_param')
             """)
         result = testdir.runpytest()
         result.stdout.fnmatch_lines("""
@@ -2797,7 +2801,7 @@ class TestParameterizedSubRequest:
 
         testfile = testdir.makepyfile("""
             def test_foo(request):
-                request.getfuncargvalue('fix_with_param')
+                request.getfixturevalue('fix_with_param')
             """)
         result = testdir.runpytest()
         result.stdout.fnmatch_lines("""
@@ -2827,7 +2831,7 @@ class TestParameterizedSubRequest:
             from fix import fix_with_param
 
             def test_foo(request):
-                request.getfuncargvalue('fix_with_param')
+                request.getfixturevalue('fix_with_param')
             """))
 
         tests_dir.chdir()
@@ -2842,3 +2846,7 @@ class TestParameterizedSubRequest:
             E*{1}:5
             *1 failed*
             """.format(fixfile.strpath, testfile.basename))
+
+
+def test_getfuncargvalue_is_deprecated(request):
+    pytest.deprecated_call(request.getfuncargvalue, 'tmpdir')

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -720,14 +720,14 @@ class TestMetafuncFunctional:
             "*4 failed*",
         ])
 
-    def test_parametrize_and_inner_getfuncargvalue(self, testdir):
+    def test_parametrize_and_inner_getfixturevalue(self, testdir):
         p = testdir.makepyfile("""
             def pytest_generate_tests(metafunc):
                 metafunc.parametrize("arg1", [1], indirect=True)
                 metafunc.parametrize("arg2", [10], indirect=True)
 
             def pytest_funcarg__arg1(request):
-                x = request.getfuncargvalue("arg2")
+                x = request.getfixturevalue("arg2")
                 return x + request.param
 
             def pytest_funcarg__arg2(request):

--- a/testing/test_genscript.py
+++ b/testing/test_genscript.py
@@ -8,7 +8,7 @@ def standalone(request):
 
 class Standalone:
     def __init__(self, request):
-        self.testdir = request.getfuncargvalue("testdir")
+        self.testdir = request.getfixturevalue("testdir")
         script = "mypytest"
         result = self.testdir.runpytest("--genscript=%s" % script)
         assert result.ret == 0

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -13,7 +13,7 @@ def runpdb_and_get_report(testdir, source):
 
 class TestPDB:
     def pytest_funcarg__pdblist(self, request):
-        monkeypatch = request.getfuncargvalue("monkeypatch")
+        monkeypatch = request.getfixturevalue("monkeypatch")
         pdblist = []
         def mypdb(*args):
             pdblist.append(args)


### PR DESCRIPTION
Fix for https://github.com/pytest-dev/pytest/issues/1625

`getfuncargvalue` will be deprecated but will still be supported for the moment.