### PR TITLE
Test against py36 official release for consistency with other python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
 matrix:
   include:
     - env: TOXENV=py36
-      python: '3.6-dev'
+      python: '3.6'
     - env: TOXENV=py37
       python: 'nightly'
   allow_failures:


### PR DESCRIPTION
Now that Python 3.6 is official, test against the official release.