### PR TITLE
Simplify Argument.__repr__

### DIFF
--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -655,20 +655,17 @@ class Argument:
                 self._long_opts.append(opt)
 
     def __repr__(self):
-        retval = 'Argument('
+        args = []
         if self._short_opts:
-            retval += '_short_opts: ' + repr(self._short_opts) + ', '
+            args += ['_short_opts: ' + repr(self._short_opts)]
         if self._long_opts:
-            retval += '_long_opts: ' + repr(self._long_opts) + ', '
-        retval += 'dest: ' + repr(self.dest) + ', '
+            args += ['_long_opts: ' + repr(self._long_opts)]
+        args += ['dest: ' + repr(self.dest)]
         if hasattr(self, 'type'):
-            retval += 'type: ' + repr(self.type) + ', '
+            args += ['type: ' + repr(self.type)]
         if hasattr(self, 'default'):
-            retval += 'default: ' + repr(self.default) + ', '
-        if retval[-2:] == ', ':  # always long enough to test ("Argument(" )
-            retval = retval[:-2]
-        retval += ')'
-        return retval
+            args += ['default: ' + repr(self.default)]
+        return 'Argument({0})'.format(', '.join(args))
 
 
 class OptionGroup:

--- a/testing/test_parseopt.py
+++ b/testing/test_parseopt.py
@@ -29,6 +29,9 @@ class TestParser:
         assert argument.dest == 'test'
         argument = parseopt.Argument('-t', '--test', dest='abc')
         assert argument.dest == 'abc'
+        assert str(argument) == (
+            "Argument(_short_opts: ['-t'], _long_opts: ['--test'], dest: 'abc')"
+        )
 
     def test_argument_type(self):
         argument = parseopt.Argument('-t', dest='abc', type='int')


### PR DESCRIPTION
I have came across this when noticing that universal-ctags fails to parse
this correctly (https://github.com/universal-ctags/ctags/issues/997).