### PR TITLE
Fix decode error in Python 2 for doctests in docstrings

### DIFF
--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -177,7 +177,6 @@ class DoctestTextfile(pytest.Module):
         name = self.fspath.basename
         globs = {'__name__': '__main__'}
 
-
         optionflags = get_optionflags(self)
         runner = doctest.DebugRunner(verbose=0, optionflags=optionflags,
                                      checker=_get_checker())
@@ -218,9 +217,6 @@ class DoctestModule(pytest.Module):
         runner = doctest.DebugRunner(verbose=0, optionflags=optionflags,
                                      checker=_get_checker())
 
-        encoding = self.config.getini("doctest_encoding")
-        _fix_spoof_python2(runner, encoding)
-        
         for test in finder.find(module, module.__name__):
             if test.examples:  # skip empty doctests
                 yield DoctestItem(test.name, self, runner, test)
@@ -332,7 +328,10 @@ def _get_report_choice(key):
 
 def _fix_spoof_python2(runner, encoding):
     """
-    Installs a "SpoofOut" into the given DebugRunner so it properly deals with unicode output.
+    Installs a "SpoofOut" into the given DebugRunner so it properly deals with unicode output. This
+    should patch only doctests for text files because they don't have a way to declare their
+    encoding. Doctests in docstrings from Python modules don't have the same problem given that
+    Python already decoded the strings.
     
     This fixes the problem related in issue #2434.
     """

--- a/changelog/2434.bugfix
+++ b/changelog/2434.bugfix
@@ -1,0 +1,1 @@
+Fix decode error in Python 2 for doctests in docstrings.

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -527,6 +527,25 @@ class TestDoctests(object):
             '*1 failed*',
         ])
 
+    def test_unicode_doctest_module(self, testdir):
+        """
+        Test case for issue 2434: DecodeError on Python 2 when doctest docstring
+        contains non-ascii characters.
+        """
+        p = testdir.makepyfile(test_unicode_doctest_module="""
+            # -*- encoding: utf-8 -*-
+            from __future__ import unicode_literals
+            
+            def fix_bad_unicode(text):
+                '''
+                    >>> print(fix_bad_unicode('Ãºnico'))
+                    único
+                '''
+                return "único"
+        """)
+        result = testdir.runpytest(p, '--doctest-modules')
+        result.stdout.fnmatch_lines(['* 1 passed *'])
+
 
 class TestLiterals(object):
 


### PR DESCRIPTION
Fix #2434
