### PR TITLE
Support py37 officially

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,6 @@ matrix:
       python: '3.5'
     - env: TOXENV=py37
       python: 'nightly'
-  allow_failures:
-    - env: TOXENV=py37
-      python: 'nightly'
 
 script: tox --recreate
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ classifiers = [
     'Topic :: Utilities',
 ] + [
     ('Programming Language :: Python :: %s' % x)
-    for x in '2 2.7 3 3.4 3.5 3.6'.split()
+    for x in '2 2.7 3 3.4 3.5 3.6 3.7'.split()
 ]
 
 with open('README.rst') as fd:


### PR DESCRIPTION
Python 3.7.0b1 has been released:

	https://www.python.org/downloads/release/python-370b1/

Fix #3168
