### PR TITLE
#2574 Options --fixtures and --fixtures-per-test keep indentation of docstrings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -104,6 +104,7 @@ Marcin Bachry
 Mark Abramowitz
 Markus Unterwaditzer
 Martijn Faassen
+Martin Altmayer
 Martin K. Scherer
 Martin Prusse
 Mathieu Clabaut

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -7,6 +7,7 @@ import sys
 import os
 import collections
 import math
+from textwrap import dedent
 from itertools import count
 
 import py
@@ -1003,14 +1004,12 @@ def _show_fixtures_per_test(config, session):
             funcargspec = argname
         tw.line(funcargspec, green=True)
 
-        INDENT = '    {0}'
         fixture_doc = fixture_def.func.__doc__
 
         if fixture_doc:
-            for line in fixture_doc.strip().split('\n'):
-                tw.line(INDENT.format(line.strip()))
+            write_docstring(tw, fixture_doc)
         else:
-            tw.line(INDENT.format('no docstring available'), red=True)
+            tw.line('    no docstring available', red=True)
 
     def write_item(item):
         name2fixturedefs = item._fixtureinfo.name2fixturedefs
@@ -1084,11 +1083,26 @@ def _showfixtures_main(config, session):
         loc = getlocation(fixturedef.func, curdir)
         doc = fixturedef.func.__doc__ or ""
         if doc:
-            for line in doc.strip().split("\n"):
-                tw.line("    " + line.strip())
+            write_docstring(tw, doc)
         else:
             tw.line("    %s: no docstring available" %(loc,),
                 red=True)
+
+
+def write_docstring(tw, doc):
+    INDENT = "    "
+    doc = doc.rstrip()
+    if "\n" in doc:
+        firstline, rest = doc.split("\n", 1)
+    else:
+        firstline, rest = doc, ""
+
+    if firstline.strip():
+        tw.line(INDENT + firstline.strip())
+
+    if rest:
+        for line in dedent(rest).split("\n"):
+            tw.write(INDENT + line + "\n")
 
 
 # builtin pytest.raises helper

--- a/changelog/2574.bugfix
+++ b/changelog/2574.bugfix
@@ -1,0 +1,1 @@
+The options --fixtures and --fixtures-per-test will now keep indentation within docstrings.

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -2713,7 +2713,7 @@ class TestShowFixtures(object):
         """)
 
     def test_show_fixtures_trimmed_doc(self, testdir):
-        p = testdir.makepyfile('''
+        p = testdir.makepyfile(dedent('''
             import pytest
             @pytest.fixture
             def arg1():
@@ -2729,9 +2729,9 @@ class TestShowFixtures(object):
                 line2
 
                 """
-        ''')
+        '''))
         result = testdir.runpytest("--fixtures", p)
-        result.stdout.fnmatch_lines("""
+        result.stdout.fnmatch_lines(dedent("""
             * fixtures defined from test_show_fixtures_trimmed_doc *
             arg2
                 line1
@@ -2740,7 +2740,64 @@ class TestShowFixtures(object):
                 line1
                 line2
 
-        """)
+        """))
+
+    def test_show_fixtures_indented_doc(self, testdir):
+        p = testdir.makepyfile(dedent('''
+            import pytest
+            @pytest.fixture
+            def fixture1():
+                """
+                line1
+                    indented line
+                """
+        '''))
+        result = testdir.runpytest("--fixtures", p)
+        result.stdout.fnmatch_lines(dedent("""
+            * fixtures defined from test_show_fixtures_indented_doc *
+            fixture1
+                line1
+                    indented line
+        """))
+
+    def test_show_fixtures_indented_doc_first_line_unindented(self, testdir):
+        p = testdir.makepyfile(dedent('''
+            import pytest
+            @pytest.fixture
+            def fixture1():
+                """line1
+                line2
+                    indented line
+                """
+        '''))
+        result = testdir.runpytest("--fixtures", p)
+        result.stdout.fnmatch_lines(dedent("""
+            * fixtures defined from test_show_fixtures_indented_doc_first_line_unindented *
+            fixture1
+                line1
+                line2
+                    indented line
+        """))
+
+    def test_show_fixtures_indented_in_class(self, testdir):
+        p = testdir.makepyfile(dedent('''
+            import pytest
+            class TestClass:
+                @pytest.fixture
+                def fixture1():
+                    """line1
+                    line2
+                        indented line
+                    """
+        '''))
+        result = testdir.runpytest("--fixtures", p)
+        result.stdout.fnmatch_lines(dedent("""
+            * fixtures defined from test_show_fixtures_indented_in_class *
+            fixture1
+                line1
+                line2
+                    indented line
+        """))
 
 
     def test_show_fixtures_different_files(self, testdir):


### PR DESCRIPTION
Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [x] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS`;
