### PR TITLE
Internal adjustments for easier integration with IDEs

### DIFF
--- a/_pytest/junitxml.py
+++ b/_pytest/junitxml.py
@@ -118,13 +118,10 @@ class _NodeReporter(object):
 
     def _write_captured_output(self, report):
         for capname in ('out', 'err'):
-            allcontent = ""
-            for name, content in report.get_sections("Captured std%s" %
-                                                     capname):
-                allcontent += content
-            if allcontent:
+            content = getattr(report, 'capstd' + capname)
+            if content:
                 tag = getattr(Junit, 'system-' + capname)
-                self.append(tag(bin_xml_escape(allcontent)))
+                self.append(tag(bin_xml_escape(content)))
 
     def append_pass(self, report):
         self.add_stats('passed')

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -357,11 +357,13 @@ class PyCollector(PyobjMixin, pytest.Collector):
             fixtures.add_funcarg_pseudo_fixture_def(self, metafunc, fm)
 
             for callspec in metafunc._calls:
-                subname = "%s[%s]" %(name, callspec.id)
+                subname = "%s[%s]" % (name, callspec.id)
                 yield Function(name=subname, parent=self,
                                callspec=callspec, callobj=funcobj,
                                fixtureinfo=fixtureinfo,
-                               keywords={callspec.id:True})
+                               keywords={callspec.id:True},
+                               originalname=name,
+                               )
 
 
 def _marked(func, mark):
@@ -1471,7 +1473,7 @@ class Function(FunctionMixin, pytest.Item, fixtures.FuncargnamesCompatAttr):
     _genid = None
     def __init__(self, name, parent, args=None, config=None,
                  callspec=None, callobj=NOTSET, keywords=None, session=None,
-                 fixtureinfo=None):
+                 fixtureinfo=None, originalname=None):
         super(Function, self).__init__(name, parent, config=config,
                                        session=session)
         self._args = args
@@ -1492,6 +1494,12 @@ class Function(FunctionMixin, pytest.Item, fixtures.FuncargnamesCompatAttr):
         self._fixtureinfo = fixtureinfo
         self.fixturenames = fixtureinfo.names_closure
         self._initrequest()
+
+        #: original function name, without any decorations (for example
+        #: parametrization adds a ``"[...]"`` suffix to function names).
+        #:
+        #: .. versionadded:: 3.0
+        self.originalname = originalname
 
     def _initrequest(self):
         self.funcargs = {}

--- a/_pytest/runner.py
+++ b/_pytest/runner.py
@@ -306,8 +306,10 @@ class TestReport(BaseReport):
         #: one of 'setup', 'call', 'teardown' to indicate runtest phase.
         self.when = when
 
-        #: list of (secname, data) extra information which needs to
-        #: marshallable
+        #: list of pairs ``(str, str)`` of extra information which needs to
+        #: marshallable. Used by pytest to add captured text
+        #: from ``stdout`` and ``stderr``, but may be used by other plugins
+        #: to add arbitrary information to reports.
         self.sections = list(sections)
 
         #: time it took to run just the test

--- a/_pytest/runner.py
+++ b/_pytest/runner.py
@@ -225,6 +225,22 @@ class BaseReport(object):
         exc = tw.stringio.getvalue()
         return exc.strip()
 
+    @property
+    def capstdout(self):
+        """Return captured text from stdout, if capturing is enabled
+
+        .. versionadded:: 3.0
+        """
+        return ''.join(content for (prefix, content) in self.get_sections('Captured stdout'))
+
+    @property
+    def capstderr(self):
+        """Return captured text from stderr, if capturing is enabled
+
+        .. versionadded:: 3.0
+        """
+        return ''.join(content for (prefix, content) in self.get_sections('Captured stderr'))
+
     passed = property(lambda x: x.outcome == "passed")
     failed = property(lambda x: x.outcome == "failed")
     skipped = property(lambda x: x.outcome == "skipped")

--- a/_pytest/runner.py
+++ b/_pytest/runner.py
@@ -211,6 +211,20 @@ class BaseReport(object):
             if name.startswith(prefix):
                 yield prefix, content
 
+    @property
+    def longreprtext(self):
+        """
+        Read-only property that returns the full string representation
+        of ``longrepr``.
+
+        .. versionadded:: 3.0
+        """
+        tw = py.io.TerminalWriter(stringio=True)
+        tw.hasmarkup = False
+        self.toterminal(tw)
+        exc = tw.stringio.getvalue()
+        return exc.strip()
+
     passed = property(lambda x: x.outcome == "passed")
     failed = property(lambda x: x.outcome == "failed")
     skipped = property(lambda x: x.outcome == "skipped")

--- a/doc/en/writing_plugins.rst
+++ b/doc/en/writing_plugins.rst
@@ -632,6 +632,7 @@ Reference of objects involved in hooks
 
 .. autoclass:: _pytest.runner.TestReport()
     :members:
+    :inherited-members:
 
 .. autoclass:: _pytest.vendored_packages.pluggy._CallOutcome()
     :members:

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -634,6 +634,15 @@ class TestFunction:
         result = testdir.runpytest()
         result.stdout.fnmatch_lines('* 3 passed in *')
 
+    def test_function_original_name(self, testdir):
+        items = testdir.getitems("""
+            import pytest
+            @pytest.mark.parametrize('arg', [1,2])
+            def test_func(arg):
+                pass
+        """)
+        assert [x.originalname for x in items] == ['test_func', 'test_func']
+
 
 class TestSorting:
     def test_check_equality(self, testdir):

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -668,3 +668,29 @@ def test_store_except_info_on_eror():
     assert sys.last_type is IndexError
     assert sys.last_value.args[0] == 'TEST'
     assert sys.last_traceback
+
+
+class TestReportContents:
+    """
+    Test ``longreprtext`` property of TestReport objects.
+    """
+
+    def test_pass(self, testdir):
+        reports = testdir.runitem("""
+            def test_func():
+                pass
+        """)
+        rep = reports[1]
+        assert rep.longreprtext == ''
+
+    def test_failure(self, testdir):
+        reports = testdir.runitem("""
+            def test_func():
+                x = 1
+                assert x == 4
+        """)
+        rep = reports[1]
+        assert 'assert 1 == 4' in rep.longreprtext
+
+    def getrunner(self):
+        return lambda item: runner.runtestprotocol(item, log=False)


### PR DESCRIPTION
Fixes related to #1790:

* Add `longreprtext `, `capstdout` and `capstderr` attributes to `TestReport`
* Add `originalname` attribute to Function
* Improve `TestReport.sections` docs

One issue which I could not figure out a good solution was about `xfail`, because the report object is decorated by the `skipping` plugin, which extends the terminal with this logic:

```python
def pytest_report_teststatus(report):
    if hasattr(report, "wasxfail"):
        if report.skipped:
            return "xfailed", "x", "xfail"
        elif report.failed:
            return "xpassed", "X", ("XPASS", {'yellow': True})
```

Suggestions on how to improve this are welcome.

cc @fabioz