### PR TITLE
replace non-breaking space with space

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -80,7 +80,7 @@ Features
   <https://github.com/pytest-dev/pytest/issues/2824>`_)
 
 - Return stdout/stderr capture results as a ``namedtuple``, so ``out`` and
-  ``err`` can be accessed by attribute. (`#2879
+  ``err`` can be accessed by attribute. (`#2879
   <https://github.com/pytest-dev/pytest/issues/2879>`_)
 
 - Add ``capfdbinary``, a version of ``capfd`` which returns bytes from


### PR DESCRIPTION
Noticed the word `err` in the release notes wasn't showing up correctly:

![image](https://user-images.githubusercontent.com/167319/33316881-6b0b0396-d42d-11e7-8720-c0cf5e963b1e.png)

Turns out there was a non-breaking space in there.