### PR TITLE
Make the "examples" section more prominent in the docs for parametrize

### DIFF
--- a/doc/en/parametrize.rst
+++ b/doc/en/parametrize.rst
@@ -201,6 +201,9 @@ list::
 Note that when calling ``metafunc.parametrize`` multiple times with different parameter sets, all parameter names across 
 those sets cannot be duplicated, otherwise an error will be raised.
 
+More examples
+-------------
+
 For further examples, you might want to look at :ref:`more
 parametrization examples <paramexamples>`.
 


### PR DESCRIPTION
I spent some time today figuring out why PR #2881 was not showing up
on `doc/parametrize`... then after some digging even on readthedocs
wondering if the last documentation build had failed, I realized the
docs I was looking for was in `doc/example/parametrize` instead.

The section that mentions this is very easy to miss, this makes it a
full fledged title and easier to find.
