### PR TITLE
Clarify pytest_configure hook call order

### DIFF
--- a/_pytest/hookspec.py
+++ b/_pytest/hookspec.py
@@ -60,9 +60,17 @@ def pytest_addoption(parser):
 
 @hookspec(historic=True)
 def pytest_configure(config):
-    """ called after command line options have been parsed
-    and all plugins and initial conftest files been loaded.
-    This hook is called for every plugin.
+    """
+    Allows plugins and conftest files to perform initial configuration.
+
+    This hook is called for every plugin and initial conftest file
+    after command line options have been parsed.
+
+    After that, the hook is called for other conftest files as they are
+    imported.
+
+    :arg config: pytest config object
+    :type config: _pytest.config.Config
     """
 
 # -------------------------------------------------------------------------

--- a/changelog/2539.doc
+++ b/changelog/2539.doc
@@ -1,0 +1,1 @@
+Clarify ``pytest_configure`` hook call order.


### PR DESCRIPTION
Fix #2539
