### PR TITLE
Fix unicode issue while running doctests in Python 2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,9 @@
 3.1.1 (unreleased)
 ==================
 
-* Fix encoding errors for unicode warnings in Python 2.
+* Fix encoding errors for unicode warnings in Python 2. (towncrier: 2436.bugfix)
+
+* Fix issue with non-ascii contents in doctest text files. (towncrier: 2434.bugfix)
 
 
 3.1.0 (2017-05-22)

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -505,6 +505,28 @@ class TestDoctests(object):
                                     "--junit-xml=junit.xml")
         reprec.assertoutcome(failed=1)
 
+    def test_unicode_doctest(self, testdir):
+        """
+        Test case for issue 2434: DecodeError on Python 2 when doctest contains non-ascii
+        characters.
+        """
+        p = testdir.maketxtfile(test_unicode_doctest="""
+            .. doctest::
+
+                >>> print(
+                ...    "Hi\\n\\nByé")
+                Hi
+                ...
+                Byé
+                >>> 1/0  # Byé
+                1
+        """)
+        result = testdir.runpytest(p)
+        result.stdout.fnmatch_lines([
+            '*UNEXPECTED EXCEPTION: ZeroDivisionError*',
+            '*1 failed*',
+        ])
+
 
 class TestLiterals(object):
 


### PR DESCRIPTION
Fix #2434 