### PR TITLE
Explicitly add setuptools to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ def has_environment_marker_support():
 
 
 def main():
-    install_requires = ['py>=1.4.29']  # pluggy is vendored in _pytest.vendored_packages
+    install_requires = ['py>=1.4.29', 'setuptools']  # pluggy is vendored in _pytest.vendored_packages
     extras_require = {}
     if has_environment_marker_support():
         extras_require[':python_version=="2.6"'] = ['argparse']


### PR DESCRIPTION
Setuptools is used in `_pytest/config.py` but was not explicitly listed as requirement. This led to an error when creating a Conda package for pytest since setuptools is not necessarily installed by default in Conda envs.
