### PR TITLE
Fix: UnicodeDecodeError: 'ascii' codec can't decode byte X.

### DIFF
--- a/_pytest/runner.py
+++ b/_pytest/runner.py
@@ -262,7 +262,10 @@ class BaseReport(object):
 
         .. versionadded:: 3.0
         """
-        return ''.join(content for (prefix, content) in self.get_sections('Captured stdout'))
+        try:
+            return ''.join(content for (prefix, content) in self.get_sections('Captured stdout'))
+        except UnicodeDecodeError:
+            return ''.join(content.decode('utf-8') for (prefix, content) in self.get_sections('Captured stdout'))
 
     @property
     def capstderr(self):
@@ -270,7 +273,10 @@ class BaseReport(object):
 
         .. versionadded:: 3.0
         """
-        return ''.join(content for (prefix, content) in self.get_sections('Captured stderr'))
+        try:
+            return ''.join(content for (prefix, content) in self.get_sections('Captured stderr'))
+        except UnicodeDecodeError:
+            return ''.join(content.decode('utf-8') for (prefix, content) in self.get_sections('Captured stderr'))
 
     passed = property(lambda x: x.outcome == "passed")
     failed = property(lambda x: x.outcome == "failed")


### PR DESCRIPTION
Our tests started failing on
```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 35: ordinal not in range(128)".
```
With this PR the issue is solved, since aparently we are printing in the logs some non ascii characters. Should we support utf-8 here or should I make sure that I print only ascii characters in the logs?
In case the PR is ok, I 'll repost adjusting the changelog file.

Thanks for your feedback!