### PR TITLE
Add issue links in the CHANGELOG entries

### DIFF
--- a/changelog/_template.rst
+++ b/changelog/_template.rst
@@ -13,7 +13,7 @@
 
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category]|dictsort(by='value') %}
-- {{ text }}{% if category != 'vendor' %} ({{ values|sort|join(', ') }}){% endif %}
+- {{ text }}{% if category != 'vendor' %} (`{{ values[0] }} <https://github.com/pytest-dev/pytest/issues/{{ values[0][1:] }}>`_){% endif %}
 
 
 {% endfor %}


### PR DESCRIPTION
This unfortunately no longer supports multiple entries with the same text,
but this is worth the improved readability and navigation IMO
