### PR TITLE
Handling case when dtest is the default None

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Thanks for submitting a PR, your contribution is really appreciated!
 Here's a quick checklist that should be present in PRs:
 
 - [ ] Add a new news fragment into the changelog folder
-  * name it `$issue_id.$type` for example (588.bug)
+  * name it `$issue_id.$type` for example (588.bugfix)
   * if you don't have an issue_id change it to the pr id after creating the pr
   * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
   * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."

--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -140,7 +140,7 @@ class DoctestItem(pytest.Item):
             return super(DoctestItem, self).repr_failure(excinfo)
 
     def reportinfo(self):
-        return self.fspath, self.dtest.lineno, "[doctest] %s" % self.name
+        return self.fspath, getattr(self.dtest, 'lineno', None), "[doctest] %s" % self.name
 
 
 def _get_flag_lookup():

--- a/changelog/2651.bugfix
+++ b/changelog/2651.bugfix
@@ -1,0 +1,1 @@
+Fix ``reportinfo`` for the default case of ``dtest=None``.


### PR DESCRIPTION
This should fix the handling of the default case when ``dtest`` is None. The bug was introduced in #2610.

Here's a quick checklist that should be present in PRs:

- [x] Add a new news fragment into the changelog folder

- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [ ] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Add yourself to `AUTHORS`;
