### PR TITLE
Fix spelling: s/outside a/outside of a/

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1215,7 +1215,7 @@ time or change existing behaviors in order to make them less surprising/more use
   dep).  Thanks Charles Cloud for analysing the issue.
 
 - fix conftest related fixture visibility issue: when running with a
-  CWD outside a test package pytest would get fixture discovery wrong.
+  CWD outside of a test package pytest would get fixture discovery wrong.
   Thanks to Wolfgang Schnerring for figuring out a reproducable example.
 
 - Introduce pytest_enter_pdb hook (needed e.g. by pytest_timeout to cancel the

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -433,8 +433,8 @@ class Module(pytest.File, PyCollector):
             )
         except _pytest.runner.Skipped:
             raise self.CollectError(
-                "Using @pytest.skip outside a test (e.g. as a test function "
-                "decorator) is not allowed. Use @pytest.mark.skip or "
+                "Using @pytest.skip outside of a test (e.g. as a test "
+                "function decorator) is not allowed. Use @pytest.mark.skip or "
                 "@pytest.mark.skipif instead."
             )
         self.config.pluginmanager.consider_module(mod)

--- a/doc/en/announce/release-2.6.3.rst
+++ b/doc/en/announce/release-2.6.3.rst
@@ -41,7 +41,7 @@ Changes 2.6.3
   dep).  Thanks Charles Cloud for analysing the issue.
 
 - fix conftest related fixture visibility issue: when running with a
-  CWD outside a test package pytest would get fixture discovery wrong.
+  CWD outside of a test package pytest would get fixture discovery wrong.
   Thanks to Wolfgang Schnerring for figuring out a reproducable example.
 
 - Introduce pytest_enter_pdb hook (needed e.g. by pytest_timeout to cancel the

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -967,5 +967,5 @@ def test_module_level_skip_error(testdir):
     """)
     result = testdir.runpytest()
     result.stdout.fnmatch_lines(
-        "*Using @pytest.skip outside a test * is not allowed*"
+        "*Using @pytest.skip outside of a test * is not allowed*"
     )


### PR DESCRIPTION
Ref: http://idioms.thefreedictionary.com/outside+of