### PR TITLE
Catch BaseException in safe_getattr

### DIFF
--- a/_pytest/compat.py
+++ b/_pytest/compat.py
@@ -11,6 +11,7 @@ import functools
 import py
 
 import _pytest
+from _pytest.outcomes import TEST_OUTCOME
 
 
 try:
@@ -221,14 +222,16 @@ def getimfunc(func):
 
 
 def safe_getattr(object, name, default):
-    """ Like getattr but return default upon any Exception.
+    """ Like getattr but return default upon any Exception or any OutcomeException.
 
     Attribute access can potentially fail for 'evil' Python objects.
     See issue #214.
+    It catches OutcomeException because of #2490 (issue #580), new outcomes are derived from BaseException
+    instead of Exception (for more details check #2707)
     """
     try:
         return getattr(object, name, default)
-    except Exception:
+    except TEST_OUTCOME:
         return default
 
 

--- a/changelog/2707.bugfix
+++ b/changelog/2707.bugfix
@@ -1,0 +1,1 @@
+`compat.safe_getattr` now catches OutcomeExceptions too

--- a/changelog/2707.bugfix
+++ b/changelog/2707.bugfix
@@ -1,1 +1,1 @@
-`compat.safe_getattr` now catches OutcomeExceptions too
+Fixed edge-case during collection: attributes which raised ``pytest.fail`` when accessed would abort the entire collection.

--- a/testing/test_compat.py
+++ b/testing/test_compat.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import, division, print_function
 import sys
 
 import pytest
-from _pytest.compat import is_generator, get_real_func
+from _pytest.compat import is_generator, get_real_func, safe_getattr
+from _pytest.outcomes import OutcomeException
 
 
 def test_is_generator():
@@ -74,3 +75,27 @@ def test_is_generator_async_syntax(testdir):
     """)
     result = testdir.runpytest()
     result.stdout.fnmatch_lines(['*1 passed*'])
+
+
+class ErrorsHelper(object):
+    @property
+    def raise_exception(self):
+        raise Exception('exception should be catched')
+
+    @property
+    def raise_fail(self):
+        pytest.fail('fail should be catched')
+
+
+def test_helper_failures():
+    helper = ErrorsHelper()
+    with pytest.raises(Exception):
+        helper.raise_exception
+    with pytest.raises(OutcomeException):
+        helper.raise_fail
+
+
+def test_safe_getattr():
+    helper = ErrorsHelper()
+    assert safe_getattr(helper, 'raise_exception', 'default') == 'default'
+    assert safe_getattr(helper, 'raise_fail', 'default') == 'default'


### PR DESCRIPTION
Hey, all!

Today I've spent few hours by tracking strange error after update to 3.2.1
`git blaming` showed that it was caused by 06a49338b2b1be8daed89f779439459a2cb4cbc7 from #2490 (that is fix for #580 ) particularly inheritance from `BaseException`

@nicoddemus  @RonnyPfannschmidt 
This is quite hard to provide minimal steps to reproduce our case, in general it is caused by https://github.com/pytest-dev/pytest-django/blob/master/pytest_django/plugin.py#L615 throws `fail`
We're doing some work during class initialization (in descriptors), thus before database is unblocked and it was fine before this commit: upon collecting it wasn't fail and during the tests, fixtures were created without errors.

1. We're creating descriptor that is trying to create object in database when we're accessing it
2. Collecting code is trying to access every attribute with safe_getattr so it triggers creation of object in database
3. `safe_getattr` isn't catching error, because new fail exception is derived from BaseException

I believe we shouldn't fail during `collecting` phase, so either:
1. we should change realization of `safe_getattr` to catch BaseException
2. we should use another `safe_getattr` realization in `FixtureManager.parsefactories`

This PR contains 1st as simplest but I can reimplement it to 2nd

