### PR TITLE
docs: remove mention of string args to main

### DIFF
--- a/doc/en/usage.rst
+++ b/doc/en/usage.rst
@@ -310,10 +310,6 @@ You can pass in options and arguments::
 
     pytest.main(['-x', 'mytestdir'])
 
-or pass in a string::
-
-    pytest.main("-x mytestdir")
-
 You can specify additional plugins to ``pytest.main``::
 
     # content of myinvoke.py


### PR DESCRIPTION


string args got deprecated due to the insane amount of edge-cases wrt splitting on windows vs posix