### PR TITLE
Remove example of "monkeypatch" used in session scope

### DIFF
--- a/doc/en/monkeypatch.rst
+++ b/doc/en/monkeypatch.rst
@@ -54,26 +54,6 @@ This autouse fixture will be executed for each test function and it
 will delete the method ``request.session.Session.request`` 
 so that any attempts within tests to create http requests will fail.
 
-example: setting an environment variable for the test session
--------------------------------------------------------------
-
-If you would like for an environment variable to be
-configured for the entire test session, you can add this to your
-top-level ``conftest.py`` file:
-
-.. code-block:: python
-
-    # content of conftest.py
-    @pytest.fixture(scope='session', autouse=True)
-    def enable_debugging(monkeypatch):
-        monkeypatch.setenv("DEBUGGING_VERBOSITY", "4")
-
-This auto-use fixture will set the ``DEBUGGING_VERBOSITY`` environment variable for
-the entire test session.
-
-Note that the ability to use a ``monkeypatch`` fixture from a ``session``-scoped
-fixture was added in pytest-3.0.
-
 
 Method reference of the monkeypatch fixture
 -------------------------------------------


### PR DESCRIPTION
This is a leftover when invocation-scoped fixtures were pulled back.

Fix #1872