### PR TITLE
Fixed error in 'Good Practices' code snippet

### DIFF
--- a/changelog/2691.trivial
+++ b/changelog/2691.trivial
@@ -1,0 +1,1 @@
+Fixed minor error in 'Good Practices/Manual Integration' code snippet.

--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -267,7 +267,7 @@ your own setuptools Test command for invoking pytest.
 
         def initialize_options(self):
             TestCommand.initialize_options(self)
-            self.pytest_args = []
+            self.pytest_args = ''
 
         def run_tests(self):
             import shlex


### PR DESCRIPTION
When initializing with `pytest_args = []`, if no arguments are passed, `shlex.split` fails parsing the empty list.
It can be easily fixed by initializing with `pytest_args = ''`.

---

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [ ] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Add yourself to `AUTHORS`;
