### PR TITLE
add matching the error message to pytest.raises

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ New Features
 * ``pytest.warns`` now checks for subclass relationship rather than
   class equality. Thanks `@lesteve`_ for the PR (`#2166`_)
 
+* ``pytest.raises`` now asserts that the error message matches a text or regex
+  with the ``match`` keyword argument. Thanks `@Kriechi`_ for the PR.
+
 
 Changes
 -------
@@ -56,6 +59,7 @@ Changes
 .. _@fogo: https://github.com/fogo
 .. _@mandeep: https://github.com/mandeep
 .. _@unsignedint: https://github.com/unsignedint
+.. _@Kriechi: https://github.com/Kriechi
 
 .. _#1512: https://github.com/pytest-dev/pytest/issues/1512
 .. _#1874: https://github.com/pytest-dev/pytest/pull/1874

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -129,7 +129,7 @@ class TestRaises:
             int('asdf')
 
         msg = "with base 16"
-        expr = r"Pattern '{}' not found in 'invalid literal for int\(\) with base 10: 'asdf''".format(msg)
+        expr = r"Pattern '{0}' not found in 'invalid literal for int\(\) with base 10: 'asdf''".format(msg)
         with pytest.raises(AssertionError, match=expr):
             with pytest.raises(ValueError, match=msg):
                 int('asdf', base=10)

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -118,3 +118,18 @@ class TestRaises:
         for o in gc.get_objects():
             assert type(o) is not T
 
+
+    def test_raises_match(self):
+        msg = r"with base \d+"
+        with pytest.raises(ValueError, match=msg):
+            int('asdf')
+
+        msg = "with base 10"
+        with pytest.raises(ValueError, match=msg):
+            int('asdf')
+
+        msg = "with base 16"
+        expr = r"Pattern '{}' not found in 'invalid literal for int\(\) with base 10: 'asdf''".format(msg)
+        with pytest.raises(AssertionError, match=expr):
+            with pytest.raises(ValueError, match=msg):
+                int('asdf', base=10)

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -112,10 +112,9 @@ class TestDeprecatedCall(object):
         pytest.deprecated_call(self.dep_explicit, 0)
 
     def test_deprecated_call_as_context_manager_no_warning(self):
-        with pytest.raises(pytest.fail.Exception) as ex:
+        with pytest.raises(pytest.fail.Exception, matches='^DID NOT WARN'):
             with pytest.deprecated_call():
                 self.dep(1)
-        assert str(ex.value).startswith("DID NOT WARN")
 
     def test_deprecated_call_as_context_manager(self):
         with pytest.deprecated_call():


### PR DESCRIPTION
`pytest.raises` can now assert that the error message contains a certain text.
Example:
```python
with raises(ValueError, match_info='must be 0'):
    raise ValueError("value must be 0 or None")
```


This is a more compact and IMHO cleaner way of doing it like this:
```python
with raises(ValueError) as exc_info:
    raise ValueError("value must be <= 10")
assert "value must be <= 10" in str(exc_info.value)
```