### PR TITLE
Honor `__suppress_context__` on exceptions.

### DIFF
--- a/_pytest/_code/code.py
+++ b/_pytest/_code/code.py
@@ -679,7 +679,7 @@ class FormattedExcinfo(object):
                     e = e.__cause__
                     excinfo = ExceptionInfo((type(e), e, e.__traceback__)) if e.__traceback__ else None
                     descr = 'The above exception was the direct cause of the following exception:'
-                elif e.__context__ is not None:
+                elif e.__context__ is not None and not getattr(e, '__suppress_context__', False):
                     e = e.__context__
                     excinfo = ExceptionInfo((type(e), e, e.__traceback__)) if e.__traceback__ else None
                     descr = 'During handling of the above exception, another exception occurred:'

--- a/changelog/2637.bugfix
+++ b/changelog/2637.bugfix
@@ -1,0 +1,1 @@
+Properly support "raise ... from None" syntax, by honoring `__suppress_context__` on exceptions.


### PR DESCRIPTION
Properly support "raise ... from None" syntax, by honoring `__suppress_context__` on exceptions.

See: https://www.python.org/dev/peps/pep-0415/  and https://docs.python.org/3.7/library/exceptions.html

> using raise new_exc from None effectively replaces the old exception with the new one for display purposes

---

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [ ] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Add yourself to `AUTHORS`;
