### PR TITLE
Refactored old style classes to new style classes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -87,6 +87,7 @@ Lukas Bednar
 Luke Murphy
 Maciek Fijalkowski
 Maho
+Mandeep Bhutani
 Manuel Krebber
 Marc Schlaich
 Marcin Bachry

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ New Features
 Changes
 -------
 
+* Old-style classes have been changed to new-style classes in order to improve
+  compatability with Python 2. Thanks to `@mandeep`_ for the PR (`#2147`_).
+
 * It is now possible to skip test classes from being collected by setting a
   ``__test__`` attribute to ``False`` in the class body (`#2007`_). Thanks
   to `@syre`_ for the report and `@lwm`_ for the PR.
@@ -44,6 +47,7 @@ Changes
 .. _@wheerd: https://github.com/wheerd
 .. _@fogo: https://github.com/fogo
 .. _@lesteve: https://github.com/lesteve
+.. _@mandeep: https://github.com/mandeep
 
 .. _#1512: https://github.com/pytest-dev/pytest/issues/1512
 .. _#1874: https://github.com/pytest-dev/pytest/pull/1874
@@ -52,6 +56,7 @@ Changes
 .. _#2013: https://github.com/pytest-dev/pytest/issues/2013
 .. _#2101: https://github.com/pytest-dev/pytest/pull/2101
 .. _#2166: https://github.com/pytest-dev/pytest/pull/2166
+.. _#2147: https://github.com/pytest-dev/pytest/issues/2147
 
 3.0.6.dev0 (unreleased)
 =======================

--- a/_pytest/_argcomplete.py
+++ b/_pytest/_argcomplete.py
@@ -62,7 +62,7 @@ import sys
 import os
 from glob import glob
 
-class FastFilesCompleter:
+class FastFilesCompleter(object):
     'Fast file completer class'
     def __init__(self, directories=True):
         self.directories = directories

--- a/_pytest/assertion/__init__.py
+++ b/_pytest/assertion/__init__.py
@@ -59,7 +59,7 @@ class DummyRewriteHook(object):
         pass
 
 
-class AssertionState:
+class AssertionState(object):
     """State for the assertion plugin."""
 
     def __init__(self, config, mode):

--- a/_pytest/cacheprovider.py
+++ b/_pytest/cacheprovider.py
@@ -87,7 +87,7 @@ class Cache(object):
                 json.dump(value, f, indent=2, sort_keys=True)
 
 
-class LFPlugin:
+class LFPlugin(object):
     """ Plugin which implements the --lf (run last-failing) option """
     def __init__(self, config):
         self.config = config

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -57,7 +57,7 @@ def pytest_load_initial_conftests(early_config, parser, args):
         sys.stderr.write(err)
 
 
-class CaptureManager:
+class CaptureManager(object):
     def __init__(self, method):
         self._method = method
 
@@ -182,7 +182,7 @@ def capfd(request):
     return c
 
 
-class CaptureFixture:
+class CaptureFixture(object):
     def __init__(self, captureclass, request):
         self.captureclass = captureclass
         self.request = request
@@ -315,10 +315,10 @@ class MultiCapture(object):
         return (self.out.snap() if self.out is not None else "",
                 self.err.snap() if self.err is not None else "")
 
-class NoCapture:
+class NoCapture(object):
     __init__ = start = done = suspend = resume = lambda *args: None
 
-class FDCapture:
+class FDCapture(object):
     """ Capture IO to/from a given os-level filedescriptor. """
 
     def __init__(self, targetfd, tmpfile=None):
@@ -394,7 +394,7 @@ class FDCapture:
         os.write(self.targetfd_save, data)
 
 
-class SysCapture:
+class SysCapture(object):
     def __init__(self, fd, tmpfile=None):
         name = patchsysdict[fd]
         self._old = getattr(sys, name)
@@ -432,7 +432,7 @@ class SysCapture:
         self._old.flush()
 
 
