### PR TITLE
Improve display of continuation lines with multiline errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,9 +3,10 @@
 
 **Bug Fixes**
 
-* Add an 'E' to the first line of error messages from FixtureLookupErrorRepr.
-  Fixes `#717`_. Thanks `@blueyed`_ for reporting, `@eolo999`_ for the PR
-  and `@tomviner`_ for his guidance during EuroPython2016 sprint.
+* Improve error message with fixture lookup errors: add an 'E' to the first
+  line and '>' to the rest. Fixes `#717`_. Thanks `@blueyed`_ for reporting and
+  a PR, `@eolo999`_ for the initial PR and `@tomviner`_ for his guidance during
+  EuroPython2016 sprint.
 
 * Text documents without any doctests no longer appear as "skipped".
   Thanks `@graingert`_ for reporting and providing a full PR (`#1580`_).

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -9,7 +9,7 @@ import warnings
 
 import py
 import pytest
-from _pytest._code.code import TerminalRepr
+from _pytest._code.code import FormattedExcinfo, TerminalRepr
 from _pytest.mark import MarkDecorator, MarkerError
 
 try:
@@ -1836,6 +1836,7 @@ class FixtureLookupError(LookupError):
 
         return FixtureLookupErrorRepr(fspath, lineno, tblines, msg, self.argname)
 
+
 class FixtureLookupErrorRepr(TerminalRepr):
     def __init__(self, filename, firstlineno, tblines, errorstring, argname):
         self.tblines = tblines
@@ -1845,18 +1846,19 @@ class FixtureLookupErrorRepr(TerminalRepr):
         self.argname = argname
 
     def toterminal(self, tw):
-        #tw.line("FixtureLookupError: %s" %(self.argname), red=True)
+        # tw.line("FixtureLookupError: %s" %(self.argname), red=True)
         for tbline in self.tblines:
             tw.line(tbline.rstrip())
         lines = self.errorstring.split("\n")
-        for line in lines:
-            if line == lines[0]:
-                prefix = 'E       '
-            else:
-                prefix = '        '
-            tw.line(prefix + line.strip(), red=True)
+        if lines:
+            tw.line('{0}       {1}'.format(FormattedExcinfo.fail_marker,
+                                           lines[0].strip()), red=True)
+            for line in lines[1:]:
+                tw.line('{0}       {1}'.format(FormattedExcinfo.flow_marker,
+                                               line.strip()), red=True)
         tw.line()
         tw.line("%s:%d" % (self.filename, self.firstlineno+1))
+
 
 class FixtureManager:
     """

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -395,10 +395,11 @@ class TestFillFixtures:
         """)
         result = testdir.runpytest()
         result.stdout.fnmatch_lines([
-            "*ERROR*test_lookup_error*",
-            "*def test_lookup_error(unknown):*",
-            "*fixture*unknown*not found*",
-            "*available fixtures*",
+            "*ERROR at setup of test_lookup_error*",
+            "  def test_lookup_error(unknown):*",
+            "E       fixture 'unknown' not found",
+            ">       available fixtures:*",
+            ">       use 'py*test --fixtures *' for help on them.",
             "*1 error*",
         ])
         assert "INTERNAL" not in result.stdout.str()


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/issues/717.
Follow-up to https://github.com/pytest-dev/pytest/pull/1762.