### PR TITLE
Fix `DeprecationWarnings` found when running py.test in Python 2.7 with the -3 flag.

### DIFF
--- a/_pytest/_code/code.py
+++ b/_pytest/_code/code.py
@@ -29,8 +29,7 @@ class Code(object):
     def __eq__(self, other):
         return self.raw == other.raw
 
-    def __hash__(self):
-        return hash(self.raw)
+    __hash__ = None
 
     def __ne__(self, other):
         return not self == other

--- a/_pytest/_code/code.py
+++ b/_pytest/_code/code.py
@@ -12,6 +12,7 @@ if sys.version_info[0] >= 3:
 else:
     from ._py2traceback import format_exception_only
 
+
 class Code(object):
     """ wrapper around Python code objects """
     def __init__(self, rawcode):
@@ -27,6 +28,9 @@ class Code(object):
 
     def __eq__(self, other):
         return self.raw == other.raw
+
+    def __hash__(self):
+        return hash(self.raw)
 
     def __ne__(self, other):
         return not self == other

--- a/_pytest/_code/source.py
+++ b/_pytest/_code/source.py
@@ -52,8 +52,7 @@ class Source(object):
                 return str(self) == other
             return False
 
-    def __hash__(self):
-        return hash(self.lines)
+    __hash__ = None
 
     def __getitem__(self, key):
         if isinstance(key, int):

--- a/_pytest/_code/source.py
+++ b/_pytest/_code/source.py
@@ -52,6 +52,9 @@ class Source(object):
                 return str(self) == other
             return False
 
+    def __hash__(self):
+        return hash(self.lines)
+
     def __getitem__(self, key):
         if isinstance(key, int):
             return self.lines[key]

--- a/_pytest/assertion/util.py
+++ b/_pytest/assertion/util.py
@@ -105,7 +105,7 @@ except NameError:
 def assertrepr_compare(config, op, left, right):
     """Return specialised explanations for some operators/operands"""
     width = 80 - 15 - len(op) - 2  # 15 chars indentation, 1 space around op
-    left_repr = py.io.saferepr(left, maxsize=int(width/2))
+    left_repr = py.io.saferepr(left, maxsize=int(width//2))
     right_repr = py.io.saferepr(right, maxsize=width-len(left_repr))
 
     summary = u('%s %s %s') % (ecu(left_repr), op, ecu(right_repr))

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1356,8 +1356,7 @@ class approx(object):
             return False
         return all(a == x for a, x in zip(actual, self.expected))
 
-    def __hash__(self):
-        return hash(self.expected)
+    __hash__ = None
 
     def __ne__(self, actual):
         return not (actual == self)
@@ -1438,8 +1437,7 @@ class ApproxNonIterable(object):
         # Return true if the two numbers are within the tolerance.
         return abs(self.expected - actual) <= self.tolerance
 
-    def __hash__(self):
-        return hash((self.expected, self.tolerance))
+    __hash__ = None
 
     def __ne__(self, actual):
         return not (actual == self)

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1356,6 +1356,9 @@ class approx(object):
             return False
         return all(a == x for a, x in zip(actual, self.expected))
 
+    def __hash__(self):
+        return hash(self.expected)
+
     def __ne__(self, actual):
         return not (actual == self)
 
@@ -1434,6 +1437,9 @@ class ApproxNonIterable(object):
 
         # Return true if the two numbers are within the tolerance.
         return abs(self.expected - actual) <= self.tolerance
+
+    def __hash__(self):
+        return hash((self.expected, self.tolerance))
 
     def __ne__(self, actual):
         return not (actual == self)


### PR DESCRIPTION
I am investigating a migration to Python 3, and to facilitate this we are using the -3 flag as decribed here:
https://docs.python.org/3/howto/pyporting.html#prevent-compatibility-regressions . When using this flag.  

Running through some of my tests with the `-3` flag in python2.7 however I encountered some errors within py.test itself.  This fixes those errors so we can use py.test in order to identify problems with our code as we transition to Python 3.