### PR TITLE
Show "trivial" category in CHANGELOG

### DIFF
--- a/changelog/_template.rst
+++ b/changelog/_template.rst
@@ -6,7 +6,7 @@
 
 {% endif %}
 {% if sections[section] %}
-{% for category, val in definitions.items() if category in sections[section] and category != 'trivial' %}
+{% for category, val in definitions.items() if category in sections[section] %}
 
 {{ definitions[category]['name'] }}
 {{ underline * definitions[category]['name']|length }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,5 @@ template = "changelog/_template.rst"
 
   [[tool.towncrier.type]]
   directory = "trivial"
-  name = "Trivial Changes"
-  showcontent = false
+  name = "Trivial/Internal Changes"
+  showcontent = true


### PR DESCRIPTION
I think it might sense to display in the CHANGELOG internal or
trivial changes because they might trip users between releases.

For example, a note about an internal refactoring (like
moving a class between modules) is useful for a user
that has been using the internal API. Of course
we are not breaking anything because it was an internal API, but no
reason not to save time for users who did use it.