### PR TITLE
Mention small doc fixes don't need tests/changelog entries in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,9 @@ Thanks for submitting a PR, your contribution is really appreciated!
 Here's a quick checklist that should be present in PRs:
 
 - [ ] Target: for bug or doc fixes, target `master`; for new features, target `features`;
+
+Unless your change is trivial documentation fix (e.g.,  a typo or reword of a small section) please:
+
 - [ ] Make sure to include one or more tests for your change;
 - [ ] Add yourself to `AUTHORS`;
 - [ ] Add a new entry to `CHANGELOG.rst`


### PR DESCRIPTION
I think because we have a checklist in place folks might think it necessary to add CHANGELOG entries for simple doc fixes.