### PR TITLE
Improve error message when pytest.warns fail

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -82,6 +82,7 @@ Katarzyna Jachim
 Kevin Cox
 Lee Kamentsky
 Lev Maximov
+Loic Esteve
 Lukas Bednar
 Luke Murphy
 Maciek Fijalkowski

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,12 +5,17 @@
 
 *
 
-*
+* Improve error message when pytest.warns fails (`#2150`_). The type(s) of the
+  expected warnings and the list of caught warnings is added to the
+  error message. Thanks `@lesteve`_ for the PR.
 
 *
 
 *
 
+.. _@lesteve: https://github.com/lesteve
+
+.. _#2150: https://github.com/pytest-dev/pytest/issues/2150
 
 
 3.0.5 (2016-12-05)

--- a/_pytest/recwarn.py
+++ b/_pytest/recwarn.py
@@ -223,4 +223,7 @@ class WarningsChecker(WarningsRecorder):
             if self.expected_warning is not None:
                 if not any(r.category in self.expected_warning for r in self):
                     __tracebackhide__ = True
-                    pytest.fail("DID NOT WARN")
+                    pytest.fail("DID NOT WARN. No warnings of type {0} was emitted. "
+                                "The list of emitted warnings is: {1}.".format(
+                                    self.expected_warning,
+                                    [each.message for each in self]))


### PR DESCRIPTION
The error message contains the expected type of warning and the
warnings that were captured. Add tests.

You could argue that having the stderr is good enough but in my original use case, either the stderr was very noisy or I managed to miss it completely. I reckon it does not hurt to have a clearer error message anyway.

The line of the error message is very long now. Let me know if you would rather have me split it manually or you have better ways to deal with it.

Simple snippet:
```py
import warnings

import pytest


def test():
    with pytest.warns(RuntimeWarning):
        warnings.warn('user', UserWarning)
        warnings.warn('import', ImportWarning)
```

master:
```
======================================================== test session starts ========================================================
platform linux -- Python 3.5.2, pytest-3.0.6.dev0, py-1.4.31, pluggy-0.4.0
rootdir: /tmp, inifile: 
plugins: cov-2.3.1
collected 1 items 

../../../../tmp/test_pytest.py F

============================================================= FAILURES ==============================================================
_______________________________________________________________ test ________________________________________________________________

    def test():
        with pytest.warns(RuntimeWarning):
            warnings.warn('user', UserWarning)
>           warnings.warn('import', ImportWarning)
E           Failed: DID NOT WARN

/tmp/test_pytest.py:9: Failed
------------------------------------------------------- Captured stderr call --------------------------------------------------------
/tmp/test_pytest.py:8: UserWarning: user
  warnings.warn('user', UserWarning)
/tmp/test_pytest.py:9: ImportWarning: import
  warnings.warn('import', ImportWarning)
===================================================== 1 failed in 0.02 seconds ======================================================
```

This PR:
```
======================================================== test session starts ========================================================
platform linux -- Python 3.5.2, pytest-3.0.6.dev0, py-1.4.31, pluggy-0.4.0
rootdir: /tmp, inifile: 
plugins: cov-2.3.1
collected 1 items 

../../../../tmp/test_pytest.py F

============================================================= FAILURES ==============================================================
_______________________________________________________________ test ________________________________________________________________

    def test():
        with pytest.warns(RuntimeWarning):
            warnings.warn('user', UserWarning)
>           warnings.warn('import', ImportWarning)
E           Failed: DID NOT WARN. No warnings of type (<class 'RuntimeWarning'>,) was emitted. The list of emitted warnings is: [UserWarning('user',), ImportWarning('import',)].

/tmp/test_pytest.py:9: Failed
------------------------------------------------------- Captured stderr call --------------------------------------------------------
/tmp/test_pytest.py:8: UserWarning: user
  warnings.warn('user', UserWarning)
/tmp/test_pytest.py:9: ImportWarning: import
  warnings.warn('import', ImportWarning)
===================================================== 1 failed in 0.02 seconds ======================================================
```
