### PR TITLE
Improve handling of pyargs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -74,6 +74,7 @@ Grig Gheorghiu
 Grigorii Eremeev (budulianin)
 Guido Wesdorp
 Harald Armin Massa
+Henk-Jaap Wagenaar
 Hugo van Kemenade
 Hui Wang (coldnight)
 Ian Bicking

--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -729,6 +729,25 @@ class Session(FSCollector):
 
         """
         import pkgutil
+
+        if six.PY2:  # python 3.4+ uses importlib instead
+            def find_module_patched(self, fullname, path=None):
+                subname = fullname.split(".")[-1]
+                if subname != fullname and self.path is None:
+                    return None
+                if self.path is None:
+                    path = None
+                else:
+                    path = [self.path]
+                try:
+                    file, filename, etc = pkgutil.imp.find_module(subname,
+                                                                  path)
+                except ImportError:
+                    return None
+                return pkgutil.ImpLoader(fullname, file, filename, etc)
+
+            pkgutil.ImpImporter.find_module = find_module_patched
+
         try:
             loader = pkgutil.find_loader(x)
         except ImportError:

--- a/changelog/2985.bugfix
+++ b/changelog/2985.bugfix
@@ -1,0 +1,1 @@
+Fix conversion of pyargs to filename to not convert symlinks and not use deprecated features on Python 3.

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -681,17 +681,17 @@ class TestInvocationVariants(object):
         # The structure of the test directory is now:
         # .
         # ├── local
-        # │   └── lib -> ../world
+        # │   └── lib -> ../lib
         # └── lib
         #     └── foo
         #         ├── __init__.py
         #         └── bar
         #             ├── __init__.py
         #             ├── conftest.py
-        #             └── test_world.py
+        #             └── test_bar.py
 
         def join_pythonpath(*dirs):
-            cur = py.std.os.environ.get('PYTHONPATH')
+            cur = os.getenv('PYTHONPATH')
             if cur:
                 dirs += (cur,)
             return os.pathsep.join(str(p) for p in dirs)

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 
+import six
+
 import _pytest._code
 import py
 import pytest
@@ -643,6 +645,69 @@ class TestInvocationVariants(object):
         result.stdout.fnmatch_lines([
             "*test_world.py::test_other*PASSED*",
             "*1 passed*"
+        ])
+
+    @pytest.mark.skipif(not hasattr(os, "symlink"), reason="requires symlinks")
+    def test_cmdline_python_package_symlink(self, testdir, monkeypatch):
+        """
+        test --pyargs option with packages with path containing symlink can
+        have conftest.py in their package (#2985)
+        """
+        monkeypatch.delenv('PYTHONDONTWRITEBYTECODE', raising=False)
+
+        search_path = ["lib", os.path.join("local", "lib")]
+
+        dirname = "lib"
+        d = testdir.mkdir(dirname)
+        foo = d.mkdir("foo")
+        foo.ensure("__init__.py")
+        lib = foo.mkdir('bar')
+        lib.ensure("__init__.py")
+        lib.join("test_bar.py"). \
+            write("def test_bar(): pass\n"
+                  "def test_other(a_fixture):pass")
+        lib.join("conftest.py"). \
+            write("import pytest\n"
+                  "@pytest.fixture\n"
+                  "def a_fixture():pass")
+
+        d_local = testdir.mkdir("local")
+        symlink_location = os.path.join(str(d_local), "lib")
+        if six.PY2:
+            os.symlink(str(d), symlink_location)
+        else:
+            os.symlink(str(d), symlink_location, target_is_directory=True)
+
+        # The structure of the test directory is now:
+        # .
+        # ├── local
+        # │   └── lib -> ../world
+        # └── lib
+        #     └── foo
+        #         ├── __init__.py
+        #         └── bar
+        #             ├── __init__.py
+        #             ├── conftest.py
+        #             └── test_world.py
+
+        def join_pythonpath(*dirs):
+            cur = py.std.os.environ.get('PYTHONPATH')
+            if cur:
+                dirs += (cur,)
+            return os.pathsep.join(str(p) for p in dirs)
+
+        monkeypatch.setenv('PYTHONPATH', join_pythonpath(*search_path))
+        for p in search_path:
+            monkeypatch.syspath_prepend(p)
+
+        # module picked up in symlink-ed directory:
+        result = testdir.runpytest("--pyargs", "-v", "foo.bar")
+        testdir.chdir()
+        assert result.ret == 0
+        result.stdout.fnmatch_lines([
+            "*lib/foo/bar/test_bar.py::test_bar*PASSED*",
+            "*lib/foo/bar/test_bar.py::test_other*PASSED*",
+            "*2 passed*"
         ])
 
     def test_cmdline_python_package_not_exists(self, testdir):


### PR DESCRIPTION
The conversion of pyargs to paths is improved here:

- patch pkgutil to fix issue #2985 in python2.7.

Note that this might not fix the issue in python 3.0-3, as ``pkgutil.find_loader`` still worked like in python2.7 but as it is not supported I did not look into it.

I couldn't just use the backport of importlib, as it does not have importlib.find_loader or importlib.util.find_spec which is what is needed. The current (3.4+) pkgutil.find_loader uses importlib.util.find_spec under the hood, instead of parts of pkgutil.