-class DontReadFromInput:
+class DontReadFromInput(object):
     """Temporary stub class.  Ideally when stdin is accessed, the
     capturing should be turned off, with possibly all data captured
     so far sent to the screen.  This should be configurable, though,

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -62,7 +62,7 @@ def main(args=None, plugins=None):
             sys.stderr.write("ERROR: %s\n" %(msg,))
         return 4
 
-class cmdline:  # compatibility namespace
+class cmdline(object):  # compatibility namespace
     main = staticmethod(main)
 
 
@@ -447,7 +447,7 @@ class PytestPluginManager(PluginManager):
             self.consider_module(mod)
 
 
-class Parser:
+class Parser(object):
     """ Parser for command line arguments and ini-file values.
 
     :ivar extra_info: dict of generic param -> value to display in case
@@ -582,7 +582,7 @@ class ArgumentError(Exception):
             return self.msg
 
 
-class Argument:
+class Argument(object):
     """class that mimics the necessary behaviour of optparse.Option
 
     its currently a least effort implementation
@@ -712,7 +712,7 @@ class Argument:
         return 'Argument({0})'.format(', '.join(args))
 
 
-class OptionGroup:
+class OptionGroup(object):
     def __init__(self, name, description="", parser=None):
         self.name = name
         self.description = description
@@ -838,7 +838,7 @@ class CmdOptions(object):
     def copy(self):
         return CmdOptions(self.__dict__)
 
-class Notset:
+class Notset(object):
     def __repr__(self):
         return "<NOTSET>"
 

--- a/_pytest/debugging.py
+++ b/_pytest/debugging.py
@@ -43,7 +43,7 @@ def pytest_configure(config):
     pytestPDB._pdb_cls = pdb_cls
     config._cleanup.append(fin)
 
-class pytestPDB:
+class pytestPDB(object):
     """ Pseudo PDB that defers to the real pdb. """
     _pluginmanager = None
     _config = None
@@ -64,7 +64,7 @@ class pytestPDB:
         self._pdb_cls().set_trace(frame)
 
 
-class PdbInvoke:
+class PdbInvoke(object):
     def pytest_exception_interact(self, node, call, report):
         capman = node.config.pluginmanager.getplugin("capturemanager")
         if capman:

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -222,7 +222,7 @@ def slice_items(items, ignore, scoped_argkeys_cache):
 
 
 
-class FuncargnamesCompatAttr:
+class FuncargnamesCompatAttr(object):
     """ helper class so that Metafunc, Function and FixtureRequest
     don't need to each define the "funcargnames" compatibility attribute.
     """
@@ -258,7 +258,7 @@ def fillfixtures(function):
 def get_direct_param_fixture_func(request):
     return request.param
 
-class FuncFixtureInfo:
+class FuncFixtureInfo(object):
     def __init__(self, argnames, names_closure, name2fixturedefs):
         self.argnames = argnames
         self.names_closure = names_closure
@@ -456,7 +456,7 @@ class FixtureRequest(FuncargnamesCompatAttr):
                 fixturedef = self._getnextfixturedef(argname)
             except FixtureLookupError:
                 if argname == "request":
-                    class PseudoFixtureDef:
+                    class PseudoFixtureDef(object):
                         cached_result = (self, [0], None)
                         scope = "function"
                     return PseudoFixtureDef
@@ -723,7 +723,7 @@ def call_fixture_func(fixturefunc, request, kwargs):
     return res
 
 
-class FixtureDef:
+class FixtureDef(object):
     """ A container for a factory definition. """
     def __init__(self, fixturemanager, baseid, argname, func, scope, params,
                  unittest=False, ids=None):
@@ -822,7 +822,7 @@ def pytest_fixture_setup(fixturedef, request):
     return result
 
 
-class FixtureFunctionMarker:
+class FixtureFunctionMarker(object):
     def __init__(self, scope, params, autouse=False, ids=None, name=None):
         self.scope = scope
         self.params = params
@@ -909,7 +909,7 @@ def pytestconfig(request):
     return request.config
 
 
-class FixtureManager:
+class FixtureManager(object):
     """
     pytest fixtures definitions and information is stored and managed
     from this class.

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -179,7 +179,7 @@ def pytest_ignore_collect(path, config):
     return False
 
 
