### PR TITLE
introduce pytest.Marked as holder for marked parameter values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ New Features
 * ``pytest.raises`` now asserts that the error message matches a text or regex
   with the ``match`` keyword argument. Thanks `@Kriechi`_ for the PR.
 
+* ``pytest.param`` can be used to declare test parameter sets with marks and test ids.
+  Thanks `@RonnyPfannschmidt`_ for the PR.
+
 
 Changes
 -------

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -788,36 +788,35 @@ class Metafunc(fixtures.FuncargnamesCompatAttr):
             to set a dynamic scope using test context or configuration.
         """
         from _pytest.fixtures import scope2index
-        from _pytest.mark import extract_argvalue
+        from _pytest.mark import ParameterSet
         from py.io import saferepr
-
-        unwrapped_argvalues = []
-        newkeywords = []
-        for maybe_marked_args in argvalues:
-            argval, newmarks = extract_argvalue(maybe_marked_args)
-            unwrapped_argvalues.append(argval)
-            newkeywords.append(newmarks)
-        argvalues = unwrapped_argvalues
 
         if not isinstance(argnames, (tuple, list)):
             argnames = [x.strip() for x in argnames.split(",") if x.strip()]
-            if len(argnames) == 1:
-                argvalues = [(val,) for val in argvalues]
-        if not argvalues:
-            argvalues = [(NOTSET,) * len(argnames)]
-            # we passed a empty list to parameterize, skip that test
-            #
+            force_tuple = len(argnames) == 1
+        else:
+            force_tuple = False
+        parameters = [
+            ParameterSet.extract_from(x, legacy_force_tuple=force_tuple)
+            for x in argvalues]
+        del argvalues
+
+        
+        if not parameters:
             fs, lineno = getfslineno(self.function)
-            newmark = pytest.mark.skip(
-                reason="got empty parameter set %r, function %s at %s:%d" % (
-                    argnames, self.function.__name__, fs, lineno))
-            newkeywords = [{newmark.markname: newmark}]
+            reason = "got empty parameter set %r, function %s at %s:%d" % (
+                    argnames, self.function.__name__, fs, lineno)
+            mark = pytest.mark.skip(reason=reason)
+            parameters.append(ParameterSet(
+                values=(NOTSET,) * len(argnames),
+                marks=[mark],
+                id=None,
+            ))
 
         if scope is None:
             scope = _find_parametrized_scope(argnames, self._arg2fixturedefs, indirect)
 
-        scopenum = scope2index(
-            scope, descr='call to {0}'.format(self.parametrize))
+        scopenum = scope2index(scope, descr='call to {0}'.format(self.parametrize))
         valtypes = {}
         for arg in argnames:
             if arg not in self.fixturenames:
@@ -845,22 +844,22 @@ class Metafunc(fixtures.FuncargnamesCompatAttr):
             idfn = ids
             ids = None
         if ids:
-            if len(ids) != len(argvalues):
-                raise ValueError('%d tests specified with %d ids' %(
-                                 len(argvalues), len(ids)))
+            if len(ids) != len(parameters):
+                raise ValueError('%d tests specified with %d ids' % (
+                                 len(parameters), len(ids)))
             for id_value in ids:
                 if id_value is not None and not isinstance(id_value, py.builtin._basestring):
                     msg = 'ids must be list of strings, found: %s (type: %s)'
                     raise ValueError(msg % (saferepr(id_value), type(id_value).__name__))
-        ids = idmaker(argnames, argvalues, idfn, ids, self.config)
+        ids = idmaker(argnames, parameters, idfn, ids, self.config)
         newcalls = []
         for callspec in self._calls or [CallSpec2(self)]:
-            elements = zip(ids, argvalues, newkeywords, count())
-            for a_id, valset, keywords, param_index in elements:
-                assert len(valset) == len(argnames)
+            elements = zip(ids, parameters, count())
+            for a_id, param, param_index in elements:
+                assert len(param.values) == len(argnames)
                 newcallspec = callspec.copy(self)
-                newcallspec.setmulti(valtypes, argnames, valset, a_id,
-                                     keywords, scopenum, param_index)
+                newcallspec.setmulti(valtypes, argnames, param.values, a_id,
+                                     param.deprecated_arg_dict, scopenum, param_index)
                 newcalls.append(newcallspec)
         self._calls = newcalls
 
@@ -959,17 +958,19 @@ def _idval(val, argname, idx, idfn, config=None):
         return val.__name__
     return str(argname)+str(idx)
 
-def _idvalset(idx, valset, argnames, idfn, ids, config=None):
+def _idvalset(idx, parameterset, argnames, idfn, ids, config=None):
+    if parameterset.id is not None:
+        return parameterset.id
     if ids is None or (idx >= len(ids) or ids[idx] is None):
         this_id = [_idval(val, argname, idx, idfn, config)
-                   for val, argname in zip(valset, argnames)]
+                   for val, argname in zip(parameterset.values, argnames)]
         return "-".join(this_id)
     else:
         return _escape_strings(ids[idx])
 
-def idmaker(argnames, argvalues, idfn=None, ids=None, config=None):
-    ids = [_idvalset(valindex, valset, argnames, idfn, ids, config)
-           for valindex, valset in enumerate(argvalues)]
+def idmaker(argnames, parametersets, idfn=None, ids=None, config=None):
+    ids = [_idvalset(valindex, parameterset, argnames, idfn, ids, config)
+           for valindex, parameterset in enumerate(parametersets)]
     if len(set(ids)) != len(ids):
         # The ids are not unique
         duplicates = [testid for testid in ids if ids.count(testid) > 1]

--- a/doc/en/parametrize.rst
+++ b/doc/en/parametrize.rst
@@ -55,17 +55,17 @@ them in turn::
 
     $ pytest
     ======= test session starts ========
-    platform linux -- Python 3.5.2, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
+    platform linux -- Python 3.5.2, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
     rootdir: $REGENDOC_TMPDIR, inifile:
     collected 3 items
-    
+
     test_expectation.py ..F
-    
+
     ======= FAILURES ========
     _______ test_eval[6*9-42] ________
-    
+
     test_input = '6*9', expected = 42
-    
+
         @pytest.mark.parametrize("test_input,expected", [
             ("3+5", 8),
             ("2+4", 6),
@@ -73,9 +73,9 @@ them in turn::
         ])
         def test_eval(test_input, expected):
     >       assert eval(test_input) == expected
-    E       AssertionError: assert 54 == 42
+    E       assert 54 == 42
     E        +  where 54 = eval('6*9')
-    
+
     test_expectation.py:8: AssertionError
     ======= 1 failed, 2 passed in 0.12 seconds ========
 
@@ -94,21 +94,42 @@ for example with the builtin ``mark.xfail``::
     @pytest.mark.parametrize("test_input,expected", [
         ("3+5", 8),
         ("2+4", 6),
-        pytest.mark.xfail(("6*9", 42)),
+        pytest.param("6*9", 42,
+                     marks=pytest.mark.xfail),
     ])
     def test_eval(test_input, expected):
         assert eval(test_input) == expected
+
+.. note::
+
+  prior to version 3.1 the supported mechanism for marking values
+  used the syntax::
+
+        import pytest
+        @pytest.mark.parametrize("test_input,expected", [
+            ("3+5", 8),
+            ("2+4", 6),
+            pytest.mark.xfail(("6*9", 42),),
+        ])
+        def test_eval(test_input, expected):
+            assert eval(test_input) == expected
+
+
+  This was an initial hack to support the feature but soon was demonstrated to be incomplete,
+  broken for passing functions or applying multiple marks with the same name but different parameters.
+  The old syntax will be removed in pytest-4.0.
+
 
 Let's run this::
 
     $ pytest
     ======= test session starts ========
-    platform linux -- Python 3.5.2, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
+    platform linux -- Python 3.5.2, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
     rootdir: $REGENDOC_TMPDIR, inifile:
     collected 3 items
-    
+
     test_expectation.py ..x
-    
+
     ======= 2 passed, 1 xfailed in 0.12 seconds ========
 
 The one parameter set which caused a failure previously now
@@ -181,15 +202,15 @@ Let's also run with a stringinput that will lead to a failing test::
     F
     ======= FAILURES ========
     _______ test_valid_string[!] ________
-    
+
     stringinput = '!'
-    
+
         def test_valid_string(stringinput):
     >       assert stringinput.isalpha()
-    E       AssertionError: assert False
+    E       assert False
     E        +  where False = <built-in method isalpha of str object at 0xdeadbeef>()
     E        +    where <built-in method isalpha of str object at 0xdeadbeef> = '!'.isalpha
-    
+
     test_strings.py:3: AssertionError
     1 failed in 0.12 seconds
 

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import, division, print_function
 import os
+import sys
 
-import py, pytest
-from _pytest.mark import MarkGenerator as Mark
+import pytest
+from _pytest.mark import MarkGenerator as Mark, ParameterSet
 
 class TestMark(object):
     def test_markinfo_repr(self):
@@ -10,9 +11,11 @@ class TestMark(object):
         m = MarkInfo(Mark("hello", (1,2), {}))
         repr(m)
 
-    def test_pytest_exists_in_namespace_all(self):
-        assert 'mark' in py.test.__all__
-        assert 'mark' in pytest.__all__
+    @pytest.mark.parametrize('attr', ['mark', 'param'])
+    @pytest.mark.parametrize('modulename', ['py.test', 'pytest'])
+    def test_pytest_exists_in_namespace_all(self, attr, modulename):
+        module = sys.modules[modulename]
+        assert attr in module.__all__
 
     def test_pytest_mark_notcallable(self):
         mark = Mark()
@@ -415,7 +418,7 @@ class TestFunctional(object):
         """)
         items, rec = testdir.inline_genitems(p)
         for item in items:
-            print (item, item.keywords)
+            print(item, item.keywords)
             assert 'a' in item.keywords
 
     def test_mark_decorator_subclass_does_not_propagate_to_base(self, testdir):
@@ -739,3 +742,16 @@ class TestKeywordSelection(object):
 
         assert_test_is_not_selected("__")
         assert_test_is_not_selected("()")
+
+
+@pytest.mark.parametrize('argval, expected', [
+    (pytest.mark.skip()((1, 2)),
+     ParameterSet(values=(1, 2), marks=[pytest.mark.skip], id=None)),
+    (pytest.mark.xfail(pytest.mark.skip()((1, 2))),
+     ParameterSet(values=(1, 2),
+                  marks=[pytest.mark.xfail, pytest.mark.skip], id=None)),
+
+])
+def test_parameterset_extractfrom(argval, expected):
+    extracted = ParameterSet.extract_from(argval)
+    assert extracted == expected


### PR DESCRIPTION
this pr introduces a actual real type to separate parameter values and marks

this enables having functions as parameters with marks

it currently mirrors the broken mark overriding of the nested mark extraction code in place

documentation and examples upcoming
