### PR TITLE
Ensure final collected line doesn't include artifacts of previous write

### DIFF
--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -290,6 +290,9 @@ class TerminalReporter:
         if self.isatty:
             if final:
                 line += " \n"
+                # Rewrite with empty line so we will not see the artifact of
+                # previous write
+                self.rewrite('')
             self.rewrite(line, bold=True)
         else:
             self.write_line(line)

--- a/changelog/2571.trivial
+++ b/changelog/2571.trivial
@@ -1,0 +1,1 @@
+Ensure final collected line doesn't include artifacts of previous write.


### PR DESCRIPTION
We sometimes would see the following line:
**``collected 1 item s``**

just because previous write to the terminal includes number of characters greater than 'collected 1 item'.
