### PR TITLE
Fix cmdline help message for custom options with two or more metavars

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@
 * Import errors when collecting test modules now display the full traceback (`#1976`_).
   Thanks `@cwitty`_ for the report and `@nicoddemus`_ for the PR.
 
+* Fix confusing command-line help message for custom options with two or more `metavar` properties (`#2004`_).
+  Thanks `@okulynyak`_ and `@davehunt`_ for the report and `@nicoddemus`_ for the PR.
+
 * When loading plugins, import errors which contain non-ascii messages are now properly handled in Python 2 (`#1998`_).
   Thanks `@nicoddemus`_ for the PR.
 
@@ -13,9 +16,11 @@
 
 
 .. _@cwitty: https://github.com/cwitty
+.. _@okulynyak: https://github.com/okulynyak
 
 .. _#1976: https://github.com/pytest-dev/pytest/issues/1976
 .. _#1998: https://github.com/pytest-dev/pytest/issues/1998
+.. _#2004: https://github.com/pytest-dev/pytest/issues/2004
 
 
 

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -793,7 +793,7 @@ class DropShorterLongHelpFormatter(argparse.HelpFormatter):
             if len(option) == 2 or option[2] == ' ':
                 return_list.append(option)
             if option[2:] == short_long.get(option.replace('-', '')):
-                return_list.append(option.replace(' ', '='))
+                return_list.append(option.replace(' ', '=', 1))
         action._formatted_action_invocation = ', '.join(return_list)
         return action._formatted_action_invocation
 

--- a/testing/test_parseopt.py
+++ b/testing/test_parseopt.py
@@ -248,7 +248,19 @@ class TestParser:
                 help="show help message and configuration info")
         parser.parse(['-h'])
         help = parser.optparser.format_help()
-        assert '-doit, --func-args  foo' in  help
+        assert '-doit, --func-args  foo' in help
+
+    def test_multiple_metavar_help(self, parser):
+        """
+        Help text for options with a metavar tuple should display help
+        in the form "--preferences=value1 value2 value3" (#2004).
+        """
+        group = parser.getgroup("general")
+        group.addoption('--preferences', metavar=('value1', 'value2', 'value3'), nargs=3)
+        group._addoption("-h", "--help", action="store_true", dest="help")
+        parser.parse(['-h'])
+        help = parser.optparser.format_help()
+        assert '--preferences=value1 value2 value3' in help
 
 
 def test_argcomplete(testdir, monkeypatch):


### PR DESCRIPTION
While fixing this I noticed pytest's own `--override-ini` help is wrong:

```
 -o [OVERRIDE_INI [OVERRIDE_INI ...]], --override-ini=[OVERRIDE_INI=[OVERRIDE_INI=...]]
``` 

With this PR:

```
  -o [OVERRIDE_INI [OVERRIDE_INI ...]], --override-ini=[OVERRIDE_INI [OVERRIDE_INI ...]]
```

Fix #2004