### PR TITLE
Add test case for #595.

### DIFF
--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -249,6 +249,18 @@ class TestPython:
         snode = tnode.find_first_by_tag("skipped")
         snode.assert_attr(type="pytest.skip", message="hello25", )
 
+    def test_mark_skip_doesnt_capture_output(self, testdir):
+        testdir.makepyfile("""
+            import pytest
+            @pytest.mark.skip(reason="foo")
+            def test_skip():
+                print("bar!")
+        """)
+        result, dom = runandparse(testdir)
+        assert result.ret == 0
+        node_xml = dom.find_first_by_tag("testsuite").toxml()
+        assert "bar!" not in node_xml
+
     def test_classname_instance(self, testdir):
         testdir.makepyfile("""
             class TestClass:


### PR DESCRIPTION
Something to move the conversation on #595 along.

@davidszotten said in #595:

> 6954363 changed junitxml to include captured output for passing and skipped tests in the output by default.

So far as I can tell, my test shows that the output of a skipped test is not captured by default.

Is this already fixed or I missed something?