### PR TITLE
Fix --last-failed reported items in terminal

### DIFF
--- a/_pytest/hookspec.py
+++ b/_pytest/hookspec.py
@@ -351,7 +351,10 @@ def pytest_report_header(config, startdir):
 
 
 def pytest_report_collectionfinish(config, startdir, items):
-    """ return a string or list of strings to be displayed after collection has finished successfully.
+    """
+    .. versionadded:: 3.2
+    
+    return a string or list of strings to be displayed after collection has finished successfully.
 
     This strings will be displayed after the standard "collected X items" message.
 

--- a/_pytest/hookspec.py
+++ b/_pytest/hookspec.py
@@ -353,7 +353,7 @@ def pytest_report_header(config, startdir):
 def pytest_report_collectionfinish(config, startdir, items):
     """
     .. versionadded:: 3.2
-    
+
     return a string or list of strings to be displayed after collection has finished successfully.
 
     This strings will be displayed after the standard "collected X items" message.


### PR DESCRIPTION
Using the new `pytest_report_collectionfinish` hook it is now possible to accurately report the items which will be rerun.

Should be reviewed only after #2621 is merged.