### PR TITLE
get PYTEST_ADDOPTS before calling _initini

### DIFF
--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -1055,9 +1055,10 @@ class Config(object):
                                  "(are you using python -O?)\n")
 
     def _preparse(self, args, addopts=True):
-        self._initini(args)
         if addopts:
             args[:] = shlex.split(os.environ.get('PYTEST_ADDOPTS', '')) + args
+        self._initini(args)
+        if addopts:
             args[:] = self.getini("addopts") + args
         self._checkversion()
         self._consider_importhook(args)

--- a/changelog/2824.feature
+++ b/changelog/2824.feature
@@ -1,0 +1,1 @@
+Allow setting ``file_or_dir``, ``-c``, and ``-o`` in PYTEST_ADDOPTS.

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -845,7 +845,7 @@ class TestOverrideIniArgs(object):
             assert inifile is None
 
     def test_addopts_before_initini(self, testdir, tmpdir, monkeypatch):
-        cache_dir = testdir.tmpdir.join('.custom_cache')
+        cache_dir = '.custom_cache'
         monkeypatch.setenv('PYTEST_ADDOPTS', '-o cache_dir=%s' % cache_dir)
         from _pytest.config import get_config
         config = get_config()

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -843,3 +843,11 @@ class TestOverrideIniArgs(object):
             rootdir, inifile, inicfg = determine_setup(None, ['a/exist'])
             assert rootdir == tmpdir
             assert inifile is None
+
+    def test_addopts_before_initini(self, testdir, tmpdir, monkeypatch):
+        cache_dir = testdir.tmpdir.join('.custom_cache')
+        monkeypatch.setenv('PYTEST_ADDOPTS', '-o cache_dir=%s' % cache_dir)
+        from _pytest.config import get_config
+        config = get_config()
+        config._preparse([], addopts=True)
+        assert config._override_ini == [['cache_dir=%s' % cache_dir]]


### PR DESCRIPTION
While it works to pass `-o cache_dir=/somewhere` as command line arguments or set the option in the `setup.cfg` file I tried to achieve the same by setting the environment variable `PYTEST_ADDOPTS="-o cache_dir=/somewhere"`.  This doesn't work atm since the variable is only being considered after [Config._initini](https://github.com/pytest-dev/pytest/blob/46e30435ebad1796e54d99572d43a5b6a1961a19/_pytest/config.py#L1005) has been called which e.g. decides on the `override_ini`.

To enable this use case this patch moves the call to `Config._initini` behind getting the environment variable `PYTEST_ADDOPTS`. I didn't see any negative side effects of this change but I am new to `pytest` so might be missing something.

I haven't added a test for this since I thought getting feedback in the patch first makes sense. If a test is desired please let me know and I am happy to do so.

I targeted `master` since the change is trivial. Please let me know if I should target `features` instead.