### PR TITLE
Testcase for overriding autouse fixture with a parametrized fixture.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Dave Hunt
 David Díaz-Barquero
 David Mohr
 David Vierra
+Diego Russo
 Edison Gustavo Muenz
 Eduardo Schettino
 Elizaveta Shashkova

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -336,6 +336,38 @@ class TestFillFixtures:
         result = testdir.runpytest(testfile)
         result.stdout.fnmatch_lines(["*3 passed*"])
 
+    def test_override_autouse_fixture_with_parametrized_fixture_conftest_conftest(self, testdir):
+        """Test override of the autouse fixture with parametrized one on the conftest level.
+        This test covers the issue explained in issue 1601
+        """
+        testdir.makeconftest("""
+            import pytest
+
+            @pytest.fixture(autouse=True)
+            def spam():
+                return 'spam'
+        """)
+        subdir = testdir.mkpydir('subdir')
+        subdir.join("conftest.py").write(_pytest._code.Source("""
+            import pytest
+
+            @pytest.fixture(params=[1, 2, 3])
+            def spam(request):
+                return request.param
+        """))
+        testfile = subdir.join("test_spam.py")
+        testfile.write(_pytest._code.Source("""
+            params = {'spam': 1}
+
+            def test_spam(spam):
+                assert spam == params['spam']
+                params['spam'] += 1
+        """))
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines(["*3 passed*"])
+        result = testdir.runpytest(testfile)
+        result.stdout.fnmatch_lines(["*3 passed*"])
+
     def test_autouse_fixture_plugin(self, testdir):
         # A fixture from a plugin has no baseid set, which screwed up
         # the autouse fixture handling.


### PR DESCRIPTION
I wasn't able to replicate the problem with the current master and the latest version (2.9.2). The test case was not present though so I created one.
pytest will raise a ValueError "Duplicate '<fixture_name>'" when overriding an autouse fixture w/ a parametrized fixture in a subdirectory's conftest.py

The related issue is #1601 

Cheers