### PR TITLE
Always escape null bytes when setting PYTEST_CURRENT_TEST

### DIFF
--- a/_pytest/runner.py
+++ b/_pytest/runner.py
@@ -7,7 +7,6 @@ import sys
 from time import time
 
 import py
-from _pytest.compat import _PY2
 from _pytest._code.code import TerminalRepr, ExceptionInfo
 from _pytest.outcomes import skip, Skipped, TEST_OUTCOME
 
@@ -131,9 +130,8 @@ def _update_current_test_var(item, when):
     var_name = 'PYTEST_CURRENT_TEST'
     if when:
         value = '{0} ({1})'.format(item.nodeid, when)
-        if _PY2:
-            # python 2 doesn't like null bytes on environment variables (see #2644)
-            value = value.replace('\x00', '(null)')
+        # don't allow null bytes on environment variables (see #2644, #2957)
+        value = value.replace('\x00', '(null)')
         os.environ[var_name] = value
     else:
         os.environ.pop(var_name)

--- a/changelog/2957.bugfix
+++ b/changelog/2957.bugfix
@@ -1,0 +1,1 @@
+Always escape null bytes when setting ``PYTEST_CURRENT_TEST``.

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -415,17 +415,17 @@ class TestGeneralUsage(object):
         ])
 
     def test_parametrized_with_null_bytes(self, testdir):
-        """Test parametrization with values that contain null bytes and unicode characters (#2644)"""
+        """Test parametrization with values that contain null bytes and unicode characters (#2644, #2957)"""
         p = testdir.makepyfile(u"""
             # encoding: UTF-8
             import pytest
 
-            @pytest.mark.parametrize("data", ["\\x00", u'ação'])
+            @pytest.mark.parametrize("data", [b"\\x00", "\\x00", u'ação'])
             def test_foo(data):
                 assert data
         """)
         res = testdir.runpytest(p)
-        res.assert_outcomes(passed=2)
+        res.assert_outcomes(passed=3)
 
 
 class TestInvocationVariants(object):


### PR DESCRIPTION
Fix #2957

cc @mattsb42-aws