### PR TITLE
Fix nondeterminism in fixture collection order

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -91,6 +91,7 @@ Kale Kundert
 Katarzyna Jachim
 Kevin Cox
 Kodi B. Arfer
+Lawrence Mitchell
 Lee Kamentsky
 Lev Maximov
 Llandy Riveron Del Risco

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -19,6 +19,11 @@ from _pytest.compat import (
 from _pytest.runner import fail
 from _pytest.compat import FuncargnamesCompatAttr
 
+if sys.version_info[:2] == (2, 6):
+    from ordereddict import OrderedDict
+else:
+    from collections import OrderedDict
+
 
 def pytest_sessionstart(session):
     import _pytest.python
@@ -136,10 +141,10 @@ def get_parametrized_fixture_keys(item, scopenum):
     except AttributeError:
         pass
     else:
-        # cs.indictes.items() is random order of argnames but
-        # then again different functions (items) can change order of
-        # arguments so it doesn't matter much probably
-        for argname, param_index in cs.indices.items():
+        # cs.indices.items() is random order of argnames.  Need to
+        # sort this so that different calls to
+        # get_parametrized_fixture_keys will be deterministic.
+        for argname, param_index in sorted(cs.indices.items()):
             if cs._arg2scopenum[argname] != scopenum:
                 continue
             if scopenum == 0:    # session
@@ -161,7 +166,7 @@ def reorder_items(items):
     for scopenum in range(0, scopenum_function):
         argkeys_cache[scopenum] = d = {}
         for item in items:
-            keys = set(get_parametrized_fixture_keys(item, scopenum))
+            keys = OrderedDict.fromkeys(get_parametrized_fixture_keys(item, scopenum))
             if keys:
                 d[item] = keys
     return reorder_items_atscope(items, set(), argkeys_cache, 0)
@@ -196,9 +201,9 @@ def slice_items(items, ignore, scoped_argkeys_cache):
         for i, item in enumerate(it):
             argkeys = scoped_argkeys_cache.get(item)
             if argkeys is not None:
-                argkeys = argkeys.difference(ignore)
-                if argkeys:  # found a slicing key
-                    slicing_argkey = argkeys.pop()
+                newargkeys = OrderedDict.fromkeys(k for k in argkeys if k not in ignore)
+                if newargkeys:  # found a slicing key
+                    slicing_argkey, _ = newargkeys.popitem()
                     items_before = items[:i]
                     items_same = [item]
                     items_other = []

--- a/changelog/920.bugfix
+++ b/changelog/920.bugfix
@@ -1,1 +1,1 @@
-Fix non-determinism in order of fixture collection.
+Fix non-determinism in order of fixture collection.  Adds new dependency (ordereddict) for Python 2.6.

--- a/changelog/920.bugfix
+++ b/changelog/920.bugfix
@@ -1,0 +1,1 @@
+Fix non-determinism in order of fixture collection.

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -9,7 +9,8 @@ Installation and Getting Started
 
 **dependencies**: `py <http://pypi.python.org/pypi/py>`_,
 `colorama (Windows) <http://pypi.python.org/pypi/colorama>`_,
-`argparse (py26) <http://pypi.python.org/pypi/argparse>`_.
+`argparse (py26) <http://pypi.python.org/pypi/argparse>`_,
+`ordereddict (py26) <http://pypi.python.org/pypi/ordereddict>`_.
 
 **documentation as PDF**: `download latest <https://media.readthedocs.org/pdf/pytest/latest/pytest.pdf>`_
 

--- a/setup.py
+++ b/setup.py
@@ -46,11 +46,12 @@ def main():
     install_requires = ['py>=1.4.33', 'setuptools']  # pluggy is vendored in _pytest.vendored_packages
     extras_require = {}
     if has_environment_marker_support():
-        extras_require[':python_version=="2.6"'] = ['argparse']
+        extras_require[':python_version=="2.6"'] = ['argparse', 'ordereddict']
         extras_require[':sys_platform=="win32"'] = ['colorama']
     else:
         if sys.version_info < (2, 7):
             install_requires.append('argparse')
+            install_requires.append('ordereddict')
         if sys.platform == 'win32':
             install_requires.append('colorama')
 

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -2548,7 +2548,6 @@ class TestFixtureMarker(object):
             '*test_foo*beta*'])
 
     @pytest.mark.issue920
