### PR TITLE
Sort fixture names when a fixture lookup error occurs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -178,6 +178,10 @@ time or change existing behaviors in order to make them less surprising/more use
 * Explicitly passed parametrize ids do not get escaped to ascii (`#1351`_).
   Thanks `@ceridwen`_ for the PR.
 
+* Fixtures are now sorted in the error message displayed when an unknown
+  fixture is declared in a test function.
+  Thanks `@nicoddemus`_ for the PR.
+
 * Parametrize ids can accept ``None`` as specific test id, in which case the
   automatically generated id for that argument will be used.
   Thanks `@palaviv`_ for the complete PR (`#1468`_).

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -668,7 +668,7 @@ class FixtureLookupError(LookupError):
                 if faclist and name not in available:
                     available.append(name)
             msg = "fixture %r not found" % (self.argname,)
-            msg += "\n available fixtures: %s" %(", ".join(available),)
+            msg += "\n available fixtures: %s" %(", ".join(sorted(available)),)
             msg += "\n use 'pytest --fixtures [testpath]' for help on them."
 
         return FixtureLookupErrorRepr(fspath, lineno, tblines, msg, self.argname)

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -404,6 +404,21 @@ class TestFillFixtures:
         assert result.ret == 0
 
     def test_funcarg_lookup_error(self, testdir):
+        testdir.makeconftest("""
+            import pytest
+
+            @pytest.fixture
+            def a_fixture(): pass
+
+            @pytest.fixture
+            def b_fixture(): pass
+
+            @pytest.fixture
+            def c_fixture(): pass
+
+            @pytest.fixture
+            def d_fixture(): pass
+        """)
         testdir.makepyfile("""
             def test_lookup_error(unknown):
                 pass
@@ -413,10 +428,12 @@ class TestFillFixtures:
             "*ERROR*test_lookup_error*",
             "*def test_lookup_error(unknown):*",
             "*fixture*unknown*not found*",
-            "*available fixtures*",
+            # check if fixtures appear sorted
+            "*available fixtures:*a_fixture,*b_fixture,*c_fixture,*d_fixture*monkeypatch,*",
             "*1 error*",
         ])
         assert "INTERNAL" not in result.stdout.str()
+        # invocation-scoped fixture should appear with their friendly name only
         assert 'monkeypatch:session' not in result.stdout.str()
 
     def test_fixture_excinfo_leak(self, testdir):


### PR DESCRIPTION
Another small issue uncovered when running `regendoc`. :grin: 