### PR TITLE
Add `:ref:` targets to `recwarn.rst`.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -83,6 +83,7 @@ Kevin Cox
 Lee Kamentsky
 Lev Maximov
 Lukas Bednar
+Luke Murphy
 Maciek Fijalkowski
 Maho
 Marc Schlaich

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@
 
 * Add hint to error message hinting possible missing __init__.py (`#478`_). Thanks `@DuncanBetts`_.
 
+* Provide ``:ref:`` targets for ``recwarn.rst`` so we can use intersphinx referencing.
+  Thanks to `@dupuy`_ for the report and `@lwm`_ for the PR.
+
 * An error message is now displayed if ``--confcutdir`` is not a valid directory, avoiding
   subtle bugs (`#2078`_).
   Thanks `@nicoddemus`_ for the PR.
@@ -19,6 +22,8 @@
 
 *
 
+.. _@dupuy: https://bitbucket.org/dupuy/
+.. _@lwm: https://github.com/lwm
 .. _@adler-j: https://github.com/adler-j
 .. _@DuncanBetts: https://github.com/DuncanBetts
 .. _@nedbat: https://github.com/nedbat

--- a/doc/en/recwarn.rst
+++ b/doc/en/recwarn.rst
@@ -1,7 +1,11 @@
+.. _`asserting warnings`:
+
 .. _assertwarnings:
 
 Asserting Warnings
 =====================================================
+
+.. _`asserting warnings with the warns function`:
 
 .. _warns:
 
@@ -45,6 +49,8 @@ Alternatively, you can examine raised warnings in detail using the
 .. note::
     ``DeprecationWarning`` and ``PendingDeprecationWarning`` are treated
     differently; see :ref:`ensuring_function_triggers`.
+
+.. _`recording warnings`:
 
 .. _recwarn:
 
@@ -95,6 +101,8 @@ class of the warning. The ``message`` is the warning itself; calling
 .. note::
     ``DeprecationWarning`` and ``PendingDeprecationWarning`` are treated
     differently; see :ref:`ensuring_function_triggers`.
+
+.. _`ensuring a function triggers a deprecation warning`:
 
 .. _ensuring_function_triggers:
 


### PR DESCRIPTION
Closes https://github.com/pytest-dev/pytest/issues/297.

[Greetings from Zagreb!](https://www.meetup.com/Python-Hrvatska/events/235507740/)