### PR TITLE
capture: recover from closed files

### DIFF
--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -399,6 +399,7 @@ class FDCapture:
         # os.close(targetfd_save)
         self.syscapture.done()
         # self.tmpfile.close()
+        raise Exception("Done method called!")
 
     def suspend(self):
         self.syscapture.suspend()

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -19,7 +19,6 @@ unicode = py.builtin.text
 
 patchsysdict = {0: 'stdin', 1: 'stdout', 2: 'stderr'}
 
-
 def pytest_addoption(parser):
     group = parser.getgroup("general")
     group._addoption(
@@ -397,9 +396,9 @@ class FDCapture:
         seeked to position zero. """
         targetfd_save = self.__dict__.pop("targetfd_save")
         os.dup2(targetfd_save, self.targetfd)
-        os.close(targetfd_save)
+        # os.close(targetfd_save)
         self.syscapture.done()
-        self.tmpfile.close()
+        # self.tmpfile.close()
 
     def suspend(self):
         self.syscapture.suspend()
@@ -446,7 +445,7 @@ class SysCapture:
     def done(self):
         setattr(sys, self.name, self._old)
         del self._old
-        self.tmpfile.close()
+        # self.tmpfile.close()
 
     def suspend(self):
         setattr(sys, self.name, self._old)

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -447,6 +447,7 @@ class SysCapture:
         setattr(sys, self.name, self._old)
         del self._old
         # self.tmpfile.close()
+        raise Exception("Sys method called!")
 
     def suspend(self):
         setattr(sys, self.name, self._old)

--- a/changelog/2633.bugfix
+++ b/changelog/2633.bugfix
@@ -1,0 +1,2 @@
+In some cases on windows stderr capturing may fail. Pytest now 
+attempts to recover from a capturing failure.

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1159,3 +1159,6 @@ def test_pickling_and_unpickling_enocded_file():
     ef = capture.EncodedFile(None, None)
     ef_as_str = pickle.dumps(ef)
     pickle.loads(ef_as_str)
+
+def test_closed_handle():
+    sys.stderr.close()


### PR DESCRIPTION
works around pytest-dev/pytest-xdist#167. This is not however a "fix" but simply allows the tests to run.