### PR TITLE
Use the correct stacklevel for getfuncargvalue() deprecation warning.

### DIFF
--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -432,7 +432,8 @@ class FixtureRequest(FuncargnamesCompatAttr):
         from _pytest import deprecated
         warnings.warn(
             deprecated.GETFUNCARGVALUE,
-            DeprecationWarning)
+            DeprecationWarning,
+            stacklevel=2)
         return self.getfixturevalue(argname)
 
     def _get_active_fixturedef(self, argname):

--- a/changelog/2681.bugfix
+++ b/changelog/2681.bugfix
@@ -1,0 +1,1 @@
+Calling the deprecated `request.getfuncargvalue()` now shows the source of the call.


### PR DESCRIPTION
Fixed #2681.
