### PR TITLE
Change exception raised by capture.DontReadFromInput.fileno()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -129,5 +129,6 @@ Tom Viner
 Trevor Bekolay
 Tyler Goodlet
 Vasily Kuznetsov
+Vlad Dragos
 Wouter van Ackooy
 Xuecong Liao

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@
 .. _@raquel-ucl: https://github.com/raquel-ucl
 .. _@axil: https://github.com/axil
 .. _@tgoodlet: https://github.com/tgoodlet
+.. _@vlad-dragos: https://github.com/vlad-dragos
 
 .. _#1905: https://github.com/pytest-dev/pytest/issues/1905
 .. _#1934: https://github.com/pytest-dev/pytest/issues/1934

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@
 * Explain a bad scope value passed to ``@fixture`` declarations or
   a ``MetaFunc.parametrize()`` call. Thanks `@tgoodlet`_ for the PR.
 
+* Change exception raised by ``capture.DontReadFromInput.fileno()`` from ``ValueError`` 
+  to ``io.UnsupportedOperation``. Thanks `@vlad-dragos`_ for the PR.
 
 .. _@philpep: https://github.com/philpep
 .. _@raquel-ucl: https://github.com/raquel-ucl

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -7,6 +7,7 @@ from __future__ import with_statement
 import contextlib
 import sys
 import os
+from io import UnsupportedOperation
 from tempfile import TemporaryFile
 
 import py
@@ -447,7 +448,7 @@ class DontReadFromInput:
     __iter__ = read
 
     def fileno(self):
-        raise ValueError("redirected Stdin is pseudofile, has no fileno()")
+        raise UnsupportedOperation("redirected Stdin is pseudofile, has no fileno()")
 
     def isatty(self):
         return False

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -448,7 +448,8 @@ class DontReadFromInput:
     __iter__ = read
 
     def fileno(self):
-        raise UnsupportedOperation("redirected Stdin is pseudofile, has no fileno()")
+        raise UnsupportedOperation("redirected stdin is pseudofile, "
+                                   "has no fileno()")
 
     def isatty(self):
         return False


### PR DESCRIPTION
Hello,

I suggest changing the exception raise by `capture.DontReadFromInput.fileno()` from `ValueError` to `io. UnsupportedOperation` which derives from both `ValueError` and `OSError`. In this way the method confirms with `IOBase.fileno()` that should raise an `OSError` if there is no file descriptor while maintaining backward compatibility. 

Best regards,
Vlad

