### PR TITLE
Try not to assume a module's file extension is .py

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -85,6 +85,7 @@ Justyna Janczyszyn
 Kale Kundert
 Katarzyna Jachim
 Kevin Cox
+Kodi B. Arfer
 Lee Kamentsky
 Lev Maximov
 Loic Esteve

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@
 * Added documentation related to issue (`#1937`_)
   Thanks `@skylarjhdownes`_ for the PR.
 
+* Allow collecting files with any file extension as Python modules (`#2369`_).
+  Thanks `@Kodiologist`_ for the PR.
+
 *
 
 *
@@ -23,11 +26,13 @@
 .. _@skylarjhdownes: https://github.com/skylarjhdownes
 .. _@fabioz: https://github.com/fabioz
 .. _@metasyn: https://github.com/metasyn
+.. _@Kodiologist: https://github.com/Kodiologist
 
 
 .. _#1937: https://github.com/pytest-dev/pytest/issues/1937
 .. _#2276: https://github.com/pytest-dev/pytest/issues/2276
 .. _#2336: https://github.com/pytest-dev/pytest/issues/2336
+.. _#2369: https://github.com/pytest-dev/pytest/issues/2369
 
 
 3.0.7 (2017-03-14)

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -3,6 +3,7 @@
 import fnmatch
 import inspect
 import sys
+import os
 import collections
 import math
 from itertools import count
@@ -235,8 +236,7 @@ class PyobjMixin(PyobjContext):
                 continue
             name = node.name
             if isinstance(node, Module):
-                assert name.endswith(".py")
-                name = name[:-3]
+                name = os.path.splitext(name)[0]
                 if stopatmodule:
                     if includemodule:
                         parts.append(name)

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -841,6 +841,34 @@ class TestConftestCustomization:
         l = modcol.collect()
         assert '_hello' not in l
 
+    def test_issue2369_collect_module_fileext(self, testdir):
+        """Ensure we can collect files with weird file extensions as Python
+        modules (#2369)"""
+        # We'll implement a little finder and loader to import files containing
+        # Python source code whose file extension is ".narf".
+        testdir.makeconftest("""
+            import sys, os, imp
+            from _pytest.python import Module
+
+            class Loader:
+                def load_module(self, name):
+                    return imp.load_source(name, name + ".narf")
+            class Finder:
+                def find_module(self, name, path=None):
+                    if os.path.exists(name + ".narf"):
+                        return Loader()
+            sys.meta_path.append(Finder())
+
+            def pytest_collect_file(path, parent):
+                if path.ext == ".narf":
+                    return Module(path, parent)""")
+        testdir.makefile(".narf", """
+            def test_something():
+                assert 1 + 1 == 2""")
+        # Use runpytest_subprocess, since we're futzing with sys.meta_path.
+        result = testdir.runpytest_subprocess()
+        result.stdout.fnmatch_lines('*1 passed*')
+
 def test_setup_only_available_in_subdir(testdir):
     sub1 = testdir.mkpydir("sub1")
     sub2 = testdir.mkpydir("sub2")


### PR DESCRIPTION
Fixes #2369.

Any hints on how to write a test for this?