### PR TITLE
Docs: Added pytest promotional talk in Russian

### DIFF
--- a/doc/en/talks.rst
+++ b/doc/en/talks.rst
@@ -11,6 +11,9 @@ Talks and Tutorials
 Talks and blog postings
 ---------------------------------------------
 
+- `Pythonic testing, Igor Starikov (Russian, PyNsk, November 2016)
+  <https://www.youtube.com/watch?v=_92nfdd5nK8>`_.
+
 - `pytest - Rapid Simple Testing, Florian Bruhin, Swiss Python Summit 2016
   <https://www.youtube.com/watch?v=rCBHkQ_LVIs>`_.
 


### PR DESCRIPTION
Hi,

Talks section extended with my latest overview talk on pytest. 
This one is in Russian. Formatted after Holger's talk in German.