### PR TITLE
[WIP] Deprecate TerminalReporter.writer 

### DIFF
--- a/_pytest/deprecated.py
+++ b/_pytest/deprecated.py
@@ -50,3 +50,6 @@ METAFUNC_ADD_CALL = (
     "Metafunc.addcall is deprecated and scheduled to be removed in pytest 4.0.\n"
     "Please use Metafunc.parametrize instead."
 )
+
+TERMINAL_REPORTER_WARNING = RemovedInPytest4Warning('The "writer" attribute is deprecated and '
+                                                    'will be removed in a future release.')

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -8,6 +8,7 @@ import itertools
 import platform
 import sys
 import time
+import warnings
 
 import pluggy
 import py
@@ -15,6 +16,7 @@ import six
 
 import pytest
 from _pytest import nodes
+from _pytest.deprecated import TERMINAL_REPORTER_WARNING
 from _pytest.main import EXIT_OK, EXIT_TESTSFAILED, EXIT_INTERRUPTED, \
     EXIT_USAGEERROR, EXIT_NOTESTSCOLLECTED
 
@@ -145,8 +147,6 @@ class TerminalReporter:
         if file is None:
             file = sys.stdout
         self._tw = _pytest.config.create_terminal_writer(config, file)
-        # self.writer will be deprecated in pytest-3.4
-        self.writer = self._tw
         self._screen_width = self._tw.fullwidth
         self.currentfspath = None
         self.reportchars = getreportopt(config)
@@ -154,6 +154,16 @@ class TerminalReporter:
         self.isatty = file.isatty()
         self._progress_items_reported = 0
         self._show_progress_info = self.config.getini('console_output_style') == 'progress'
+
+    @property
+    def writer(self):
+        warnings.warn(TERMINAL_REPORTER_WARNING, stacklevel=2)
+        return self._tw
+
+    @writer.setter
+    def writer(self, writer):
+        warnings.warn(TERMINAL_REPORTER_WARNING, stacklevel=2)
+        self._tw = writer
 
     def hasopt(self, char):
         char = {'xfailed': 'x', 'skipped': 's'}.get(char, char)

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -145,6 +145,8 @@ class TerminalReporter:
         if file is None:
             file = sys.stdout
         self._tw = _pytest.config.create_terminal_writer(config, file)
+        # self.writer will be deprecated in pytest-3.4
+        self.writer = self._tw
         self._screen_width = self._tw.fullwidth
         self.currentfspath = None
         self.reportchars = getreportopt(config)

--- a/changelog/2984.bugfix
+++ b/changelog/2984.bugfix
@@ -1,0 +1,1 @@
+Bring back ``TerminalReporter.writer`` as an alias to ``TerminalReporter._tw``. This alias was removed by accident in the ``3.3.0`` release.

--- a/changelog/2984.removal
+++ b/changelog/2984.removal
@@ -1,0 +1,1 @@
+``TerminalReporter.writer`` has been deprecated and will be removed in a future release. This attribute is an internal API which was not meant to be exposed as public, if needed use the functions of ``TerminalReporter`` directly.

--- a/doc/en/backwards-compatibility.rst
+++ b/doc/en/backwards-compatibility.rst
@@ -79,6 +79,10 @@ Use ``[tool:pytest]`` instead for compatibility with other tools.
 
 Deprecated in ``3.0``.
 
+**TerminalReporter.writer**
+
+This attribute was never meant to be part of the public API and has been deprecated in ``3.4``.
+
 Past Releases
 ~~~~~~~~~~~~~
 

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -101,6 +101,19 @@ def test_metafunc_addcall_deprecated(testdir):
     ])
 
 
+def test_terminal_reporter_writer_attr(pytestconfig):
+    """Check that TerminalReporter._tw is also available as 'writer' (#2984)
+    This attribute is planned to be deprecated in 3.4.
+    """
+    try:
+        import xdist  # noqa
+        pytest.skip('xdist workers disable the terminal reporter plugin')
+    except ImportError:
+        pass
+    terminal_reporter = pytestconfig.pluginmanager.get_plugin('terminalreporter')
+    assert terminal_reporter.writer is terminal_reporter._tw
+
+
 def test_pytest_catchlog_deprecated(testdir):
     testdir.makepyfile("""
         def test_func(pytestconfig):

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -101,9 +101,8 @@ def test_metafunc_addcall_deprecated(testdir):
     ])
 
 
-def test_terminal_reporter_writer_attr(pytestconfig):
-    """Check that TerminalReporter._tw is also available as 'writer' (#2984)
-    This attribute is planned to be deprecated in 3.4.
+def test_terminal_reporter_writer_deprecated(pytestconfig):
+    """TerminalReporter.writer is deprecated and meant to be removed in a future release (#2984)
     """
     try:
         import xdist  # noqa
@@ -111,7 +110,12 @@ def test_terminal_reporter_writer_attr(pytestconfig):
     except ImportError:
         pass
     terminal_reporter = pytestconfig.pluginmanager.get_plugin('terminalreporter')
-    assert terminal_reporter.writer is terminal_reporter._tw
+    with pytest.deprecated_call():
+        # getter
+        _ = terminal_reporter.writer  # noqa
+    with pytest.deprecated_call():
+        # setter
+        terminal_reporter.writer = terminal_reporter._tw
 
 
 def test_pytest_catchlog_deprecated(testdir):


### PR DESCRIPTION
Note that this is meant to be merged **after** #2989 and into the `features` branch.