### PR TITLE
Stop marks from applying to parent classes.

### DIFF
--- a/_pytest/mark.py
+++ b/_pytest/mark.py
@@ -462,4 +462,9 @@ def transfer_markers(funcobj, cls, mod):
     for obj in (cls, mod):
         for mark in get_unpacked_marks(obj):
             if not _marked(funcobj, mark):
-                store_legacy_markinfo(funcobj, mark)
+                if funcobj.__name__ not in obj.__dict__:
+                    def _wrapper(*args, **kwargs):
+                        return funcobj(*args, **kwargs)
+                    setattr(obj, funcobj.__name__, _wrapper)
+                store_legacy_markinfo(getattr(obj, funcobj.__name__), mark)
+


### PR DESCRIPTION
This PR isn't remotely well formatted or tested, but hopefully it's helpful to someone as a workaround.

This is a hack based on the pykafka workaround for inheritance, and seems to work for my use case at least.  Basically it creates a thin wrapper around inherited methods so the marks apply to the wrapper instead of the (shared) parent function.

This probably has unwanted side effects somewhere, such as class marks not being inherited by child classes.  Also, the wrapper should have some wraps decorator magic and such to not horribly break introspection.