### PR TITLE
Only execute "coveralls" toxenv once on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ environment:
     # https://www.appveyor.com/docs/build-configuration#secure-variables
 
   matrix:
+  # coveralls is not in the default env list
+  - TOXENV: "coveralls"
   # note: please use "tox --listenvs" to populate the build matrix below
   - TOXENV: "linting"
   - TOXENV: "py26"
@@ -29,14 +31,11 @@ install:
   - echo Installed Pythons
   - dir c:\Python*
 
-  - if "%TOXENV%" == "pypy" scripts\install-pypy.bat
+  - if "%TOXENV%" == "pypy" call scripts\install-pypy.bat
 
   - C:\Python35\python -m pip install tox
 
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-  - C:\Python35\python -m tox
-  # coveralls is not in tox's envlist, plus for PRs the secure variable
-  # is not defined so we have to check for it
-  - if defined COVERALLS_REPO_TOKEN C:\Python35\python -m tox -e coveralls
+  - call scripts\call-tox.bat

--- a/scripts/call-tox.bat
+++ b/scripts/call-tox.bat
@@ -1,0 +1,8 @@
+REM skip "coveralls" run in PRs or forks
+if "%TOXENV%" == "coveralls" (
+    if not defined COVERALLS_REPO_TOKEN (
+        echo skipping coveralls run because COVERALLS_REPO_TOKEN is not defined
+        exit /b 0
+    )
+)
+C:\Python35\python -m tox


### PR DESCRIPTION
Just noticed that the "coveralls" env was being execute after each env, making builds for pytest's own branches take unnecessarily long.

This was introduced by mistake in #2056