### PR TITLE
#3236 Use platform module in pytest.mark

### DIFF
--- a/_pytest/mark/evaluate.py
+++ b/_pytest/mark/evaluate.py
@@ -1,6 +1,7 @@
 import os
 import six
 import sys
+import platform
 import traceback
 
 from . import MarkDecorator, MarkInfo
@@ -67,7 +68,7 @@ class MarkEvaluator(object):
                  pytrace=False)
 
     def _getglobals(self):
-        d = {'os': os, 'sys': sys, 'config': self.item.config}
+        d = {'os': os, 'sys': sys, 'platform': platform, 'config': self.item.config}
         if hasattr(self.item, 'obj'):
             d.update(self.item.obj.__globals__)
         return d

--- a/changelog/3236.trivial.rst
+++ b/changelog/3236.trivial.rst
@@ -1,1 +1,1 @@
-Add the usage of ``platform`` in ``pytest.mark.skipif``
+Add the usage of ``platform`` in ``pytest.mark``

--- a/changelog/3236.trivial.rst
+++ b/changelog/3236.trivial.rst
@@ -1,0 +1,1 @@
+Add the usage of ``platform`` in ``pytest.mark.skipif``

--- a/changelog/3236.trivial.rst
+++ b/changelog/3236.trivial.rst
@@ -1,1 +1,1 @@
-Add the usage of ``platform`` in ``pytest.mark``
+The builtin module ``platform`` is now available for use in expressions in ``pytest.mark``.

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -156,6 +156,21 @@ class TestXFail(object):
         assert callreport.passed
         assert callreport.wasxfail == "this is an xfail"
 
+    def test_xfail_use_platform(self, testdir):
+        """
+        Verify that platform can be used with xfail statements.
+        """
+        item = testdir.getitem("""
+            import pytest
+            @pytest.mark.xfail("platform.platform() == platform.platform()")
+            def test_func():
+                assert 0
+        """)
+        reports = runtestprotocol(item, log=False)
+        assert len(reports) == 3
+        callreport = reports[1]
+        assert callreport.wasxfail
+
     def test_xfail_xpassed_strict(self, testdir):
         item = testdir.getitem("""
             import pytest

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -612,6 +612,16 @@ class TestSkipif(object):
         ])
         assert result.ret == 0
 
+    def test_skipif_using_platform(self, testdir):
+        item = testdir.getitem("""
+            import pytest
+            @pytest.mark.skipif("platform.platform() == platform.platform()")
+            def test_func():
+                pass
+        """)
+        pytest.raises(pytest.skip.Exception, lambda:
+                      pytest_runtest_setup(item))
+
     @pytest.mark.parametrize('marker, msg1, msg2', [
         ('skipif', 'SKIP', 'skipped'),
         ('xfail', 'XPASS', 'xpassed'),

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -156,7 +156,7 @@ class TestXFail(object):
         assert callreport.passed
         assert callreport.wasxfail == "this is an xfail"
 
-    def test_xfail_use_platform(self, testdir):
+    def test_xfail_using_platform(self, testdir):
         """
         Verify that platform can be used with xfail statements.
         """


### PR DESCRIPTION
Per https://github.com/pytest-dev/pytest/issues/3236 I've gone ahead and added the ability to use platform in pytest.mark statements.