### PR TITLE
fixes #1210 adds stderr write for pytest.exit(msg) call

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -96,3 +96,4 @@ Tom Viner
 Trevor Bekolay
 Wouter van Ackooy
 Bernard Pratz
+Jon Sonesen

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,20 +31,26 @@
   deprecated but still present. Thanks to `@RedBeardCode`_ and `@tomviner`_
   for PR (`#1626`_).
 
-*
+* Add stderr write for pytest.exit(msg) calls. Previously the message was never shown.
+  Thanks `@BeyondEvil`_ for reporting `#1210`_. Thanks to `@JonathonSonesen`_ and
+  `@tomviner`_ for PR.
 
+*
 .. _#1580: https://github.com/pytest-dev/pytest/pull/1580
 .. _#1605: https://github.com/pytest-dev/pytest/issues/1605
 .. _#1597: https://github.com/pytest-dev/pytest/pull/1597
 .. _#460: https://github.com/pytest-dev/pytest/pull/460
 .. _#1553: https://github.com/pytest-dev/pytest/issues/1553
 .. _#1626: https://github.com/pytest-dev/pytest/pull/1626
+.. _#1210: https://github.com/pytest-dev/pytest/issues/1210
 
 .. _@graingert: https://github.com/graingert
 .. _@taschini: https://github.com/taschini
 .. _@nikratio: https://github.com/nikratio
 .. _@RedBeardCode: https://github.com/RedBeardCode
 .. _@Vogtinator: https://github.com/Vogtinator
+.. _@BeyondEvil: https://github.com/BeyondEvil
+.. _@JonathonSonesen: https://github.com/JonathonSonesen
 
 
 2.9.2

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -90,10 +90,12 @@ def wrap_session(config, doit):
             session.exitstatus = doit(config, session) or 0
         except pytest.UsageError:
             raise
-        except KeyboardInterrupt:
+        except KeyboardInterrupt as e:
             excinfo = _pytest._code.ExceptionInfo()
             config.hook.pytest_keyboard_interrupt(excinfo=excinfo)
             session.exitstatus = EXIT_INTERRUPTED
+        except pytest.Exit as e:
+            sys.stderr.write('{0}: {1}\n'.format(type(e).__name__, e.msg))
         except:
             excinfo = _pytest._code.ExceptionInfo()
             config.notify_exception(excinfo, config.option)

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -457,6 +457,18 @@ def test_pytest_fail():
         s = excinfo.exconly(tryshort=True)
         assert s.startswith("Failed")
 
+def test_pytest_exit_msg(testdir):
+    testdir.makeconftest("""
+    import pytest
+
+    def pytest_configure(config):
+        pytest.exit('oh noes')
+    """)
+    result = testdir.runpytest()
+    result.stderr.fnmatch_lines([
+        "Exit: oh noes",
+    ])
+
 def test_pytest_fail_notrace(testdir):
     testdir.makepyfile("""
         import pytest


### PR DESCRIPTION
This PR addresses issue #1210 writing the exception message to stderr as well as the class name of the exception.
