### PR TITLE
Fix ZeroDivisionError with 0 collected tests

### DIFF
--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -313,8 +313,11 @@ class TerminalReporter:
     _PROGRESS_LENGTH = len(' [100%]')
 
     def _get_progress_information_message(self):
-        progress = self._progress_items_reported * 100 // self._session.testscollected
-        return ' [{:3d}%]'.format(progress)
+        collected = self._session.testscollected
+        if collected:
+            progress = self._progress_items_reported * 100 // collected
+            return ' [{:3d}%]'.format(progress)
+        return ' [100%]'
 
     def _write_progress_information_filling_space(self):
         if not self._show_progress_info:

--- a/changelog/2971.bugfix
+++ b/changelog/2971.bugfix
@@ -1,0 +1,1 @@
+Fix ``ZeroDivisionError`` when using the ``testmon`` plugin when no tests were actually collected.


### PR DESCRIPTION
This can easily happen with pytest-testmon.

Here's a quick checklist that should be present in PRs:

- [ ] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bug)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [ ] Make sure to include reasonable tests for your change if necessary