### PR TITLE
Add "fix-lint" tox environment 

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -212,7 +212,12 @@ but here is a simple overview:
     $ tox -e linting,py27,py36
 
    This command will run tests via the "tox" tool against Python 2.7 and 3.6
-   and also perform "lint" coding-style checks.
+   and also perform "lint" coding-style checks. If you have too much linting errors,
+   try running::
+
+    $ tox -e fix-lint
+
+   To fix pep8 related errors. 
 
 #. You can now edit your local working copy.
 

--- a/changelog/2375.bugfix
+++ b/changelog/2375.bugfix
@@ -1,0 +1,1 @@
+Add missing ``encoding`` attribute to ``sys.std*`` streams when using ``capsys`` capture mode.

--- a/changelog/2375.trivial
+++ b/changelog/2375.trivial
@@ -1,1 +1,0 @@
-Provides encoding attribute on CaptureIO.

--- a/changelog/2533.trivial
+++ b/changelog/2533.trivial
@@ -1,1 +1,1 @@
-Renamed the utility function `_pytest.compat._escape_strings` to `_ascii_escaped` to better communicate the function's purpose.
+Renamed the utility function ``_pytest.compat._escape_strings`` to ``_ascii_escaped`` to better communicate the function's purpose.

--- a/changelog/2562.trivial
+++ b/changelog/2562.trivial
@@ -1,1 +1,1 @@
-Emit yield test warning only once per generator
+Emit warning about ``yield`` tests being deprecated only once per generator.

--- a/changelog/2574.bugfix
+++ b/changelog/2574.bugfix
@@ -1,1 +1,1 @@
-The options --fixtures and --fixtures-per-test will now keep indentation within docstrings.
+The options ```--fixtures`` and ```--fixtures-per-test`` will now keep indentation within docstrings.

--- a/changelog/2581.trivial
+++ b/changelog/2581.trivial
@@ -1,1 +1,1 @@
-Fixed all flake8 errors and warnings
+Fixed all flake8 errors and warnings.

--- a/changelog/2582.trivial
+++ b/changelog/2582.trivial
@@ -1,0 +1,1 @@
+Added ``fix-lint`` tox environment to run automatic pep8 fixes on the code.

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -144,10 +144,10 @@ class TestTraceback_f_g_h(object):
             xyz()
         """)
         try:
-            exec (source.compile())
+            exec(source.compile())
         except NameError:
             tb = _pytest._code.ExceptionInfo().traceback
-            print (tb[-1].getsource())
+            print(tb[-1].getsource())
             s = str(tb[-1].getsource())
             assert s.startswith("def xyz():\n    try:")
             assert s.strip().endswith("except somenoname:")
@@ -341,7 +341,7 @@ def test_excinfo_errisinstance():
 
 def test_excinfo_no_sourcecode():
     try:
-        exec ("raise ValueError()")
+        exec("raise ValueError()")
     except ValueError:
         excinfo = _pytest._code.ExceptionInfo()
     s = str(excinfo.traceback[-1])
@@ -431,7 +431,7 @@ class TestFormattedExcinfo(object):
     def excinfo_from_exec(self, source):
         source = _pytest._code.Source(source).strip()
         try:
-            exec (source.compile())
+            exec(source.compile())
         except KeyboardInterrupt:
             raise
         except:
@@ -471,7 +471,7 @@ class TestFormattedExcinfo(object):
         pr = FormattedExcinfo()
         co = compile("raise ValueError()", "", "exec")
         try:
-            exec (co)
+            exec(co)
         except ValueError:
             excinfo = _pytest._code.ExceptionInfo()
         repr = pr.repr_excinfo(excinfo)
@@ -486,7 +486,7 @@ a = 1
 raise ValueError()
 """, "", "exec")
         try:
-            exec (co)
+            exec(co)
         except ValueError:
             excinfo = _pytest._code.ExceptionInfo()
         repr = pr.repr_excinfo(excinfo)
@@ -992,7 +992,7 @@ raise ValueError()
         tw = TWMock()
         r.toterminal(tw)
         for line in tw.lines:
