### PR TITLE
Issue 2836 fixture collection bug

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -164,6 +164,7 @@ Stephan Obermann
 Tareq Alayan
 Ted Xiao
 Thomas Grainger
+Tom Dalton
 Tom Viner
 Trevor Bekolay
 Tyler Goodlet

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -8,6 +8,7 @@ import py
 from py._code.code import FormattedExcinfo
 
 import _pytest
+from _pytest import nodes
 from _pytest._code.code import TerminalRepr
 from _pytest.compat import (
     NOTSET, exc_clear, _format_args,
@@ -17,7 +18,6 @@ from _pytest.compat import (
     safe_getattr,
     FuncargnamesCompatAttr,
 )
-from _pytest.nodes import ischildnode
 from _pytest.outcomes import fail, TEST_OUTCOME
 
 
@@ -983,8 +983,8 @@ class FixtureManager:
             # by their test id)
             if p.basename.startswith("conftest.py"):
                 nodeid = p.dirpath().relto(self.config.rootdir)
-                if p.sep != "/":
-                    nodeid = nodeid.replace(p.sep, "/")
+                if p.sep != nodes.SEP:
+                    nodeid = nodeid.replace(p.sep, nodes.SEP)
         self.parsefactories(plugin, nodeid)
 
     def _getautousenames(self, nodeid):
@@ -1134,5 +1134,5 @@ class FixtureManager:
 
     def _matchfactories(self, fixturedefs, nodeid):
         for fixturedef in fixturedefs:
-            if ischildnode(fixturedef.baseid, nodeid):
+            if nodes.ischildnode(fixturedef.baseid, nodeid):
                 yield fixturedef

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -1145,11 +1145,10 @@ class FixtureManager:
             return []
         sep = py.path.local.sep
         parts = nodeid.split(sep)
-        if parts:
-            last_part = parts[-1]
-            if '::' in last_part:
-                namespace_parts = last_part.split("::")
-                parts[-1:] = namespace_parts
+        last_part = parts[-1]
+        if '::' in last_part:
+            # Replace single last element 'test_foo.py::Bar::()' with multiple elements 'test_foo.py', 'Bar', '()'
+            parts[-1:] = last_part.split("::")
         return parts
 
     @classmethod

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -1135,20 +1135,20 @@ class FixtureManager:
         """Split a nodeid into constituent 'parts'.
 
         Node IDs are strings, and can be things like:
-            '',
-            'testing/code',
+            ''
+            'testing/code'
             'testing/code/test_excinfo.py'
             'testing/code/test_excinfo.py::TestFormattedExcinfo::()'
 
+        Return values are lists e.g.
+            ['']
+            ['testing', 'code']
+            ['testing', 'code', test_excinfo.py']
+            ['testing', 'code', 'test_excinfo.py', 'TestFormattedExcinfo', '()']
         """
-        if nodeid == '':
-            return []
-        sep = py.path.local.sep
-        parts = nodeid.split(sep)
-        last_part = parts[-1]
-        if '::' in last_part:
-            # Replace single last element 'test_foo.py::Bar::()' with multiple elements 'test_foo.py', 'Bar', '()'
-            parts[-1:] = last_part.split("::")
+        parts = nodeid.split(py.path.local.sep)
+        # Replace single last element 'test_foo.py::Bar::()' with multiple elements 'test_foo.py', 'Bar', '()'
+        parts[-1:] = parts[-1].split("::")
         return parts
 
     @classmethod

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -1143,7 +1143,7 @@ class FixtureManager:
         Return values are lists e.g.
             ['']
             ['testing', 'code']
-            ['testing', 'code', test_excinfo.py']
+            ['testing', 'code', 'test_excinfo.py']
             ['testing', 'code', 'test_excinfo.py', 'TestFormattedExcinfo', '()']
         """
         parts = nodeid.split(py.path.local.sep)

--- a/_pytest/junitxml.py
+++ b/_pytest/junitxml.py
@@ -17,6 +17,7 @@ import re
 import sys
 import time
 import pytest
+from _pytest import nodes
 from _pytest.config import filename_arg
 
 # Python 2.X and 3.X compatibility
@@ -252,7 +253,7 @@ def mangle_test_address(address):
     except ValueError:
         pass
     # convert file path to dotted path
-    names[0] = names[0].replace("/", '.')
+    names[0] = names[0].replace(nodes.SEP, '.')
     names[0] = _py_ext_re.sub("", names[0])
     # put any params back
     names[-1] += possible_open_bracket + params

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -6,6 +6,7 @@ import os
 import sys
 
 import _pytest
+from _pytest import nodes
 import _pytest._code
 import py
 try:
@@ -14,8 +15,8 @@ except ImportError:
     from UserDict import DictMixin as MappingMixin
 
 from _pytest.config import directory_arg, UsageError, hookimpl
-from _pytest.runner import collect_one_node
 from _pytest.outcomes import exit
+from _pytest.runner import collect_one_node
 
 tracebackcutdir = py.path.local(_pytest.__file__).dirpath()
 
@@ -516,14 +517,14 @@ class FSCollector(Collector):
             rel = fspath.relto(parent.fspath)
             if rel:
                 name = rel
-            name = name.replace(os.sep, "/")
+            name = name.replace(os.sep, nodes.SEP)
         super(FSCollector, self).__init__(name, parent, config, session)
         self.fspath = fspath
 
     def _makeid(self):
         relpath = self.fspath.relto(self.config.rootdir)
-        if os.sep != "/":
-            relpath = relpath.replace(os.sep, "/")
+        if os.sep != nodes.SEP:
+            relpath = relpath.replace(os.sep, nodes.SEP)
         return relpath
 
 

--- a/_pytest/nodes.py
+++ b/_pytest/nodes.py
@@ -1,6 +1,3 @@
-import py
-
-
 SEP = "/"
 
 

--- a/_pytest/nodes.py
+++ b/_pytest/nodes.py
@@ -1,0 +1,37 @@
+import py
+
+
+def _splitnode(nodeid):
+    """Split a nodeid into constituent 'parts'.
+
+    Node IDs are strings, and can be things like:
+        ''
+        'testing/code'
+        'testing/code/test_excinfo.py'
+        'testing/code/test_excinfo.py::TestFormattedExcinfo::()'
+
+    Return values are lists e.g.
+        []
+        ['testing', 'code']
+        ['testing', 'code', 'test_excinfo.py']
+        ['testing', 'code', 'test_excinfo.py', 'TestFormattedExcinfo', '()']
+    """
+    if nodeid == '':
+        # If there is no root node at all, return an empty list so the caller's logic can remain sane
+        return []
+    parts = nodeid.split(py.path.local.sep)
+    # Replace single last element 'test_foo.py::Bar::()' with multiple elements 'test_foo.py', 'Bar', '()'
+    parts[-1:] = parts[-1].split("::")
+    return parts
+
+
+def ischildnode(baseid, nodeid):
+    """Return True if the nodeid is a child node of the baseid.
+
+    E.g. 'foo/bar::Baz::()' is a child of 'foo', 'foo/bar' and 'foo/bar::Baz', but not of 'foo/blorp'
+    """
+    base_parts = _splitnode(baseid)
+    node_parts = _splitnode(nodeid)
+    if len(node_parts) < len(base_parts):
+        return False
+    return node_parts[:len(base_parts)] == base_parts

--- a/_pytest/nodes.py
+++ b/_pytest/nodes.py
@@ -1,6 +1,9 @@
 import py
 
 
+SEP = "/"
+
+
 def _splitnode(nodeid):
     """Split a nodeid into constituent 'parts'.
 
@@ -19,7 +22,7 @@ def _splitnode(nodeid):
     if nodeid == '':
         # If there is no root node at all, return an empty list so the caller's logic can remain sane
         return []
-    parts = nodeid.split(py.path.local.sep)
+    parts = nodeid.split(SEP)
     # Replace single last element 'test_foo.py::Bar::()' with multiple elements 'test_foo.py', 'Bar', '()'
     parts[-1:] = parts[-1].split("::")
     return parts

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -13,6 +13,7 @@ import sys
 import time
 import platform
 
+from _pytest import nodes
 import _pytest._pluggy as pluggy
 
 
@@ -452,7 +453,7 @@ class TerminalReporter:
 
         if fspath:
             res = mkrel(nodeid).replace("::()", "")  # parens-normalization
-            if nodeid.split("::")[0] != fspath.replace("\\", "/"):
+            if nodeid.split("::")[0] != fspath.replace("\\", nodes.SEP):
                 res += " <- " + self.startdir.bestrelpath(fspath)
         else:
             res = "[location]"

--- a/changelog/2836.bug
+++ b/changelog/2836.bug
@@ -1,3 +1,1 @@
-Attempted fix for https://github.com/pytest-dev/pytest/issues/2836
-
-Improves the handling of "nodeid"s to be more aware of path and class separators.
+Match fixture paths against actual path segments in order to avoid matching folders which share a prefix.

--- a/changelog/2836.bug
+++ b/changelog/2836.bug
@@ -1,0 +1,3 @@
+Attempted fix for https://github.com/pytest-dev/pytest/issues/2836
+
+Improves the handling of "nodeid"s to be more aware of path and class separators.

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import py
 
+import _pytest._code
 from _pytest.main import Session, EXIT_NOTESTSCOLLECTED, _in_venv
 
 
@@ -829,4 +830,29 @@ def test_continue_on_collection_errors_maxfail(testdir):
         "collected 2 items / 2 errors",
         "*Interrupted: stopping after 3 failures*",
         "*1 failed, 2 error*",
+    ])
+
+
+def test_fixture_scope_sibling_conftests(testdir):
+    """Regression test case for https://github.com/pytest-dev/pytest/issues/2836"""
+    foo_path = testdir.mkpydir("foo")
+    foo_path.join("conftest.py").write(_pytest._code.Source("""
+        import pytest
+        @pytest.fixture
+        def fix():
+            return 1
+    """))
+    foo_path.join("test_foo.py").write("def test_foo(fix): assert fix == 1")
+
+    # Tests in `food/` should not see the conftest fixture from `foo/`
+    food_path = testdir.mkpydir("food")
+    food_path.join("test_food.py").write("def test_food(fix): assert fix == 1")
+
+    res = testdir.runpytest()
+    assert res.ret == 1
+
+    # TODO Work out what this will really look like. Currently the retcode assertion above fails (as expected).
+    res.stdout.fnmatch_lines([
+        "collected 2 items / 1 errors",
+        "*1 passed, 1 error*",
     ])

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -851,8 +851,8 @@ def test_fixture_scope_sibling_conftests(testdir):
     res = testdir.runpytest()
     assert res.ret == 1
 
