### PR TITLE
skip failing pdb/doctest test on mac

### DIFF
--- a/changelog/985.bugfix
+++ b/changelog/985.bugfix
@@ -1,0 +1,1 @@
+Skip failing pdb/doctest test on mac.

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -267,6 +267,10 @@ class TestPDB(object):
         child.read()
         self.flush(child)
 
+    # For some reason the interaction between doctest's and pytest's output
+    # capturing mechanisms are messing up the stdout on mac. (See #985).
+    # Should be solvable, but skipping until we have a chance to investigate.
+    @pytest.mark.skipif("sys.platform == 'darwin'")
     def test_pdb_interaction_doctest(self, testdir):
         p1 = testdir.makepyfile("""
             import pytest

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -270,7 +270,7 @@ class TestPDB(object):
     # For some reason the interaction between doctest's and pytest's output
     # capturing mechanisms are messing up the stdout on mac. (See #985).
     # Should be solvable, but skipping until we have a chance to investigate.
-    @pytest.mark.skipif("sys.platform == 'darwin'")
+    @pytest.mark.xfail("sys.platform == 'darwin'", reason='See issue #985', run=False)
     def test_pdb_interaction_doctest(self, testdir):
         p1 = testdir.makepyfile("""
             import pytest


### PR DESCRIPTION
Relates to #985 
