### PR TITLE
Switch `for_parameterize` to `for_parametrize`

### DIFF
--- a/_pytest/mark.py
+++ b/_pytest/mark.py
@@ -70,7 +70,7 @@ class ParameterSet(namedtuple('ParameterSet', 'values, marks, id')):
         return cls(argval, marks=newmarks, id=None)
 
     @classmethod
-    def _for_parameterize(cls, argnames, argvalues, function):
+    def _for_parametrize(cls, argnames, argvalues, function, config):
         if not isinstance(argnames, (tuple, list)):
             argnames = [x.strip() for x in argnames.split(",") if x.strip()]
             force_tuple = len(argnames) == 1

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -785,8 +785,8 @@ class Metafunc(fixtures.FuncargnamesCompatAttr):
         from _pytest.fixtures import scope2index
         from _pytest.mark import ParameterSet
         from py.io import saferepr
-        argnames, parameters = ParameterSet._for_parameterize(
-            argnames, argvalues, self.function)
+        argnames, parameters = ParameterSet._for_parametrize(
+            argnames, argvalues, self.function, self.config)
         del argvalues
 
         if scope is None:

--- a/changelog/3166.trivial
+++ b/changelog/3166.trivial
@@ -1,0 +1,1 @@
+Change the naming of ``_for_parameterize()`` to ``_for_parametrize()`` in order to comply with the naming convention.

--- a/changelog/3166.trivial
+++ b/changelog/3166.trivial
@@ -1,1 +1,1 @@
-Change the naming of ``_for_parameterize()`` to ``_for_parametrize()`` in order to comply with the naming convention.
+Rename ``ParameterSet._for_parameterize()`` to ``_for_parametrize()`` in order to comply with the naming convention.


### PR DESCRIPTION
_From the authors that brought you the controversial #3159..._

Change the naming of `for_parameterize` to `for_parametrize` in order to comply with the current convention on naming. This should make the whole codebase as of now have the `parametrize` spelling.
🐍 

_Now in theaters close to your location_