### PR TITLE
Deprecate yield tests funcarg prefix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -185,7 +185,8 @@
   Before, you only got exceptions later from ``argparse`` library,
   giving no clue about the actual reason for double-added options.
 
-*
+* ``yield``-based tests are considered deprecated and will be removed in pytest-4.0.
+  Thanks `@nicoddemus`_ for the PR.
 
 *
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,7 +40,8 @@
   2])`` only ran once. Now a failure is raised. Fixes `#460`_. Thanks to
   `@nikratio`_ for bug report, `@RedBeardCode`_ and `@tomviner`_ for PR.
 
-*
+* ``_pytest.monkeypatch.monkeypatch`` class has been renamed to ``_pytest.monkeypatch.MonkeyPatch``
+  so it doesn't conflict with the ``monkeypatch`` fixture.
 
 *
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -188,7 +188,9 @@
 * ``yield``-based tests are considered deprecated and will be removed in pytest-4.0.
   Thanks `@nicoddemus`_ for the PR.
 
-*
+* Using ``pytest_funcarg__`` prefix to declare fixtures is considered deprecated and will be
+  removed in pytest-4.0 (`#1684`_).
+  Thanks `@nicoddemus`_ for the PR.
 
 *
 
@@ -262,6 +264,7 @@
 .. _#1632: https://github.com/pytest-dev/pytest/issues/1632
 .. _#1633: https://github.com/pytest-dev/pytest/pull/1633
 .. _#1664: https://github.com/pytest-dev/pytest/pull/1664
+.. _#1684: https://github.com/pytest-dev/pytest/pull/1684
 
 .. _@DRMacIver: https://github.com/DRMacIver
 .. _@RedBeardCode: https://github.com/RedBeardCode

--- a/_pytest/assertion/__init__.py
+++ b/_pytest/assertion/__init__.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 from _pytest.config import hookimpl
-from _pytest.monkeypatch import monkeypatch
+from _pytest.monkeypatch import MonkeyPatch
 from _pytest.assertion import util
 
 
@@ -56,7 +56,7 @@ def pytest_load_initial_conftests(early_config, parser, args):
 
     if mode != "plain":
         _load_modules(mode)
