### PR TITLE
Allow trial environments to fail on CI for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ env:
 
 matrix:
   allow_failures:
-    # py35-trial failing on Linux: #1989
+    # see #1989
+    - env: TESTENV=py27-trial
     - env: TESTENV=py35-trial
 
 script: tox --recreate -e $TESTENV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,12 @@ environment:
   - TOXENV: "freeze"
   - TOXENV: "docs"
 
+matrix:
+  allow_failures:
+    # see #1989
+    - TOXENV: "py27-trial"
+    - TOXENV: "py35-trial"
+
 install:
   - echo Installed Pythons
   - dir c:\Python*


### PR DESCRIPTION
While I agree this is *far* from ideal, IMHO It is better to ignore them for now otherwise we hamper contributors with unrelated errors.

We should fix this before the next release.

Related to #1989
