### PR TITLE
If we fail to import doctest.UnexpectedException during postmortem, fail quietly

### DIFF
--- a/_pytest/debugging.py
+++ b/_pytest/debugging.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function
 import pdb
 import sys
+from doctest import UnexpectedException
 
 
 def pytest_addoption(parser):
@@ -95,17 +96,12 @@ def _enter_pdb(node, excinfo, rep):
 
 
 def _postmortem_traceback(excinfo):
-    try:
-        from doctest import UnexpectedException
-        if isinstance(excinfo.value, UnexpectedException):
-            # A doctest.UnexpectedException is not useful for post_mortem.
-            # Use the underlying exception instead:
-            return excinfo.value.exc_info[2]
-    except ImportError:
-        # If we fail to import, continue quietly (if we ran out of file descriptors, for example: #1810)
-        pass
-
-    return excinfo._excinfo[2]
+    if isinstance(excinfo.value, UnexpectedException):
+        # A doctest.UnexpectedException is not useful for post_mortem.
+        # Use the underlying exception instead:
+        return excinfo.value.exc_info[2]
+    else:
+        return excinfo._excinfo[2]
 
 
 def _find_last_non_hidden_frame(stack):

--- a/_pytest/debugging.py
+++ b/_pytest/debugging.py
@@ -95,13 +95,17 @@ def _enter_pdb(node, excinfo, rep):
 
 
 def _postmortem_traceback(excinfo):
-    # A doctest.UnexpectedException is not useful for post_mortem.
-    # Use the underlying exception instead:
-    from doctest import UnexpectedException
-    if isinstance(excinfo.value, UnexpectedException):
-        return excinfo.value.exc_info[2]
-    else:
-        return excinfo._excinfo[2]
+    try:
+        from doctest import UnexpectedException
+        if isinstance(excinfo.value, UnexpectedException):
+            # A doctest.UnexpectedException is not useful for post_mortem.
+            # Use the underlying exception instead:
+            return excinfo.value.exc_info[2]
+    except ImportError:
+        # If we fail to import, continue quietly (if we ran out of file descriptors, for example: #1810)
+        pass
+
+    return excinfo._excinfo[2]
 
 
 def _find_last_non_hidden_frame(stack):

--- a/changelog/1810.bugfix
+++ b/changelog/1810.bugfix
@@ -1,0 +1,1 @@
+If we fail to import doctest.UnexpectedException during postmortem, fail quietly and continue.

--- a/changelog/1810.bugfix
+++ b/changelog/1810.bugfix
@@ -1,1 +1,1 @@
-If we fail to import doctest.UnexpectedException during postmortem, fail quietly and continue.
+Move import of doctest.UnexpectedException to top-level.

--- a/changelog/1810.bugfix
+++ b/changelog/1810.bugfix
@@ -1,1 +1,1 @@
-Move import of doctest.UnexpectedException to top-level.
+Move import of ``doctest.UnexpectedException`` to top-level to avoid possible errors when using ``--pdb``.


### PR DESCRIPTION
Fixes #1810