### PR TITLE
Added 'Possible exit codes' section to docs (#2239)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -117,6 +117,7 @@ Oliver Bestwalter
 Omar Kohl
 Omer Hadari
 Patrick Hayes
+Paweł Adamczak
 Pieter Mulder
 Piotr Banaszkiewicz
 Punyashloka Biswal

--- a/doc/en/usage.rst
+++ b/doc/en/usage.rst
@@ -19,6 +19,18 @@ You can invoke testing through the Python interpreter from the command line::
 This is almost equivalent to invoking the command line script ``pytest [...]``
 directly, except that python will also add the current directory to ``sys.path``.
 
+Possible exit codes
+--------------------------------------------------------------
+
+Running ``pytest`` can result in six different exit codes:
+
+:Exit code 0: All tests were collected and passed successfully
+:Exit code 1: Tests were collected and run but some of the tests failed
+:Exit code 2: Test execution was interrupted by the user
+:Exit code 3: Internal error happened while executing tests
+:Exit code 4: pytest command line usage error
+:Exit code 5: No tests were collected
+
 Getting help on version, option names, environment variables
 --------------------------------------------------------------
 


### PR DESCRIPTION
Added small 'Possible exit codes' section to documentation.
Fixes #2239.

---

Please feel free to suggest any changes, especially to the status code 'explanation' as I was basing them only on the variable name and the place where they were invoked.