### PR TITLE
[MRG][feature] Change warns signature to mimic the raises call

### DIFF
--- a/_pytest/recwarn.py
+++ b/_pytest/recwarn.py
@@ -8,6 +8,8 @@ import py
 import sys
 import warnings
 
+import re
+
 from _pytest.fixtures import yield_fixture
 from _pytest.outcomes import fail
 
@@ -99,9 +101,11 @@ def warns(expected_warning, *args, **kwargs):
         >>> with warns(RuntimeWarning):
         ...    warnings.warn("my warning", RuntimeWarning)
     """
-    wcheck = WarningsChecker(expected_warning)
+    match_expr = None
     if not args:
-        return wcheck
+        if "match" in kwargs:
+            match_expr = kwargs.pop("match")
+        return WarningsChecker(expected_warning, match_expr=match_expr)
     elif isinstance(args[0], str):
         code, = args
         assert isinstance(code, str)
@@ -109,12 +113,12 @@ def warns(expected_warning, *args, **kwargs):
         loc = frame.f_locals.copy()
         loc.update(kwargs)
 
-        with wcheck:
+        with WarningsChecker(expected_warning, match_expr=match_expr):
             code = _pytest._code.Source(code).compile()
             py.builtin.exec_(code, frame.f_globals, loc)
     else:
         func = args[0]
-        with wcheck:
+        with WarningsChecker(expected_warning, match_expr=match_expr):
             return func(*args[1:], **kwargs)
 
 
@@ -174,7 +178,7 @@ class WarningsRecorder(warnings.catch_warnings):
 
 
 class WarningsChecker(WarningsRecorder):
-    def __init__(self, expected_warning=None):
+    def __init__(self, expected_warning=None, match_expr=None):
         super(WarningsChecker, self).__init__()
 
         msg = ("exceptions must be old-style classes or "
@@ -189,6 +193,7 @@ class WarningsChecker(WarningsRecorder):
             raise TypeError(msg % type(expected_warning))
 
         self.expected_warning = expected_warning
+        self.match_expr = match_expr
 
     def __exit__(self, *exc_info):
         super(WarningsChecker, self).__exit__(*exc_info)
@@ -203,3 +208,15 @@ class WarningsChecker(WarningsRecorder):
                          "The list of emitted warnings is: {1}.".format(
                              self.expected_warning,
                              [each.message for each in self]))
+                elif self.match_expr is not None:
+                    for r in self:
+                        if issubclass(r.category, self.expected_warning):
+                            if re.compile(self.match_expr).search(str(r.message)):
+                                break
+                    else:
+                        fail("DID NOT WARN. No warnings of type {0} matching"
+                             " ('{1}') was emitted. The list of emitted warnings"
+                             " is: {2}.".format(
+                                self.expected_warning,
+                                self.match_expr,
+                                [each.message for each in self]))

--- a/_pytest/recwarn.py
+++ b/_pytest/recwarn.py
@@ -100,6 +100,22 @@ def warns(expected_warning, *args, **kwargs):
 
         >>> with warns(RuntimeWarning):
         ...    warnings.warn("my warning", RuntimeWarning)
+
+    In the context manager form you may use the keyword argument ``match`` to assert
+    that the exception matches a text or regex::
+
+        >>> with warns(UserWarning, match='must be 0 or None'):
+        ...     warnings.warn("value must be 0 or None", UserWarning)
+
+        >>> with warns(UserWarning, match=r'must be \d+$'):
+        ...     warnings.warn("value must be 42", UserWarning)
+
+        >>> with warns(UserWarning, match=r'must be \d+$'):
+        ...     warnings.warn("this is not here", UserWarning)
+        Traceback (most recent call last):
+          ...
+        Failed: DID NOT WARN. No warnings of type ...UserWarning... was emitted...
+
     """
     match_expr = None
     if not args:

--- a/changelog/2708.feature
+++ b/changelog/2708.feature
@@ -1,0 +1,1 @@
+Match ``warns`` signature to ``raises`` by adding ``match`` keyworkd.

