### PR TITLE
Consider all modules

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -81,6 +81,8 @@ Changes
 * fix `#2308`_: When using both ``--lf`` and ``--ff``, only the last failed tests are run.
   Thanks `@ojii`_ for the PR.
 
+* fix `#2391`_: consider pytest_plugins on all plugin modules
+  Thansks `@RonnyPfannschmidt`_ for the PR.
 
 Bug Fixes
 ---------
@@ -114,8 +116,9 @@ Bug Fixes
 .. _#2166: https://github.com/pytest-dev/pytest/pull/2166
 .. _#2147: https://github.com/pytest-dev/pytest/issues/2147
 .. _#2208: https://github.com/pytest-dev/pytest/issues/2208
-.. _#2228:  https://github.com/pytest-dev/pytest/issues/2228
+.. _#2228: https://github.com/pytest-dev/pytest/issues/2228
 .. _#2308: https://github.com/pytest-dev/pytest/issues/2308
+.. _#2391: https://github.com/pytest-dev/pytest/issues/2391
 
 
 3.0.8 (unreleased)

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -8,7 +8,8 @@ import warnings
 
 import py
 # DON't import pytest here because it causes import cycle troubles
-import sys, os
+import sys
+import os
 import _pytest._code
 import _pytest.hookspec  # the extension point definitions
 import _pytest.assertion
@@ -252,6 +253,9 @@ class PytestPluginManager(PluginManager):
         if ret:
             self.hook.pytest_plugin_registered.call_historic(
                       kwargs=dict(plugin=plugin, manager=self))
+
+            if isinstance(plugin, types.ModuleType):
+                self.consider_module(plugin)
         return ret
 
     def getplugin(self, name):
@@ -396,8 +400,7 @@ class PytestPluginManager(PluginManager):
             self.import_plugin(arg)
 
     def consider_conftest(self, conftestmodule):
-        if self.register(conftestmodule, name=conftestmodule.__file__):
-            self.consider_module(conftestmodule)
+        self.register(conftestmodule, name=conftestmodule.__file__)
 
     def consider_env(self):
         self._import_plugin_specs(os.environ.get("PYTEST_PLUGINS"))
@@ -441,7 +444,6 @@ class PytestPluginManager(PluginManager):
         else:
             mod = sys.modules[importspec]
             self.register(mod, modname)
-            self.consider_module(mod)
 
 
 def _get_plugin_specs_as_list(specs):


### PR DESCRIPTION
this pr is to make the plugin manager run consider_module on all modules registred as plugin

this is supposed to address #2391 in a more general manner
however after moving the trigger i get a lot of errors that are hard to comprehend because pytest-spagetti

