### PR TITLE
Detect and warn/ignore local python installations

### DIFF
--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -179,7 +179,7 @@ def pytest_ignore_collect(path, config):
     if py.path.local(path) in ignore_paths:
         return True
 
-    invenv =  py.path.local(sys.prefix) == path 
+    invenv =  py.path.local(sys.prefix) == path
     allow_invenv = config.getoption("collect_in_virtualenv")
     if invenv and not allow_invenv:
         config.warn(RuntimeWarning,

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -70,6 +70,8 @@ def pytest_addoption(parser):
     group.addoption('--keepduplicates', '--keep-duplicates', action="store_true",
         dest="keepduplicates", default=False,
         help="Keep duplicate tests.")
+    group.addoption('--collect-in-virtualenv', action='store_true',
+        help="Collect tests in the current Python installation (default False)")
 
     group = parser.getgroup("debugconfig",
         "test session debugging and configuration")
@@ -175,6 +177,16 @@ def pytest_ignore_collect(path, config):
         ignore_paths.extend([py.path.local(x) for x in excludeopt])
 
     if py.path.local(path) in ignore_paths:
+        return True
+
+    invenv =  py.path.local(sys.prefix) == path 
+    allow_invenv = config.getoption("collect_in_virtualenv")
+    if invenv and not allow_invenv:
+        config.warn(RuntimeWarning,
+            'Path "%s" appears to be a Python installation; skipping\n'
+            'Pass --collect-in-virtualenv to force collection of tests in "%s"\n'
+            'Use --ignore="%s" to silence this warning' % (path, path, path)
+        )
         return True
 
     # Skip duplicate paths.

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -71,7 +71,8 @@ def pytest_addoption(parser):
         dest="keepduplicates", default=False,
         help="Keep duplicate tests.")
     group.addoption('--collect-in-virtualenv', action='store_true',
-        help="Collect tests in the current Python installation (default False)")
+        dest='collect_in_virtualenv', default=False,
+        help="Don't ignore tests in a local virtualenv directory")
 
     group = parser.getgroup("debugconfig",
         "test session debugging and configuration")
@@ -192,11 +193,6 @@ def pytest_ignore_collect(path, config):
 
     allow_in_venv = config.getoption("collect_in_virtualenv")
     if _in_venv(path) and not allow_in_venv:
-        config.warn(RuntimeWarning,
-            'Path "%s" appears to be a Python virtual installation; skipping\n'
-            'Pass --collect-in-virtualenv to force collection of tests in "%s"\n'
-            'Use --ignore="%s" to silence this warning' % (path, path, path)
-        )
         return True
 
     # Skip duplicate paths.

--- a/changelog/2518.feature
+++ b/changelog/2518.feature
@@ -1,1 +1,1 @@
-Collection ignores the currently active Python installation by default; `--collect-in-virtualenv` overrides this behavior.
+Collection ignores local virtualenvs by default; `--collect-in-virtualenv` overrides this behavior.

--- a/changelog/2518.feature
+++ b/changelog/2518.feature
@@ -1,0 +1,1 @@
+Collection ignores the currently active Python installation by default; `--collect-in-virtualenv` overrides this behavior.

--- a/doc/en/customize.rst
+++ b/doc/en/customize.rst
@@ -171,7 +171,16 @@ Builtin configuration file options
         norecursedirs = .svn _build tmp*
 
    This would tell ``pytest`` to not look into typical subversion or
-   sphinx-build directories or into any ``tmp`` prefixed directory.
+   sphinx-build directories or into any ``tmp`` prefixed directory.  
+   
+   Additionally, ``pytest`` will attempt to intelligently identify and ignore a
+   virtualenv by the presence of an activation script.  Any directory deemed to
+   be the root of a virtual environment will not be considered during test
+   collection unless ``‑‑collect‑in‑virtualenv`` is given.  Note also that
+   ``norecursedirs`` takes precedence over ``‑‑collect‑in‑virtualenv``; e.g. if
+   you intend to run tests in a virtualenv with a base directory that matches
+   ``'.*'`` you *must* override ``norecursedirs`` in addition to using the
+   ``‑‑collect‑in‑virtualenv`` flag.
 
 .. confval:: testpaths
 

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 import pytest, py
 
