### PR TITLE
Introduce a task to generate the announcement file for releases

### DIFF
--- a/HOWTORELEASE.rst
+++ b/HOWTORELEASE.rst
@@ -1,18 +1,20 @@
 How to release pytest
 --------------------------------------------
 
-Note: this assumes you have already registered on pypi.
+Note: this assumes you have already registered on PyPI and you have
+`invoke <https://pypi.org/project/invoke/>`_ installed.
 
 #. Check and finalize ``CHANGELOG.rst``.
 
-#. Write ``doc/en/announce/release-VERSION.txt`` and include
-   it in ``doc/en/announce/index.txt``. Run this command to list names of authors involved::
+#. Generate a new release announcement::
 
-        git log $(git describe --abbrev=0 --tags)..HEAD --format='%aN' | sort -u
+     invoke generate.announce VERSION
+
+Feel free to modify the generated files before committing.
 
 #. Regenerate the docs examples using tox::
 
-      tox -e regen
+     tox -e regen
 
 #. At this point, open a PR named ``release-X`` so others can help find regressions or provide suggestions.
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,6 +20,7 @@ recursive-include extra *.py
 graft testing
 graft doc
 prune doc/en/_build
+graft tasks
 
 exclude _pytest/impl
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,0 +1,9 @@
+"""
+Invoke tasks to help with pytest development and release process.
+"""
+
+import invoke
+
+from . import generate
+
+ns = invoke.Collection(generate)

--- a/tasks/generate.py
+++ b/tasks/generate.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+from subprocess import check_output
+
+import invoke
+
+
+@invoke.task(help={
+    'version': 'version being released',
+})
+def announce(ctx, version):
+    """Generates a new release announcement entry in the docs."""
+    print("[generate.announce] Generating Announce")
+
+    # Get our list of authors
+    print("[generate.announce] Collecting author names")
+
+    stdout = check_output(["git", "describe", "--abbrev=0", '--tags'])
+    stdout = stdout.decode('utf-8')
+    last_version = stdout.strip()
+
+    stdout = check_output(["git", "log", "{}..HEAD".format(last_version), "--format=%aN"])
+    stdout = stdout.decode('utf-8')
+
+    contributors = set(stdout.splitlines())
+
+    template_name = 'release.minor.rst' if version.endswith('.0') else 'release.patch.rst'
+    template_text = Path(__file__).parent.joinpath(template_name).read_text(encoding='UTF-8')
+
+    contributors_text = '\n'.join('* {}'.format(name) for name in sorted(contributors)) + '\n'
+    text = template_text.format(version=version, contributors=contributors_text)
+
+    target = Path(__file__).joinpath('../../doc/en/announce/release-{}.rst'.format(version))
+    target.write_text(text, encoding='UTF-8')
+    print("[generate.announce] Generated {}".format(target.name))
+
+    # Update index with the new release entry
+    index_path = Path(__file__).joinpath('../../doc/en/announce/index.rst')
+    lines = index_path.read_text(encoding='UTF-8').splitlines()
+    indent = '   '
+    for index, line in enumerate(lines):
+        if line.startswith('{}release-'.format(indent)):
+            new_line = indent + target.stem
+            if line != new_line:
+                lines.insert(index, new_line)
+                index_path.write_text('\n'.join(lines) + '\n', encoding='UTF-8')
+                print("[generate.announce] Updated {}".format(index_path.name))
+            else:
+                print("[generate.announce] Skip {} (already contains release)".format(index_path.name))
+            break
+
+    print()
+    print('Please review the generated files and commit with:')
+    print('    git commit -a -m "Generate new release announcement for {}'.format(version))
+
+
+

--- a/tasks/release.minor.rst
+++ b/tasks/release.minor.rst
@@ -1,0 +1,27 @@
+pytest-{version}
+=======================================
+
+The pytest team is proud to announce the {version} release!
+
+pytest is a mature Python testing tool with more than a 1600 tests
+against itself, passing on many different interpreters and platforms.
+
+This release contains a bugs fixes and improvements, so users are encouraged
+to take a look at the CHANGELOG:
+
+http://doc.pytest.org/en/latest/changelog.html
+
+For complete documentation, please visit:
+
+    http://docs.pytest.org
+
+As usual, you can upgrade from pypi via:
+
+    pip install -U pytest
+
+Thanks to all who contributed to this release, among them:
+
+{contributors}
+
+Happy testing,
+The Pytest Development Team

--- a/tasks/release.patch.rst
+++ b/tasks/release.patch.rst
@@ -1,0 +1,17 @@
+pytest-{version}
+=======================================
+
+pytest {version} has just been released to PyPI.
+
+This is a bug-fix release, being a drop-in replacement. To upgrade::
+
+  pip install --upgrade pytest
+  
+The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+
+Thanks to all who contributed to this release, among them:
+
+{contributors}
+
+Happy testing,
+The pytest Development Team


### PR DESCRIPTION
As discussed in the mailing list, introducing [invoke](https://pypi.org/project/invoke/) tasks to simplify development and release process.

I started with a task to generate the AUTHORS file from git history but because pytest has a very old history, a lot of the names (60+) are not in a proper "name" format, a few examples:

```
famousgarkin
fijal
foxx
gabriel.reis
getxsick
```

I realized that finding the proper names would be a ton of work and not really worth the trouble, given that the AUTHORS file is updated during PRs and not during the release process.

This is the perfect place to introduce a task to update the CHANGELOG (#2390) IMO. 😁 