### PR TITLE
Fix crash in FastFilesCompleter with no prefix

### DIFF
--- a/_pytest/_argcomplete.py
+++ b/_pytest/_argcomplete.py
@@ -78,7 +78,8 @@ class FastFilesCompleter:
         completion = []
         globbed = []
         if '*' not in prefix and '?' not in prefix:
-            if prefix[-1] == os.path.sep:  # we are on unix, otherwise no bash
+            # we are on unix, otherwise no bash
+            if not prefix or prefix[-1] == os.path.sep:
                 globbed.extend(glob(prefix + '.*'))
             prefix += '*'
         globbed.extend(glob(prefix))
@@ -98,7 +99,7 @@ if os.environ.get('_ARGCOMPLETE'):
     filescompleter = FastFilesCompleter()
 
     def try_argcomplete(parser):
-        argcomplete.autocomplete(parser)
+        argcomplete.autocomplete(parser, always_complete_options=False)
 else:
     def try_argcomplete(parser):
         pass

--- a/changelog/2748.bugfix
+++ b/changelog/2748.bugfix
@@ -1,0 +1,1 @@
+Fix crash in tab completion when no prefix is given.

--- a/testing/test_argcomplete.py
+++ b/testing/test_argcomplete.py
@@ -82,7 +82,7 @@ class TestArgComplete(object):
         from _pytest._argcomplete import FastFilesCompleter
         ffc = FastFilesCompleter()
         fc = FilesCompleter()
-        for x in '/ /d /data qqq'.split():
+        for x in ['/', '/d', '/data', 'qqq', '']:
             assert equal_with_bash(x, ffc, fc, out=py.std.sys.stdout)
 
     @pytest.mark.skipif("sys.platform in ('win32', 'darwin')")


### PR DESCRIPTION
Fixes #2748. This fixes the crash without altering the existing behavior.