### PR TITLE
Add fail fast strategy to appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,5 +40,8 @@ install:
 
 build: false  # Not a C# project, build stuff at the test step instead.
 
+matrix:
+    fast_finish: true
+
 test_script:
   - call scripts\call-tox.bat


### PR DESCRIPTION
From : https://www.appveyor.com/docs/build-configuration/#failing-strategy
By default AppVeyor runs all build jobs. If at least one job has failed the entire build is marked as failed. Sometimes, you want the build fail immediately once one of the job fails. To enable fast fail strategy add fast_finish setting into appveyor.yml:

```
matrix:
  fast_finish: true

```