### PR TITLE
clear root log handlers between tests

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -114,6 +114,7 @@ Piotr Banaszkiewicz
 Punyashloka Biswal
 Quentin Pradet
 Ralf Schmitt
+Raphael Deem
 Raphael Pierzina
 Raquel Alegre
 Roberto Polli

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -7,6 +7,8 @@ import _pytest
 import _pytest._code
 import py
 import pytest
+import logging
+
 try:
     from collections import MutableMapping as MappingMixin
 except ImportError:
@@ -86,6 +88,7 @@ def pytest_configure(config):
 
 def wrap_session(config, doit):
     """Skeleton command line program"""
+
     session = Session(config)
     session.exitstatus = EXIT_OK
     initstate = 0
@@ -141,6 +144,8 @@ def pytest_collection(session):
     return session.perform_collect()
 
 def pytest_runtestloop(session):
+    for handler in logging.root.handlers[:]:
+        logging.root.removeHandler(handler)
     if (session.testsfailed and
             not session.config.option.continue_on_collection_errors):
         raise session.Interrupted(

--- a/testing/test_log1.py
+++ b/testing/test_log1.py
@@ -1,0 +1,12 @@
+from io import StringIO
+import logging
+
+# This tests that basicConfig settings from test_log2.py don't
+# interfere with those from this test
+def test_log():
+    log_stream = StringIO()
+    logging.basicConfig(stream=log_stream, level=logging.INFO)
+    log = logging.getLogger()
+
+    log.warn('test')
+    assert log_stream.getvalue() == 'WARNING:root:test\n'

--- a/testing/test_log2.py
+++ b/testing/test_log2.py
@@ -1,0 +1,10 @@
+import logging
+
+# This tests that basicConfig settings from test_log1.py don't
+# interfere with those from this test
+logging.basicConfig()
+log = logging.getLogger()
+def test_foo():
+    foo = 1
+    log.warn(foo)
+    assert foo == 1


### PR DESCRIPTION
Addresses #2158 which qualifies as a bug to me. Hence target should be master. The implementation is not ideal: it clears module level logging settings, whereas ideally those would be preserved. However, I think it's better than the current behavior, where the module settings overlap between different tests.