### PR TITLE
Fix pytester internal plugin to work correctly with latest versions of zope.interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,6 @@ env:
     - TESTENV=docs
 
 matrix:
-  allow_failures:
-    # see #1989
-    - env: TESTENV=py27-trial
-    - env: TESTENV=py35-trial
   include:
     - env: TESTENV=py36
       python: '3.6-dev'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@
   expected warnings and the list of caught warnings is added to the
   error message. Thanks `@lesteve`_ for the PR.
 
+* Fix ``pytester`` internal plugin to work correctly with latest versions of
+  ``zope.interface`` (`#1989`_). Thanks `@nicoddemus`_ for the PR.
+
 * Specifying tests with colons like ``test_foo.py::test_bar`` for tests in
   subdirectories with ini configuration files now uses the correct ini file
   (`#2148`_).  Thanks `@pelme`_.
@@ -24,6 +27,7 @@
 .. _@malinoff: https://github.com/malinoff
 .. _@pelme: https://github.com/pelme
 
+.. _#1989: https://github.com/pytest-dev/pytest/issues/1989
 .. _#2129: https://github.com/pytest-dev/pytest/issues/2129
 .. _#2148: https://github.com/pytest-dev/pytest/issues/2148
 .. _#2150: https://github.com/pytest-dev/pytest/issues/2150

--- a/_pytest/pytester.py
+++ b/_pytest/pytester.py
@@ -446,9 +446,9 @@ class Testdir:
         the module is re-imported.
         """
         for name in set(sys.modules).difference(self._savemodulekeys):
-            # it seems zope.interfaces is keeping some state
-            # (used by twisted related tests)
-            if name != "zope.interface":
+            # zope.interface (used by twisted-related tests) keeps internal
+            # state and can't be deleted
+            if not name.startswith("zope.interface"):
                 del sys.modules[name]
 
     def make_hook_recorder(self, pluginmanager):

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,12 +28,6 @@ environment:
   - TOXENV: "freeze"
   - TOXENV: "docs"
 
-matrix:
-  allow_failures:
-    # see #1989
-    - TOXENV: "py27-trial"
-    - TOXENV: "py35-trial"
-
 install:
   - echo Installed Pythons
   - dir c:\Python*


### PR DESCRIPTION
There's a little hack on `pytester` that deletes modules from `sys.modules` that were imported during inline runs and it included a little nugget that prevented `zope.interface` from being deleted; apparently `zope.interface` keeps some internal state that can't just be deleted from `sys.modules`.

I guess at some point `zope.interface` was split into internal modules and the condition no longer had any effect. causing things to blow up spectacularly. 🔥 

At first glance this seems like an internal testing issue and I wasn't going to add a `CHANGELOG` entry, but then realized that `pytester` is part our public API so it warrants an entry.

Fix #1989