### PR TITLE
Add venv to the default norecursedirs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,9 @@ Changes
   additional parameter.
   Thanks `@unsignedint`_ for the PR.
 
+* Add ``venv`` to the default ``norecursedirs`` setting.
+  Thanks `@The-Compiler`_ for the PR.
+
 
 .. _@davidszotten: https://github.com/davidszotten
 .. _@fushi: https://github.com/fushi

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -27,7 +27,7 @@ EXIT_NOTESTSCOLLECTED = 5
 
 def pytest_addoption(parser):
     parser.addini("norecursedirs", "directory patterns to avoid for recursion",
-        type="args", default=['.*', 'build', 'dist', 'CVS', '_darcs', '{arch}', '*.egg'])
+        type="args", default=['.*', 'build', 'dist', 'CVS', '_darcs', '{arch}', '*.egg', 'venv'])
     parser.addini("testpaths", "directories to search for tests when no files or directories are given in the command line.",
         type="args", default=[])
     #parser.addini("dirpatterns",

--- a/doc/en/customize.rst
+++ b/doc/en/customize.rst
@@ -158,7 +158,7 @@ Builtin configuration file options
         [seq]   matches any character in seq
         [!seq]  matches any char not in seq
 
-   Default patterns are ``'.*', 'build', 'dist', 'CVS', '_darcs', '{arch}', '*.egg'``.
+   Default patterns are ``'.*', 'build', 'dist', 'CVS', '_darcs', '{arch}', '*.egg', 'venv'``.
    Setting a ``norecursedirs`` replaces the default.  Here is an example of
    how to avoid certain directories:
 


### PR DESCRIPTION
venv (without a dot) is commonly used as a name for a virtualenv directory, and
we don't want to collect that.