-class FSHookProxy:
+class FSHookProxy(object):
     def __init__(self, fspath, pm, remove_mods):
         self.fspath = fspath
         self.pm = pm

--- a/_pytest/mark.py
+++ b/_pytest/mark.py
@@ -99,7 +99,7 @@ def pytest_collection_modifyitems(items, config):
         items[:] = remaining
 
 
-class MarkMapping:
+class MarkMapping(object):
     """Provides a local mapping for markers where item access
     resolves to True if the marker is present. """
     def __init__(self, keywords):
@@ -113,7 +113,7 @@ class MarkMapping:
         return name in self._mymarks
 
 
-class KeywordMapping:
+class KeywordMapping(object):
     """Provides a local mapping for keywords.
     Given a list of names, map any substring of one of these names to True.
     """
@@ -173,7 +173,7 @@ def pytest_configure(config):
         pytest.mark._config = config
 
 
-class MarkGenerator:
+class MarkGenerator(object):
     """ Factory for :class:`MarkDecorator` objects - exposed as
     a ``pytest.mark`` singleton instance.  Example::
 
@@ -210,7 +210,7 @@ def istestfunc(func):
     return hasattr(func, "__call__") and \
         getattr(func, "__name__", "<lambda>") != "<lambda>"
 
-class MarkDecorator:
+class MarkDecorator(object):
     """ A decorator for test functions and test classes.  When applied
     it will create :class:`MarkInfo` objects which may be
     :ref:`retrieved by hooks as item keywords <excontrolskip>`.

--- a/_pytest/monkeypatch.py
+++ b/_pytest/monkeypatch.py
@@ -88,7 +88,7 @@ def derive_importpath(import_path, raising):
     return attr, target
 
 
-class Notset:
+class Notset(object):
     def __repr__(self):
         return "<notset>"
 
@@ -96,7 +96,7 @@ class Notset:
 notset = Notset()
 
 
-class MonkeyPatch:
+class MonkeyPatch(object):
     """ Object returned by the ``monkeypatch`` fixture keeping a record of setattr/item/env/syspath changes.
     """
 

--- a/_pytest/pytester.py
+++ b/_pytest/pytester.py
@@ -165,7 +165,7 @@ def _pytest(request):
     """
     return PytestArg(request)
 
-class PytestArg:
+class PytestArg(object):
     def __init__(self, request):
         self.request = request
 
@@ -180,7 +180,7 @@ def get_public_names(l):
     return [x for x in l if x[0] != "_"]
 
 
-class ParsedCall:
+class ParsedCall(object):
     def __init__(self, name, kwargs):
         self.__dict__.update(kwargs)
         self._name = name
@@ -191,7 +191,7 @@ class ParsedCall:
         return "<ParsedCall %r(**%r)>" %(self._name, d)
 
 
-class HookRecorder:
+class HookRecorder(object):
     """Record all hooks called in a plugin manager.
 
     This wraps all the hook calls in the plugin manager, recording
@@ -335,7 +335,7 @@ def testdir(request, tmpdir_factory):
 
 
 rex_outcome = re.compile("(\d+) ([\w-]+)")
-class RunResult:
+class RunResult(object):
     """The result of running a command.
 
     Attributes:
@@ -380,7 +380,7 @@ class RunResult:
 
 
 
-class Testdir:
+class Testdir(object):
     """Temporary test directory with tools to test/run pytest itself.
 
     This is based on the ``tmpdir`` fixture but provides a number of
@@ -707,7 +707,7 @@ class Testdir:
 
         rec = []
 
-        class Collect:
+        class Collect(object):
             def pytest_configure(x, config):
                 rec.append(self.make_hook_recorder(config.pluginmanager))
 
@@ -718,7 +718,7 @@ class Testdir:
         if len(rec) == 1:
             reprec = rec.pop()
         else:
-            class reprec:
+            class reprec(object):
                 pass
         reprec.ret = ret
 
@@ -742,13 +742,13 @@ class Testdir:
                 reprec = self.inline_run(*args, **kwargs)
             except SystemExit as e:
 
