### PR TITLE
Fold skipped tests with global pytestmark variable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -117,6 +117,7 @@ Matt Bachmann
 Matt Duck
 Matt Williams
 Matthias Hafner
+Maxim Filipenko
 mbyt
 Michael Aquilina
 Michael Birtwell

--- a/_pytest/skipping.py
+++ b/_pytest/skipping.py
@@ -345,6 +345,12 @@ def folded_skips(skipped):
     for event in skipped:
         key = event.longrepr
         assert len(key) == 3, (event, key)
+        keywords = getattr(event, 'keywords', {})
+        # folding reports with global pytestmark variable
+        # this is workaround, because for now we cannot identify the scope of a skip marker
+        # TODO: revisit after marks scope would be fixed
+        if event.when == 'setup' and 'skip' in keywords and 'pytestmark' not in keywords:
+            key = (key[0], None, key[2], )
         d.setdefault(key, []).append(event)
     l = []
     for key, events in d.items():
@@ -367,6 +373,11 @@ def show_skipped(terminalreporter, lines):
             for num, fspath, lineno, reason in fskips:
                 if reason.startswith("Skipped: "):
                     reason = reason[9:]
-                lines.append(
-                    "SKIP [%d] %s:%d: %s" %
-                    (num, fspath, lineno + 1, reason))
+                if lineno is not None:
+                    lines.append(
+                        "SKIP [%d] %s:%d: %s" %
+                        (num, fspath, lineno + 1, reason))
+                else:
+                    lines.append(
+                        "SKIP [%d] %s: %s" %
+                        (num, fspath, reason))

--- a/changelog/2549.feature
+++ b/changelog/2549.feature
@@ -1,0 +1,1 @@
+Report only once tests with global ``pytestmark`` variable.

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -676,6 +676,7 @@ def test_skip_reasons_folding():
     ev1.longrepr = longrepr
 
     ev2 = X()
+    ev2.when = "execute"
     ev2.longrepr = longrepr
     ev2.skipped = True
 
@@ -709,6 +710,27 @@ def test_skipped_reasons_functional(testdir):
     result = testdir.runpytest('-rs')
     result.stdout.fnmatch_lines([
         "*SKIP*2*conftest.py:4: test",
+    ])
+    assert result.ret == 0
+
+
+def test_skipped_folding(testdir):
+    testdir.makepyfile(
+        test_one="""
+            import pytest
+            pytestmark = pytest.mark.skip("Folding")
+            def setup_function(func):
+                pass
+            def test_func():
+                pass
+            class TestClass(object):
+                def test_method(self):
+                    pass
+       """,
+    )
+    result = testdir.runpytest('-rs')
+    result.stdout.fnmatch_lines([
+        "*SKIP*2*test_one.py: Folding"
     ])
     assert result.ret == 0
 


### PR DESCRIPTION
Hi!

Address #2549

Current check based on `keywords` dict. Maybe better solution will be to introduce additional `keywords` entry for tests, skipped because of global `pytestmark` variable. What do you think?

===

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [x] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS`;
