### PR TITLE
Fix pytest.parametrize when argnames are specified as kwarg

### DIFF
--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -1037,9 +1037,13 @@ class FixtureManager:
             if faclist:
                 fixturedef = faclist[-1]
                 if fixturedef.params is not None:
-                    func_params = getattr(getattr(metafunc.function, 'parametrize', None), 'args', [[None]])
+                    parametrize_func = getattr(metafunc.function, 'parametrize', None)
+                    func_params = getattr(parametrize_func, 'args', [[None]])
                     # skip directly parametrized arguments
-                    argnames = func_params[0]
+                    if "argnames" in parametrize_func.kwargs:
+                        argnames = parametrize_func.kwargs["argnames"]
+                    else:
+                        argnames = func_params[0]
                     if not isinstance(argnames, (tuple, list)):
                         argnames = [x.strip() for x in argnames.split(",") if x.strip()]
                     if argname not in func_params and argname not in argnames:

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -1039,8 +1039,9 @@ class FixtureManager:
                 if fixturedef.params is not None:
                     parametrize_func = getattr(metafunc.function, 'parametrize', None)
                     func_params = getattr(parametrize_func, 'args', [[None]])
+                    func_kwargs = getattr(parametrize_func, 'kwargs', {})
                     # skip directly parametrized arguments
-                    if "argnames" in parametrize_func.kwargs:
+                    if "argnames" in func_kwargs:
                         argnames = parametrize_func.kwargs["argnames"]
                     else:
                         argnames = func_params[0]

--- a/changelog/2819.bugfix
+++ b/changelog/2819.bugfix
@@ -1,0 +1,1 @@
+Fix issue with @pytest.parametrize if argnames was specified as kwarg.

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -342,6 +342,24 @@ def test_parametrized_collect_with_wrong_args(testdir):
     ])
 
 
+def test_parametrized_with_kwargs(testdir):
+    """Test collect parametrized func with wrong number of args."""
+    py_file = testdir.makepyfile("""
+        import pytest
+
+        @pytest.fixture(params=[1,2])
+        def a(request):
+            return request.param
+
+        @pytest.mark.parametrize(argnames='b', argvalues=[1, 2])
+        def test_func(a, b):
+            pass
+    """)
+
+    result = testdir.runpytest(py_file)
+    assert(result.ret == 0)
+
+
 class TestFunctional(object):
 
     def test_mark_per_function(self, testdir):


### PR DESCRIPTION
Previously only this worked:
`@pytest.mark.parametrize("A", argvalues=[(A1, ), (A2, )])`
Now argnames can be specified explicitly:
`@pytest.mark.parametrize(argnames="A", argvalues=[(A1, ), (A2, )])`
