### PR TITLE
Add __future__ imports to all pytest modules

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -206,12 +206,12 @@ but here is a simple overview:
 
 #. Run all the tests
 
-   You need to have Python 2.7 and 3.5 available in your system.  Now
+   You need to have Python 2.7 and 3.6 available in your system.  Now
    running tests is as simple as issuing this command::
 
-    $ tox -e linting,py27,py35
+    $ tox -e linting,py27,py36
 
-   This command will run tests via the "tox" tool against Python 2.7 and 3.5
+   This command will run tests via the "tox" tool against Python 2.7 and 3.6
    and also perform "lint" coding-style checks.
 
 #. You can now edit your local working copy.
@@ -223,9 +223,9 @@ but here is a simple overview:
 
     $ tox -e py27 -- --pdb
 
-   Or to only run tests in a particular test module on Python 3.5::
+   Or to only run tests in a particular test module on Python 3.6::
 
-    $ tox -e py35 -- testing/test_config.py
+    $ tox -e py36 -- testing/test_config.py
 
 #. Commit and push once your tests pass and you are happy with your change(s)::
 

--- a/_pytest/_argcomplete.py
+++ b/_pytest/_argcomplete.py
@@ -57,7 +57,7 @@ If things do not work right away:
   which should throw a KeyError: 'COMPLINE' (which is properly set by the
   global argcomplete script).
 """
-
+from __future__ import absolute_import, division, print_function
 import sys
 import os
 from glob import glob

--- a/_pytest/_code/__init__.py
+++ b/_pytest/_code/__init__.py
@@ -1,4 +1,5 @@
 """ python inspection/code generation API """
+from __future__ import absolute_import, division, print_function
 from .code import Code  # noqa
 from .code import ExceptionInfo  # noqa
 from .code import Frame  # noqa

--- a/_pytest/_code/_py2traceback.py
+++ b/_pytest/_code/_py2traceback.py
@@ -2,6 +2,7 @@
 # CHANGES:
 # - some_str is replaced, trying to create unicode strings
 #
+from __future__ import absolute_import, division, print_function
 import types
 
 def format_exception_only(etype, value):

--- a/_pytest/_code/code.py
+++ b/_pytest/_code/code.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import sys
 from inspect import CO_VARARGS, CO_VARKEYWORDS
 import re

--- a/_pytest/_code/source.py
+++ b/_pytest/_code/source.py
@@ -1,4 +1,4 @@
-from __future__ import generators
+from __future__ import absolute_import, division, generators, print_function
 
 from bisect import bisect_right
 import sys

--- a/_pytest/_pluggy.py
+++ b/_pytest/_pluggy.py
@@ -2,7 +2,7 @@
 imports symbols from vendored "pluggy" if available, otherwise
 falls back to importing "pluggy" from the default namespace.
 """
-
+from __future__ import absolute_import, division, print_function
 try:
     from _pytest.vendored_packages.pluggy import *  # noqa
     from _pytest.vendored_packages.pluggy import __version__  # noqa

--- a/_pytest/assertion/__init__.py
+++ b/_pytest/assertion/__init__.py
@@ -1,6 +1,7 @@
 """
 support for presenting detailed information in failing assertions.
 """
+from __future__ import absolute_import, division, print_function
 import py
 import sys
 

--- a/_pytest/assertion/rewrite.py
+++ b/_pytest/assertion/rewrite.py
@@ -1,5 +1,5 @@
 """Rewrite assertion AST to produce nice error messages"""
-
+from __future__ import absolute_import, division, print_function
 import ast
 import _ast
 import errno

--- a/_pytest/assertion/truncate.py
+++ b/_pytest/assertion/truncate.py
@@ -4,7 +4,7 @@ Utilities for truncating assertion output.
 Current default behaviour is to truncate assertion explanations at
 ~8 terminal lines, unless running in "-vv" mode or running on CI.
 """
-
+from __future__ import absolute_import, division, print_function
 import os
 
 import py

--- a/_pytest/assertion/util.py
+++ b/_pytest/assertion/util.py
@@ -1,4 +1,5 @@
 """Utilities for assertion debugging"""
+from __future__ import absolute_import, division, print_function
 import pprint
 
 import _pytest._code

--- a/_pytest/cacheprovider.py
+++ b/_pytest/cacheprovider.py
@@ -4,7 +4,7 @@ merged implementation of the cache provider
 the name cache was not chosen to ensure pluggy automatically
 ignores the external pytest-cache
 """
