### PR TITLE
Add changelog entry explicitly deprecating old-style classes from pytest API

### DIFF
--- a/changelog/2147.removal
+++ b/changelog/2147.removal
@@ -1,0 +1,1 @@
+All old-style specific behavior in current classes in the pytest's API is considered deprecated at this point and will be removed in a future release. This affects Python 2 users only and in rare situations.


### PR DESCRIPTION
This note at least makes that official, given that it is difficult/nearly impossible to add warnings to the code for them.

Related to #2147
