### PR TITLE
Fixed#2591: Replaced os.sep with '/' as it behaves differently on linux and windows.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -155,6 +155,7 @@ Samuele Pedroni
 Segev Finer
 Simon Gomizelj
 Skylar Downes
+Srinivas Reddy Thatiparthy
 Stefan Farmbauer
 Stefan Zimmermann
 Stefano Taschini

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -881,6 +881,18 @@ notset = Notset()
 FILE_OR_DIR = 'file_or_dir'
 
 
+def _iter_rewritable_modules(package_files):
+    for fn in package_files:
+        is_simple_module = '/' not in fn and fn.endswith('.py')
+        is_package = fn.count('/') == 1 and fn.endswith('__init__.py')
+        if is_simple_module:
+            module_name, _ = os.path.splitext(fn)
+            yield module_name
+        elif is_package:
+            package_name = os.path.dirname(fn)
+            yield package_name
+
+
 class Config(object):
     """ access to configuration values, pluginmanager and plugin hooks.  """
 
@@ -1041,15 +1053,8 @@ class Config(object):
             for entry in entrypoint.dist._get_metadata(metadata)
         )
 
-        for fn in package_files:
-            is_simple_module = os.sep not in fn and fn.endswith('.py')
-            is_package = fn.count(os.sep) == 1 and fn.endswith('__init__.py')
-            if is_simple_module:
-                module_name, ext = os.path.splitext(fn)
-                hook.mark_rewrite(module_name)
-            elif is_package:
-                package_name = os.path.dirname(fn)
-                hook.mark_rewrite(package_name)
+        for name in _iter_rewritable_modules(package_files):
+            hook.mark_rewrite(name)
 
     def _warn_about_missing_assertion(self, mode):
         try:
@@ -1351,7 +1356,7 @@ def determine_setup(inifile, args, warnfunc=None):
                 rootdir, inifile, inicfg = getcfg(dirs, warnfunc=warnfunc)
                 if rootdir is None:
                     rootdir = get_common_ancestor([py.path.local(), ancestor])
-                    is_fs_root = os.path.splitdrive(str(rootdir))[1] == os.sep
+                    is_fs_root = os.path.splitdrive(str(rootdir))[1] == '/'
                     if is_fs_root:
                         rootdir = ancestor
     return rootdir, inifile, inicfg or {}

--- a/changelog/2591.bugfix
+++ b/changelog/2591.bugfix
@@ -1,0 +1,1 @@
+Correctly consider ``/`` as the file separator to automatically mark plugin files for rewrite on Windows.

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -3,7 +3,7 @@ import py
 import pytest
 
 import _pytest._code
-from _pytest.config import getcfg, get_common_ancestor, determine_setup
+from _pytest.config import getcfg, get_common_ancestor, determine_setup, _iter_rewritable_modules
 from _pytest.main import EXIT_NOTESTSCOLLECTED
 
 
@@ -307,6 +307,16 @@ class TestConfigAPI(object):
             testdir.parseconfig('--confcutdir', testdir.tmpdir.join('inexistant'))
         config = testdir.parseconfig('--confcutdir', testdir.tmpdir.join('dir').ensure(dir=1))
         assert config.getoption('confcutdir') == str(testdir.tmpdir.join('dir'))
+
+    @pytest.mark.parametrize('names, expected', [
+        (['bar.py'], ['bar']),
+        (['foo', 'bar.py'], []),
+        (['foo', 'bar.pyc'], []),
+        (['foo', '__init__.py'], ['foo']),
+        (['foo', 'bar', '__init__.py'], []),
+    ])
+    def test_iter_rewritable_modules(self, names, expected):
+        assert list(_iter_rewritable_modules(['/'.join(names)])) == expected
 
 
 class TestConfigFromdictargs(object):


### PR DESCRIPTION
Removed os.sep as it behaves differently linux and windows
* on linux it is '/'
* on windows it is '\\\\'
