### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,4 @@
 omit = 
     # standlonetemplate is read dynamically and tested by test_genscript
     *standalonetemplate.py
-    # oldinterpret could be removed, as it is no longer used in py26+
-    *oldinterpret.py
     vendored_packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - TESTENV=coveralls
     # note: please use "tox --listenvs" to populate the build matrix below
     - TESTENV=linting
-    - TESTENV=py26
     - TESTENV=py27
     - TESTENV=py33
     - TESTENV=py34

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Features
 - Can run `unittest <http://docs.pytest.org/en/latest/unittest.html>`_ (or trial),
   `nose <http://docs.pytest.org/en/latest/nose.html>`_ test suites out of the box;
 
-- Python2.6+, Python3.3+, PyPy-2.3, Jython-2.5 (untested);
+- Python2.7+, Python3.3+, PyPy-2.3, Jython-2.5 (untested);
 
 - Rich plugin architecture, with over 150+ `external plugins <http://docs.pytest.org/en/latest/plugins.html#installing-external-plugins-searching>`_ and thriving community;
 

--- a/_pytest/compat.py
+++ b/_pytest/compat.py
@@ -3,7 +3,6 @@ python version compatibility code
 """
 import sys
 import inspect
-import types
 import re
 import functools
 
@@ -97,16 +96,6 @@ def getfuncargnames(function, startindex=None):
         return tuple(argnames[startindex:-numdefaults])
     return tuple(argnames[startindex:])
 
-
-
-if  sys.version_info[:2] == (2, 6):
-    def isclass(object):
-        """ Return true if the object is a class. Overrides inspect.isclass for
-        python 2.6 because it will return True for objects which always return
-        something on __getattr__ calls (see #1035).
-        Backport of https://hg.python.org/cpython/rev/35bf8f7a8edc
-        """
-        return isinstance(object, (type, types.ClassType))
 
 
 if _PY3:

--- a/_pytest/pytester.py
+++ b/_pytest/pytester.py
@@ -92,7 +92,7 @@ class LsofFdLeakChecker(object):
             gc.collect()
         lines2 = self.get_open_files()
 
-        new_fds = set([t[0] for t in lines2]) - set([t[0] for t in lines1])
+        new_fds = {t[0] for t in lines2} - {t[0] for t in lines1}
         leaked_files = [t for t in lines2 if t[0] in new_fds]
         if leaked_files:
             error = []
@@ -110,7 +110,6 @@ class LsofFdLeakChecker(object):
 # XXX copied from execnet's conftest.py - needs to be merged
 winpymap = {
     'python2.7': r'C:\Python27\python.exe',
-    'python2.6': r'C:\Python26\python.exe',
     'python3.1': r'C:\Python31\python.exe',
     'python3.2': r'C:\Python32\python.exe',
     'python3.3': r'C:\Python33\python.exe',
@@ -139,8 +138,8 @@ def getexecutable(name, cache={}):
         cache[name] = executable
         return executable
 
-@pytest.fixture(params=['python2.6', 'python2.7', 'python3.3', "python3.4",
-                        'pypy', 'pypy3'])
+@pytest.fixture(params=['python2.7', 'python3.3', "python3.4", 'pypy',
+                        'pypy3'])
 def anypython(request):
     name = request.param
     executable = getexecutable(name)

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1229,13 +1229,6 @@ class RaisesContext(object):
         __tracebackhide__ = True
         if tp[0] is None:
             pytest.fail(self.message)
-        if sys.version_info < (2, 7):
-            # py26: on __exit__() exc_value often does not contain the
-            # exception value.
-            # http://bugs.python.org/issue7853
-            if not isinstance(tp[1], BaseException):
-                exc_type, value, traceback = tp
-                tp = exc_type, exc_type(value), traceback
         self.excinfo.__init__(tp)
         return issubclass(self.excinfo.type, self.expected_exception)
 

--- a/_pytest/runner.py
+++ b/_pytest/runner.py
@@ -252,7 +252,7 @@ class BaseReport(object):
 def pytest_runtest_makereport(item, call):
     when = call.when
     duration = call.stop-call.start
-    keywords = dict([(x,1) for x in item.keywords])
+    keywords = {x: 1 for x in item.keywords}
     excinfo = call.excinfo
     sections = []
     if not call.excinfo:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
   # create multiple jobs to execute a set of tox runs on each; this is to workaround having
   # builds timing out in AppVeyor
   # pypy is disabled until #1963 gets fixed
-  - TOXENV: "linting,py26,py27,py33,py34,py35"
+  - TOXENV: "linting,py27,py33,py34,py35"
   - TOXENV: "py27-pexpect,py27-xdist,py27-trial,py35-pexpect,py35-xdist,py35-trial"
   - TOXENV: "py27-nobyte,doctesting,freeze,docs"
 

--- a/doc/en/example/multipython.py
+++ b/doc/en/example/multipython.py
@@ -6,7 +6,7 @@ import py
 import pytest
 import _pytest._code
 
-pythonlist = ['python2.6', 'python2.7', 'python3.4', 'python3.5']
+pythonlist = ['python2.7', 'python3.4', 'python3.5']
 @pytest.fixture(params=pythonlist)
 def python1(request, tmpdir):
     picklefile = tmpdir.join("data.pickle")

--- a/doc/en/example/special.rst
+++ b/doc/en/example/special.rst
@@ -14,7 +14,7 @@ calls it::
     @pytest.fixture(scope="session", autouse=True)
     def callattr_ahead_of_alltests(request):
         print ("callattr_ahead_of_alltests called")
-        seen = set([None])
+        seen = {None}
         session = request.node
         for item in session.items:
             cls = item.getparent(pytest.Class)

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -1,15 +1,14 @@
 Installation and Getting Started
 ===================================
 
-**Pythons**: Python 2.6,2.7,3.3,3.4,3.5, Jython, PyPy-2.3
+**Pythons**: Python 2.7,3.3,3.4,3.5, Jython, PyPy-2.3
 
 **Platforms**: Unix/Posix and Windows
 
 **PyPI package name**: `pytest <http://pypi.python.org/pypi/pytest>`_
 
 **dependencies**: `py <http://pypi.python.org/pypi/py>`_,
-`colorama (Windows) <http://pypi.python.org/pypi/colorama>`_,
-`argparse (py26) <http://pypi.python.org/pypi/argparse>`_.
+`colorama (Windows) <http://pypi.python.org/pypi/colorama>`_.
 
 **documentation as PDF**: `download latest <https://media.readthedocs.org/pdf/pytest/latest/pytest.pdf>`_
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ classifiers = ['Development Status :: 6 - Mature',
                'Topic :: Software Development :: Libraries',
                'Topic :: Utilities'] + [
               ('Programming Language :: Python :: %s' % x) for x in
-                  '2 2.6 2.7 3 3.3 3.4 3.5'.split()]
+                  '2 2.7 3 3.3 3.4 3.5'.split()]
 
 with open('README.rst') as fd:
     long_description = fd.read()
@@ -51,11 +51,8 @@ def main():
     install_requires = ['py>=1.4.29']  # pluggy is vendored in _pytest.vendored_packages
     extras_require = {}
     if has_environment_marker_support():
-        extras_require[':python_version=="2.6"'] = ['argparse']
         extras_require[':sys_platform=="win32"'] = ['colorama']
     else:
-        if sys.version_info < (2, 7):
-            install_requires.append('argparse')
         if sys.platform == 'win32':
             install_requires.append('colorama')
 

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -662,8 +662,8 @@ class TestRequestBasic:
                 pass
             def test_function(request, farg):
                 assert set(get_public_names(request.fixturenames)) == \
-                       set(["tmpdir", "sarg", "arg1", "request", "farg",
-                            "tmpdir_factory"])
+                        {"tmpdir", "sarg", "arg1", "request", "farg",
+                         "tmpdir_factory"}
         """)
         reprec = testdir.inline_run()
         reprec.assertoutcome(passed=1)

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -225,7 +225,7 @@ class TestMetafunc:
                                       (re.compile('foo'), re.compile('bar')),
                                       (str, int),
                                       (list("six"), [66, 66]),
