### PR TITLE
ignore property errors when parsing fixure factories

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -118,6 +118,7 @@ Piotr Banaszkiewicz
 Punyashloka Biswal
 Quentin Pradet
 Ralf Schmitt
+Ran Benita
 Raphael Pierzina
 Raquel Alegre
 Roberto Polli

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@
 
 *
 
+* Ignore exceptions raised from descriptors (e.g. properties) during Python test collection (`#2234`_).
+  Thanks to `@bluetech`_.
+
 * Replace ``raise StopIteration`` usages in the code by simple ``returns`` to finish generators, in accordance to `PEP-479`_ (`#2160`_).
   Thanks `@tgoodlet`_ for the report and `@nicoddemus`_ for the PR.
 
@@ -15,6 +18,10 @@
   PR.
 
 *
+
+.. _#2234: https://github.com/pytest-dev/pytest/issues/2234
+
+.. _@bluetech: https://github.com/bluetech
 
 .. _#2160: https://github.com/pytest-dev/pytest/issues/2160
 

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -14,6 +14,7 @@ from _pytest.compat import (
     getfslineno, get_real_func,
     is_generator, isclass, getimfunc,
     getlocation, getfuncargnames,
+    safe_getattr,
 )
 
 def pytest_sessionstart(session):
@@ -1066,7 +1067,9 @@ class FixtureManager:
         self._holderobjseen.add(holderobj)
         autousenames = []
         for name in dir(holderobj):
-            obj = getattr(holderobj, name, None)
+            # The attribute can be an arbitrary descriptor, so the attribute
+            # access below can raise. safe_getatt() ignores such exceptions.
+            obj = safe_getattr(holderobj, name, None)
             # fixture functions have a pytest_funcarg__ prefix (pre-2.3 style)
             # or are "@pytest.fixture" marked
             marker = getfixturemarker(obj)

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -124,8 +124,6 @@ def getfixturemarker(obj):
     exceptions."""
     try:
         return getattr(obj, "_pytestfixturefunction", None)
-    except KeyboardInterrupt:
-        raise
     except Exception:
         # some objects raise errors like request (from flask import request)
         # we don't expect them to be fixture functions

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -166,6 +166,16 @@ class TestClass:
             "because it has a __new__ constructor*"
         )
 
+    def test_issue2234_property(self, testdir):
+        testdir.makepyfile("""
+            class TestCase(object):
+                @property
+                def prop(self):
+                    raise NotImplementedError()
+        """)
+        result = testdir.runpytest()
+        assert result.ret == EXIT_NOTESTSCOLLECTED
+
 
 class TestGenerator:
     def test_generative_functions(self, testdir):


### PR DESCRIPTION
Previously, properties such as in the added test case were triggered
during collection, possibly executing unintended code. Let's skip them
instead.

We should probably skip all custom descriptors, however I am not sure
how to do this cleanly, so for now just skip properties.

Fixes #2234.