### PR TITLE
[wip] Fix ignore_path condition

### DIFF
--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -168,14 +168,13 @@ def pytest_runtestloop(session):
 
 
 def pytest_ignore_collect(path, config):
-    p = path.dirpath()
-    ignore_paths = config._getconftest_pathlist("collect_ignore", path=p)
+    ignore_paths = config._getconftest_pathlist("collect_ignore", path=path.dirpath())
     ignore_paths = ignore_paths or []
     excludeopt = config.getoption("ignore")
     if excludeopt:
         ignore_paths.extend([py.path.local(x) for x in excludeopt])
 
-    if path in ignore_paths:
+    if py.path.local(path) in ignore_paths:
         return True
 
     # Skip duplicate paths.

--- a/changelog/2475.bugfix
+++ b/changelog/2475.bugfix
@@ -1,0 +1,1 @@
+Fix issue where paths collected by pytest could have triple leading ``/`` characters.


### PR DESCRIPTION
For some legacy reason, I have a container copying source to '/' directly. 
From there `rootdir='/'` and paths gathered by pytest have 3 leading /. 

the condition https://github.com/pytest-dev/pytest/pull/2475/files#diff-5b415004cf343fc3c36aebb8aad93882L178
is checking the following and it doesn't match: 
```
if "///endpoints/test/test_api.py" in [local('/endpoints/test')]
```
This pr simply format the path the way the excludepath is formatted

----

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [ ] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [ ] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [ ] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Add yourself to `AUTHORS`;
