### PR TITLE
Fix: do not load hypothesis during test_logging_initialized_in_test

### DIFF
--- a/_pytest/compat.py
+++ b/_pytest/compat.py
@@ -284,7 +284,6 @@ if _PY2:
     # Without this the test_dupfile_on_textio will fail, otherwise CaptureIO could directly inherit from StringIO.
     from py.io import TextIO
 
-
     class CaptureIO(TextIO):
 
         @property

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -355,7 +355,7 @@ class TestLoggingInteraction(object):
         """)
         result = testdir.runpytest_subprocess(
             p, "--traceconfig",
-            "-p", "no:capturelog")
+            "-p", "no:capturelog", "-p", "no:hypothesis", "-p", "no:hypothesispytest")
         assert result.ret != 0
         result.stdout.fnmatch_lines([
             "*hello432*",


### PR DESCRIPTION
A recent `hypothesis` release seems to have added a "logging" import to the top-level,
which breaks test_logging_initialized_in_test
