### PR TITLE
Capture result namedtuple

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -156,6 +156,7 @@ Ronny Pfannschmidt
 Ross Lawley
 Russel Winder
 Ryan Wooden
+Samuel Dion-Girardeau
 Samuele Pedroni
 Segev Finer
 Simon Gomizelj

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -4,6 +4,7 @@ per-test stdout/stderr capturing mechanism.
 """
 from __future__ import absolute_import, division, print_function
 
+import collections
 import contextlib
 import sys
 import os
@@ -306,6 +307,9 @@ class EncodedFile(object):
         return getattr(object.__getattribute__(self, "buffer"), name)
 
 
+CaptureResult = collections.namedtuple("CaptureResult", ["out", "err"])
+
+
 class MultiCapture(object):
     out = err = in_ = None
 
@@ -366,8 +370,8 @@ class MultiCapture(object):
 
     def readouterr(self):
         """ return snapshot unicode value of stdout/stderr capturings. """
-        return (self.out.snap() if self.out is not None else "",
-                self.err.snap() if self.err is not None else "")
+        return CaptureResult(self.out.snap() if self.out is not None else "",
+                             self.err.snap() if self.err is not None else "")
 
 
 class NoCapture:

--- a/changelog/2879.feature
+++ b/changelog/2879.feature
@@ -1,0 +1,1 @@
+Return stdout/stderr capture results as a ``namedtuple``, so ``out`` and ``err`` can be accessed by attribute.

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -922,6 +922,14 @@ class TestStdCapture(object):
             out, err = cap.readouterr()
         assert err == "error2"
 
+    def test_capture_results_accessible_by_attribute(self):
+        with self.getcapture() as cap:
+            sys.stdout.write("hello")
+            sys.stderr.write("world")
+            capture_result = cap.readouterr()
+        assert capture_result.out == "hello"
+        assert capture_result.err == "world"
+
     def test_capturing_readouterr_unicode(self):
         with self.getcapture() as cap:
             print("hx\xc4\x85\xc4\x87")
@@ -1081,6 +1089,14 @@ def test_using_capsys_fixture_works_with_sys_stdout_encoding(capsys):
     (out, err) = capsys.readouterr()
     assert out
     assert err == ''
+
+
+def test_capsys_results_accessible_by_attribute(capsys):
+    sys.stdout.write("spam")
+    sys.stderr.write("eggs")
+    capture_result = capsys.readouterr()
+    assert capture_result.out == "spam"
+    assert capture_result.err == "eggs"
 
 
 @needsosdup


### PR DESCRIPTION
Return stdout/stderr capture results as a `namedtuple`,
so `out` and `err` can be accessed by attribute.

Includes tests for the `capsys` fixture, and for the context manager class.

Closes #2879