### PR TITLE
Enhancement to `make_parametrize_id`hook function

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -120,6 +120,7 @@ Quentin Pradet
 Ralf Schmitt
 Raphael Pierzina
 Raquel Alegre
+Ravi Chandra
 Roberto Polli
 Romain Dorgueil
 Roman Bolshakov

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,10 +79,15 @@ Changes
   subdirectories with ini configuration files now uses the correct ini file
   (`#2148`_).  Thanks `@pelme`_.
 
+* Modify ``pytest_make_parametrize_id()`` hook to accept ``argname`` as an
+  additional parameter.
+  Thanks `@unsignedint`_ for the PR.
+
 *
 
 .. _@malinoff: https://github.com/malinoff
 .. _@pelme: https://github.com/pelme
+.. _@unsignedint: https://github.com/unsignedint
 
 .. _#2129: https://github.com/pytest-dev/pytest/issues/2129
 .. _#2148: https://github.com/pytest-dev/pytest/issues/2148

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,10 @@ Changes
 * fix `#2208`_: ensure a iteration limit for _pytest.compat.get_real_func.
   Thanks `@RonnyPfannschmidt`_ for the Report and PR
 
+* Modify ``pytest_make_parametrize_id()`` hook to accept ``argname`` as an
+  additional parameter.
+  Thanks `@unsignedint`_ for the PR.
+
 
 .. _@davidszotten: https://github.com/davidszotten
 .. _@fushi: https://github.com/fushi
@@ -52,6 +56,7 @@ Changes
 .. _@fogo: https://github.com/fogo
 .. _@lesteve: https://github.com/lesteve
 .. _@mandeep: https://github.com/mandeep
+.. _@unsignedint: https://github.com/unsignedint
 
 .. _#1512: https://github.com/pytest-dev/pytest/issues/1512
 .. _#1874: https://github.com/pytest-dev/pytest/pull/1874
@@ -79,15 +84,10 @@ Changes
   subdirectories with ini configuration files now uses the correct ini file
   (`#2148`_).  Thanks `@pelme`_.
 
-* Modify ``pytest_make_parametrize_id()`` hook to accept ``argname`` as an
-  additional parameter.
-  Thanks `@unsignedint`_ for the PR.
-
 *
 
 .. _@malinoff: https://github.com/malinoff
 .. _@pelme: https://github.com/pelme
-.. _@unsignedint: https://github.com/unsignedint
 
 .. _#2129: https://github.com/pytest-dev/pytest/issues/2129
 .. _#2148: https://github.com/pytest-dev/pytest/issues/2148

--- a/_pytest/hookspec.py
+++ b/_pytest/hookspec.py
@@ -157,9 +157,10 @@ def pytest_generate_tests(metafunc):
     """ generate (multiple) parametrized calls to a test function."""
 
 @hookspec(firstresult=True)
-def pytest_make_parametrize_id(config, val):
+def pytest_make_parametrize_id(config, val, argname=None):
     """Return a user-friendly string representation of the given ``val`` that will be used
     by @pytest.mark.parametrize calls. Return None if the hook doesn't know about ``val``.
+    The parameter name is available as ``argname``, if required.
     """
 
 # -------------------------------------------------------------------------

--- a/_pytest/hookspec.py
+++ b/_pytest/hookspec.py
@@ -157,7 +157,7 @@ def pytest_generate_tests(metafunc):
     """ generate (multiple) parametrized calls to a test function."""
 
 @hookspec(firstresult=True)
-def pytest_make_parametrize_id(config, val, argname=None):
+def pytest_make_parametrize_id(config, val, argname):
     """Return a user-friendly string representation of the given ``val`` that will be used
     by @pytest.mark.parametrize calls. Return None if the hook doesn't know about ``val``.
     The parameter name is available as ``argname``, if required.

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -197,7 +197,7 @@ def pytest_pycollect_makeitem(collector, name, obj):
                 res = list(collector._genfunctions(name, obj))
             outcome.force_result(res)
 
-def pytest_make_parametrize_id(config, val):
+def pytest_make_parametrize_id(config, val, argname=None):
     return None
 
 
@@ -941,7 +941,8 @@ def _idval(val, argname, idx, idfn, config=None):
             return _escape_strings(s)
 
     if config:
-        hook_id = config.hook.pytest_make_parametrize_id(config=config, val=val)
+        hook_id = config.hook.pytest_make_parametrize_id(
+            config=config, val=val, argname=argname)
         if hook_id:
             return hook_id
 

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1455,3 +1455,26 @@ class TestMarkersWithParametrization:
             "*test_func*0*PASS*",
             "*test_func*2*PASS*",
         ])
+
+    def test_pytest_make_parametrize_id_with_argname(self, testdir):
+        testdir.makeconftest("""
+            def pytest_make_parametrize_id(config, val, argname):
+                return str(val * 2 if argname == 'x' else val * 10)
+        """)
+        testdir.makepyfile("""
+                import pytest
+
+                @pytest.mark.parametrize("x", range(2))
+                def test_func(x):
+                    pass
+
+                @pytest.mark.parametrize("y", [1])
+                def test_func2(y):
+                    pass
+                """)
+        result = testdir.runpytest("-v")
+        result.stdout.fnmatch_lines([
+            "*test_func*0*PASS*",
+            "*test_func*2*PASS*",
+            "*test_func2*10*PASS*",
+        ])

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1465,16 +1465,16 @@ class TestMarkersWithParametrization:
                 import pytest
 
                 @pytest.mark.parametrize("x", range(2))
-                def test_func(x):
+                def test_func_a(x):
                     pass
 
                 @pytest.mark.parametrize("y", [1])
-                def test_func2(y):
+                def test_func_b(y):
                     pass
                 """)
         result = testdir.runpytest("-v")
         result.stdout.fnmatch_lines([
-            "*test_func*0*PASS*",
-            "*test_func*2*PASS*",
-            "*test_func2*10*PASS*",
+            "*test_func_a*0*PASS*",
+            "*test_func_a*2*PASS*",
+            "*test_func_b*10*PASS*",
         ])


### PR DESCRIPTION
* Allow `make_parametrize_id()` to return an empty string as id name

Bug: the doc states that "Return None if the hook doesn’t know about val" however. This should facilitate the hook function returning an empty string for a parameter's ID name. However, due to the `if return_value:` conditional a `None` value would skip the branch and therefore an automatic ID name would be generated.

* Pass parameter name to `make_parametrize_id` hook function

Feature: passing the parameter name into the hook function can be useful in some circumstances to control the name generation behaviour.
  