### PR TITLE
Update Freezing pytest description in simple.rst

### DIFF
--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -826,15 +826,20 @@ Instead of freezing the pytest runner as a separate executable, you can make
 your frozen program work as the pytest runner by some clever
 argument handling during program startup. This allows you to 
 have a single executable, which is usually more convenient.
+Please note that the mechanism for plugin discovery used by pytest
+(setupttools entry points) doesn't work with frozen executables so pytest
+can't find any third party plugins automatically. To include third party plugins 
+like ``pytest-timeout`` they must be imported explicitly and passed on to pytest.main.
 
 .. code-block:: python
 
     # contents of app_main.py
     import sys
+    import pytest_timeout  # Third party plugin
 
     if len(sys.argv) > 1 and sys.argv[1] == '--pytest':
         import pytest
-        sys.exit(pytest.main(sys.argv[2:]))
+        sys.exit(pytest.main(sys.argv[2:], plugins=[pytest_timeout]))
     else:
         # normal application execution: at this point argv can be parsed
         # by your argument-parsing library of choice as usual
@@ -845,3 +850,4 @@ This allows you to execute tests using the frozen
 application with standard ``pytest`` command-line options::
 
     ./app_main --pytest --verbose --tb=long --junitxml=results.xml test-suite/
+


### PR DESCRIPTION
I have trouble using third party plugins in my frozen program and discovered 
that other people have experienced it as well:
https://mail.python.org/pipermail//pytest-dev/2015-June/003015.html

The problem is that the mechanism for plugin discovery used by pytest
(setupttools entry points) doesn't work with frozen executables so pytest
can't find any plugins. The solution seems to be to import the third party 
plugins explicitly as shown here:
https://mail.python.org/pipermail//pytest-dev/2015-June/003018.html

This is not mentioned anywhere in the documentaion.

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [ ] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bugfix)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [ ] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [ ] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Add yourself to `AUTHORS`, in alphabetical order;
