### PR TITLE
Make CONTRIBUTING and PR template more consistent regarding doc contributions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,4 @@ Here's a quick checklist that should be present in PRs:
 
 Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:
 
-- [ ] Add yourself to `AUTHORS`;
+- [ ] Add yourself to `AUTHORS`, in alphabetical order;

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -177,7 +177,8 @@ Short version
 #. Write a ``changelog`` entry: ``changelog/2574.bugfix``, use issue id number
    and one of ``bugfix``, ``removal``, ``feature``, ``vendor``, ``doc`` or
    ``trivial`` for the issue type.
-#. Add yourself to ``AUTHORS`` file if not there yet, in alphabetical order.
+#. Unless your change is a trivial or a documentation fix (e.g., a typo or reword of a small section) please
+   add yourself to the ``AUTHORS`` file, in alphabetical order;
 
 
 Long version


### PR DESCRIPTION
As brought to attention by in [this comment](https://github.com/pytest-dev/pytest/pull/2864#issuecomment-338790369) by @bilderbuchi.
