### PR TITLE
Support PEP-415's Exception.__suppress_context__

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -84,6 +84,7 @@ John Towler
 Jon Sonesen
 Jonas Obrist
 Jordan Guymon
+Jordan Moldow
 Joshua Bronson
 Jurko Gospodnetić
 Justyna Janczyszyn

--- a/_pytest/_code/code.py
+++ b/_pytest/_code/code.py
@@ -679,7 +679,7 @@ class FormattedExcinfo(object):
                     e = e.__cause__
                     excinfo = ExceptionInfo((type(e), e, e.__traceback__)) if e.__traceback__ else None
                     descr = 'The above exception was the direct cause of the following exception:'
-                elif e.__context__ is not None:
+                elif (e.__context__ is not None and not e.__suppress_context__):
                     e = e.__context__
                     excinfo = ExceptionInfo((type(e), e, e.__traceback__)) if e.__traceback__ else None
                     descr = 'During handling of the above exception, another exception occurred:'

--- a/changelog/2631.feature
+++ b/changelog/2631.feature
@@ -1,0 +1,4 @@
+Added support for `PEP-415's <https://www.python.org/dev/peps/pep-0415/>`_
+``Exception.__suppress_context__``. Now if a ``raise exception from None`` is
+caught by pytest, pytest will no longer chain the context in the test report.
+The behavior now matches Python's traceback behavior.


### PR DESCRIPTION
PEP-415 states that `exception.__context__` should be suppressed
in traceback outputs, if `exception.__suppress_context__` is
`True`.

Now if a ``raise exception from None`` is caught by pytest,
pytest will no longer chain the context in the test report.

The algorithm in `FormattedExcinfo` now better matches the one
in `traceback.TracebackException`.

`Exception.__suppress_context__` is available in all of the
versions of Python 3 that are supported by pytest.

Fixes #2631.