### PR TITLE
Provides encoding attribute on CaptureIO

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -92,6 +92,7 @@ Kevin Cox
 Kodi B. Arfer
 Lee Kamentsky
 Lev Maximov
+Llandy Riveron Del Risco
 Loic Esteve
 Lukas Bednar
 Luke Murphy
@@ -165,3 +166,4 @@ Vitaly Lashmanov
 Vlad Dragos
 Wouter van Ackooy
 Xuecong Liao
+Zoltán Máté

--- a/_pytest/compat.py
+++ b/_pytest/compat.py
@@ -283,7 +283,16 @@ def _setup_collect_fakemodule():
 
 
 if _PY2:
-    from py.io import TextIO as CaptureIO
+    # Without this the test_dupfile_on_textio will fail, otherwise CaptureIO could directly inherit from StringIO.
+    from py.io import TextIO
+
+
+    class CaptureIO(TextIO):
+
+        @property
+        def encoding(self):
+            return getattr(self, '_encoding', 'UTF-8')
+
 else:
     import io
 

--- a/changelog/2375.trivial
+++ b/changelog/2375.trivial
@@ -1,0 +1,1 @@
+Provides encoding attribute on CaptureIO.

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1037,6 +1037,15 @@ def test_capture_not_started_but_reset():
     capsys.stop_capturing()
 
 
+def test_using_capsys_fixture_works_with_sys_stdout_encoding(capsys):
+    test_text = 'test text'
+
+    print(test_text.encode(sys.stdout.encoding, 'replace'))
+    (out, err) = capsys.readouterr()
+    assert out
+    assert err == ''
+
+
 @needsosdup
 @pytest.mark.parametrize('use', [True, False])
 def test_fdcapture_tmpfile_remains_the_same(tmpfile, use):


### PR DESCRIPTION
Fixes patching sys.stdout.encoding when using Capsys fixture on Python 2.

Fix #2375
