### PR TITLE
Handle exceptions in subrequest finalizers

### DIFF
--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -733,10 +733,16 @@ class FixtureDef:
         self._finalizer.append(finalizer)
 
     def finish(self):
+        exceptions = []
         try:
             while self._finalizer:
-                func = self._finalizer.pop()
-                func()
+                try:
+                    func = self._finalizer.pop()
+                    func()
+                except:
+                    exceptions.append(sys.exc_info())
+            if exceptions:
+                py.builtin._reraise(*exceptions[0])
         finally:
             ihook = self._fixturemanager.session.ihook
             ihook.pytest_fixture_post_finalizer(fixturedef=self)

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -742,7 +742,10 @@ class FixtureDef:
                 except:
                     exceptions.append(sys.exc_info())
             if exceptions:
-                py.builtin._reraise(*exceptions[0])
+                e = exceptions[0]
+                del exceptions  # ensure we don't keep all frames alive because of the traceback
+                py.builtin._reraise(*e)
+
         finally:
             ihook = self._fixturemanager.session.ihook
             ihook.pytest_fixture_post_finalizer(fixturedef=self)

--- a/changelog/2440.bugfix
+++ b/changelog/2440.bugfix
@@ -1,0 +1,1 @@
+Exceptions in a SubRequest's finish() block are suppressed until all finalizers are called, with the initial exception reraised.

--- a/changelog/2440.bugfix
+++ b/changelog/2440.bugfix
@@ -1,1 +1,1 @@
-Exceptions in a SubRequest's finish() block are suppressed until all finalizers are called, with the initial exception reraised.
+Exceptions raised during teardown by finalizers are now suppressed until all finalizers are called, with the initial exception reraised.

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -658,11 +658,15 @@ class TestRequestBasic(object):
             ])
 
     def test_request_subrequest_addfinalizer_exceptions(self, testdir):
+        """
+        Ensure exceptions raised during teardown by a finalizer are suppressed
+        until all finalizers are called, re-raising the first exception (#2440)
+        """
         testdir.makepyfile("""
             import pytest
             l = []
-            def _excepts():
-                raise Exception('Error')
+            def _excepts(where):
+                raise Exception('Error in %s fixture' % where)
             @pytest.fixture
             def subrequest(request):
                 return request
@@ -670,18 +674,21 @@ class TestRequestBasic(object):
             def something(subrequest):
                 subrequest.addfinalizer(lambda: l.append(1))
                 subrequest.addfinalizer(lambda: l.append(2))
-                subrequest.addfinalizer(_excepts)
+                subrequest.addfinalizer(lambda: _excepts('something'))
             @pytest.fixture
             def excepts(subrequest):
-                subrequest.addfinalizer(_excepts)
+                subrequest.addfinalizer(lambda: _excepts('excepts'))
                 subrequest.addfinalizer(lambda: l.append(3))
             def test_first(something, excepts):
                 pass
             def test_second():
                 assert l == [3, 2, 1]
         """)
-        reprec = testdir.inline_run()
-        reprec.assertoutcome(passed=2, failed=1)
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines([
+            '*Exception: Error in excepts fixture',
+            '* 2 passed, 1 error in *',
+        ])
 
     def test_request_getmodulepath(self, testdir):
         modcol = testdir.getmodulecol("def test_somefunc(): pass")


### PR DESCRIPTION
Should resolve https://github.com/pytest-dev/pytest/issues/2440 by following a similar procedure as `SetupState._callfinalizers()`.

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [x] Make sure to include reasonable tests for your change if necessary
