### PR TITLE
--override-ini now correctly overrides some fundamental options like "python_files"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,8 @@
 * Ignore exceptions raised from descriptors (e.g. properties) during Python test collection (`#2234`_).
   Thanks to `@bluetech`_.
   
-*  
+* ``--override-ini`` now correctly overrides some fundamental options like ``python_files`` (`#2238`_).
+  Thanks `@sirex`_ for the report and `@nicoddemus`_ for the PR.
 
 * Replace ``raise StopIteration`` usages in the code by simple ``returns`` to finish generators, in accordance to `PEP-479`_ (`#2160`_).
   Thanks `@tgoodlet`_ for the report and `@nicoddemus`_ for the PR.
@@ -28,12 +29,14 @@
 
 .. _@bluetech: https://github.com/bluetech
 .. _@gst: https://github.com/gst
+.. _@sirex: https://github.com/sirex
 .. _@vidartf: https://github.com/vidartf
 
 .. _#2137: https://github.com/pytest-dev/pytest/issues/2137
 .. _#2160: https://github.com/pytest-dev/pytest/issues/2160
 .. _#2231: https://github.com/pytest-dev/pytest/issues/2231
 .. _#2234: https://github.com/pytest-dev/pytest/issues/2234
+.. _#2238: https://github.com/pytest-dev/pytest/issues/2238
 
 .. _PEP-479: https://www.python.org/dev/peps/pep-0479/
 

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -877,6 +877,7 @@ class Config(object):
         self.trace = self.pluginmanager.trace.root.get("config")
         self.hook = self.pluginmanager.hook
         self._inicache = {}
+        self._override_ini = ()
         self._opt2dest = {}
         self._cleanup = []
         self._warn = self.pluginmanager._warn
@@ -977,6 +978,7 @@ class Config(object):
         self.invocation_dir = py.path.local()
         self._parser.addini('addopts', 'extra command line options', 'args')
         self._parser.addini('minversion', 'minimally required pytest version')
+        self._override_ini = ns.override_ini or ()
 
     def _consider_importhook(self, args, entrypoint_name):
         """Install the PEP 302 import hook if using assertion re-writing.
@@ -1159,15 +1161,14 @@ class Config(object):
         # and -o foo1=bar1 -o foo2=bar2 options
         # always use the last item if multiple value set for same ini-name,
         # e.g. -o foo=bar1 -o foo=bar2 will set foo to bar2
-        if self.getoption("override_ini", None):
-            for ini_config_list in self.option.override_ini:
-                for ini_config in ini_config_list:
-                    try:
-                        (key, user_ini_value) = ini_config.split("=", 1)
-                    except ValueError:
-                        raise UsageError("-o/--override-ini expects option=value style.")
-                    if key == name:
-                        value = user_ini_value
+        for ini_config_list in self._override_ini:
+            for ini_config in ini_config_list:
+                try:
+                    (key, user_ini_value) = ini_config.split("=", 1)
+                except ValueError:
+                    raise UsageError("-o/--override-ini expects option=value style.")
+                if key == name:
+                    value = user_ini_value
         return value
 
     def getoption(self, name, default=notset, skip=False):

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -778,6 +778,21 @@ class TestOverrideIniArgs:
         result = testdir.runpytest("--override-ini", 'xdist_strict True', "-s")
         result.stderr.fnmatch_lines(["*ERROR* *expects option=value*"])
 
+    @pytest.mark.parametrize('with_ini', [True, False])
+    def test_override_ini_handled_asap(self, testdir, with_ini):
+        """-o should be handled as soon as possible and always override what's in ini files (#2238)"""
+        if with_ini:
+            testdir.makeini("""
+                [pytest]
+                python_files=test_*.py
+            """)
+        testdir.makepyfile(unittest_ini_handle="""
+            def test():
+                pass
+        """)
+        result = testdir.runpytest("--override-ini", 'python_files=unittest_*.py')
+        result.stdout.fnmatch_lines(["*1 passed in*"])
+
     def test_with_arg_outside_cwd_without_inifile(self, tmpdir, monkeypatch):
         monkeypatch.chdir(str(tmpdir))
         a = tmpdir.mkdir("a")


### PR DESCRIPTION
#2238
