### PR TITLE
help the user in the rare case this assertion actually fails

### DIFF
--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1987,7 +1987,7 @@ class FixtureManager:
                 # fixture attribute
                 continue
             else:
-                assert not name.startswith(self._argprefix)
+                assert not name.startswith(self._argprefix), name
             fixturedef = FixtureDef(self, nodeid, name, obj,
                                     marker.scope, marker.params,
                                     yieldctx=marker.yieldctx,


### PR DESCRIPTION
Trivial change discussed during the sprint to give the user the name, where the assertion fails.