### PR TITLE
docs: Create links for objects to show the api

### DIFF
--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -169,7 +169,7 @@ def _prepareconfig(args=None, plugins=None):
 
 class PytestPluginManager(PluginManager):
     """
-    Overwrites :py:class:`pluggy.PluginManager` to add pytest-specific
+    Overwrites :py:class:`pluggy.PluginManager <_pytest.vendored_packages.pluggy.PluginManager>` to add pytest-specific
     functionality:
 
     * loading plugins from the command line, ``PYTEST_PLUGIN`` env variable and
@@ -206,7 +206,7 @@ class PytestPluginManager(PluginManager):
         """
         .. deprecated:: 2.8
 
-        Use :py:meth:`pluggy.PluginManager.add_hookspecs` instead.
+        Use :py:meth:`pluggy.PluginManager.add_hookspecs <_pytest.vendored_packages.pluggy.PluginManager.add_hookspecs>` instead.
         """
         warning = dict(code="I2",
                        fslocation=_pytest._code.getfslineno(sys._getframe(1)),
@@ -1130,7 +1130,7 @@ class Config(object):
     def getini(self, name):
         """ return configuration value from an :ref:`ini file <inifiles>`. If the
         specified name hasn't been registered through a prior
-        :py:func:`parser.addini <pytest.config.Parser.addini>`
+        :py:func:`parser.addini <_pytest.config.Parser.addini>`
         call (usually from a plugin), a ValueError is raised. """
         try:
             return self._inicache[name]

--- a/_pytest/hookspec.py
+++ b/_pytest/hookspec.py
@@ -213,7 +213,7 @@ def pytest_runtest_teardown(item, nextitem):
 @hookspec(firstresult=True)
 def pytest_runtest_makereport(item, call):
     """ return a :py:class:`_pytest.runner.TestReport` object
-    for the given :py:class:`pytest.Item` and
+    for the given :py:class:`pytest.Item <_pytest.main.Item>` and
     :py:class:`_pytest.runner.CallInfo`.
     """
 

--- a/_pytest/vendored_packages/pluggy.py
+++ b/_pytest/vendored_packages/pluggy.py
@@ -540,7 +540,7 @@ class PluginManager(object):
         of HookImpl instances and the keyword arguments for the hook call.
 
         ``after(outcome, hook_name, hook_impls, kwargs)`` receives the
-        same arguments as ``before`` but also a :py:class:`_CallOutcome`` object
+        same arguments as ``before`` but also a :py:class:`_CallOutcome <_pytest.vendored_packages.pluggy._CallOutcome>` object
         which represents the result of the overall hook call.
         """
         return _TracedHookExecution(self, before, after).undo

--- a/changelog/2331.doc
+++ b/changelog/2331.doc
@@ -1,0 +1,1 @@
+Fix internal API links to ``pluggy`` objects.

--- a/doc/en/writing_plugins.rst
+++ b/doc/en/writing_plugins.rst
@@ -383,7 +383,7 @@ hook wrappers and passes the same arguments as to the regular hooks.
 
 At the yield point of the hook wrapper pytest will execute the next hook
 implementations and return their result to the yield point in the form of
-a :py:class:`CallOutcome` instance which encapsulates a result or
+a :py:class:`CallOutcome <_pytest.vendored_packages.pluggy._CallOutcome>` instance which encapsulates a result or
 exception info.  The yield point itself will thus typically not raise
 exceptions (unless there are bugs).
 
@@ -448,7 +448,7 @@ Here is the order of execution:
    Plugin1).
 
 4. Plugin3's pytest_collection_modifyitems then executing the code after the yield
-   point.  The yield receives a :py:class:`CallOutcome` instance which encapsulates
+   point.  The yield receives a :py:class:`CallOutcome <_pytest.vendored_packages.pluggy._CallOutcome>` instance which encapsulates
    the result from calling the non-wrappers.  Wrappers shall not modify the result.
 
 It's possible to use ``tryfirst`` and ``trylast`` also in conjunction with
@@ -525,7 +525,7 @@ Initialization, command line and configuration hooks
 Generic "runtest" hooks
 -----------------------
 
-All runtest related hooks receive a :py:class:`pytest.Item` object.
+All runtest related hooks receive a :py:class:`pytest.Item <_pytest.main.Item>` object.
 
 .. autofunction:: pytest_runtest_protocol
 .. autofunction:: pytest_runtest_setup


### PR DESCRIPTION
**Fixes: https://github.com/pytest-dev/pytest/issues/2331** 
head-fork: ApaDoctor/pytest
compare: docs-fixes

base-fork: pytest-dev/pytest
base: master          # if it's a bugfix