### PR TITLE
Ensure the LICENSE is included in built wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,5 +9,8 @@ upload-dir = doc/en/build/html
 [bdist_wheel]
 universal = 1
 
+[metadata]
+license_file = LICENSE
+
 [devpi:upload]
 formats = sdist.tgz,bdist_wheel


### PR DESCRIPTION
Otherwise it is not included by default as wheels do not honor the MANIFEST.in

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>