### PR TITLE
small fix in an example from the docs

### DIFF
--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -269,6 +269,7 @@ running from a test you can do something like this:
         sys._called_from_test = True
 
     def pytest_unconfigure(config):
+        import sys
         del sys._called_from_test
 
 and then check for the ``sys._called_from_test`` flag:


### PR DESCRIPTION
Target: master

trivial documentation fix (e.g.,  a typo or reword of a small section)

Fix taken from http://stackoverflow.com/questions/25188119/test-if-code-is-executed-from-within-a-py-test-session