### PR TITLE
Fix mock patchings detection when both mock and unittest.mock are present

### DIFF
--- a/_pytest/compat.py
+++ b/_pytest/compat.py
@@ -79,10 +79,11 @@ def num_mock_patch_args(function):
     patchings = getattr(function, "patchings", None)
     if not patchings:
         return 0
-    mock = sys.modules.get("mock", sys.modules.get("unittest.mock", None))
-    if mock is not None:
+    mock_modules = [sys.modules.get("mock"), sys.modules.get("unittest.mock")]
+    if any(mock_modules):
+        sentinels = [m.DEFAULT for m in mock_modules if m is not None]
         return len([p for p in patchings
-                    if not p.attribute_name and p.new is mock.DEFAULT])
+                    if not p.attribute_name and p.new in sentinels])
     return len(patchings)
 
 

--- a/changelog/3206.bugfix.rst
+++ b/changelog/3206.bugfix.rst
@@ -1,0 +1,1 @@
+Detect arguments injected by ``unittest.mock.patch`` decorator correctly when pypi ``mock.patch`` is installed and imported.

--- a/testing/python/integration.py
+++ b/testing/python/integration.py
@@ -147,6 +147,28 @@ class TestMockDecoration(object):
         reprec = testdir.inline_run()
         reprec.assertoutcome(passed=1)
 
+    def test_unittest_mock_and_pypi_mock(self, testdir):
+        pytest.importorskip("unittest.mock")
+        pytest.importorskip("mock", "1.0.1")
+        testdir.makepyfile("""
+            import mock
+            import unittest.mock
+            class TestBoth(object):
+                @unittest.mock.patch("os.path.abspath")
+                def test_hello(self, abspath):
+                    import os
+                    os.path.abspath("hello")
+                    abspath.assert_any_call("hello")
+
+                @mock.patch("os.path.abspath")
+                def test_hello_mock(self, abspath):
+                    import os
+                    os.path.abspath("hello")
+                    abspath.assert_any_call("hello")
+        """)
+        reprec = testdir.inline_run()
+        reprec.assertoutcome(passed=2)
+
     def test_mock(self, testdir):
         pytest.importorskip("mock", "1.0.1")
         testdir.makepyfile("""


### PR DESCRIPTION
If pypi `mock` package is installed and imported at any time during test run, it's impossible to use Python 3 `@unittest.mock.patch(...)` decorator. Mock object argument is not recognized by pytest with error like this:

```
      @unittest.mock.patch("os.path.abspath")
      def test_hello(self, abspath):
E       fixture 'abspath' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, monkeypatch, pytestconfig, record_xml_attribute, record_xml_property, recwarn, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.
```

It's often not possible to go with `unittest.mock` only, as pypi `mock` can be implicitly pulled by one of project dependencies. In my case, it's `moto` package.