### PR TITLE
pdbcls ipython example with tab completion

### DIFF
--- a/_pytest/debugging.py
+++ b/_pytest/debugging.py
@@ -14,7 +14,7 @@ def pytest_addoption(parser):
     group._addoption(
         '--pdbcls', dest="usepdb_cls", metavar="modulename:classname",
         help="start a custom interactive Python debugger on errors. "
-             "For example: --pdbcls=IPython.core.debugger:Pdb")
+             "For example: --pdbcls=IPython.terminal.debugger:TerminalPdb")
 
 def pytest_namespace():
     return {'set_trace': pytestPDB().set_trace}


### PR DESCRIPTION
I really like the pytest 3.0 command line option`--pdb --pdbcls=IPython.core.debugger:Pdb`, which directly allows to drop into the IPython debugger. That's great news!

I tried that with IPython 5.1 and it works fine, however tab completion is deactivated. Using the command line option `--pdb --pdbcls=IPython.terminal.debugger:TerminalPdb` will also activate tab completion.

