### PR TITLE
Fix importer call

### DIFF
--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -687,7 +687,7 @@ class Session(FSCollector):
         # This method is sometimes invoked when AssertionRewritingHook, which
         # does not define a get_filename method, is already in place:
         try:
-            path = loader.get_filename()
+            path = loader.get_filename(x)
         except AttributeError:
             # Retrieve path from AssertionRewritingHook:
             path = loader.modules[x][0].co_filename


### PR DESCRIPTION
`get_filename` expects full module name as a parameter. Currently pytest fails, if I run it with zip importer.