### PR TITLE
Prefer https://*.readthedocs.io over http://*.rtfd.org

### DIFF
--- a/changelog/3092.doc
+++ b/changelog/3092.doc
@@ -1,0 +1,1 @@
+Prefer https://*.readthedocs.io over http://*.rtfd.org for links in the documentation.

--- a/changelog/3092.doc
+++ b/changelog/3092.doc
@@ -1,1 +1,1 @@
-Prefer https://*.readthedocs.io over http://*.rtfd.org for links in the documentation.
+Prefer ``https://*.readthedocs.io`` over ``http://*.rtfd.org`` for links in the documentation.

--- a/doc/en/projects.rst
+++ b/doc/en/projects.rst
@@ -37,7 +37,7 @@ Here are some examples of projects using ``pytest`` (please send notes via :ref:
 * `mwlib <http://pypi.python.org/pypi/mwlib>`_ mediawiki parser and utility library
 * `The Translate Toolkit <http://translate.sourceforge.net/wiki/toolkit/index>`_ for localization and conversion
 * `execnet <http://codespeak.net/execnet>`_ rapid multi-Python deployment
-* `pylib <http://py.rtfd.org>`_ cross-platform path, IO, dynamic code library
+* `pylib <https://py.readthedocs.io>`_ cross-platform path, IO, dynamic code library
 * `Pacha <http://pacha.cafepais.com/>`_ configuration management in five minutes
 * `bbfreeze <http://pypi.python.org/pypi/bbfreeze>`_ create standalone executables from Python scripts
 * `pdb++ <http://bitbucket.org/antocuni/pdb>`_ a fancier version of PDB

--- a/doc/en/tmpdir.rst
+++ b/doc/en/tmpdir.rst
@@ -106,6 +106,4 @@ When distributing tests on the local machine, ``pytest`` takes care to
 configure a basetemp directory for the sub processes such that all temporary
 data lands below a single per-test run basetemp directory.
 
-.. _`py.path.local`: http://py.rtfd.org/en/latest/path.html
-
-
+.. _`py.path.local`: https://py.readthedocs.io/en/latest/path.html


### PR DESCRIPTION
- Requests URL using https instead of http
- Avoids unnecessary redirect of `*.rtfd.org` -> `*.readthedocs.io`

`*.rtfd.org` exists as a means for pasting short URLs, which doesn't much apply for links in documentation.

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bugfix)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [ ] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Add yourself to `AUTHORS`, in alphabetical order;
