### PR TITLE
Dont read from input exceptions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ Contributors include::
 Abdeali JK
 Abhijeet Kasurde
 Ahn Ki-Wook
+Alexander Johnson
 Alexei Kozlenok
 Anatoly Bubenkoff
 Andreas Zeidler

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,9 @@
 3.0.8 (unreleased)
 ==================
 
-*
+* Change capture.py's ``DontReadFromInput`` class to throw ``io.UnsupportedOperation`` errors rather
+  than ValueErrors in the ``fileno`` method (`#2276`_).
+  Thanks `@metasyn`_ for the PR.
 
 *
 
@@ -10,18 +12,21 @@
 *
 
 *
+
+
+.. _@metasyn: https://github.com/metasyn
+
+
+.. _#2276: https://github.com/pytest-dev/pytest/issues/2276
 
 
 3.0.7 (2017-03-14)
 ==================
 
-* Change capture.py's DontReadFromInput class to throw io.UnsupportedOperation errors rather
-  than ValueErrors in the fileno method (`#2276`).
-  Thanks `@metasyn` for the PR.
 
 * Fix issue in assertion rewriting breaking due to modules silently discarding
   other modules when importing fails
-  Notably, importing the `anydbm` module is fixed. (`#2248`_).
+  Notably, importing the ``anydbm`` module is fixed. (`#2248`_).
   Thanks `@pfhayes`_ for the PR.
 
 * junitxml: Fix problematic case where system-out tag occured twice per testcase
@@ -61,7 +66,6 @@
 .. _@kkoukiou: https://github.com/KKoukiou
 .. _@omerhadari: https://github.com/omerhadari
 .. _@fbjorn: https://github.com/fbjorn
-.. _@metasyn: https://github.com/metasyn
 
 .. _#2248: https://github.com/pytest-dev/pytest/issues/2248
 .. _#2137: https://github.com/pytest-dev/pytest/issues/2137
@@ -70,7 +74,6 @@
 .. _#2234: https://github.com/pytest-dev/pytest/issues/2234
 .. _#2238: https://github.com/pytest-dev/pytest/issues/2238
 .. _#2281: https://github.com/pytest-dev/pytest/issues/2281
-.. _#2276: https://github.com/pytest-dev/pytest/issues/2276
 
 .. _PEP-479: https://www.python.org/dev/peps/pep-0479/
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@
 3.0.7 (2017-03-14)
 ==================
 
+* Change capture.py's DontReadFromInput class to throw io.UnsupportedOperation errors rather
+  than ValueErrors in the fileno method (`#2276`).
+  Thanks `@metasyn` for the PR.
 
 * Fix issue in assertion rewriting breaking due to modules silently discarding
   other modules when importing fails
@@ -58,6 +61,7 @@
 .. _@kkoukiou: https://github.com/KKoukiou
 .. _@omerhadari: https://github.com/omerhadari
 .. _@fbjorn: https://github.com/fbjorn
+.. _@metasyn: https://github.com/metasyn
 
 .. _#2248: https://github.com/pytest-dev/pytest/issues/2248
 .. _#2137: https://github.com/pytest-dev/pytest/issues/2137
@@ -66,6 +70,7 @@
 .. _#2234: https://github.com/pytest-dev/pytest/issues/2234
 .. _#2238: https://github.com/pytest-dev/pytest/issues/2238
 .. _#2281: https://github.com/pytest-dev/pytest/issues/2281
+.. _#2276: https://github.com/pytest-dev/pytest/issues/2276
 
 .. _PEP-479: https://www.python.org/dev/peps/pep-0479/
 

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -13,6 +13,7 @@ import py
 import pytest
 
 from py.io import TextIO
+from io import UnsupportedOperation
 unicode = py.builtin.text
 
 patchsysdict = {0: 'stdin', 1: 'stdout', 2: 'stderr'}
@@ -448,7 +449,7 @@ class DontReadFromInput:
     __iter__ = read
 
     def fileno(self):
-        raise ValueError("redirected Stdin is pseudofile, has no fileno()")
+        raise UnsupportedOperation("redirected Stdin is pseudofile, has no fileno()")
 
     def isatty(self):
         return False

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -4,6 +4,7 @@ from __future__ import with_statement
 import pickle
 import os
 import sys
+from io import UnsupportedOperation
 
 import _pytest._code
 import py
@@ -658,7 +659,7 @@ def test_dontreadfrominput():
     pytest.raises(IOError, f.read)
     pytest.raises(IOError, f.readlines)
     pytest.raises(IOError, iter, f)
-    pytest.raises(ValueError, f.fileno)
+    pytest.raises(UnsupportedOperation, f.fileno)
     f.close()  # just for completeness
 
 


### PR DESCRIPTION
@metasyn took the liberty of rebasing your commit on `master` now that `3.0.7` is out and moved tweaked the `CHANGELOG` a bit.

Supersedes #2311