### PR TITLE
Make YIELD_TEST warning less spammy

### DIFF
--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -615,7 +615,7 @@ class Generator(FunctionMixin, PyCollector):
                 raise ValueError("%r generated tests with non-unique name %r" %(self, name))
             seen[name] = True
             l.append(self.Function(name, self, args=args, callobj=call))
-            self.config.warn('C1', deprecated.YIELD_TESTS, fslocation=self.fspath)
+        self.warn('C1', deprecated.YIELD_TESTS)
         return l
 
     def getcallargs(self, obj):

--- a/changelog/2562.trivial
+++ b/changelog/2562.trivial
@@ -1,0 +1,1 @@
+Emit yield test warning only once per generator

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -9,12 +9,16 @@ def test_yield_tests_deprecation(testdir):
         def test_gen():
             yield "m1", func1, 15, 3*5
             yield "m2", func1, 42, 6*7
+        def test_gen2():
+            for k in range(10):
+                yield func1, 1, 1
     """)
     result = testdir.runpytest('-ra')
     result.stdout.fnmatch_lines([
         '*yield tests are deprecated, and scheduled to be removed in pytest 4.0*',
         '*2 passed*',
     ])
+    assert result.stdout.str().count('yield tests are deprecated') == 2
 
 
 def test_funcarg_prefix_deprecation(testdir):


### PR DESCRIPTION
Emit the yield test deprecation warning only once per generator, rather than for each generated function.

This is important when porting old projects with a large number of legacy yield tests --- you don't want to have the warning repeated 10000+ times in the output.

Addresses #2562 (apart from the fact that these warnings cannot be ignored via filterwarnings)