-                class reprec:
+                class reprec(object):
                     ret = e.args[0]
 
             except Exception:
                 traceback.print_exc()
 
-                class reprec:
+                class reprec(object):
                     ret = 3
         finally:
             out, err = capture.reset()
@@ -1033,7 +1033,7 @@ def getdecoded(out):
                     py.io.saferepr(out),)
 
 
-class LineComp:
+class LineComp(object):
     def __init__(self):
         self.stringio = py.io.TextIO()
 
@@ -1049,7 +1049,7 @@ class LineComp:
         return LineMatcher(lines1).fnmatch_lines(lines2)
 
 
-class LineMatcher:
+class LineMatcher(object):
     """Flexible matching of text.
 
     This is a convenience class to test large texts like the output of

--- a/_pytest/runner.py
+++ b/_pytest/runner.py
@@ -55,7 +55,7 @@ def pytest_sessionstart(session):
 def pytest_sessionfinish(session):
     session._setupstate.teardown_all()
 
-class NodeInfo:
+class NodeInfo(object):
     def __init__(self, location):
         self.location = location
 
@@ -150,7 +150,7 @@ def call_runtest_hook(item, when, **kwds):
     ihook = getattr(item.ihook, hookname)
     return CallInfo(lambda: ihook(item=item, **kwds), when=when)
 
-class CallInfo:
+class CallInfo(object):
     """ Result/Exception info a function invocation. """
     #: None or ExceptionInfo object.
     excinfo = None

--- a/_pytest/skipping.py
+++ b/_pytest/skipping.py
@@ -72,7 +72,7 @@ def xfail(reason=""):
 xfail.Exception = XFailed
 
 
-class MarkEvaluator:
+class MarkEvaluator(object):
     def __init__(self, item, name):
         self.item = item
         self.name = name

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -80,7 +80,7 @@ def pytest_report_teststatus(report):
             letter = "f"
     return report.outcome, letter, report.outcome.upper()
 
-class WarningReport:
+class WarningReport(object):
     def __init__(self, code, message, nodeid=None, fslocation=None):
         self.code = code
         self.message = message
@@ -88,7 +88,7 @@ class WarningReport:
         self.fslocation = fslocation
 
 
-class TerminalReporter:
+class TerminalReporter(object):
     def __init__(self, config, file=None):
         import _pytest.config
         self.config = config

--- a/_pytest/tmpdir.py
+++ b/_pytest/tmpdir.py
@@ -6,7 +6,7 @@ import py
 from _pytest.monkeypatch import MonkeyPatch
 
 
-class TempdirFactory:
+class TempdirFactory(object):
     """Factory for temporary directories under the common base temp directory.
 
     The base directory can be configured using the ``--basetemp`` option.

--- a/_pytest/vendored_packages/pluggy.py
+++ b/_pytest/vendored_packages/pluggy.py
@@ -75,7 +75,7 @@ __all__ = ["PluginManager", "PluginValidationError", "HookCallError",
 _py3 = sys.version_info > (3, 0)
 
 
-class HookspecMarker:
+class HookspecMarker(object):
     """ Decorator helper class for marking functions as hook specifications.
 
     You can instantiate it with a project_name to get a decorator.
@@ -113,7 +113,7 @@ class HookspecMarker:
             return setattr_hookspec_opts
 
 
-class HookimplMarker:
+class HookimplMarker(object):
     """ Decorator helper class for marking functions as hook implementations.
 
     You can instantiate with a project_name to get a decorator.
@@ -770,7 +770,7 @@ class _HookCaller(object):
                     proc(res[0])
 
 
-class HookImpl:
+class HookImpl(object):
     def __init__(self, plugin, plugin_name, function, hook_impl_opts):
         self.function = function
         self.argnames = varnames(self.function)


### PR DESCRIPTION
Added (object) to the end of class names as discussed in #2147. I searched the pytest package folder with the regex "class [A-Z]\w*(?<!\():" and added (object) before the colon of each class. The tests passed as expected. Thoughts?