### PR TITLE
Fix false-positive assert rewrite warnings when using 'pytest_plugins'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,10 @@
 * Fix error message using ``approx`` with complex numbers (`#2082`_).
   Thanks `@adler-j`_ for the report and `@nicoddemus`_ for the PR.
 
+* Fixed false-positives warnings from assertion rewrite hook for modules imported more than
+  once by the ``pytest_plugins`` mechanism.
+  Thanks `@nicoddemus`_ for the PR.
+
 * Remove internal code meant to support earlier Python 3 versions that produced the side effect
   of leaving ``None`` in ``sys.modules`` when expressions were evaluated by pytest (for example passing a condition
   as a string to ``pytest.mark.skipif``)(`#2103`_).

--- a/_pytest/assertion/rewrite.py
+++ b/_pytest/assertion/rewrite.py
@@ -186,16 +186,15 @@ class AssertionRewritingHook(object):
         """
         already_imported = set(names).intersection(set(sys.modules))
         if already_imported:
-            for name in names:
+            for name in already_imported:
                 if name not in self._rewritten_names:
-                    self._warn_already_imported(already_imported)
+                    self._warn_already_imported(name)
         self._must_rewrite.update(names)
 
-    def _warn_already_imported(self, names):
+    def _warn_already_imported(self, name):
         self.config.warn(
             'P1',
-            'Modules are already imported so can not be re-written: %s' %
-            ','.join(names))
+            'Module already imported so can not be re-written: %s' % name)
 
     def load_module(self, name):
         # If there is an existing module object named 'fullname' in

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -682,6 +682,19 @@ def test_rewritten():
         hook.mark_rewrite('test_remember_rewritten_modules')
         assert warnings == []
 
+    def test_rewrite_warning_using_pytest_plugins(self, testdir, monkeypatch):
+        testdir.makepyfile(**{
+            'conftest.py': "pytest_plugins = ['core', 'gui', 'sci']",
+            'core.py': "",
+            'gui.py': "pytest_plugins = ['core', 'sci']",
+            'sci.py': "pytest_plugins = ['core']",
+            'test_rewrite_warning_pytest_plugins.py': "def test(): pass",
+        })
+        testdir.chdir()
+        result = testdir.runpytest_subprocess()
+        result.stdout.fnmatch_lines(['*= 1 passed in *=*'])
+        assert 'pytest-warning summary' not in result.stdout.str()
+
 
 class TestAssertionRewriteHookDetails(object):
     def test_loader_is_package_false_for_module(self, testdir):


### PR DESCRIPTION
pytest would emit false-positive warnings about assertion-rewrite when a module appears multiple times in plugins which depend on other plugins using the `pytest_plugins` mechanism.

Here's the output of the test added by this PR on `master`:

```
self = <test_assertrewrite.TestRewriteOnImport instance at 0x000000000430A208>
monkeypatch = <_pytest.monkeypatch.MonkeyPatch instance at 0x000000000401FF88>

    def test_rewrite_warning_using_pytest_plugins(self, testdir, monkeypatch):
        testdir.makepyfile(**{
            'conftest.py': "pytest_plugins = ['core', 'gui', 'sci']",
            'core.py': "",
            'gui.py': "pytest_plugins = ['core', 'sci']",
            'sci.py': "pytest_plugins = ['core']",
            'test_rewrite_warning_pytest_plugins.py': "def test(): pass",
        })
        testdir.chdir()
        result = testdir.runpytest_subprocess()
>       result.stdout.fnmatch_lines(['*= 1 passed in *=*'])
E       Failed: nomatch: '*= 1 passed in *=*'
E           and: u'============================= test session starts ============================='
E           and: u'platform win32 -- Python 2.7.9, pytest-3.0.5.dev0, py-1.4.31, pluggy-0.4.0'
E           and: u'plugins: hypothesis-3.6.0'
E           and: u'collected 1 items'
E           and: u''
E           and: u'test_rewrite_warning_pytest_plugins.py .'
E           and: u''
E           and: u'=========================== pytest-warning summary ============================'
E           and: u'WP1 None Modules are already imported so can not be re-written: core'
E           and: u'================= 1 passed, 1 pytest-warnings in 0.01 seconds ================='
E       remains unmatched: '*= 1 passed in *=*'

```