### PR TITLE
Fix #1210 display msg for early calls to exit

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ Jan Balster
 Janne Vanhala
 Jason R. Coombs
 John Towler
+Jon Sonesen
 Joshua Bronson
 Jurko Gospodnetić
 Katarzyna Jachim

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,7 +44,9 @@
 
 * Updated docstrings with a more uniform style.
 
-*
+* Add stderr write for ``pytest.exit(msg)`` during startup. Previously the message was never shown.
+  Thanks `@BeyondEvil`_ for reporting `#1210`_. Thanks to `@JonathonSonesen`_ and
+  `@tomviner`_ for PR.
 
 * ImportErrors in plugins now are a fatal error instead of issuing a
   pytest warning (`#1479`_). Thanks to `@The-Compiler`_ for the PR.
@@ -58,6 +60,7 @@
 .. _#1503: https://github.com/pytest-dev/pytest/issues/1503
 .. _#1479: https://github.com/pytest-dev/pytest/issues/1479
 .. _#925: https://github.com/pytest-dev/pytest/issues/925
+.. _#1210: https://github.com/pytest-dev/pytest/issues/1210
 
 .. _@graingert: https://github.com/graingert
 .. _@taschini: https://github.com/taschini
@@ -67,6 +70,8 @@
 .. _@bagerard: https://github.com/bagerard
 .. _@davehunt: https://github.com/davehunt
 .. _@DRMacIver: https://github.com/DRMacIver
+.. _@BeyondEvil: https://github.com/BeyondEvil
+.. _@JonathonSonesen: https://github.com/JonathonSonesen
 
 
 2.9.2

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -92,6 +92,11 @@ def wrap_session(config, doit):
             raise
         except KeyboardInterrupt:
             excinfo = _pytest._code.ExceptionInfo()
+            if initstate < 2 and isinstance(
+                    excinfo.value, pytest.exit.Exception):
+                excinfo = _pytest._code.ExceptionInfo()
+                sys.stderr.write('{0}: {1}\n'.format(
+                    type(excinfo.value).__name__, excinfo.value.msg))
             config.hook.pytest_keyboard_interrupt(excinfo=excinfo)
             session.exitstatus = EXIT_INTERRUPTED
         except:

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -457,6 +457,18 @@ def test_pytest_fail():
         s = excinfo.exconly(tryshort=True)
         assert s.startswith("Failed")
 
+def test_pytest_exit_msg(testdir):
+    testdir.makeconftest("""
+    import pytest
+
+    def pytest_configure(config):
+        pytest.exit('oh noes')
+    """)
+    result = testdir.runpytest()
+    result.stderr.fnmatch_lines([
+        "Exit: oh noes",
+    ])
+
 def test_pytest_fail_notrace(testdir):
     testdir.makepyfile("""
         import pytest


### PR DESCRIPTION
Fix for https://github.com/pytest-dev/pytest/issues/1210

Previously, calls to `pytest.exit(msg)` during startup, for example in `pytest_configure` swallowed the `msg`. Now it gets printed to stderr.