### PR TITLE
Re-enable docstring testing of _pytest modules on CI

### DIFF
--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1105,7 +1105,9 @@ def raises(expected_exception, *args, **kwargs):
 
         >>> with raises(ZeroDivisionError, message="Expecting ZeroDivisionError"):
         ...    pass
-        ... Failed: Expecting ZeroDivisionError
+        Traceback (most recent call last):
+          ...
+        Failed: Expecting ZeroDivisionError
 
 
     .. note::
@@ -1116,19 +1118,21 @@ def raises(expected_exception, *args, **kwargs):
        Lines of code after that, within the scope of the context manager will
        not be executed. For example::
 
-           >>> with raises(OSError) as exc_info:
-                   assert 1 == 1  # this will execute as expected
-                   raise OSError(errno.EEXISTS, 'directory exists')
-                   assert exc_info.value.errno == errno.EEXISTS  # this will not execute
+           >>> value = 15
+           >>> with raises(ValueError) as exc_info:
+           ...     if value > 10:
+           ...         raise ValueError("value must be <= 10")
+           ...     assert str(exc_info.value) == "value must be <= 10"  # this will not execute
 
        Instead, the following approach must be taken (note the difference in
        scope)::
 
-           >>> with raises(OSError) as exc_info:
-                   assert 1 == 1  # this will execute as expected
-                   raise OSError(errno.EEXISTS, 'directory exists')
+           >>> with raises(ValueError) as exc_info:
+           ...     if value > 10:
+           ...         raise ValueError("value must be <= 10")
+           ...
+           >>> assert str(exc_info.value) == "value must be <= 10"
 
-               assert exc_info.value.errno == errno.EEXISTS  # this will now execute
 
     Or you can specify a callable by passing a to-be-called lambda::
 

--- a/_pytest/recwarn.py
+++ b/_pytest/recwarn.py
@@ -36,8 +36,13 @@ def deprecated_call(func=None, *args, **kwargs):
 
     This function can be used as a context manager::
 
+        >>> import warnings
+        >>> def api_call_v2():
+        ...     warnings.warn('use v3 of this api', DeprecationWarning)
+        ...     return 200
+
         >>> with deprecated_call():
-        ...    myobject.deprecated_method()
+        ...    assert api_call_v2() == 200
 
     Note: we cannot use WarningsRecorder here because it is still subject
     to the mechanism that prevents warnings of the same type from being

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,10 +20,11 @@ install:
   # install pypy using choco (redirect to a file and write to console in case
   # choco install returns non-zero, because choco install python.pypy is too
   # noisy)
-  - choco install python.pypy > pypy-inst.log 2>&1 || (type pypy-inst.log & exit /b 1)
-  - set PATH=C:\tools\pypy\pypy;%PATH% # so tox can find pypy
-  - echo PyPy installed
-  - pypy --version
+  # pypy is disabled until #1963 gets fixed
+  #- choco install python.pypy > pypy-inst.log 2>&1 || (type pypy-inst.log & exit /b 1)
+  #- set PATH=C:\tools\pypy\pypy;%PATH% # so tox can find pypy
+  #- echo PyPy installed
+  #- pypy --version
 
   - C:\Python35\python -m pip install tox
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,18 @@ minversion=2.0
 distshare={homedir}/.tox/distshare
 # make sure to update enviroment list on appveyor.yml
 envlist=
-     linting,py26,py27,py33,py34,py35,pypy,
-     {py27,py35}-{pexpect,xdist,trial},
-     py27-nobyte,doctesting,freeze,docs
+     linting
+     py26
+     py27
+     py33
+     py34
+     py35
+     pypy
+     {py27,py35}-{pexpect,xdist,trial}
+     py27-nobyte
+     doctesting
+     freeze
+     docs
 
 [testenv]
 commands= pytest --lsof -rfsxX {posargs:testing}
@@ -90,10 +99,6 @@ deps={[testenv:py27-trial]deps}
 commands=
   pytest -ra {posargs:testing/test_unittest.py}
 
-[testenv:doctest]
-commands=pytest --doctest-modules _pytest
-deps=
-
 [testenv:docs]
 basepython=python
 changedir=doc/en
@@ -106,9 +111,12 @@ commands=
 
 [testenv:doctesting]
 basepython = python
-changedir=doc/en
+usedevelop=True
+skipsdist=True
 deps=PyYAML
-commands= pytest -rfsxX {posargs}
+commands=
+    pytest -rfsxX doc/en
+    pytest --doctest-modules {toxinidir}/_pytest
 
 [testenv:regen]
 changedir=doc/en
@@ -139,7 +147,7 @@ commands=
 [testenv:coveralls]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH COVERALLS_REPO_TOKEN
 usedevelop=True
-basepython=python3.4
+basepython=python3.5
 changedir=.
 deps =
     {[testenv]deps}


### PR DESCRIPTION
* Fix doctests
* List one env per line in tox.ini
* "doctesting" tox env now also tests docstrings using doctest