### PR TITLE
Disable py35-trial while #1989 is not fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ env:
     - TESTENV=py27-trial
     - TESTENV=py35-pexpect
     - TESTENV=py35-xdist
-    - TESTENV=py35-trial
+    # Disable py35-trial temporarily: #1989
+    #- TESTENV=py35-trial
     - TESTENV=py27-nobyte
     - TESTENV=doctesting
     - TESTENV=freeze


### PR DESCRIPTION
Better disable `py35-trial` temporarily than to keep marking PRs as failed. ☹️ 