### PR TITLE
Clarify language of proposal for fixtures parameters

### DIFF
--- a/changelog/2893.doc
+++ b/changelog/2893.doc
@@ -1,0 +1,1 @@
+Clarify language of proposal for fixtures parameters

--- a/doc/en/proposals/parametrize_with_fixtures.rst
+++ b/doc/en/proposals/parametrize_with_fixtures.rst
@@ -1,8 +1,13 @@
 :orphan:
 
-=========================
-Parametrize with fixtures
-=========================
+===================================
+PROPOSAL: Parametrize with fixtures
+===================================
+
+.. warning::
+
+    This document outlines a proposal around using fixtures as input
+    of parametrized tests or fixtures.
 
 Problem
 -------
@@ -108,8 +113,8 @@ the following values.
 Alternative approach
 --------------------
 
-A new helper function named ``fixture_request`` tells pytest to yield all
-parameters of a fixture.
+A new helper function named ``fixture_request`` would tell pytest to yield
+all parameters marked as a fixture.
 
 .. code-block:: python
 


### PR DESCRIPTION
This change slightly modifies the language of the proposal document around use of fixture as parameters of pytest.mark.parametrize.

When looking for documentation around this, I very quickly scrolled through this document and landed on the last paragraph thinking it was documenting a real function. This change attempts to make it less likely for this to happen.