### PR TITLE
Revert "introduce deprecation warnings for legacy parametersets"

### DIFF
--- a/_pytest/deprecated.py
+++ b/_pytest/deprecated.py
@@ -31,9 +31,3 @@ RESULT_LOG = '--result-log is deprecated and scheduled for removal in pytest 4.0
 MARK_INFO_ATTRIBUTE = RemovedInPytest4Warning(
     "MarkInfo objects are deprecated as they contain the merged marks"
 )
-
-MARK_PARAMETERSET_UNPACKING = RemovedInPytest4Warning(
-    "Applying marks directly to parameters is deprecated,"
-    " please use pytest.param(..., marks=...) instead.\n"
-    "For more details, see: https://docs.pytest.org/en/latest/parametrize.html"
-)

--- a/_pytest/mark.py
+++ b/_pytest/mark.py
@@ -6,7 +6,7 @@ import warnings
 from collections import namedtuple
 from operator import attrgetter
 from .compat import imap
-from .deprecated import MARK_INFO_ATTRIBUTE, MARK_PARAMETERSET_UNPACKING
+from .deprecated import MARK_INFO_ATTRIBUTE
 
 def alias(name, warning=None):
     getter = attrgetter(name)
@@ -60,9 +60,6 @@ class ParameterSet(namedtuple('ParameterSet', 'values, marks, id')):
         assert not isinstance(argval, ParameterSet)
         if legacy_force_tuple:
             argval = argval,
-
-        if newmarks:
-            warnings.warn(MARK_PARAMETERSET_UNPACKING)
 
         return cls(argval, marks=newmarks, id=None)
 

--- a/changelog/2427.removal
+++ b/changelog/2427.removal
@@ -1,1 +1,0 @@
-introduce deprecation warnings for legacy marks based parametersets


### PR DESCRIPTION
As discussed in #2573, this change introduced a serious regression.

Fix #2573

We should reopen #2427 after this is merged.

This reverts commit 0d0b01bded8ab758118d9be1ea64db493045dcf4.
