### PR TITLE
[bugfix] Checking MarkDecorator equality returns False for non-MarkDecorator object

### DIFF
--- a/_pytest/mark.py
+++ b/_pytest/mark.py
@@ -330,7 +330,7 @@ class MarkDecorator:
         return self.name  # for backward-compat (2.4.1 had this attr)
 
     def __eq__(self, other):
-        return self.mark == other.mark
+        return self.mark == other.mark if isinstance(other, MarkDecorator) else False
 
     def __repr__(self):
         return "<MarkDecorator %r>" % (self.mark,)

--- a/changelog/2758.bugfix
+++ b/changelog/2758.bugfix
@@ -1,0 +1,1 @@
+The equality checking function (``__eq__``) of ``MarkDecorator`` returns ``False`` if one object is not an instance of ``MarkDecorator``.

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -812,3 +812,15 @@ def test_legacy_transfer():
     assert fake_method.fun
     # pristine marks dont transfer
     assert fake_method.pytestmark == [pytest.mark.fun.mark]
+
+
+class TestMarkDecorator(object):
+
+    @pytest.mark.parametrize('lhs, rhs, expected', [
+        (pytest.mark.foo(), pytest.mark.foo(), True),
+        (pytest.mark.foo(), pytest.mark.bar(), False),
+        (pytest.mark.foo(), 'bar', False),
+        ('foo', pytest.mark.bar(), False)
+    ])
+    def test__eq__(self, lhs, rhs, expected):
+        assert (lhs == rhs) == expected


### PR DESCRIPTION
Fix https://github.com/pytest-dev/pytest/issues/2758

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [x] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS`;
