### PR TITLE
Add Sphinx parameter docs for `match` and `message` args to `pytest.raises()`

### DIFF
--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -453,6 +453,10 @@ def raises(expected_exception, *args, **kwargs):
     Assert that a code block/function call raises ``expected_exception``
     and raise a failure exception otherwise.
 
+    :arg message: if specified, provides a custom failure message if the
+        exception is not raised
+    :arg match: if specified, asserts that the exception matches a text or regex
+
     This helper produces a ``ExceptionInfo()`` object (see below).
 
     You may use this function as a context manager::

--- a/changelog/3202.doc.rst
+++ b/changelog/3202.doc.rst
@@ -1,0 +1,1 @@
+Add Sphinx parameter docs for ``match`` and ``message`` args to ``pytest.raises``.

--- a/changelog/3202.trivial.rst
+++ b/changelog/3202.trivial.rst
@@ -1,1 +1,0 @@
-Add Sphinx parameter docs for ``match`` and ``message`` args to :func:`pytest.raises`.

--- a/changelog/3202.trivial.rst
+++ b/changelog/3202.trivial.rst
@@ -1,0 +1,1 @@
+Add Sphinx parameter docs for ``match`` and ``message`` args to :func:`pytest.raises`.


### PR DESCRIPTION
I've been using pytest for years and never noticed either of these until this week!