### PR TITLE
[WIP] A workaround for Python 3.6 WindowsConsoleIO breaking with FDCapture

### DIFF
--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -515,7 +515,7 @@ def _py36_windowsconsoleio_workaround():
 
     See https://github.com/pytest-dev/py/issues/103
     """
-    if not sys.platform.startswith('win32') and sys.version_info[:2] >= (3, 6):
+    if not sys.platform.startswith('win32') or sys.version_info[:2] < (3, 6):
         return
 
     buffered = hasattr(sys.stdout.buffer, 'raw')

--- a/changelog/103.bugfix
+++ b/changelog/103.bugfix
@@ -1,0 +1,3 @@
+Added a workaround for Python 3.6 WindowsConsoleIO breaking due to Pytests's
+FDCapture. Other code using console handles might still be affected by the
+very same issue and might require further workarounds/fixes, i.e. colorama.


### PR DESCRIPTION
Python 3.6 implemented unicode console handling for Windows. This works by reading/writing to the raw console handle using ``{Read,Write}ConsoleW``.

The problem is that we are going to ``dup2`` over the stdio file descriptors when doing ``FDCapture`` and this will ``CloseHandle`` the handles used by Python to write to the console. Though there is still some weirdness and the console handle seems to only be closed randomly and not on the first call to ``CloseHandle``, or maybe it gets reopened with the same handle value when we suspend capturing.

The workaround in this case will reopen stdio with a different fd which also means a different handle by replicating the logic in "Py_lifecycle.c:[initstdio](https://github.com/python/cpython/blob/aead53b6ee27915de248b07de509529174aaad21/Python/pylifecycle.c#L1393)/[create_stdio](https://github.com/python/cpython/blob/aead53b6ee27915de248b07de509529174aaad21/Python/pylifecycle.c#L1275)".

Obviously not very pretty, I don't know what other side effects this might have and I'm not even sure this is the right way to go about this. Since the std handles are getting clobbered, other code which does `GetStdHandle`, or something similar, is also affected. Meaning that this is only a partial fix.

For example: colorama breaks just as randomly. But it ignores the errors and all colorama features just randomly stop working (e.g. Colors stop working). Adding error handling to `colorama.winterm` reveals the very same exception. Essentially colorama caches the std handles in `colorama.win32.handles` and it breaks, even without `_WindowsConsoleIO` being used by Python, due to `FDCapture`.

Of course, who knows what other stuff might get broken by this. And I'm still baffled by why it's random and only have a guess as to why (Described above).

Also note that I currently ignored the case if `sys.stdout != sys.__stdout__` and similarly for the other `std.std*`. I'm not sure what is the right thing to do in such a case...

I'm using the Pytest test suite and this to reproduce the issue (Running with `pytest -v`):
```python
import time
import random
import pytest


@pytest.mark.parametrize("i", range(1000))
def test_random_sleep(i, capfd):
    time.sleep(random.random() * 0.2)
```

## See also
* https://github.com/pytest-dev/py/issues/103
* https://bugs.python.org/issue30544 - `GetLastError()` mishap in `_io.WindowsConsoleIO.write`.
* **EDIT:** https://bugs.python.org/issue30555 - About this issue
* **EDIT:** https://github.com/pytest-dev/pytest/issues/2465 - The issue with colorama breaking

## PR Checklist
Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [X] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [X] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [ ] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [X] Add yourself to `AUTHORS`;
