### PR TITLE
Access captures logs in teardown

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Ahn Ki-Wook
 Alexander Johnson
 Alexei Kozlenok
 Anatoly Bubenkoff
+Anders Hovmöller
 Andras Tim
 Andreas Zeidler
 Andrzej Ostrowski

--- a/changelog/3117.feature
+++ b/changelog/3117.feature
@@ -1,0 +1,1 @@
+New member on the `_item` member of the `caplog` fixture: `catch_log_handlers`. This contains a dict for the logs for the different stages of the test (setup, call, teardown). So to access the logs for the setup phase in your tests you can get to them via `caplog._item.catch_log_handlers`.

--- a/changelog/3117.feature
+++ b/changelog/3117.feature
@@ -1,1 +1,1 @@
-New member on the `_item` member of the `caplog` fixture: `catch_log_handlers`. This contains a dict for the logs for the different stages of the test (setup, call, teardown). So to access the logs for the setup phase in your tests you can get to them via `caplog._item.catch_log_handlers`.
+New ``caplog.get_handler(when)`` method which provides access to the underlying ``Handler`` class used to capture logging during each testing stage, allowing users to obtain the captured records during ``"setup"`` and ``"teardown"`` stages.

--- a/doc/en/logging.rst
+++ b/doc/en/logging.rst
@@ -190,3 +190,12 @@ option names are:
 * ``log_file_level``
 * ``log_file_format``
 * ``log_file_date_format``
+
+Accessing logs from other test stages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``caplop.records`` fixture contains records from the current stage only. So
+inside the setup phase it contains only setup logs, same with the call and
+teardown phases. To access logs from other stages you can use
+``caplog.get_handler('setup').records``. Valid stages are ``setup``, ``call``
+and ``teardown``.

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
+import pytest
 
 logger = logging.getLogger(__name__)
 sublogger = logging.getLogger(__name__ + '.baz')
@@ -68,3 +69,23 @@ def test_clear(caplog):
     assert len(caplog.records)
     caplog.clear()
     assert not len(caplog.records)
+
+
+@pytest.fixture
+def logging_during_setup_and_teardown(caplog):
+    logger.info('a_setup_log')
+    yield
+    logger.info('a_teardown_log')
+    assert [x.message for x in caplog.get_handler('teardown').records] == ['a_teardown_log']
+
+
+def test_caplog_captures_for_all_stages(caplog, logging_during_setup_and_teardown):
+    assert not caplog.records
+    assert not caplog.get_handler('call').records
+    logger.info('a_call_log')
+    assert [x.message for x in caplog.get_handler('call').records] == ['a_call_log']
+
+    assert [x.message for x in caplog.get_handler('setup').records] == ['a_setup_log']
+
+    # This reachers into private API, don't use this type of thing in real tests!
+    assert set(caplog._item.catch_log_handlers.keys()) == {'setup', 'call'}


### PR DESCRIPTION
This is a fix for the problem seen here: https://github.com/eisensheng/pytest-catchlog/issues/37

I would like to validate some logs globally for the entire test suite. The problem is that caplog gives you one bucket of logs for the phase you're currently in, but I want to check the 'call' bucket when I'm in 'teardown'. This change makes it possible to access all the buckets from all the other.