### PR TITLE
Pin py<1.5 as 1.5 drops py26 and py33 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ def has_environment_marker_support():
 
 
 def main():
-    install_requires = ['py>=1.4.33', 'setuptools']  # pluggy is vendored in _pytest.vendored_packages
+    install_requires = ['py>=1.4.33,<1.5', 'setuptools']  # pluggy is vendored in _pytest.vendored_packages
     extras_require = {}
     if has_environment_marker_support():
         extras_require[':python_version=="2.6"'] = ['argparse', 'ordereddict']


### PR DESCRIPTION
As discussed in pytest-dev/py#165