### PR TITLE
Avoid interactive pdb when pytest tests itself - fix #2023

### DIFF
--- a/_pytest/pytester.py
+++ b/_pytest/pytester.py
@@ -916,8 +916,11 @@ class Testdir:
         env['PYTHONPATH'] = os.pathsep.join(filter(None, [
             str(os.getcwd()), env.get('PYTHONPATH', '')]))
         kw['env'] = env
-        return subprocess.Popen(cmdargs,
-                                stdout=stdout, stderr=stderr, **kw)
+
+        popen = subprocess.Popen(cmdargs, stdin=subprocess.PIPE, stdout=stdout, stderr=stderr, **kw)
+        popen.stdin.close()
+
+        return popen
 
     def run(self, *cmdargs):
         """Run a command with arguments.

--- a/changelog/2023.bugfix
+++ b/changelog/2023.bugfix
@@ -1,0 +1,1 @@
+Set ``stdin`` to a closed ``PIPE`` in ``pytester.py.Testdir.popen()`` for avoid unwanted interactive ``pdb``


### PR DESCRIPTION
The debugging.py calls post_mortem() on error and pdb will drops an
interactive debugger when the stdin is a readable fd.

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [x] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS`;
