### PR TITLE
Show traceback during collection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,11 +3,18 @@
 
 *
 
-*
+* Import errors when collecting test modules now display the full traceback (`#1976`_).
+  Thanks `@cwitty`_ for the report and `@nicoddemus`_ for the PR.
 
 *
 
 *
+
+
+.. _@cwitty: https://github.com/cwitty
+
+.. _#1976: https://github.com/pytest-dev/pytest/issues/1976
+
 
 
 3.0.3

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -424,12 +424,15 @@ class Module(pytest.File, PyCollector):
                  % e.args
             )
         except ImportError:
-            exc_class, exc, _ = sys.exc_info()
+            import traceback
+            stream = py.io.TextIO()
+            traceback.print_exc(file=stream)
+            formatted_tb = stream.getvalue()
             raise self.CollectError(
-                "ImportError while importing test module '%s'.\n"
-                "Original error message:\n'%s'\n"
-                "Make sure your test modules/packages have valid Python names."
-                % (self.fspath, exc or exc_class)
+                "ImportError while importing test module '{fspath}'.\n"
+                "Hint: make sure your test modules/packages have valid Python names.\n"
+                "Original traceback:\n"
+                "{traceback}".format(fspath=self.fspath, traceback=formatted_tb)
             )
         except _pytest.runner.Skipped as e:
             if e.allow_module_level:

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -120,7 +120,7 @@ class TestGeneralUsage:
         result.stdout.fnmatch_lines([
             #XXX on jython this fails:  ">   import import_fails",
             "ImportError while importing test module*",
-            "'No module named *does_not_work*",
+            "*No module named *does_not_work*",
         ])
         assert result.ret == 2
 

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -172,17 +172,6 @@ class TestCollectPluginHookRelay:
         assert "world" in wascalled
 
 class TestPrunetraceback:
-    def test_collection_error(self, testdir):
-        p = testdir.makepyfile("""
-            import not_exists
-        """)
-        result = testdir.runpytest(p)
-        assert "__import__" not in result.stdout.str(), "too long traceback"
-        result.stdout.fnmatch_lines([
-            "*ERROR collecting*",
-            "ImportError while importing test module*",
-            "'No module named *not_exists*",
-        ])
 
     def test_custom_repr_failure(self, testdir):
         p = testdir.makepyfile("""

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -667,7 +667,7 @@ class TestGenericReporting:
         result = testdir.runpytest(*option.args)
         result.stdout.fnmatch_lines([
             "ImportError while importing*",
-            "'No module named *xyz*",
+            "*No module named *xyz*",
             "*1 error*",
         ])
 


### PR DESCRIPTION
Fixes #1976.

Here's the output:

**master**

```
______________________ ERROR collecting .tmp/test_foo.py ______________________
ImportError while importing test module 'C:\pytest\.tmp\test_foo.py'.
Original error message:
'cannot import name 'non_existing''
Make sure your test modules/packages have valid Python names.
!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!
```

**this PR**

```
______________________ ERROR collecting .tmp/test_foo.py ______________________
ImportError while importing test module 'C:\pytest\.tmp\test_foo.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
test_foo.py:1: in <module>
    import foo
foo.py:1: in <module>
    from bar import non_existing
E   ImportError: cannot import name 'non_existing'
!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!
```

**this PR with -vv**

```
______________________ ERROR collecting .tmp/test_foo.py ______________________
ImportError while importing test module 'C:\pytest\.tmp\test_foo.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
..\_pytest\python.py:415: in _importtestmodule
    mod = self.fspath.pyimport(ensuresyspath=importmode)
..\.env35\lib\site-packages\py\_path\local.py:650: in pyimport
    __import__(modname)
..\_pytest\assertion\rewrite.py:207: in load_module
    py.builtin.exec_(co, mod.__dict__)
test_foo.py:1: in <module>
    import foo
foo.py:1: in <module>
    from bar import non_existing
E   ImportError: cannot import name 'non_existing'
!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!
```
