### PR TITLE
Fix internal error when parametrizing using and empty list of ids()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,12 +8,14 @@
   with normal parameters in the same call (`#1832`_).
   Thanks `@The-Compiler`_ for the report, `@Kingdread`_ and `@nicoddemus`_ for the PR.
 
+* Fix internal error when parametrizing tests or fixtures using an empty ``ids`` argument (`#1849`_).
+  Thanks `@OPpuolitaival`_ for the report and `@nicoddemus`_ for the PR.
+
 * Fix loader error when running ``pytest`` embedded in a zipfile.
   Thanks `@mbachry`_ for the PR.
 
 *
 
-*
 
 *
 
@@ -21,9 +23,11 @@
 
 .. _@Kingdread: https://github.com/Kingdread
 .. _@mbachry: https://github.com/mbachry
+.. _@OPpuolitaival: https://github.com/OPpuolitaival
 
 .. _#1822: https://github.com/pytest-dev/pytest/issues/1822
 .. _#1832: https://github.com/pytest-dev/pytest/issues/1832
+.. _#1849: https://github.com/pytest-dev/pytest/issues/1849
 
 
 3.0.0

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -936,7 +936,7 @@ def _idval(val, argname, idx, idfn, config=None):
     return str(argname)+str(idx)
 
 def _idvalset(idx, valset, argnames, idfn, ids, config=None):
-    if ids is None or ids[idx] is None:
+    if ids is None or (idx >= len(ids) or ids[idx] is None):
         this_id = [_idval(val, argname, idx, idfn, config)
                    for val, argname in zip(valset, argnames)]
         return "-".join(this_id)

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -889,6 +889,33 @@ class TestMetafuncFunctional:
             "*test_function*advanced*FAILED",
         ])
 
+    def test_fixture_parametrized_empty_ids(self, testdir):
+        """Fixtures parametrized with empty ids cause an internal error (#1849)."""
+        testdir.makepyfile('''
+            import pytest
+
+            @pytest.fixture(scope="module", ids=[], params=[])
+            def temp(request):
+               return request.param
+
+            def test_temp(temp):
+                 pass
+        ''')
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines(['* 1 skipped *'])
+
+    def test_parametrized_empty_ids(self, testdir):
+        """Tests parametrized with empty ids cause an internal error (#1849)."""
+        testdir.makepyfile('''
+            import pytest
+
+            @pytest.mark.parametrize('temp', [], ids=list())
+            def test_temp(temp):
+                 pass
+        ''')
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines(['* 1 skipped *'])
+
     def test_parametrize_with_identical_ids_get_unique_names(self, testdir):
         testdir.makepyfile("""
             import pytest


### PR DESCRIPTION
Fix #1849