-        m = monkeypatch()
+        m = MonkeyPatch()
         early_config._cleanup.append(m.undo)
         m.setattr(py.builtin.builtins, 'AssertionError',
                   reinterpret.AssertionError)  # noqa

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -865,7 +865,7 @@ def yield_fixture(scope="function", params=None, autouse=False, ids=None, name=N
         return FixtureFunctionMarker(scope, params, autouse, ids=ids, name=name)
 
 defaultfuncargprefixmarker = fixture()
-funcarg_prefix_warning = 'declaring fixtures using "pytest_funcarg__" prefix is deprecated ' \
+funcarg_prefix_warning = '{name}: declaring fixtures using "pytest_funcarg__" prefix is deprecated ' \
                          'and scheduled to be removed in pytest 4.0.\n' \
                          'remove the prefix and use the @pytest.fixture decorator instead'
 
@@ -1046,8 +1046,8 @@ class FixtureManager:
                 if not callable(obj):
                     continue
                 marker = defaultfuncargprefixmarker
+                self.config.warn('C1', funcarg_prefix_warning.format(name=name))
                 name = name[len(self._argprefix):]
-                self.config.warn('C1', funcarg_prefix_warning)
             elif not isinstance(marker, FixtureFunctionMarker):
                 # magic globals  with __getattr__ might have got us a wrong
                 # fixture attribute
@@ -1055,7 +1055,9 @@ class FixtureManager:
             else:
                 if marker.name:
                     name = marker.name
-                assert not name.startswith(self._argprefix), name
+                msg = 'fixtures cannot have "pytest_funcarg__" prefix ' \
+                      'and be decorated with @pytest.fixture:\n%s' % name
+                assert not name.startswith(self._argprefix), msg
             fixturedef = FixtureDef(self, nodeid, name, obj,
                                     marker.scope, marker.params,
                                     unittest=unittest, ids=marker.ids)

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -865,6 +865,10 @@ def yield_fixture(scope="function", params=None, autouse=False, ids=None, name=N
         return FixtureFunctionMarker(scope, params, autouse, ids=ids, name=name)
 
 defaultfuncargprefixmarker = fixture()
+funcarg_prefix_warning = 'declaring fixtures using "pytest_funcarg__" prefix is deprecated ' \
+                         'and scheduled to be removed in pytest 4.0.\n' \
+                         'remove the prefix and use the @pytest.fixture decorator instead'
+
 
 
 @fixture(scope="session")
@@ -1043,6 +1047,7 @@ class FixtureManager:
                     continue
                 marker = defaultfuncargprefixmarker
                 name = name[len(self._argprefix):]
+                self.config.warn('C1', funcarg_prefix_warning)
             elif not isinstance(marker, FixtureFunctionMarker):
                 # magic globals  with __getattr__ might have got us a wrong
                 # fixture attribute

--- a/_pytest/monkeypatch.py
+++ b/_pytest/monkeypatch.py
@@ -5,11 +5,14 @@ import re
 
 from py.builtin import _basestring
 
+import pytest
+
 RE_IMPORT_ERROR_NAME = re.compile("^No module named (.*)$")
 
 
-def pytest_funcarg__monkeypatch(request):
-    """The returned ``monkeypatch`` funcarg provides these
+@pytest.fixture
+def monkeypatch(request):
+    """The returned ``monkeypatch`` fixture provides these
     helper methods to modify objects, dictionaries or os.environ::
 
         monkeypatch.setattr(obj, name, value, raising=True)
@@ -26,7 +29,7 @@ def pytest_funcarg__monkeypatch(request):
     parameter determines if a KeyError or AttributeError
     will be raised if the set/deletion operation has no target.
     """
-    mpatch = monkeypatch()
+    mpatch = MonkeyPatch()
     request.addfinalizer(mpatch.undo)
     return mpatch
 
@@ -93,7 +96,7 @@ class Notset:
 notset = Notset()
 
 
-class monkeypatch:
+class MonkeyPatch:
     """ Object keeping a record of setattr/item/env/syspath changes. """
 
     def __init__(self):

--- a/_pytest/pytester.py
+++ b/_pytest/pytester.py
@@ -321,7 +321,8 @@ def linecomp(request):
     return LineComp()
 
 
-def pytest_funcarg__LineMatcher(request):
+@pytest.fixture(name='LineMatcher')
+def LineMatcher_fixture(request):
     return LineMatcher
 
 

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -589,6 +589,8 @@ class Generator(FunctionMixin, PyCollector):
                 raise ValueError("%r generated tests with non-unique name %r" %(self, name))
             seen[name] = True
             l.append(self.Function(name, self, args=args, callobj=call))
+            msg = 'yield tests are deprecated, and scheduled to be removed in pytest 4.0'
+            self.config.warn('C1', msg, fslocation=self.fspath)
         return l
 
     def getcallargs(self, obj):
@@ -609,8 +611,6 @@ def hasinit(obj):
     if init:
         if init != object.__init__:
             return True
-
-
 
 
 class CallSpec2(object):

--- a/_pytest/tmpdir.py
+++ b/_pytest/tmpdir.py
@@ -3,7 +3,7 @@ import re
 
 import pytest
 import py
-from _pytest.monkeypatch import monkeypatch
+from _pytest.monkeypatch import MonkeyPatch
 
 
 class TempdirFactory:
@@ -92,7 +92,7 @@ def pytest_configure(config):
     available at pytest_configure time, but ideally should be moved entirely
     to the tmpdir_factory session fixture.
     """
-    mp = monkeypatch()
+    mp = MonkeyPatch()
     t = TempdirFactory(config)
     config._cleanup.extend([mp.undo, t.finish])
     mp.setattr(config, '_tmpdirhandler', t, raising=False)

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -777,3 +777,19 @@ def test_yield_tests_deprecation(testdir):
         '*yield tests are deprecated, and scheduled to be removed in pytest 4.0*',
         '*2 passed*',
     ])
