### PR TITLE
Clean up unittest TestCase objects after tests are complete (#1649).

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Christopher Gilling
 Daniel Grana
 Daniel Hahler
 Daniel Nuri
+Daniel Wandschneider
 Danielle Jenkins
 Dave Hunt
 David Díaz-Barquero

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,8 @@
 * Properly handle exceptions in ``multiprocessing`` tasks (`#1984`_).
   Thanks `@adborden`_ for the report and `@nicoddemus`_ for the PR.
 
-*
+* Clean up unittest TestCase objects after tests are complete (`#1649`_).
+  Thanks `@d_b_w`_ for the report and PR.
 
 *
 
@@ -38,6 +39,7 @@
 .. _@okulynyak: https://github.com/okulynyak
 .. _@matclab: https://github.com/matclab
 .. _@gdyuldin: https://github.com/gdyuldin
+.. _@d_b_w: https://github.com/d_b_w
 
 .. _#442: https://github.com/pytest-dev/pytest/issues/442
 .. _#1976: https://github.com/pytest-dev/pytest/issues/1976
@@ -45,6 +47,7 @@
 .. _#1998: https://github.com/pytest-dev/pytest/issues/1998
 .. _#2004: https://github.com/pytest-dev/pytest/issues/2004
 .. _#2005: https://github.com/pytest-dev/pytest/issues/2005
+.. _#1649: https://github.com/pytest-dev/pytest/issues/1649
 
 
 3.0.3

--- a/_pytest/unittest.py
+++ b/_pytest/unittest.py
@@ -94,6 +94,9 @@ class TestCaseFunction(pytest.Function):
     def teardown(self):
         if hasattr(self._testcase, 'teardown_method'):
             self._testcase.teardown_method(self._obj)
+        # Allow garbage collection on TestCase instance attributes.
+        self._testcase = None
+        self._obj = None
 
     def startTest(self, testcase):
         pass


### PR DESCRIPTION
Fix [#1649](https://github.com/pytest-dev/pytest/issues/1649)

Users of unittest style TestCases will create expensive objects
in setUp. We should clean up TestCase instances that are lying
around so that they don't fill up memory.

Here's a quick checklist that should be present in PRs:

- [x] Target: for bug or doc fixes, target `master`; for new features, target `features`; (master)
- [x] Make sure to include one or more tests for your change; (`test_teardown_issue1649()`, fails before and passes after)
- [x] Add yourself to `AUTHORS`; (as Daniel Wandschneider)
- [x] Add a new entry to `CHANGELOG.rst` (Added first line of this description)