### PR TITLE
Fix test for py37

### DIFF
--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -206,13 +206,13 @@ class TestWarns(object):
             with pytest.warns(RuntimeWarning):
                 warnings.warn("user", UserWarning)
         excinfo.match(r"DID NOT WARN. No warnings of type \(.+RuntimeWarning.+,\) was emitted. "
-                      r"The list of emitted warnings is: \[UserWarning\('user',\)\].")
+                      r"The list of emitted warnings is: \[UserWarning\('user',?\)\].")
 
         with pytest.raises(pytest.fail.Exception) as excinfo:
             with pytest.warns(UserWarning):
                 warnings.warn("runtime", RuntimeWarning)
         excinfo.match(r"DID NOT WARN. No warnings of type \(.+UserWarning.+,\) was emitted. "
-                      r"The list of emitted warnings is: \[RuntimeWarning\('runtime',\)\].")
+                      r"The list of emitted warnings is: \[RuntimeWarning\('runtime',?\)\].")
 
         with pytest.raises(pytest.fail.Exception) as excinfo:
             with pytest.warns(UserWarning):


### PR DESCRIPTION
In previous Python versions, the list of warnings when `pytest.warns` fails appears like:

```
	... list of emitted warnings is: [UserWarning('user',)].
```

In Python 3.7 apparently the string representation has been improved to:

```
	... list of emitted warnings is: [UserWarning('user')].
```

Fix #3011

I would recommend to leave py37 in the "allowed failures" section for now, at least until py37 releases its first beta.