### PR TITLE
Fixes #3149 so a doctest will continue to generate output after failures

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -186,6 +186,7 @@ Victor Uriarte
 Vidar T. Fauske
 Vitaly Lashmanov
 Vlad Dragos
+William Lee
 Wouter van Ackooy
 Xuan Luong
 Xuecong Liao

--- a/_pytest/debugging.py
+++ b/_pytest/debugging.py
@@ -97,11 +97,15 @@ def _enter_pdb(node, excinfo, rep):
 def _postmortem_traceback(excinfo):
     # A doctest.UnexpectedException is not useful for post_mortem.
     # Use the underlying exception instead:
+    from _pytest.doctest import MultipleDoctestFailures
     from doctest import UnexpectedException
-    if isinstance(excinfo.value, UnexpectedException):
-        return excinfo.value.exc_info[2]
-    else:
-        return excinfo._excinfo[2]
+    if isinstance(excinfo.value, MultipleDoctestFailures):
+        failures = excinfo.value.failures
+        for failure in failures:
+            if isinstance(failure, UnexpectedException):
+                return failure.exc_info[2]
+
+    return excinfo._excinfo[2]
 
 
 def _find_last_non_hidden_frame(stack):

--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -125,8 +125,8 @@ def _init_runner_class():
         """
         def __init__(self, checker=None, verbose=None, optionflags=0,
                      continue_on_failure=True):
-            super(PytestDoctestRunner, self).__init__(
-                checker=checker, verbose=verbose, optionflags=optionflags)
+            doctest.DocTestRunner.__init__(
+                self, checker=checker, verbose=verbose, optionflags=optionflags)
             self.continue_on_failure = continue_on_failure
 
         def report_start(self, out, test, example):

--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -22,6 +22,9 @@ DOCTEST_REPORT_CHOICES = (
     DOCTEST_REPORT_CHOICE_ONLY_FIRST_FAILURE,
 )
 
+# Lazy definiton of runner class
+RUNNER_CLASS = None
+
 
 def pytest_addoption(parser):
     parser.addini('doctest_optionflags', 'option flags for doctests',
@@ -75,14 +78,72 @@ def _is_doctest(config, path, parent):
 
 class ReprFailDoctest(TerminalRepr):
 
-    def __init__(self, reprlocation, lines):
-        self.reprlocation = reprlocation
-        self.lines = lines
+    def __init__(self, reprlocation_lines):
+        # List of (reprlocation, lines) tuples
+        self.reprlocation_lines = reprlocation_lines
 
     def toterminal(self, tw):
-        for line in self.lines:
-            tw.line(line)
-        self.reprlocation.toterminal(tw)
+        for reprlocation, lines in self.reprlocation_lines:
+            for line in lines:
+                tw.line(line)
+            reprlocation.toterminal(tw)
+
+
+class DoctestFailureContainer(object):
+
+    NAME = 'DocTestFailure'
+
+    def __init__(self, test, example, got):
+        self.test = test
+        self.example = example
+        self.got = got
+
+
+class DoctestUnexpectedExceptionContainer(object):
+
+    NAME = 'DoctestUnexpectedException'
+
+    def __init__(self, test, example, exc_info):
+        self.test = test
+        self.example = example
+        self.exc_info = exc_info
+
+
+def _init_runner_class():
+    import doctest
+
+    class PytestDoctestRunner(doctest.DocTestRunner):
+        """
+        Runner to collect failures.  Note that the out variable in this case is
+        a list instead of a stdout-like object
+        """
+        def report_start(self, out, test, example):
+            pass
+
+        def report_success(self, out, test, example, got):
+            pass
+
+        def report_failure(self, out, test, example, got):
+            out.append(DoctestFailureContainer(test, example, got))
+
+        def report_unexpected_exception(self, out, test, example, exc_info):
+            out.append(DoctestUnexpectedExceptionContainer(test, example, exc_info))
+
+    return PytestDoctestRunner
+
+
+def _get_runner(*args, **kwargs):
+    # We need this in order to do a lazy import on doctest
+    global RUNNER_CLASS
+    if RUNNER_CLASS is None:
+        RUNNER_CLASS = _init_runner_class()
+    return RUNNER_CLASS(*args, **kwargs)
+
+
+class DoctestFailure(Exception):
+    def __init__(self, failures):
+        super(DoctestFailure, self).__init__()
+        self.failures = failures
 
 
 class DoctestItem(pytest.Item):
@@ -103,46 +164,52 @@ class DoctestItem(pytest.Item):
 
     def runtest(self):
         _check_all_skipped(self.dtest)
-        self.runner.run(self.dtest)
+        failures = []
+        self.runner.run(self.dtest, out=failures)
+        if failures:
+            raise DoctestFailure(failures)
 
     def repr_failure(self, excinfo):
-        import doctest
-        if excinfo.errisinstance((doctest.DocTestFailure,
-                                  doctest.UnexpectedException)):
+        if excinfo.errisinstance(DoctestFailure):
             doctestfailure = excinfo.value
-            example = doctestfailure.example
-            test = doctestfailure.test
-            filename = test.filename
-            if test.lineno is None:
-                lineno = None
-            else:
-                lineno = test.lineno + example.lineno + 1
-            message = excinfo.type.__name__
-            reprlocation = ReprFileLocation(filename, lineno, message)
-            checker = _get_checker()
-            report_choice = _get_report_choice(self.config.getoption("doctestreport"))
-            if lineno is not None:
-                lines = doctestfailure.test.docstring.splitlines(False)
-                # add line numbers to the left of the error message
-                lines = ["%03d %s" % (i + test.lineno + 1, x)
-                         for (i, x) in enumerate(lines)]
-                # trim docstring error lines to 10
-                lines = lines[max(example.lineno - 9, 0):example.lineno + 1]
-            else:
-                lines = ['EXAMPLE LOCATION UNKNOWN, not showing all tests of that example']
-                indent = '>>>'
-                for line in example.source.splitlines():
-                    lines.append('??? %s %s' % (indent, line))
-                    indent = '...'
-            if excinfo.errisinstance(doctest.DocTestFailure):
-                lines += checker.output_difference(example,
-                                                   doctestfailure.got, report_choice).split("\n")
-            else:
-                inner_excinfo = ExceptionInfo(excinfo.value.exc_info)
-                lines += ["UNEXPECTED EXCEPTION: %s" %
-                          repr(inner_excinfo.value)]
-                lines += traceback.format_exception(*excinfo.value.exc_info)
-            return ReprFailDoctest(reprlocation, lines)
+            failures = doctestfailure.failures
+            reprlocation_lines = []
+            for failure in failures:
+                example = failure.example
+                test = failure.test
+                filename = test.filename
+                if test.lineno is None:
+                    lineno = None
+                else:
+                    lineno = test.lineno + example.lineno + 1
+                message = failure.NAME
+                reprlocation = ReprFileLocation(filename, lineno, message)
+                checker = _get_checker()
+                report_choice = _get_report_choice(self.config.getoption("doctestreport"))
+                if lineno is not None:
+                    lines = failure.test.docstring.splitlines(False)
+                    # add line numbers to the left of the error message
+                    lines = ["%03d %s" % (i + test.lineno + 1, x)
+                             for (i, x) in enumerate(lines)]
+                    # trim docstring error lines to 10
+                    lines = lines[max(example.lineno - 9, 0):example.lineno + 1]
+                else:
+                    lines = ['EXAMPLE LOCATION UNKNOWN, not showing all tests of that example']
+                    indent = '>>>'
+                    for line in example.source.splitlines():
+                        lines.append('??? %s %s' % (indent, line))
+                        indent = '...'
+                if isinstance(failure, DoctestFailureContainer):
+                    lines += checker.output_difference(example,
+                                                       failure.got,
+                                                       report_choice).split("\n")
+                else:
+                    inner_excinfo = ExceptionInfo(failure.exc_info)
+                    lines += ["UNEXPECTED EXCEPTION: %s" %
+                              repr(inner_excinfo.value)]
+                    lines += traceback.format_exception(*failure.exc_info)
+                reprlocation_lines.append((reprlocation, lines))
+            return ReprFailDoctest(reprlocation_lines)
         else:
             return super(DoctestItem, self).repr_failure(excinfo)
 
@@ -187,8 +254,8 @@ class DoctestTextfile(pytest.Module):
         globs = {'__name__': '__main__'}
 
         optionflags = get_optionflags(self)
-        runner = doctest.DebugRunner(verbose=0, optionflags=optionflags,
-                                     checker=_get_checker())
+        runner = _get_runner(verbose=0, optionflags=optionflags,
+                             checker=_get_checker())
         _fix_spoof_python2(runner, encoding)
 
         parser = doctest.DocTestParser()
@@ -223,8 +290,8 @@ class DoctestModule(pytest.Module):
         # uses internal doctest module parsing mechanism
         finder = doctest.DocTestFinder()
         optionflags = get_optionflags(self)
-        runner = doctest.DebugRunner(verbose=0, optionflags=optionflags,
-                                     checker=_get_checker())
+        runner = _get_runner(verbose=0, optionflags=optionflags,
+                             checker=_get_checker())
 
         for test in finder.find(module, module.__name__):
             if test.examples:  # skip empty doctests

--- a/changelog/3149.bugfix
+++ b/changelog/3149.bugfix
@@ -1,0 +1,1 @@
+Fix doctest failure output so that it will continue to run despite the first failure.

--- a/changelog/3149.bugfix
+++ b/changelog/3149.bugfix
@@ -1,1 +1,0 @@
-Fix doctest failure output so that it will continue to run despite the first failure.

--- a/changelog/3149.feature
+++ b/changelog/3149.feature
@@ -1,0 +1,1 @@
+Doctest runs now show multiple failures for each doctest snippet, instead of stopping at the first failure.

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -756,6 +756,25 @@ class TestDoctestSkips(object):
         reprec = testdir.inline_run("--doctest-modules")
         reprec.assertoutcome(passed=0, skipped=0)
 
+    def test_continue_on_failure(self, testdir):
+        testdir.maketxtfile(test_something="""
+            >>> i = 5
+            >>> def foo():
+            ...     raise ValueError('error1')
+            >>> foo()
+            >>> i
+            >>> i + 2
+            7
+            >>> i + 1
+        """)
+        result = testdir.runpytest("--doctest-modules")
+        result.assert_outcomes(passed=0, failed=1)
+        # We need to make sure we have two failure lines (4, 5, and 8) instead of
+        # one.
+        result.stdout.fnmatch_lines("*test_something.txt:4: DoctestUnexpectedException*")
+        result.stdout.fnmatch_lines("*test_something.txt:5: DocTestFailure*")
+        result.stdout.fnmatch_lines("*test_something.txt:8: DocTestFailure*")
+
 
 class TestDoctestAutoUseFixtures(object):
 


### PR DESCRIPTION
Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [x] Add a new news fragment into the changelog folder
  * name it `$issue_id.$type` for example (588.bugfix)
  * if you don't have an issue_id change it to the pr id after creating the pr
  * ensure type is one of `removal`, `feature`, `bugfix`, `vendor`, `doc` or `trivial`
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
- [x] Target: for `bugfix`, `vendor`, `doc` or `trivial` fixes, target `master`; for removals or features target `features`;
- [x] Make sure to include reasonable tests for your change if necessary

Unless your change is a trivial or a documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS`, in alphabetical order;