-    @pytest.mark.xfail(reason="Fixture reordering not deterministic with hash randomisation")
     def test_deterministic_fixture_collection(self, testdir, monkeypatch):
         testdir.makepyfile("""
             import pytest

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ deps =
     hypothesis<3.0
     nose
     mock<1.1
+    ordereddict
 
 [testenv:py27-subprocess]
 changedir = .

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,6 @@ deps =
     hypothesis<3.0
     nose
     mock<1.1
-    ordereddict
 
 [testenv:py27-subprocess]
 changedir = .


### PR DESCRIPTION
fixtures.reorder_items is non-deterministic because it reorders based
on iteration over an (unordered) set.  Change the code to use an
OrderedDict instead, so that we get deterministic behaviour.

The xdist issue in #920 is a red-herring.  Fixture collection is non-deterministic across pytest invocations full stop if hash randomisation is on.

For example, consider the following test file:

```python
import pytest

@pytest.fixture(scope="module",
                params=["A",
                        "B",
                        "C"])
def A(request):
    return request.param


@pytest.fixture(scope="module",
                params=["DDDDDDDDD", "EEEEEEEEEEEE", "FFFFFFFFFFF", "GGGGGGGGGGGG"])
def B(request, A):
    return request.param


def test_foo(B):
    assert True
```

```sh
$pytest test_foo.py --collect-only
=============================================================================================== test session starts ================================================================================================
platform linux -- Python 3.5.2, pytest-3.1.3, py-1.4.34, pluggy-0.4.0
rootdir: /data/lmitche1/src/doodles, inifile:
plugins: xdist-1.18.1
collected 12 items 
<Module 'test_foo.py'>
  <Function 'test_foo[DDDDDDDDD-A]'>
  <Function 'test_foo[DDDDDDDDD-B]'>
  <Function 'test_foo[EEEEEEEEEEEE-B]'>
  <Function 'test_foo[EEEEEEEEEEEE-A]'>
  <Function 'test_foo[EEEEEEEEEEEE-C]'>
  <Function 'test_foo[DDDDDDDDD-C]'>
  <Function 'test_foo[FFFFFFFFFFF-C]'>
  <Function 'test_foo[FFFFFFFFFFF-B]'>
  <Function 'test_foo[FFFFFFFFFFF-A]'>
  <Function 'test_foo[GGGGGGGGGGGG-C]'>
  <Function 'test_foo[GGGGGGGGGGGG-B]'>
  <Function 'test_foo[GGGGGGGGGGGG-A]'>

=========================================================================================== no tests ran in 0.01 seconds ===========================================================================================
$ pytest test_foo.py --collect-only
=============================================================================================== test session starts ================================================================================================
platform linux -- Python 3.5.2, pytest-3.1.3, py-1.4.34, pluggy-0.4.0
rootdir: /data/lmitche1/src/doodles, inifile:
plugins: xdist-1.18.1
collected 12 items 
<Module 'test_foo.py'>
  <Function 'test_foo[DDDDDDDDD-A]'>
  <Function 'test_foo[EEEEEEEEEEEE-A]'>
  <Function 'test_foo[EEEEEEEEEEEE-B]'>
  <Function 'test_foo[DDDDDDDDD-B]'>
  <Function 'test_foo[FFFFFFFFFFF-B]'>
  <Function 'test_foo[FFFFFFFFFFF-A]'>
  <Function 'test_foo[FFFFFFFFFFF-C]'>
  <Function 'test_foo[EEEEEEEEEEEE-C]'>
  <Function 'test_foo[DDDDDDDDD-C]'>
  <Function 'test_foo[GGGGGGGGGGGG-C]'>
  <Function 'test_foo[GGGGGGGGGGGG-B]'>
  <Function 'test_foo[GGGGGGGGGGGG-A]'>

=========================================================================================== no tests ran in 0.01 seconds ===========================================================================================
```

Note how successive incantations of pytest arrive at different orders of the collected tests.

The problem lies in `fixtures.reorder_items` which reorders (in part) based on iteration over an unordered set.  Fix this by switching to using an `OrderedDict`.

It's not obvious to me how to write a good test for this.

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [x] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS`;
