### PR TITLE
Making conftest import failures easier to debug

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ Jaap Broekhuizen
 Jan Balster
 Janne Vanhala
 Jason R. Coombs
+Javier Domingo Cansino
 John Towler
 Joshua Bronson
 Jurko Gospodnetić

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@
   level an error will be raised during collection.
   Thanks `@omarkohl`_ for the complete PR (`#1519`_).
 
-*
+* Fix (`1516`_): ConftestImportFailure now shows the traceback
 
 **Incompatible changes**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@
   level an error will be raised during collection.
   Thanks `@omarkohl`_ for the complete PR (`#1519`_).
 
-* Fix (`1516`_): ConftestImportFailure now shows the traceback
+* Fix (`#1516`_): ConftestImportFailure now shows the traceback
 
 **Incompatible changes**
 
@@ -30,6 +30,7 @@
 * removed support code for python 3 < 3.3 addressing (`#1627`_)
 
 .. _#607: https://github.com/pytest-dev/pytest/issues/607
+.. _#1516: https://github.com/pytest-dev/pytest/issues/1516
 .. _#1519: https://github.com/pytest-dev/pytest/pull/1519
 .. _#1664: https://github.com/pytest-dev/pytest/pull/1664
 .. _#1627: https://github.com/pytest-dev/pytest/pull/1627

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -25,6 +25,12 @@ class ConftestImportFailure(Exception):
         self.path = path
         self.excinfo = excinfo
 
+    def __str__(self):
+        etype, evalue, etb = self.excinfo
+        formatted = traceback.format_tb(etb)
+        # The level of the tracebacks we want to print is hand crafted :(
+        return repr(evalue) + '\n' + ''.join(formatted[2:])
+
 
 def main(args=None, plugins=None):
     """ return exit code, after performing an in-process test run.

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -407,3 +407,16 @@ def test_issue1073_conftest_special_objects(testdir):
     """)
     res = testdir.runpytest()
     assert res.ret == 0
+
+
+def test_conftest_exception_handling(testdir):
+    testdir.makeconftest('''
+        raise ValueError()
+    ''')
+    testdir.makepyfile("""
+        def test_some():
+            pass
+    """)
+    res = testdir.runpytest()
+    assert res.ret == 4
+    assert 'raise ValueError()' in [line.strip() for line in res.errlines]


### PR DESCRIPTION
We had problems at the office debugging a conftest error, so I am submitting this patch to close #1516 