### PR TITLE
2731.bug Fix ReprFuncArgs with mixed unicode and utf-8 args.

### DIFF
--- a/_pytest/_code/code.py
+++ b/_pytest/_code/code.py
@@ -863,7 +863,7 @@ class ReprFuncArgs(TerminalRepr):
         if self.args:
             linesofar = ""
             for name, value in self.args:
-                ns = "%s = %s" % (name, value)
+                ns = "%s = %s" % (safe_str(name), safe_str(value))
                 if len(ns) + len(linesofar) + 2 > tw.fullwidth:
                     if linesofar:
                         tw.line(linesofar)

--- a/changelog/2731.bugfix
+++ b/changelog/2731.bugfix
@@ -1,0 +1,1 @@
+Fix ``ReprFuncArgs`` with mixed unicode and UTF-8 args.

--- a/testing/code/test_code.py
+++ b/testing/code/test_code.py
@@ -1,9 +1,11 @@
+# coding: utf-8
 from __future__ import absolute_import, division, print_function
 import sys
 
 import _pytest._code
 import py
 import pytest
+from test_excinfo import TWMock
 
 
 def test_ne():
@@ -172,3 +174,24 @@ class TestTracebackEntry(object):
         source = entry.getsource()
         assert len(source) == 6
         assert 'assert False' in source[5]
+
+
+class TestReprFuncArgs(object):
+
+    def test_not_raise_exception_with_mixed_encoding(self):
+        from _pytest._code.code import ReprFuncArgs
+
+        tw = TWMock()
+
+        args = [
+            ('unicode_string', u"São Paulo"),
+            ('utf8_string', 'S\xc3\xa3o Paulo'),
+        ]
+
+        r = ReprFuncArgs(args)
+        r.toterminal(tw)
+        if sys.version_info[0] >= 3:
+            assert tw.lines[0] == 'unicode_string = São Paulo, utf8_string = SÃ£o Paulo'
+        else:
+            assert tw.lines[0] == 'unicode_string = São Paulo, utf8_string = São Paulo'
+

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 """
 terminal reporting of the full testing process.
 """
@@ -346,6 +347,26 @@ class TestFixtureReporting(object):
             "*ERROR at setup of test_nada*",
             "*setup_function(function):*",
             "*setup func*",
+            "*assert 0*",
+            "*1 error*",
+        ])
+        assert result.ret != 0
+
+    def test_setup_fixture_error_with_mixed_encoding(self, testdir):
+        testdir.makepyfile("""
+            def mixed_encoding(as_unicode, as_utf8):
+                assert 0
+            def setup_function(function):
+                mixed_encoding(u"'São Paulo'", "'S\xc3\xa3o Paulo'")
+            def test_nada():
+                pass
+        """)
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines([
+            "*ERROR at setup of test_nada*",
+            "*setup_function(function):*",
+            "*as_unicode = \"'São Paulo'\", as_utf8 = \"'SÃ£o Paulo'\"*",
+            "*mixed_encoding(as_unicode, as_utf8):*",
             "*assert 0*",
             "*1 error*",
         ])

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -352,26 +352,6 @@ class TestFixtureReporting(object):
         ])
         assert result.ret != 0
 
-    def test_setup_fixture_error_with_mixed_encoding(self, testdir):
-        testdir.makepyfile("""
-            def mixed_encoding(as_unicode, as_utf8):
-                assert 0
-            def setup_function(function):
-                mixed_encoding(u"'São Paulo'", "'S\xc3\xa3o Paulo'")
-            def test_nada():
-                pass
-        """)
-        result = testdir.runpytest()
-        result.stdout.fnmatch_lines([
-            "*ERROR at setup of test_nada*",
-            "*setup_function(function):*",
-            "*as_unicode = \"'São Paulo'\", as_utf8 = \"'SÃ£o Paulo'\"*",
-            "*mixed_encoding(as_unicode, as_utf8):*",
-            "*assert 0*",
-            "*1 error*",
-        ])
-        assert result.ret != 0
-
     def test_teardown_fixture_error(self, testdir):
         testdir.makepyfile("""
             def test_nada():


### PR DESCRIPTION
The class `_pytest._code.code.ReprFuncArgs` crashes with `UnicodeDecodeError` when trying to write args with mixed `unicode` and `utf-8` strings.

Fixes #2731.