### PR TITLE
Pin setuptools to < 29 because of AppVeyor failures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -117,7 +117,10 @@ commands=
 basepython = python
 usedevelop=True
 skipsdist=True
-deps=PyYAML
+deps=
+    PyYAML
+    # pinning setuptools because of AppVeyor failures, see pypa/setuptools#861
+    setuptools<29.0.0
 commands=
     pytest -rfsxX doc/en
     pytest --doctest-modules {toxinidir}/_pytest


### PR DESCRIPTION

Related to pypa/setuptools#861

Remove the pin when we have a new setuptools release