### PR TITLE
Fix issue pytest_plugins as string was marking wrong modules for rewrite

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,13 @@
   Thanks `@joguSD`_ for the PR.
 
 * Fix ``UnicodeEncodeError`` when string comparison with unicode has failed. (`#1864`_)
-  Thanks `@AiOO`_ for the PR
+  Thanks `@AiOO`_ for the PR.
+
+* ``pytest_plugins`` is now handled correctly if defined as a string (as opposed as
+  a sequence of strings) when modules are considered for assertion rewriting.
+  Due to this bug, much more modules were being rewritten than necessary
+  if a test suite uses ``pytest_plugins`` to load internal plugins (`#1888`_).
+  Thanks `@jaraco`_ for the report and `@nicoddemus`_ for the PR (`#1891`_).
 
 *
 
@@ -19,6 +25,8 @@
 
 .. _#1857: https://github.com/pytest-dev/pytest/issues/1857
 .. _#1864: https://github.com/pytest-dev/pytest/issues/1864
+.. _#1888: https://github.com/pytest-dev/pytest/issues/1888
+.. _#1891: https://github.com/pytest-dev/pytest/pull/1891
 
 
 3.0.1

--- a/_pytest/assertion/__init__.py
+++ b/_pytest/assertion/__init__.py
@@ -36,7 +36,13 @@ def register_assert_rewrite(*names):
     Thus you should make sure to call this before the module is
     actually imported, usually in your __init__.py if you are a plugin
     using a package.
+
+    :raise TypeError: if the given module names are not strings.
     """
+    for name in names:
+        if not isinstance(name, str):
+            msg = 'expected module names as *args, got {0} instead'
+            raise TypeError(msg.format(repr(names)))
     for hook in sys.meta_path:
         if isinstance(hook, rewrite.AssertionRewritingHook):
             importhook = hook

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -379,6 +379,8 @@ class PytestPluginManager(PluginManager):
 
     def consider_module(self, mod):
         plugins = getattr(mod, 'pytest_plugins', [])
+        if isinstance(plugins, str):
+            plugins = [plugins]
         self.rewrite_hook.mark_rewrite(*plugins)
         self._import_plugin_specs(plugins)
 


### PR DESCRIPTION
Unfortunately due to a small bug on how the `pytest_plugins` variable was handled, we are currently rewriting assertions in much more modules than we initially thought:

```python
pytest_plugins = 'setuptools.tests.fixtures'
```

The code that handles that in `config.py` was expecting `pytest_plugins` to be a `list[str]` only:

```python
    def consider_module(self, mod):
        plugins = getattr(mod, 'pytest_plugins', [])
        self.rewrite_hook.mark_rewrite(*plugins)
        self._import_plugin_specs(plugins)
```

So it would end up marking each letter in `"setuptools.tests.fixtures"` as an individual module, which basically means rewriting every module which starts with `s`, `e`, `t`, `u` and so on. 

Coupling that with some advanced bootstrapping done in `setuptools` between each test and a lot of tests were failing quite catastrophically.

Initially I started the investigation for this issue by implementing the optional [`find_spec` API](https://docs.python.org/3/library/importlib.html?highlight=find_spec#importlib.util.find_spec), but it was only hiding the real bug so I decided to not touch that for now.

Beside testing locally, I opened pypa/setuptools#768 to make sure the fix worked. :sweat_smile: 

This fixes #1888