### PR TITLE
Fix memory leak with pytest.raises by using weakref

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -99,6 +99,7 @@ mbyt
 Michael Aquilina
 Michael Birtwell
 Michael Droettboom
+Michael Seifert
 Mike Lundy
 Nicolas Delaby
 Oleg Pidsadnyi

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@
   Thanks `@nicoddemus`_ for the PR.
 
 * Fixed memory leak in the RaisesContext (pytest.raises) (`#1965`_).
-  Thanks `@MSeifert04`_ for the report the PR.
+  Thanks `@MSeifert04`_ for the report and the PR.
 
 * Fixed false-positives warnings from assertion rewrite hook for modules that were rewritten but
   were later marked explicitly by ``pytest.register_assert_rewrite``
@@ -39,12 +39,14 @@
 
 .. _@adborden: https://github.com/adborden
 .. _@cwitty: https://github.com/cwitty
-.. _@okulynyak: https://github.com/okulynyak
-.. _@matclab: https://github.com/matclab
-.. _@gdyuldin: https://github.com/gdyuldin
 .. _@d_b_w: https://github.com/d_b_w
+.. _@gdyuldin: https://github.com/gdyuldin
+.. _@matclab: https://github.com/matclab
+.. _@MSeifert04: https://github.com/MSeifert04
+.. _@okulynyak: https://github.com/okulynyak
 
 .. _#442: https://github.com/pytest-dev/pytest/issues/442
+.. _#1965: https://github.com/pytest-dev/pytest/issues/1965
 .. _#1976: https://github.com/pytest-dev/pytest/issues/1976
 .. _#1984: https://github.com/pytest-dev/pytest/issues/1984
 .. _#1998: https://github.com/pytest-dev/pytest/issues/1998

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,10 @@
 * When loading plugins, import errors which contain non-ascii messages are now properly handled in Python 2 (`#1998`_).
   Thanks `@nicoddemus`_ for the PR.
 
-* Fixed memory leak in the RaisesContext (pytest.raises) (`#1965`_).
+* Fixed cyclic reference when ``pytest.raises`` is used in context-manager form (`#1965`_). Also as a
+  result of this fix, ``sys.exc_info()`` is left empty in both context-manager and function call usages.
+  Previously, ``sys.exc_info`` would contain the exception caught by the context manager,
+  even when the expected exception occurred.
   Thanks `@MSeifert04`_ for the report and the PR.
 
 * Fixed false-positives warnings from assertion rewrite hook for modules that were rewritten but

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@
 * When loading plugins, import errors which contain non-ascii messages are now properly handled in Python 2 (`#1998`_).
   Thanks `@nicoddemus`_ for the PR.
 
+* Fixed memory leak in the RaisesContext (pytest.raises) (`#1965`_).
+  Thanks `@MSeifert04`_ for the report the PR.
+
 * Fixed false-positives warnings from assertion rewrite hook for modules that were rewritten but
   were later marked explicitly by ``pytest.register_assert_rewrite``
   or implicitly as a plugin (`#2005`_).

--- a/_pytest/_code/code.py
+++ b/_pytest/_code/code.py
@@ -1,6 +1,7 @@
 import sys
 from inspect import CO_VARARGS, CO_VARKEYWORDS
 import re
+from weakref import ref
 
 import py
 builtin_repr = repr
@@ -230,7 +231,7 @@ class TracebackEntry(object):
                 return False
 
         if py.builtin.callable(tbh):
-            return tbh(self._excinfo)
+            return tbh(None if self._excinfo is None else self._excinfo())
         else:
             return tbh
 
@@ -370,7 +371,7 @@ class ExceptionInfo(object):
         #: the exception type name
         self.typename = self.type.__name__
         #: the exception traceback (_pytest._code.Traceback instance)
-        self.traceback = _pytest._code.Traceback(self.tb, excinfo=self)
+        self.traceback = _pytest._code.Traceback(self.tb, excinfo=ref(self))
 
     def __repr__(self):
         return "<ExceptionInfo %s tblen=%d>" % (self.typename, len(self.traceback))

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1237,7 +1237,11 @@ class RaisesContext(object):
                 exc_type, value, traceback = tp
                 tp = exc_type, exc_type(value), traceback
         self.excinfo.__init__(tp)
-        return issubclass(self.excinfo.type, self.expected_exception)
+        suppress_exception = issubclass(self.excinfo.type, self.expected_exception)
+        if sys.version_info[0] == 2 and suppress_exception:
+            sys.exc_clear()
+        return suppress_exception
+
 
 # builtin pytest.approx helper
 

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -96,3 +96,21 @@ class TestRaises:
             assert e.msg == message
         else:
             assert False, "Expected pytest.raises.Exception"
+
+    @pytest.mark.parametrize('method', ['function', 'with'])
+    def test_raises_memoryleak(self, method):
+        import weakref
+
+        class T:
+            def __call__(self):
+                raise ValueError
+
+        t = T()
+        if method == 'function':
+            pytest.raises(ValueError, t)
+        else:
+            with pytest.raises(ValueError):
+                t()
+
+        t = weakref.ref(t)
+        assert t() is None


### PR DESCRIPTION
Checklist:
- [x] Fixes #1965 (Reference to bug report)
- [x] Add yourself to `AUTHORS`;
- [x] Add a new entry to `CHANGELOG.rst`
- [x] Tests: Not sure how to properly test for memory leaks. I always used some weird homebrewed functions. See for example #1965. Is there already some utility implemented in pytest?

This fixes the memory leak locally (#1965) but I had a lot of problems when running the tests. I hope I don't waste too much of your CI ressources if I use the PR to run the tests.
