### PR TITLE
Fix pdf links in docs and point to docs.pytest.org in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: http://pytest.org/latest/_static/pytest1.png
-   :target: http://pytest.org
+.. image:: http://docs.pytest.org/en/latest/_static/pytest1.png
+   :target: http://docs.pytest.org
    :align: center
    :alt: pytest
 
@@ -51,33 +51,33 @@ To execute it::
     test_sample.py:5: AssertionError
     ======= 1 failed in 0.12 seconds ========
 
-Due to ``py.test``'s detailed assertion introspection, only plain ``assert`` statements are used. See `getting-started <http://pytest.org/latest/getting-started.html#our-first-test-run>`_ for more examples.
+Due to ``py.test``'s detailed assertion introspection, only plain ``assert`` statements are used. See `getting-started <http://docs.pytest.org/en/latest/getting-started.html#our-first-test-run>`_ for more examples.
         
 
 Features
 --------
 
-- Detailed info on failing `assert statements <http://pytest.org/latest/assert.html>`_ (no need to remember ``self.assert*`` names);
+- Detailed info on failing `assert statements <http://docs.pytest.org/en/latest/assert.html>`_ (no need to remember ``self.assert*`` names);
 
 - `Auto-discovery
-  <http://pytest.org/latest/goodpractices.html#python-test-discovery>`_
+  <http://docs.pytest.org/en/latest/goodpractices.html#python-test-discovery>`_
   of test modules and functions;
 
-- `Modular fixtures <http://pytest.org/latest/fixture.html>`_  for
+- `Modular fixtures <http://docs.pytest.org/en/latest/fixture.html>`_  for
   managing small or parametrized long-lived test resources;
 
-- Can run `unittest <http://pytest.org/latest/unittest.html>`_ (or trial),
-  `nose <http://pytest.org/latest/nose.html>`_ test suites out of the box;
+- Can run `unittest <http://docs.pytest.org/en/latest/unittest.html>`_ (or trial),
+  `nose <http://docs.pytest.org/en/latest/nose.html>`_ test suites out of the box;
 
 - Python2.6+, Python3.2+, PyPy-2.3, Jython-2.5 (untested);
 
-- Rich plugin architecture, with over 150+ `external plugins <http://pytest.org/latest/plugins.html#installing-external-plugins-searching>`_ and thriving community;
+- Rich plugin architecture, with over 150+ `external plugins <http://docs.pytest.org/en/latest/plugins.html#installing-external-plugins-searching>`_ and thriving community;
 
 
 Documentation
 -------------
 
-For full documentation, including installation, tutorials and PDF documents, please see http://pytest.org.
+For full documentation, including installation, tutorials and PDF documents, please see http://docs.pytest.org.
 
 
 Bugs/Requests
@@ -89,7 +89,7 @@ Please use the `GitHub issue tracker <https://github.com/pytest-dev/pytest/issue
 Changelog
 ---------
 
-Consult the `Changelog <http://pytest.org/latest/changelog.html>`_ page for fixes and enhancements of each version.
+Consult the `Changelog <http://docs.pytest.org/en/latest/changelog.html>`_ page for fixes and enhancements of each version.
 
 
 License

--- a/doc/en/contents.rst
+++ b/doc/en/contents.rst
@@ -3,7 +3,7 @@
 Full pytest documentation
 ===========================
 
-`Download latest version as PDF <pytest.pdf>`_
+`Download latest version as PDF <https://media.readthedocs.org/pdf/pytest/latest/pytest.pdf>`_
 
 .. `Download latest version as EPUB <http://media.readthedocs.org/epub/pytest/latest/pytest.epub>`_
 

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -11,7 +11,7 @@ Installation and Getting Started
 `colorama (Windows) <http://pypi.python.org/pypi/colorama>`_,
 `argparse (py26) <http://pypi.python.org/pypi/argparse>`_.
 
-**documentation as PDF**: `download latest <http://pytest.org/latest/pytest.pdf>`_
+**documentation as PDF**: `download latest <https://media.readthedocs.org/pdf/pytest/latest/pytest.pdf>`_
 
 .. _`getstarted`:
 .. _installation:

--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -10,7 +10,7 @@ pytest: helps you write better programs
  - free and open source software, distributed under the terms of the :ref:`MIT license <license>`
  - **well tested** with more than a thousand tests against itself
  - **strict backward compatibility policy** for safe pytest upgrades
- - :ref:`comprehensive online <toc>` and `PDF documentation <pytest.pdf>`_
+ - :ref:`comprehensive online <toc>` and `PDF documentation <https://media.readthedocs.org/pdf/pytest/latest/pytest.pdf>`_
  - many :ref:`third party plugins <extplugins>` and :ref:`builtin helpers <pytest helpers>`,
  - used in :ref:`many small and large projects and organisations <projects>`
  - comes with many :ref:`tested examples <examples>`


### PR DESCRIPTION
Fix #1436