### PR TITLE
Fix UnicodeEncodeError when string comparison with unicode has failed.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,6 +5,7 @@ Contributors include::
 
 Abdeali JK
 Abhijeet Kasurde
+Ahn Ki-Wook
 Alexei Kozlenok
 Anatoly Bubenkoff
 Andreas Zeidler

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,11 +9,16 @@
 * Add ``buffer`` attribute to stdin stub class ``pytest.capture.DontReadFromInput``
   Thanks `@joguSD`_ for the PR.
 
+* Fix ``UnicodeEncodeError`` when string comparison with unicode has failed. (`#1864`_)
+  Thanks `@AiOO`_ for the PR
+
 *
 
 .. _@joguSD: https://github.com/joguSD
+.. _@AiOO: https://github.com/AiOO
 
 .. _#1857: https://github.com/pytest-dev/pytest/issues/1857
+.. _#1864: https://github.com/pytest-dev/pytest/issues/1864
 
 
 3.0.1

--- a/_pytest/_code/code.py
+++ b/_pytest/_code/code.py
@@ -354,7 +354,7 @@ class ExceptionInfo(object):
             if exprinfo is None and isinstance(tup[1], AssertionError):
                 exprinfo = getattr(tup[1], 'msg', None)
                 if exprinfo is None:
-                    exprinfo = str(tup[1])
+                    exprinfo = py._builtin._totext(tup[1])
                 if exprinfo and exprinfo.startswith('assert '):
                     self._striptext = 'AssertionError: '
         self._excinfo = tup

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -816,3 +816,12 @@ def test_assert_indirect_tuple_no_warning(testdir):
     result = testdir.runpytest('-rw')
     output = '\n'.join(result.stdout.lines)
     assert 'WR1' not in output
+
+def test_assert_with_unicode(monkeypatch, testdir):
+    testdir.makepyfile(u"""
+        # -*- coding: utf-8 -*-
+        def test_unicode():
+            assert u'유니코드' == u'Unicode'
+    """)
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(['*AssertionError*'])


### PR DESCRIPTION
Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [v] Target: for bug or doc fixes, target `master`; for new features, target `features`;
- [v] Make sure to include one or more tests for your change;
- [v] Add yourself to `AUTHORS`;
- [v] Add a new entry to `CHANGELOG.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using RST syntax.
  * The pytest team likes to have people to acknowledged in the `CHANGELOG`, so please add a thank note to yourself ("Thanks @user for the PR") and a link to your GitHub profile. It may sound weird thanking yourself, but otherwise a maintainer would have to do it manually before or after merging instead of just using GitHub's merge button. This makes it easier on the maintainers to merge PRs. 

UnicodeEncodeError is occurred when comparing two strings with any unicode character. This PR fixes this error.

Relative issue: #1864.

**Error reproduction:**
```
$ cat test.py
# -*- coding: utf-8 -*-
def test_with_unicode_literal():
    assert u'테스트' == u'Test'

$ py.test test.py
==================================================== test session starts =====================================================
platform darwin -- Python 2.7.12, pytest-3.0.0, py-1.4.31, pluggy-0.3.1
rootdir: /Users/bright/Playground/test_test, inifile:
collected 1 items
test.py
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/main.py", line 96, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/main.py", line 131, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 724, in __call__
INTERNALERROR>     return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 338, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 333, in <lambda>
INTERNALERROR>     _MultiCall(methods, kwargs, hook.spec_opts).execute()
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 596, in execute
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/main.py", line 152, in pytest_runtestloop
INTERNALERROR>     item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 724, in __call__
INTERNALERROR>     return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 338, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 333, in <lambda>
INTERNALERROR>     _MultiCall(methods, kwargs, hook.spec_opts).execute()
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 595, in execute
INTERNALERROR>     return _wrapped_call(hook_impl.function(*args), self.execute)
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 253, in _wrapped_call
INTERNALERROR>     return call_outcome.get_result()
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 279, in get_result
INTERNALERROR>     _reraise(*ex)  # noqa
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 264, in __init__
INTERNALERROR>     self.result = func()
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 596, in execute
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/runner.py", line 66, in pytest_runtest_protocol
INTERNALERROR>     runtestprotocol(item, nextitem=nextitem)
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/runner.py", line 79, in runtestprotocol
INTERNALERROR>     reports.append(call_and_report(item, "call", log))
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/runner.py", line 133, in call_and_report
INTERNALERROR>     call = call_runtest_hook(item, when, **kwds)
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/runner.py", line 151, in call_runtest_hook
INTERNALERROR>     return CallInfo(lambda: ihook(item=item, **kwds), when=when)
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/runner.py", line 168, in __init__
INTERNALERROR>     self.excinfo = ExceptionInfo()
INTERNALERROR>   File "/REDUCED/lib/python2.7/site-packages/_pytest/_code/code.py", line 357, in __init__
INTERNALERROR>     exprinfo = str(tup[1])
INTERNALERROR> UnicodeEncodeError: 'ascii' codec can't encode characters in position 8-10: ordinal not in range(128)
================================================ no tests ran in 0.01 seconds ================================================
```