### PR TITLE
Fix assertion rewrite to match module names correctly

### DIFF
--- a/_pytest/assertion/rewrite.py
+++ b/_pytest/assertion/rewrite.py
@@ -168,7 +168,7 @@ class AssertionRewritingHook(object):
                 return True
 
         for marked in self._must_rewrite:
-            if name.startswith(marked):
+            if name == marked or name.startswith(marked + '.'):
                 state.trace("matched marked file %r (from %r)" % (name, marked))
                 return True
 

--- a/changelog/2939.bugfix
+++ b/changelog/2939.bugfix
@@ -1,0 +1,1 @@
+Fix issue in assertion rewriting which could lead it to rewrite modules which should not be rewritten.

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -129,6 +129,24 @@ class TestImportHookInstallation(object):
         result = testdir.runpytest_subprocess('--assert=rewrite')
         assert result.ret == 0
 
+    def test_pytest_plugins_rewrite_module_names_correctly(self, testdir):
+        """Test that we match files correctly when they are marked for rewriting (#2939)."""
+        contents = {
+            'conftest.py': """
+                pytest_plugins = "ham"
+            """,
+            'ham.py': "",
+            'hamster.py': "",
+            'test_foo.py': """
+                def test_foo(pytestconfig):
+                    assert pytestconfig.pluginmanager.rewrite_hook.find_module('ham') is not None
+                    assert pytestconfig.pluginmanager.rewrite_hook.find_module('hamster') is None
+            """,
+        }
+        testdir.makepyfile(**contents)
+        result = testdir.runpytest_subprocess('--assert=rewrite')
+        assert result.ret == 0
+
     @pytest.mark.parametrize('mode', ['plain', 'rewrite'])
     @pytest.mark.parametrize('plugin_state', ['development', 'installed'])
     def test_installed_plugin_rewrite(self, testdir, mode, plugin_state):


### PR DESCRIPTION
Fix #2939

@hroncok, I managed use your reproducer to verify that the fix works:

```
{env36} X:\setuptools [master]>python -m pytest -k test_unicode_filename_in_sdist -v --tb=line
============================= test session starts =============================
platform win32 -- Python 3.6.0, pytest-3.2.5, py-1.5.2, pluggy-0.4.0 -- X:\setuptools\.env36\Scripts\python.exe
cachedir: .cache
rootdir: X:\setuptools, inifile: pytest.ini
plugins: virtualenv-1.2.11, shutil-1.2.11, flake8-0.9.1
collected 391 items

setuptools/tests/test_easy_install.py::TestEasyInstallTest::test_unicode_filename_in_sdist FAILED

================================== FAILURES ===================================
<frozen importlib._bootstrap>:960: RecursionError: maximum recursion depth exceeded
============================ 390 tests deselected =============================
================== 1 failed, 390 deselected in 2.01 seconds ===================
```

Using the code from this branch fixes the issue:

```
{env36} X:\setuptools [master]>pip install -e c:\pytest
Obtaining file:///C:/pytest
Requirement already satisfied: py>=1.4.33 in x:\setuptools\.env36\lib\site-packages (from pytest==3.2.6.dev5+gd13086a)
Requirement already satisfied: setuptools in x:\setuptools\.env36\lib\site-packages (from pytest==3.2.6.dev5+gd13086a)
Requirement already satisfied: colorama in x:\setuptools\.env36\lib\site-packages (from pytest==3.2.6.dev5+gd13086a)
Installing collected packages: pytest
  Found existing installation: pytest 3.2.5
    Uninstalling pytest-3.2.5:
      Successfully uninstalled pytest-3.2.5
  Running setup.py develop for pytest
Successfully installed pytest

{env36} X:\setuptools [master]>python -m pytest -k test_unicode_filename_in_sdist -v --tb=line
============================= test session starts =============================
platform win32 -- Python 3.6.0, pytest-3.2.6.dev5+gd13086a, py-1.5.2, pluggy-0.4.0 -- X:\setuptools\.env36\Scripts\python.exe
cachedir: .cache
rootdir: X:\setuptools, inifile: pytest.ini
plugins: virtualenv-1.2.11, shutil-1.2.11, flake8-0.9.1
collected 391 items

setuptools/tests/test_easy_install.py::TestEasyInstallTest::test_unicode_filename_in_sdist PASSED

============================ 390 tests deselected =============================
================== 1 passed, 390 deselected in 7.82 seconds ===================
```

Thanks again for taking the time to analyze the issue!
