### PR TITLE
Correct warnings that contains Unicode message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+3.1.1 (unreleased)
+==================
+
+* Fix encoding errors for unicode warnings in Python 2.
+
+
 3.1.0 (2017-05-22)
 ==================
 

--- a/_pytest/compat.py
+++ b/_pytest/compat.py
@@ -126,6 +126,7 @@ if _PY3:
     import codecs
     imap = map
     STRING_TYPES = bytes, str
+    UNICODE_TYPES = str,
 
     def _escape_strings(val):
         """If val is pure ascii, returns it as a str().  Otherwise, escapes
@@ -157,6 +158,7 @@ if _PY3:
             return val.encode('unicode_escape').decode('ascii')
 else:
     STRING_TYPES = bytes, str, unicode
+    UNICODE_TYPES = unicode,
 
     from itertools import imap  # NOQA
 

--- a/_pytest/warnings.py
+++ b/_pytest/warnings.py
@@ -63,10 +63,23 @@ def catch_warnings_for_item(item):
         yield
 
         for warning in log:
+            warn_msg = warning.message
+            unicode_warning = False
+
+            if compat._PY2 and any(isinstance(m, compat.UNICODE_TYPES) for m in warn_msg.args):
+                warn_msg.args = [compat.safe_str(m) for m in warn_msg.args]
+                unicode_warning = True
+
             msg = warnings.formatwarning(
-                compat.safe_str(warning.message), warning.category,
+                warn_msg, warning.category,
                 warning.filename, warning.lineno, warning.line)
             item.warn("unused", msg)
+
+            if unicode_warning:
+                warnings.warn(
+                    "This warning %s is broken as it's message is not a str instance"
+                    "(after all this is a stdlib problem workaround)" % msg,
+                    UnicodeWarning)
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/_pytest/warnings.py
+++ b/_pytest/warnings.py
@@ -5,6 +5,8 @@ from contextlib import contextmanager
 
 import pytest
 
+from _pytest import compat
+
 
 def _setoption(wmod, arg):
     """
@@ -62,7 +64,7 @@ def catch_warnings_for_item(item):
 
         for warning in log:
             msg = warnings.formatwarning(
-                warning.message, warning.category,
+                compat.safe_str(warning.message), warning.category,
                 warning.filename, warning.lineno, warning.line)
             item.warn("unused", msg)
 

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -1,3 +1,6 @@
+# -*- coding: utf8 -*-
+from __future__ import unicode_literals
+
 import pytest
 
 
@@ -105,4 +108,30 @@ def test_ignore(testdir, pyfile_with_warnings, method):
         '* 1 passed in *',
     ])
     assert WARNINGS_SUMMARY_HEADER not in result.stdout.str()
+
+
+
+def test_unicode(testdir, pyfile_with_warnings):
+    testdir.makepyfile('''
+        # -*- coding: utf8 -*-
+        import warnings
+        import pytest
+
+
+        @pytest.fixture
+        def fix():
+            warnings.warn(u"测试")
+            yield
+
+        def test_func(fix):
+            pass
+    ''')
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines([
+        '*== %s ==*' % WARNINGS_SUMMARY_HEADER,
+
+        '*test_unicode.py:8: UserWarning: \u6d4b\u8bd5',
+        '*warnings.warn(u"\u6d4b\u8bd5")',
+        '* 1 passed, 1 warnings*',
+    ])
 

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -1,6 +1,8 @@
 # -*- coding: utf8 -*-
 from __future__ import unicode_literals
 
+import sys
+
 import pytest
 
 
@@ -111,6 +113,8 @@ def test_ignore(testdir, pyfile_with_warnings, method):
 
 
 
+@pytest.mark.skipif(sys.version_info < (3, 0),
+                    reason='warnings message is unicode is ok in python3')
 def test_unicode(testdir, pyfile_with_warnings):
     testdir.makepyfile('''
         # -*- coding: utf8 -*-
@@ -135,3 +139,30 @@ def test_unicode(testdir, pyfile_with_warnings):
         '* 1 passed, 1 warnings*',
     ])
 
+
+@pytest.mark.skipif(sys.version_info >= (3, 0),
+                    reason='warnings message is broken as it is not str instance')
+def test_py2_unicode(testdir, pyfile_with_warnings):
+    testdir.makepyfile('''
+        # -*- coding: utf8 -*-
+        import warnings
+        import pytest
+
+
+        @pytest.fixture
+        def fix():
+            warnings.warn(u"测试")
+            yield
+
+        def test_func(fix):
+            pass
+    ''')
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines([
+        '*== %s ==*' % WARNINGS_SUMMARY_HEADER,
+
+        '*test_py2_unicode.py:8: UserWarning: \u6d4b\u8bd5',
+        '*warnings.warn(u"\u6d4b\u8bd5")',
+        '*warnings.py:82: UnicodeWarning: This warning*\u6d4b\u8bd5',
+        '* 1 passed, 2 warnings*',
+    ])


### PR DESCRIPTION
This PR try to fix #2436.

- [x] Target: `master`;

Unless your change is trivial documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Make sure to include one or more tests for your change;
- [ ] Add yourself to `AUTHORS`;
- [x] Add a new entry to `CHANGELOG.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using RST syntax.
  * The pytest team likes to have people to acknowledged in the `CHANGELOG`, so please add a thank note to yourself ("Thanks @user for the PR") and a link to your GitHub profile. It may sound weird thanking yourself, but otherwise a maintainer would have to do it manually before or after merging instead of just using GitHub's merge button. This makes it easier on the maintainers to merge PRs. 
