### PR TITLE
Rewrite asserts in test-modules loaded very early in the startup

### DIFF
--- a/_pytest/assertion/__init__.py
+++ b/_pytest/assertion/__init__.py
@@ -31,10 +31,11 @@ def pytest_namespace():
 def register_assert_rewrite(*names):
     """Register a module name to be rewritten on import.
 
-    This function will make sure that the module will get it's assert
-    statements rewritten when it is imported.  Thus you should make
-    sure to call this before the module is actually imported, usually
-    in your __init__.py if you are a plugin using a package.
+    This function will make sure that this module or all modules inside
+    the package will get their assert statements rewritten.
+    Thus you should make sure to call this before the module is
+    actually imported, usually in your __init__.py if you are a plugin
+    using a package.
     """
     for hook in sys.meta_path:
         if isinstance(hook, rewrite.AssertionRewritingHook):

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -533,6 +533,16 @@ def test_rewritten():
         hook.mark_rewrite('_pytest')
         assert '_pytest' in warnings[0][1]
 
+    def test_rewrite_module_imported_from_conftest(self, testdir):
+        testdir.makeconftest('''
+            import test_rewrite_module_imported
+        ''')
+        testdir.makepyfile(test_rewrite_module_imported='''
+            def test_rewritten():
+                assert "@py_builtins" in globals()
+        ''')
+        assert testdir.runpytest_subprocess().ret == 0
+
 
 class TestAssertionRewriteHookDetails(object):
     def test_loader_is_package_false_for_module(self, testdir):


### PR DESCRIPTION
I investigated this some more and found the problem:

The assertion-rewrite hook is installed very early on, during the construction of the `Config` object. After installing the hook and still during `Config`'s construction, plugins and `conftest` files are also imported and are rewritten if `AssertionRewriteHook._should_rewrite` returns `True`. 

Now the problem with the example posted in #1784 is that it imports `test_foocompare` at the top-level of the `conftest.py` file which is loaded very early, when the `session` object has not even been created yet (much less set on the hook), so it doesn't try to rewrite that module.

Looking at the code I noticed that the code block that should handle this, the `for pat in self.fnpaths` loop, doesn't really depend on `self.session` at all except for that weird comment about a cycle. Changing the code to always check if the filename matches one of the test patterns seems to do the trick.

Fix #1784