### PR TITLE
Mention next training event.

### DIFF
--- a/doc/en/talks.rst
+++ b/doc/en/talks.rst
@@ -4,7 +4,9 @@ Talks and Tutorials
 
 .. sidebar:: Next Open Trainings
 
-   `pytest workshop <http://www.meetup.com/Python-Django-User-Group-Bern/events/235151115/>`_, 8th December 2016, Bern, Switzerland
+   `Professional Testing with Python
+   <http://www.python-academy.com/courses/specialtopics/python_course_testing.html>`_,
+   26-28 April 2017, Leipzig, Germany.
 
 .. _`funcargs`: funcargs.html
 


### PR DESCRIPTION
I think this should target master?

I also notice that HOWTORELEASE.rst does not seem to mention how to publish the new documentation.