### PR TITLE
Split AppVeyor test runs in multiple jobs to avoid timeout issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,13 @@ environment:
     # using pytestbot account as detailed here:
     # https://www.appveyor.com/docs/build-configuration#secure-variables
 
+  matrix:
+  # create multiple jobs to execute a set of tox runs on each; this is to workaround having
+  # builds timing out in AppVeyor
+  - TOXENV: "linting,py26,py27,py33,py34,py35,pypy"
+  - TOXENV: "py27-pexpect,py27-xdist,py27-trial,py35-pexpect,py35-xdist,py35-trial"
+  - TOXENV: "py27-nobyte,doctesting,py27-cxfreeze"
+
 install:
   - echo Installed Pythons
   - dir c:\Python*

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 minversion=2.0
 distshare={homedir}/.tox/distshare
+# make sure to update enviroment list on appveyor.yml
 envlist=
      linting,py26,py27,py33,py34,py35,pypy,
      {py27,py35}-{pexpect,xdist,trial},


### PR DESCRIPTION
Some of our builds have been timing out (over 1 hour) on AppVeyor