### PR TITLE
Properly escape test names when setting PYTEST_CURRENT_TEST environment variable

### DIFF
--- a/_pytest/pytester.py
+++ b/_pytest/pytester.py
@@ -381,13 +381,17 @@ class RunResult:
                     return d
         raise ValueError("Pytest terminal report not found")
 
-    def assert_outcomes(self, passed=0, skipped=0, failed=0):
+    def assert_outcomes(self, passed=0, skipped=0, failed=0, error=0):
         """ assert that the specified outcomes appear with the respective
         numbers (0 means it didn't occur) in the text output from a test run."""
         d = self.parseoutcomes()
-        assert passed == d.get("passed", 0)
-        assert skipped == d.get("skipped", 0)
-        assert failed == d.get("failed", 0)
+        obtained = {
+            'passed': d.get('passed', 0),
+            'skipped': d.get('skipped', 0),
+            'failed': d.get('failed', 0),
+            'error': d.get('error', 0),
+        }
+        assert obtained == dict(passed=passed, skipped=skipped, failed=failed, error=error)
 
 
 class Testdir:

--- a/_pytest/runner.py
+++ b/_pytest/runner.py
@@ -7,6 +7,7 @@ import sys
 from time import time
 
 import py
+from _pytest.compat import _ascii_escaped, _PY2
 from _pytest._code.code import TerminalRepr, ExceptionInfo
 from _pytest.outcomes import skip, Skipped, TEST_OUTCOME
 
@@ -134,7 +135,11 @@ def _update_current_test_var(item, when):
     """
     var_name = 'PYTEST_CURRENT_TEST'
     if when:
-        os.environ[var_name] = '{0} ({1})'.format(item.nodeid, when)
+        value = _ascii_escaped('{0} ({1})'.format(item.nodeid, when))
+        if _PY2:
+            # python 2 doesn't like null bytes on environment variables (see #2644)
+            value = value.replace('\x00', '(null)')
+        os.environ[var_name] = value
     else:
         os.environ.pop(var_name)
 

--- a/_pytest/runner.py
+++ b/_pytest/runner.py
@@ -7,7 +7,7 @@ import sys
 from time import time
 
 import py
-from _pytest.compat import _ascii_escaped, _PY2
+from _pytest.compat import _PY2
 from _pytest._code.code import TerminalRepr, ExceptionInfo
 from _pytest.outcomes import skip, Skipped, TEST_OUTCOME
 
@@ -135,7 +135,7 @@ def _update_current_test_var(item, when):
     """
     var_name = 'PYTEST_CURRENT_TEST'
     if when:
-        value = _ascii_escaped('{0} ({1})'.format(item.nodeid, when))
+        value = '{0} ({1})'.format(item.nodeid, when)
         if _PY2:
             # python 2 doesn't like null bytes on environment variables (see #2644)
             value = value.replace('\x00', '(null)')

--- a/changelog/2644.bugfix
+++ b/changelog/2644.bugfix
@@ -1,0 +1,1 @@
+Properly escape test names when setting ``PYTEST_CURRENT_TEST`` environment variable.

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -400,7 +400,7 @@ class TestGeneralUsage(object):
         monkeypatch.setitem(sys.modules, 'myplugin', mod)
         assert pytest.main(args=[str(tmpdir)], plugins=['myplugin']) == 0
 
-    def test_parameterized_with_bytes_regex(self, testdir):
+    def test_parametrized_with_bytes_regex(self, testdir):
         p = testdir.makepyfile("""
             import re
             import pytest
@@ -413,6 +413,19 @@ class TestGeneralUsage(object):
         res.stdout.fnmatch_lines([
             '*1 passed*'
         ])
+
+    def test_parametrized_with_null_bytes(self, testdir):
+        """Test parametrization with values that contain null bytes and unicode characters (#2644)"""
+        p = testdir.makepyfile(u"""
+            # encoding: UTF-8
+            import pytest
+
+            @pytest.mark.parametrize("data", ["\\x00", u'ação'])
+            def test_foo(data):
+                assert data
+        """)
+        res = testdir.runpytest(p)
+        res.assert_outcomes(passed=2)
 
 
 class TestInvocationVariants(object):


### PR DESCRIPTION
Fix #2644
