### PR TITLE
unittest runner: avoid tearDown and cleanup to ease post mortem debugging

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -91,6 +91,7 @@ Martin Prusse
 Matt Bachmann
 Matt Williams
 Matthias Hafner
+mbyt
 Michael Aquilina
 Michael Birtwell
 Michael Droettboom

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,9 +18,10 @@
   if a test suite uses ``pytest_plugins`` to load internal plugins (`#1888`_).
   Thanks `@jaraco`_ for the report and `@nicoddemus`_ for the PR (`#1891`_).
 
-* Do not call tearDown (and cleanups) when running unittest with ``--pdb``
+* Do not call tearDown and cleanups when running tests from
+  ``unittest.TestCase`` subclasses with ``--pdb``
   enabled. This allows proper post mortem debugging for all applications
-  which have significant logic in their tearDown method (`#1890`_). Thanks
+  which have significant logic in their tearDown machinery (`#1890`_). Thanks
   `@mbyt`_ for the PR.
 
 *

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,13 +12,20 @@
 * Fix ``UnicodeEncodeError`` when string comparison with unicode has failed. (`#1864`_)
   Thanks `@AiOO`_ for the PR
 
+* Do not call tearDown (and cleanups) when running unittest with ``--pdb``
+  enabled. This allows proper post mortem debugging for all applications
+  which have significant logic in their tearDown method (`#1890`_). Thanks
+  `@mbyt`_ for the PR.
+
 *
 
 .. _@joguSD: https://github.com/joguSD
 .. _@AiOO: https://github.com/AiOO
+.. _@mbyt: https://github.com/mbyt
 
 .. _#1857: https://github.com/pytest-dev/pytest/issues/1857
 .. _#1864: https://github.com/pytest-dev/pytest/issues/1864
+.. _#1890: https://github.com/pytest-dev/pytest/issues/1890
 
 
 3.0.1

--- a/_pytest/unittest.py
+++ b/_pytest/unittest.py
@@ -150,7 +150,12 @@ class TestCaseFunction(pytest.Function):
         pass
 
     def runtest(self):
-        self._testcase(result=self)
+        if self.config.pluginmanager.get_plugin("pdbinvoke") is None:
+            self._testcase(result=self)
+        else:
+            # disables tearDown and cleanups for post mortem debugging
+            self._testcase.debug()
+
 
     def _prunetraceback(self, excinfo):
         pytest.Function._prunetraceback(self, excinfo)

--- a/_pytest/unittest.py
+++ b/_pytest/unittest.py
@@ -153,7 +153,7 @@ class TestCaseFunction(pytest.Function):
         if self.config.pluginmanager.get_plugin("pdbinvoke") is None:
             self._testcase(result=self)
         else:
-            # disables tearDown and cleanups for post mortem debugging
+            # disables tearDown and cleanups for post mortem debugging (see #1890)
             self._testcase.debug()
 
 

--- a/doc/en/unittest.rst
+++ b/doc/en/unittest.rst
@@ -36,7 +36,7 @@ the general ``pytest`` documentation for many more examples.
 .. note::
 
     Running tests from ``unittest.TestCase`` subclasses with ``--pdb`` will
-    disable tearDown and cleanup methods for the case that an Exception is
+    disable tearDown and cleanup methods for the case that an Exception
     occurs. This allows proper post mortem debugging for all applications
     which have significant logic in their tearDown machinery.
 

--- a/doc/en/unittest.rst
+++ b/doc/en/unittest.rst
@@ -33,6 +33,13 @@ distributing tests to multiple CPUs via the ``-nNUM`` option if you
 installed the ``pytest-xdist`` plugin.  Please refer to
 the general ``pytest`` documentation for many more examples.
 
+.. note::
+
+    Running tests from ``unittest.TestCase`` subclasses with ``--pdb`` will
+    disable tearDown and cleanup methods for the case that an Exception is
+    occurs. This allows proper post mortem debugging for all applications
+    which have significant logic in their tearDown machinery.
+
 Mixing pytest fixtures into unittest.TestCase style tests
 -----------------------------------------------------------
 

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -79,6 +79,25 @@ class TestPDB:
         if child.isalive():
             child.wait()
 
+    def test_pdb_unittest_postmortem(self, testdir):
+        p1 = testdir.makepyfile("""
+            import unittest
+            class Blub(unittest.TestCase):
+                def tearDown(self):
+                    self.filename = None
+                def test_false(self):
+                    self.filename = 'bla' + '.txt'
+                    assert 0
+        """)
+        child = testdir.spawn_pytest("--pdb %s" % p1)
+        child.expect('(Pdb)')
+        child.sendline('p self.filename')
+        child.sendeof()
+        rest = child.read().decode("utf8")
+        assert 'bla.txt' in rest
+        if child.isalive():
+            child.wait()
+
     def test_pdb_interaction_capture(self, testdir):
         p1 = testdir.makepyfile("""
             def test_1():

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -86,7 +86,7 @@ class TestPDB:
                 def tearDown(self):
                     self.filename = None
                 def test_false(self):
-                    self.filename = 'bla' + '.txt'
+                    self.filename = 'debug' + '.me'
                     assert 0
         """)
         child = testdir.spawn_pytest("--pdb %s" % p1)
@@ -94,7 +94,7 @@ class TestPDB:
         child.sendline('p self.filename')
         child.sendeof()
         rest = child.read().decode("utf8")
-        assert 'bla.txt' in rest
+        assert 'debug.me' in rest
         if child.isalive():
             child.wait()
 


### PR DESCRIPTION
Assuming pytest is used to run a GUI test unittest suite. Typically GUI tests close the GUI in the unittest tearDowns or cleanup methods.

These tests cannot be easily post mortem debugged (`pytest --pdb`), as unittests tearDown and cleanup (which close the GUI) are called on an exception before the post mortem debugger jumps into place. Therefore, the GUI is closed and no direct interaction is possible any more.

A work around when running the unittest via the unittest runner is to add the following line to ~/.pdbrc: `!import unittest; unittest.TestCase.run = lambda self,*args,**kw: unittest.TestCase.debug(self)`, start the tests with `python -m pdb test.py` and hit continue.

This pull request accomplishes the same within the pytest unittest compatibility layer. It is solely activated if pytest ist called with --pdb.

An example program which shows the problem would be the following (run with and without this change):
```
from __future__ import print_function
import unittest

class Blub(unittest.TestCase):
    def setUp(self):
        self.addCleanup(lambda: print("2 Cleanup"))

    def tearDown(self):
        print("1 tearDown")

    @classmethod
    def tearDownClass(self):
        print("3 tearDownClass")

    def test_false(self):
        self.assertTrue(False)

def suite():
    return unittest.makeSuite(Blub, 'test_')

if __name__ == '__main__':
    unittest.main(defaultTest='suite')
```