### PR TITLE
Extend _pytest.python._idval to return __name__ of functions as well

### DIFF
--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -933,7 +933,7 @@ def _idval(val, argname, idx, idfn, config=None):
         return ascii_escaped(val.pattern)
     elif enum is not None and isinstance(val, enum.Enum):
         return str(val)
-    elif isclass(val) and hasattr(val, '__name__'):
+    elif (isclass(val) or isfunction(val)) and hasattr(val, '__name__'):
         return val.__name__
     return str(argname) + str(idx)
 

--- a/changelog/2976.trivial
+++ b/changelog/2976.trivial
@@ -1,0 +1,1 @@
+Change _pytest.python._idval to return __name__ for functions instead of using the fallback (argument name plus counter).

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -240,8 +240,13 @@ class TestMetafunc(object):
         values that are classes or functions: their __name__.
         """
         from _pytest.python import _idval
-        class TestClass: pass
-        def test_function(): pass
+
+        class TestClass:
+            pass
+
+        def test_function():
+            pass
+
         values = [
             (TestClass, "TestClass"),
             (test_function, "test_function"),

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -235,6 +235,20 @@ class TestMetafunc(object):
         for val, expected in values:
             assert _idval(val, 'a', 6, None) == expected
 
+    def test_class_or_function_idval(self):
+        """unittest for the expected behavior to obtain ids for parametrized
+        values that are classes or functions: their __name__.
+        """
+        from _pytest.python import _idval
+        class TestClass: pass
+        def test_function(): pass
+        values = [
+            (TestClass, "TestClass"),
+            (test_function, "test_function"),
+        ]
+        for val, expected in values:
+            assert _idval(val, 'a', 6, None) == expected
+
     @pytest.mark.issue250
     def test_idmaker_autoname(self):
         from _pytest.python import idmaker


### PR DESCRIPTION
I want to parametrize over factory functions, which I believe is a valid use-case. At the moment, the autogenerated id for the test name is then based on the argument name, plus counter to disambiguate (e.g. feature_factory0, feature_factory1, etc.). With this PR, the default behavior for functions will be the same as for classes: return the `__name__`. I think this is a more sensible default behaviour.

Semi-pseudocode example:
```
def factory_IP(T, Kernel): return do_something_with(T, Kernel)
def factory_FF(T, Kernel): return do_something_else(T, Kernel)

pytest.mark.parametrize('feature_factory,kernel_class', [
    (factory_IP, Kernel1),
    (factory_IP, Kernel2),
    (factory_FF, Kernel1),
    (factory_FF, Kernel3),
])
def test_my_model(feature_factory, kernel_class):
    """test code"""
```

As Kernel1, Kernel2, Kernel3 are classes, currently, the tests would be named as follows:
```
test_my_model[feature_factory0-Kernel1]
test_my_model[feature_factory1-Kernel2]
test_my_model[feature_factory2-Kernel1]
test_my_model[feature_factory3-Kernel3]
```

With this PR, the test names would be:
```
test_my_model[factory_IP-Kernel1]
test_my_model[factory_IP-Kernel2]
test_my_model[factory_FF-Kernel1]
test_my_model[factory_FF-Kernel3]
```
This allows you to immediately figure out which factory function is being used, and doesn't hide the fact that "feature_factory0" and "feature_factory1" are the same thing.

I hope you'll be happy to merge this :-)

PS: Pytest is great, thanks!!