### PR TITLE
Add `make_parameterize_legacy` ini option to alter `make_parametrize_id` behaviour

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -118,6 +118,7 @@ Quentin Pradet
 Ralf Schmitt
 Raphael Pierzina
 Raquel Alegre
+Ravi Chandra
 Roberto Polli
 Romain Dorgueil
 Roman Bolshakov

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,11 +18,18 @@
   subdirectories with ini configuration files now uses the correct ini file
   (`#2148`_).  Thanks `@pelme`_.
 
+* Add ``make_parameterize_legacy`` ini option to alter the behaviour of the
+  ``pytest_make_parametrize_id`` hook function (defaults to ``True``). When
+  enabled the hook function will be skipped if it returns any False-like value.
+  When disabled the hook will only be skipped when it returns ``None``.
+  Thanks `@unsignedint`_ for the PR.
+
 *
 
 .. _@lesteve: https://github.com/lesteve
 .. _@malinoff: https://github.com/malinoff
 .. _@pelme: https://github.com/pelme
+.. _@unsignedint: https://github.com/unsignedint
 
 .. _#2129: https://github.com/pytest-dev/pytest/issues/2129
 .. _#2148: https://github.com/pytest-dev/pytest/issues/2148

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -977,6 +977,9 @@ class Config(object):
         self.invocation_dir = py.path.local()
         self._parser.addini('addopts', 'extra command line options', 'args')
         self._parser.addini('minversion', 'minimally required pytest version')
+        self._parser.addini('make_parameterize_legacy',
+                            'legacy return value behaviour of `make_parametrize` hook (skips false looking values)',
+                            type='bool', default=True)
 
     def _consider_importhook(self, args, entrypoint_name):
         """Install the PEP 302 import hook if using assertion re-writing.

--- a/_pytest/hookspec.py
+++ b/_pytest/hookspec.py
@@ -159,7 +159,9 @@ def pytest_generate_tests(metafunc):
 @hookspec(firstresult=True)
 def pytest_make_parametrize_id(config, val):
     """Return a user-friendly string representation of the given ``val`` that will be used
-    by @pytest.mark.parametrize calls. Return None if the hook doesn't know about ``val``.
+    by @pytest.mark.parametrize calls. Legacy behaviour: return any false-like value
+    to ignore the hook. New behaviour: return `None` instead. Behaviour can be configured
+    using the `make_parameterize_legacy` ini option.
     """
 
 # -------------------------------------------------------------------------

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -933,8 +933,13 @@ def _idval(val, argname, idx, idfn, config=None):
             pass
 
     if config:
+        # hook function return value checking behaviour is controlled by
+        # this ini setting; long-term we want to deprecate legacy mode
+        legacy_behaviour = config.getini('make_parameterize_legacy')
         hook_id = config.hook.pytest_make_parametrize_id(config=config, val=val)
-        if hook_id:
+        if legacy_behaviour and hook_id:
+            return hook_id
+        elif not legacy_behaviour and hook_id is not None:
             return hook_id
 
     if isinstance(val, STRING_TYPES):

--- a/doc/en/customize.rst
+++ b/doc/en/customize.rst
@@ -240,3 +240,10 @@ Builtin configuration file options
    By default, pytest will stop searching for ``conftest.py`` files upwards
    from ``pytest.ini``/``tox.ini``/``setup.cfg`` of the project if any,
    or up to the file-system root.
+
+.. confval:: make_parameterize_legacy
+
+  Alters the behaviour of the ``pytest_make_parametrize_id`` hook function. When
+  enabled the hook function will be skipped if it returns any False-like value.
+  When disabled the hook will only be skipped when it returns ``None``. Defaults
+  to ``True``.

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1415,3 +1415,31 @@ class TestMarkersWithParametrization:
             "*test_func*0*PASS*",
             "*test_func*2*PASS*",
         ])
+
+    _make_parametrize_return_conf_blob = """
+            def pytest_make_parametrize_id(config, val):
+                return ''
+            """
+    _make_parametrize_return_test_blob = """
+            import pytest
+
+            @pytest.mark.parametrize("x", ['foo'])
+            def test_func(x):
+                pass
+            """
+
+    def test_pytest_make_parametrize_legacy_return_behaviour(self, testdir):
+        testdir.makeconftest(self._make_parametrize_return_conf_blob)
+        testdir.makepyfile(self._make_parametrize_return_test_blob)
+        result = testdir.runpytest("-v")
+        result.stdout.fnmatch_lines([
+            "*test_func?foo? PASS*",
+        ])
+
+    def test_pytest_make_parametrize_new_return_behaviour(self, testdir):
+        testdir.makeconftest(self._make_parametrize_return_conf_blob)
+        testdir.makepyfile(self._make_parametrize_return_test_blob)
+        result = testdir.runpytest("--override-ini", "make_parameterize_legacy=false", "-v")
+        result.stdout.fnmatch_lines([
+            "*test_func?? PASS*",
+        ])


### PR DESCRIPTION
When enabled the hook function will be skipped if it returns any False-like value. When disabled the hook will only be skipped when it returns `None`.

Defaults to `True` for now.

This resolves a current bug: the doc states that "Return None if the hook doesn’t know about val" however. This should facilitate the hook function returning an empty string for a parameter's ID name. However, due to the `if return_value:` conditional a `None` value would skip the branch and therefore an automatic ID name would be generated.