-            print (line)
+            print(line)
         assert tw.lines[0] == ""
         assert tw.lines[1] == "    def f():"
         assert tw.lines[2] == ">       g()"
@@ -1040,7 +1040,7 @@ raise ValueError()
         tw = TWMock()
         r.toterminal(tw)
         for line in tw.lines:
-            print (line)
+            print(line)
         assert tw.lines[0] == ""
         assert tw.lines[1] == "    def f():"
         assert tw.lines[2] == "        try:"

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -170,12 +170,12 @@ class TestSourceParsingAndCompiling(object):
     def test_compile(self):
         co = _pytest._code.compile("x=3")
         d = {}
-        exec (co, d)
+        exec(co, d)
         assert d['x'] == 3
 
     def test_compile_and_getsource_simple(self):
         co = _pytest._code.compile("x=3")
-        exec (co)
+        exec(co)
         source = _pytest._code.Source(co)
         assert str(source) == "x=3"
 
@@ -333,21 +333,6 @@ def test_getstartingblock_singleline():
 
     l = [i for i in x.source.lines if i.strip()]
     assert len(l) == 1
-
-
-def test_getstartingblock_multiline():
-    class A(object):
-        def __init__(self, *args):
-            frame = sys._getframe(1)
-            self.source = _pytest._code.Frame(frame).statement
-
-    x = A('x',
-          'y'
-          ,
-          'z')
-
-    l = [i for i in x.source.lines if i.strip()]
-    assert len(l) == 4
 
 
 def test_getline_finally():

--- a/testing/code/test_source_multiline_block.py
+++ b/testing/code/test_source_multiline_block.py
@@ -1,0 +1,26 @@
+# flake8: noqa
+import sys
+
+import _pytest._code
+
+
+def test_getstartingblock_multiline():
+    """
+    This test was originally found in test_source.py, but it depends on the weird
+    formatting of the ``x = A`` construct seen here and our autopep8 tool can only exclude entire
+    files (it does not support excluding lines/blocks using the traditional #noqa comment yet,
+    see hhatto/autopep8#307). It was considered better to just move this single test to its own
+    file and exclude it from autopep8 than try to complicate things.
+    """
+    class A(object):
+        def __init__(self, *args):
+            frame = sys._getframe(1)
+            self.source = _pytest._code.Frame(frame).statement
+
+    x = A('x',
+          'y'
+          ,
+          'z')
+
+    l = [i for i in x.source.lines if i.strip()]
+    assert len(l) == 4

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -83,14 +83,14 @@ class TestCaptureManager(object):
             assert outerr == ("", "")
             outerr = capman.suspendcapture()
             assert outerr == ("", "")
-            print ("hello")
+            print("hello")
             out, err = capman.suspendcapture()
             if method == "no":
                 assert old == (sys.stdout, sys.stderr, sys.stdin)
             else:
                 assert not out
             capman.resumecapture()
-            print ("hello")
+            print("hello")
             out, err = capman.suspendcapture()
             if method != "no":
                 assert out == "hello\n"
@@ -288,7 +288,7 @@ class TestLoggingInteraction(object):
                 stream.close() # to free memory/release resources
         """)
         result = testdir.runpytest_subprocess(p)
-        result.stderr.str().find("atexit") == -1
+        assert result.stderr.str().find("atexit") == -1
 
     def test_logging_and_immediate_setupteardown(self, testdir):
         p = testdir.makepyfile("""
@@ -305,7 +305,7 @@ class TestLoggingInteraction(object):
                 assert 0
         """)
         for optargs in (('--capture=sys',), ('--capture=fd',)):
-            print (optargs)
+            print(optargs)
             result = testdir.runpytest_subprocess(p, *optargs)
             s = result.stdout.str()
             result.stdout.fnmatch_lines([
@@ -331,7 +331,7 @@ class TestLoggingInteraction(object):
                 assert 0
         """)
         for optargs in (('--capture=sys',), ('--capture=fd',)):
