### PR TITLE
Use 3.6 as preferred Python 3 interpreter for CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 python:
-  - '3.5'
+  - '3.6'
 # command to install dependencies
 install:
   - pip install --upgrade --pre tox
@@ -14,18 +14,17 @@ env:
     - TOXENV=linting
     - TOXENV=py27
     - TOXENV=py34
-    - TOXENV=py35
+    - TOXENV=py36
     - TOXENV=py27-pexpect
     - TOXENV=py27-xdist
     - TOXENV=py27-trial
     - TOXENV=py27-numpy
-    - TOXENV=py35-pexpect
-    - TOXENV=py35-xdist
-    - TOXENV=py35-trial
-    - TOXENV=py35-numpy
+    - TOXENV=py36-pexpect
+    - TOXENV=py36-xdist
+    - TOXENV=py36-trial
+    - TOXENV=py36-numpy
     - TOXENV=py27-nobyte
     - TOXENV=doctesting
-    - TOXENV=freeze
     - TOXENV=docs
 
 matrix:
@@ -36,8 +35,10 @@ matrix:
       python: '3.3'
     - env: TOXENV=pypy
       python: 'pypy-5.4'
-    - env: TOXENV=py36
-      python: '3.6'
+    - env: TOXENV=py35
+      python: '3.5'
+    - env: TOXENV=py35-freeze
+      python: '3.5'
     - env: TOXENV=py37
       python: 'nightly'
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 sudo: false
 language: python
 python:
-    - '3.5'
+  - '3.5'
 # command to install dependencies
-install: "pip install -U tox"
+install:
+  - pip install --upgrade --pre tox
 # # command to run tests
 env:
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,13 +21,13 @@ environment:
   - TOXENV: "py27-xdist"
   - TOXENV: "py27-trial"
   - TOXENV: "py27-numpy"
-  - TOXENV: "py35-pexpect"
-  - TOXENV: "py35-xdist"
-  - TOXENV: "py35-trial"
-  - TOXENV: "py35-numpy"
+  - TOXENV: "py36-pexpect"
+  - TOXENV: "py36-xdist"
+  - TOXENV: "py36-trial"
+  - TOXENV: "py36-numpy"
   - TOXENV: "py27-nobyte"
   - TOXENV: "doctesting"
-  - TOXENV: "freeze"
+  - TOXENV: "py35-freeze"
   - TOXENV: "docs"
 
 install:
@@ -36,7 +36,7 @@ install:
 
   - if "%TOXENV%" == "pypy" call scripts\install-pypy.bat
 
-  - C:\Python35\python -m pip install --upgrade --pre tox
+  - C:\Python36\python -m pip install --upgrade --pre tox
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ install:
 
   - if "%TOXENV%" == "pypy" call scripts\install-pypy.bat
 
-  - C:\Python35\python -m pip install tox
+  - C:\Python35\python -m pip install --upgrade --pre tox
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/scripts/call-tox.bat
+++ b/scripts/call-tox.bat
@@ -5,4 +5,4 @@ if "%TOXENV%" == "coveralls" (
         exit /b 0
     )
 )
-C:\Python35\python -m tox
+C:\Python36\python -m tox

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ envlist =
     {py27,py35}-{pexpect,xdist,trial,numpy}
     py27-nobyte
     doctesting
-    freeze
+    py35-freeze
     docs
 
 [testenv]
@@ -169,7 +169,7 @@ changedir = testing
 commands =
     {envpython} {envbindir}/py.test-jython -rfsxX {posargs}
 
-[testenv:freeze]
+[testenv:py35-freeze]
 changedir = testing/freeze
 deps = pyinstaller
 commands =


### PR DESCRIPTION
This should be reviewed after #2685 as it builds on the commit of that PR.