### PR TITLE
Fixed how files are opened in capture.py to be compatible on Windows

### DIFF
--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -320,7 +320,7 @@ def safe_text_dupfile(f, mode, default_encoding="UTF8"):
         newfd = os.dup(fd)
         if "b" not in mode:
             mode += "b"
-        f = os.fdopen(newfd, mode, 0)  # no buffering
+        f = io.open(newfd, mode)
     return EncodedFile(f, encoding or default_encoding)
 
 

--- a/changelog/3197.bugfix.rst
+++ b/changelog/3197.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed how files are opened in pytest/_pytest/capture.py to be compatible on Windows.


### PR DESCRIPTION
My build system, which uses Pytest, was running into a file IO error on Windows. Specifically: 
```
  File "C:\jenkins\workspace\PR+name\.venv\lib\site-packages\_pytest\capture.py", line 337, in write
    self.buffer.write(obj)
IOError: [Errno 0] Error
```
_fdopen on Windows requires an intervening fflush, fsetpos, fseek, or rewind operation when switching between reading and writing. See: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fdopen-wfdopen

This fix is to circumvent this requirement by using io.open() instead.