### PR TITLE
Release 3.1 automated steps (preview, DO NOT MERGE)

### DIFF
--- a/HOWTORELEASE.rst
+++ b/HOWTORELEASE.rst
@@ -1,27 +1,28 @@
 How to release pytest
 --------------------------------------------
 
-Note: this assumes you have already registered on PyPI and you have
-`invoke <https://pypi.org/project/invoke/>`_ installed.
+.. important::
 
-#. Check and finalize ``CHANGELOG.rst``.
+    pytest releases must be prepared on **linux** because the docs and examples expect
+    to be executed in that platform.
 
-#. Generate a new release announcement::
+#. Install development dependencies in a virtual environment with::
 
-     invoke generate.announce VERSION
+    pip3 install -r tasks/requirements.txt
 
-Feel free to modify the generated files before committing.
+#. Create a branch ``release-X.Y.Z`` with the version for the release. Make sure it is up to date
+   with the latest ``master`` (for patch releases) and with the latest ``features`` merged with
+   the latest ``master`` (for minor releases). Ensure your are in a clean work tree.
 
-#. Regenerate the docs examples using tox::
+#. Check and finalize ``CHANGELOG.rst`` (will be automated soon).
 
-     tox -e regen
+#. Execute to automatically generate docs, announcements and upload a package to
+   your ``devpi`` staging server::
 
-#. At this point, open a PR named ``release-X`` so others can help find regressions or provide suggestions.
+     invoke generate.pre_release <VERSION> <DEVPI USER> --password <DEVPI PASSWORD>
 
-#. Use devpi for uploading a release tarball to a staging area::
-
-     devpi use https://devpi.net/USER/dev
-     devpi upload --formats sdist,bdist_wheel
+   If ``--password`` is not given, it is assumed the user is already logged in. If you don't have
+   an account, please ask for one!
 
 #. Run from multiple machines::
 

--- a/doc/en/Makefile
+++ b/doc/en/Makefile
@@ -41,7 +41,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 regen:
-	PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPT=-p\	 no:hypothesis COLUMNS=76 regendoc --update *.rst */*.rst ${REGENDOC_ARGS}
+	PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPT=-pno:hypothesis COLUMNS=76 regendoc --update *.rst */*.rst ${REGENDOC_ARGS}
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/doc/en/announce/index.rst
+++ b/doc/en/announce/index.rst
@@ -6,6 +6,7 @@ Release announcements
    :maxdepth: 2
 
    
+   release-3.1.0
    release-3.0.7
    release-3.0.6
    release-3.0.5

--- a/doc/en/announce/release-3.1.0.rst
+++ b/doc/en/announce/release-3.1.0.rst
@@ -1,0 +1,60 @@
+pytest-3.1.0
+=======================================
+
+The pytest team is proud to announce the 3.1.0 release!
+
+pytest is a mature Python testing tool with more than a 1600 tests
+against itself, passing on many different interpreters and platforms.
+
+This release contains a bugs fixes and improvements, so users are encouraged
+to take a look at the CHANGELOG:
+
+http://doc.pytest.org/en/latest/changelog.html
+
+For complete documentation, please visit:
+
+    http://docs.pytest.org
+
+As usual, you can upgrade from pypi via:
+
+    pip install -U pytest
+
+Thanks to all who contributed to this release, among them:
+
+* Anthony Sottile
+* Ben Lloyd
+* Bruno Oliveira
+* David Giese
+* David Szotten
+* Dmitri Pribysh
+* Florian Bruhin
+* Florian Schulze
+* Floris Bruynooghe
+* John Towler
+* Jonas Obrist
+* Katerina Koukiou
+* Kodi Arfer
+* Krzysztof Szularz
+* Loïc Estève
+* Luke Murphy
+* Manuel Krebber
+* Matthew Duck
+* Matthias Bussonnier
+* Michael Howitz
+* Michal Wajszczuk
+* Paweł Adamczak
+* Rafael Bertoldi
+* Ravi Chandra
+* Ronny Pfannschmidt
+* Skylar Downes
+* Thomas Kriechbaumer
+* Vitaly Lashmanov
+* Vlad Dragos
+* Wheerd
+* Xander Johnson
+* mandeep
+* reut
+
+
+Happy testing,
+The Pytest Development Team

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -397,8 +397,10 @@ is to be run with different sets of arguments for its three arguments:
 Running it results in some skips if we don't have all the python interpreters installed and otherwise runs all combinations (5 interpreters times 5 interpreters times 3 objects to serialize/deserialize)::
 
    . $ pytest -rs -q multipython.py
-   ................................................
-   48 passed in 0.12 seconds
+   sssssssssssssss.........sss.........sss.........
+   ======= short test summary info ========
+   SKIP [21] $REGENDOC_TMPDIR/CWD/multipython.py:23: 'python2.6' not found
+   27 passed, 21 skipped in 0.12 seconds
 
 Indirect parametrization of optional implementations/imports
 --------------------------------------------------------------------

