### PR TITLE
Check README.rst with rst-lint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ Please use the `GitHub issue tracker <https://github.com/pytest-dev/pytest/issue
 Changelog
 ---------
 
-Consult the `Changelog <http://docs.pytest.org/en/latest/changelog.html>`_ page for fixes and enhancements of each version.
+Consult the `Changelog <http://docs.pytest.org/en/latest/changelog.html>`__ page for fixes and enhancements of each version.
 
 
 License

--- a/tox.ini
+++ b/tox.ini
@@ -42,8 +42,6 @@ deps=pytest-xdist>=1.13
 commands=
   pytest -n3 -rfsxX --runpytest=subprocess {posargs:testing}
 
-[testenv:genscript]
-commands= pytest --genscript=pytest1
 
 [testenv:linting]
 basepython = python2.7
@@ -54,7 +52,7 @@ deps =
 commands =
     check-manifest
     flake8 pytest.py _pytest testing
-    rst-lint CHANGELOG.rst HOWTORELEASE.rst
+    rst-lint CHANGELOG.rst HOWTORELEASE.rst README.rst
 
 [testenv:py27-xdist]
 deps=pytest-xdist>=1.13

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,8 @@ commands=
 basepython = python2.7
 deps =
     flake8
+    # pygments required by rst-lint
+    pygments  
     restructuredtext_lint
     check-manifest
 commands =


### PR DESCRIPTION
While adding the same check for tox I realized we don't do the same for pytest.