### PR TITLE
Fix/1512 - improve truncated assertion output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -89,6 +89,7 @@ Martijn Faassen
 Martin K. Scherer
 Martin Prusse
 Matt Bachmann
+Matt Duck
 Matt Williams
 Matthias Hafner
 mbyt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,14 +12,19 @@
 * Fix pkg_resources import error in Jython projects (`#1853`).
   Thanks `@raquel-ucl`_ for the PR.
 
-*
+* Remove common items from dict comparision output when verbosity=1. Also update
+  the truncation message to make it clearer that pytest truncates all
+  assertion messages if verbosity < 2 (`#1512`_).
+  Thanks `@mattduck`_ for the PR
 
 
 .. _@philpep: https://github.com/philpep
 .. _@raquel-ucl: https://github.com/raquel-ucl
+.. _@mattduck: https://github.com/mattduck
 
 .. _#1905: https://github.com/pytest-dev/pytest/issues/1905
 .. _#1934: https://github.com/pytest-dev/pytest/issues/1934
+.. _#1512: https://github.com/pytest-dev/pytest/issues/1512
 
 
 3.0.2

--- a/_pytest/assertion/__init__.py
+++ b/_pytest/assertion/__init__.py
@@ -131,14 +131,21 @@ def pytest_runtest_setup(item):
             config=item.config, op=op, left=left, right=right)
         for new_expl in hook_result:
             if new_expl:
+
+                # Truncate lines if required
                 if (sum(len(p) for p in new_expl[1:]) > 80*8 and
                         item.config.option.verbose < 2 and
                         not _running_on_ci()):
                     show_max = 10
-                    truncated_lines = len(new_expl) - show_max
-                    new_expl[show_max:] = [py.builtin._totext(
-                        'Detailed information truncated (%d more lines)'
-                        ', use "-vv" to show' % truncated_lines)]
+                    truncated_count = len(new_expl) - show_max
+                    new_expl[show_max - 1] += " ..."
+                    new_expl[show_max:] = [
+                        py.builtin._totext(""),
+                        py.builtin._totext('...Full output truncated (%d more lines)'
+                                           ', use "-vv" to show' % truncated_count
+                        ),
+                    ]
+
                 new_expl = [line.replace("\n", "\\n") for line in new_expl]
                 res = py.builtin._totext("\n~").join(new_expl)
                 if item.config.getvalue("assertmode") == "rewrite":

--- a/_pytest/assertion/util.py
+++ b/_pytest/assertion/util.py
@@ -256,8 +256,8 @@ def _compare_eq_dict(left, right, verbose=False):
     explanation = []
     common = set(left).intersection(set(right))
     same = dict((k, left[k]) for k in common if left[k] == right[k])
-    if same and not verbose:
-        explanation += [u('Omitting %s identical items, use -v to show') %
+    if same and verbose < 2:
+        explanation += [u('Omitting %s identical items, use -vv to show') %
                         len(same)]
     elif same:
         explanation += [u('Common items:')]

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -361,8 +361,16 @@ class TestAssert_reprcompare:
         for line in lines[1:]:
             assert 'b' not in line
 
-    def test_dict_omitting_verbose(self):
-        lines = callequal({'a': 0, 'b': 1}, {'a': 1, 'b': 1}, verbose=True)
+    def test_dict_omitting_with_verbosity_1(self):
+        """ Ensure differing items are visible for verbosity=1 (#1512) """
+        lines = callequal({'a': 0, 'b': 1}, {'a': 1, 'b': 1}, verbose=1)
+        assert lines[1].startswith('Omitting 1 identical item')
+        assert lines[2].startswith('Differing items')
+        assert lines[3] == "{'a': 0} != {'a': 1}"
+        assert 'Common items' not in lines
+
+    def test_dict_omitting_with_verbosity_2(self):
+        lines = callequal({'a': 0, 'b': 1}, {'a': 1, 'b': 1}, verbose=2)
         assert lines[1].startswith('Common items:')
         assert 'Omitting' not in lines[1]
         assert lines[2] == "{'b': 1}"


### PR DESCRIPTION
Improve user experience for #1512. Removes common items from dictionary comparisions when verbosity=1. Also updates truncation format:

<img width="725" alt="screen shot 2016-09-19 at 14 14 41" src="https://cloud.githubusercontent.com/assets/1607892/18633989/e7207014-7e76-11e6-961c-4bf73e89c085.png">

@flub let me know what you think re: the new formatting
