### PR TITLE
Remove support code for earlier Python 3 version in Source.compile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,10 @@
 * Fix error message using ``approx`` with complex numbers (`#2082`_).
   Thanks `@adler-j`_ for the report and `@nicoddemus`_ for the PR.
 
-*
+* Remove internal code meant to support earlier Python 3 versions that produced the side effect
+  of leaving ``None`` in ``sys.modules`` when expressions were evaluated by pytest (for example passing a condition
+  as a string to ``pytest.mark.skipif``)(`#2103`_).
+  Thanks `@jaraco`_ for the report and `@nicoddemus`_ for the PR.
 
 * Cope gracefully with a .pyc file with no matching .py file (`#2038`_). Thanks
   `@nedbat`_.
@@ -41,6 +44,7 @@
 .. _#2038: https://github.com/pytest-dev/pytest/issues/2038
 .. _#2078: https://github.com/pytest-dev/pytest/issues/2078
 .. _#2082: https://github.com/pytest-dev/pytest/issues/2082
+.. _#2103: https://github.com/pytest-dev/pytest/issues/2103
 
 
 3.0.4

--- a/_pytest/_code/source.py
+++ b/_pytest/_code/source.py
@@ -192,14 +192,6 @@ class Source(object):
             if flag & _AST_FLAG:
                 return co
             lines = [(x + "\n") for x in self.lines]
-            if sys.version_info[0] >= 3:
-                # XXX py3's inspect.getsourcefile() checks for a module
-                # and a pep302 __loader__ ... we don't have a module
-                # at code compile-time so we need to fake it here
-                m = ModuleType("_pycodecompile_pseudo_module")
-                py.std.inspect.modulesbyfile[filename] = None
-                py.std.sys.modules[None] = m
-                m.__loader__ = 1
             py.std.linecache.cache[filename] = (1, None, lines, filename)
             return co
 

--- a/_pytest/_code/source.py
+++ b/_pytest/_code/source.py
@@ -4,7 +4,6 @@ from bisect import bisect_right
 import sys
 import inspect, tokenize
 import py
-from types import ModuleType
 cpy_compile = compile
 
 try:


### PR DESCRIPTION
This code leaves `None` in sys.modules as a side effect but is no longer needed in the Python 3 versions we support, it seems.

Fix #2103