### PR TITLE
No longer silently ignore errors in parametrize callable ids

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ New Features
 * Added an ini option ``doctest_encoding`` to specify which encoding to use for doctest files.
   Thanks `@wheerd`_ for the PR (`#2101`_).
 
+* pytest now warns when a callable ids raises in a parametrized test. Thanks `@fogo`_ for the PR.
+
 *
 
 
@@ -39,6 +41,7 @@ Changes
 .. _@fushi: https://github.com/fushi
 .. _@mattduck: https://github.com/mattduck
 .. _@wheerd: https://github.com/wheerd
+.. _@fogo: https://github.com/fogo
 
 .. _#1512: https://github.com/pytest-dev/pytest/issues/1512
 .. _#1874: https://github.com/pytest-dev/pytest/pull/1874

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -928,12 +928,17 @@ def _find_parametrized_scope(argnames, arg2fixturedefs, indirect):
 
 def _idval(val, argname, idx, idfn, config=None):
     if idfn:
+        s = None
         try:
             s = idfn(val)
-            if s:
-                return _escape_strings(s)
         except Exception:
-            pass
+            # See issue https://github.com/pytest-dev/pytest/issues/2169
+            import warnings
+            msg = "Raised while trying to determine id of parameter %s at position %d." % (argname, idx)
+            msg += '\nUpdate your code as this will raise an error in pytest-4.0.'
+            warnings.warn(msg)
+        if s:
+            return _escape_strings(s)
 
     if config:
         hook_id = config.hook.pytest_make_parametrize_id(config=config, val=val)


### PR DESCRIPTION
I had recently an issue with a complex parametrized test with a callable `ids`. The `ids` function was wrong but it took me sometime to notice as pytest was silently swallowing any errors when it was called.

I changed the code necessary so this won't happen anymore and modified/created some tests.

One more thing though, a question for you, guys: I tried to do some kind of `raise...from` with a better exception with fixture name but the meta-function information doesn't propagate up to ids function (unlike the `config` object, which happens to be available there, though it isn't mandatory). If the meta-function got there it'd probably be possible to be way clearer about error, what do you think about this?
