### PR TITLE
allow --exitfirst/-x to be overridden by a following --maxfail

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,9 @@ time or change existing behaviors in order to make them less surprising/more use
 * ``_pytest.monkeypatch.monkeypatch`` class has been renamed to ``_pytest.monkeypatch.MonkeyPatch``
   so it doesn't conflict with the ``monkeypatch`` fixture.
 
+* ``--exitfirst / -x`` can now be overridden by a following ``--maxfail=N``
+  and is just a synonym for ``--maxfail=1``.
+
 *
 
 *

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -34,8 +34,8 @@ def pytest_addoption(parser):
     #            "**/test_*.py", "**/*_test.py"]
     #)
     group = parser.getgroup("general", "running and selection options")
-    group._addoption('-x', '--exitfirst', action="store_true", default=False,
-               dest="exitfirst",
+    group._addoption('-x', '--exitfirst', action="store_const",
+               dest="maxfail", const=1,
                help="exit instantly on first error or failed test."),
     group._addoption('--maxfail', metavar="num",
                action="store", type=int, dest="maxfail", default=0,
@@ -74,10 +74,10 @@ def pytest_namespace():
     collect = dict(Item=Item, Collector=Collector, File=File, Session=Session)
     return dict(collect=collect)
 
+
 def pytest_configure(config):
     pytest.config = config # compatibiltiy
-    if config.option.exitfirst:
-        config.option.maxfail = 1
+
 
 def wrap_session(config, doit):
     """Skeleton command line program"""

--- a/testing/test_session.py
+++ b/testing/test_session.py
@@ -197,6 +197,14 @@ class TestNewSession(SessionTests):
         colfail = [x for x in finished if x.failed]
         assert len(colfail) == 1
 
+    def test_minus_x_overriden_by_maxfail(self, testdir):
+        testdir.makepyfile(__init__="")
+        testdir.makepyfile(test_one="xxxx", test_two="yyyy", test_third="zzz")
+        reprec = testdir.inline_run("-x", "--maxfail=2", testdir.tmpdir)
+        finished = reprec.getreports("pytest_collectreport")
+        colfail = [x for x in finished if x.failed]
+        assert len(colfail) == 2
+
 
 def test_plugin_specify(testdir):
     pytest.raises(ImportError, """


### PR DESCRIPTION
by implementing `--exitfirst` in terms of a `store_const`
we gain the ability to let a following `--maxfail=N` override it