-                                      (set([7]), set("seven")),
+                                      ({7}, set("seven")),
                                       (tuple("eight"), (8, -8, 8)),
                                       (b'\xc3\xb4', b"name"),
                                       (b'\xc3\xb4', totext("other")),

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -318,7 +318,7 @@ class TestAssert_reprcompare:
                 + {0: 2}
                 ?     ^
             """),
-            (set([0, 1]), set([0, 2]), """
+            ({0, 1}, {0, 2}, """
                 Full diff:
                 - set([0, 1])
                 ?         ^
@@ -368,11 +368,11 @@ class TestAssert_reprcompare:
         assert lines[2] == "{'b': 1}"
 
     def test_set(self):
-        expl = callequal(set([0, 1]), set([0, 2]))
+        expl = callequal({0, 1}, {0, 2})
         assert len(expl) > 1
 
     def test_frozenzet(self):
-        expl = callequal(frozenset([0, 1]), set([0, 2]))
+        expl = callequal(frozenset([0, 1]), {0, 2})
         assert len(expl) > 1
 
     def test_Sequence(self):

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -134,7 +134,7 @@ class TestConfigAPI:
             assert config.getoption(x) == "this"
         pytest.raises(ValueError, "config.getoption('qweqwe')")
 
-    @pytest.mark.skipif('sys.version_info[:2] not in [(2, 6), (2, 7)]')
+    @pytest.mark.skipif('sys.version_info[:2] != (2, 7)')
     def test_config_getoption_unicode(self, testdir):
         testdir.makeconftest("""
             from __future__ import unicode_literals

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -114,7 +114,7 @@ class TestDoctests:
             >>> 1
             1
         """)
-        expected = set(['xdoc.txt', 'test.foo', 'test_normal.txt'])
+        expected = {'xdoc.txt', 'test.foo', 'test_normal.txt'}
         assert set(x.basename for x in testdir.tmpdir.listdir()) == expected
         args = ["--doctest-glob=xdoc*.txt", "--doctest-glob=*.foo"]
         result = testdir.runpytest(*args)

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -586,8 +586,8 @@ class TestFunctional:
         items = dict((x.name, x) for x in items)
         for name, expected_markers in expected.items():
             markers = items[name].keywords._markers
-            marker_names = set([name for (name, v) in markers.items()
-                                if isinstance(v, MarkInfo)])
+            marker_names = {name for (name, v) in markers.items()
+                            if isinstance(v, MarkInfo)}
             assert marker_names == set(expected_markers)
 
     @pytest.mark.xfail(reason='callspec2.setmulti misuses keywords')

--- a/testing/test_parseopt.py
+++ b/testing/test_parseopt.py
@@ -85,7 +85,7 @@ class TestParser:
         group.addoption("--option1", "--option-1", action="store_true")
         with pytest.raises(ValueError) as err:
             group.addoption("--option1", "--option-one", action="store_true")
-        assert str(set(["--option1"])) in str(err.value)
+        assert str({"--option1"}) in str(err.value)
 
     def test_group_shortopt_lowercase(self, parser):
         group = parser.getgroup("hello")

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ distshare={homedir}/.tox/distshare
 # make sure to update enviroment list on appveyor.yml
 envlist=
      linting
-     py26
      py27
      py33
      py34
@@ -24,14 +23,6 @@ deps=
     nose
     mock
     requests
-
-[testenv:py26]
-commands= pytest --lsof -rfsxX {posargs:testing}
-# pinning mock to last supported version for python 2.6
-deps=
-    hypothesis<3.0
-    nose
-    mock<1.1
 
 [testenv:py27-subprocess]
 changedir=.


### PR DESCRIPTION
Yesterday marks 3 years since the last release of Python 2.6! 🎉

To celebrate, I'm attempting to drop support for it from 156 prominent Python packages (one for every week it's past end-of-life)--including this one!

I've tried my best to remove as much 2.6-specific cruft as I can, but at the very least, this PR will remove the `'Programming Language :: Python :: 2.6'` trove classifier from this projects `setup.py`.
