### PR TITLE
cache.rst: Fix wrong command used

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,6 +22,7 @@ Bruno Oliveira
 Cal Leeming
 Carl Friedrich Bolz
 Charles Cloud
+Charnjit SiNGH (CCSJ)
 Chris Lamb
 Christian Theunert
 Christian Tismer

--- a/doc/en/cache.rst
+++ b/doc/en/cache.rst
@@ -222,9 +222,9 @@ Inspecting Cache content
 -------------------------------
 
 You can always peek at the content of the cache using the
-``--cache-clear`` command line option::
+``--cache-show`` command line option::
 
-    $ py.test --cache-clear
+    $ py.test --cache-show
     ======= test session starts ========
     platform linux -- Python 3.5.1, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
     rootdir: $REGENDOC_TMPDIR, inifile: 


### PR DESCRIPTION
  The "Inspecting Cache content" section was showing --cache-clear command,
  but should actually be using --cache-show command.

  Also; update AUTHORS