### PR TITLE
Add warning for assertions on tuples #1562

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,6 +79,10 @@
   finalizer and has access to the fixture's result cache.
   Thanks `@d6e`_, `@sallner`_
 
+* Issue a warning for asserts whose test is a tuple literal. Such asserts will
+  never fail because tuples are always truthy and are usually a mistake
+  (see `#1562`_). Thanks `@kvas-it`_, for the PR.
+
 * New cli flag ``--override-ini`` or ``-o`` that overrides values from the ini file.
   Example '-o xfail_strict=True'. A complete ini-options can be viewed
   by py.test --help. Thanks `@blueyed`_ and `@fengxx`_ for the PR
@@ -207,6 +211,7 @@
 .. _#1619: https://github.com/pytest-dev/pytest/issues/1619
 .. _#372: https://github.com/pytest-dev/pytest/issues/372
 .. _#1544: https://github.com/pytest-dev/pytest/issues/1544
+.. _#1562: https://github.com/pytest-dev/pytest/issues/1562
 .. _#1616: https://github.com/pytest-dev/pytest/pull/1616
 .. _#1628: https://github.com/pytest-dev/pytest/pull/1628
 .. _#1629: https://github.com/pytest-dev/pytest/issues/1629

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -640,3 +640,11 @@ def test_diff_newline_at_end(monkeypatch, testdir):
         *  + asdf
         *  ?     +
     """)
+
+def test_assert_tuple_warning(testdir):
+    testdir.makepyfile("""
+        def test_tuple():
+            assert(False, 'you shall not pass')
+    """)
+    result = testdir.runpytest('-rw')
+    result.stdout.fnmatch_lines('WR1*:2 assertion is always true*')

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -648,3 +648,13 @@ def test_assert_tuple_warning(testdir):
     """)
     result = testdir.runpytest('-rw')
     result.stdout.fnmatch_lines('WR1*:2 assertion is always true*')
+
+def test_assert_indirect_tuple_no_warning(testdir):
+    testdir.makepyfile("""
+        def test_tuple():
+            tpl = ('foo', 'bar')
+            assert tpl
+    """)
+    result = testdir.runpytest('-rw')
+    output = '\n'.join(result.stdout.lines)
+    assert 'WR1' not in output


### PR DESCRIPTION
This PR adds a warning for assertions on tuples. The warning is issued by the assertion rewriter, as suggested by @RonnyPfannschmidt, so it will only be shown if the asserts are being rewritten (which is the default in most cases).

Checklist:

- [x] Target: for bug or doc fixes, target `master`; for new features, target `features`
- [x] Make sure to include one or more tests for your change
- [x] Add yourself to `AUTHORS`
- [x] Add a new entry to the `CHANGELOG` (choose any open position to avoid merge conflicts with other PRs)