### PR TITLE
terminal: dont pretend to know the deselection reason

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -256,7 +256,10 @@ time or change existing behaviors in order to make them less surprising/more use
 
 * Add stderr write for ``pytest.exit(msg)`` during startup. Previously the message was never shown.
   Thanks `@BeyondEvil`_ for reporting `#1210`_. Thanks to `@JonathonSonesen`_ and
-  `@tomviner`_ for PR.
+  `@tomviner`_ for the PR.
+
+* fix `#1372`_ no longer display the incorrect test deselection reason,
+  thanks `@ronnypfannschmidt`_ for the PR.
 
 *
 
@@ -308,6 +311,7 @@ time or change existing behaviors in order to make them less surprising/more use
 .. _#1210: https://github.com/pytest-dev/pytest/issues/1210
 .. _#1235: https://github.com/pytest-dev/pytest/issues/1235
 .. _#1351: https://github.com/pytest-dev/pytest/issues/1351
+.. _#1372: https://github.com/pytest-dev/pytest/issues/1372
 .. _#1421: https://github.com/pytest-dev/pytest/issues/1421
 .. _#1426: https://github.com/pytest-dev/pytest/issues/1426
 .. _#1428: https://github.com/pytest-dev/pytest/pull/1428

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -512,16 +512,8 @@ class TerminalReporter:
 
     def summary_deselected(self):
         if 'deselected' in self.stats:
-            l = []
-            k = self.config.option.keyword
-            if k:
-                l.append("-k%s" % k)
-            m = self.config.option.markexpr
-            if m:
-                l.append("-m %r" % m)
-            if l:
-                self.write_sep("=", "%d tests deselected by %r" % (
-                    len(self.stats['deselected']), " ".join(l)), bold=True)
+            self.write_sep("=", "%d tests deselected" % (
+                len(self.stats['deselected'])), bold=True)
 
 def repr_pythonversion(v=None):
     if v is None:

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -384,7 +384,7 @@ class TestTerminalFunctional:
         result = testdir.runpytest("-k", "test_two:", testpath)
         result.stdout.fnmatch_lines([
             "*test_deselected.py ..",
-            "=* 1 test*deselected by*test_two:*=",
+            "=* 1 test*deselected *=",
         ])
         assert result.ret == 0
 


### PR DESCRIPTION


this addresses #1372 - we pretend we know the deselection reason from internal plugins and ignore 3rd party/local reasons