-
+from __future__ import absolute_import, division, print_function
 import py
 import pytest
 import json

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -2,7 +2,7 @@
 per-test stdout/stderr capturing mechanism.
 
 """
-from __future__ import with_statement
+from __future__ import absolute_import, division, print_function
 
 import contextlib
 import sys

--- a/_pytest/compat.py
+++ b/_pytest/compat.py
@@ -1,6 +1,7 @@
 """
 python version compatibility code
 """
+from __future__ import absolute_import, division, print_function
 import sys
 import inspect
 import types

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -1,4 +1,5 @@
 """ command line options, ini-file and conftest.py processing. """
+from __future__ import absolute_import, division, print_function
 import argparse
 import shlex
 import traceback

--- a/_pytest/debugging.py
+++ b/_pytest/debugging.py
@@ -1,5 +1,5 @@
 """ interactive debugging with PDB, the Python Debugger. """
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 import pdb
 import sys
 

--- a/_pytest/deprecated.py
+++ b/_pytest/deprecated.py
@@ -5,7 +5,7 @@ that is planned to be removed in the next pytest release.
 Keeping it in a central location makes it easy to track what is deprecated and should
 be removed when the time comes.
 """
-
+from __future__ import absolute_import, division, print_function
 
 MAIN_STR_ARGS = 'passing a string to pytest.main() is deprecated, ' \
                       'pass a list of arguments instead.'

--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -1,5 +1,5 @@
 """ discover and run doctests in modules and test files."""
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 import traceback
 

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import sys
 
 from py._code.code import FormattedExcinfo

--- a/_pytest/freeze_support.py
+++ b/_pytest/freeze_support.py
@@ -2,6 +2,8 @@
 Provides a function to report all internal modules for using freezing tools
 pytest
 """
+from __future__ import absolute_import, division, print_function
+
 
 def pytest_namespace():
     return {'freeze_includes': freeze_includes}

--- a/_pytest/helpconfig.py
+++ b/_pytest/helpconfig.py
@@ -1,4 +1,6 @@
 """ version info, help messages, tracing configuration.  """
+from __future__ import absolute_import, division, print_function
+
 import py
 import pytest
 import os, sys

--- a/_pytest/junitxml.py
+++ b/_pytest/junitxml.py
@@ -4,9 +4,11 @@
 
 
 Based on initial code from Ross Lawley.
+
+Output conforms to https://github.com/jenkinsci/xunit-plugin/blob/master/
+src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
 """
-# Output conforms to https://github.com/jenkinsci/xunit-plugin/blob/master/
-# src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
+from __future__ import absolute_import, division, print_function
 
 import functools
 import py

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -1,4 +1,6 @@
 """ core implementation of testing process: init, session, runtest loop. """
+from __future__ import absolute_import, division, print_function
+
 import functools
 import os
 import sys

--- a/_pytest/mark.py
+++ b/_pytest/mark.py
@@ -1,4 +1,6 @@
 """ generic mechanism for marking and selecting python functions. """
+from __future__ import absolute_import, division, print_function
+
 import inspect
 from collections import namedtuple
 from operator import attrgetter

--- a/_pytest/monkeypatch.py
+++ b/_pytest/monkeypatch.py
@@ -1,4 +1,5 @@
 """ monkeypatching and mocking functionality.  """
+from __future__ import absolute_import, division, print_function
 
 import os, sys
 import re

--- a/_pytest/nose.py
+++ b/_pytest/nose.py
@@ -1,4 +1,5 @@
 """ run test suites written for nose. """
+from __future__ import absolute_import, division, print_function
 
 import sys
 

--- a/_pytest/pastebin.py
+++ b/_pytest/pastebin.py
@@ -1,4 +1,6 @@
 """ submit failure or test session information to a pastebin service. """
+from __future__ import absolute_import, division, print_function
+
 import pytest
 import sys
 import tempfile