--- a/doc/en/parametrize.rst
+++ b/doc/en/parametrize.rst
@@ -9,17 +9,16 @@
 Parametrizing fixtures and test functions
 ==========================================================================
 
-pytest supports test parametrization in several well-integrated ways:
+pytest enables test parametrization at several levels:
 
-- :py:func:`pytest.fixture` allows to define :ref:`parametrization
-  at the level of fixture functions <fixture-parametrize>`.
+- :py:func:`pytest.fixture` allows one to :ref:`parametrize fixture 
+  functions <fixture-parametrize>`.
 
-* `@pytest.mark.parametrize`_ allows to define parametrization at the
-  function or class level, provides multiple argument/fixture sets
-  for a particular test function or class.
+* `@pytest.mark.parametrize`_ allows one to define multiple sets of 
+  arguments and fixtures at the test function or class.
 
-* `pytest_generate_tests`_ enables implementing your own custom
-  dynamic parametrization scheme or extensions.
+* `pytest_generate_tests`_ allows one to define custom parametrization 
+  schemes or extensions.
 
 .. _parametrizemark:
 .. _`@pytest.mark.parametrize`:

--- a/doc/en/unittest.rst
+++ b/doc/en/unittest.rst
@@ -171,7 +171,8 @@ creation of a per-test temporary directory::
             tmpdir.join("samplefile.ini").write("# testdata")
 
         def test_method(self):
-            s = open("samplefile.ini").read() 
+            with open("samplefile.ini") as f:
+                s = f.read()
             assert "testdata" in s
 
 Due to the ``autouse`` flag the ``initdir`` fixture function will be

--- a/doc/en/unittest.rst
+++ b/doc/en/unittest.rst
@@ -184,13 +184,7 @@ Running this test module ...::
 
     $ pytest -q test_unittest_cleandir.py
     .
-    ======= warnings summary ========
-    test_unittest_cleandir.py::MyTest::test_method
-      $REGENDOC_TMPDIR/test_unittest_cleandir.py:11: ResourceWarning: unclosed file <_io.TextIOWrapper name='samplefile.ini' mode='r' encoding='UTF-8'>
-        s = open("samplefile.ini").read()
-    
-    -- Docs: http://doc.pytest.org/en/latest/warnings.html
-    1 passed, 1 warnings in 0.12 seconds
+    1 passed in 0.12 seconds
 
 ... gives us one passed test because the ``initdir`` fixture function
 was executed ahead of the ``test_method``.

--- a/doc/en/warnings.rst
+++ b/doc/en/warnings.rst
@@ -40,9 +40,22 @@ The ``-W`` flag can be passed to control which warnings will be displayed or eve
 them into errors::
 
     $ pytest -q test_show_warnings.py -W error::DeprecationWarning
+    F
+    ======= FAILURES ========
+    _______ test_one ________
     
-    no tests ran in 0.12 seconds
-    ERROR: file not found: test_show_warning.py
+        def test_one():
+    >       assert deprecated_function() == 1
+    
+    test_show_warnings.py:8: 
+    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+    
+        def deprecated_function():
+    >       warnings.warn("this function is deprecated, use another_function()", DeprecationWarning)
+    E       DeprecationWarning: this function is deprecated, use another_function()
+    
+    test_show_warnings.py:4: DeprecationWarning
+    1 failed in 0.12 seconds
 
 The same option can be set in the ``pytest.ini`` file using the ``filterwarnings`` ini option.
 For example, the configuration below will ignore all deprecation warnings, but will transform

--- a/doc/en/warnings.rst
+++ b/doc/en/warnings.rst
@@ -39,7 +39,7 @@ Running pytest now produces this output::
 The ``-W`` flag can be passed to control which warnings will be displayed or even turn
 them into errors::
 
-    $ pytest -q test_show_warning.py -W error::DeprecationWarning
+    $ pytest -q test_show_warnings.py -W error::DeprecationWarning
     
     no tests ran in 0.12 seconds
     ERROR: file not found: test_show_warning.py

--- a/tasks/requirements.txt
+++ b/tasks/requirements.txt
@@ -1,0 +1,3 @@
+invoke
+tox
+gitpython

--- a/tox.ini
+++ b/tox.ini
@@ -134,6 +134,7 @@ commands=
 
 [testenv:regen]
 changedir=doc/en
+skipsdist=True
 basepython = python3.5
 deps=sphinx
      PyYAML


### PR DESCRIPTION
I automated most of the pre-release steps into `invoke` tasks. I also updated the `HOWTORELEASE.txt` document, but I didn't actually change the steps, only automated them.

(@RonnyPfannschmidt I don't plan to release right away, I want to wait for feedback on the mailing list regarding 3.1 vs 4.0 release).

Build links:

* [Travis](https://travis-ci.org/nicoddemus/devpi-cloud-test-pytest)
* [AppVeyor](https://ci.appveyor.com/project/nicoddemus/devpi-cloud-test-pytest)

I'm now using [obestwalter/devpi-cloud-test](https://github.com/obestwalter/devpi-cloud-test) for the builds. 😁 

cc @obestwalter 