### PR TITLE
deprecated_call context manager captures warnings already raised

### DIFF
--- a/_pytest/recwarn.py
+++ b/_pytest/recwarn.py
@@ -45,6 +45,7 @@ def deprecated_call(func=None, *args, **kwargs):
     if not func:
         return _DeprecatedCallContext()
     else:
+        __tracebackhide__ = True
         with _DeprecatedCallContext():
             return func(*args, **kwargs)
 
@@ -71,7 +72,7 @@ class _DeprecatedCallContext(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         warnings.warn_explicit = self._old_warn_explicit
         warnings.warn = self._old_warn
-        
+
         if exc_type is None:
             deprecation_categories = (DeprecationWarning, PendingDeprecationWarning)
             if not any(issubclass(c, deprecation_categories) for c in self._captured_categories):

--- a/changelog/2469.bugfix
+++ b/changelog/2469.bugfix
@@ -1,0 +1,4 @@
+``deprecated_call`` in context-manager form now captures deprecation warnings even if
+the same warning has already been raised. Also, ``deprecated_call`` will always produce
+the same error message (previously it would produce different messages in context-manager vs.
+function-call mode).


### PR DESCRIPTION
This normalizes the context-manager and function form of `deprecated_call` by using the exact same implementation.

I also updated the docs to mention the context-manager form first.

Fix #2469
