### PR TITLE
Fix windows console workaround error with non-standard io-streams

### DIFF
--- a/changelog/2666.bugfix
+++ b/changelog/2666.bugfix
@@ -1,0 +1,3 @@
+Fix error on Windows and Python 3.6+ when ``sys.stdout`` has been replaced with
+a stream-like object which does not implement the full ``io`` module buffer protocol. In particular this
+affects ``pytest-xdist`` users on the aforementioned platform.

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1140,6 +1140,23 @@ def test_error_attribute_issue555(testdir):
     reprec.assertoutcome(passed=1)
 
 
+@pytest.mark.skipif(not sys.platform.startswith('win') and sys.version_info[:2] >= (3, 6),
+                    reason='only py3.6+ on windows')
+def test_py36_windowsconsoleio_workaround_non_standard_streams():
+    """
+    Ensure _py36_windowsconsoleio_workaround function works with objects that
+    do not implement the full ``io``-based stream protocol, for example execnet channels (#2666).
+    """
+    from _pytest.capture import _py36_windowsconsoleio_workaround
+
+    class DummyStream:
+        def write(self, s):
+            pass
+
+    stream = DummyStream()
+    _py36_windowsconsoleio_workaround(stream)
+
+
 def test_dontreadfrominput_has_encoding(testdir):
     testdir.makepyfile("""
         import sys


### PR DESCRIPTION
Fix #2666
