### PR TITLE
[wip] reintroduce Warnings on customclass usage

### DIFF
--- a/_pytest/deprecated.py
+++ b/_pytest/deprecated.py
@@ -37,3 +37,18 @@ MARK_PARAMETERSET_UNPACKING = RemovedInPytest4Warning(
     " please use pytest.param(..., marks=...) instead.\n"
     "For more details, see: https://docs.pytest.org/en/latest/parametrize.html"
 )
+
+
+def node_customclass_warning(name):
+    return RemovedInPytest4Warning(
+        "use of node.{name} is deprecated, "
+        "use pytest_pycollect_makeitem(...) to create custom "
+        "collection nodes".format(name=name)
+    )
+
+
+def node_class_use_pytest_instead_warning(owner, name):
+    return RemovedInPytest4Warning(
+        "usage of {owner!r}.{name} is deprecated, "
+        "please use pytest.{name} instead".format(
+            name=name, owner=type(owner).__name__))

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -18,7 +18,7 @@ from _pytest.compat import (
 )
 from _pytest.outcomes import fail, TEST_OUTCOME
 from _pytest.compat import FuncargnamesCompatAttr
-
+from _pytest.main import Node
 if sys.version_info[:2] == (2, 6):
     from ordereddict import OrderedDict
 else:
@@ -1063,6 +1063,10 @@ class FixtureManager:
             holderobj = node_or_obj.obj
             nodeid = node_or_obj.nodeid
         if holderobj in self._holderobjseen:
+            return
+        if isinstance(holderobj, Node):
+            # ignore internal plugin instances that are also nodes
+            # this is a massive wtf
             return
         self._holderobjseen.add(holderobj)
         autousenames = []

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function
 
 import functools
+import warnings
 import os
 import six
 import sys
@@ -14,6 +15,7 @@ try:
 except ImportError:
     from UserDict import DictMixin as MappingMixin
 
+from _pytest import deprecated
 from _pytest.config import directory_arg, UsageError, hookimpl
 from _pytest.runner import collect_one_node
 from _pytest.outcomes import exit
@@ -220,12 +222,8 @@ class _CompatProperty(object):
     def __get__(self, obj, owner):
         if obj is None:
             return self
-
-        # TODO: reenable in the features branch
-        # warnings.warn(
-        #     "usage of {owner!r}.{name} is deprecated, please use pytest.{name} instead".format(
-        #         name=self.name, owner=type(owner).__name__),
-        #     PendingDeprecationWarning, stacklevel=2)
+        warnings.warn(deprecated.node_class_use_pytest_instead_warning(
+            owner=owner, name=self.name), stacklevel=2)
         return getattr(__import__('pytest'), self.name)
 
 
@@ -308,14 +306,14 @@ class Node(object):
 
     def _getcustomclass(self, name):
         maybe_compatprop = getattr(type(self), name)
+        warnings.warn(str(maybe_compatprop), category=UserWarning)
         if isinstance(maybe_compatprop, _CompatProperty):
             return getattr(__import__('pytest'), name)
         else:
             cls = getattr(self, name)
-            # TODO: reenable in the features branch
-            # warnings.warn("use of node.%s is deprecated, "
-            #    "use pytest_pycollect_makeitem(...) to create custom "
-            #    "collection nodes" % name, category=DeprecationWarning)
+            # OPTIONAL TODO: find a way to show the definition location
+            # of the class that owns that attribute
+            warnings.warn(deprecated.node_customclass_warning(name))
         return cls
 
     def __repr__(self):

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -306,7 +306,6 @@ class Node(object):
 
     def _getcustomclass(self, name):
         maybe_compatprop = getattr(type(self), name)
-        warnings.warn(str(maybe_compatprop), category=UserWarning)
         if isinstance(maybe_compatprop, _CompatProperty):
             return getattr(__import__('pytest'), name)
         else:

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -595,6 +595,9 @@ class Generator(FunctionMixin, PyCollector):
         self._preservedparent = self.parent.obj
         l = []
         seen = {}
+
+        mk_function = self._getcustomclass("Function")
+
         for i, x in enumerate(self.obj()):
             name, call, args = self.getcallargs(x)
             if not callable(call):
@@ -606,7 +609,8 @@ class Generator(FunctionMixin, PyCollector):
             if name in seen:
                 raise ValueError("%r generated tests with non-unique name %r" % (self, name))
             seen[name] = True
-            l.append(self.Function(name, self, args=args, callobj=call))
+
+            l.append(mk_function(name, self, args=args, callobj=call))
         self.warn('C1', deprecated.YIELD_TESTS)
         return l
 

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -1204,7 +1204,8 @@ def test_collector_attributes(testdir):
          def test_hello():
             pass
     """)
-    result = testdir.runpytest()
+    result = testdir.runpytest(
+        '-W', "ignore::_pytest.deprecated.RemovedInPytest4Warning")
     result.stdout.fnmatch_lines([
         "*1 passed*",
     ])
@@ -1229,7 +1230,9 @@ def test_customize_through_attributes(testdir):
             def test_hello(self):
                 pass
     """)
-    result = testdir.runpytest("--collect-only")
+    result = testdir.runpytest(
+        "--collect-only",
+        '-W', "ignore::_pytest.deprecated.RemovedInPytest4Warning")
     result.stdout.fnmatch_lines([
         "*MyClass*",
         "*MyInstance*",


### PR DESCRIPTION
while resolving i found that we do have quite a mess in there because we register a node as a plugin, which in turn gets parsed for factories

i opted into ignoring plain nodes for factory parsing for now,
but that solution is incomplete

however it seems strictly impossible to implement this bit cleanly without breaking the world,
as introducing a session interaction plugin implementing the needed api

