### PR TITLE
2731.bug Fix ReprFuncArgs with mixed unicode and utf-8 args.

### DIFF
--- a/_pytest/_code/code.py
+++ b/_pytest/_code/code.py
@@ -863,7 +863,7 @@ class ReprFuncArgs(TerminalRepr):
         if self.args:
             linesofar = ""
             for name, value in self.args:
-                ns = "%s = %s" % (name, value)
+                ns = "%s = %s" % (safe_str(name), safe_str(value))
                 if len(ns) + len(linesofar) + 2 > tw.fullwidth:
                     if linesofar:
                         tw.line(linesofar)

--- a/changelog/2731.bugfix
+++ b/changelog/2731.bugfix
@@ -1,0 +1,1 @@
+Fix ``ReprFuncArgs`` with mixed unicode and UTF-8 args.

--- a/testing/code/test_code.py
+++ b/testing/code/test_code.py
@@ -1,9 +1,11 @@
+# coding: utf-8
 from __future__ import absolute_import, division, print_function
 import sys
 
 import _pytest._code
 import py
 import pytest
+from test_excinfo import TWMock
 
 
 def test_ne():
@@ -172,3 +174,23 @@ class TestTracebackEntry(object):
         source = entry.getsource()
         assert len(source) == 6
         assert 'assert False' in source[5]
+
+
+class TestReprFuncArgs(object):
+
+    def test_not_raise_exception_with_mixed_encoding(self):
+        from _pytest._code.code import ReprFuncArgs
+
+        tw = TWMock()
+
+        args = [
+            ('unicode_string', u"São Paulo"),
+            ('utf8_string', 'S\xc3\xa3o Paulo'),
+        ]
+
+        r = ReprFuncArgs(args)
+        r.toterminal(tw)
+        if sys.version_info[0] >= 3:
+            assert tw.lines[0] == 'unicode_string = São Paulo, utf8_string = SÃ£o Paulo'
+        else:
+            assert tw.lines[0] == 'unicode_string = São Paulo, utf8_string = São Paulo'


### PR DESCRIPTION
The class `_pytest._code.code.ReprFuncArgs` crashes with `UnicodeDecodeError` when trying to write args with mixed `unicode` and `utf-8` strings.

Fixes #2731.