### PR TITLE
Remove implementation of `__getslice__`

### DIFF
--- a/_pytest/_code/source.py
+++ b/_pytest/_code/source.py
@@ -60,15 +60,12 @@ class Source(object):
         else:
             if key.step not in (None, 1):
                 raise IndexError("cannot slice a Source with a step")
-            return self.__getslice__(key.start, key.stop)
+            newsource = Source()
+            newsource.lines = self.lines[key.start:key.stop]
+            return newsource
 
     def __len__(self):
         return len(self.lines)
-
-    def __getslice__(self, start, end):
-        newsource = Source()
-        newsource.lines = self.lines[start:end]
-        return newsource
 
     def strip(self):
         """ return new source object with trailing


### PR DESCRIPTION
`__getslice__` has been Deprecated since Python 2.0 and is removed in Python 3.  See
https://docs.python.org/2/reference/datamodel.html#object.__getslice__

Unfortunately, Python 2 will still dispatch to `__getslice__` over `__getitem__`, See
http://bugs.python.org/issue2041, which causes Warnings when running with `-3` in 2.7.