### PR TITLE
Add support for new environment marker usages

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -179,6 +179,7 @@ Tom Dalton
 Tom Viner
 Trevor Bekolay
 Tyler Goodlet
+Tzu-ping Chung
 Vasily Kuznetsov
 Victor Uriarte
 Vidar T. Fauske

--- a/setup.py
+++ b/setup.py
@@ -23,23 +23,34 @@ with open('README.rst') as fd:
     long_description = fd.read()
 
 
-def has_environment_marker_support():
+def get_environment_marker_support_level():
     """
-    Tests that setuptools has support for PEP-426 environment marker support.
+    Tests how well setuptools supports PEP-426 environment marker.
 
     The first known release to support it is 0.7 (and the earliest on PyPI seems to be 0.7.2
-    so we're using that), see: http://pythonhosted.org/setuptools/history.html#id142
+    so we're using that), see: https://setuptools.readthedocs.io/en/latest/history.html#id350
+
+    The support is later enhanced to allow direct conditional inclusions inside install_requires,
+    which is now recommended by setuptools. It first appeared in 36.2.0, went broken with 36.2.1, and
+    again worked since 36.2.2, so we're using that. See:
+    https://setuptools.readthedocs.io/en/latest/history.html#v36-2-2
+    https://github.com/pypa/setuptools/issues/1099
 
     References:
 
     * https://wheel.readthedocs.io/en/latest/index.html#defining-conditional-dependencies
     * https://www.python.org/dev/peps/pep-0426/#environment-markers
+    * https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies
     """
     try:
-        return pkg_resources.parse_version(setuptools.__version__) >= pkg_resources.parse_version('0.7.2')
+        version = pkg_resources.parse_version(setuptools.__version__)
+        if version >= pkg_resources.parse_version('36.2.2'):
+            return 2
+        if version >= pkg_resources.parse_version('0.7.2'):
+            return 1
     except Exception as exc:
         sys.stderr.write("Could not test setuptool's version: %s\n" % exc)
-        return False
+    return 0
 
 
 def main():
@@ -54,7 +65,11 @@ def main():
     # used by tox.ini to test with pluggy master
     if '_PYTEST_SETUP_SKIP_PLUGGY_DEP' not in os.environ:
         install_requires.append('pluggy>=0.5,<0.7')
-    if has_environment_marker_support():
+    environment_marker_support_level = get_environment_marker_support_level()
+    if environment_marker_support_level >= 2:
+        install_requires.append('funcsigs;python_version<"3.0"')
+        install_requires.append('colorama;sys_platform=="win32"')
+    elif environment_marker_support_level == 1:
         extras_require[':python_version<"3.0"'] = ['funcsigs']
         extras_require[':sys_platform=="win32"'] = ['colorama']
     else:


### PR DESCRIPTION
Ref pypa/pipenv#1229.

Setuptools added a new syntax in 36.2.1 for conditional requirements. This is recommended in the [documentation](https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies), and works better with dependency resolution tools that do not actually install the package.

I’m having trouble deciding whether this should be a bugfix or feature. Any suggestions?

---

- [ ] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bugfix)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [ ] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [ ] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS`, in alphabetical order;
  