### PR TITLE
Ensure rewritten modules don't inherit __future__ flags from pytest

### DIFF
--- a/_pytest/assertion/rewrite.py
+++ b/_pytest/assertion/rewrite.py
@@ -337,7 +337,7 @@ def _rewrite_test(config, fn):
         return None, None
     rewrite_asserts(tree, fn, config)
     try:
-        co = compile(tree, fn.strpath, "exec")
+        co = compile(tree, fn.strpath, "exec", dont_inherit=True)
     except SyntaxError:
         # It's possible that this error is from some bug in the
         # assertion rewriting, but I don't know of a fast way to tell.

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -712,6 +712,24 @@ def test_rewritten():
         result.stdout.fnmatch_lines(['*= 1 passed in *=*'])
         assert 'pytest-warning summary' not in result.stdout.str()
 
+    @pytest.mark.skipif(sys.version_info[0] > 2, reason='python 2 only')
+    def test_rewrite_future_imports(self, testdir):
+        """Test that rewritten modules don't inherit the __future__ flags
+        from the assertrewrite module.
+
+        assertion.rewrite imports __future__.division (and others), so
+        ensure rewritten modules don't inherit those flags.
+
+        The test below will fail if __future__.division is enabled
+        """
+        testdir.makepyfile('''
+            def test():
+                x = 1 / 2
+                assert type(x) is int
+        ''')
+        result = testdir.runpytest()
+        assert result.ret == 0
+
 
 class TestAssertionRewriteHookDetails(object):
     def test_loader_is_package_false_for_module(self, testdir):


### PR DESCRIPTION
In a recent refactoring (#2316) I enabled all `__future__` features in all pytest modules, but that has the unwanted side effect of propagating those features to compile()'d modules inside assertion rewriting, unless we pass `dont_inherit=False` to `compile()`:

> The optional arguments flags and dont_inherit control which future statements (see PEP 236) affect the compilation of source. If neither is present (or both are zero) the code is compiled with those future statements that are in effect in the code that is calling compile. If the flags argument is given and dont_inherit is not (or is zero) then the future statements specified by the flags argument are used in addition to those that would be used anyway. If dont_inherit is a non-zero integer then the flags argument is it – the future statements in effect around the call to compile are ignored.

[Reference](https://docs.python.org/3.1/library/functions.html?highlight=compile#compile).

Wow it was lucky of us to catch this before the `3.1` release, I can't imagine how many suites would break by this! 😱 