### PR TITLE
Execute 'async def' test functions

### DIFF
--- a/_pytest/compat.py
+++ b/_pytest/compat.py
@@ -227,6 +227,13 @@ def _is_unittest_unexpected_success_a_failure():
     return sys.version_info >= (3, 4)
 
 
+if hasattr(inspect, 'isawaitable'):
+    isawaitable = inspect.isawaitable
+else:
+    def isawaitable(f):
+        return False
+
+
 if _PY3:
     def safe_str(v):
         """returns v as string"""

--- a/testing/test_async.py
+++ b/testing/test_async.py
@@ -1,0 +1,14 @@
+import sys
+
+import pytest
+
+
+@pytest.mark.skipif(sys.version_info < (3, 5), reason='async syntax available in Python 3.5+')
+def test_async_function(testdir):
+    testdir.makepyfile("""
+        async def test_async_function_py35():
+            assert False
+    """)
+    # avoid importing asyncio into pytest's own process, which in turn imports logging (#8)
+    result = testdir.runpytest_subprocess()
+    result.stdout.fnmatch_lines(['*1 failed*'])


### PR DESCRIPTION
pytest didn't use the result of test functions but `async def` functions return an awaitable object.

Though `async def` functions were just passed like they don't have any problem, their codes actually didn't run. For users, it was really hard to detect the tests really were run or not.

This patch makes to check the result of test functions and if it is an awaitable object then actually run the functions to ensure its code is run.

----
Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Target: for bug or doc fixes, target `master`; for new features, target `features`;

Unless your change is trivial documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Make sure to include one or more tests for your change;
- [ ] Add yourself to `AUTHORS`;
- [ ] Add a new entry to `CHANGELOG.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using RST syntax.
  * The pytest team likes to have people to acknowledged in the `CHANGELOG`, so please add a thank note to yourself ("Thanks @user for the PR") and a link to your GitHub profile. It may sound weird thanking yourself, but otherwise a maintainer would have to do it manually before or after merging instead of just using GitHub's merge button. This makes it easier on the maintainers to merge PRs. 
