### PR TITLE
Pdbcls without pdb on fail

### DIFF
--- a/_pytest/debugging.py
+++ b/_pytest/debugging.py
@@ -20,15 +20,15 @@ def pytest_namespace():
     return {'set_trace': pytestPDB().set_trace}
 
 def pytest_configure(config):
-    if config.getvalue("usepdb") or config.getvalue("usepdb_cls"):
+    if config.getvalue("usepdb_cls"):
+        modname, classname = config.getvalue("usepdb_cls").split(":")
+        __import__(modname)
+        pdb_cls = getattr(sys.modules[modname], classname)
+    else:
+        pdb_cls = pdb.Pdb
+
+    if config.getvalue("usepdb"):
         config.pluginmanager.register(PdbInvoke(), 'pdbinvoke')
-        if config.getvalue("usepdb_cls"):
-            modname, classname = config.getvalue("usepdb_cls").split(":")
-            __import__(modname)
-            pdb_cls = getattr(sys.modules[modname], classname)
-        else:
-            pdb_cls = pdb.Pdb
-        pytestPDB._pdb_cls = pdb_cls
 
     old = (pdb.set_trace, pytestPDB._pluginmanager)
     def fin():
@@ -38,6 +38,7 @@ def pytest_configure(config):
     pdb.set_trace = pytest.set_trace
     pytestPDB._pluginmanager = config.pluginmanager
     pytestPDB._config = config
+    pytestPDB._pdb_cls = pdb_cls
     config._cleanup.append(fin)
 
 class pytestPDB:

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -12,6 +12,26 @@ def runpdb_and_get_report(testdir, source):
     return reports[1]
 
 
+@pytest.fixture
+def custom_pdb_calls():
+    called = []
+
+    # install dummy debugger class and track which methods were called on it
+    class _CustomPdb:
+        def __init__(self, *args, **kwargs):
+            called.append("init")
+
+        def reset(self):
+            called.append("reset")
+
+        def interaction(self, *args):
+            called.append("interaction")
+
+    _pytest._CustomPdb = _CustomPdb
+    return called
+
+
+
 class TestPDB:
 
     @pytest.fixture
@@ -334,22 +354,18 @@ class TestPDB:
         if child.isalive():
             child.wait()
 
-    def test_pdb_custom_cls(self, testdir):
-        called = []
+    def test_pdb_custom_cls(self, testdir, custom_pdb_calls):
+        p1 = testdir.makepyfile("""xxx """)
+        result = testdir.runpytest_inprocess(
+            "--pdb", "--pdbcls=_pytest:_CustomPdb", p1)
+        result.stdout.fnmatch_lines([
+            "*NameError*xxx*",
+            "*1 error*",
+        ])
+        assert custom_pdb_calls == ["init", "reset", "interaction"]
 
-        # install dummy debugger class and track which methods were called on it
-        class _CustomPdb:
-            def __init__(self, *args, **kwargs):
-                called.append("init")
 
-            def reset(self):
-                called.append("reset")
-
-            def interaction(self, *args):
-                called.append("interaction")
-
-        _pytest._CustomPdb = _CustomPdb
-
+    def test_pdb_custom_cls_without_pdb(self, testdir, custom_pdb_calls):
         p1 = testdir.makepyfile("""xxx """)
         result = testdir.runpytest_inprocess(
             "--pdbcls=_pytest:_CustomPdb", p1)
@@ -357,4 +373,4 @@ class TestPDB:
             "*NameError*xxx*",
             "*1 error*",
         ])
-        assert called == ["init", "reset", "interaction"]
+        assert custom_pdb_calls == []


### PR DESCRIPTION
fixes #1948 

i tried to add a final test for using `pdb.set_trace()`, but couldn't get it to work. any advice appreciated

```python
    def test_pdb_custom_cls_with_settrace(self, testdir, custom_pdb_calls):
        testdir.makepyfile(custom_pdb="""
            class CustomPdb:
                def __init__(self, *args, **kwargs):
                    called.append("init")

                def reset(self):
                    called.append("reset")

                def interaction(self, *args):
                    called.append("interaction")
         """)
        p1 = testdir.makepyfile("""
            import pytest

            def test_foo():
                pytest.set_trace()
        """)
        child = testdir.spawn_pytest("--pdbcls=custom_pdb:CustomPdb %s" % str(p1))
        child.expect("interaction")
        child.send('c\n')
        child.sendeof()
        if child.isalive():
            child.wait()
        assert custom_pdb_calls == ["init", "reset", "interaction"]
```