### PR TITLE
Fix approx default tolerances for Decimal

### DIFF
--- a/changelog/3247.bugfix.rst
+++ b/changelog/3247.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue with approx on Decimal value.

--- a/changelog/3247.bugfix.rst
+++ b/changelog/3247.bugfix.rst
@@ -1,1 +1,1 @@
-Fix issue with approx on Decimal value.
+Fix ``TypeError`` issue when using ``approx`` with a ``Decimal`` value.

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -249,6 +249,7 @@ class TestApprox(object):
             (Decimal('-1.000001'), Decimal('-1.0')),
         ]
         for a, x in within_1e6:
+            assert a == approx(x)
             assert a == approx(x, rel=Decimal('5e-6'), abs=0)
             assert a != approx(x, rel=Decimal('5e-7'), abs=0)
             assert approx(x, rel=Decimal('5e-6'), abs=0) == a


### PR DESCRIPTION
Fixes #3247
Added python_api.ApproxDecimal to handle with Decimal numbers.