-            print (optargs)
+            print(optargs)
             result = testdir.runpytest_subprocess(p, *optargs)
             s = result.stdout.str()
             result.stdout.fnmatch_lines([
@@ -879,7 +879,7 @@ class TestStdCapture(object):
 
     def test_capturing_readouterr(self):
         with self.getcapture() as cap:
-            print ("hello world")
+            print("hello world")
             sys.stderr.write("hello error\n")
             out, err = cap.readouterr()
             assert out == "hello world\n"
@@ -890,7 +890,7 @@ class TestStdCapture(object):
 
     def test_capturing_readouterr_unicode(self):
         with self.getcapture() as cap:
-            print ("hx\xc4\x85\xc4\x87")
+            print("hx\xc4\x85\xc4\x87")
             out, err = cap.readouterr()
         assert out == py.builtin._totext("hx\xc4\x85\xc4\x87\n", "utf8")
 
@@ -905,7 +905,7 @@ class TestStdCapture(object):
 
     def test_reset_twice_error(self):
         with self.getcapture() as cap:
-            print ("hello")
+            print("hello")
             out, err = cap.readouterr()
         pytest.raises(ValueError, cap.stop_capturing)
         assert out == "hello\n"
@@ -919,7 +919,7 @@ class TestStdCapture(object):
             sys.stderr.write("world")
             sys.stdout = capture.CaptureIO()
             sys.stderr = capture.CaptureIO()
-            print ("not seen")
+            print("not seen")
             sys.stderr.write("not seen\n")
             out, err = cap.readouterr()
         assert out == "hello"
@@ -929,9 +929,9 @@ class TestStdCapture(object):
 
     def test_capturing_error_recursive(self):
         with self.getcapture() as cap1:
-            print ("cap1")
+            print("cap1")
             with self.getcapture() as cap2:
-                print ("cap2")
+                print("cap2")
                 out2, err2 = cap2.readouterr()
                 out1, err1 = cap1.readouterr()
         assert out1 == "cap1\n"
@@ -961,9 +961,9 @@ class TestStdCapture(object):
         assert sys.stdin is old
 
     def test_stdin_nulled_by_default(self):
-        print ("XXX this test may well hang instead of crashing")
-        print ("XXX which indicates an error in the underlying capturing")
-        print ("XXX mechanisms")
+        print("XXX this test may well hang instead of crashing")
+        print("XXX which indicates an error in the underlying capturing")
+        print("XXX mechanisms")
         with self.getcapture():
             pytest.raises(IOError, "sys.stdin.read()")
 

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -321,9 +321,9 @@ class TestConftestVisibility(object):
                                                 # use value from parent dir's
 
         """))
-        print ("created directory structure:")
+        print("created directory structure:")
         for x in testdir.tmpdir.visit():
-            print ("   " + x.relto(testdir.tmpdir))
+            print("   " + x.relto(testdir.tmpdir))
 
         return {
             "runner": runner,

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -226,7 +226,7 @@ class BaseFunctionalTests(object):
                 raise ValueError(42)
         """)
         reps = rec.getreports("pytest_runtest_logreport")
-        print (reps)
+        print(reps)
         for i in range(2):
             assert reps[i].nodeid.endswith("test_method")
             assert reps[i].passed
@@ -253,7 +253,7 @@ class BaseFunctionalTests(object):
                     assert True
         """)
         reps = rec.getreports("pytest_runtest_logreport")
-        print (reps)
+        print(reps)
         assert len(reps) == 3
         #
         assert reps[0].nodeid.endswith("test_method")

--- a/tox.ini
+++ b/tox.ini
@@ -149,6 +149,14 @@ commands =
     rm -rf /tmp/doc-exec*
     make regen
 
+[testenv:fix-lint]
+skipsdist = True
+usedevelop = True
+deps =
+    autopep8
+commands =
+    autopep8 --in-place -r --max-line-length=120 --exclude=vendored_packages,test_source_multiline_block.py _pytest testing
+
 [testenv:jython]
 changedir = testing
 commands =


### PR DESCRIPTION
As discussed in #2582, adding a small tox env to make it easy to fix linting errors.