-    # TODO Work out what this will really look like. Currently the retcode assertion above fails (as expected).
     res.stdout.fnmatch_lines([
-        "collected 2 items / 1 errors",
+        "*ERROR at setup of test_food*",
+        "E*fixture 'fix' not found",
         "*1 passed, 1 error*",
     ])

--- a/testing/test_fixtures.py
+++ b/testing/test_fixtures.py
@@ -1,0 +1,18 @@
+import pytest
+
+from _pytest import fixtures
+
+
+@pytest.mark.parametrize("baseid, nodeid, expected", (
+    ('', '', True),
+    ('', 'foo', True),
+    ('', 'foo/bar', True),
+    ('', 'foo/bar::TestBaz::()', True),
+    ('foo', 'food', False),
+    ('foo/bar::TestBaz::()', 'foo/bar', False),
+    ('foo/bar::TestBaz::()', 'foo/bar::TestBop::()', False),
+    ('foo/bar', 'foo/bar::TestBop::()', True),
+))
+def test_fixturemanager_ischildnode(baseid, nodeid, expected):
+    result = fixtures.FixtureManager._ischildnode(baseid, nodeid)
+    assert result is expected

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -1,6 +1,6 @@
 import pytest
 
-from _pytest import fixtures
+from _pytest import nodes
 
 
 @pytest.mark.parametrize("baseid, nodeid, expected", (
@@ -13,6 +13,6 @@ from _pytest import fixtures
     ('foo/bar::TestBaz::()', 'foo/bar::TestBop::()', False),
     ('foo/bar', 'foo/bar::TestBop::()', True),
 ))
