### PR TITLE
Remove UnicodeWarning from pytest warnings

### DIFF
--- a/_pytest/warnings.py
+++ b/_pytest/warnings.py
@@ -66,8 +66,9 @@ def catch_warnings_for_item(item):
             unicode_warning = False
 
             if compat._PY2 and any(isinstance(m, compat.UNICODE_TYPES) for m in warn_msg.args):
-                warn_msg.args = [compat.safe_str(m) for m in warn_msg.args]
-                unicode_warning = True
+                new_args = [compat.safe_str(m) for m in warn_msg.args]
+                unicode_warning = warn_msg.args != new_args
+                warn_msg.args = new_args
 
             msg = warnings.formatwarning(
                 warn_msg, warning.category,
@@ -76,8 +77,8 @@ def catch_warnings_for_item(item):
 
             if unicode_warning:
                 warnings.warn(
-                    "This warning %s is broken as it's message is not a str instance"
-                    "(after all this is a stdlib problem workaround)" % msg,
+                    "Warning is using unicode non convertible to ascii, "
+                    "converting to a safe representation:\n  %s"  % msg,
                     UnicodeWarning)
 
 

--- a/changelog/2463.bugfix
+++ b/changelog/2463.bugfix
@@ -1,0 +1,2 @@
+``UnicodeWarning`` is issued from the internal pytest warnings plugin only when the message contains non-ascii
+unicode (Python 2 only).

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -161,7 +161,7 @@ def test_py2_unicode(testdir, pyfile_with_warnings):
 
         '*test_py2_unicode.py:8: UserWarning: \u6d4b\u8bd5',
         '*warnings.warn(u"\u6d4b\u8bd5")',
-        '*warnings.py:*: UnicodeWarning: This warning*\u6d4b\u8bd5',
+        '*warnings.py:*: UnicodeWarning: Warning is using unicode non*',
         '* 1 passed, 2 warnings*',
     ])
 


### PR DESCRIPTION
I agree with @dwaynebailey in that it is not pytest's job to issue a warning about this, specially because it might be out of the user's control and the standard library does not prohibit it anyway.

Fix #2463
