### PR TITLE
Consolidate behavior by using filterfalse and always_iterable

### DIFF
--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -2,7 +2,8 @@ import math
 import sys
 
 import py
-from six.moves import zip
+from six.moves import zip, filterfalse
+from more_itertools.more import always_iterable
 
 from _pytest.compat import isclass
 from _pytest.outcomes import fail
@@ -566,14 +567,10 @@ def raises(expected_exception, *args, **kwargs):
 
     """
     __tracebackhide__ = True
-    msg = ("exceptions must be old-style classes or"
-           " derived from BaseException, not %s")
-    if isinstance(expected_exception, tuple):
-        for exc in expected_exception:
-            if not isclass(exc):
-                raise TypeError(msg % type(exc))
-    elif not isclass(expected_exception):
-        raise TypeError(msg % type(expected_exception))
+    for exc in filterfalse(isclass, always_iterable(expected_exception)):
+        msg = ("exceptions must be old-style classes or"
+               " derived from BaseException, not %s")
+        raise TypeError(msg % type(exc))
 
     message = "DID NOT RAISE {0}".format(expected_exception)
     match_expr = None

--- a/changelog/3265.trivial.rst
+++ b/changelog/3265.trivial.rst
@@ -1,0 +1,1 @@
+``pytest`` now depends on the `more_itertools <https://github.com/erikrose/more-itertools>`_ package.

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ def main():
         'six>=1.10.0',
         'setuptools',
         'attrs>=17.2.0',
+        'more_itertools>=4.0.0',
     ]
     # if _PYTEST_SETUP_SKIP_PLUGGY_DEP is set, skip installing pluggy;
     # used by tox.ini to test with pluggy master


### PR DESCRIPTION
As I was searching through the code for a completely different purpose, I stumbled across this pattern, which I've seen many times before:

```
if variable is a singleton -> do one thing
otherwise if it's an iterable -> do the thing across each item
```

This common pattern is the reason I created [always_iterable](https://more-itertools.readthedocs.io/en/latest/api.html#more_itertools.always_iterable), as it allows looping over the items even if there's just one.

Using this technique, along with [filterfalse](https://docs.python.org/3/library/itertools.html#itertools.filterfalse), the code is more concise, less nested, and in my opinion, more directly conveys the intention. One slightly awkward aspect is that the for loop is abruptly terminated if it fails the isclass test, but that was the behavior before as well.

The main reservation I have about this change is that it adds a new dependency, and I'm unsure how important it is to avoid new dependencies. Given that more_itertools implements the [recipes from itertools](https://docs.python.org/3/library/itertools.html#itertools-recipes), I find that it tends to have broad appeal and would likely find beneficial use throughout the package (though I haven't surveyed it).

Thoughts?