### PR TITLE
Fix internal error when a recursion error occurs and frames contain objects that can't be compared

### DIFF
--- a/changelog/2459.bugfix
+++ b/changelog/2459.bugfix
@@ -1,0 +1,1 @@
+Fix recursion error detection when frames in the traceback contain objects that can't be compared (like ``numpy`` arrays).


### PR DESCRIPTION
Fix #2459
