### PR TITLE
Early import colorama so that it get's the correct terminal

### DIFF
--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -478,7 +478,7 @@ def _colorama_workaround():
     """
     Ensure colorama is imported so that it attaches to the correct stdio
     handles on Windows.
-    
+
     colorama uses the terminal on import time. So if something does the
     first import of colorama while I/O capture is active, colorama will
     fail in various ways.

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -37,6 +37,7 @@ def pytest_load_initial_conftests(early_config, parser, args):
     ns = early_config.known_args_namespace
     if ns.capture == "fd":
         _py36_windowsconsoleio_workaround()
+    _colorama_workaround()
     _readline_workaround()
     pluginmanager = early_config.pluginmanager
     capman = CaptureManager(ns.capture)
@@ -471,6 +472,24 @@ class DontReadFromInput:
             return self
         else:
             raise AttributeError('redirected stdin has no attribute buffer')
+
+
+def _colorama_workaround():
+    """
+    Ensure colorama is imported so that it attaches to the correct stdio
+    handles on Windows.
+    
+    colorama uses the terminal on import time. So if something does the
+    first import of colorama while I/O capture is active, colorama will
+    fail in various ways.
+    """
+
+    if not sys.platform.startswith('win32'):
+        return
+    try:
+        import colorama  # noqa
+    except ImportError:
+        pass
 
 
 def _readline_workaround():

--- a/changelog/2510.bugfix
+++ b/changelog/2510.bugfix
@@ -1,0 +1,1 @@
+Fix terminal color changing to black on Windows if ``colorama`` is imported in a ``conftest.py`` file.

--- a/changelog/2611.bugfix
+++ b/changelog/2611.bugfix
@@ -1,0 +1,1 @@
+Early import colorama so that it get's the correct terminal.

--- a/changelog/2611.bugfix
+++ b/changelog/2611.bugfix
@@ -1,1 +1,0 @@
-Early import colorama so that it get's the correct terminal.


### PR DESCRIPTION
I have had it print ANSI escapes without stripping or conversion. With https://github.com/tartley/colorama/pull/131 it captures the wrong default terminal attributes so that the default text color is black (colorama doesn't check for errors).

Importing colorama in a conftest.py should reproduce this.

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [ ] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS`;