### PR TITLE
remove the MARK_INFO_ATTRIBUTE warning until we can fix internal usage

### DIFF
--- a/_pytest/mark.py
+++ b/_pytest/mark.py
@@ -6,7 +6,7 @@ import warnings
 from collections import namedtuple
 from operator import attrgetter
 from .compat import imap
-from .deprecated import MARK_INFO_ATTRIBUTE, MARK_PARAMETERSET_UNPACKING
+from .deprecated import MARK_PARAMETERSET_UNPACKING
 
 def alias(name, warning=None):
     getter = attrgetter(name)
@@ -401,9 +401,9 @@ class MarkInfo(object):
         self.combined = mark
         self._marks = [mark]
 
-    name = alias('combined.name', warning=MARK_INFO_ATTRIBUTE)
-    args = alias('combined.args', warning=MARK_INFO_ATTRIBUTE)
-    kwargs = alias('combined.kwargs', warning=MARK_INFO_ATTRIBUTE)
+    name = alias('combined.name')
+    args = alias('combined.args')
+    kwargs = alias('combined.kwargs')
 
     def __repr__(self):
         return "<MarkInfo {0!r}>".format(self.combined)


### PR DESCRIPTION
fixes #2573

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [ ] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [ ] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [x] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS`;
