### PR TITLE
Add warning for incorrect passing args to `-o`.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 3.0.5.dev0
 ==========
 
+* Add warning when not passing ``option=value`` correctly to ``-o/--override-ini`` (`#2105`_).
+  Also improved the help documentation. Thanks to `@mbukatov`_ for the report and
+  `@lwm`_ for the PR.
+
 * Now ``--confcutdir`` and ``--junit-xml`` are properly validated if they are directories
   and filenames, respectively (`#2089`_ and `#2078`_). Thanks to `@lwm`_ for the PR.
 
@@ -30,6 +34,7 @@
 
 *
 
+.. _@mbukatov: https://github.com/mbukatov
 .. _@dupuy: https://bitbucket.org/dupuy/
 .. _@lwm: https://github.com/lwm
 .. _@adler-j: https://github.com/adler-j
@@ -45,6 +50,7 @@
 .. _#2078: https://github.com/pytest-dev/pytest/issues/2078
 .. _#2082: https://github.com/pytest-dev/pytest/issues/2082
 .. _#2103: https://github.com/pytest-dev/pytest/issues/2103
+.. _#2105: https://github.com/pytest-dev/pytest/issues/2105
 
 
 3.0.4

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -1149,7 +1149,10 @@ class Config(object):
         if self.getoption("override_ini", None):
             for ini_config_list in self.option.override_ini:
                 for ini_config in ini_config_list:
-                    (key, user_ini_value) = ini_config.split("=", 1)
+                    try:
+                        (key, user_ini_value) = ini_config.split("=", 1)
+                    except ValueError:
+                        raise UsageError("-o/--override-ini expects option=value style.")
                     if key == name:
                         value = user_ini_value
         return value

--- a/_pytest/helpconfig.py
+++ b/_pytest/helpconfig.py
@@ -23,7 +23,7 @@ def pytest_addoption(parser):
     group._addoption(
         '-o', '--override-ini', nargs='*', dest="override_ini",
         action="append",
-        help="override config option, e.g. `-o xfail_strict=True`.")
+        help="override config option with option=value style, e.g. `-o xfail_strict=True`.")
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -83,7 +83,7 @@ class TestParseIni:
         """)
         result = testdir.inline_run("--confcutdir=.")
         assert result.ret == 0
-        
+
 class TestConfigCmdlineParsing:
     def test_parsing_again_fails(self, testdir):
         config = testdir.parseconfig()
@@ -731,6 +731,14 @@ class TestOverrideIniArgs:
                                      "ini2:url=/tmp/user2?a=b&d=e",
                                      "ini3:True",
                                      "ini4:False"])
+
+    def test_override_ini_usage_error_bad_style(self, testdir):
+        testdir.makeini("""
+            [pytest]
+            xdist_strict=False
+        """)
+        result = testdir.runpytest("--override-ini", 'xdist_strict True', "-s")
+        result.stderr.fnmatch_lines(["*ERROR* *expects option=value*"])
 
     def test_with_arg_outside_cwd_without_inifile(self, tmpdir, monkeypatch):
         monkeypatch.chdir(str(tmpdir))


### PR DESCRIPTION
Closes #2105.