### PR TITLE
Correct docs to config.pluginmanager.get_plugin()

### DIFF
--- a/doc/en/writing_plugins.rst
+++ b/doc/en/writing_plugins.rst
@@ -278,7 +278,7 @@ the plugin manager like this:
 
 .. sourcecode:: python
 
-    plugin = config.pluginmanager.getplugin("name_of_plugin")
+    plugin = config.pluginmanager.get_plugin("name_of_plugin")
 
 If you want to look at the names of existing plugins, use
 the ``--trace-config`` option.


### PR DESCRIPTION
`getplugin()` is deprecated in favor of `get_plugin()`.

https://github.com/pytest-dev/pytest/blob/dd97c940359079fd874795a731d54d1abb7d4c8e/_pytest/config.py#L261