-from _pytest.main import Session, EXIT_NOTESTSCOLLECTED
+from _pytest.main import Session, EXIT_NOTESTSCOLLECTED, _in_venv
 
 class TestCollector(object):
     def test_collect_versus_item(self):
@@ -120,6 +120,53 @@ class TestCollectFS(object):
         s = result.stdout.str()
         assert "test_notfound" not in s
         assert "test_found" in s
+
+    @pytest.mark.parametrize('fname',
+                             ("activate", "activate.csh", "activate.fish",
+                              "Activate", "Activate.bat", "Activate.ps1"))
+    def test_ignored_virtualenvs(self, testdir, fname):
+        bindir = "Scripts" if py.std.sys.platform.startswith("win") else "bin"
+        testdir.tmpdir.ensure("virtual", bindir, fname)
+        testfile = testdir.tmpdir.ensure("virtual", "test_invenv.py")
+        testfile.write("def test_hello(): pass")
+
+        # by default, ignore tests inside a virtualenv
+        result = testdir.runpytest()
+        assert "test_invenv" not in result.stdout.str()
+        # allow test collection if user insists
+        result = testdir.runpytest("--collect-in-virtualenv")
+        assert "test_invenv" in result.stdout.str()
+        # allow test collection if user directly passes in the directory
+        result = testdir.runpytest("virtual")
+        assert "test_invenv" in result.stdout.str()
+
+    @pytest.mark.parametrize('fname',
+                             ("activate", "activate.csh", "activate.fish",
+                              "Activate", "Activate.bat", "Activate.ps1"))
+    def test_ignored_virtualenvs_norecursedirs_precedence(self, testdir, fname):
+        bindir = "Scripts" if py.std.sys.platform.startswith("win") else "bin"
+        # norecursedirs takes priority
+        testdir.tmpdir.ensure(".virtual", bindir, fname)
+        testfile = testdir.tmpdir.ensure(".virtual", "test_invenv.py")
+        testfile.write("def test_hello(): pass")
+        result = testdir.runpytest("--collect-in-virtualenv")
+        assert "test_invenv" not in result.stdout.str()
+        # ...unless the virtualenv is explicitly given on the CLI
+        result = testdir.runpytest("--collect-in-virtualenv", ".virtual")
+        assert "test_invenv" in result.stdout.str()
+
+    @pytest.mark.parametrize('fname',
+                             ("activate", "activate.csh", "activate.fish",
+                              "Activate", "Activate.bat", "Activate.ps1"))
+    def test__in_venv(self, testdir, fname):
+        """Directly test the virtual env detection function"""
+        bindir = "Scripts" if py.std.sys.platform.startswith("win") else "bin"
+        # no bin/activate, not a virtualenv
+        base_path = testdir.tmpdir.mkdir('venv')
+        assert _in_venv(base_path) is False
+        # with bin/activate, totally a virtualenv
+        base_path.ensure(bindir, fname)
+        assert _in_venv(base_path) is True
 
     def test_custom_norecursedirs(self, testdir):
         testdir.makeini("""


### PR DESCRIPTION
This should address / close ticket #2518.  The behaviour implemented is as follows:

1.  During collection, if pytest detects that the directory it is considering is `sys.prefix`, the directory and any tests it contains will be ignored and a helpful warning will be issued.
2.  If `--collect-in-virtualenv` (a new CLI flag) is passed, pytest will collect anyways.
3.  If the relevant path is explicitly ignored; i.e. `--ignore=./.env` or what have you, the warning is silenced.

I tried to write a test but couldn't quite figure out how to effectively mock `sys.prefix`; I'd appreciate some help there.  Other feedback is also totally welcome.