### PR TITLE
Fix outcome result in latest pluggy

### DIFF
--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -841,7 +841,7 @@ class TestConftestCustomization(object):
             def pytest_pycollect_makeitem():
                 outcome = yield
                 if outcome.excinfo is None:
-                    result = outcome.result
+                    result = outcome.get_result()
                     if result:
                         for func in result:
                             func._some123 = "world"


### PR DESCRIPTION
`_Result.result` has been removed in favor of `_Result.get_result()`.

Perhaps we should change it into a read-only property instead?