### PR TITLE
Tests: Check for ModuleNotFoundError on Python 3.6+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ matrix:
   allow_failures:
     # py35-trial failing on Linux: #1989
     - env: TESTENV=py35-trial
+  include:
+    - env: TESTENV=py36
+      python: '3.6-dev'
 
 script: tox --recreate -e $TESTENV
 

--- a/_pytest/compat.py
+++ b/_pytest/compat.py
@@ -26,6 +26,9 @@ _PY2 = not _PY3
 NoneType = type(None)
 NOTSET = object()
 
+PY36 = sys.version_info[:2] >= (3, 6)
+MODULE_NOT_FOUND_ERROR = 'ModuleNotFoundError' if PY36 else 'ImportError'
+
 if hasattr(inspect, 'signature'):
     def _format_args(func):
         return str(inspect.signature(func))

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -1,11 +1,9 @@
 # encoding: utf-8
 import sys
 import _pytest._code
+from _pytest.compat import MODULE_NOT_FOUND_ERROR
 from _pytest.doctest import DoctestItem, DoctestModule, DoctestTextfile
 import pytest
-
-PY36 = sys.version_info[:2] >= (3, 6)
-MODULE_NOT_FOUND_ERROR = 'ModuleNotFoundError' if PY36 else 'ImportError'
 
 
 class TestDoctests:

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -4,6 +4,10 @@ import _pytest._code
 from _pytest.doctest import DoctestItem, DoctestModule, DoctestTextfile
 import pytest
 
+PY36 = sys.version_info[:2] >= (3, 6)
+MODULE_NOT_FOUND_ERROR = 'ModuleNotFoundError' if PY36 else 'ImportError'
+
+
 class TestDoctests:
 
     def test_collect_testtextfile(self, testdir):
@@ -211,8 +215,8 @@ class TestDoctests:
         # doctest is never executed because of error during hello.py collection
         result.stdout.fnmatch_lines([
             "*>>> import asdals*",
-            "*UNEXPECTED*ImportError*",
-            "ImportError: No module named *asdal*",
+            "*UNEXPECTED*{e}*".format(e=MODULE_NOT_FOUND_ERROR),
+            "{e}: No module named *asdal*".format(e=MODULE_NOT_FOUND_ERROR),
         ])
 
     def test_doctest_unex_importerror_with_module(self, testdir):
@@ -227,7 +231,7 @@ class TestDoctests:
         # doctest is never executed because of error during hello.py collection
         result.stdout.fnmatch_lines([
             "*ERROR collecting hello.py*",
-            "*ImportError: No module named *asdals*",
+            "*{e}: No module named *asdals*".format(e=MODULE_NOT_FOUND_ERROR),
             "*Interrupted: 1 errors during collection*",
         ])
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist=
      py33
      py34
      py35
+     py36
      pypy
      {py27,py35}-{pexpect,xdist,trial}
      py27-nobyte


### PR DESCRIPTION
This tests originally checked for ImportError. Since Python 3.6
ModuleNotFoundError is raised in this context instead, the test didn't work
as it is text based (so exception inheritance does not save the day).

The test now simply checks for any *Error, which makes it less specific,
but still valuable.

Fixes https://github.com/pytest-dev/pytest/issues/2132

I consider this a trivial fix (I realize it's not in documentation, but it's in tests, so I think the same logic applies).