### PR TITLE
Change cache directory structure to include `pytest`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ Contributors include::
 Abdeali JK
 Abhijeet Kasurde
 Ahn Ki-Wook
+Alan Velasco
 Alexander Johnson
 Alexei Kozlenok
 Anatoly Bubenkoff

--- a/_pytest/cacheprovider.py
+++ b/_pytest/cacheprovider.py
@@ -114,7 +114,8 @@ class LFPlugin(object):
                 mode = "run all (no recorded failures)"
             else:
                 noun = 'failure' if self._previously_failed_count == 1 else 'failures'
-                suffix = " first" if self.config.getvalue("failedfirst") else ""
+                suffix = " first" if self.config.getvalue(
+                    "failedfirst") else ""
                 mode = "rerun previous {count} {noun}{suffix}".format(
                     count=self._previously_failed_count, suffix=suffix, noun=noun
                 )
@@ -185,7 +186,7 @@ def pytest_addoption(parser):
         '--cache-clear', action='store_true', dest="cacheclear",
         help="remove all cache contents at start of test run.")
     parser.addini(
-        "cache_dir", default='.cache',
+        "cache_dir", default='.pytest_cache',
         help="cache directory path.")
 
 

--- a/changelog/3138.feature
+++ b/changelog/3138.feature
@@ -1,0 +1,1 @@
+The default cache directory has been renamed from ``.cache`` to ``.pytest_cache`` after community feedback that the name ``.cache`` did not make it clear that it was used by pytest.

--- a/changelog/3150.feature
+++ b/changelog/3150.feature
@@ -1,0 +1,1 @@
+Change default cache directory name from `.cache` to `.pytest_cache`

--- a/changelog/3150.feature
+++ b/changelog/3150.feature
@@ -1,1 +1,0 @@
-Change default cache directory name from `.cache` to `.pytest_cache`

--- a/testing/test_cache.py
+++ b/testing/test_cache.py
@@ -31,7 +31,7 @@ class TestNewAPI(object):
 
     def test_cache_writefail_cachfile_silent(self, testdir):
         testdir.makeini("[pytest]")
-        testdir.tmpdir.join('.cache').write('gone wrong')
+        testdir.tmpdir.join('.pytest_cache').write('gone wrong')
         config = testdir.parseconfigure()
         cache = config.cache
         cache.set('test/broken', [])
@@ -39,14 +39,14 @@ class TestNewAPI(object):
     @pytest.mark.skipif(sys.platform.startswith('win'), reason='no chmod on windows')
     def test_cache_writefail_permissions(self, testdir):
         testdir.makeini("[pytest]")
-        testdir.tmpdir.ensure_dir('.cache').chmod(0)
+        testdir.tmpdir.ensure_dir('.pytest_cache').chmod(0)
         config = testdir.parseconfigure()
         cache = config.cache
         cache.set('test/broken', [])
 
     @pytest.mark.skipif(sys.platform.startswith('win'), reason='no chmod on windows')
     def test_cache_failure_warns(self, testdir):
-        testdir.tmpdir.ensure_dir('.cache').chmod(0)
+        testdir.tmpdir.ensure_dir('.pytest_cache').chmod(0)
         testdir.makepyfile("""
             def test_error():
                 raise Exception
@@ -127,7 +127,7 @@ def test_cache_reportheader(testdir):
     """)
     result = testdir.runpytest("-v")
     result.stdout.fnmatch_lines([
-        "cachedir: .cache"
+        "cachedir: .pytest_cache"
     ])
 
 
@@ -201,8 +201,8 @@ class TestLastFailed(object):
         ])
 
         # Run this again to make sure clear-cache is robust
-        if os.path.isdir('.cache'):
-            shutil.rmtree('.cache')
+        if os.path.isdir('.pytest_cache'):
+            shutil.rmtree('.pytest_cache')
         result = testdir.runpytest("--lf", "--cache-clear")
         result.stdout.fnmatch_lines([
             "*1 failed*2 passed*",
@@ -495,15 +495,15 @@ class TestLastFailed(object):
         # Issue #1342
         testdir.makepyfile(test_empty='')
         testdir.runpytest('-q', '--lf')
-        assert not os.path.exists('.cache')
+        assert not os.path.exists('.pytest_cache')
 
         testdir.makepyfile(test_successful='def test_success():\n    assert True')
         testdir.runpytest('-q', '--lf')
-        assert not os.path.exists('.cache')
+        assert not os.path.exists('.pytest_cache')
 
         testdir.makepyfile(test_errored='def test_error():\n    assert False')
         testdir.runpytest('-q', '--lf')
-        assert os.path.exists('.cache')
+        assert os.path.exists('.pytest_cache')
 
     def test_xfail_not_considered_failure(self, testdir):
         testdir.makepyfile('''


### PR DESCRIPTION
Hi all. This should deal with the issue discussed in #3138. I've basically done the following:

- Change the `v` folder to `pytest_values`
- Change the `cache/lastfailed` directory/file to just `lastfailed` inside the `pytest_values` directory
- Change the tests accordingly.


----
Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bugfix)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [x] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS`, in alphabetical order;
