### PR TITLE
Pin hypothesis to 3.5.0 because 3.5.1 breaks the test suite

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ envlist=
 commands= pytest --lsof -rfsxX {posargs:testing}
 passenv = USER USERNAME
 deps=
-    hypothesis
+    # pin to 3.5.0 until 3.5.2 is released
+    hypothesis==3.5.0
     nose
     mock
     requests
@@ -47,7 +48,8 @@ commands = flake8 pytest.py _pytest testing
 deps=pytest-xdist>=1.13
     mock
     nose
-    hypothesis
+    # pin to 3.5.0 until 3.5.2 is released
+    hypothesis==3.5.0
 commands=
   pytest -n1 -rfsxX {posargs:testing}
 
@@ -71,8 +73,10 @@ commands=
   pytest -rfsxX test_pdb.py test_terminal.py test_unittest.py
 
 [testenv:py27-nobyte]
-deps=pytest-xdist>=1.13
-    hypothesis
+deps=
+    pytest-xdist>=1.13
+    # pin to 3.5.0 until 3.5.2 is released
+    hypothesis==3.5.0
 distribute=true
 setenv=
     PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
Related to HypothesisWorks/hypothesis-python#368