### PR TITLE
Fix PseudoFixtureDef reference cycle.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -197,3 +197,4 @@ Xuan Luong
 Xuecong Liao
 Zoltán Máté
 Roland Puntaier
+Allan Feldman

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -4,7 +4,7 @@ import functools
 import inspect
 import sys
 import warnings
-from collections import OrderedDict, deque, defaultdict, namedtuple
+from collections import OrderedDict, deque, defaultdict
 
 import attr
 import py
@@ -23,7 +23,11 @@ from _pytest.compat import (
 )
 from _pytest.outcomes import fail, TEST_OUTCOME
 
-PseudoFixtureDef = namedtuple('PseudoFixtureDef', ('cached_result', 'scope'))
+
+@attr.s(frozen=True)
+class PseudoFixtureDef(object):
+    cached_result = attr.ib()
+    scope = attr.ib()
 
 
 def pytest_sessionstart(session):

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -4,7 +4,7 @@ import functools
 import inspect
 import sys
 import warnings
-from collections import OrderedDict, deque, defaultdict
+from collections import OrderedDict, deque, defaultdict, namedtuple
 
 import attr
 import py
@@ -22,6 +22,8 @@ from _pytest.compat import (
     FuncargnamesCompatAttr,
 )
 from _pytest.outcomes import fail, TEST_OUTCOME
+
+PseudoFixtureDef = namedtuple('PseudoFixtureDef', ('cached_result', 'scope'))
 
 
 def pytest_sessionstart(session):
@@ -440,10 +442,9 @@ class FixtureRequest(FuncargnamesCompatAttr):
                 fixturedef = self._getnextfixturedef(argname)
             except FixtureLookupError:
                 if argname == "request":
-                    class PseudoFixtureDef(object):
-                        cached_result = (self, [0], None)
-                        scope = "function"
-                    return PseudoFixtureDef
+                    cached_result = (self, [0], None)
+                    scope = "function"
+                    return PseudoFixtureDef(cached_result, scope)
                 raise
         # remove indent to prevent the python3 exception
         # from leaking into the call

--- a/changelog/3249.bugfix.rst
+++ b/changelog/3249.bugfix.rst
@@ -1,0 +1,1 @@
+Fix reference cycle generated when using the ``request`` fixture.


### PR DESCRIPTION
Hi there! Apologies in advance for the long-winded description!

I was working on a talk for a local Python meetup on reference cycles in Python and noticed that a reference cycle was generated from within pytest which was causing test failures in my example code.

Here's the fixture I was running:
```python
import pytest
import gc


@pytest.fixture(autouse=True)
def garbage_detect(request):
    # Clean up all objects
    gc.set_debug(0)
    gc.collect()

    # Save garbage and run test
    gc.set_debug(gc.DEBUG_SAVEALL)
    yield

    # Invoke the garbage collector
    gc.collect()

    # Check that there is no garbage
    garbage_expected = request.node.get_marker('garbage')

    if not garbage_expected:
        assert len(gc.garbage) == 0
```

The fixture is checking that garbage is not generated by the code under test. I was hitting test failures due to a reference cycle generated by the insertion of the `request` fixture into `garbage_detect`.

Here's an overview of the cycle
![image](https://user-images.githubusercontent.com/6374032/36522823-80981474-1753-11e8-9da9-47cbc8b8e101.png)

The `PseudoFixtureDef` class becomes garbage when the reference to the generated class is discarded in `pytest_fixture_setup` (details in the commit message).

This PR updates the implementation to avoid the situation where `PseudoFixtureDef` becomes garbage by using a class instance. I've also included a test which exposes the leaked `PseudoFixtureDef` types.

This isn't really a problem/bug per-se since the garbage collector will take care of this but I figured I'd open a PR to fix the issue anyway.