### PR TITLE
Pass exitstatus to pytest_terminal_summary hook

### DIFF
--- a/_pytest/hookspec.py
+++ b/_pytest/hookspec.py
@@ -269,7 +269,7 @@ def pytest_report_header(config, startdir):
 def pytest_report_teststatus(report):
     """ return result-category, shortletter and verbose word for reporting."""
 
-def pytest_terminal_summary(terminalreporter):
+def pytest_terminal_summary(terminalreporter, exitstatus):
     """ add additional section in terminal summary reporting.  """
 
 

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -361,7 +361,8 @@ class TerminalReporter:
             EXIT_OK, EXIT_TESTSFAILED, EXIT_INTERRUPTED, EXIT_USAGEERROR,
             EXIT_NOTESTSCOLLECTED)
         if exitstatus in summary_exit_codes:
-            self.config.hook.pytest_terminal_summary(terminalreporter=self)
+            self.config.hook.pytest_terminal_summary(terminalreporter=self,
+                                                     exitstatus=exitstatus)
             self.summary_errors()
             self.summary_failures()
             self.summary_warnings()

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -787,15 +787,17 @@ def test_tbstyle_native_setup_error(testdir):
 
 def test_terminal_summary(testdir):
     testdir.makeconftest("""
-        def pytest_terminal_summary(terminalreporter):
+        def pytest_terminal_summary(terminalreporter, exitstatus):
             w = terminalreporter
             w.section("hello")
             w.line("world")
+            w.line("exitstatus: {0}".format(exitstatus))
     """)
     result = testdir.runpytest()
     result.stdout.fnmatch_lines("""
         *==== hello ====*
         world
+        exitstatus: 5
     """)
 
 


### PR DESCRIPTION
This is useful to know if a testrun has been interrupted
(EXIT_INTERRUPTED).

- [ ] Add a new entry to `CHANGELOG.rst`