### PR TITLE
Issue #2383 - AssertionError with wrong number of parametrize arguments

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -151,5 +151,6 @@ Tyler Goodlet
 Vasily Kuznetsov
 Victor Uriarte
 Vidar T. Fauske
+Vitaly Lashmanov
 Wouter van Ackooy
 Xuecong Liao

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@
 * Allow collecting files with any file extension as Python modules (`#2369`_).
   Thanks `@Kodiologist`_ for the PR.
 
+* Show the correct error message when collect "parametrize" func with wrong args (`#2383`_).
+  Thanks `@The-Compiler`_ for the report and `@robin0371`_ for the PR.
+
 *
 
 *
@@ -27,12 +30,14 @@
 .. _@fabioz: https://github.com/fabioz
 .. _@metasyn: https://github.com/metasyn
 .. _@Kodiologist: https://github.com/Kodiologist
+.. _@robin0371: https://github.com/robin0371
 
 
 .. _#1937: https://github.com/pytest-dev/pytest/issues/1937
 .. _#2276: https://github.com/pytest-dev/pytest/issues/2276
 .. _#2336: https://github.com/pytest-dev/pytest/issues/2336
 .. _#2369: https://github.com/pytest-dev/pytest/issues/2369
+.. _#2383: https://github.com/pytest-dev/pytest/issues/2383
 
 
 3.0.7 (2017-03-14)

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -853,7 +853,11 @@ class Metafunc(fixtures.FuncargnamesCompatAttr):
         for callspec in self._calls or [CallSpec2(self)]:
             elements = zip(ids, argvalues, newkeywords, count())
             for a_id, valset, keywords, param_index in elements:
-                assert len(valset) == len(argnames)
+                if len(valset) != len(argnames):
+                    raise ValueError(
+                        'In "parametrize" the number of values ({0}) must be '
+                        'equal to the number of names ({1})'.format(
+                            valset, argnames))
                 newcallspec = callspec.copy(self)
                 newcallspec.setmulti(valtypes, argnames, valset, a_id,
                                      keywords, scopenum, param_index)

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -301,6 +301,23 @@ def test_parametrized_collected_from_command_line(testdir):
     rec.assertoutcome(passed=3)
 
 
+def test_parametrized_collect_with_wrong_args(testdir):
+    """Test collect parametrized func with wrong number of args."""
+    py_file = testdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.parametrize('foo, bar', [(1, 2, 3)])
+        def test_func(foo, bar):
+            pass
+    """)
+
+    result = testdir.runpytest(py_file)
+    result.stdout.fnmatch_lines([
+        'E   ValueError: In "parametrize" the number of values ((1, 2, 3)) '
+        'must be equal to the number of names ([\'foo\', \'bar\'])'
+    ])
+
+
 class TestFunctional:
 
     def test_mark_per_function(self, testdir):


### PR DESCRIPTION
Show the correct error message when collect "parametrize" func with wrong args and add test to this case