### PR TITLE
Show multiple issue links in CHANGELOG entries

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -120,6 +120,7 @@ Michael Birtwell
 Michael Droettboom
 Michael Seifert
 Michal Wajszczuk
+Mihai Capotă
 Mike Lundy
 Ned Batchelder
 Neven Mundar

--- a/changelog/2620.trivial
+++ b/changelog/2620.trivial
@@ -1,0 +1,1 @@
+Show multiple issue links in CHANGELOG entries.

--- a/changelog/_template.rst
+++ b/changelog/_template.rst
@@ -13,7 +13,8 @@
 
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category]|dictsort(by='value') %}
-- {{ text }}{% if category != 'vendor' %} (`{{ values[0] }} <https://github.com/pytest-dev/pytest/issues/{{ values[0][1:] }}>`_){% endif %}
+{% set issue_joiner = joiner(', ') %}
+- {{ text }}{% if category != 'vendor' %} ({% for value in values|sort %}{{ issue_joiner() }}`{{ value }} <https://github.com/pytest-dev/pytest/issues/{{ value[1:] }}>`_{% endfor %}){% endif %}
 
 
 {% endfor %}


### PR DESCRIPTION
Restores the functionality removed in PR #2488.

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [x] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS`;
