### PR TITLE
#3034 Added new option "--new-first"

### DIFF
--- a/changelog/3034.feature
+++ b/changelog/3034.feature
@@ -1,0 +1,1 @@
+Added new option `--nf`, `--new-first`. This option enables run tests in next order: first new tests, then last modified files with tests in descending order (default order inside file).

--- a/changelog/3034.feature
+++ b/changelog/3034.feature
@@ -1,1 +1,1 @@
-Added new option `--nf`, `--new-first`. This option enables run tests in next order: first new tests, then last modified files with tests in descending order (default order inside file).
+New ``--nf``, ``--new-first`` options: run new tests first followed by the rest of the tests, in both cases tests are also sorted by the file modified time, with more recent files coming first.

--- a/doc/en/cache.rst
+++ b/doc/en/cache.rst
@@ -152,6 +152,10 @@ of ``FF`` and dots)::
 
 .. _`config.cache`:
 
+New ``--nf``, ``--new-first`` options: run new tests first followed by the rest
+of the tests, in both cases tests are also sorted by the file modified time,
+with more recent files coming first.
+
 The new config.cache object
 --------------------------------
 
@@ -266,13 +270,3 @@ dumps/loads API of the json stdlib module
 .. automethod:: Cache.get
 .. automethod:: Cache.set
 .. automethod:: Cache.makedir
-
-
-New tests first
------------------
-
-The plugin provides command line options to run tests in another order:
-
-* ``--nf``, ``--new-first`` - to run tests in next order: first new tests, then
-  last modified files with tests in descending order (default order inside file).
-

--- a/doc/en/cache.rst
+++ b/doc/en/cache.rst
@@ -266,3 +266,13 @@ dumps/loads API of the json stdlib module
 .. automethod:: Cache.get
 .. automethod:: Cache.set
 .. automethod:: Cache.makedir
+
+
+New tests first
+-----------------
+
+The plugin provides command line options to run tests in another order:
+
+* ``--nf``, ``--new-first`` - to run tests in next order: first new tests, then
+  last modified files with tests in descending order (default order inside file).
+

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -56,7 +56,7 @@ class TestNewAPI(object):
         assert result.ret == 1
         result.stdout.fnmatch_lines([
             "*could not create cache path*",
-            "*1 warnings*",
+            "*2 warnings*",
         ])
 
     def test_config_cache(self, testdir):
@@ -495,15 +495,15 @@ class TestLastFailed(object):
         # Issue #1342
         testdir.makepyfile(test_empty='')
         testdir.runpytest('-q', '--lf')
-        assert not os.path.exists('.pytest_cache')
+        assert not os.path.exists('.pytest_cache/v/cache/lastfailed')
 
         testdir.makepyfile(test_successful='def test_success():\n    assert True')
         testdir.runpytest('-q', '--lf')
-        assert not os.path.exists('.pytest_cache')
+        assert not os.path.exists('.pytest_cache/v/cache/lastfailed')
 
         testdir.makepyfile(test_errored='def test_error():\n    assert False')
         testdir.runpytest('-q', '--lf')
