### PR TITLE
Also blacklist pytest-capturelog plugin

### DIFF
--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -242,9 +242,10 @@ class PytestPluginManager(PluginManager):
         return opts
 
     def register(self, plugin, name=None):
-        if name == 'pytest_catchlog':
-            self._warn('pytest-catchlog plugin has been merged into the core, '
-                       'please remove it from your requirements.')
+        if name in ['pytest_catchlog', 'pytest_capturelog']:
+            self._warn('{0} plugin has been merged into the core, '
+                       'please remove it from your requirements.'.format(
+                           name.replace('_', '-')))
             return
         ret = super(PytestPluginManager, self).register(plugin, name)
         if ret:

--- a/changelog/3004.bugfix
+++ b/changelog/3004.bugfix
@@ -1,0 +1,1 @@
+The pytest-capturelog plugin is now also blacklisted, avoiding errors when running pytest with it still installed.

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -114,14 +114,15 @@ def test_terminal_reporter_writer_attr(pytestconfig):
     assert terminal_reporter.writer is terminal_reporter._tw
 
 
-def test_pytest_catchlog_deprecated(testdir):
+@pytest.mark.parametrize('plugin', ['catchlog', 'capturelog'])
+def test_pytest_catchlog_deprecated(testdir, plugin):
     testdir.makepyfile("""
         def test_func(pytestconfig):
-            pytestconfig.pluginmanager.register(None, 'pytest_catchlog')
-    """)
+            pytestconfig.pluginmanager.register(None, 'pytest_{0}')
+    """.format(plugin))
     res = testdir.runpytest()
     assert res.ret == 0
     res.stdout.fnmatch_lines([
-        "*pytest-catchlog plugin has been merged into the core*",
+        "*pytest-*log plugin has been merged into the core*",
         "*1 passed, 1 warnings*",
     ])


### PR DESCRIPTION
This is the older plugin before pytest-catchlog was around. Apparently there are
people still using it.

Fixes #3004