### PR TITLE
#1478 Added --no-stdout option

### DIFF
--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -42,9 +42,10 @@ def pytest_addoption(parser):
                      action="store", dest="tbstyle", default='auto',
                      choices=['auto', 'long', 'short', 'no', 'line', 'native'],
                      help="traceback print mode (auto/long/short/line/native/no).")
-    group._addoption('--no-stdout',
-                     action="store_false", dest="nostdout",
-                     help="Do not print stdout")
+    group._addoption('--show-capture',
+                     action="store", dest="showcapture",
+                     choices=['no', 'stdout', 'stderr'],
+                     help="Print only stdout/stderr on not print both.")
     group._addoption('--fulltrace', '--full-trace',
                      action="store_true", default=False,
                      help="don't cut any tracebacks (default is to cut).")
@@ -625,8 +626,10 @@ class TerminalReporter:
 
     def _outrep_summary(self, rep):
         rep.toterminal(self._tw)
+        if self.config.option.showcapture == 'no':
+            return
         for secname, content in rep.sections:
-            if not self.config.option.nostdout and 'stdout' in secname:
+            if self.config.option.showcapture and not (self.config.option.showcapture in secname):
                 continue
             self._tw.sep("-", secname)
             if content[-1:] == "\n":

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -630,7 +630,6 @@ class TerminalReporter:
         if self.config.option.showcapture == 'no':
             return
         for secname, content in rep.sections:
-            print(self.config.option.showcapture)
             if self.config.option.showcapture != 'both':
                 if not (self.config.option.showcapture in secname):
                     continue

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -44,8 +44,9 @@ def pytest_addoption(parser):
                      help="traceback print mode (auto/long/short/line/native/no).")
     group._addoption('--show-capture',
                      action="store", dest="showcapture",
-                     choices=['no', 'stdout', 'stderr'],
-                     help="Print only stdout/stderr on not print both.")
+                     choices=['no', 'stdout', 'stderr', 'both'], default='both',
+                     help="Controls how captured stdout/stderr is shown on failed tests. "
+                          "Default is 'both'.")
     group._addoption('--fulltrace', '--full-trace',
                      action="store_true", default=False,
                      help="don't cut any tracebacks (default is to cut).")
@@ -629,8 +630,10 @@ class TerminalReporter:
         if self.config.option.showcapture == 'no':
             return
         for secname, content in rep.sections:
-            if self.config.option.showcapture and not (self.config.option.showcapture in secname):
-                continue
+            print(self.config.option.showcapture)
+            if self.config.option.showcapture != 'both':
+                if not (self.config.option.showcapture in secname):
+                    continue
             self._tw.sep("-", secname)
             if content[-1:] == "\n":
                 content = content[:-1]

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -42,6 +42,9 @@ def pytest_addoption(parser):
                      action="store", dest="tbstyle", default='auto',
                      choices=['auto', 'long', 'short', 'no', 'line', 'native'],
                      help="traceback print mode (auto/long/short/line/native/no).")
+    group._addoption('--no-stdout',
+                     action="store_false", dest="nostdout",
+                     help="Do not print stdout")
     group._addoption('--fulltrace', '--full-trace',
                      action="store_true", default=False,
                      help="don't cut any tracebacks (default is to cut).")
@@ -623,6 +626,8 @@ class TerminalReporter:
     def _outrep_summary(self, rep):
         rep.toterminal(self._tw)
         for secname, content in rep.sections:
+            if not self.config.option.nostdout and 'stdout' in secname:
+                continue
             self._tw.sep("-", secname)
             if content[-1:] == "\n":
                 content = content[:-1]

--- a/changelog/1478.feature
+++ b/changelog/1478.feature
@@ -1,0 +1,4 @@
+Added `--show-capture` feature. You can choose 'no', 'stdout' or 'stderr' option.
+'no': stdout and stderr will now shown
+'stdout': stdout will shown in terminal if you use this option but stderr will not shown.
+'stderr': stderr will shown in terminal if you use this option but stdout will not shown.

--- a/changelog/1478.feature
+++ b/changelog/1478.feature
@@ -1,4 +1,1 @@
-Added `--show-capture` feature. You can choose 'no', 'stdout' or 'stderr' option.
-'no': stdout and stderr will now shown
-'stdout': stdout will shown in terminal if you use this option but stderr will not shown.
-'stderr': stderr will shown in terminal if you use this option but stdout will not shown.
+New ``--show-capture`` command-line option that allows to specify how to display captured output when tests fail: ``no``, ``stdout``, ``stderr`` or ``both`` (the default).

--- a/changelog/1478.trivial
+++ b/changelog/1478.trivial
@@ -1,1 +1,0 @@
-Added `--no-stdout` feature. Stdout will not shown in terminal if you use this option. Only Stderr will shown.

--- a/changelog/1478.trivial
+++ b/changelog/1478.trivial
@@ -1,0 +1,1 @@
+Added `--no-stdout` feature. Stdout will not shown in terminal if you use this option. Only Stderr will shown.