--- a/_pytest/pytester.py
+++ b/_pytest/pytester.py
@@ -14,8 +14,6 @@ from fnmatch import fnmatch
 
 from weakref import WeakKeyDictionary
 
-from py.builtin import print_
-
 from _pytest.capture import MultiCapture, SysCapture
 from _pytest._code import Source
 import py
@@ -231,15 +229,15 @@ class HookRecorder(object):
             name, check = entries.pop(0)
             for ind, call in enumerate(self.calls[i:]):
                 if call._name == name:
-                    print_("NAMEMATCH", name, call)
+                    print("NAMEMATCH", name, call)
                     if eval(check, backlocals, call.__dict__):
-                        print_("CHECKERMATCH", repr(check), "->", call)
+                        print("CHECKERMATCH", repr(check), "->", call)
                     else:
-                        print_("NOCHECKERMATCH", repr(check), "-", call)
+                        print("NOCHECKERMATCH", repr(check), "-", call)
                         continue
                     i += ind + 1
                     break
-                print_("NONAMEMATCH", name, "with", call)
+                print("NONAMEMATCH", name, "with", call)
             else:
                 pytest.fail("could not find %r check %r" % (name, check))
 
@@ -926,8 +924,8 @@ class Testdir(object):
         cmdargs = [str(x) for x in cmdargs]
         p1 = self.tmpdir.join("stdout")
         p2 = self.tmpdir.join("stderr")
-        print_("running:", ' '.join(cmdargs))
-        print_("     in:", str(py.path.local()))
+        print("running:", ' '.join(cmdargs))
+        print("     in:", str(py.path.local()))
         f1 = codecs.open(str(p1), "w", encoding="utf8")
         f2 = codecs.open(str(p2), "w", encoding="utf8")
         try:
@@ -953,7 +951,7 @@ class Testdir(object):
     def _dump_lines(self, lines, fp):
         try:
             for line in lines:
-                py.builtin.print_(line, file=fp)
+                print(line, file=fp)
         except UnicodeEncodeError:
             print("couldn't print to %s because of encoding" % (fp,))
 

--- a/_pytest/pytester.py
+++ b/_pytest/pytester.py
@@ -1,4 +1,6 @@
 """ (disabled by default) support for testing pytest and pytest plugins. """
+from __future__ import absolute_import, division, print_function
+
 import codecs
 import gc
 import os

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1,4 +1,5 @@
 """ Python test discovery, setup and run of test functions. """
+from __future__ import absolute_import, division, print_function
 
 import fnmatch
 import inspect

--- a/_pytest/recwarn.py
+++ b/_pytest/recwarn.py
@@ -1,4 +1,6 @@
 """ recording warnings during test function execution. """
+from __future__ import absolute_import, division, print_function
+
 import inspect
 
 import _pytest._code

--- a/_pytest/resultlog.py
+++ b/_pytest/resultlog.py
@@ -62,9 +62,9 @@ class ResultLog(object):
         self.logfile = logfile # preferably line buffered
 
     def write_log_entry(self, testpath, lettercode, longrepr):
-        py.builtin.print_("%s %s" % (lettercode, testpath), file=self.logfile)
+        print("%s %s" % (lettercode, testpath), file=self.logfile)
         for line in longrepr.splitlines():
-            py.builtin.print_(" %s" % line, file=self.logfile)
+            print(" %s" % line, file=self.logfile)
 
     def log_outcome(self, report, lettercode, longrepr):
         testpath = getattr(report, 'nodeid', None)

--- a/_pytest/resultlog.py
+++ b/_pytest/resultlog.py
@@ -1,6 +1,7 @@
 """ log machine-parseable test session result information in a plain
 text file.
 """
+from __future__ import absolute_import, division, print_function
 
 import py
 import os

--- a/_pytest/runner.py
+++ b/_pytest/runner.py
@@ -1,4 +1,6 @@
 """ basic collect and runtest protocol implementations """
+from __future__ import absolute_import, division, print_function
+
 import bdb
 import sys
 from time import time

--- a/_pytest/setuponly.py
+++ b/_pytest/setuponly.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import pytest
 import sys
 

--- a/_pytest/setupplan.py
+++ b/_pytest/setupplan.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import pytest
 
 

