### PR TITLE
Fix py35-trial environment

### DIFF
--- a/_pytest/pytester.py
+++ b/_pytest/pytester.py
@@ -447,9 +447,10 @@ class Testdir:
         the module is re-imported.
         """
         for name in set(sys.modules).difference(self._savemodulekeys):
-            # zope.interface (used by twisted-related tests) keeps internal
-            # state and can't be deleted
-            if not name.startswith("zope.interface"):
+            # some zope modules used by twisted-related tests keeps internal
+            # state and can't be deleted; we had some trouble in the past
+            # with zope.interface for example
+            if not name.startswith("zope"):
                 del sys.modules[name]
 
     def make_hook_recorder(self, pluginmanager):


### PR DESCRIPTION
After updating to twisted 17.1.0, again the trial tests started to fail; didn't investigate too deep, decided to just no longer delete `zope` modules when cleaning up after pytester because it seems more modules keep global state that shouldn't be discarded

