### PR TITLE
pdb: resume capturing after `continue`

### DIFF
--- a/changelog/2619.feature.rst
+++ b/changelog/2619.feature.rst
@@ -1,0 +1,1 @@
+Resume capturing output after ``continue`` with ``__import__("pdb").set_trace()``.

--- a/changelog/2619.feature.rst
+++ b/changelog/2619.feature.rst
@@ -1,1 +1,4 @@
 Resume capturing output after ``continue`` with ``__import__("pdb").set_trace()``.
+
+This also adds a new ``pytest_leave_pdb`` hook, and passes in ``pdb`` to the
+existing ``pytest_enter_pdb`` hook.

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -95,7 +95,6 @@ class pytestPDB(object):
             tw = _pytest.config.create_terminal_writer(cls._config)
             tw.line()
             tw.sep(">", "PDB set_trace (IO-capturing turned off)")
-            cls._pluginmanager.hook.pytest_enter_pdb(config=cls._config)
 
             class _PdbWrapper(cls._pdb_cls, object):
                 _pytest_capman = capman
@@ -108,7 +107,9 @@ class pytestPDB(object):
                         tw.line()
                         tw.sep(">", "PDB continue (IO-capturing resumed)")
                         self._pytest_capman.resume_global_capture()
-                    cls._pluginmanager.hook.pytest_leave_pdb(config=cls._config)
+                    cls._pluginmanager.hook.pytest_leave_pdb(
+                        config=cls._config, pdb=self
+                    )
                     self._continued = True
                     return ret
 
@@ -129,6 +130,7 @@ class pytestPDB(object):
                     return ret
 
             _pdb = _PdbWrapper()
+            cls._pluginmanager.hook.pytest_enter_pdb(config=cls._config, pdb=_pdb)
         else:
             _pdb = cls._pdb_cls()
 

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -603,19 +603,21 @@ def pytest_exception_interact(node, call, report):
     """
 
 
-def pytest_enter_pdb(config):
+def pytest_enter_pdb(config, pdb):
     """ called upon pdb.set_trace(), can be used by plugins to take special
     action just before the python debugger enters in interactive mode.
 
     :param _pytest.config.Config config: pytest config object
+    :param pdb.Pdb pdb: Pdb instance
     """
 
 
-def pytest_leave_pdb(config):
+def pytest_leave_pdb(config, pdb):
     """ called when leaving pdb (e.g. with continue after pdb.set_trace()).
 
     Can be used by plugins to take special action just after the python
     debugger leaves interactive mode.
 
     :param _pytest.config.Config config: pytest config object
+    :param pdb.Pdb pdb: Pdb instance
     """

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -609,3 +609,13 @@ def pytest_enter_pdb(config):
 
     :param _pytest.config.Config config: pytest config object
     """
+
+
+def pytest_leave_pdb(config):
+    """ called when leaving pdb (e.g. with continue after pdb.set_trace()).
+
+    Can be used by plugins to take special action just after the python
+    debugger leaves interactive mode.
+
+    :param _pytest.config.Config config: pytest config object
+    """

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -550,16 +550,26 @@ class TestPDB(object):
     def test_enter_leave_pdb_hooks_are_called(self, testdir):
         testdir.makeconftest(
             """
+            mypdb = None
+
             def pytest_configure(config):
                 config.testing_verification = 'configured'
 
-            def pytest_enter_pdb(config):
+            def pytest_enter_pdb(config, pdb):
                 assert config.testing_verification == 'configured'
                 print('enter_pdb_hook')
 
-            def pytest_leave_pdb(config):
+                global mypdb
+                mypdb = pdb
+                mypdb.set_attribute = "bar"
+
+            def pytest_leave_pdb(config, pdb):
                 assert config.testing_verification == 'configured'
                 print('leave_pdb_hook')
+
+                global mypdb
+                assert mypdb is pdb
+                assert mypdb.set_attribute == "bar"
         """
         )
         p1 = testdir.makepyfile(

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -158,6 +158,7 @@ class TestPDB(object):
         assert "= 1 failed in" in rest
         assert "def test_1" not in rest
         assert "Exit: Quitting debugger" in rest
+        assert "PDB continue (IO-capturing resumed)" not in rest
         self.flush(child)
 
     @staticmethod
@@ -489,18 +490,23 @@ class TestPDB(object):
         """
         )
         child = testdir.spawn_pytest(str(p1))
+        child.expect(r"PDB set_trace \(IO-capturing turned off\)")
         child.expect("test_1")
         child.expect("x = 3")
         child.expect("Pdb")
         child.sendline("c")
+        child.expect(r"PDB continue \(IO-capturing resumed\)")
+        child.expect(r"PDB set_trace \(IO-capturing turned off\)")
         child.expect("x = 4")
         child.expect("Pdb")
         child.sendeof()
+        child.expect("_ test_1 _")
+        child.expect("def test_1")
+        child.expect("Captured stdout call")
         rest = child.read().decode("utf8")
-        assert "1 failed" in rest
-        assert "def test_1" in rest
         assert "hello17" in rest  # out is captured
         assert "hello18" in rest  # out is captured
+        assert "1 failed" in rest
         self.flush(child)
 
     def test_pdb_used_outside_test(self, testdir):
@@ -541,15 +547,19 @@ class TestPDB(object):
             ["E   NameError: *xxx*", "*! *Exit: Quitting debugger !*"]  # due to EOF
         )
 
-    def test_enter_pdb_hook_is_called(self, testdir):
+    def test_enter_leave_pdb_hooks_are_called(self, testdir):
         testdir.makeconftest(
             """
+            def pytest_configure(config):
+                config.testing_verification = 'configured'
+
             def pytest_enter_pdb(config):
                 assert config.testing_verification == 'configured'
                 print('enter_pdb_hook')
 
-            def pytest_configure(config):
-                config.testing_verification = 'configured'
+            def pytest_leave_pdb(config):
+                assert config.testing_verification == 'configured'
+                print('leave_pdb_hook')
         """
         )
         p1 = testdir.makepyfile(
@@ -558,11 +568,17 @@ class TestPDB(object):
 
             def test_foo():
                 pytest.set_trace()
+                assert 0
         """
         )
         child = testdir.spawn_pytest(str(p1))
         child.expect("enter_pdb_hook")
-        child.send("c\n")
+        child.sendline("c")
+        child.expect(r"PDB continue \(IO-capturing resumed\)")
+        child.expect("Captured stdout call")
+        rest = child.read().decode("utf8")
+        assert "leave_pdb_hook" in rest
+        assert "1 failed" in rest
         child.sendeof()
         self.flush(child)
 


### PR DESCRIPTION
After `pdb.set_trace()` capturing is turned off.
This patch resumes it after using the `continue` (or `c` / `cont`)
command.

I've noticed that any captured output from before the `set_trace` is lost, but that does not appear to be caused by my patch - need to investigate.
I've only tested this on `master` for now.

TODO:

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [x] Make sure to include reasonable tests for your change if necessary
