### PR TITLE
Change to py36 as main environment for Python 3 environments in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist =
     py36
     py37
     pypy
-    {py27,py35}-{pexpect,xdist,trial,numpy}
+    {py27,py36}-{pexpect,xdist,trial,numpy}
     py27-nobyte
     doctesting
     py35-freeze
@@ -37,7 +37,6 @@ deps =
 
 [testenv:py27-subprocess]
 changedir = .
-basepython = python2.7
 deps =
     pytest-xdist>=1.13
     mock
@@ -68,7 +67,7 @@ deps =
 commands =
     pytest -n1 -rfsxX {posargs:testing}
 
-[testenv:py35-xdist]
+[testenv:py36-xdist]
 deps = {[testenv:py27-xdist]deps}
 commands =
     pytest -n3 -rfsxX {posargs:testing}
@@ -80,7 +79,7 @@ deps = pexpect
 commands =
     pytest -rfsxX test_pdb.py test_terminal.py test_unittest.py
 
-[testenv:py35-pexpect]
+[testenv:py36-pexpect]
 changedir = testing
 platform = linux|darwin
 deps = {[testenv:py27-pexpect]deps}
@@ -102,7 +101,7 @@ deps = twisted
 commands =
     pytest -ra {posargs:testing/test_unittest.py}
 
-[testenv:py35-trial]
+[testenv:py36-trial]
 deps = {[testenv:py27-trial]deps}
 commands =
     pytest -ra {posargs:testing/test_unittest.py}
@@ -112,7 +111,7 @@ deps=numpy
 commands=
   pytest -rfsxX {posargs:testing/python/approx.py}
 
-[testenv:py35-numpy]
+[testenv:py36-numpy]
 deps=numpy
 commands=
   pytest -rfsxX {posargs:testing/python/approx.py}
@@ -180,7 +179,6 @@ commands =
 [testenv:coveralls]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH COVERALLS_REPO_TOKEN
 usedevelop = True
-basepython = python3.5
 changedir = .
 deps =
     {[testenv]deps}


### PR DESCRIPTION
This also has the benefit of working around Travis recent failures
in Python 3.5 environments.
