### PR TITLE
Fix incorrect "collected items" report when specifying tests on the command-line

### DIFF
--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -763,7 +763,11 @@ class Session(FSCollector):
                 if not has_matched and len(rep.result) == 1 and x.name == "()":
                     nextnames.insert(0, name)
                     resultnodes.extend(self.matchnodes([x], nextnames))
-            node.ihook.pytest_collectreport(report=rep)
+            else:
+                # report collection failures here to avoid failing to run some test
+                # specified in the command line because the module could not be
+                # imported (#134)
+                node.ihook.pytest_collectreport(report=rep)
         return resultnodes
 
     def genitems(self, node):

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -282,7 +282,7 @@ class TerminalReporter:
             line = "collected "
         else:
             line = "collecting "
-        line += str(self._numcollected) + " items"
+        line += str(self._numcollected) + " item" + ('' if self._numcollected == 1 else 's')
         if errors:
             line += " / %d errors" % errors
         if skipped:

--- a/changelog/2464.bugfix
+++ b/changelog/2464.bugfix
@@ -1,0 +1,1 @@
+Fix incorrect "collected items" report when specifying tests on the command-line.

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -317,8 +317,8 @@ class TestGeneralUsage(object):
         ])
         assert 'sessionstarttime' not in result.stderr.str()
 
-    @pytest.mark.parametrize('lookfor', ['test_fun.py', 'test_fun.py::test_a'])
-    def test_issue134_report_syntaxerror_when_collecting_member(self, testdir, lookfor):
+    @pytest.mark.parametrize('lookfor', ['test_fun.py::test_a'])
+    def test_issue134_report_error_when_collecting_member(self, testdir, lookfor):
         testdir.makepyfile(test_fun="""
             def test_a():
                 pass

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -513,12 +513,12 @@ def test_pytest_no_tests_collected_exit_status(testdir):
             assert 1
     """)
     result = testdir.runpytest()
-    result.stdout.fnmatch_lines('*collected 1 items*')
+    result.stdout.fnmatch_lines('*collected 1 item*')
     result.stdout.fnmatch_lines('*1 passed*')
     assert result.ret == main.EXIT_OK
 
     result = testdir.runpytest('-k nonmatch')
-    result.stdout.fnmatch_lines('*collected 1 items*')
+    result.stdout.fnmatch_lines('*collected 1 item*')
     result.stdout.fnmatch_lines('*1 deselected*')
     assert result.ret == main.EXIT_NOTESTSCOLLECTED
 

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -204,6 +204,15 @@ class TestTerminal(object):
         assert result.ret == 2
         result.stdout.fnmatch_lines(['*KeyboardInterrupt*'])
 
+    def test_collect_single_item(self, testdir):
+        """Use singular 'item' when reporting a single test item"""
+        testdir.makepyfile("""
+            def test_foobar():
+                pass
+        """)
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines(['collected 1 item'])
+
 
 class TestCollectonly(object):
     def test_collectonly_basic(self, testdir):


### PR DESCRIPTION
It turns out pytest was triggering the `pytest_collectreport` hook when collecting the nodes in order to find the item specified in the command-line, but this is incorrect given that those nodes might not end up in the final list of items that will actually be run.

As a bonus this now only reports the exact number of items that will be executed:

```python
class TestClass(object):
    
    def test_main(self):
        assert 1
        
    def test_bla(self):
        assert True

```
```
$ pytest .tmp\test_foo.py::TestClass::test_main
============================= test session starts =============================
platform win32 -- Python 3.6.0, pytest-2.0.1, py-1.4.33, pluggy-0.4.0
rootdir: C:\pytest, inifile: tox.ini
plugins: hypothesis-3.7.0
collected 1 item

.tmp\test_foo.py .

========================== 1 passed in 0.01 seconds ===========================
```

cc @rev112

Fix #2464
