### PR TITLE
Allow staticmethods to be detected as test functions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -118,6 +118,7 @@ Michael Droettboom
 Michael Seifert
 Michal Wajszczuk
 Mike Lundy
+Nathaniel Waisbrot
 Ned Batchelder
 Neven Mundar
 Nicolas Delaby

--- a/changelog/2528.feature
+++ b/changelog/2528.feature
@@ -1,0 +1,1 @@
+Allow class methods decorated as ``@staticmethod`` to be candidates for collection as a test function. (Only for Python 2.7 and above. Python 2.6 will still ignore static methods.)

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -143,6 +143,26 @@ class TestClass(object):
             "*collected 0*",
         ])
 
+    def test_static_method(self, testdir):
+        testdir.getmodulecol("""
+            class Test(object):
+                @staticmethod
+                def test_something():
+                    pass
+        """)
+        result = testdir.runpytest()
+        if sys.version_info < (2,7):
+            # in 2.6, the code to handle static methods doesn't work
+            result.stdout.fnmatch_lines([
+                "*collected 0 items*",
+                "*cannot collect static method*",
+            ])
+        else:
+            result.stdout.fnmatch_lines([
+                "*collected 1 item*",
+                "*1 passed in*",
+            ])
+
     def test_setup_teardown_class_as_classmethod(self, testdir):
         testdir.makepyfile(test_mod1="""
             class TestClassMethod(object):


### PR DESCRIPTION
Allow a class method decorated `@staticmethod` to be collected as a test function
(if it meets the usual criteria).

Fixes #2528 

----

- [x] Add a new news fragment into the changelog folder
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [x] Make sure to include reasonable tests for your change if necessary
- [x] Add yourself to `AUTHORS`;