--- a/doc/en/warnings.rst
+++ b/doc/en/warnings.rst
@@ -168,7 +168,20 @@ which works in a similar manner to :ref:`raises <assertraises>`::
         with pytest.warns(UserWarning):
             warnings.warn("my warning", UserWarning)
 
-The test will fail if the warning in question is not raised.
+The test will fail if the warning in question is not raised. The keyword
+argument ``match`` to assert that the exception matches a text or regex::
+
+    >>> with warns(UserWarning, match='must be 0 or None'):
+    ...     warnings.warn("value must be 0 or None", UserWarning)
+
+    >>> with warns(UserWarning, match=r'must be \d+$'):
+    ...     warnings.warn("value must be 42", UserWarning)
+
+    >>> with warns(UserWarning, match=r'must be \d+$'):
+    ...     warnings.warn("this is not here", UserWarning)
+    Traceback (most recent call last):
+      ...
+    Failed: DID NOT WARN. No warnings of type ...UserWarning... was emitted...
 
 You can also call ``pytest.warns`` on a function or code string::
 

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -284,3 +284,25 @@ class TestWarns(object):
         ''')
         result = testdir.runpytest()
         result.stdout.fnmatch_lines(['*2 passed in*'])
+
+    def test_match_regex(self):
+        with pytest.warns(UserWarning, match=r'must be \d+$'):
+            warnings.warn("value must be 42", UserWarning)
+
+        with pytest.raises(AssertionError, match='pattern not found'):
+            with pytest.warns(UserWarning, match=r'must be \d+$'):
+                warnings.warn("this is not here", UserWarning)
+
+    def test_one_from_multiple_warns():
+        with warns(UserWarning, match=r'aaa'):
+            warnings.warn("cccccccccc", UserWarning)
+            warnings.warn("bbbbbbbbbb", UserWarning)
+            warnings.warn("aaaaaaaaaa", UserWarning)
+
+    def test_none_of_multiple_warns():
+        a, b, c = ('aaa', 'bbbbbbbbbb', 'cccccccccc')
+        expected_msg = "'{}' pattern not found in \['{}', '{}'\]".format(a, b, c)
+        with raises(AssertionError, match=expected_msg):
+            with warns(UserWarning, match=r'aaa'):
+                warnings.warn("bbbbbbbbbb", UserWarning)
+                warnings.warn("cccccccccc", UserWarning)

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -289,20 +289,22 @@ class TestWarns(object):
         with pytest.warns(UserWarning, match=r'must be \d+$'):
             warnings.warn("value must be 42", UserWarning)
 
-        with pytest.raises(AssertionError, match='pattern not found'):
+        with pytest.raises(pytest.fail.Exception):
             with pytest.warns(UserWarning, match=r'must be \d+$'):
                 warnings.warn("this is not here", UserWarning)
 
-    def test_one_from_multiple_warns():
-        with warns(UserWarning, match=r'aaa'):
+        with pytest.raises(pytest.fail.Exception):
+            with pytest.warns(FutureWarning, match=r'must be \d+$'):
+                warnings.warn("value must be 42", UserWarning)
+
+    def test_one_from_multiple_warns(self):
+        with pytest.warns(UserWarning, match=r'aaa'):
             warnings.warn("cccccccccc", UserWarning)
             warnings.warn("bbbbbbbbbb", UserWarning)
             warnings.warn("aaaaaaaaaa", UserWarning)
 
-    def test_none_of_multiple_warns():
-        a, b, c = ('aaa', 'bbbbbbbbbb', 'cccccccccc')
-        expected_msg = "'{}' pattern not found in \['{}', '{}'\]".format(a, b, c)
-        with raises(AssertionError, match=expected_msg):
-            with warns(UserWarning, match=r'aaa'):
+    def test_none_of_multiple_warns(self):
+        with pytest.raises(pytest.fail.Exception):
+            with pytest.warns(UserWarning, match=r'aaa'):
                 warnings.warn("bbbbbbbbbb", UserWarning)
                 warnings.warn("cccccccccc", UserWarning)


### PR DESCRIPTION
fixes #2708 providing warns with `message` and `match` parameters (similarly to `pytest.raises`. see #2227) 