### PR TITLE
Add --overwrite-ini ININAME=INIVALUE cli option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -100,6 +100,7 @@ Samuele Pedroni
 Steffen Allner
 Stephan Obermann
 Tareq Alayan
+Ted Xiao
 Simon Gomizelj
 Stefano Taschini
 Stefan Farmbauer

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,6 +79,10 @@
   finalizer and has access to the fixture's result cache.
   Thanks `@d6e`_, `@sallner`_
 
+* New cli flag ``--override-ini`` or ``-o`` that overrides values from the ini file.
+  Example '-o xfail_strict=True'. A complete ini-options can be viewed
+  by py.test --help. Thanks `@blueyed`_ and `@fengxx`_ for the PR
+
 
 **Changes**
 
@@ -155,6 +159,8 @@
 .. _@nikratio: https://github.com/nikratio
 .. _@RedBeardCode: https://github.com/RedBeardCode
 .. _@Vogtinator: https://github.com/Vogtinator
+.. _@blueyed: https://github.com/blueyed
+.. _@fengxx: https://github.com/fengxx
 
 * Fix `#1421`_: Exit tests if a collection error occurs and add
   ``--continue-on-collection-errors`` option to restore previous behaviour.

--- a/_pytest/helpconfig.py
+++ b/_pytest/helpconfig.py
@@ -20,6 +20,10 @@ def pytest_addoption(parser):
     group.addoption('--debug',
                action="store_true", dest="debug", default=False,
                help="store internal tracing debug information in 'pytestdebug.log'.")
+    # support for "--overwrite-ini ININAME=INIVALUE" to override values from the ini file
+    # Example '-o xfail_strict=True'.
+    group._addoption('-o', '--override-ini', nargs='*', dest="override_ini", action="append",
+               help="overrides ini values which do not have a separate command-line flag")
 
 
 @pytest.hookimpl(hookwrapper=True)


### PR DESCRIPTION
support for "--overwrite-ini ININAME=INIVALUE" to overrides ini values from the command line
so that one can do e.g. "-o xfail_strict=True". 