### PR TITLE
Use a wrapper script to bypass check-manifest if not under git

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,8 @@ include HOWTORELEASE.rst
 include tox.ini
 include setup.py
 
+recursive-include scripts *.py
+
 include .coveragerc
 
 recursive-include bench *.py

--- a/scripts/check-manifest.py
+++ b/scripts/check-manifest.py
@@ -1,0 +1,21 @@
+"""
+Script used by tox.ini to check the manifest file if we are under version control, or skip the
+check altogether if not.
+
+"check-manifest" will needs a vcs to work, which is not available when testing the package
+instead of the source code (with ``devpi test`` for example).
+"""
+
+from __future__ import print_function
+
+import os
+import subprocess
+import sys
+
+
+if os.path.isdir('.git'):
+    sys.exit(subprocess.call('check-manifest', shell=True))
+else:
+    print('No .git directory found, skipping checking the manifest file')
+    sys.exit(0)
+

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ deps =
     restructuredtext_lint
     check-manifest
 commands =
-    check-manifest
+    {envpython} scripts/check-manifest.py
     flake8 pytest.py _pytest testing
     rst-lint CHANGELOG.rst HOWTORELEASE.rst README.rst
 


### PR DESCRIPTION
Wrapper script is necessary because we are not under version when testing the package directly using `devpi test`.

Related to comment in #2051