### PR TITLE
Support [tool:pytest] in setup.cfg files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -232,6 +232,11 @@ time or change existing behaviors in order to make them less surprising/more use
 * ``yield``-based tests are considered deprecated and will be removed in pytest-4.0.
   Thanks `@nicoddemus`_ for the PR.
 
+* ``[pytest]`` sections in ``setup.cfg`` files should now be named ``[tool:pytest]``
+  to avoid conflicts with other distutils commands (see `#567`_). ``[pytest]`` sections in
+  ``pytest.ini`` or ``tox.ini`` files are supported and unchanged.
+  Thanks `@nicoddemus`_ for the PR.
+
 * Using ``pytest_funcarg__`` prefix to declare fixtures is considered deprecated and will be
   removed in pytest-4.0 (`#1684`_).
   Thanks `@nicoddemus`_ for the PR.
@@ -374,6 +379,7 @@ time or change existing behaviors in order to make them less surprising/more use
 .. _#372: https://github.com/pytest-dev/pytest/issues/372
 .. _#457: https://github.com/pytest-dev/pytest/issues/457
 .. _#460: https://github.com/pytest-dev/pytest/pull/460
+.. _#567: https://github.com/pytest-dev/pytest/pull/567
 .. _#607: https://github.com/pytest-dev/pytest/issues/607
 .. _#634: https://github.com/pytest-dev/pytest/issues/634
 .. _#717: https://github.com/pytest-dev/pytest/issues/717

--- a/_pytest/deprecated.py
+++ b/_pytest/deprecated.py
@@ -17,5 +17,7 @@ FUNCARG_PREFIX = (
     'and scheduled to be removed in pytest 4.0.  '
     'Please remove the prefix and use the @pytest.fixture decorator instead.')
 
+SETUP_CFG_PYTEST = '[pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.'
+
 GETFUNCARGVALUE = "use of getfuncargvalue is deprecated, use getfixturevalue"
 

--- a/_pytest/helpconfig.py
+++ b/_pytest/helpconfig.py
@@ -71,7 +71,6 @@ def showhelp(config):
     tw.write(config._parser.optparser.format_help())
     tw.line()
     tw.line()
-    #tw.sep( "=", "config file settings")
     tw.line("[pytest] ini-options in the next "
             "pytest.ini|tox.ini|setup.cfg file:")
     tw.line()

--- a/doc/en/customize.rst
+++ b/doc/en/customize.rst
@@ -50,7 +50,7 @@ Here is the algorithm which finds the rootdir from ``args``:
 
 Note that an existing ``pytest.ini`` file will always be considered a match,
 whereas ``tox.ini`` and ``setup.cfg`` will only match if they contain a
-``[pytest]`` section. Options from multiple ini-files candidates are never
+``[pytest]`` or ``[tool:pytest]`` section, respectively. Options from multiple ini-files candidates are never
 merged - the first one wins (``pytest.ini`` always wins, even if it does not
 contain a ``[pytest]`` section).
 
@@ -73,7 +73,7 @@ check for ini-files as follows::
 
     # first look for pytest.ini files
     path/pytest.ini
-    path/setup.cfg  # must also contain [pytest] section to match
+    path/setup.cfg  # must also contain [tool:pytest] section to match
     path/tox.ini    # must also contain [pytest] section to match
     pytest.ini
     ... # all the way down to the root
@@ -154,7 +154,7 @@ Builtin configuration file options
 
    .. code-block:: ini
 
-        # content of setup.cfg
+        # content of pytest.ini
         [pytest]
         norecursedirs = .svn _build tmp*
 

--- a/doc/en/example/pythoncollection.rst
+++ b/doc/en/example/pythoncollection.rst
@@ -77,9 +77,9 @@ Example::
 Changing directory recursion
 -----------------------------------------------------
 
-You can set the :confval:`norecursedirs` option in an ini-file, for example your ``setup.cfg`` in the project root directory::
+You can set the :confval:`norecursedirs` option in an ini-file, for example your ``pytest.ini`` in the project root directory::
 
-    # content of setup.cfg
+    # content of pytest.ini
     [pytest]
     norecursedirs = .svn _build tmp*
 
@@ -94,8 +94,9 @@ You can configure different naming conventions by setting
 the :confval:`python_files`, :confval:`python_classes` and
 :confval:`python_functions` configuration options.  Example::
 
-    # content of setup.cfg
-    # can also be defined in in tox.ini or pytest.ini file
+    # content of pytest.ini
+    # can also be defined in in tox.ini or setup.cfg file, although the section
+    # name in setup.cfg files should be "tool:pytest"
     [pytest]
     python_files=check_*.py
     python_classes=Check

--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -196,6 +196,24 @@ required for calling the test command. You can also pass additional
 arguments to pytest such as your test directory or other
 options using ``--addopts``.
 
+You can also specify other pytest-ini options in your ``setup.cfg`` file
+by putting them into a ``[tool:pytest]`` section:
+
+.. code-block:: ini
+
+    [tool:pytest]
+    addopts = --verbose
+    python_files = testing/*/*.py
+
+
+.. note::
+    Prior to 3.0, the supported section name was ``[pytest]``. Due to how
+    this may collide with some distutils commands, the recommended
+    section name for ``setup.cfg`` files is now ``[tool:pytest]``.
+
+    Note that for ``pytest.ini`` and ``tox.ini`` files the section
+    name is ``[pytest]``.
+
 
 Manual Integration
 ^^^^^^^^^^^^^^^^^^

--- a/doc/en/xdist.rst
+++ b/doc/en/xdist.rst
@@ -90,7 +90,7 @@ and ``pytest`` will run your tests. Assuming you have failures it will then
 wait for file changes and re-run the failing test set.  File changes are detected by looking at ``looponfailingroots`` root directories and all of their contents (recursively).  If the default for this value does not work for you you
 can change it in your project by setting a configuration option::
 
-    # content of a pytest.ini, setup.cfg or tox.ini file
+    # content of a pytest.ini or tox.ini file
     [pytest]
     looponfailroots = mypkg testdir
 
@@ -181,7 +181,7 @@ to run tests in each of the environments.
 Specifying "rsync" dirs in an ini-file
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-In a ``tox.ini`` or ``setup.cfg`` file in your root project directory
+In a ``pytest.ini`` or ``tox.ini`` file in your root project directory
 you may specify directories to include or to exclude in synchronisation::
 
     [pytest]

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -34,6 +34,15 @@ def test_funcarg_prefix_deprecation(testdir):
     ])
 
 
+def test_pytest_setup_cfg_deprecated(testdir):
+    testdir.makefile('.cfg', setup='''
+        [pytest]
+        addopts = --verbose
+    ''')
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(['*pytest*section in setup.cfg files is deprecated*use*tool:pytest*instead*'])
+
+
 def test_str_args_deprecated(tmpdir, testdir):
     """Deprecate passing strings to pytest.main(). Scheduled for removal in pytest-4.0."""
     from _pytest.main import EXIT_NOTESTSCOLLECTED


### PR DESCRIPTION
Also deprecate `[pytest]` usage in `setup.cfg` files

Fix #567