### PR TITLE
Automate pre release steps

### DIFF
--- a/HOWTORELEASE.rst
+++ b/HOWTORELEASE.rst
@@ -1,27 +1,28 @@
 How to release pytest
 --------------------------------------------
 
-Note: this assumes you have already registered on PyPI and you have
-`invoke <https://pypi.org/project/invoke/>`_ installed.
+.. important::
 
-#. Check and finalize ``CHANGELOG.rst``.
+    pytest releases must be prepared on **linux** because the docs and examples expect
+    to be executed in that platform.
 
-#. Generate a new release announcement::
+#. Install development dependencies in a virtual environment with::
 
-     invoke generate.announce VERSION
+    pip3 install -r tasks/requirements.txt
 
-Feel free to modify the generated files before committing.
+#. Create a branch ``release-X.Y.Z`` with the version for the release. Make sure it is up to date
+   with the latest ``master`` (for patch releases) and with the latest ``features`` merged with
+   the latest ``master`` (for minor releases). Ensure your are in a clean work tree.
 
-#. Regenerate the docs examples using tox::
+#. Check and finalize ``CHANGELOG.rst`` (will be automated soon).
 
-     tox -e regen
+#. Execute to automatically generate docs, announcements and upload a package to
+   your ``devpi`` staging server::
 
-#. At this point, open a PR named ``release-X`` so others can help find regressions or provide suggestions.
+     invoke generate.pre_release <VERSION> <DEVPI USER> --password <DEVPI PASSWORD>
 
-#. Use devpi for uploading a release tarball to a staging area::
-
-     devpi use https://devpi.net/USER/dev
-     devpi upload --formats sdist,bdist_wheel
+   If ``--password`` is not given, it is assumed the user is already logged in. If you don't have
+   an account, please ask for one!
 
 #. Run from multiple machines::
 

--- a/doc/en/Makefile
+++ b/doc/en/Makefile
@@ -41,7 +41,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 regen:
-	PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPT=-p\	 no:hypothesis COLUMNS=76 regendoc --update *.rst */*.rst ${REGENDOC_ARGS}
+	PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPT=-pno:hypothesis COLUMNS=76 regendoc --update *.rst */*.rst ${REGENDOC_ARGS}
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/doc/en/parametrize.rst
+++ b/doc/en/parametrize.rst
@@ -9,17 +9,16 @@
 Parametrizing fixtures and test functions
 ==========================================================================
 
-pytest supports test parametrization in several well-integrated ways:
+pytest enables test parametrization at several levels:
 
-- :py:func:`pytest.fixture` allows to define :ref:`parametrization
-  at the level of fixture functions <fixture-parametrize>`.
+- :py:func:`pytest.fixture` allows one to :ref:`parametrize fixture 
+  functions <fixture-parametrize>`.
 
-* `@pytest.mark.parametrize`_ allows to define parametrization at the
-  function or class level, provides multiple argument/fixture sets
-  for a particular test function or class.
+* `@pytest.mark.parametrize`_ allows one to define multiple sets of 
+  arguments and fixtures at the test function or class.
 
-* `pytest_generate_tests`_ enables implementing your own custom
-  dynamic parametrization scheme or extensions.
+* `pytest_generate_tests`_ allows one to define custom parametrization 
+  schemes or extensions.
 
 .. _parametrizemark:
 .. _`@pytest.mark.parametrize`:

--- a/doc/en/unittest.rst
+++ b/doc/en/unittest.rst
@@ -171,7 +171,8 @@ creation of a per-test temporary directory::
             tmpdir.join("samplefile.ini").write("# testdata")
 
         def test_method(self):
-            s = open("samplefile.ini").read() 
+            with open("samplefile.ini") as f:
+                s = f.read()
             assert "testdata" in s
 
 Due to the ``autouse`` flag the ``initdir`` fixture function will be

--- a/doc/en/warnings.rst
+++ b/doc/en/warnings.rst
@@ -39,7 +39,7 @@ Running pytest now produces this output::
 The ``-W`` flag can be passed to control which warnings will be displayed or even turn
 them into errors::
 
-    $ pytest -q test_show_warning.py -W error::DeprecationWarning
+    $ pytest -q test_show_warnings.py -W error::DeprecationWarning
     
     no tests ran in 0.12 seconds
     ERROR: file not found: test_show_warning.py

--- a/tasks/requirements.txt
+++ b/tasks/requirements.txt
@@ -1,0 +1,3 @@
+invoke
+tox
+gitpython

--- a/tox.ini
+++ b/tox.ini
@@ -134,6 +134,7 @@ commands=
 
 [testenv:regen]
 changedir=doc/en
+skipsdist=True
 basepython = python3.5
 deps=sphinx
      PyYAML


### PR DESCRIPTION
Automate most pre-release steps into invoke tasks, except for the CHANGELOG.

Follow up of #2410, without the actual changes made for a pre-release.