### PR TITLE
Allow problematic jobs to fail instead of commenting them out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,16 @@ env:
     - TESTENV=py27-trial
     - TESTENV=py35-pexpect
     - TESTENV=py35-xdist
-    # Disable py35-trial temporarily: #1989
-    #- TESTENV=py35-trial
+    - TESTENV=py35-trial
     - TESTENV=py27-nobyte
     - TESTENV=doctesting
     - TESTENV=freeze
     - TESTENV=docs
+
+matrix:
+  allow_failures:
+    # py35-trial failing on Linux: #1989
+    - env: TESTENV=py35-trial
 
 script: tox --recreate -e $TESTENV
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,15 @@ environment:
   matrix:
   # create multiple jobs to execute a set of tox runs on each; this is to workaround having
   # builds timing out in AppVeyor
-  # pypy is disabled until #1963 gets fixed
   - TOXENV: "linting,py26,py27,py33,py34,py35"
   - TOXENV: "py27-pexpect,py27-xdist,py27-trial,py35-pexpect,py35-xdist,py35-trial"
   - TOXENV: "py27-nobyte,doctesting,freeze,docs"
+  - TOXENV: "pypy"
+
+matrix:
+  allow_failures:
+    # pypy is disabled until #1963 gets fixed
+    - TOXENV: "pypy"
 
 install:
   - echo Installed Pythons
@@ -21,10 +26,10 @@ install:
   # choco install returns non-zero, because choco install python.pypy is too
   # noisy)
   # pypy is disabled until #1963 gets fixed
-  #- choco install python.pypy > pypy-inst.log 2>&1 || (type pypy-inst.log & exit /b 1)
-  #- set PATH=C:\tools\pypy\pypy;%PATH% # so tox can find pypy
-  #- echo PyPy installed
-  #- pypy --version
+  - choco install python.pypy > pypy-inst.log 2>&1 || (type pypy-inst.log & exit /b 1)
+  - set PATH=C:\tools\pypy\pypy;%PATH% # so tox can find pypy
+  - echo PyPy installed
+  - pypy --version
 
   - C:\Python35\python -m pip install tox
 


### PR DESCRIPTION
Instead of commenting out jobs, allow them to fail in CI. 

This seems like a better strategy because at least they will appear in the job list, as a constant reminder for us to take a look or even better, start to get green again because of an upstream change.

Related to #1989 and #1963