### PR TITLE
Allow fixtures to use capsys and capfd 

### DIFF
--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -252,12 +252,14 @@ class CaptureFixture:
 
     @contextlib.contextmanager
     def disabled(self):
+        self._capture.suspend_capturing()
         capmanager = self.request.config.pluginmanager.getplugin('capturemanager')
-        capmanager.suspend_capture_item(self.request.node, "call", in_=True)
+        capmanager.suspend_global_capture(item=None, in_=False)
         try:
             yield
         finally:
             capmanager.resume_global_capture()
+            self._capture.resume_capturing()
 
 
 def safe_text_dupfile(f, mode, default_encoding="UTF8"):

--- a/_pytest/debugging.py
+++ b/_pytest/debugging.py
@@ -54,7 +54,7 @@ class pytestPDB:
         if cls._pluginmanager is not None:
             capman = cls._pluginmanager.getplugin("capturemanager")
             if capman:
-                capman.suspendcapture(in_=True)
+                capman.suspend_global_capture(in_=True)
             tw = _pytest.config.create_terminal_writer(cls._config)
             tw.line()
             tw.sep(">", "PDB set_trace (IO-capturing turned off)")
@@ -66,7 +66,7 @@ class PdbInvoke:
     def pytest_exception_interact(self, node, call, report):
         capman = node.config.pluginmanager.getplugin("capturemanager")
         if capman:
-            out, err = capman.suspendcapture(in_=True)
+            out, err = capman.suspend_global_capture(in_=True)
             sys.stdout.write(out)
             sys.stdout.write(err)
         _enter_pdb(node, call.excinfo, report)

--- a/_pytest/setuponly.py
+++ b/_pytest/setuponly.py
@@ -44,7 +44,7 @@ def _show_fixture_action(fixturedef, msg):
     config = fixturedef._fixturemanager.config
     capman = config.pluginmanager.getplugin('capturemanager')
     if capman:
-        out, err = capman.suspendcapture()
+        out, err = capman.suspend_global_capture()
 
     tw = config.get_terminal_writer()
     tw.line()
@@ -63,7 +63,7 @@ def _show_fixture_action(fixturedef, msg):
         tw.write('[{0}]'.format(fixturedef.cached_param))
 
     if capman:
-        capman.resumecapture()
+        capman.resume_global_capture()
         sys.stdout.write(out)
         sys.stderr.write(err)
 

--- a/changelog/1993.bugfix
+++ b/changelog/1993.bugfix
@@ -1,0 +1,1 @@
+Resume output capturing after ``capsys/capfd.disabled()`` context manager.

--- a/changelog/2709.bugfix
+++ b/changelog/2709.bugfix
@@ -1,0 +1,1 @@
+``capsys`` and ``capfd`` can now be used by other fixtures.

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -78,23 +78,23 @@ class TestCaptureManager(object):
         old = sys.stdout, sys.stderr, sys.stdin
         try:
             capman = CaptureManager(method)
-            capman.init_capturings()
-            outerr = capman.suspendcapture()
+            capman.start_global_capturing()
+            outerr = capman.suspend_global_capture()
             assert outerr == ("", "")
-            outerr = capman.suspendcapture()
+            outerr = capman.suspend_global_capture()
             assert outerr == ("", "")
             print("hello")
-            out, err = capman.suspendcapture()
+            out, err = capman.suspend_global_capture()
             if method == "no":
                 assert old == (sys.stdout, sys.stderr, sys.stdin)
             else:
                 assert not out
-            capman.resumecapture()
+            capman.resume_global_capture()
             print("hello")
-            out, err = capman.suspendcapture()
+            out, err = capman.suspend_global_capture()
             if method != "no":
                 assert out == "hello\n"
-            capman.reset_capturings()
+            capman.stop_global_capturing()
         finally:
             capouter.stop_capturing()
 
@@ -103,9 +103,9 @@ class TestCaptureManager(object):
         capouter = StdCaptureFD()
         try:
             capman = CaptureManager("fd")
-            capman.init_capturings()
-            pytest.raises(AssertionError, "capman.init_capturings()")
-            capman.reset_capturings()
+            capman.start_global_capturing()
+            pytest.raises(AssertionError, "capman.start_global_capturing()")
+            capman.stop_global_capturing()
         finally:
             capouter.stop_capturing()
 


### PR DESCRIPTION
Fix #2709

Also refactor some names for better understanding and consistency, and although they are all internal I'm targeting `features`. Those renames are in a separate commit and we can drop it if we wouldn't like to touch the names.



