### PR TITLE
Fix auto-use fixture doc

### DIFF
--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -858,7 +858,7 @@ into a conftest.py file **without** using ``autouse``::
 
     # content of conftest.py
     @pytest.fixture
-    def transact(self, request, db):
+    def transact(request, db):
         db.begin()
         yield
         db.rollback()


### PR DESCRIPTION
I may be wrong but it looks like `self` shouldn't appear in the fixture signature if it's a not a class method.