### PR TITLE
Continue on doctest failure

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -195,6 +195,7 @@ Victor Uriarte
 Vidar T. Fauske
 Vitaly Lashmanov
 Vlad Dragos
+William Lee
 Wouter van Ackooy
 Xuan Luong
 Xuecong Liao

--- a/_pytest/doctest.py
+++ b/_pytest/doctest.py
@@ -91,26 +91,6 @@ class ReprFailDoctest(TerminalRepr):
             reprlocation.toterminal(tw)
 
 
-# class DoctestFailureContainer(object):
-#
-#     NAME = 'DocTestFailure'
-#
-#     def __init__(self, test, example, got):
-#         self.test = test
-#         self.example = example
-#         self.got = got
-#
-#
-# class DoctestUnexpectedExceptionContainer(object):
-#
-#     NAME = 'DoctestUnexpectedException'
-#
-#     def __init__(self, test, example, exc_info):
-#         self.test = test
-#         self.example = example
-#         self.exc_info = exc_info
-
-
 class MultipleDoctestFailures(Exception):
     def __init__(self, failures):
         super(MultipleDoctestFailures, self).__init__()
@@ -138,7 +118,6 @@ def _init_runner_class():
             pass
 
         def report_failure(self, out, test, example, got):
-            # failure = DoctestFailureContainer(test, example, got)
             failure = doctest.DocTestFailure(test, example, got)
             if self.continue_on_failure:
                 out.append(failure)
@@ -146,7 +125,6 @@ def _init_runner_class():
                 raise failure
 
         def report_unexpected_exception(self, out, test, example, exc_info):
-            # failure = DoctestUnexpectedExceptionContainer(test, example, exc_info)
             failure = doctest.UnexpectedException(test, example, exc_info)
             if self.continue_on_failure:
                 out.append(failure)

--- a/changelog/3149.feature
+++ b/changelog/3149.feature
@@ -1,0 +1,1 @@
+Doctest runs now show multiple failures for each doctest snippet, instead of stopping at the first failure.

--- a/changelog/3149.feature
+++ b/changelog/3149.feature
@@ -1,1 +1,1 @@
-Doctest runs now show multiple failures for each doctest snippet, instead of stopping at the first failure.
+New ``--doctest-continue-on-failure`` command-line option to enable doctests to show multiple failures for each snippet, instead of stopping at the first failure.

--- a/doc/en/doctest.rst
+++ b/doc/en/doctest.rst
@@ -115,6 +115,11 @@ itself::
     >>> get_unicode_greeting()  # doctest: +ALLOW_UNICODE
     'Hello'
 
+By default, pytest would report only the first failure for a given doctest.  If
+you want to continue the test even when you have failures, do::
+
+    pytest --doctest-modules --doctest-continue-on-failure
+
 
 The 'doctest_namespace' fixture
 -------------------------------

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -769,11 +769,13 @@ class TestDoctestSkips(object):
         """)
         result = testdir.runpytest("--doctest-modules")
         result.assert_outcomes(passed=0, failed=1)
-        # We need to make sure we have two failure lines (4, 5, and 8) instead of
-        # one.
-        result.stdout.fnmatch_lines("*test_something.txt:4: DoctestUnexpectedException*")
-        result.stdout.fnmatch_lines("*test_something.txt:5: DocTestFailure*")
-        result.stdout.fnmatch_lines("*test_something.txt:8: DocTestFailure*")
+        # The lines that contains the failure are 4, 5, and 8.  The first one
+        # is a stack trace and the other two are mismatches.
+        result.stdout.fnmatch_lines([
+            "*4: UnexpectedException*",
+            "*5: DocTestFailure*",
+            "*8: DocTestFailure*",
+        ])
 
 
 class TestDoctestAutoUseFixtures(object):

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -756,6 +756,25 @@ class TestDoctestSkips(object):
         reprec = testdir.inline_run("--doctest-modules")
         reprec.assertoutcome(passed=0, skipped=0)
 
+    def test_continue_on_failure(self, testdir):
+        testdir.maketxtfile(test_something="""
+            >>> i = 5
+            >>> def foo():
+            ...     raise ValueError('error1')
+            >>> foo()
+            >>> i
+            >>> i + 2
+            7
+            >>> i + 1
+        """)
+        result = testdir.runpytest("--doctest-modules")
+        result.assert_outcomes(passed=0, failed=1)
+        # We need to make sure we have two failure lines (4, 5, and 8) instead of
+        # one.
+        result.stdout.fnmatch_lines("*test_something.txt:4: DoctestUnexpectedException*")
+        result.stdout.fnmatch_lines("*test_something.txt:5: DocTestFailure*")
+        result.stdout.fnmatch_lines("*test_something.txt:8: DocTestFailure*")
+
 
 class TestDoctestAutoUseFixtures(object):
 

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -767,7 +767,7 @@ class TestDoctestSkips(object):
             7
             >>> i + 1
         """)
-        result = testdir.runpytest("--doctest-modules")
+        result = testdir.runpytest("--doctest-modules", "--doctest-continue-on-failure")
         result.assert_outcomes(passed=0, failed=1)
         # The lines that contains the failure are 4, 5, and 8.  The first one
         # is a stack trace and the other two are mismatches.


### PR DESCRIPTION
Here is try two of the attempt to fix #3149.  This is targeting the features branch instead of master.  The pdb timeout issue should be resolved and the feature is turned on only when the --doctest-continue-on-failure is set.  Otherwise the behavior should be the same as the original.  The code is somewhat more streamlined as well.
