### PR TITLE
Write formatted traceback to stderr upon conftest import error

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,6 +58,7 @@ Guido Wesdorp
 Harald Armin Massa
 Ian Bicking
 Jaap Broekhuizen
+Jan-Philip Gehrcke
 Jan Balster
 Janne Vanhala
 Jason R. Coombs

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -156,6 +156,9 @@ time or change existing behaviors in order to make them less surprising/more use
 
 **Changes**
 
+* Exceptions raised during import of ``conftest.py`` modules now
+  cause pytest to write the corresponding traceback to stderr.
+
 * Plugins now benefit from assertion rewriting.  Thanks
   `@sober7`_, `@nicoddemus`_ and `@flub`_ for the PR.
 

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -17,6 +17,8 @@ from _pytest._pluggy import PluginManager, HookimplMarker, HookspecMarker
 hookimpl = HookimplMarker("pytest")
 hookspec = HookspecMarker("pytest")
 
+_PY2 = sys.version_info[0] == 2
+
 # pytest startup
 #
 
@@ -338,7 +340,19 @@ class PytestPluginManager(PluginManager):
             try:
                 mod = conftestpath.pyimport()
             except Exception:
-                raise ConftestImportFailure(conftestpath, sys.exc_info())
+                exc_info = sys.exc_info()
+
+                if _PY2:
+                    lines = traceback.format_exception(*exc_info)
+                else:
+                    # Python 3 supports exception chaining. Do not show
+                    # tracebacks for regular pytest-internal exceptions.
+                    lines = traceback.format_exception(*exc_info, chain=False)
+
+                sys.stderr.write(
+                    "Exception during conftest import. %s\n" % "".join(lines))
+
+                raise ConftestImportFailure(conftestpath, exc_info)
 
             self._conftest_plugins.add(mod)
             self._conftestpath2mod[conftestpath] = mod


### PR DESCRIPTION
This tackles https://github.com/pytest-dev/pytest/issues/1752 -- comments appreciated!