### PR TITLE
ignore valid setup.py during --doctest-modules

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -82,6 +82,7 @@ Jason R. Coombs
 Javier Domingo Cansino
 Javier Romero
 Jeff Widman
+John Eddie Ayson
 John Towler
 Jon Sonesen
 Jonas Obrist

--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -59,8 +59,7 @@ def pytest_collect_file(path, parent):
 def _is_setup_py(config, path, parent):
     if path.basename != "setup.py":
         return False
-    with open(path.strpath, 'r') as f:
-        contents = f.read()
+    contents = path.read()
     return 'setuptools' in contents or 'distutils' in contents
 
 

--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -50,10 +50,18 @@ def pytest_addoption(parser):
 def pytest_collect_file(path, parent):
     config = parent.config
     if path.ext == ".py":
-        if config.option.doctestmodules:
+        if config.option.doctestmodules and not _is_setup_py(config, path, parent):
             return DoctestModule(path, parent)
     elif _is_doctest(config, path, parent):
         return DoctestTextfile(path, parent)
+
+
+def _is_setup_py(config, path, parent):
+    if path.basename != "setup.py":
+        return False
+    with open(path.strpath, 'r') as f:
+        contents = f.read()
+    return 'setuptools' in contents or 'distutils' in contents
 
 
 def _is_doctest(config, path, parent):

--- a/changelog/502.feature
+++ b/changelog/502.feature
@@ -1,1 +1,1 @@
-Implement feature to skip valid setup.py files when ran with --doctest-modules
+Implement feature to skip ``setup.py`` files when ran with ``--doctest-modules``.

--- a/changelog/502.feature
+++ b/changelog/502.feature
@@ -1,0 +1,1 @@
+Implement feature to skip valid setup.py files when ran with --doctest-modules

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -561,6 +561,34 @@ class TestDoctests(object):
         reportinfo = items[0].reportinfo()
         assert reportinfo[1] == 1
 
+    def test_valid_setup_py(self, testdir):
+        '''
+        Test to make sure that pytest ignores valid setup.py files when ran
+        with --doctest-modules
+        '''
+        p = testdir.makepyfile(setup="""
+            from setuptools import setup, find_packages
+            setup(name='sample',
+                  version='0.0',
+                  description='description',
+                  packages=find_packages()
+            )
+        """)
+        result = testdir.runpytest(p, '--doctest-modules')
+        result.stdout.fnmatch_lines(['*collected 0 items*'])
+
+    def test_invalid_setup_py(self, testdir):
+        '''
+        Test to make sure that pytest reads setup.py files that are not used
+        for python packages when ran with --doctest-modules
+        '''
+        p = testdir.makepyfile(setup="""
+            def test_foo():
+                return 'bar'
+        """)
+        result = testdir.runpytest(p, '--doctest-modules')
+        result.stdout.fnmatch_lines(['*collected 1 item*'])
+
 
 class TestLiterals(object):
 


### PR DESCRIPTION
Addresses https://github.com/pytest-dev/pytest/issues/502

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [x] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS`;
