### PR TITLE
junitxml: Fix double system-out tags per testcase

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 3.0.7 (unreleased)
 ==================
 
+* junitxml: Fix problematic case where system-out tag occured twice per testcase
+  element in the XML report. Thanks `@kkoukiou`_ for the PR.
+
 * Fix regression, pytest now skips unittest correctly if run with ``--pdb``
   (`#2137`_). Thanks to `@gst`_ for the report and `@mbyt`_ for the PR.
 
@@ -31,6 +34,7 @@
 .. _@gst: https://github.com/gst
 .. _@sirex: https://github.com/sirex
 .. _@vidartf: https://github.com/vidartf
+.. _@kkoukiou: https://github.com/KKoukiou
 
 .. _#2137: https://github.com/pytest-dev/pytest/issues/2137
 .. _#2160: https://github.com/pytest-dev/pytest/issues/2160

--- a/_pytest/junitxml.py
+++ b/_pytest/junitxml.py
@@ -119,7 +119,7 @@ class _NodeReporter(object):
         node = kind(data, message=message)
         self.append(node)
 
-    def _write_captured_output(self, report):
+    def write_captured_output(self, report):
         for capname in ('out', 'err'):
             content = getattr(report, 'capstd' + capname)
             if content:
@@ -128,7 +128,6 @@ class _NodeReporter(object):
 
     def append_pass(self, report):
         self.add_stats('passed')
-        self._write_captured_output(report)
 
     def append_failure(self, report):
         # msg = str(report.longrepr.reprtraceback.extraline)
@@ -147,7 +146,6 @@ class _NodeReporter(object):
             fail = Junit.failure(message=message)
             fail.append(bin_xml_escape(report.longrepr))
             self.append(fail)
-        self._write_captured_output(report)
 
     def append_collect_error(self, report):
         # msg = str(report.longrepr.reprtraceback.extraline)
@@ -165,7 +163,6 @@ class _NodeReporter(object):
             msg = "test setup failure"
         self._add_simple(
             Junit.error, msg, report.longrepr)
-        self._write_captured_output(report)
 
     def append_skipped(self, report):
         if hasattr(report, "wasxfail"):
@@ -180,7 +177,7 @@ class _NodeReporter(object):
                 Junit.skipped("%s:%s: %s" % (filename, lineno, skipreason),
                               type="pytest.skip",
                               message=skipreason))
-        self._write_captured_output(report)
+        self.write_captured_output(report)
 
     def finalize(self):
         data = self.to_xml().unicode(indent=0)
@@ -345,6 +342,8 @@ class LogXML(object):
             reporter.append_skipped(report)
         self.update_testcase_duration(report)
         if report.when == "teardown":
+            reporter = self._opentestcase(report)
+            reporter.write_captured_output(report)
             self.finalize(report)
 
     def update_testcase_duration(self, report):


### PR DESCRIPTION
In the xml report we now have two occurrences for the system-out tag if
the testcase writes to stdout both on call and teardown and fails in
teardown.
This behaviour is against the xsd.
This patch makes sure that the system-out section exists only once per testcase.

How to reproduce:


```python
@pytest.fixture(scope="function")
def setup_test(request):
    print("I am in setup")
    yield
    print("I am in teardown")
    raise Exception("test teardown Exception!")
    
def test_1(setup_test):
    print("I am in call")
```

Gives output:

```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuite errors="1" failures="0" name="pytest" skips="0" tests="2" time="0.017">
  <testcase classname="test.test2" file="test/test2.py" line="11" name="test_1" time="0.000563859939575">
    <system-out>
    I am in setup
    I am in call
    </system-out>
    <error message="test teardown failure">request = &lt;SubRequest 'setup_test' for &lt;Function 'test_1'&gt;&gt;

    @pytest.fixture(scope="function")
    def setup_test(request):
        print("I am in setup")
        yield
        print("I am in teardown")
&gt;       raise Exception("test teardown Exception!")
E       Exception: test teardown Exception!

../../test/test2.py:9: Exception
    </error>
    <system-out>
    I am in setup
    I am in call
    I am in teardown
    </system-out>
  </testcase>
</testsuite>
```

Notice int he above output the double occurrence of the system-out tag.