### PR TITLE
Disable output capturing in doctest

### DIFF
--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -105,10 +105,10 @@ class DoctestItem(pytest.Item):
 
     def runtest(self):
         _check_all_skipped(self.dtest)
-        self._disable_output_capturing()
+        self._disable_output_capturing_for_darwin()
         self.runner.run(self.dtest)
 
-    def _disable_output_capturing(self):
+    def _disable_output_capturing_for_darwin(self):
         """
         Disable output capturing. Otherwise, stdout is lost to doctest (#985)
         """

--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -118,7 +118,7 @@ class DoctestItem(pytest.Item):
         if capman:
             out, err = capman.suspend_global_capture(in_=True)
             sys.stdout.write(out)
-        sys.stdout.write(err)
+            sys.stdout.write(err)
 
     def repr_failure(self, excinfo):
         import doctest

--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 
 import traceback
 import sys
+import platform
 
 import pytest
 from _pytest._code.code import ExceptionInfo, ReprFileLocation, TerminalRepr
@@ -111,6 +112,8 @@ class DoctestItem(pytest.Item):
         """
         Disable output capturing. Otherwise, stdout is lost to doctest (#985)
         """
+        if platform.system() != 'Darwin':
+            return
         capman = self.config.pluginmanager.getplugin("capturemanager")
         if capman:
             out, err = capman.suspend_global_capture(in_=True)

--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -118,7 +118,7 @@ class DoctestItem(pytest.Item):
         if capman:
             out, err = capman.suspend_global_capture(in_=True)
             sys.stdout.write(out)
-            sys.stdout.write(err)
+            sys.stderr.write(err)
 
     def repr_failure(self, excinfo):
         import doctest

--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function
 
 import traceback
+import sys
 
 import pytest
 from _pytest._code.code import ExceptionInfo, ReprFileLocation, TerminalRepr
@@ -103,7 +104,18 @@ class DoctestItem(pytest.Item):
 
     def runtest(self):
         _check_all_skipped(self.dtest)
+        self._disable_output_capturing()
         self.runner.run(self.dtest)
+
+    def _disable_output_capturing(self):
+        """
+        Disable output capturing. Otherwise, stdout is lost to doctest (#985)
+        """
+        capman = self.config.pluginmanager.getplugin("capturemanager")
+        if capman:
+            out, err = capman.suspend_global_capture(in_=True)
+            sys.stdout.write(out)
+        sys.stdout.write(err)
 
     def repr_failure(self, excinfo):
         import doctest

--- a/changelog/985.bugfix
+++ b/changelog/985.bugfix
@@ -1,0 +1,1 @@
+Fixed output capture handling in doctests on macOS.

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -267,10 +267,6 @@ class TestPDB(object):
         child.read()
         self.flush(child)
 
-    # For some reason the interaction between doctest's and pytest's output
-    # capturing mechanisms are messing up the stdout on mac. (See #985).
-    # Should be solvable, but skipping until we have a chance to investigate.
-    @pytest.mark.xfail("sys.platform == 'darwin'", reason='See issue #985', run=False)
     def test_pdb_interaction_doctest(self, testdir):
         p1 = testdir.makepyfile("""
             import pytest


### PR DESCRIPTION
... to avoid losing reference to stdout. Fixes #985.

This patch implements the [change proposed](https://github.com/pytest-dev/pytest/issues/985#issuecomment-357541238), but encapsulates the workaround and documents it with a docstring.

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](/changelog/README.rst) for details.
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [x] Target the `features` branch for new features and removals/deprecations.
- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
