### PR TITLE
Add possibility to read parametrized params

### DIFF
--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1100,6 +1100,7 @@ class Function(FunctionMixin, main.Item, fixtures.FuncargnamesCompatAttr):
     Python test function.
     """
     _genid = None
+    _parametrized_params = {}
 
     def __init__(self, name, parent, args=None, config=None,
                  callspec=None, callobj=NOTSET, keywords=None, session=None,
@@ -1149,6 +1150,8 @@ class Function(FunctionMixin, main.Item, fixtures.FuncargnamesCompatAttr):
                 self._genid = callspec.id
                 if hasattr(callspec, "param"):
                     self.param = callspec.param
+                if hasattr(callspec, "params"):
+                    self._parametrized_params = callspec.params.copy()
         self._request = fixtures.FixtureRequest(self)
 
     @property

--- a/changelog/2886.feature
+++ b/changelog/2886.feature
@@ -1,0 +1,2 @@
+Adds possibility to access parametrized values from pytest item from
+pytest hooks.


### PR DESCRIPTION
This adds possibility to access parametrized values from pytest item from
pytest hooks.

E.g: we use dynamic parametrize of our tests in pytest_generate_tests. Then
we would like to access these parametrized values and its names from some
other hook like pytest_runtest_setup or pytest_runtest_call. Unfortunately I
didn't find parametrized values nowhere. So this patch add
_parametrized_params attribute for that purpose and we can read values from
parametrized values from other hooks.

Example:
```
def pytest_generate_tests(metafunc):
    metafunc.parametrize(
        ["storage", "api"], [("nfs", "cli"), ('iscsi', 'rest')],
        indirect=True, scope="class"
    )

def pytest_runtest_setup(item):
    storage = item._parametrized_params.get('storage')
    if storage:
        print("Here I can do something with %s" % storage)

```
Change-Id: I68380e67ba5188048554cc7532a6ca2e3dd620e2

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [x] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS`, in alphabetical order;
