### PR TITLE
Documentation update for rootdir discovery

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -78,6 +78,7 @@ Martijn Faassen
 Martin Prusse
 Martin K. Scherer
 Matt Bachmann
+Matthias Hafner
 Michael Aquilina
 Michael Birtwell
 Michael Droettboom

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -127,6 +127,7 @@
 .. _@Stranger6667: https://github.com/Stranger6667
 .. _@taschini: https://github.com/taschini
 .. _@Vogtinator: https://github.com/Vogtinator
+.. _@matthiasha: https://github.com/matthiasha
 
 
 2.9.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,7 +38,8 @@
 
 * Refined logic for determining the ``rootdir``, considering only valid
   paths which fixes a number of issues: `#1594`_, `#1435`_ and `#1471`_.
-  Thanks to `@blueyed`_ and `@davehunt`_ for the PR.
+  Updated the documentation according to current behavior. Thanks to 
+  `@blueyed`_, `@davehunt`_ and `@matthiasha`_ for the PR.
 
 * Always include full assertion explanation. The previous behaviour was hiding
   sub-expressions that happened to be False, assuming this was redundant information.

--- a/doc/en/customize.rst
+++ b/doc/en/customize.rst
@@ -52,7 +52,7 @@ If no ``args`` are given, pytest collects test below the current working
 directory and also starts determining the rootdir from there. 
 
 :warning: custom pytest plugin commandline arguments may include a path, as in
-    ``py.test --log-output ../../test.log args``. Then ``args`` is mandatory,
+    ``pytest --log-output ../../test.log args``. Then ``args`` is mandatory,
     otherwise pytest uses the folder of test.log for rootdir determination
     (see also `issue 1435 <https://github.com/pytest-dev/pytest/issues/1435>`_).
     A dot ``.`` for referencing to the current working directory is also

--- a/doc/en/customize.rst
+++ b/doc/en/customize.rst
@@ -48,6 +48,16 @@ Here is the algorithm which finds the rootdir from ``args``:
   directory. This allows to work with pytest in structures that are not part of
   a package and don't have any particular ini-file configuration.
 
+If no ``args`` are given, pytest collects test below the current working
+directory and also starts determining the rootdir from there. 
+
+:warning: custom pytest plugin commandline arguments may include a path, as in
+    ``py.test --log-output ../../test.log args``. Then ``args`` is mandatory,
+    otherwise pytest uses the folder of test.log for rootdir determination
+    (see also `issue 1435 <https://github.com/pytest-dev/pytest/issues/1435>`_).
+    A dot ``.`` for referencing to the current working directory is also
+    possible.
+
 Note that an existing ``pytest.ini`` file will always be considered a match,
 whereas ``tox.ini`` and ``setup.cfg`` will only match if they contain a
 ``[pytest]`` section. Options from multiple ini-files candidates are never


### PR DESCRIPTION
This covers issue #1435: if ``args`` is not explicitly given, custom pytest commandline arguments are misleading pytest's rootdir discovery, if they point to an existing file/folder.

Target: `master` (as an addition to PR #1621 )