-def test_fixturemanager_ischildnode(baseid, nodeid, expected):
-    result = fixtures.FixtureManager._ischildnode(baseid, nodeid)
+def test_ischildnode(baseid, nodeid, expected):
+    result = nodes.ischildnode(baseid, nodeid)
     assert result is expected


### PR DESCRIPTION
Attempted fix for #2836.

The existing handling of 'nodeid' when determining what fixtures are visible is overly simplistic - it considers 'tests/food' to be a 'child' node of 'tests/foo', when in fact they are sibling nodes. This causes fixtures from 'tests/foo/conftest.py' to be used in tests like 'tests/food/test_food.py'.

This PR makes the hanlding more sophisticated - splitting the node id into components and then ensuring the base node id parts fully match the target node id's initial parts. This is still a little imperfect, in that would treat `foo/bar::Baz::()` as if it was the same as `foo/bar/Baz/()`. That seems a somewhat unlikely situation...

I'm not super keen on having `_splitnode` and `_ischildnode` as members of FixtureManager, but I don't really see any obvious other place for them and I was reluctant to create a while new module/class for these two 'nodeid' helper functions. I'm not 100% sure where the spec/definiton of a node id comes from, so maybe there is a better place, very open to suggestions on that. If someone with some better knowledge of what 'nodeid's look like can have a look over this it would be good - hopefulyl I haven't missed any edge cases but without having a good definition I am slightly worried about it.

The fixtures module didn't (seem to) have any existing unit tests, so I've added one for my new  `FixtureManager_ischildnode` method (mainly for my own sanity). I've also added a more 'integration'-y test to `test_collection.py` which will catch regression and (hopefully) follows the style of other tests there too. Hopefully `test_collection` is the right place for that test - certainly the fixture code I've modified seems to be run as part of the collection phase.