### PR TITLE
Colorize live-log levelnames

### DIFF
--- a/changelog/3142.feature
+++ b/changelog/3142.feature
@@ -1,0 +1,1 @@
+Colorize the levelname column in the live-log output.

--- a/testing/logging/test_formatter.py
+++ b/testing/logging/test_formatter.py
@@ -1,0 +1,29 @@
+import logging
+
+import py.io
+from _pytest.logging import ColoredLevelFormatter
+
+
+def test_coloredlogformatter():
+    logfmt = '%(filename)-25s %(lineno)4d %(levelname)-8s %(message)s'
+
+    record = logging.LogRecord(
+        name='dummy', level=logging.INFO, pathname='dummypath', lineno=10,
+        msg='Test Message', args=(), exc_info=False)
+
+    class ColorConfig(object):
+        class option(object):
+            pass
+
+    tw = py.io.TerminalWriter()
+    tw.hasmarkup = True
+    formatter = ColoredLevelFormatter(tw, logfmt)
+    output = formatter.format(record)
+    assert output == ('dummypath                   10 '
+                      '\x1b[32mINFO    \x1b[0m Test Message')
+
+    tw.hasmarkup = False
+    formatter = ColoredLevelFormatter(tw, logfmt)
+    output = formatter.format(record)
+    assert output == ('dummypath                   10 '
+                      'INFO     Test Message')


### PR DESCRIPTION
I propose to prettify the default output of the live logs a bit by colorizing the levelnames. 

A screenshot paints a thousand words:
![image](https://user-images.githubusercontent.com/206581/35250898-1f680628-ffd9-11e7-93ae-56fd004eafbc.png)