### PR TITLE
Change directory for py27 xdist-related envs

### DIFF
--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -66,7 +66,7 @@ class TestAssertionRewrite(object):
         s = """'Doc string'\nother = stuff"""
         m = rewrite(s)
         # Module docstrings in 3.7 are part of Module node, it's not in the body
-        # so we remove it so the following body items have the same indexes on 
+        # so we remove it so the following body items have the same indexes on
         # all Python versions
         if sys.version_info < (3, 7):
             assert isinstance(m.body[0], ast.Expr)

--- a/tox.ini
+++ b/tox.ini
@@ -64,8 +64,9 @@ deps =
     mock
     nose
     hypothesis>=3.5.2
+changedir=testing
 commands =
-    pytest -n1 -rfsxX {posargs:testing}
+    pytest -n1 -rfsxX {posargs:.}
 
 [testenv:py36-xdist]
 deps = {[testenv:py27-xdist]deps}
@@ -91,10 +92,11 @@ deps =
     pytest-xdist>=1.13
     hypothesis>=3.5.2
 distribute = true
+changedir=testing
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 commands =
-    pytest -n3 -rfsxX {posargs:testing}
+    pytest -n3 -rfsxX {posargs:.}
 
 [testenv:py27-trial]
 deps = twisted


### PR DESCRIPTION
The `filter_traceback` function was not filtering the frames
that belonged to the pytest internals.

"filter_traceback" was receiving *relative* paths when running with
xdist, and full paths in non-distributed runs; for this reason
the traceback function did not consider the received path to be
relative to the pytest internal modules:

https://github.com/pytest-dev/pytest/blob/111d640bdb69a0bba25f86e5c265ab02415698c3/_pytest/python.py#L48-L49

`py.path.local(entry.path)` will create a full path using `cwd` because `entry.path` is relative, and `cwd` would point to the `testdir` directory (as it should).

I debugged up until `Code.__init__`:

https://github.com/pytest-dev/pytest/blob/111d640bdb69a0bba25f86e5c265ab02415698c3/_pytest/_code/code.py#L19-L28

And I verified that the `rawcode.co_filename` is indeed a relative path when executed with xdist and a full path in non-distributed, but I don't have a clue as to why.

By running the tests in a directory other than where `_pytest` is, then `rawcode.co_filename` is always a full path and everything works.

I tried to back trace to other versions (pytest 3.1.0, execnet 1.4 and pytest-xdist 1.19) but the problem still happens in those versions, so I can't figure out why this suddenly started to fail.

I thought I would at least open a PR with my findings and a "workaround" to see if people have any suggestions.

Fix #2843

