### PR TITLE
Delete unreferenced setup.cfg from docs

### DIFF
--- a/doc/en/example/layout1/setup.cfg
+++ b/doc/en/example/layout1/setup.cfg
@@ -1,4 +1,0 @@
-[pytest]
-testfilepatterns =
-    ${topdir}/tests/unit/test_${basename}
-    ${topdir}/tests/functional/*.py


### PR DESCRIPTION
Noticed it's not using the new `[tool:pytest]` header as changed in #567, can't find any reference to it or `testfilepatterns`. It was added in b1e430145706556cc676e7cbe49d625b7540088e 6 years ago, there don't seem to have ever been references to it.