### PR TITLE
#2003 Change behavior of `approx.py` to only support `__eq__` comparison

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -99,6 +99,7 @@ Lukas Bednar
 Luke Murphy
 Maciek Fijalkowski
 Maho
+Maik Figura
 Mandeep Bhutani
 Manuel Krebber
 Marc Schlaich

--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -372,8 +372,8 @@ def approx(expected, rel=None, abs=None, nan_ok=False):
     
     .. warning::
 
-       In order to avoid inconsistent behavior, a ``NotImplementedError`` is 
-       raised for ``__lt__`` and ``__gt__`` comparisons. The example below 
+       In order to avoid inconsistent behavior, a ``NotImplementedError`` is
+       raised for ``__lt__`` and ``__gt__`` comparisons. The example below
        illustrates the problem::
 
            assert approx(0.1) > 0.1 + 1e-10  # calls approx(0.1).__gt__(0.1 + 1e-10)

--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -1,6 +1,5 @@
 import math
 import sys
-
 import py
 
 from _pytest.compat import isclass, izip
@@ -32,6 +31,12 @@ class ApproxBase(object):
 
     __hash__ = None
 
+    def __gt__(self, actual):
+        raise NotImplementedError
+
+    def __lt__(self, actual):
+        raise NotImplementedError
+
     def __ne__(self, actual):
         return not (actual == self)
 
@@ -59,6 +64,12 @@ class ApproxNumpy(ApproxBase):
         # shape of the array...
         return "approx({0!r})".format(list(
             self._approx_scalar(x) for x in self.expected))
+
+    def __gt__(self, actual):
+        raise NotImplementedError
+
+    def __lt__(self, actual):
+        raise NotImplementedError
 
     def __eq__(self, actual):
         import numpy as np
@@ -358,6 +369,22 @@ def approx(expected, rel=None, abs=None, nan_ok=False):
       is asymmetric and you can think of ``b`` as the reference value.  In the
       special case that you explicitly specify an absolute tolerance but not a
       relative tolerance, only the absolute tolerance is considered.
+    
+    .. warning::
+
+       In order to avoid inconsistent behavior, a ``NotImplementedError`` is 
+       raised for ``__lt__`` and ``__gt__`` comparisons. The example below 
+       illustrates the problem::
+
+           assert approx(0.1) > 0.1 + 1e-10  # calls approx(0.1).__gt__(0.1 + 1e-10)
+           assert 0.1 + 1e-10 > approx(0.1)  # calls approx(0.1).__lt__(0.1 + 1e-10)
+
+       In the second example one expects ``approx(0.1).__le__(0.1 + 1e-10)``
+       to be called. But instead, ``approx(0.1).__lt__(0.1 + 1e-10)`` is used to
+       comparison. This is because the call hierarchy of rich comparisons
+       follows a fixed behavior. `More information...`__
+
+       __ https://docs.python.org/3/reference/datamodel.html#object.__ge__
     """
 
     from collections import Mapping, Sequence

--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -1,5 +1,6 @@
 import math
 import sys
+
 import py
 
 from _pytest.compat import isclass, izip

--- a/changelog/2003.feature
+++ b/changelog/2003.feature
@@ -1,0 +1,1 @@
+Remove support for `<` and `>` support in approx.

--- a/changelog/2003.feature
+++ b/changelog/2003.feature
@@ -1,1 +1,0 @@
-Remove support for `<` and `>` support in approx.

--- a/changelog/2003.removal
+++ b/changelog/2003.removal
@@ -1,0 +1,2 @@
+``pytest.approx`` no longer supports ``>``, ``>=``, ``<`` and ``<=`` operators to avoid surprising/inconsistent
+behavior. See `the docs <https://docs.pytest.org/en/latest/builtin.html#pytest.approx>`_ for more information.

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+import operator
 import sys
 import pytest
 import doctest
@@ -382,3 +383,16 @@ class TestApprox(object):
             '*At index 0 diff: 3 != 4 * {0}'.format(expected),
             '=* 1 failed in *=',
         ])
+
+    @pytest.mark.parametrize('op', [
+        pytest.param(operator.le, id='<='),
+        pytest.param(operator.lt, id='<'),
+        pytest.param(operator.ge, id='>='),
+        pytest.param(operator.gt, id='>'),
+    ])
+    def test_comparison_operator_type_error(self, op):
+        """
+        pytest.approx should raise TypeError for operators other than == and != (#2003).
+        """
+        with pytest.raises(TypeError):
+            op(1, approx(1, rel=1e-6, abs=1e-12))


### PR DESCRIPTION
This PR changes the current behavior of `approx` to raise `NotImplementedError` for all comparisons but `__eq__` as discussed in #2003 

Note: I thought about adding a warn that this is currently not supported like: 

```bash 
warnings.warn("Currently not supported")
raise NotImplementedError
```

But we found #2452 mentioning that `pytest.config.warn` should be deprecated. Also, I was not sure how to use this in approx, as it is not a fixture and the `config` object is not available out of the box. Can we just use the `warnings` module there? Or is mentioning this in the docs enough? 