### PR TITLE
Add buffer attribute to DontReadFromInput

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -69,6 +69,7 @@ Javier Domingo Cansino
 Javier Romero
 John Towler
 Jon Sonesen
+Jordan Guymon
 Joshua Bronson
 Jurko Gospodnetić
 Justyna Janczyszyn

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,12 @@
 * Improve error message when passing non-string ids to ``pytest.mark.parametrize`` (`#1857`_).
   Thanks `@okken`_ for the report and `@nicoddemus`_ for the PR.
 
-*
+* Add ``buffer`` attribute to stdin stub class ``pytest.capture.DontReadFromInput``
+  Thanks `@joguSD`_ for the PR.
 
 *
 
+.. _@joguSD: https://github.com/joguSD
 
 .. _#1857: https://github.com/pytest-dev/pytest/issues/1857
 

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -455,6 +455,13 @@ class DontReadFromInput:
     def close(self):
         pass
 
+    @property
+    def buffer(self):
+        if sys.version_info >= (3,0):
+            return self
+        else:
+            raise AttributeError('redirected stdin has no attribute buffer')
+
 
 def _readline_workaround():
     """

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -662,6 +662,28 @@ def test_dontreadfrominput():
     f.close()  # just for completeness
 
 
+@pytest.mark.skipif('sys.version_info < (3,)', reason='python2 has no buffer')
+def test_dontreadfrominput_buffer_python3():
+    from _pytest.capture import DontReadFromInput
+    f = DontReadFromInput()
+    fb = f.buffer
+    assert not fb.isatty()
+    pytest.raises(IOError, fb.read)
+    pytest.raises(IOError, fb.readlines)
+    pytest.raises(IOError, iter, fb)
+    pytest.raises(ValueError, fb.fileno)
+    f.close()  # just for completeness
+
+
+@pytest.mark.skipif('sys.version_info >= (3,)', reason='python2 has no buffer')
+def test_dontreadfrominput_buffer_python2():
+    from _pytest.capture import DontReadFromInput
+    f = DontReadFromInput()
+    with pytest.raises(AttributeError):
+        f.buffer
+    f.close()  # just for completeness
+
+
 @pytest.yield_fixture
 def tmpfile(testdir):
     f = testdir.makepyfile("").open('wb+')


### PR DESCRIPTION
Python 3 added a `buffer` attribute to `sys.stdin`. Simply accessing this attribute doesn't imply the program has read from `stdin`, as such this attribute should behave similarly to the stubbed input presently. This PR will add this property and return `self` such that attempting to read the buffer will raise exceptions the same as had you read from `stdin`. 