### PR TITLE
Proposal: make parametrize accept a dict to provide both ids and argvalues

### DIFF
--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -772,6 +772,14 @@ class Metafunc(fixtures.FuncargnamesCompatAttr):
         from _pytest.mark import MARK_GEN, ParameterSet
         from py.io import saferepr
 
+        if isinstance(argvalues, dict):
+            if ids is not None:
+                fs, lineno = getfslineno(self.function)
+                raise ValueError("got ids for parametrize with dictionary for %s at %s:%d" % (
+                    self.function.__name__, fs, lineno)
+                )
+            argvalues, ids = list(argvalues.values()), list(argvalues.keys())
+
         if not isinstance(argnames, (tuple, list)):
             argnames = [x.strip() for x in argnames.split(",") if x.strip()]
             force_tuple = len(argnames) == 1


### PR DESCRIPTION
Hello!

I was unsure what the process for proposing a change to pytest is, so I'm submitting this PR to get your feedback on this idea.

Basically parametrized tests and fixtures are awesome, but passing ids feels very cumbersome. My proposal is to allow passing a dict for argvalues and extracting the ids from the dict keys. This alternate syntax avoids mismatched ids (no playing "match the two lists").

For example:
```
@pytest.mark.parametrize(
    "recipe_name, target", [
        ("Tofu", NV(protein=4.44, carbs=2.19, fat=4, error=0.1)), # halve all nutrients
        ("Burger de vită", NV(34.37 + 3, 78.90, 24.62 + 2, error=0.1)), # bump fat + protein 10%
        ('Legume la woc cu lapte de cocos, turmeric și tăițeti de orez', NV(23.61, 152.89, 10.59, error=0.01))]
    ids=["tofu", "burger", "legume-la-wok"]
    )
def test_recipe_adapt(recipes, recipe_name, target):
    pass
```

could  be expressed as:
```
@pytest.mark.parametrize(
    "recipe_name, target", {
        'tofu': (
            "Tofu",
            NV(protein=4.44, carbs=2.19, fat=4, error=0.1)), # halve all nutrients
        'burger': (
            "Burger de vită",
            NV(34.37 + 3, 78.90, 24.62 + 2, error=0.1)), # bump fat + protein 10%
        'legume-la-wok': (
            'Legume la woc cu lapte de cocos, turmeric și tăițeti de orez',
            NV(23.61, 152.89, 10.59, error=0.01))
    },
)
def test_recipe_adapt(recipes, recipe_name, target):
    pass
```

If this seems like a good idea, I'll finish this PR (update the docs, add the changelog entry and add myself to authors).