### PR TITLE
Correctly reference values from the example in parametrize docs

### DIFF
--- a/doc/en/new-docs/user/parametrize.rst
+++ b/doc/en/new-docs/user/parametrize.rst
@@ -52,7 +52,7 @@ comma-separated values provided in the decorator::
 
 As designed in this example, only one pair of input/output values fails
 the simple test function.  And as usual with test function arguments,
-you can see the ``input`` and ``output`` values in the traceback.
+you can see the ``test_input`` and ``expected`` values in the traceback.
 
 See also
 --------


### PR DESCRIPTION
Making the suggested change from https://github.com/pytest-dev/pytest/pull/1646#discussion_r68103355.