### PR TITLE
Provide better message when accessing ExceptionInfo inside with blocks

### DIFF
--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -602,7 +602,7 @@ class RaisesContext(object):
         self.excinfo = None
 
     def __enter__(self):
-        self.excinfo = object.__new__(_pytest._code.ExceptionInfo)
+        self.excinfo = _pytest._code.ExceptionInfo()
         return self.excinfo
 
     def __exit__(self, *tp):
@@ -616,7 +616,7 @@ class RaisesContext(object):
             if not isinstance(tp[1], BaseException):
                 exc_type, value, traceback = tp
                 tp = exc_type, exc_type(value), traceback
-        self.excinfo.__init__(tp)
+        self.excinfo._set_exc_info(tp)
         suppress_exception = issubclass(self.excinfo.type, self.expected_exception)
         if sys.version_info[0] == 2 and suppress_exception:
             sys.exc_clear()

--- a/changelog/2795.bugfix
+++ b/changelog/2795.bugfix
@@ -1,0 +1,1 @@
+``ExceptionInfo`` objects returned by ``pytest.raises`` now issue a better error message if accessed within a ``with`` block.

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -1250,3 +1250,19 @@ def test_no_recursion_index_on_recursion_error():
             assert 'maximum recursion' in str(exc_info.getrepr())
     else:
         assert 0
+
+
+def test_exception_info_not_initialized():
+    """Tests the behavior of ExceptionInfo not initialized with an exception (#2795)."""
+    from _pytest._code.code import ExceptionInfo
+    exc_info = ExceptionInfo()
+    assert exc_info.type is None
+    assert exc_info.value is None
+    assert exc_info.tb is None
+    assert exc_info.traceback is None
+    assert 'ExceptionInfo not initialized' in str(exc_info)
+    assert 'ExceptionInfo not initialized' in repr(exc_info)
+    assert 'ExceptionInfo not initialized' in exc_info.getrepr()
+    assert not exc_info.errisinstance(ValueError())
+    if sys.version_info[0] == 2:
+        assert 'ExceptionInfo not initialized' in unicode(exc_info)

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -132,3 +132,14 @@ class TestRaises(object):
         with pytest.raises(AssertionError, match=expr):
             with pytest.raises(ValueError, match=msg):
                 int('asdf', base=10)
+
+    def test_exc_info_not_initialized(self):
+        """Tests the behavior of ExceptionInfo while inside a 'with' block (#2795)."""
+        with pytest.raises(ValueError) as exc_info:
+            assert exc_info.type is None
+            assert exc_info.value is None
+            assert exc_info.tb is None
+            assert 'ExceptionInfo not initialized' in str(exc_info)
+            raise ValueError('some value error')
+
+        assert str(exc_info.value) == 'some value error'


### PR DESCRIPTION
Also took the opportunity to improve the documentation and refactor
the implementation to remove the weird `__new__`/`__init__` hack done
in `pytest.raises()`

Fix #2795
