### PR TITLE
Pin sphinx to 1.4 when generating docs to workaround search issues on RTD

### DIFF
--- a/doc/en/requirements.txt
+++ b/doc/en/requirements.txt
@@ -1,0 +1,3 @@
+# pinning sphinx to 1.4.* due to search issues with rtd:
+# https://github.com/rtfd/readthedocs-sphinx-ext/issues/25
+sphinx ==1.4.*


### PR DESCRIPTION
As discussed in rtfd/readthedocs-sphinx-ext#25, pinning to 1.4 to get correct search results back.

I pushed to pytest's repo instead of my own fork so I could test the results on RTD and it works:

https://docs.pytest.org/en/fix-search-docs/search.html?q=pytest_addoption&check_keywords=yes&area=default

Fix #2302


