### PR TITLE
Add note on sharing the `slow` marker in the basic examples

### DIFF
--- a/changelog/2653.doc
+++ b/changelog/2653.doc
@@ -1,0 +1,1 @@
+In one of the simple examples, use `pytest_collection_modifyitems()` to skip tests based on a command-line option, allowing its sharing while preventing a user error when acessing `pytest.config` before the argument parsing.


### PR DESCRIPTION
Hi! I recently faced the same issue as in #472 when trying to reuse the `slow` marker and it took me a while to understand why that was failing. I figured that having this note would be useful. If someone agrees, I can go through the checklist to make it a proper PR.

Question: in a similar issue (#1688) @nicoddemus said that "using `pytest.config` is discouraged". Is its use discouraged in that specific case or there is a better way to use the configs in general?

Thanks!

---

Here's a quick checklist that should be present in PRs:

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [x] ~~Make sure to include reasonable tests for your change if necessary~~

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] ~~Add yourself to `AUTHORS`;~~
