### PR TITLE
Start first line of FixtureLookupErrorRepr messages with an 'E'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ David Díaz-Barquero
 David Mohr
 David Vierra
 Edison Gustavo Muenz
+Edoardo Batini
 Eduardo Schettino
 Elizaveta Shashkova
 Endre Galaczi

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@
 **Bug Fixes**
 
 * Add an 'E' to the first line of error messages from FixtureLookupErrorRepr.
-  Fixes (`#717`_). Thanks `@blueyed`_ for reporting, `@eolo999`_ for the PR
+  Fixes `#717`_. Thanks `@blueyed`_ for reporting, `@eolo999`_ for the PR
   and `@tomviner`_ for his guidance during EuroPython2016 sprint.
 
 * Text documents without any doctests no longer appear as "skipped".

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@
 **Bug Fixes**
 
 * Add an 'E' to the first line of error messages from FixtureLookupErrorRepr.
-  Fixes (`#717`_). Thanks `@blueyed`_ for reporting and `@eolo999`_ for the PR.
+  Fixes (`#717`_). Thanks `@blueyed`_ for reporting, `@eolo999`_ for the PR
+  and `@tomviner`_ for his guidance during EuroPython2016 sprint.
 
 * Text documents without any doctests no longer appear as "skipped".
   Thanks `@graingert`_ for reporting and providing a full PR (`#1580`_).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,7 @@
 * ImportErrors in plugins now are a fatal error instead of issuing a
   pytest warning (`#1479`_). Thanks to `@The-Compiler`_ for the PR.
 
+.. _#717: https://github.com/pytest-dev/pytest/issues/717
 .. _#1580: https://github.com/pytest-dev/pytest/pull/1580
 .. _#1605: https://github.com/pytest-dev/pytest/issues/1605
 .. _#1597: https://github.com/pytest-dev/pytest/pull/1597
@@ -63,6 +64,8 @@
 .. _#1479: https://github.com/pytest-dev/pytest/issues/1479
 .. _#925: https://github.com/pytest-dev/pytest/issues/925
 
+.. _@eolo999: https://github.com/eolo999
+.. _@blueyed: https://github.com/blueyed
 .. _@graingert: https://github.com/graingert
 .. _@taschini: https://github.com/taschini
 .. _@nikratio: https://github.com/nikratio

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@
 **Bug Fixes**
 
 * Add an 'E' to the first line of error messages from FixtureLookupErrorRepr.
-  Fixes (`#717`_). Thanks `@blueyed`_ for reporting.
+  Fixes (`#717`_). Thanks `@blueyed`_ for reporting and `@eolo999`_ for the PR.
 
 * Text documents without any doctests no longer appear as "skipped".
   Thanks `@graingert`_ for reporting and providing a full PR (`#1580`_).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@
 
 **Bug Fixes**
 
+* Add an 'E' to the first line of error messages from FixtureLookupErrorRepr.
+  Fixes (`#717`_). Thanks `@blueyed`_ for reporting.
+
 * Text documents without any doctests no longer appear as "skipped".
   Thanks `@graingert`_ for reporting and providing a full PR (`#1580`_).
 

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1835,8 +1835,13 @@ class FixtureLookupErrorRepr(TerminalRepr):
         #tw.line("FixtureLookupError: %s" %(self.argname), red=True)
         for tbline in self.tblines:
             tw.line(tbline.rstrip())
-        for line in self.errorstring.split("\n"):
-            tw.line("        " + line.strip(), red=True)
+        lines = self.errorstring.split("\n")
+        for line in lines:
+            if line == lines[0]:
+                prefix = 'E       '
+            else:
+                prefix = '        '
+            tw.line(prefix + line.strip(), red=True)
         tw.line()
         tw.line("%s:%d" % (self.filename, self.firstlineno+1))
 

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -376,7 +376,7 @@ class TestGeneralUsage:
         res = testdir.runpytest(p)
         res.stdout.fnmatch_lines([
             "*source code not available*",
-            "*fixture 'invalid_fixture' not found",
+            "E*fixture 'invalid_fixture' not found",
         ])
 
     def test_plugins_given_as_strings(self, tmpdir, monkeypatch):

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -416,9 +416,9 @@ class TestCaptureFixture:
         result = testdir.runpytest(p)
         result.stdout.fnmatch_lines([
             "*ERROR*setup*test_one*",
-            "*capsys*capfd*same*time*",
+            "E*capsys*capfd*same*time*",
             "*ERROR*setup*test_two*",
-            "*capsys*capfd*same*time*",
+            "E*capsys*capfd*same*time*",
             "*2 error*"])
 
     @pytest.mark.parametrize("method", ["sys", "fd"])


### PR DESCRIPTION
Add an 'E' to the first line of error messages from FixtureLookupErrorRepr.

Fixes #717.