--- a/_pytest/skipping.py
+++ b/_pytest/skipping.py
@@ -1,4 +1,6 @@
 """ support for skip/xfail functions and markers. """
+from __future__ import absolute_import, division, print_function
+
 import os
 import sys
 import traceback

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -2,6 +2,8 @@
 
 This is a good source for looking at the various reporting hooks.
 """
+from __future__ import absolute_import, division, print_function
+
 from _pytest.main import EXIT_OK, EXIT_TESTSFAILED, EXIT_INTERRUPTED, \
     EXIT_USAGEERROR, EXIT_NOTESTSCOLLECTED
 import pytest

--- a/_pytest/tmpdir.py
+++ b/_pytest/tmpdir.py
@@ -1,4 +1,6 @@
 """ support for providing temporary directories to test functions.  """
+from __future__ import absolute_import, division, print_function
+
 import re
 
 import pytest

--- a/_pytest/unittest.py
+++ b/_pytest/unittest.py
@@ -1,5 +1,5 @@
 """ discovery and running of std-library "unittest" style tests. """
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 import sys
 import traceback

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
 import os
 import sys
 

--- a/testing/code/test_code.py
+++ b/testing/code/test_code.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import sys
 
 import _pytest._code

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
 
 import operator
 import _pytest

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -370,7 +370,7 @@ def test_codepath_Queue_example():
 
 def test_match_succeeds():
     with pytest.raises(ZeroDivisionError) as excinfo:
-        0 / 0
+        0 // 0
     excinfo.match(r'.*zero.*')
 
 def test_match_raises_error(testdir):

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 # disable flake check on this file because some constructs are strange
 # or redundant on purpose and can't be disable on a line-by-line basis
+from __future__ import absolute_import, division, print_function
 import sys
 
 import _pytest._code

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import pytest
 
 

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -274,6 +274,7 @@ class TestGenerator(object):
 
     def test_order_of_execution_generator_same_codeline(self, testdir, tmpdir):
         o = testdir.makepyfile("""
+            from __future__ import print_function
             def test_generative_order_of_execution():
                 import py, pytest
                 test_list = []
@@ -283,8 +284,8 @@ class TestGenerator(object):
                     test_list.append(item)
 
                 def assert_order_of_execution():
-                    py.builtin.print_('expected order', expected_list)
-                    py.builtin.print_('but got       ', test_list)
+                    print('expected order', expected_list)
+                    print('but got       ', test_list)
                     assert test_list == expected_list
 
                 for i in expected_list:
