### PR TITLE
Bring back TerminalReporter.writer as an alias to TerminalReporter._tw

### DIFF
--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -145,6 +145,8 @@ class TerminalReporter:
         if file is None:
             file = sys.stdout
         self._tw = _pytest.config.create_terminal_writer(config, file)
+        # self.writer will be deprecated in pytest-3.4
+        self.writer = self._tw
         self._screen_width = self._tw.fullwidth
         self.currentfspath = None
         self.reportchars = getreportopt(config)

--- a/changelog/2984.bugfix
+++ b/changelog/2984.bugfix
@@ -1,0 +1,1 @@
+Bring back ``TerminalReporter.writer`` as an alias to ``TerminalReporter._tw``. This alias was removed by accident in the ``3.3.0`` release.

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -101,6 +101,19 @@ def test_metafunc_addcall_deprecated(testdir):
     ])
 
 
+def test_terminal_reporter_writer_attr(pytestconfig):
+    """Check that TerminalReporter._tw is also available as 'writer' (#2984)
+    This attribute is planned to be deprecated in 3.4.
+    """
+    try:
+        import xdist  # noqa
+        pytest.skip('xdist workers disable the terminal reporter plugin')
+    except ImportError:
+        pass
+    terminal_reporter = pytestconfig.pluginmanager.get_plugin('terminalreporter')
+    assert terminal_reporter.writer is terminal_reporter._tw
+
+
 def test_pytest_catchlog_deprecated(testdir):
     testdir.makepyfile("""
         def test_func(pytestconfig):


### PR DESCRIPTION
Fix #2984

