### PR TITLE
Assert statements of the pytester plugin again benefit from assertion rewriting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@
   expected warnings and the list of caught warnings is added to the
   error message. Thanks `@lesteve`_ for the PR.
 
+* Assert statements of the ``pytester`` plugin again benefit from assertion rewriting (`#1920`_).
+  Thanks `@RonnyPfannschmidt`_ for the report and `@nicoddemus`_ for the PR.
+
 * Specifying tests with colons like ``test_foo.py::test_bar`` for tests in
   subdirectories with ini configuration files now uses the correct ini file
   (`#2148`_).  Thanks `@pelme`_.
@@ -24,6 +27,7 @@
 .. _@malinoff: https://github.com/malinoff
 .. _@pelme: https://github.com/pelme
 
+.. _#1920: https://github.com/pytest-dev/pytest/issues/1920
 .. _#2129: https://github.com/pytest-dev/pytest/issues/2129
 .. _#2148: https://github.com/pytest-dev/pytest/issues/2148
 .. _#2150: https://github.com/pytest-dev/pytest/issues/2150

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -421,7 +421,7 @@ class PytestPluginManager(PluginManager):
             importspec = "_pytest." + modname
         else:
             importspec = modname
-        self.rewrite_hook.mark_rewrite(modname)
+        self.rewrite_hook.mark_rewrite(importspec)
         try:
             __import__(importspec)
         except ImportError as e:

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -58,6 +58,23 @@ class TestImportHookInstallation:
             assert 0
         result.stdout.fnmatch_lines([expected])
 
+    def test_rewrite_assertions_pytester_plugin(self, testdir):
+        """
+        Assertions in the pytester plugin must also benefit from assertion
+        rewriting (#1920).
+        """
+        testdir.makepyfile("""
+            pytest_plugins = ['pytester']
+            def test_dummy_failure(testdir):  # how meta!
+                testdir.makepyfile('def test(): assert 0')
+                r = testdir.inline_run()
+                r.assertoutcome(passed=1)
+        """)
+        result = testdir.runpytest_subprocess()
+        result.stdout.fnmatch_lines([
+            '*assert 1 == 0*',
+        ])
+
     @pytest.mark.parametrize('mode', ['plain', 'rewrite'])
     def test_pytest_plugins_rewrite(self, testdir, mode):
         contents = {


### PR DESCRIPTION
Fix #1920
