### PR TITLE
pytest.warns checks for subclass relationship rather than class equality

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,11 +42,8 @@ Changes
 .. _@fushi: https://github.com/fushi
 .. _@mattduck: https://github.com/mattduck
 .. _@wheerd: https://github.com/wheerd
-<<<<<<< HEAD
 .. _@fogo: https://github.com/fogo
-=======
 .. _@lesteve: https://github.com/lesteve
->>>>>>> pytest.warns checks for subclass relationship
 
 .. _#1512: https://github.com/pytest-dev/pytest/issues/1512
 .. _#1874: https://github.com/pytest-dev/pytest/pull/1874

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,7 +71,6 @@ Changes
 
 *
 
-.. _@lesteve: https://github.com/lesteve
 .. _@malinoff: https://github.com/malinoff
 .. _@pelme: https://github.com/pelme
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,8 @@ New Features
 
 * pytest now warns when a callable ids raises in a parametrized test. Thanks `@fogo`_ for the PR.
 
-*
+* ``pytest.warns`` now checks for subclass relationship rather than
+  class equality. Thanks `@lesteve`_ for the PR (`#2166`_)
 
 
 Changes
@@ -41,7 +42,11 @@ Changes
 .. _@fushi: https://github.com/fushi
 .. _@mattduck: https://github.com/mattduck
 .. _@wheerd: https://github.com/wheerd
+<<<<<<< HEAD
 .. _@fogo: https://github.com/fogo
+=======
+.. _@lesteve: https://github.com/lesteve
+>>>>>>> pytest.warns checks for subclass relationship
 
 .. _#1512: https://github.com/pytest-dev/pytest/issues/1512
 .. _#1874: https://github.com/pytest-dev/pytest/pull/1874
@@ -49,7 +54,7 @@ Changes
 .. _#2007: https://github.com/pytest-dev/pytest/issues/2007
 .. _#2013: https://github.com/pytest-dev/pytest/issues/2013
 .. _#2101: https://github.com/pytest-dev/pytest/pull/2101
-
+.. _#2166: https://github.com/pytest-dev/pytest/pull/2166
 
 3.0.6.dev0 (unreleased)
 =======================

--- a/_pytest/recwarn.py
+++ b/_pytest/recwarn.py
@@ -216,7 +216,8 @@ class WarningsChecker(WarningsRecorder):
         # only check if we're not currently handling an exception
         if all(a is None for a in exc_info):
             if self.expected_warning is not None:
-                if not any(r.category in self.expected_warning for r in self):
+                if not any(issubclass(r.category, exp_warning) for
+                           exp_warning in self.expected_warning for r in self):
                     __tracebackhide__ = True
                     pytest.fail("DID NOT WARN. No warnings of type {0} was emitted. "
                                 "The list of emitted warnings is: {1}.".format(

--- a/_pytest/recwarn.py
+++ b/_pytest/recwarn.py
@@ -216,8 +216,8 @@ class WarningsChecker(WarningsRecorder):
         # only check if we're not currently handling an exception
         if all(a is None for a in exc_info):
             if self.expected_warning is not None:
-                if not any(issubclass(r.category, exp_warning) for
-                           exp_warning in self.expected_warning for r in self):
+                if not any(issubclass(r.category, self.expected_warning)
+                           for r in self):
                     __tracebackhide__ = True
                     pytest.fail("DID NOT WARN. No warnings of type {0} was emitted. "
                                 "The list of emitted warnings is: {1}.".format(

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -247,6 +247,17 @@ class TestWarns(object):
         assert str(record[0].message) == "user"
         assert str(record[1].message) == "runtime"
 
+        class MyUserWarning(UserWarning): pass
+        class MyRuntimeWarning(RuntimeWarning): pass
+
+        with pytest.warns((UserWarning, RuntimeWarning)) as record:
+            warnings.warn("user", MyUserWarning)
+            warnings.warn("runtime", MyRuntimeWarning)
+
+        assert len(record) == 2
+        assert str(record[0].message) == "user"
+        assert str(record[1].message) == "runtime"
+
 
     def test_double_test(self, testdir):
         """If a test is run again, the warning should still be raised"""

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -248,6 +248,7 @@ class TestWarns(object):
         assert str(record[1].message) == "runtime"
 
         class MyUserWarning(UserWarning): pass
+
         class MyRuntimeWarning(RuntimeWarning): pass
 
         with pytest.warns((UserWarning, RuntimeWarning)) as record:

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -238,6 +238,16 @@ class TestWarns(object):
         assert str(record[0].message) == "user"
         assert str(record[1].message) == "runtime"
 
+    def test_record_by_subclass(self):
+        with pytest.warns(Warning) as record:
+            warnings.warn("user", UserWarning)
+            warnings.warn("runtime", RuntimeWarning)
+
+        assert len(record) == 2
+        assert str(record[0].message) == "user"
+        assert str(record[1].message) == "runtime"
+
+
     def test_double_test(self, testdir):
         """If a test is run again, the warning should still be raised"""
         testdir.makepyfile('''


### PR DESCRIPTION
This makes it more similar to pytest.raises. Fixes #2151.