### PR TITLE
print captured logs before entering pdb

### DIFF
--- a/_pytest/debugging.py
+++ b/_pytest/debugging.py
@@ -97,6 +97,12 @@ def _enter_pdb(node, excinfo, rep):
         tw.sep(">", "captured stderr")
         tw.line(captured_stderr)
 
+    captured_logs = rep.caplog
+    if len(captured_logs) > 0:
+        if node.config.getoption('log_print') is not False:
+            tw.sep(">", "captured logs")
+            tw.line(captured_logs)
+
     tw.sep(">", "traceback")
     rep.toterminal(tw)
     tw.sep(">", "entering PDB")

--- a/changelog/3204.feature
+++ b/changelog/3204.feature
@@ -1,0 +1,1 @@
+Captured logs are printed before entering pdb, unless ``--no-print-logs`` is defined.


### PR DESCRIPTION
Fixes #3204. This is conceptually a continuation of #3186 but is not actually dependent on it.