### PR TITLE
Set xfail_strict=True in pytest's own test suite

### DIFF
--- a/changelog/2722.trivial
+++ b/changelog/2722.trivial
@@ -1,0 +1,1 @@
+Set ``xfail_strict=True`` in pytest's own test suite to catch expected failures as soon as they start to pass.

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -391,7 +391,6 @@ def test_deindent():
     assert lines == ['', 'def f():', '    def g():', '        pass', '    ']
 
 
-@pytest.mark.xfail("sys.version_info[:3] < (2,7,0)")
 def test_source_of_class_at_eof_without_newline(tmpdir):
     # this test fails because the implicit inspect.getsource(A) below
     # does not return the "x = 1" last line.

--- a/tox.ini
+++ b/tox.ini
@@ -200,6 +200,7 @@ python_files = test_*.py *_test.py testing/*/*.py
 python_classes = Test Acceptance
 python_functions = test
 norecursedirs = .tox ja .hg cx_freeze_source
+xfail_strict=true
 filterwarnings =
     error
     # produced by path.local


### PR DESCRIPTION
Fix #2722

