### PR TITLE
The "ids" argument to "parametrize" again accepts unicode strings in Python 2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,9 @@
 3.0.3.dev0
 ==========
 
-*
+* The ``ids`` argument to ``parametrize`` again accepts ``unicode`` strings
+  in Python 2 (`#1905`_).
+  Thanks `@philpep`_ for the report and `@nicoddemus`_ for the PR.
 
 *
 
@@ -10,6 +12,11 @@
 *
 
 *
+
+
+.. _@philpep: https://github.com/philpep
+
+.. _#1905: https://github.com/pytest-dev/pytest/issues/1905
 
 
 3.0.2

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -832,7 +832,7 @@ class Metafunc(fixtures.FuncargnamesCompatAttr):
                 raise ValueError('%d tests specified with %d ids' %(
                                  len(argvalues), len(ids)))
             for id_value in ids:
-                if id_value is not None and not isinstance(id_value, str):
+                if id_value is not None and not isinstance(id_value, py.builtin._basestring):
                     msg = 'ids must be list of strings, found: %s (type: %s)'
                     raise ValueError(msg % (saferepr(id_value), type(id_value).__name__))
         ids = idmaker(argnames, argvalues, idfn, ids, self.config)

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -105,6 +105,14 @@ class TestMetafunc:
         ids = [x.id for x in metafunc._calls]
         assert ids == ["basic-abc", "basic-def", "advanced-abc", "advanced-def"]
 
+    def test_parametrize_and_id_unicode(self):
+        """Allow unicode strings for "ids" parameter in Python 2 (##1905)"""
+        def func(x): pass
+        metafunc = self.Metafunc(func)
+        metafunc.parametrize("x", [1, 2], ids=[u'basic', u'advanced'])
+        ids = [x.id for x in metafunc._calls]
+        assert ids == [u"basic", u"advanced"]
+
     def test_parametrize_with_wrong_number_of_ids(self, testdir):
         def func(x, y): pass
         metafunc = self.Metafunc(func)


### PR DESCRIPTION
Fixes #1905