### PR TITLE
Fix lineno offset in show_skipped

### DIFF
--- a/_pytest/skipping.py
+++ b/_pytest/skipping.py
@@ -382,4 +382,4 @@ def show_skipped(terminalreporter, lines):
                     reason = reason[9:]
                 lines.append(
                     "SKIP [%d] %s:%d: %s" %
-                    (num, fspath, lineno, reason))
+                    (num, fspath, lineno + 1, reason))

--- a/changelog/2548.bugfix
+++ b/changelog/2548.bugfix
@@ -1,0 +1,1 @@
+Fix lineno offset in show_skipped.

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -708,7 +708,7 @@ def test_skipped_reasons_functional(testdir):
     )
     result = testdir.runpytest('-rs')
     result.stdout.fnmatch_lines([
-        "*SKIP*2*conftest.py:3: test",
+        "*SKIP*2*conftest.py:4: test",
     ])
     assert result.ret == 0
 


### PR DESCRIPTION
The line number is 0-based here, so add 1.

I've done similar fixes before, and asked already before if this should be fixed more upwards in the end, since it seems to cripple down everywhere?!