### PR TITLE
2747.feature: Customise fixture test ID by declaring an attr `pytest_id` in the object itself.

### DIFF
--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -936,6 +936,8 @@ def _idval(val, argname, idx, idfn, config=None):
         return str(val)
     elif isinstance(val, REGEX_TYPE):
         return _ascii_escaped(val.pattern)
+    elif hasattr(val, 'pytest_id'):
+        return _ascii_escaped(val.pytest_id)
     elif enum is not None and isinstance(val, enum.Enum):
         return str(val)
     elif isclass(val) and hasattr(val, '__name__'):

--- a/changelog/2747.feature
+++ b/changelog/2747.feature
@@ -1,0 +1,1 @@
+Customise the string used in a test ID for a certain fixture value by declaring an attribute `pytest_id` in the object itself.

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -492,11 +492,15 @@ with ``--collect-only`` will show the generated IDs.
 Numbers, strings, booleans and None will have their usual string
 representation used in the test ID. For other objects, pytest will
 make a string based on the argument name.  It is possible to customise
-the string used in a test ID for a certain fixture value by using the
-``ids`` keyword argument::
+the string used in a test ID for a certain fixture value, by declaring an attribute
+`pytest_id` in the object itself, or by using the ``ids`` keyword argument::
 
    # content of test_ids.py
    import pytest
+
+   class Cheese(object):
+       def __init__(self, name)
+           self.pytest_id = name
 
    @pytest.fixture(params=[0, 1], ids=["spam", "ham"])
    def a(request):
@@ -516,6 +520,10 @@ the string used in a test ID for a certain fixture value by using the
        return request.param
 
    def test_b(b):
+       pass
+
+   @pytest.fixture.parametrize('c', [Cheese('gouda'), Cheese('edam')])
+   def test_c(c):
        pass
 
 The above shows how ``ids`` can be either a list of strings to use or
@@ -538,6 +546,8 @@ Running the above tests results in the following test IDs being used::
      <Function 'test_a[ham]'>
      <Function 'test_b[eggs]'>
      <Function 'test_b[1]'>
+     <Function 'test_c[gouda]'>
+     <Function 'test_c[edam]'>
    <Module 'test_module.py'>
      <Function 'test_ehlo[smtp.gmail.com]'>
      <Function 'test_noop[smtp.gmail.com]'>

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -294,6 +294,19 @@ class TestMetafunc(object):
         result = idmaker(("a", "b"), [pytest.param(e.one, e.two)])
         assert result == ["Foo.one-Foo.two"]
 
+    def test_idmaker_custom_instance_id(self):
+        from _pytest.python import idmaker
+
+        class Cheese(object):
+            def __init__(self, name):
+                self.pytest_id = name
+
+        a = Cheese('gouda')
+        b = Cheese('edam')
+
+        result = idmaker(("a", "b"), [pytest.param(a, b)])
+        assert result == ["gouda-edam"]
+
     @pytest.mark.issue351
     def test_idmaker_idfn(self):
         from _pytest.python import idmaker


### PR DESCRIPTION
Customise the string used in a test ID for a certain fixture value by declaring an attribute `pytest_id` in the object itself.

Here's a test that exemplifies the proposal:

``` python

    def test_idmaker_custom_instance_id(self):
        from _pytest.python import idmaker

        class Cheese(object):
            def __init__(self, name):
                self.pytest_id = name

        a = Cheese('gouda')
        b = Cheese('edam')

        result = idmaker(("a", "b"), [pytest.param(a, b)])
        assert result == ["gouda-edam"]
```

The main motivator for this feature request/proposal is to give the opportunity to friendly classes and libs to customize their objects to play nice as `fixtures`. As an example and first candidate, I've open-sourced a custom enum type that can be used as choices field for Django, but their `str` is implemented as `str(self.value)`, so there's no way to get a nice `repr` when using this enum with `pytest.mark.parametrize`.

Example usage: https://github.com/loggi/python-choicesenum/pull/2/files
