### PR TITLE
Fix off-by-one error with lines from request.node.warn

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -72,7 +72,8 @@
 
 *
 
-*
+* Fixed off-by-one error with lines from ``request.node.warn``.
+  Thanks to `@blueyed`_ for the PR.
 
 *
 

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -267,7 +267,7 @@ class Node(object):
         if fslocation is None:
             fslocation = getattr(self, "fspath", None)
         else:
-            fslocation = "%s:%s" % fslocation[:2]
+            fslocation = "%s:%s" % (fslocation[0], fslocation[1] + 1)
 
         self.ihook.pytest_logwarning.call_historic(kwargs=dict(
             code=code, message=message,

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -525,13 +525,14 @@ class TestWarning:
         reprec = testdir.inline_run()
         reprec.assertoutcome(passed=1)
 
-    def test_warn_on_test_item_from_request(self, testdir):
+    def test_warn_on_test_item_from_request(self, testdir, request):
         testdir.makepyfile("""
             import pytest
 
             @pytest.fixture
             def fix(request):
                 request.node.warn("T1", "hello")
+
             def test_hello(fix):
                 pass
         """)
@@ -542,7 +543,7 @@ class TestWarning:
         result = testdir.runpytest("-rw")
         result.stdout.fnmatch_lines("""
             ===*pytest-warning summary*===
-            *WT1*test_warn_on_test_item*:5*hello*
+            *WT1*test_warn_on_test_item*:7 hello*
         """)
 
 class TestRootdir:


### PR DESCRIPTION
The line numbers in `node.location` seem to be zero-based?!