### PR TITLE
Fail assert_outcomes() on missing terminal report

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -141,3 +141,4 @@ Tyler Goodlet
 Vasily Kuznetsov
 Wouter van Ackooy
 Xuecong Liao
+Eli Boyarski

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,11 +14,15 @@
   subdirectories with ini configuration files now uses the correct ini file
   (`#2148`_).  Thanks `@pelme`_.
 
+* Fail ``testdir.runpytest().assert_outcomes()`` explicitly if the pytest
+  terminal output it relies on is missing. Thanks to `@eli-b`_ for the PR.
+
 *
 
 .. _@lesteve: https://github.com/lesteve
 .. _@malinoff: https://github.com/malinoff
 .. _@pelme: https://github.com/pelme
+.. _@eli-b: https://github.com/eli-b
 
 .. _#2129: https://github.com/pytest-dev/pytest/issues/2129
 .. _#2148: https://github.com/pytest-dev/pytest/issues/2148

--- a/_pytest/pytester.py
+++ b/_pytest/pytester.py
@@ -367,6 +367,7 @@ class RunResult:
                     for num, cat in outcomes:
                         d[cat] = int(num)
                     return d
+        raise ValueError("Pytest terminal report not found")
 
     def assert_outcomes(self, passed=0, skipped=0, failed=0):
         """ assert that the specified outcomes appear with the respective

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -124,3 +124,10 @@ def test_inline_run_clean_modules(testdir):
     test_mod.write("def test_foo(): assert False")
     result2 = testdir.inline_run(str(test_mod))
     assert result2.ret == EXIT_TESTSFAILED
+
+def test_assert_outcomes_after_pytest_erro(testdir):
+    testdir.makepyfile("def test_foo(): assert True")
+
+    result = testdir.runpytest('--unexpected-argument')
+    with pytest.raises(ValueError, message="Pytest terminal report not found"):
+        result.assert_outcomes(passed=0)


### PR DESCRIPTION
Currently if the terminal report of testdir.runpytest() is missing,
assert_outcomes() on its output fails because parseoutcomes()
returns an unexpected value (None).
It's better to fail parseoutcomes() directly.
