### PR TITLE
Fix context output handling for doctests

### DIFF
--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -120,7 +120,7 @@ class DoctestItem(pytest.Item):
                 lines = ["%03d %s" % (i + test.lineno + 1, x)
                          for (i, x) in enumerate(lines)]
                 # trim docstring error lines to 10
-                lines = lines[example.lineno - 9:example.lineno + 1]
+                lines = lines[max(example.lineno - 9, 0):example.lineno + 1]
             else:
                 lines = ['EXAMPLE LOCATION UNKNOWN, not showing all tests of that example']
                 indent = '>>>'

--- a/changelog/2882.bugfix
+++ b/changelog/2882.bugfix
@@ -1,0 +1,1 @@
+Show full context of doctest source in the pytest output, if the lineno of failed example in the docstring is < 9.

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -173,7 +173,7 @@ class TestDoctests(object):
             "*UNEXPECTED*ZeroDivision*",
         ])
 
-    def test_docstring_context_around_error(self, testdir):
+    def test_docstring_partial_context_around_error(self, testdir):
         """Test that we show some context before the actual line of a failing
         doctest.
         """
@@ -199,7 +199,7 @@ class TestDoctests(object):
         ''')
         result = testdir.runpytest('--doctest-modules')
         result.stdout.fnmatch_lines([
-            '*docstring_context_around_error*',
+            '*docstring_partial_context_around_error*',
             '005*text-line-3',
             '006*text-line-4',
             '013*text-line-11',
@@ -212,6 +212,32 @@ class TestDoctests(object):
         # lines below should be trimmed out
         assert 'text-line-2' not in result.stdout.str()
         assert 'text-line-after' not in result.stdout.str()
+
+    def test_docstring_full_context_around_error(self, testdir):
+        """Test that we show the whole context before the actual line of a failing
+        doctest, provided that the context is up to 10 lines long.
+        """
+        testdir.makepyfile('''
+            def foo():
+                """
+                text-line-1
+                text-line-2
+
+                >>> 1 + 1
+                3
+                """
+        ''')
+        result = testdir.runpytest('--doctest-modules')
+        result.stdout.fnmatch_lines([
+            '*docstring_full_context_around_error*',
+            '003*text-line-1',
+            '004*text-line-2',
+            '006*>>> 1 + 1',
+            'Expected:',
+            '    3',
+            'Got:',
+            '    2',
+        ])
 
     def test_doctest_linedata_missing(self, testdir):
         testdir.tmpdir.join('hello.py').write(_pytest._code.Source("""


### PR DESCRIPTION
If the linenumber of a failing doctest is < 9, the failure/error report is wrong.

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [x] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Add yourself to `AUTHORS`, in alphabetical order;
