### PR TITLE
Enable py35-trial testenv on Windows

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -78,13 +78,12 @@ commands=
 [testenv:py27-trial]
 deps=twisted
 commands=
-  py.test -rsxf {posargs:testing/test_unittest.py}
+  py.test -ra {posargs:testing/test_unittest.py}
 
 [testenv:py35-trial]
-platform=linux|darwin
 deps={[testenv:py27-trial]deps}
 commands=
-  py.test -rsxf {posargs:testing/test_unittest.py}
+  py.test -ra {posargs:testing/test_unittest.py}
 
 [testenv:doctest]
 commands=py.test --doctest-modules _pytest


### PR DESCRIPTION
Not sure why this is turned off, works on my computer.

