### PR TITLE
ensure callspecs contain the list of marks

### DIFF
--- a/_pytest/mark.py
+++ b/_pytest/mark.py
@@ -67,10 +67,6 @@ class ParameterSet(namedtuple('ParameterSet', 'values, marks, id')):
 
         return cls(argval, marks=newmarks, id=None)
 
-    @property
-    def deprecated_arg_dict(self):
-        return dict((mark.name, mark) for mark in self.marks)
-
 
 class MarkerError(Exception):
 

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -645,14 +645,14 @@ class CallSpec2(object):
         self._globalid_args = set()
         self._globalparam = NOTSET
         self._arg2scopenum = {}  # used for sorting parametrized resources
-        self.keywords = {}
+        self.marks = []
         self.indices = {}
 
     def copy(self, metafunc):
         cs = CallSpec2(self.metafunc)
         cs.funcargs.update(self.funcargs)
         cs.params.update(self.params)
-        cs.keywords.update(self.keywords)
+        cs.marks.extend(self.marks)
         cs.indices.update(self.indices)
         cs._arg2scopenum.update(self._arg2scopenum)
         cs._idlist = list(self._idlist)
@@ -677,8 +677,8 @@ class CallSpec2(object):
     def id(self):
         return "-".join(map(str, filter(None, self._idlist)))
 
-    def setmulti(self, valtypes, argnames, valset, id, keywords, scopenum,
-                 param_index):
+    def setmulti2(self, valtypes, argnames, valset, id, marks, scopenum,
+                  param_index):
         for arg, val in zip(argnames, valset):
             self._checkargnotcontained(arg)
             valtype_for_arg = valtypes[arg]
@@ -686,7 +686,7 @@ class CallSpec2(object):
             self.indices[arg] = param_index
             self._arg2scopenum[arg] = scopenum
         self._idlist.append(id)
-        self.keywords.update(keywords)
+        self.marks.extend(marks)
 
     def setall(self, funcargs, id, param):
         for x in funcargs:
@@ -842,8 +842,8 @@ class Metafunc(fixtures.FuncargnamesCompatAttr):
                         'equal to the number of names ({1})'.format(
                             param.values, argnames))
                 newcallspec = callspec.copy(self)
-                newcallspec.setmulti(valtypes, argnames, param.values, a_id,
-                                     param.deprecated_arg_dict, scopenum, param_index)
+                newcallspec.setmulti2(valtypes, argnames, param.values, a_id,
+                                      param.marks, scopenum, param_index)
                 newcalls.append(newcallspec)
         self._calls = newcalls
 
@@ -1115,7 +1115,13 @@ class Function(FunctionMixin, main.Item, fixtures.FuncargnamesCompatAttr):
         self.keywords.update(self.obj.__dict__)
         if callspec:
             self.callspec = callspec
-            self.keywords.update(callspec.keywords)
+            # this is total hostile and a mess
+            # keywords are broken by design by now
+            # this will be redeemed later
+            for mark in callspec.marks:
+                # feel free to cry, this was broken for years before
+                # and keywords cant fix it per design
+                self.keywords[mark.name] = mark
         if keywords:
             self.keywords.update(keywords)
 

--- a/changelog/2672.removal
+++ b/changelog/2672.removal
@@ -1,0 +1,2 @@
+Internally change ``CallSpec2`` to have a list of marks instead of a broken mapping of keywords.
+This removes the keywords attribute of the internal ``CallSpec2`` class.

--- a/changelog/2675.removal
+++ b/changelog/2675.removal
@@ -1,0 +1,1 @@
+remove ParameterSet.deprecated_arg_dict - its not a public api and the lack of the underscore was a naming error.

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -158,7 +158,7 @@ class TestMetafunc(object):
             pass
         metafunc = self.Metafunc(func)
         metafunc.parametrize("y", [])
-        assert 'skip' in metafunc._calls[0].keywords
+        assert 'skip' == metafunc._calls[0].marks[0].name
 
     def test_parametrize_with_userobjects(self):
         def func(x, y):


### PR DESCRIPTION
this ensures we don't override in that area

the final parts of the transfer are still broken, but with the list, we at least have a chance to do better in future

this is also base to fix #1540 in future
