### PR TITLE
Remove BuiltinAssertionError

### DIFF
--- a/_pytest/assertion/util.py
+++ b/_pytest/assertion/util.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     Sequence = list
 
-BuiltinAssertionError = py.builtin.builtins.AssertionError
+
 u = py.builtin._totext
 
 # The _reprcompare attribute on the util module is used by the new assertion

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1146,12 +1146,6 @@ def raises(expected_exception, *args, **kwargs):
 
     """
     __tracebackhide__ = True
-    if expected_exception is AssertionError:
-        # we want to catch a AssertionError
-        # replace our subclass with the builtin one
-        # see https://github.com/pytest-dev/pytest/issues/176
-        from _pytest.assertion.util import BuiltinAssertionError \
-            as expected_exception
     msg = ("exceptions must be old-style classes or"
            " derived from BaseException, not %s")
     if isinstance(expected_exception, tuple):

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -26,14 +26,6 @@ class TestRaises:
         except pytest.raises.Exception:
             pass
 
-    def test_raises_flip_builtin_AssertionError(self):
-        # we replace AssertionError on python level
-        # however c code might still raise the builtin one
-        from _pytest.assertion.util import BuiltinAssertionError # noqa
-        pytest.raises(AssertionError,"""
-            raise BuiltinAssertionError
-        """)
-
     def test_raises_as_contextmanager(self, testdir):
         testdir.makepyfile("""
             from __future__ import with_statement


### PR DESCRIPTION
We used to have this when we where patching the real Python
AssertionError for use with reinterpret, but reinterpret is now
gone so we no longer need this as it is not used by rewrite.

This was never public so I don't believe this needs a changelog mention.