### PR TITLE
Report teardown output on test failure

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -90,6 +90,7 @@ Markus Unterwaditzer
 Martijn Faassen
 Martin K. Scherer
 Martin Prusse
+Mathieu Clabaut
 Matt Bachmann
 Matt Williams
 Matthias Hafner

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,8 @@
   or implicitly as a plugin (`#2005`_).
   Thanks `@RonnyPfannschmidt`_ for the report and `@nicoddemus`_ for the PR.
 
-*
+* Report teardown output on test failure (`#442`_).
+  Thanks `@matclab`_ or the PR.
 
 *
 
@@ -26,7 +27,9 @@
 
 .. _@cwitty: https://github.com/cwitty
 .. _@okulynyak: https://github.com/okulynyak
+.. _@matclab: https://github.com/matclab
 
+.. _#442: https://github.com/pytest-dev/pytest/issues/442
 .. _#1976: https://github.com/pytest-dev/pytest/issues/1976
 .. _#1998: https://github.com/pytest-dev/pytest/issues/1998
 .. _#2004: https://github.com/pytest-dev/pytest/issues/2004

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -458,6 +458,15 @@ class TerminalReporter:
                     self.write_sep("_", msg)
                     self._outrep_summary(rep)
 
+    def print_teardown_sections(self, rep):
+        for secname, content in rep.sections:
+            if 'teardown' in secname:
+                self._tw.sep('-', secname)
+                if content[-1:] == "\n":
+                    content = content[:-1]
+                self._tw.line(content)
+
+
     def summary_failures(self):
         if self.config.option.tbstyle != "no":
             reports = self.getreports('failed')
@@ -473,6 +482,9 @@ class TerminalReporter:
                     markup = {'red': True, 'bold': True}
                     self.write_sep("_", msg, **markup)
                     self._outrep_summary(rep)
+                    for report in self.getreports(''):
+                        if report.nodeid == rep.nodeid and report.when == 'teardown':
+                            self.print_teardown_sections(report)
 
     def summary_errors(self):
         if self.config.option.tbstyle != "no":

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -370,6 +370,31 @@ class TestFixtureReporting:
             "*1 failed*1 error*",
          ])
 
+    def test_setup_teardown_output_and_test_failure(self, testdir):
+        """ Test for issue #442 """
+        testdir.makepyfile("""
+            def setup_function(function):
+                print ("setup func")
+
+            def test_fail():
+                assert 0, "failingfunc"
+
+            def teardown_function(function):
+                print ("teardown func")
+        """)
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines([
+            "*test_fail*",
+            "*def test_fail():",
+            "*failingfunc*",
+            "*Captured stdout setup*",
+            "*setup func*",
+            "*Captured stdout teardown*",
+            "*teardown func*",
+
+            "*1 failed*",
+         ])
+
 class TestTerminalFunctional:
     def test_deselected(self, testdir):
         testpath = testdir.makepyfile("""


### PR DESCRIPTION
Until now, teardown stdout/stderr output was not reported upon test failure.
However such output is sometime necessary to understand the failure.

fix #442
