### PR TITLE
Issue 1553: Include terminal newlines in diffs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,15 +23,23 @@
   only ran once. Now a failure is raised. Fixes (`#460`_). Thanks to
   `@nikratio`_ for bug report, `@RedBeardCode`_ and `@tomviner`_ for PR.
 
+* Create correct diff for strings ending with newlines. Fixes (`#1553`_).
+  Thanks `@Vogtinator`_ for reporting. Thanks to `@RedBeardCode`_ and
+  `@tomviner`_ for PR.
+
+*
+
 .. _#1580: https://github.com/pytest-dev/pytest/pull/1580
 .. _#1605: https://github.com/pytest-dev/pytest/issues/1605
 .. _#1597: https://github.com/pytest-dev/pytest/pull/1597
 .. _#460: https://github.com/pytest-dev/pytest/pull/460
+.. _#1553: https://github.com/pytest-dev/pytest/issues/1553
 
 .. _@graingert: https://github.com/graingert
 .. _@taschini: https://github.com/taschini
 .. _@nikratio: https://github.com/nikratio
 .. _@RedBeardCode: https://github.com/RedBeardCode
+.. _@Vogtinator: https://github.com/Vogtinator
 
 
 2.9.2

--- a/_pytest/assertion/util.py
+++ b/_pytest/assertion/util.py
@@ -225,9 +225,10 @@ def _diff_text(left, right, verbose=False):
                                   'characters in diff, use -v to show') % i]
                 left = left[:-i]
                 right = right[:-i]
+    keepends = True
     explanation += [line.strip('\n')
-                    for line in ndiff(left.splitlines(),
-                                      right.splitlines())]
+                    for line in ndiff(left.splitlines(keepends),
+                                      right.splitlines(keepends))]
     return explanation
 
 

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -428,7 +428,7 @@ def test_assert_compare_truncate_longmessage(monkeypatch, testdir):
         "*- 3",
         "*- 5",
         "*- 7",
-        "*truncated (191 more lines)*use*-vv*",
+        "*truncated (193 more lines)*use*-vv*",
     ])
 
 
@@ -626,3 +626,17 @@ def test_set_with_unsortable_elements():
         + repr(3)
     """).strip()
     assert '\n'.join(expl) == dedent
+
+def test_diff_newline_at_end(monkeypatch, testdir):
+    testdir.makepyfile(r"""
+        def test_diff():
+            assert 'asdf' == 'asdf\n'
+    """)
+
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(r"""
+        *assert 'asdf' == 'asdf\n'
+        *  - asdf
+        *  + asdf
+        *  ?     +
+    """)


### PR DESCRIPTION
Fix for https://github.com/pytest-dev/pytest/issues/1553

By default [Python's splitlines method](https://docs.python.org/2/library/stdtypes.html#str.splitlines) splits so "a terminal line break does not result in an extra line". This means that comparing strings that differ only in whether they contain a terminal newline, results in a bad diff.

This PR sets splitlines' `keepends=True`, which keeps all newlines when splitting.