+
+
+def test_funcarg_prefix_deprecation(testdir):
+    testdir.makepyfile("""
+        def pytest_funcarg__value():
+            return 10
+
+        def test_funcarg_prefix(value):
+            assert value == 10
+    """)
+    result = testdir.runpytest('-ra')
+    result.stdout.fnmatch_lines([
+        '*declaring fixtures using "pytest_funcarg__" prefix is deprecated and scheduled to be removed in pytest 4.0*',
+        '*remove the prefix and use the @pytest.fixture decorator instead*',
+        '*1 passed*',
+    ])

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -762,3 +762,18 @@ class TestDurationWithFixture:
             * setup *test_1*
             * call *test_1*
         """)
+
+
+def test_yield_tests_deprecation(testdir):
+    testdir.makepyfile("""
+        def func1(arg, arg2):
+            assert arg == arg2
+        def test_gen():
+            yield "m1", func1, 15, 3*5
+            yield "m2", func1, 42, 6*7
+    """)
+    result = testdir.runpytest('-ra')
+    result.stdout.fnmatch_lines([
+        '*yield tests are deprecated, and scheduled to be removed in pytest 4.0*',
+        '*2 passed*',
+    ])

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -381,7 +381,9 @@ def test_match_raises_error(testdir):
     ])
 
 class TestFormattedExcinfo:
-    def pytest_funcarg__importasmod(self, request):
+
+    @pytest.fixture
+    def importasmod(self, request):
         def importasmod(source):
             source = _pytest._code.Source(source)
             tmpdir = request.getfixturevalue("tmpdir")

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -285,13 +285,14 @@ class TestSourceParsingAndCompiling:
         #print "block", str(block)
         assert str(stmt).strip().startswith('assert')
 
-    def test_compilefuncs_and_path_sanity(self):
+    @pytest.mark.parametrize('name', ['', None, 'my'])
+    def test_compilefuncs_and_path_sanity(self, name):
         def check(comp, name):
             co = comp(self.source, name)
             if not name:
-                expected = "codegen %s:%d>" %(mypath, mylineno+2+1)
+                expected = "codegen %s:%d>" %(mypath, mylineno+2+2)
             else:
-                expected = "codegen %r %s:%d>" % (name, mypath, mylineno+2+1)
+                expected = "codegen %r %s:%d>" % (name, mypath, mylineno+2+2)
             fn = co.co_filename
             assert fn.endswith(expected)
 
@@ -300,8 +301,7 @@ class TestSourceParsingAndCompiling:
         mypath = mycode.path
 
         for comp in _pytest._code.compile, _pytest._code.Source.compile:
-            for name in '', None, 'my':
-                yield check, comp, name
+            check(comp, name)
 
     def test_offsetless_synerr(self):
         pytest.raises(SyntaxError, _pytest._code.compile, "lambda a,a: 0", mode='eval')

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -795,21 +795,24 @@ class TestTracebackCutting:
 
     def test_traceback_argsetup(self, testdir):
         testdir.makeconftest("""
-            def pytest_funcarg__hello(request):
+            import pytest
+
+            @pytest.fixture
+            def hello(request):
                 raise ValueError("xyz")
         """)
         p = testdir.makepyfile("def test(hello): pass")
         result = testdir.runpytest(p)
         assert result.ret != 0
         out = result.stdout.str()
-        assert out.find("xyz") != -1
-        assert out.find("conftest.py:2: ValueError") != -1
+        assert "xyz" in out
+        assert "conftest.py:5: ValueError" in out
         numentries = out.count("_ _ _") # separator for traceback entries
         assert numentries == 0
 
         result = testdir.runpytest("--fulltrace", p)
         out = result.stdout.str()
-        assert out.find("conftest.py:2: ValueError") != -1
+        assert "conftest.py:5: ValueError" in out
         numentries = out.count("_ _ _ _") # separator for traceback entries
         assert numentries > 3
 

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -30,7 +30,10 @@ class TestFillFixtures:
 
     def test_funcarg_lookupfails(self, testdir):
         testdir.makepyfile("""
-            def pytest_funcarg__xyzsomething(request):
+            import pytest
+
+            @pytest.fixture
+            def xyzsomething(request):
                 return 42
 
             def test_func(some):