@@ -298,6 +299,7 @@ class TestGenerator(object):
 
     def test_order_of_execution_generator_different_codeline(self, testdir):
         o = testdir.makepyfile("""
+            from __future__ import print_function
             def test_generative_tests_different_codeline():
                 import py, pytest
                 test_list = []
@@ -313,8 +315,8 @@ class TestGenerator(object):
                     test_list.append(0)
 
                 def assert_order_of_execution():
-                    py.builtin.print_('expected order', expected_list)
-                    py.builtin.print_('but got       ', test_list)
+                    print('expected order', expected_list)
+                    print('but got       ', test_list)
                     assert test_list == expected_list
 
                 yield list_append_0

--- a/testing/test_argcomplete.py
+++ b/testing/test_argcomplete.py
@@ -1,4 +1,4 @@
-from __future__ import with_statement
+from __future__ import absolute_import, division, print_function
 import py, pytest
 
 # test for _argcomplete but not specific for any application

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
 import sys
 import textwrap
 

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import glob
 import os
 import py_compile

--- a/testing/test_cache.py
+++ b/testing/test_cache.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import sys
 
 import _pytest

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 # note: py.io capture tests where copied from
 # pylib 1.4.20.dev2 (rev 13d9af95547e)
 from __future__ import with_statement

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -14,7 +14,7 @@ import contextlib
 from _pytest import capture
 from _pytest.capture import CaptureManager
 from _pytest.main import EXIT_NOTESTSCOLLECTED
-from py.builtin import print_
+
 
 needsosdup = pytest.mark.xfail("not hasattr(os, 'dup')")
 
@@ -712,7 +712,7 @@ def test_dupfile(tmpfile):
         assert nf != tmpfile
         assert nf.fileno() != tmpfile.fileno()
         assert nf not in flist
-        print_(i, end="", file=nf)
+        print(i, end="", file=nf)
         flist.append(nf)
     for i in range(5):
         f = flist[i]
@@ -786,7 +786,7 @@ class TestFDCapture(object):
     def test_stderr(self):
         cap = capture.FDCapture(2)
         cap.start()
-        print_("hello", file=sys.stderr)
+        print("hello", file=sys.stderr)
         s = cap.snap()
         cap.done()
         assert s == "hello\n"

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import pytest, py
 
 from _pytest.main import Session, EXIT_NOTESTSCOLLECTED

--- a/testing/test_compat.py
+++ b/testing/test_compat.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import sys
 
 import pytest

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import py, pytest
 
 import _pytest._code

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 from textwrap import dedent
 
 import _pytest._code

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+from __future__ import absolute_import, division, print_function
 import sys
 import _pytest._code
 from _pytest.compat import MODULE_NOT_FOUND_ERROR

--- a/testing/test_entry_points.py
+++ b/testing/test_entry_points.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import pkg_resources
 
 import pytest

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 from _pytest.main import EXIT_NOTESTSCOLLECTED
 import pytest
 

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from __future__ import absolute_import, division, print_function
 from xml.dom import minidom
 import py
 import sys

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import os
 
 import py, pytest

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -674,7 +674,7 @@ class TestKeywordSelection(object):
                     item.extra_keyword_matches.add("xxx")
         """)
         reprec = testdir.inline_run(p.dirpath(), '-s', '-k', keyword)
-        py.builtin.print_("keyword", repr(keyword))
+        print("keyword", repr(keyword))
         passed, skipped, failed = reprec.listoutcomes()
         assert len(passed) == 1
         assert passed[0].nodeid.endswith("test_2")

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import os
 import sys
 import textwrap

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import pytest
 
 def setup_module(mod):

--- a/testing/test_parseopt.py
+++ b/testing/test_parseopt.py
@@ -1,4 +1,4 @@
-from __future__ import with_statement
+from __future__ import absolute_import, division, print_function
 import sys
 import os
 import py, pytest

--- a/testing/test_pastebin.py
+++ b/testing/test_pastebin.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+from __future__ import absolute_import, division, print_function
 import sys
 import pytest
 

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import sys
 import platform
 

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+from __future__ import absolute_import, division, print_function
 import pytest
 import py
 import os

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import pytest
 import os
 from _pytest.pytester import HookRecorder

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import warnings
 import re
 import py

--- a/testing/test_resultlog.py
+++ b/testing/test_resultlog.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import os
 
 import _pytest._code

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import with_statement
+from __future__ import absolute_import, division, print_function
 
 import _pytest._code
 import os

--- a/testing/test_runner_xunit.py
+++ b/testing/test_runner_xunit.py
@@ -1,6 +1,8 @@
-#
-# test correct setup/teardowns at
-# module, class, and instance level
+"""
+ test correct setup/teardowns at
+ module, class, and instance level
+"""
+from __future__ import absolute_import, division, print_function
 import pytest
 
 

--- a/testing/test_session.py
+++ b/testing/test_session.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import pytest
 
 from _pytest.main import EXIT_NOTESTSCOLLECTED

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import pytest
 import sys
 

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1,6 +1,7 @@
 """
 terminal reporting of the full testing process.
 """
+from __future__ import absolute_import, division, print_function
 import collections
 import sys
 

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import sys
 import py
 import pytest

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 from _pytest.main import EXIT_NOTESTSCOLLECTED
 import pytest
 import gc


### PR DESCRIPTION
This prevents silly errors from creeping in Python 2 when testing in Python 3.

Noticed this while working on the "pytest warnings" branch and things failed horribly on Python 2 because the module is named `warnings.py`. Thought about renaming it, but thought "hey it's 2017 we shouldn't worry about this type of silly error anymore". 😉 

While at it:

* Replaced all `py.builtin.print_` calls by native `print()` calls;
* Noticed that our `CONTRIBUTION` could use an update and recommend testing with `py36`;