### PR TITLE
#2953 show a simple and easy error when keyword expressions trigger a syntax error

### DIFF
--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -60,8 +60,9 @@ def main(args=None, plugins=None):
             finally:
                 config._ensure_unconfigure()
     except UsageError as e:
+        tw = py.io.TerminalWriter(sys.stderr)
         for msg in e.args:
-            sys.stderr.write("ERROR: %s\n" % (msg,))
+            tw.line("ERROR: {}\n".format(msg), red=True)
         return 4
 
 

--- a/_pytest/mark.py
+++ b/_pytest/mark.py
@@ -222,6 +222,12 @@ class KeywordMapping(object):
         return False
 
 
+# python keywords except or, and, not
+python_keywords_list = ["False", "None", "True", "as", "assert", "break", "class", "continue", "def", "del",
+                        "elif", "else", "except", "finally", "for", "from", "global", "if", "import", "in", "is",
+                        "lambda", "nonlocal", "pass", "raise", "return", "try", "while", "with", "yield"]
+
+
 def matchmark(colitem, markexpr):
     """Tries to match on any marker names, attached to the given colitem."""
     return eval(markexpr, {}, MarkMapping.from_keywords(colitem.keywords))
@@ -259,7 +265,13 @@ def matchkeyword(colitem, keywordexpr):
         return mapping[keywordexpr]
     elif keywordexpr.startswith("not ") and " " not in keywordexpr[4:]:
         return not mapping[keywordexpr[4:]]
-    return eval(keywordexpr, {}, mapping)
+    for keyword in keywordexpr.split():
+        if keyword in python_keywords_list:
+            raise AttributeError("Python keyword '{}' not accepted in expressions passed to '-k'".format(keyword))
+    try:
+        return eval(keywordexpr, {}, mapping)
+    except SyntaxError:
+        raise AttributeError("Wrong expression passed to '-k': {}".format(keywordexpr))
 
 
 def pytest_configure(config):

--- a/_pytest/mark.py
+++ b/_pytest/mark.py
@@ -8,6 +8,8 @@ import attr
 from collections import namedtuple
 from operator import attrgetter
 from six.moves import map
+
+from _pytest.config import UsageError
 from .deprecated import MARK_PARAMETERSET_UNPACKING
 from .compat import NOTSET, getfslineno
 
@@ -265,11 +267,11 @@ def matchkeyword(colitem, keywordexpr):
         return not mapping[keywordexpr[4:]]
     for kwd in keywordexpr.split():
         if keyword.iskeyword(kwd) and kwd not in python_keywords_allowed_list:
-            raise AttributeError("Python keyword '{}' not accepted in expressions passed to '-k'".format(kwd))
+            raise UsageError("Python keyword '{}' not accepted in expressions passed to '-k'".format(kwd))
     try:
         return eval(keywordexpr, {}, mapping)
     except SyntaxError:
-        raise AttributeError("Wrong expression passed to '-k': {}".format(keywordexpr))
+        raise UsageError("Wrong expression passed to '-k': {}".format(keywordexpr))
 
 
 def pytest_configure(config):

--- a/_pytest/mark.py
+++ b/_pytest/mark.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function
 
 import inspect
+import keyword
 import warnings
 import attr
 from collections import namedtuple
@@ -222,10 +223,7 @@ class KeywordMapping(object):
         return False
 
 
-# python keywords except or, and, not
-python_keywords_list = ["False", "None", "True", "as", "assert", "break", "class", "continue", "def", "del",
-                        "elif", "else", "except", "finally", "for", "from", "global", "if", "import", "in", "is",
-                        "lambda", "nonlocal", "pass", "raise", "return", "try", "while", "with", "yield"]
+python_keywords_allowed_list = ["or", "and", "not"]
 
 
 def matchmark(colitem, markexpr):
@@ -265,9 +263,9 @@ def matchkeyword(colitem, keywordexpr):
         return mapping[keywordexpr]
     elif keywordexpr.startswith("not ") and " " not in keywordexpr[4:]:
         return not mapping[keywordexpr[4:]]
-    for keyword in keywordexpr.split():
-        if keyword in python_keywords_list:
-            raise AttributeError("Python keyword '{}' not accepted in expressions passed to '-k'".format(keyword))
+    for kwd in keywordexpr.split():
+        if keyword.iskeyword(kwd) and kwd not in python_keywords_allowed_list:
+            raise AttributeError("Python keyword '{}' not accepted in expressions passed to '-k'".format(kwd))
     try:
         return eval(keywordexpr, {}, mapping)
     except SyntaxError:

--- a/changelog/2953.trivial
+++ b/changelog/2953.trivial
@@ -1,1 +1,1 @@
-Show a simple and easy error when keyword expressions trigger a syntax error (for example, "-k foo and import" will show an error that you can not use import in expressions)
+Show a simple and easy error when keyword expressions trigger a syntax error (for example, ``"-k foo and import"`` will show an error that you can not use the ``import`` keyword in expressions).

--- a/changelog/2953.trivial
+++ b/changelog/2953.trivial
@@ -1,0 +1,1 @@
+Show a simple and easy error when keyword expressions trigger a syntax error (for example, "-k foo and import" will show an error that you can not use import in expressions)

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -344,6 +344,21 @@ def test_keyword_option_parametrize(spec, testdir):
     assert list(passed) == list(passed_result)
 
 
+@pytest.mark.parametrize("spec", [
+    ("foo or import", "AttributeError: Python keyword 'import' not accepted in expressions passed to '-k'"),
+    ("foo or", "AttributeError: Wrong expression passed to '-k': foo or")
+])
+def test_keyword_option_wrong_arguments(spec, testdir, capsys):
+    testdir.makepyfile("""
+            def test_func(arg):
+                pass
+        """)
+    opt, expected_result = spec
+    testdir.inline_run("-k", opt)
+    out = capsys.readouterr()[0]
+    assert expected_result in out
+
+
 def test_parametrized_collected_from_command_line(testdir):
     """Parametrized test not collected if test named specified
        in command line issue#649.

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -345,8 +345,8 @@ def test_keyword_option_parametrize(spec, testdir):
 
 
 @pytest.mark.parametrize("spec", [
-    ("foo or import", "AttributeError: Python keyword 'import' not accepted in expressions passed to '-k'"),
-    ("foo or", "AttributeError: Wrong expression passed to '-k': foo or")
+    ("foo or import", "ERROR: Python keyword 'import' not accepted in expressions passed to '-k'"),
+    ("foo or", "ERROR: Wrong expression passed to '-k': foo or")
 ])
 def test_keyword_option_wrong_arguments(spec, testdir, capsys):
     testdir.makepyfile("""
@@ -355,7 +355,7 @@ def test_keyword_option_wrong_arguments(spec, testdir, capsys):
         """)
     opt, expected_result = spec
     testdir.inline_run("-k", opt)
-    out = capsys.readouterr()[0]
+    out = capsys.readouterr().err
     assert expected_result in out
 
 


### PR DESCRIPTION
If we use expressions in -k option we get an error if this expression wrong of has python keywords:

> -k "foo or import"

`AttributeError: Python keyword 'import' not accepted in expressions passed to '-k'`

> -k "foo or"

`AttributeError: Wrong expression passed to '-k': foo or`