@@ -46,9 +49,13 @@ class TestFillFixtures:
 
     def test_funcarg_basic(self, testdir):
         item = testdir.getitem("""
-            def pytest_funcarg__some(request):
+            import pytest
+
+            @pytest.fixture
+            def some(request):
                 return request.function.__name__
-            def pytest_funcarg__other(request):
+            @pytest.fixture
+            def other(request):
                 return 42
             def test_func(some, other):
                 pass
@@ -61,7 +68,10 @@ class TestFillFixtures:
 
     def test_funcarg_lookup_modulelevel(self, testdir):
         testdir.makepyfile("""
-            def pytest_funcarg__something(request):
+            import pytest
+
+            @pytest.fixture
+            def something(request):
                 return request.function.__name__
 
             class TestClass:
@@ -75,9 +85,13 @@ class TestFillFixtures:
 
     def test_funcarg_lookup_classlevel(self, testdir):
         p = testdir.makepyfile("""
+            import pytest
             class TestClass:
-                def pytest_funcarg__something(self, request):
+
+                @pytest.fixture
+                def something(self, request):
                     return request.instance
+
                 def test_method(self, something):
                     assert something is self
         """)
@@ -91,12 +105,14 @@ class TestFillFixtures:
         sub2 = testdir.mkpydir("sub2")
         sub1.join("conftest.py").write(_pytest._code.Source("""
             import pytest
-            def pytest_funcarg__arg1(request):
+            @pytest.fixture
+            def arg1(request):
                 pytest.raises(Exception, "request.getfixturevalue('arg2')")
         """))
         sub2.join("conftest.py").write(_pytest._code.Source("""
             import pytest
-            def pytest_funcarg__arg2(request):
+            @pytest.fixture
+            def arg2(request):
                 pytest.raises(Exception, "request.getfixturevalue('arg1')")
         """))
 
@@ -396,7 +412,10 @@ class TestFillFixtures:
 class TestRequestBasic:
     def test_request_attributes(self, testdir):
         item = testdir.getitem("""
-            def pytest_funcarg__something(request): pass
+            import pytest
+
+            @pytest.fixture
+            def something(request): pass
             def test_func(something): pass
         """)
         req = fixtures.FixtureRequest(item)
@@ -410,8 +429,11 @@ class TestRequestBasic:
 
     def test_request_attributes_method(self, testdir):
         item, = testdir.getitems("""
+            import pytest
             class TestB:
-                def pytest_funcarg__something(self, request):
+
+                @pytest.fixture
+                def something(self, request):
                     return 1
                 def test_func(self, something):
                     pass
@@ -420,9 +442,11 @@ class TestRequestBasic:
         assert req.cls.__name__ == "TestB"
         assert req.instance.__class__ == req.cls
 
-    def XXXtest_request_contains_funcarg_arg2fixturedefs(self, testdir):
+    def test_request_contains_funcarg_arg2fixturedefs(self, testdir):
         modcol = testdir.getmodulecol("""
-            def pytest_funcarg__something(request):
+            import pytest
+            @pytest.fixture
+            def something(request):
                 pass
             class TestClass:
                 def test_method(self, something):
@@ -432,15 +456,21 @@ class TestRequestBasic:
         assert item1.name == "test_method"
         arg2fixturedefs = fixtures.FixtureRequest(item1)._arg2fixturedefs
         assert len(arg2fixturedefs) == 1
-        assert arg2fixturedefs[0].__name__ == "pytest_funcarg__something"
+        assert arg2fixturedefs['something'][0].argname == "something"
 
     def test_getfixturevalue_recursive(self, testdir):
         testdir.makeconftest("""
-            def pytest_funcarg__something(request):
+            import pytest
+
+            @pytest.fixture
+            def something(request):
                 return 1
         """)
         testdir.makepyfile("""
-            def pytest_funcarg__something(request):
+            import pytest
+
+            @pytest.fixture
+            def something(request):
                 return request.getfixturevalue("something") + 1
             def test_func(something):
                 assert something == 2
@@ -452,9 +482,12 @@ class TestRequestBasic:
         'getfixmethod', ('getfixturevalue', 'getfuncargvalue'))
     def test_getfixturevalue(self, testdir, getfixmethod):
         item = testdir.getitem("""
+            import pytest
             l = [2]
-            def pytest_funcarg__something(request): return 1
-            def pytest_funcarg__other(request):
+            @pytest.fixture
+            def something(request): return 1
+            @pytest.fixture
+            def other(request):
                 return l.pop()
             def test_func(something): pass
         """)
@@ -477,8 +510,10 @@ class TestRequestBasic:
 
     def test_request_addfinalizer(self, testdir):
         item = testdir.getitem("""
+            import pytest
             teardownlist = []
-            def pytest_funcarg__something(request):
+            @pytest.fixture
+            def something(request):
                 request.addfinalizer(lambda: teardownlist.append(1))
             def test_func(something): pass
         """)
@@ -503,7 +538,8 @@ class TestRequestBasic:
         result = testdir.runpytest_subprocess()
         assert result.ret != 0
         result.stdout.fnmatch_lines([
-            "*AssertionError:*pytest_funcarg__marked_with_prefix_and_decorator*"
+            "*AssertionError: fixtures cannot have*@pytest.fixture*",
+            "*pytest_funcarg__marked_with_prefix_and_decorator*"
         ])
 
     def test_request_addfinalizer_failing_setup(self, testdir):
@@ -541,8 +577,10 @@ class TestRequestBasic:
 
     def test_request_addfinalizer_partial_setup_failure(self, testdir):
         p = testdir.makepyfile("""
+            import pytest
             l = []
-            def pytest_funcarg__something(request):
+            @pytest.fixture
+            def something(request):
                 request.addfinalizer(lambda: l.append(None))
             def test_func(something, missingarg):
                 pass
@@ -583,9 +621,11 @@ class TestRequestBasic:
 
     def test_funcargnames_compatattr(self, testdir):
         testdir.makepyfile("""
+            import pytest
             def pytest_generate_tests(metafunc):
                 assert metafunc.funcargnames == metafunc.fixturenames
-            def pytest_funcarg__fn(request):
+            @pytest.fixture
+            def fn(request):
                 assert request._pyfuncitem.funcargnames == \
                        request._pyfuncitem.fixturenames
                 return request.funcargnames, request.fixturenames
@@ -630,7 +670,9 @@ class TestRequestBasic:
         # this tests that normalization of nodeids takes place
         b = testdir.mkdir("tests").mkdir("unit")
         b.join("conftest.py").write(_pytest._code.Source("""
-            def pytest_funcarg__arg1():
+            import pytest
+            @pytest.fixture
+            def arg1():
                 pass
         """))
         p = b.join("test_module.py")
@@ -678,7 +720,10 @@ class TestRequestBasic:
 class TestRequestMarking:
     def test_applymarker(self, testdir):
         item1,item2 = testdir.getitems("""
-            def pytest_funcarg__something(request):
+            import pytest
+
+            @pytest.fixture
+            def something(request):
                 pass
             class TestClass:
                 def test_func1(self, something):
@@ -737,7 +782,10 @@ class TestRequestCachedSetup:
         reprec = testdir.inline_runsource("""
             mysetup = ["hello",].pop
 
-            def pytest_funcarg__something(request):
+            import pytest
+
+            @pytest.fixture
+            def something(request):
                 return request.cached_setup(mysetup, scope="module")
 
             def test_func1(something):
@@ -752,7 +800,9 @@ class TestRequestCachedSetup:
         reprec = testdir.inline_runsource("""
             mysetup = ["hello", "hello2", "hello3"].pop
 
-            def pytest_funcarg__something(request):
+            import pytest
+            @pytest.fixture
+            def something(request):
                 return request.cached_setup(mysetup, scope="class")
             def test_func1(something):
                 assert something == "hello3"
@@ -802,9 +852,13 @@ class TestRequestCachedSetup:
 
     def test_request_cached_setup_two_args(self, testdir):
         testdir.makepyfile("""
-            def pytest_funcarg__arg1(request):
+            import pytest
+
+            @pytest.fixture
+            def arg1(request):
                 return request.cached_setup(lambda: 42)
-            def pytest_funcarg__arg2(request):
+            @pytest.fixture
+            def arg2(request):
                 return request.cached_setup(lambda: 17)
             def test_two_different_setups(arg1, arg2):
                 assert arg1 != arg2
@@ -816,10 +870,14 @@ class TestRequestCachedSetup:
 
     def test_request_cached_setup_getfixturevalue(self, testdir):
         testdir.makepyfile("""
-            def pytest_funcarg__arg1(request):
+            import pytest
+
+            @pytest.fixture
+            def arg1(request):
                 arg1 = request.getfixturevalue("arg2")
                 return request.cached_setup(lambda: arg1 + 1)
-            def pytest_funcarg__arg2(request):
+            @pytest.fixture
+            def arg2(request):
                 return request.cached_setup(lambda: 10)
             def test_two_funcarg(arg1):
                 assert arg1 == 11
@@ -831,8 +889,10 @@ class TestRequestCachedSetup:
 
     def test_request_cached_setup_functional(self, testdir):
         testdir.makepyfile(test_0="""
+            import pytest
             l = []
-            def pytest_funcarg__something(request):
+            @pytest.fixture
+            def something(request):
                 val = request.cached_setup(fsetup, fteardown)
                 return val
             def fsetup(mycache=[1]):
@@ -858,7 +918,10 @@ class TestRequestCachedSetup:
 
     def test_issue117_sessionscopeteardown(self, testdir):
         testdir.makepyfile("""
-            def pytest_funcarg__app(request):
+            import pytest
+
+            @pytest.fixture
+            def app(request):
                 app = request.cached_setup(
                     scope='session',
                     setup=lambda: 0,
@@ -1119,16 +1182,23 @@ class TestFixtureUsages:
 
 
 class TestFixtureManagerParseFactories:
-    def pytest_funcarg__testdir(self, request):
+
+    @pytest.fixture
+    def testdir(self, request):
         testdir = request.getfixturevalue("testdir")
         testdir.makeconftest("""
-            def pytest_funcarg__hello(request):
+            import pytest
+
+            @pytest.fixture
+            def hello(request):
                 return "conftest"
 
-            def pytest_funcarg__fm(request):
+            @pytest.fixture
+            def fm(request):
                 return request._fixturemanager
 
-            def pytest_funcarg__item(request):
+            @pytest.fixture
+            def item(request):
                 return request._pyfuncitem
         """)
         return testdir
@@ -1154,17 +1224,21 @@ class TestFixtureManagerParseFactories:
                     faclist = fm.getfixturedefs(name, item.nodeid)
                     assert len(faclist) == 1
                     fac = faclist[0]
-                    assert fac.func.__name__ == "pytest_funcarg__" + name
+                    assert fac.func.__name__ == name
         """)
         reprec = testdir.inline_run("-s")
         reprec.assertoutcome(passed=1)
 
     def test_parsefactories_conftest_and_module_and_class(self, testdir):
         testdir.makepyfile("""
-            def pytest_funcarg__hello(request):
+            import pytest
+
+            @pytest.fixture
+            def hello(request):
                 return "module"
             class TestClass:
-                def pytest_funcarg__hello(self, request):
+                @pytest.fixture
+                def hello(self, request):
                     return "class"
                 def test_hello(self, item, fm):
                     faclist = fm.getfixturedefs("hello", item.nodeid)
@@ -1212,7 +1286,9 @@ class TestFixtureManagerParseFactories:
 
 
 class TestAutouseDiscovery:
-    def pytest_funcarg__testdir(self, testdir):
+
+    @pytest.fixture
+    def testdir(self, testdir):
         testdir.makeconftest("""
             import pytest
             @pytest.fixture(autouse=True)
@@ -1226,10 +1302,12 @@ class TestAutouseDiscovery:
             def perfunction2(arg1):
                 pass
 
-            def pytest_funcarg__fm(request):
+            @pytest.fixture
+            def fm(request):
                 return request._fixturemanager
 
-            def pytest_funcarg__item(request):
+            @pytest.fixture
+            def item(request):
                 return request._pyfuncitem
         """)
         return testdir
@@ -1773,17 +1851,19 @@ class TestFixtureMarker:
     def test_scope_module_and_finalizer(self, testdir):
         testdir.makeconftest("""
             import pytest
-            finalized = []
-            created = []
+            finalized_list = []
+            created_list = []
             @pytest.fixture(scope="module")
             def arg(request):
-                created.append(1)
+                created_list.append(1)
                 assert request.scope == "module"
-                request.addfinalizer(lambda: finalized.append(1))
-            def pytest_funcarg__created(request):
-                return len(created)
-            def pytest_funcarg__finalized(request):
-                return len(finalized)
+                request.addfinalizer(lambda: finalized_list.append(1))
+            @pytest.fixture
+            def created(request):
+                return len(created_list)
+            @pytest.fixture
+            def finalized(request):
+                return len(finalized_list)
         """)
         testdir.makepyfile(
             test_mod1="""

--- a/testing/python/integration.py
+++ b/testing/python/integration.py
@@ -15,7 +15,9 @@ class TestOEJSKITSpecials:
                     return self.fspath, 3, "xyz"
         """)
         modcol = testdir.getmodulecol("""
-            def pytest_funcarg__arg1(request):
+            import pytest
+            @pytest.fixture
+            def arg1(request):
                 return 42
             class MyClass:
                 pass
@@ -43,7 +45,8 @@ class TestOEJSKITSpecials:
             @pytest.fixture(autouse=True)
             def hello():
                 pass
-            def pytest_funcarg__arg1(request):
+            @pytest.fixture
+            def arg1(request):
                 return 42
             class MyClass:
                 pass

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -448,13 +448,13 @@ class TestMetafunc:
 
     def test_parametrize_functional(self, testdir):
         testdir.makepyfile("""
+            import pytest
             def pytest_generate_tests(metafunc):
                 metafunc.parametrize('x', [1,2], indirect=True)
                 metafunc.parametrize('y', [2])
-            def pytest_funcarg__x(request):
+            @pytest.fixture
+            def x(request):
                 return request.param * 10
-            #def pytest_funcarg__y(request):
-            #    return request.param
 
             def test_simple(x,y):
                 assert x in (10,20)
@@ -578,7 +578,8 @@ class TestMetafuncFunctional:
             def pytest_generate_tests(metafunc):
                 metafunc.addcall(param=metafunc)
 
-            def pytest_funcarg__metafunc(request):
+            @pytest.fixture
+            def metafunc(request):
                 assert request._pyfuncitem._genid == "0"
                 return request.param
 
@@ -630,7 +631,9 @@ class TestMetafuncFunctional:
                 metafunc.addcall(param=10)
                 metafunc.addcall(param=20)
 
-            def pytest_funcarg__arg1(request):
+            import pytest
+            @pytest.fixture
+            def arg1(request):
                 return request.param
 
             def test_func1(arg1):
@@ -669,9 +672,12 @@ class TestMetafuncFunctional:
             def pytest_generate_tests(metafunc):
                 metafunc.addcall(param=(1,1), id="hello")
 
-            def pytest_funcarg__arg1(request):
+            import pytest
+            @pytest.fixture
+            def arg1(request):
                 return request.param[0]
-            def pytest_funcarg__arg2(request):
+            @pytest.fixture
+            def arg2(request):
                 return request.param[1]
 
             class TestClass:
@@ -755,11 +761,14 @@ class TestMetafuncFunctional:
                 metafunc.parametrize("arg1", [1], indirect=True)
                 metafunc.parametrize("arg2", [10], indirect=True)
 
-            def pytest_funcarg__arg1(request):
+            import pytest
+            @pytest.fixture
+            def arg1(request):
                 x = request.getfixturevalue("arg2")
                 return x + request.param
 
-            def pytest_funcarg__arg2(request):
+            @pytest.fixture
+            def arg2(request):
                 return request.param
 
             def test_func1(arg1, arg2):
@@ -777,10 +786,13 @@ class TestMetafuncFunctional:
                 assert "arg1" in metafunc.fixturenames
                 metafunc.parametrize("arg1", [1], indirect=True)
 
-            def pytest_funcarg__arg1(request):
+            import pytest
+            @pytest.fixture
+            def arg1(request):
                 return request.param
 
-            def pytest_funcarg__arg2(request, arg1):
+            @pytest.fixture
+            def arg2(request, arg1):
                 return 10 * arg1
 
             def test_func(arg2):
@@ -870,7 +882,8 @@ class TestMetafuncFunctional:
                 if "arg" in metafunc.funcargnames:
                     metafunc.parametrize("arg", [1,2], indirect=True,
                                          scope=%r)
-            def pytest_funcarg__arg(request):
+            @pytest.fixture
+            def arg(request):
                 l.append(request.param)
                 return request.param
             def test_hello(arg):

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -30,17 +30,20 @@ class TestBinReprIntegration:
 
     def test_pytest_assertrepr_compare_called(self, testdir):
         testdir.makeconftest("""
+            import pytest
             l = []
             def pytest_assertrepr_compare(op, left, right):
                 l.append((op, left, right))
-            def pytest_funcarg__l(request):
+
+            @pytest.fixture
+            def list(request):
                 return l
         """)
         testdir.makepyfile("""
             def test_hello():
                 assert 0 == 1
-            def test_check(l):
-                assert l == [("==", 0, 1)]
+            def test_check(list):
+                assert list == [("==", 0, 1)]
         """)
         result = testdir.runpytest("-v")
         result.stdout.fnmatch_lines([

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -119,7 +119,10 @@ class TestPython:
 
     def test_setup_error(self, testdir):
         testdir.makepyfile("""
-            def pytest_funcarg__arg(request):
+            import pytest
+
+            @pytest.fixture
+            def arg(request):
                 raise ValueError()
             def test_function(arg):
                 pass
@@ -131,7 +134,7 @@ class TestPython:
         tnode = node.find_first_by_tag("testcase")
         tnode.assert_attr(
             file="test_setup_error.py",
-            line="2",
+            line="5",
             classname="test_setup_error",
             name="test_function")
         fnode = tnode.find_first_by_tag("error")
@@ -444,7 +447,10 @@ class TestPython:
 
     def test_setup_error_captures_stdout(self, testdir):
         testdir.makepyfile("""
-            def pytest_funcarg__arg(request):
+            import pytest
+
+            @pytest.fixture
+            def arg(request):
                 print('hello-stdout')
                 raise ValueError()
             def test_function(arg):
@@ -459,7 +465,10 @@ class TestPython:
     def test_setup_error_captures_stderr(self, testdir):
         testdir.makepyfile("""
             import sys
-            def pytest_funcarg__arg(request):
+            import pytest
+
+            @pytest.fixture
+            def arg(request):
                 sys.stderr.write('hello-stderr')
                 raise ValueError()
             def test_function(arg):

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -481,7 +481,8 @@ class TestFunctional:
     def test_mark_dynamically_in_funcarg(self, testdir):
         testdir.makeconftest("""
             import pytest
-            def pytest_funcarg__arg(request):
+            @pytest.fixture
+            def arg(request):
                 request.applymarker(pytest.mark.hello)
             def pytest_terminal_summary(terminalreporter):
                 l = terminalreporter.stats['passed']

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -3,10 +3,11 @@ import sys
 import textwrap
 
 import pytest
-from _pytest.monkeypatch import monkeypatch as MonkeyPatch
+from _pytest.monkeypatch import MonkeyPatch
 
 
-def pytest_funcarg__mp(request):
+@pytest.fixture
+def mp(request):
     cwd = os.getcwd()
     sys_path = list(sys.path)
 
@@ -205,7 +206,7 @@ def test_setenv_prepend():
 def test_monkeypatch_plugin(testdir):
     reprec = testdir.inline_runsource("""
         def test_method(monkeypatch):
-            assert monkeypatch.__class__.__name__ == "monkeypatch"
+            assert monkeypatch.__class__.__name__ == "MonkeyPatch"
     """)
     res = reprec.countoutcomes()
     assert tuple(res) == (1, 0, 0), res

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1,6 +1,7 @@
 import sys
 
 import _pytest._code
+import pytest
 
 
 def runpdb_and_get_report(testdir, source):
@@ -12,7 +13,9 @@ def runpdb_and_get_report(testdir, source):
 
 
 class TestPDB:
-    def pytest_funcarg__pdblist(self, request):
+
+    @pytest.fixture
+    def pdblist(self, request):
         monkeypatch = request.getfixturevalue("monkeypatch")
         pdblist = []
         def mypdb(*args):

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -399,13 +399,15 @@ def test_callinfo():
 @pytest.mark.xfail
 def test_runtest_in_module_ordering(testdir):
     p1 = testdir.makepyfile("""
+        import pytest
         def pytest_runtest_setup(item): # runs after class-level!
             item.function.mylist.append("module")
         class TestClass:
             def pytest_runtest_setup(self, item):
                 assert not hasattr(item.function, 'mylist')
                 item.function.mylist = ['class']
-            def pytest_funcarg__mylist(self, request):
+            @pytest.fixture
+            def mylist(self, request):
                 return request.function.mylist
             def pytest_runtest_call(self, item, __multicall__):
                 try:

--- a/testing/test_runner_xunit.py
+++ b/testing/test_runner_xunit.py
@@ -234,7 +234,8 @@ def test_setup_funcarg_setup_when_outer_scope_fails(testdir):
         import pytest
         def setup_module(mod):
             raise ValueError(42)
-        def pytest_funcarg__hello(request):
+        @pytest.fixture
+        def hello(request):
             raise ValueError("xyz43")
         def test_function1(hello):
             pass

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -309,7 +309,8 @@ class TestXFail:
     def test_dynamic_xfail_no_run(self, testdir):
         p = testdir.makepyfile("""
             import pytest
-            def pytest_funcarg__arg(request):
+            @pytest.fixture
+            def arg(request):
                 request.applymarker(pytest.mark.xfail(run=False))
             def test_this(arg):
                 assert 0
@@ -323,7 +324,8 @@ class TestXFail:
     def test_dynamic_xfail_set_during_funcarg_setup(self, testdir):
         p = testdir.makepyfile("""
             import pytest
-            def pytest_funcarg__arg(request):
+            @pytest.fixture
+            def arg(request):
                 request.applymarker(pytest.mark.xfail)
             def test_this2(arg):
                 assert 0

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -600,7 +600,10 @@ def test_getreportopt():
 def test_terminalreporter_reportopt_addopts(testdir):
     testdir.makeini("[pytest]\naddopts=-rs")
     testdir.makepyfile("""
-        def pytest_funcarg__tr(request):
+        import pytest
+
+        @pytest.fixture
+        def tr(request):
             tr = request.config.pluginmanager.getplugin("terminalreporter")
             return tr
         def test_opt(tr):
@@ -614,7 +617,10 @@ def test_terminalreporter_reportopt_addopts(testdir):
 
 def test_tbstyle_short(testdir):
     p = testdir.makepyfile("""
-        def pytest_funcarg__arg(request):
+        import pytest
+
+        @pytest.fixture
+        def arg(request):
             return 42
         def test_opt(arg):
             x = 0
@@ -625,7 +631,7 @@ def test_tbstyle_short(testdir):
     assert 'arg = 42' not in s
     assert 'x = 0' not in s
     result.stdout.fnmatch_lines([
-        "*%s:5*" % p.basename,
+        "*%s:8*" % p.basename,
         "    assert x",
         "E   assert*",
     ])

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -265,8 +265,8 @@ def test_testcase_custom_exception_info(testdir, type):
             def run(self, result):
                 excinfo = pytest.raises(ZeroDivisionError, lambda: 0/0)
                 # we fake an incompatible exception info
-                from _pytest.monkeypatch import monkeypatch
-                mp = monkeypatch()
+                from _pytest.monkeypatch import MonkeyPatch
+                mp = MonkeyPatch()
                 def t(*args):
                     mp.undo()
                     raise TypeError()


### PR DESCRIPTION
Deprecating both `yield tests` and `pytest_funcarg__` prefix for declaring fixtures.

* Added deprecation warnings when one of the features is used;
* Removed `pytest_funcarg__` and `yield tests`  usages from core;

Closes #16
Closes #1324
Fixes #1684