### PR TITLE
Changed behavior if --lf and --ff are both used.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -78,6 +78,7 @@ Javier Romero
 Jeff Widman
 John Towler
 Jon Sonesen
+Jonas Obrist
 Jordan Guymon
 Joshua Bronson
 Jurko Gospodnetić

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,6 +69,9 @@ Changes
 * ``PluginManager.import_plugin`` now accepts unicode plugin names in Python 2.
   Thanks `@reutsharabani`_ for the PR.
 
+* fix `#2308`_: When using both ``--lf`` and ``--ff``, only the last failed tests are run.
+  Thanks `@ojii`_ for the PR.
+
 
 Bug Fixes
 ---------
@@ -88,6 +91,7 @@ Bug Fixes
 .. _@reutsharabani: https://github.com/reutsharabani
 .. _@unsignedint: https://github.com/unsignedint
 .. _@Kriechi: https://github.com/Kriechi
+.. _@ojii: https://github.com/ojii
 
 
 .. _#1407: https://github.com/pytest-dev/pytest/issues/1407
@@ -101,6 +105,7 @@ Bug Fixes
 .. _#2147: https://github.com/pytest-dev/pytest/issues/2147
 .. _#2208: https://github.com/pytest-dev/pytest/issues/2208
 .. _#2228:  https://github.com/pytest-dev/pytest/issues/2228
+.. _#2308: https://github.com/pytest-dev/pytest/issues/2308
 
 
 3.0.8 (unreleased)

--- a/_pytest/cacheprovider.py
+++ b/_pytest/cacheprovider.py
@@ -139,11 +139,11 @@ class LFPlugin(object):
                 # running a subset of all tests with recorded failures outside
                 # of the set of tests currently executing
                 pass
-            elif self.config.getvalue("failedfirst"):
-                items[:] = previously_failed + previously_passed
-            else:
+            elif self.config.getvalue("lf"):
                 items[:] = previously_failed
                 config.hook.pytest_deselected(items=previously_passed)
+            else:
+                items[:] = previously_failed + previously_passed
 
     def pytest_sessionfinish(self, session):
         config = self.config

--- a/testing/test_cache.py
+++ b/testing/test_cache.py
@@ -200,14 +200,16 @@ class TestLastFailed(object):
         ])
 
     def test_lastfailed_failedfirst_order(self, testdir):
-        testdir.tmpdir.join('test_a.py').write(_pytest._code.Source("""
-            def test_always_passes():
-                assert 1
-        """))
-        testdir.tmpdir.join('test_b.py').write(_pytest._code.Source("""
-            def test_always_fails():
-                assert 0
-        """))
+        testdir.makepyfile(**{
+            'test_a.py': """
+                def test_always_passes():
+                    assert 1
+            """,
+            'test_b.py': """
+                def test_always_fails():
+                    assert 0
+            """,
+        })
         result = testdir.runpytest()
         # Test order will be collection order; alphabetical
         result.stdout.fnmatch_lines([
@@ -219,6 +221,7 @@ class TestLastFailed(object):
         result.stdout.fnmatch_lines([
             "test_b.py*",
         ])
+        assert 'test_a.py' not in result.stdout.str()
 
     def test_lastfailed_difference_invocations(self, testdir, monkeypatch):
         monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", 1)

--- a/testing/test_cache.py
+++ b/testing/test_cache.py
@@ -192,11 +192,32 @@ class TestLastFailed(object):
             "test_a.py*",
             "test_b.py*",
         ])
-        result = testdir.runpytest("--lf", "--ff")
+        result = testdir.runpytest("--ff")
         # Test order will be failing tests firs
         result.stdout.fnmatch_lines([
             "test_b.py*",
             "test_a.py*",
+        ])
+
+    def test_lastfailed_failedfirst_order(self, testdir):
+        testdir.tmpdir.join('test_a.py').write(_pytest._code.Source("""
+            def test_always_passes():
+                assert 1
+        """))
+        testdir.tmpdir.join('test_b.py').write(_pytest._code.Source("""
+            def test_always_fails():
+                assert 0
+        """))
+        result = testdir.runpytest()
+        # Test order will be collection order; alphabetical
+        result.stdout.fnmatch_lines([
+            "test_a.py*",
+            "test_b.py*",
+        ])
+        result = testdir.runpytest("--lf", "--ff")
+        # Test order will be failing tests firs
+        result.stdout.fnmatch_lines([
+            "test_b.py*",
         ])
 
     def test_lastfailed_difference_invocations(self, testdir, monkeypatch):


### PR DESCRIPTION
When using both --last-failed/--lf and --failed-first/--ff pytest would
run all tests with failed tests first (as if --lf was not provied). This
patch changes it so that when using both flags, only the last failed
tests are run. This makes it easier to set --ff as the default behavior
via the config file and then selectively use --lf to only run the last
failed tests.