### PR TITLE
Improve of the test output for logical expression with brackets.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,10 @@
 
 * Renamed the pytest ``pdb`` module (plugin) into ``debugging``. 
 
+* Improve of the test output for logical expression with brackets.
+  Fixes(`#925`_). Thanks `@DRMacIver`_ for reporting. Thanks to `@RedBeardCode`_
+  for PR.
+
 *
 
 * ImportErrors in plugins now are a fatal error instead of issuing a
@@ -50,7 +54,11 @@
 .. _#1553: https://github.com/pytest-dev/pytest/issues/1553
 .. _#1626: https://github.com/pytest-dev/pytest/pull/1626
 .. _#1503: https://github.com/pytest-dev/pytest/issues/1503
+<<<<<<< HEAD
 .. _#1479: https://github.com/pytest-dev/pytest/issues/1479
+=======
+.. _#925: https://github.com/pytest-dev/pytest/issues/925
+>>>>>>> Improve of the test output for logical expression with brackets.
 
 .. _@graingert: https://github.com/graingert
 .. _@taschini: https://github.com/taschini
@@ -59,6 +67,7 @@
 .. _@Vogtinator: https://github.com/Vogtinator
 .. _@bagerard: https://github.com/bagerard
 .. _@davehunt: https://github.com/davehunt
+.. _@DRMacIver: https://github.com/DRMacIver
 
 
 2.9.2

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -720,3 +720,30 @@ def test_issue731(testdir):
     """)
     result = testdir.runpytest()
     assert 'unbalanced braces' not in result.stdout.str()
+
+
+class TestIssue925():
+    def test_simple_case(self, testdir):
+        testdir.makepyfile("""
+        def test_ternary_display():
+            assert (False == False) == False
+        """)
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines('*E*assert (False == False) == False')
+
+    def test_long_case(self, testdir):
+        testdir.makepyfile("""
+        def test_ternary_display():
+             assert False == (False == True) == True
+        """)
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines('*E*assert (False == True) == True')
+
+    def test_many_brackets(self, testdir):
+        testdir.makepyfile("""
+            def test_ternary_display():
+                 assert True == ((False == True) == True)
+            """)
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines('*E*assert True == ((False == True) == True)')
+


### PR DESCRIPTION
Tries put subexpression into brackets. Checks in the assertion rewriting in one operator is a expression itself and put it in brackets

  Fixes #925