### PR TITLE
remove preinit, its no longer needed

### DIFF
--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -100,8 +100,6 @@ def directory_arg(path, optname):
     return path
 
 
-_preinit = []
-
 default_plugins = (
     "mark main terminal runner python fixtures debugging unittest capture skipping "
     "tmpdir monkeypatch recwarn pastebin helpconfig nose assertion "
@@ -113,14 +111,7 @@ builtin_plugins = set(default_plugins)
 builtin_plugins.add("pytester")
 
 
-def _preloadplugins():
-    assert not _preinit
-    _preinit.append(get_config())
-
-
 def get_config():
-    if _preinit:
-        return _preinit.pop(0)
     # subsequent calls to main will create a fresh instance
     pluginmanager = PytestPluginManager()
     config = Config(pluginmanager)

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -83,15 +83,6 @@ def pytest_addoption(parser):
                     help="base temporary directory for this test run.")
 
 
-def pytest_namespace():
-    """keeping this one works around a deeper startup issue in pytest
-
-    i tried to find it for a while but the amount of time turned unsustainable,
-    so i put a hack in to revisit later
-    """
-    return {}
-
-
 def pytest_configure(config):
     __import__('pytest').config = config  # compatibiltiy
 

--- a/changelog/2236.removal
+++ b/changelog/2236.removal
@@ -1,0 +1,1 @@
+- remove plugin preinit, we no longer need to do that because the namespace is initialized in the module now

--- a/changelog/2236.removal
+++ b/changelog/2236.removal
@@ -1,1 +1,1 @@
-- remove plugin preinit, we no longer need to do that because the namespace is initialized in the module now
+- Remove internal ``_preloadplugins()`` function. This removal is part of the ``pytest_namespace()`` hook deprecation.

--- a/pytest.py
+++ b/pytest.py
@@ -7,7 +7,7 @@ pytest: unit and functional testing with Python.
 # else we are imported
 
 from _pytest.config import (
-    main, UsageError, _preloadplugins, cmdline,
+    main, UsageError, cmdline,
     hookspec, hookimpl
 )
 from _pytest.fixtures import fixture, yield_fixture
@@ -74,5 +74,4 @@ if __name__ == '__main__':
 else:
 
     from _pytest.compat import _setup_collect_fakemodule
-    _preloadplugins()  # to populate pytest.* namespace so help(pytest) works
     _setup_collect_fakemodule()


### PR DESCRIPTION
by removing preinit we remove loading the initial plugin list

this is no longer needed, since we no longer use pytest-namespace for pytest itself

the followup for this one is to deprecate the pytest-namespace hook alltogether