### PR TITLE
Fix teardown error message in generated xUnit XML

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,8 @@
 * Report teardown output on test failure (`#442`_).
   Thanks `@matclab`_ or the PR.
 
-*
+* Fix teardown error message in generated xUnit XML.
+  Thanks `@gdyuldin`_ or the PR.
 
 *
 
@@ -28,6 +29,7 @@
 .. _@cwitty: https://github.com/cwitty
 .. _@okulynyak: https://github.com/okulynyak
 .. _@matclab: https://github.com/matclab
+.. _@gdyuldin: https://github.com/gdyuldin
 
 .. _#442: https://github.com/pytest-dev/pytest/issues/442
 .. _#1976: https://github.com/pytest-dev/pytest/issues/1976
@@ -98,7 +100,7 @@
   enabled. This allows proper post mortem debugging for all applications
   which have significant logic in their tearDown machinery (`#1890`_). Thanks
   `@mbyt`_ for the PR.
-  
+
 * Fix use of deprecated ``getfuncargvalue`` method in the internal doctest plugin.
   Thanks `@ViviCoder`_ for the report (`#1898`_).
 
@@ -395,7 +397,7 @@ time or change existing behaviors in order to make them less surprising/more use
 
 * Refined logic for determining the ``rootdir``, considering only valid
   paths which fixes a number of issues: `#1594`_, `#1435`_ and `#1471`_.
-  Updated the documentation according to current behavior. Thanks to 
+  Updated the documentation according to current behavior. Thanks to
   `@blueyed`_, `@davehunt`_ and `@matthiasha`_ for the PR.
 
 * Always include full assertion explanation. The previous behaviour was hiding

--- a/_pytest/junitxml.py
+++ b/_pytest/junitxml.py
@@ -156,8 +156,12 @@ class _NodeReporter(object):
             Junit.skipped, "collection skipped", report.longrepr)
 
     def append_error(self, report):
+        if getattr(report, 'when', None) == 'teardown':
+            msg = "test teardown failure"
+        else:
+            msg = "test setup failure"
         self._add_simple(
-            Junit.error, "test setup failure", report.longrepr)
+            Junit.error, msg, report.longrepr)
         self._write_captured_output(report)
 
     def append_skipped(self, report):

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -165,6 +165,30 @@ class TestPython:
         fnode.assert_attr(message="test setup failure")
         assert "ValueError" in fnode.toxml()
 
+    def test_teardown_error(self, testdir):
+        testdir.makepyfile("""
+            import pytest
+
+            @pytest.fixture
+            def arg():
+                yield
+                raise ValueError()
+            def test_function(arg):
+                pass
+        """)
+        result, dom = runandparse(testdir)
+        assert result.ret
+        node = dom.find_first_by_tag("testsuite")
+        tnode = node.find_first_by_tag("testcase")
+        tnode.assert_attr(
+            file="test_teardown_error.py",
+            line="6",
+            classname="test_teardown_error",
+            name="test_function")
+        fnode = tnode.find_first_by_tag("error")
+        fnode.assert_attr(message="test teardown failure")
+        assert "ValueError" in fnode.toxml()
+
     def test_skip_contains_name_reason(self, testdir):
         testdir.makepyfile("""
             import pytest


### PR DESCRIPTION
Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [ ] Target: for bug or doc fixes, target `master`; for new features, target `features`;

Unless your change is trivial documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Make sure to include one or more tests for your change;
- [ ] Add yourself to `AUTHORS`;
- [ ] Add a new entry to `CHANGELOG.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using RST syntax.
  * The pytest team likes to have people to acknowledged in the `CHANGELOG`, so please add a thank note to yourself ("Thanks @user for the PR") and a link to your GitHub profile. It may sound weird thanking yourself, but otherwise a maintainer would have to do it manually before or after merging instead of just using GitHub's merge button. This makes it easier on the maintainers to merge PRs. 

It was "test setup failure" even error happens on test teardown.