### PR TITLE
[DOC] update raises documentation regarding regex match

### DIFF
--- a/doc/en/assert.rst
+++ b/doc/en/assert.rst
@@ -119,9 +119,9 @@ exceptions your own code is deliberately raising, whereas using
 like documenting unfixed bugs (where the test describes what "should" happen)
 or bugs in dependencies.
 
-If you want to test that a regular expression matches on the string
-representation of an exception (like the ``TestCase.assertRaisesRegexp`` method
-from ``unittest``) you can use the ``ExceptionInfo.match`` method::
+Also, the context manager form accepts a ``match`` keyword parameter to test
+that a regular expression matches on the string representation of an exception
+(like the ``TestCase.assertRaisesRegexp`` method from ``unittest``)::
 
     import pytest
 
@@ -129,12 +129,11 @@ from ``unittest``) you can use the ``ExceptionInfo.match`` method::
         raise ValueError("Exception 123 raised")
 
     def test_match():
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError, match=r'.* 123 .*'):
             myfunc()
-        excinfo.match(r'.* 123 .*')
 
 The regexp parameter of the ``match`` method is matched with the ``re.search``
-function. So in the above example ``excinfo.match('123')`` would have worked as
+function. So in the above example ``match='123'`` would have worked as
 well.
 
 


### PR DESCRIPTION
This PR modifies the regular expressions and custom messages of raises to include `match` parameter in `pytest.raises` according to its docstring documentation.