### PR TITLE
setup_* and teardown_* functions argument now optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -159,6 +159,10 @@ time or change existing behaviors in order to make them less surprising/more use
   automatically generated id for that argument will be used.
   Thanks `@palaviv`_ for the complete PR (`#1468`_).
 
+* The parameter to xunit-style setup/teardown methods (``setup_method``,
+  ``setup_module``, etc.) is now optional and may be omitted.
+  Thanks `@okken`_ for bringing this to attention and `@nicoddemus`_ for the PR.
+
 * Improved automatic id generation selection in case of duplicate ids in
   parametrize.
   Thanks `@palaviv`_ for the complete PR (`#1474`_).
@@ -308,6 +312,7 @@ time or change existing behaviors in order to make them less surprising/more use
 .. _@nikratio: https://github.com/nikratio
 .. _@novas0x2a: https://github.com/novas0x2a
 .. _@obestwalter: https://github.com/obestwalter
+.. _@okken: https://github.com/okken
 .. _@olegpidsadnyi: https://github.com/olegpidsadnyi
 .. _@omarkohl: https://github.com/omarkohl
 .. _@palaviv: https://github.com/palaviv

--- a/doc/en/xunit_setup.rst
+++ b/doc/en/xunit_setup.rst
@@ -7,21 +7,20 @@ classic xunit-style setup
 
 This section describes a classic and popular way how you can implement
 fixtures (setup and teardown test state) on a per-module/class/function basis.  
-pytest started supporting these methods around 2005 and subsequently
-nose and the standard library introduced them (under slightly different
-names).  While these setup/teardown methods are and will remain fully
-supported you may also use pytest's more powerful :ref:`fixture mechanism
-<fixture>` which leverages the concept of dependency injection, allowing
-for a more modular and more scalable approach for managing test state, 
-especially for larger projects and for functional testing.  You can
-mix both fixture mechanisms in the same file but unittest-based
-test methods cannot receive fixture arguments.
+
 
 .. note::
 
-    As of pytest-2.4, teardownX functions are not called if 
-    setupX existed and failed/was skipped.  This harmonizes
-    behaviour across all major python testing tools.
+    While these setup/teardown methods are simple and familiar to those
+    coming from a ``unittest`` or nose ``background``, you may also consider
+    using pytest's more powerful :ref:`fixture mechanism
+    <fixture>` which leverages the concept of dependency injection, allowing
+    for a more modular and more scalable approach for managing test state,
+    especially for larger projects and for functional testing.  You can
+    mix both fixture mechanisms in the same file but
+    test methods of ``unittest.TestCase`` subclasses
+    cannot receive fixture arguments.
+
 
 Module level setup/teardown
 --------------------------------------
@@ -37,6 +36,8 @@ which will usually be called once for all the functions::
         """ teardown any state that was previously setup with a setup_module
         method.
         """
+
+As of pytest-3.0, the ``module`` parameter is optional.
 
 Class level setup/teardown
 ----------------------------------
@@ -71,6 +72,8 @@ Similarly, the following methods are called around each method invocation::
         call.
         """
 
+As of pytest-3.0, the ``method`` parameter is optional.
+
 If you would rather define test functions directly at module level
 you can also use the following functions to implement fixtures::
 
@@ -84,7 +87,13 @@ you can also use the following functions to implement fixtures::
         call.
         """
 
-Note that it is possible for setup/teardown pairs to be invoked multiple times
-per testing process.
+As of pytest-3.0, the ``function`` parameter is optional.
+
+Remarks:
+
+* It is possible for setup/teardown pairs to be invoked multiple times
+  per testing process.
+* teardown functions are not called if the corresponding setup function existed
+  and failed/was skipped.
 
 .. _`unittest.py module`: http://docs.python.org/library/unittest.html

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -229,11 +229,12 @@ class BaseFunctionalTests:
         assert reps[5].failed
 
     def test_exact_teardown_issue1206(self, testdir):
+        """issue shadowing error with wrong number of arguments on teardown_method."""
         rec = testdir.inline_runsource("""
             import pytest
 
             class TestClass:
-                def teardown_method(self):
+                def teardown_method(self, x, y, z):
                     pass
 
                 def test_method(self):
@@ -256,9 +257,9 @@ class BaseFunctionalTests:
         assert reps[2].when == "teardown"
         assert reps[2].longrepr.reprcrash.message in (
                 # python3 error
-                'TypeError: teardown_method() takes 1 positional argument but 2 were given',
+                "TypeError: teardown_method() missing 2 required positional arguments: 'y' and 'z'",
                 # python2 error
-                'TypeError: teardown_method() takes exactly 1 argument (2 given)'
+                'TypeError: teardown_method() takes exactly 4 arguments (2 given)'
                 )
 
     def test_failure_in_setup_function_ignores_custom_repr(self, testdir):


### PR DESCRIPTION
setup_module, setup_function and setup_method extra argument are now optional and may be omitted.

Fix #1728