--- a/doc/en/capture.rst
+++ b/doc/en/capture.rst
@@ -9,7 +9,8 @@ Default stdout/stderr/stdin capturing behaviour
 
 During test execution any output sent to ``stdout`` and ``stderr`` is
 captured.  If a test or a setup method fails its according captured
-output will usually be shown along with the failure traceback.
+output will usually be shown along with the failure traceback. (this
+behavior can be configured by the ``--show-capture`` command-line option).
 
 In addition, ``stdin`` is set to a "null" object which will
 fail on attempts to read from it because it is rarely desired

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -823,6 +823,19 @@ def pytest_report_header(config, startdir):
             str(testdir.tmpdir),
         ])
 
+    def test_no_stdout(self, testdir):
+        testdir.makepyfile("""
+            def test_one():
+                print('!This is stdout!')
+                assert False, 'Something failed'
+        """)
+
+        result = testdir.runpytest("--tb=short")
+        result.stdout.fnmatch_lines(["!This is stdout!"])
+
+        result = testdir.runpytest("--no-stdout", "--tb=short")
+        assert "!This is stdout!" not in result.stdout.str()
+
 
 @pytest.mark.xfail("not hasattr(os, 'dup')")
 def test_fdopen_kept_alive_issue124(testdir):

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -836,6 +836,10 @@ def pytest_report_header(config, startdir):
         result.stdout.fnmatch_lines(["!This is stdout!"])
         result.stdout.fnmatch_lines(["!This is stderr!"])
 
+        result = testdir.runpytest("--show-capture=both", "--tb=short")
+        result.stdout.fnmatch_lines(["!This is stdout!"])
+        result.stdout.fnmatch_lines(["!This is stderr!"])
+
         result = testdir.runpytest("--show-capture=stdout", "--tb=short")
         assert "!This is stderr!" not in result.stdout.str()
         assert "!This is stdout!" in result.stdout.str()
@@ -843,6 +847,10 @@ def pytest_report_header(config, startdir):
         result = testdir.runpytest("--show-capture=stderr", "--tb=short")
         assert "!This is stdout!" not in result.stdout.str()
         assert "!This is stderr!" in result.stdout.str()
+
+        result = testdir.runpytest("--show-capture=no", "--tb=short")
+        assert "!This is stdout!" not in result.stdout.str()
+        assert "!This is stderr!" not in result.stdout.str()
 
 
 @pytest.mark.xfail("not hasattr(os, 'dup')")

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -823,18 +823,26 @@ def pytest_report_header(config, startdir):
             str(testdir.tmpdir),
         ])
 
-    def test_no_stdout(self, testdir):
+    def test_show_capture(self, testdir):
         testdir.makepyfile("""
+            import sys
             def test_one():
-                print('!This is stdout!')
+                sys.stdout.write('!This is stdout!')
+                sys.stderr.write('!This is stderr!')
                 assert False, 'Something failed'
         """)
 
         result = testdir.runpytest("--tb=short")
         result.stdout.fnmatch_lines(["!This is stdout!"])
+        result.stdout.fnmatch_lines(["!This is stderr!"])
 
-        result = testdir.runpytest("--no-stdout", "--tb=short")
+        result = testdir.runpytest("--show-capture=stdout", "--tb=short")
+        assert "!This is stderr!" not in result.stdout.str()
+        assert "!This is stdout!" in result.stdout.str()
+
+        result = testdir.runpytest("--show-capture=stderr", "--tb=short")
         assert "!This is stdout!" not in result.stdout.str()
+        assert "!This is stderr!" in result.stdout.str()
 
 
 @pytest.mark.xfail("not hasattr(os, 'dup')")


### PR DESCRIPTION
Task #1478 

How it works:

We have a test:
```
def test_one():
    print('This is stdout!')
    assert 0
```
Run pytest:
```
pytest --tb=short
```
We got this:
```
tests/test_one.py F                                                                                                                                                                     [100%]
=================================================================================== short test summary info ===================================================================================
FAIL tests/test_one.py::test_one

========================================================================================== FAILURES ===========================================================================================
__________________________________________________________________________________________ test_one ___________________________________________________________________________________________
tests/test_one.py:3: in test_one
    assert 0
E   assert 0
------------------------------------------------------------------------------------ Captured stdout call -------------------------------------------------------------------------------------
This is stdout!
================================================================================== 1 failed in 0.03 seconds ===================================================================================
```
If we call pytest with option --no-stdout we will not see Captured stdout call section:
```
pytest --tb=short --no-stdout
```
```
tests/test_one.py F                                                                                                                                                                     [100%]
=================================================================================== short test summary info ===================================================================================
FAIL tests/test_one.py::test_one

========================================================================================== FAILURES ===========================================================================================
__________________________________________________________________________________________ test_one ___________________________________________________________________________________________
tests/test_one.py:3: in test_one
    assert 0
E   assert 0
================================================================================== 1 failed in 0.04 seconds ===================================================================================
```

P.S. stderr will be shown fine