### PR TITLE
Remove logger parameter from catching_logs

### DIFF
--- a/_pytest/logging.py
+++ b/_pytest/logging.py
@@ -79,10 +79,9 @@ def pytest_addoption(parser):
 
 
 @contextmanager
-def catching_logs(handler, formatter=None,
-                  level=logging.NOTSET, logger=None):
+def catching_logs(handler, formatter=None, level=logging.NOTSET):
     """Context manager that prepares the whole logging machinery properly."""
-    logger = logger or logging.getLogger(logger)
+    root_logger = logging.getLogger()
 
     if formatter is not None:
         handler.setFormatter(formatter)
@@ -90,18 +89,18 @@ def catching_logs(handler, formatter=None,
 
     # Adding the same handler twice would confuse logging system.
     # Just don't do that.
-    add_new_handler = handler not in logger.handlers
+    add_new_handler = handler not in root_logger.handlers
 
     if add_new_handler:
-        logger.addHandler(handler)
-    orig_level = logger.level
-    logger.setLevel(min(orig_level, level))
+        root_logger.addHandler(handler)
+    orig_level = root_logger.level
+    root_logger.setLevel(min(orig_level, level))
     try:
         yield handler
     finally:
-        logger.setLevel(orig_level)
+        root_logger.setLevel(orig_level)
         if add_new_handler:
-            logger.removeHandler(handler)
+            root_logger.removeHandler(handler)
 
 
 class LogCaptureHandler(logging.StreamHandler):


### PR DESCRIPTION
The logger parameter of catching_logs is not used anywhere. The main
motivation for removing the logger parameter is that it removes the

logger = logger or logging.getLogger(logger)

line. IMO there are too many occurrences of the string 'logg' ;)

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [ ] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bugfix)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [ ] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [ ] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Add yourself to `AUTHORS`, in alphabetical order;
