### PR TITLE
Only escape str-like arguments passed to warnings

### DIFF
--- a/_pytest/warnings.py
+++ b/_pytest/warnings.py
@@ -72,7 +72,9 @@ def catch_warnings_for_item(item):
             unicode_warning = False
 
             if compat._PY2 and any(isinstance(m, compat.UNICODE_TYPES) for m in warn_msg.args):
-                new_args = [compat.ascii_escaped(m) for m in warn_msg.args]
+                new_args = []
+                for m in warn_msg.args:
+                    new_args.append(compat.ascii_escaped(m) if isinstance(m, compat.UNICODE_TYPES) else m)
                 unicode_warning = list(warn_msg.args) != new_args
                 warn_msg.args = new_args
 

--- a/changelog/2956.bugfix
+++ b/changelog/2956.bugfix
@@ -1,0 +1,1 @@
+Fix regression with warnings that contained non-strings in their arguments in Python 2.

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -243,3 +243,16 @@ def test_filterwarnings_mark(testdir, default_config):
     """)
     result = testdir.runpytest('-W always' if default_config == 'cmdline' else '')
     result.stdout.fnmatch_lines(['*= 1 failed, 2 passed, 1 warnings in *'])
+
+
+def test_non_string_warning_argument(testdir):
+    """Non-str argument passed to warning breaks pytest (#2956)"""
+    testdir.makepyfile("""
+        import warnings
+        import pytest
+
+        def test():
+            warnings.warn(UserWarning(1, u'foo'))
+    """)
+    result = testdir.runpytest('-W', 'always')
+    result.stdout.fnmatch_lines(['*= 1 passed, 1 warnings in *'])


### PR DESCRIPTION
Fix #2956
