### PR TITLE
showing pytest warnings summary by default.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Alexei Kozlenok
 Anatoly Bubenkoff
 Andreas Zeidler
 Andy Freeland
+Andrzej Ostrowski
 Anthon van der Neut
 Armin Rigo
 Aron Curzon

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,10 @@
   Thanks `@bagerard`_ for reporting (`#1503`_). Thanks to `@davehunt`_ and
   `@tomviner`_ for PR.
 
+* Whitelisted pytest warnings to show up warnings summary by default. Added a new
+  flag ``--disable-pytest-warnings`` to explicitly disable the warnings summary.
+  This change resolves the (`#1668`_).
+
 * Renamed the pytest ``pdb`` module (plugin) into ``debugging``. 
 
 *

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,7 @@
 .. _#1553: https://github.com/pytest-dev/pytest/issues/1553
 .. _#1626: https://github.com/pytest-dev/pytest/pull/1626
 .. _#1503: https://github.com/pytest-dev/pytest/issues/1503
+.. _#1668: https://github.com/pytest-dev/pytest/issues/1668
 
 .. _@graingert: https://github.com/graingert
 .. _@taschini: https://github.com/taschini

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -20,10 +20,15 @@ def pytest_addoption(parser):
     group._addoption('-q', '--quiet', action="count",
                dest="quiet", default=0, help="decrease verbosity."),
     group._addoption('-r',
-         action="store", dest="reportchars", default=None, metavar="chars",
+         action="store", dest="reportchars", default='', metavar="chars",
          help="show extra test summary info as specified by chars (f)ailed, "
               "(E)error, (s)skipped, (x)failed, (X)passed (w)pytest-warnings "
-              "(p)passed, (P)passed with output, (a)all except pP.")
+              "(p)passed, (P)passed with output, (a)all except pP. "
+              "The pytest warnings are displayed at all times except when "
+              "--disable-pytest-warnings is set")
+    group._addoption('--disable-pytest-warnings', default=False, 
+                     dest='disablepytestwarnings', action='store_true',
+                     help='disable warnings summary, overrides -r w flag')
     group._addoption('-l', '--showlocals',
          action="store_true", dest="showlocals", default=False,
          help="show locals in tracebacks (disabled by default).")
@@ -66,6 +71,10 @@ def getreportopt(config):
                 elif setting == "xfailed":
                     reportopts += "x"
     reportchars = config.option.reportchars
+    if not config.option.disablepytestwarnings and 'w' not in reportchars:
+        reportchars += 'w'
+    elif config.option.disablepytestwarnings and 'w' in reportchars:
+        reportchars = reportchars.replace('w', '')
     if reportchars:
         for char in reportchars:
             if char not in reportopts and char != 'a':

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -26,7 +26,7 @@ def pytest_addoption(parser):
               "(p)passed, (P)passed with output, (a)all except pP. "
               "The pytest warnings are displayed at all times except when "
               "--disable-pytest-warnings is set")
-    group._addoption('--disable-pytest-warnings', default=False, 
+    group._addoption('--disable-pytest-warnings', default=False,
                      dest='disablepytestwarnings', action='store_true',
                      help='disable warnings summary, overrides -r w flag')
     group._addoption('-l', '--showlocals',

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -519,7 +519,7 @@ class TestWarning:
         """)
         result = testdir.runpytest()
         assert result.parseoutcomes()["pytest-warnings"] > 0
-        assert "hello" not in result.stdout.str()
+        assert "hello" in result.stdout.str()
 
         result = testdir.runpytest("-rw")
         result.stdout.fnmatch_lines("""

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -613,7 +613,7 @@ def test_getreportopt():
     assert getreportopt(config) == "sfxw"
 
     config.option.reportchars = "sfxw"
-    config.option.disablepytestwarnings = False 
+    config.option.disablepytestwarnings = False
     assert getreportopt(config) == "sfxw"
 
 

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -591,6 +591,7 @@ def test_getreportopt():
     class config:
         class option:
             reportchars = ""
+            disablepytestwarnings = True
     config.option.report = "xfailed"
     assert getreportopt(config) == "x"
 
@@ -601,11 +602,20 @@ def test_getreportopt():
     assert getreportopt(config) == "sx"
 
     config.option.report = "skipped"
-    config.option.reportchars = "sf"
+    config.option.reportchars = "sfw"
     assert getreportopt(config) == "sf"
 
-    config.option.reportchars = "sfx"
+    config.option.reportchars = "sfxw"
     assert getreportopt(config) == "sfx"
+
+    config.option.reportchars = "sfx"
+    config.option.disablepytestwarnings = False
+    assert getreportopt(config) == "sfxw"
+
+    config.option.reportchars = "sfxw"
+    config.option.disablepytestwarnings = False 
+    assert getreportopt(config) == "sfxw"
+
 
 def test_terminalreporter_reportopt_addopts(testdir):
     testdir.makeini("[pytest]\naddopts=-rs")


### PR DESCRIPTION
Hi,

Did the following
* added ``--disable-pytest-warnings` flag to let users disable the warnings summary.
* extended/changed unit tests for the changes in the pytest core.


Additionally, I decided to add myself to the authors.