-        assert os.path.exists('.pytest_cache')
+        assert os.path.exists('.pytest_cache/v/cache/lastfailed')
 
     def test_xfail_not_considered_failure(self, testdir):
         testdir.makepyfile('''
@@ -603,3 +603,116 @@ class TestLastFailed(object):
         result = testdir.runpytest('--last-failed')
         result.stdout.fnmatch_lines('*4 passed*')
         assert self.get_cached_last_failed(testdir) == []
+
+
+class TestNewFirst(object):
+    def test_newfirst_usecase(self, testdir):
+        t1 = testdir.mkdir("test_1")
+        t2 = testdir.mkdir("test_2")
+
+        t1.join("test_1.py").write(
+            "def test_1(): assert 1\n"
+            "def test_2(): assert 1\n"
+            "def test_3(): assert 1\n"
+        )
+        t2.join("test_2.py").write(
+            "def test_1(): assert 1\n"
+            "def test_2(): assert 1\n"
+            "def test_3(): assert 1\n"
+        )
+
+        path_to_test_1 = str('{}/test_1/test_1.py'.format(testdir.tmpdir))
+        os.utime(path_to_test_1, (1, 1))
+
+        result = testdir.runpytest("-v")
+        result.stdout.fnmatch_lines([
+            "*test_1/test_1.py::test_1 PASSED*",
+            "*test_1/test_1.py::test_2 PASSED*",
+            "*test_1/test_1.py::test_3 PASSED*",
+            "*test_2/test_2.py::test_1 PASSED*",
+            "*test_2/test_2.py::test_2 PASSED*",
+            "*test_2/test_2.py::test_3 PASSED*",
+        ])
+
+        result = testdir.runpytest("-v", "--nf")
+
+        result.stdout.fnmatch_lines([
+            "*test_2/test_2.py::test_1 PASSED*",
+            "*test_2/test_2.py::test_2 PASSED*",
+            "*test_2/test_2.py::test_3 PASSED*",
+            "*test_1/test_1.py::test_1 PASSED*",
+            "*test_1/test_1.py::test_2 PASSED*",
+            "*test_1/test_1.py::test_3 PASSED*",
+        ])
+
+        t1.join("test_1.py").write(
+            "def test_1(): assert 1\n"
+            "def test_2(): assert 1\n"
+            "def test_3(): assert 1\n"
+            "def test_4(): assert 1\n"
+        )
+        os.utime(path_to_test_1, (1, 1))
+
+        result = testdir.runpytest("-v", "--nf")
+
+        result.stdout.fnmatch_lines([
+            "*test_1/test_1.py::test_4 PASSED*",
+            "*test_2/test_2.py::test_1 PASSED*",
+            "*test_2/test_2.py::test_2 PASSED*",
+            "*test_2/test_2.py::test_3 PASSED*",
+            "*test_1/test_1.py::test_1 PASSED*",
+            "*test_1/test_1.py::test_2 PASSED*",
+            "*test_1/test_1.py::test_3 PASSED*",
+        ])
+
+    def test_newfirst_parametrize(self, testdir):
+        t1 = testdir.mkdir("test_1")
+        t2 = testdir.mkdir("test_2")
+
+        t1.join("test_1.py").write(
+            "import pytest\n"
+            "@pytest.mark.parametrize('num', [1, 2])\n"
+            "def test_1(num): assert num\n"
+        )
+        t2.join("test_2.py").write(
+            "import pytest\n"
+            "@pytest.mark.parametrize('num', [1, 2])\n"
+            "def test_1(num): assert num\n"
+        )
+
+        path_to_test_1 = str('{}/test_1/test_1.py'.format(testdir.tmpdir))
+        os.utime(path_to_test_1, (1, 1))
+
+        result = testdir.runpytest("-v")
+        result.stdout.fnmatch_lines([
+            "*test_1/test_1.py::test_1[1*",
+            "*test_1/test_1.py::test_1[2*",
+            "*test_2/test_2.py::test_1[1*",
+            "*test_2/test_2.py::test_1[2*"
+        ])
+
+        result = testdir.runpytest("-v", "--nf")
+
+        result.stdout.fnmatch_lines([
+            "*test_2/test_2.py::test_1[1*",
+            "*test_2/test_2.py::test_1[2*",
+            "*test_1/test_1.py::test_1[1*",
+            "*test_1/test_1.py::test_1[2*",
+        ])
+
+        t1.join("test_1.py").write(
+            "import pytest\n"
+            "@pytest.mark.parametrize('num', [1, 2, 3])\n"
+            "def test_1(num): assert num\n"
+        )
+        os.utime(path_to_test_1, (1, 1))
+
+        result = testdir.runpytest("-v", "--nf")
+
+        result.stdout.fnmatch_lines([
+            "*test_1/test_1.py::test_1[3*",
+            "*test_2/test_2.py::test_1[1*",
+            "*test_2/test_2.py::test_1[2*",
+            "*test_1/test_1.py::test_1[1*",
+            "*test_1/test_1.py::test_1[2*",
+        ])

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -607,22 +607,20 @@ class TestLastFailed(object):
 
 class TestNewFirst(object):
     def test_newfirst_usecase(self, testdir):
-        t1 = testdir.mkdir("test_1")
-        t2 = testdir.mkdir("test_2")
+        testdir.makepyfile(**{
+            'test_1/test_1.py': '''
+                def test_1(): assert 1
+                def test_2(): assert 1
+                def test_3(): assert 1
+            ''',
+            'test_2/test_2.py': '''
+                def test_1(): assert 1
+                def test_2(): assert 1
+                def test_3(): assert 1
+            '''
+        })
 
-        t1.join("test_1.py").write(
-            "def test_1(): assert 1\n"
-            "def test_2(): assert 1\n"
-            "def test_3(): assert 1\n"
-        )
-        t2.join("test_2.py").write(
-            "def test_1(): assert 1\n"
-            "def test_2(): assert 1\n"
-            "def test_3(): assert 1\n"
-        )
-
-        path_to_test_1 = str('{}/test_1/test_1.py'.format(testdir.tmpdir))
-        os.utime(path_to_test_1, (1, 1))
+        testdir.tmpdir.join('test_1/test_1.py').setmtime(1)
 
         result = testdir.runpytest("-v")
         result.stdout.fnmatch_lines([
@@ -645,13 +643,13 @@ class TestNewFirst(object):
             "*test_1/test_1.py::test_3 PASSED*",
         ])
 
-        t1.join("test_1.py").write(
+        testdir.tmpdir.join("test_1/test_1.py").write(
             "def test_1(): assert 1\n"
             "def test_2(): assert 1\n"
             "def test_3(): assert 1\n"
             "def test_4(): assert 1\n"
         )
-        os.utime(path_to_test_1, (1, 1))
+        testdir.tmpdir.join('test_1/test_1.py').setmtime(1)
 
         result = testdir.runpytest("-v", "--nf")
 
@@ -666,22 +664,20 @@ class TestNewFirst(object):
         ])
 
     def test_newfirst_parametrize(self, testdir):
-        t1 = testdir.mkdir("test_1")
-        t2 = testdir.mkdir("test_2")
+        testdir.makepyfile(**{
+            'test_1/test_1.py': '''
+                import pytest
+                @pytest.mark.parametrize('num', [1, 2])
+                def test_1(num): assert num
+            ''',
+            'test_2/test_2.py': '''
+                import pytest
+                @pytest.mark.parametrize('num', [1, 2])
+                def test_1(num): assert num
+            '''
+        })
 
-        t1.join("test_1.py").write(
-            "import pytest\n"
-            "@pytest.mark.parametrize('num', [1, 2])\n"
-            "def test_1(num): assert num\n"
-        )
-        t2.join("test_2.py").write(
-            "import pytest\n"
-            "@pytest.mark.parametrize('num', [1, 2])\n"
-            "def test_1(num): assert num\n"
-        )
-
-        path_to_test_1 = str('{}/test_1/test_1.py'.format(testdir.tmpdir))
-        os.utime(path_to_test_1, (1, 1))
+        testdir.tmpdir.join('test_1/test_1.py').setmtime(1)
 
         result = testdir.runpytest("-v")
         result.stdout.fnmatch_lines([
@@ -700,12 +696,12 @@ class TestNewFirst(object):
             "*test_1/test_1.py::test_1[2*",
         ])
 
-        t1.join("test_1.py").write(
+        testdir.tmpdir.join("test_1/test_1.py").write(
             "import pytest\n"
             "@pytest.mark.parametrize('num', [1, 2, 3])\n"
             "def test_1(num): assert num\n"
         )
-        os.utime(path_to_test_1, (1, 1))
+        testdir.tmpdir.join('test_1/test_1.py').setmtime(1)
 
         result = testdir.runpytest("-v", "--nf")
 


### PR DESCRIPTION
Fixes #3034
Added new option --new-first

How it works:
Create different test files:
tests
|- test_one.py
\- test_two.py

Every file contains two tests:
```
def test_1():
    assert 1

def test_2():
    assert 1
```

run command 
```
pytest tests -v
```
result:
```
tests/test_one.py::test_1 PASSED
tests/test_one.py::test_2 PASSED
tests/test_two.py::test_1 PASSED
tests/test_two.py::test_2 PASSED
```

run command 
```
pytest tests -v --nf
```
result:
```
tests/test_two.py::test_1 PASSED
tests/test_two.py::test_2 PASSED
tests/test_one.py::test_1 PASSED
tests/test_one.py::test_2 PASSED
```
Order changed to modifyed files first

Add new test to test_two.py file and then modify test_one.py file

run command 
```
pytest tests -v --nf
```
result:
```
tests/test_two.py::test_3 PASSED
tests/test_one.py::test_1 PASSED
tests/test_one.py::test_2 PASSED
tests/test_two.py::test_1 PASSED
tests/test_two.py::test_2 PASSED
```
Order changed: first new test, then modified files