### PR TITLE
fix devpi test for doctesting env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -118,11 +118,13 @@ commands=
 basepython = python
 usedevelop=True
 skipsdist=True
+# ensure the given pyargs cant mean anytrhing else
+changedir=doc/
 deps=
     PyYAML
 commands=
-    pytest -rfsxX doc/en
-    pytest --doctest-modules {toxinidir}/_pytest
+    pytest -rfsxX en
+    pytest --doctest-modules --pyargs _pytest
 
 [testenv:regen]
 changedir=doc/en


### PR DESCRIPTION
due to a devpi bug, we always get a sdist install which in turn triggers
the pytest issue #2042 / #726

going for pyargs and a changed folder, it should no longer happen
(and will be tested further after rebasing the release branch)
