### PR TITLE
Make cache plugin cumulative

### DIFF
--- a/_pytest/cacheprovider.py
+++ b/_pytest/cacheprovider.py
@@ -117,7 +117,7 @@ class LFPlugin:
             return "run-last-failure: %s" % mode
 
     def pytest_runtest_logreport(self, report):
-        if report.passed and report.when == 'call':
+        if (report.when == 'call' and report.passed) or report.skipped:
             self.lastfailed.pop(report.nodeid, None)
         elif report.failed:
             self.lastfailed[report.nodeid] = True

--- a/_pytest/cacheprovider.py
+++ b/_pytest/cacheprovider.py
@@ -105,27 +105,22 @@ class LFPlugin:
         self.config = config
         active_keys = 'lf', 'failedfirst'
         self.active = any(config.getvalue(key) for key in active_keys)
-        if self.active:
-            self.lastfailed = config.cache.get("cache/lastfailed", {})
-        else:
-            self.lastfailed = {}
+        self.lastfailed = config.cache.get("cache/lastfailed", {})
 
     def pytest_report_header(self):
         if self.active:
             if not self.lastfailed:
                 mode = "run all (no recorded failures)"
             else:
-                mode = "rerun last %d failures%s" % (
-                    len(self.lastfailed),
+                mode = "rerun previous failures%s" % (
                     " first" if self.config.getvalue("failedfirst") else "")
             return "run-last-failure: %s" % mode
 
     def pytest_runtest_logreport(self, report):
-        if report.failed and "xfail" not in report.keywords:
+        if report.passed and report.when == 'call':
+            self.lastfailed.pop(report.nodeid, None)
+        elif report.failed:
             self.lastfailed[report.nodeid] = True
-        elif not report.failed:
-            if report.when == "call":
-                self.lastfailed.pop(report.nodeid, None)
 
     def pytest_collectreport(self, report):
         passed = report.outcome in ('passed', 'skipped')
@@ -147,11 +142,11 @@ class LFPlugin:
                     previously_failed.append(item)
                 else:
                     previously_passed.append(item)
-            if not previously_failed and previously_passed:
+            if not previously_failed:
                 # running a subset of all tests with recorded failures outside
                 # of the set of tests currently executing
-                pass
-            elif self.config.getvalue("lf"):
+                return
+            if self.config.getvalue("lf"):
                 items[:] = previously_failed
                 config.hook.pytest_deselected(items=previously_passed)
             else:
@@ -161,8 +156,9 @@ class LFPlugin:
         config = self.config
         if config.getvalue("cacheshow") or hasattr(config, "slaveinput"):
             return
-        prev_failed = config.cache.get("cache/lastfailed", None) is not None
-        if (session.testscollected and prev_failed) or self.lastfailed:
+
+        saved_lastfailed = config.cache.get("cache/lastfailed", {})
+        if saved_lastfailed != self.lastfailed:
             config.cache.set("cache/lastfailed", self.lastfailed)
 
 

--- a/changelog/2621.feature
+++ b/changelog/2621.feature
@@ -1,0 +1,2 @@
+``--last-failed`` now remembers forever when a test has failed and only forgets it if it passes again. This makes it
+easy to fix a test suite by selectively running files and fixing tests incrementally.


### PR DESCRIPTION
When introducing a delicate change to a large code base (2000+ tests), I often run all tests (using xdist) to see what has been affected, then ooops, 400 broken tests.

I would like to go fixing module by module to get everything green again.

What happens currently is this:

1. Run all tests: `pytest tests`. BOOM, 400 failures. Oh boy. 
1. Run tests from the first module with failures: `pytest tests/core --lf`. Fix all failures, get a green run.
1. Run tests from the next module with failures: `pytest tests/controller --lf`. At this point the cache plugin forgets the previous failures, running *all* tests found in `test/controller` again, regardless if they have failed before or not.

Because of this, I often find myself copying/pasting the list of failed modules somewhere so I can run them selectively, instead of relying on the caching mechanism.

The workflow I want:

1. Run all tests: `pytest tests`. BOOM, 400 failures. Oh boy. 
1. Run tests from the first module with failures: `pytest tests/core --lf`. Fix all failures, get a green run.
1. Run tests from the next module with failures: `pytest tests/controller --lf`. Fix all failures, get a green run.
1. Repeat until all modules are fixed.

This PR attempts to fix this by making the cache plugin always remember which tests failed at a certain point, discarding a test failure only when it sees that test passing again.

~~This is still a WIP because it needs docs/changelog/etc plus I wanted to gather feedback.~~