### PR TITLE
Add --pep420-mode to deal with PEP 420

### DIFF
--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -84,6 +84,17 @@ def pytest_addoption(parser):
         help="prepend/append to sys.path when importing test modules, "
              "default is to prepend.")
 
+    group.addoption("--pep420-mode", action="store_true", default=False,
+        help="by default, the module name by which a discovered test module "
+             "is imported is determined by traversing the file system "
+             "upwards from the module path as long as an __init__.py is "
+             "found. In this mode, the traversal will instead stop when it "
+             "encounters a directory that is in sys.path. This is useful "
+             "when PEP 420 implicit namespace packages are present, which "
+             "lack an __init__.py, but requires you as a user to ensure "
+             "that sys.path is configured property (typically that it "
+             "contains your project root directory)")
+
 
 def pytest_cmdline_main(config):
     if config.option.showfixtures:
@@ -402,6 +413,30 @@ def transfer_markers(funcobj, cls, mod):
             if not _marked(funcobj, pytestmark):
                 pytestmark(funcobj)
 
+
+def pyimport420(path):
+    def isimportable(name):
+        if name and (name[0].isalpha() or name[0] == '_'):
+            name = name.replace("_", '')
+        return not name or name.isalnum()
+
+    def pypkgpath(path):
+        sys_path = [py.path.local(p) for p in sys.path]
+        pkgpath = None
+        for parent in path.parts(reverse=True):
+            if parent.isdir():
+                pkgpath = parent
+                if parent in sys_path:
+                    break
+                if not isimportable(parent.basename):
+                    break
+        return pkgpath
+
+    modname = ".".join(path.new(ext="").relto(pypkgpath(path)).split(path.sep))
+    __import__(modname)
+    return sys.modules[modname]
+
+
 class Module(pytest.File, PyCollector):
     """ Collector for test classes and functions. """
     def _getobj(self):
@@ -415,7 +450,10 @@ class Module(pytest.File, PyCollector):
         # we assume we are only called once per module
         importmode = self.config.getoption("--import-mode")
         try:
-            mod = self.fspath.pyimport(ensuresyspath=importmode)
+            if self.config.getoption("--pep420-mode"):
+                mod = pyimport420(self.fspath)
+            else:
+                mod = self.fspath.pyimport(ensuresyspath=importmode)
         except SyntaxError:
             raise self.CollectError(
                 _pytest._code.ExceptionInfo().getrepr(style="short"))


### PR DESCRIPTION
A note at [Good Integration Practices](http://doc.pytest.org/en/latest/goodpractices.html) has the following to say about PEP 420:

```text
You can use Python3 namespace packages (PEP420) for your application but pytest
will still perform test package name discovery based on the presence of __init__.py
files. If you use one of the two recommended file system layouts above but leave away
the __init__.py files from your directories it should just work on Python3.3 and above.
From “inlined tests”, however, you will need to use absolute imports for getting at
your application code.
```

But contrary to this, the presence of PEP-420 namespace packages is problematic.

Consider this project `proj`, which provides a package `pkg` in the PEP 420 namespace package `suite`:

```
proj
proj/suite
proj/suite/pkg
proj/suite/pkg/tests
proj/suite/pkg/tests/test_foo.py
proj/suite/pkg/tests/__init__.py
proj/suite/pkg/foo.py
proj/suite/pkg/__init__.py
proj/setup.py
```

**foo.py**
```python
def func():
    return 'foo'
```

**test_foo.py**
```python
import sys

from suite.pkg.foo import func

def test_func():
    assert func() == 'foo'
```

A simple `py.test` in the project directory will fail, as expected, during the import of `test_foo.py` with `ImportError: No module named 'suite'`, because `pytest` will prepend `/path/to/proj/suite` to `sys.path`, not `/path/to/proj` (the upwards traversal when determining the test module name, and the path to prepend, stopped at `suite`).

The simple solution is to manually add `/path/to/proj` to `PYTHONPATH`. This "fixes" the problem (the `import` in the test will now work), but is less than ideal, because having `/path/to/proj/suite` in `sys.path` (which is still there as well, and needs to be there since `pytest` will import `test_foo.py` by the name `pkg.tests.test_foo`) could lead to nasty surprises.

This pull request adds a `--pep420-mode`, in which the traversal when determining the module name is not based on the presence of `__init__.py`, but instead stops when it hits a directory that is in `sys.path`. The mode is intended for when you have PEP 420 namespace packages, and when using this mode it is your responsibility to ensure `sys.path` has the appropriate path(s) (typically your project root).

It's not meant to be merged as-is, but is meant to start a discussion about how `py.test` should handle the presence of PEP 420 packages. What do you think, could a mode like this be a good solution?

I don't think `pytest` can do correct "file system path" -> "dotted module name" deduction in the presence of PEP 420 packages without some form of additional user input (such as configuring `PYTHONPATH` properly). I know `setuptools` is also struggling with PEP 420 in its [issue 97](https://github.com/pypa/setuptools/issues/97).