### PR TITLE
Fixes #1503 no longer collapse false explanations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,13 @@
   deprecated but still present. Thanks to `@RedBeardCode`_ and `@tomviner`_
   for PR (`#1626`_).
 
+* Always include full assertion explanation. The previous behaviour was hiding
+  sub-expressions that happened to be False, assuming this was redundant information.
+  Thanks `@bagerard`_ for reporting (`#1503`_). Thanks to `@davehunt`_ and
+  `@tomviner`_ for PR.
+
+*
+
 *
 
 .. _#1580: https://github.com/pytest-dev/pytest/pull/1580
@@ -39,12 +46,15 @@
 .. _#460: https://github.com/pytest-dev/pytest/pull/460
 .. _#1553: https://github.com/pytest-dev/pytest/issues/1553
 .. _#1626: https://github.com/pytest-dev/pytest/pull/1626
+.. _#1503: https://github.com/pytest-dev/pytest/issues/1503
 
 .. _@graingert: https://github.com/graingert
 .. _@taschini: https://github.com/taschini
 .. _@nikratio: https://github.com/nikratio
 .. _@RedBeardCode: https://github.com/RedBeardCode
 .. _@Vogtinator: https://github.com/Vogtinator
+.. _@bagerard: https://github.com/bagerard
+.. _@davehunt: https://github.com/davehunt
 
 
 2.9.2

--- a/_pytest/assertion/util.py
+++ b/_pytest/assertion/util.py
@@ -38,42 +38,9 @@ def format_explanation(explanation):
     displaying diffs.
     """
     explanation = ecu(explanation)
-    explanation = _collapse_false(explanation)
     lines = _split_explanation(explanation)
     result = _format_lines(lines)
     return u('\n').join(result)
-
-
-def _collapse_false(explanation):
-    """Collapse expansions of False
-
-    So this strips out any "assert False\n{where False = ...\n}"
-    blocks.
-    """
-    where = 0
-    while True:
-        start = where = explanation.find("False\n{False = ", where)
-        if where == -1:
-            break
-        level = 0
-        prev_c = explanation[start]
-        for i, c in enumerate(explanation[start:]):
-            if prev_c + c == "\n{":
-                level += 1
-            elif prev_c + c == "\n}":
-                level -= 1
-                if not level:
-                    break
-            prev_c = c
-        else:
-            raise AssertionError("unbalanced braces: %r" % (explanation,))
-        end = start + i
-        where = end
-        if explanation[end - 1] == '\n':
-            explanation = (explanation[:start] + explanation[start+15:end-1] +
-                           explanation[end+1:])
-            where -= 17
-    return explanation
 
 
 def _split_explanation(explanation):

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -213,10 +213,12 @@ class TestAssertionRewrite:
             return False
         def f():
             assert x() and x()
-        assert getmsg(f, {"x" : x}) == "assert (x())"
+        assert getmsg(f, {"x" : x}) == """assert (False)
+ +  where False = x()"""
         def f():
             assert False or x()
-        assert getmsg(f, {"x" : x}) == "assert (False or x())"
+        assert getmsg(f, {"x" : x}) == """assert (False or False)
+ +  where False = x()"""
         def f():
             assert 1 in {} and 2 in {}
         assert getmsg(f) == "assert (1 in {})"
@@ -299,27 +301,34 @@ class TestAssertionRewrite:
         ns = {"g" : g}
         def f():
             assert g()
-        assert getmsg(f, ns) == """assert g()"""
+        assert getmsg(f, ns) == """assert False
+ +  where False = g()"""
         def f():
             assert g(1)
-        assert getmsg(f, ns) == """assert g(1)"""
+        assert getmsg(f, ns) == """assert False
+ +  where False = g(1)"""
         def f():
             assert g(1, 2)
-        assert getmsg(f, ns) == """assert g(1, 2)"""
+        assert getmsg(f, ns) == """assert False
+ +  where False = g(1, 2)"""
         def f():
             assert g(1, g=42)
-        assert getmsg(f, ns) == """assert g(1, g=42)"""
+        assert getmsg(f, ns) == """assert False
+ +  where False = g(1, g=42)"""
         def f():
             assert g(1, 3, g=23)
-        assert getmsg(f, ns) == """assert g(1, 3, g=23)"""
+        assert getmsg(f, ns) == """assert False
+ +  where False = g(1, 3, g=23)"""
         def f():
             seq = [1, 2, 3]
             assert g(*seq)
-        assert getmsg(f, ns) == """assert g(*[1, 2, 3])"""
+        assert getmsg(f, ns) == """assert False
+ +  where False = g(*[1, 2, 3])"""
         def f():
             x = "a"
             assert g(**{x : 2})
-        assert getmsg(f, ns) == """assert g(**{'a': 2})"""
+        assert getmsg(f, ns) == """assert False
+ +  where False = g(**{'a': 2})"""
 
     def test_attribute(self):
         class X(object):
@@ -332,7 +341,8 @@ class TestAssertionRewrite:
         def f():
             x.a = False  # noqa
             assert x.a   # noqa
-        assert getmsg(f, ns) == """assert x.a"""
+        assert getmsg(f, ns) == """assert False
+ +  where False = x.a"""
 
     def test_comparisons(self):
         def f():
@@ -710,7 +720,3 @@ def test_issue731(testdir):
     """)
     result = testdir.runpytest()
     assert 'unbalanced braces' not in result.stdout.str()
-
-
-def test_collapse_false_unbalanced_braces():
-    util._collapse_false('some text{ False\n{False = some more text\n}')


### PR DESCRIPTION
Always include full assertion explanation. The previous behaviour was hiding sub-expressions that happened to be False, assuming this was redundant information. Fixes #1503.

At first glance it may seem that the additional explanation is redundant, closer inspection demonstrates value in this detail. For an example see #1503 where the reporter covers their use case.