### PR TITLE
Fix memory leak caused by fixture values never been garbage collected

### DIFF
--- a/changelog/2981.bugfix
+++ b/changelog/2981.bugfix
@@ -1,0 +1,1 @@
+Fix **memory leak** where objects returned by fixtures were never destructed by the garbage collector.


### PR DESCRIPTION
The leak was caused by the (unused) `FixtureRequest._fixture_values`
cache.

This was introduced because the `partial` object (created to call
FixtureDef.finish() bound with the Request) is kept alive
through the entire session when a function-scoped fixture depends
on a session-scoped (or higher) fixture because of the nested
`addfinalizer` calls.

FixtureDef.finish() started receiving a request object in order to
obtain the proper hook proxy object (#2127), but this does not seem
useful at all in practice because `pytest_fixture_post_finalizer`
will be called with the `request` object of the moment the fixture value
was *created*, not the request object active when the fixture value
is being destroyed. We should probably deprecate/remove the request
parameter from `pytest_fixture_post_finalizer`.

Fix #2981
