### PR TITLE
#3260 fix pytest section

### DIFF
--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -1327,14 +1327,15 @@ def determine_setup(inifile, args, warnfunc=None):
     dirs = get_dirs_from_args(args)
     if inifile:
         iniconfig = py.iniconfig.IniConfig(inifile)
-        is_cfg_file = '.cfg' in inifile
+        is_cfg_file = str(inifile).endswith('.cfg')
+        # TODO: [pytest] section in *.cfg files is depricated. Need refactoring.
         sections = ['tool:pytest', 'pytest'] if is_cfg_file else ['pytest']
         for section in sections:
             try:
                 inicfg = iniconfig[section]
                 if is_cfg_file and section == 'pytest' and warnfunc:
                     from _pytest.deprecated import SETUP_CFG_PYTEST
-                    warnfunc('C1', SETUP_CFG_PYTEST.replace('setup.cfg', inifile))
+                    warnfunc('C1', SETUP_CFG_PYTEST.replace('setup.cfg', str(inifile)))
                 break
             except KeyError:
                 inicfg = None

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -1328,14 +1328,10 @@ def determine_setup(inifile, args, warnfunc=None):
     if inifile:
         iniconfig = py.iniconfig.IniConfig(inifile)
         is_cfg_file = str(inifile).endswith('.cfg')
-        # TODO: [pytest] section in *.cfg files is depricated. Need refactoring.
         sections = ['tool:pytest', 'pytest'] if is_cfg_file else ['pytest']
         for section in sections:
             try:
                 inicfg = iniconfig[section]
-                if is_cfg_file and section == 'pytest' and warnfunc:
-                    from _pytest.deprecated import SETUP_CFG_PYTEST
-                    warnfunc('C1', SETUP_CFG_PYTEST.replace('setup.cfg', str(inifile)))
                 break
             except KeyError:
                 inicfg = None

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -1327,10 +1327,17 @@ def determine_setup(inifile, args, warnfunc=None):
     dirs = get_dirs_from_args(args)
     if inifile:
         iniconfig = py.iniconfig.IniConfig(inifile)
-        try:
-            inicfg = iniconfig["pytest"]
-        except KeyError:
-            inicfg = None
+        is_cfg_file = '.cfg' in inifile
+        sections = ['tool:pytest', 'pytest'] if is_cfg_file else ['pytest']
+        for section in sections:
+            try:
+                inicfg = iniconfig[section]
+                if is_cfg_file and section == 'pytest' and warnfunc:
+                    from _pytest.deprecated import SETUP_CFG_PYTEST
+                    warnfunc('C1', SETUP_CFG_PYTEST.replace('setup.cfg', inifile))
+                break
+            except KeyError:
+                inicfg = None
         rootdir = get_common_ancestor(dirs)
     else:
         ancestor = get_common_ancestor(dirs)

--- a/changelog/3260.bugfix
+++ b/changelog/3260.bugfix
@@ -1,0 +1,1 @@
+Fixed ``tool:pytest`` section when setup.cfg passed by option ``-c``

--- a/changelog/3260.bugfix
+++ b/changelog/3260.bugfix
@@ -1,1 +1,0 @@
-Fixed ``tool:pytest`` section when setup.cfg passed by option ``-c``

--- a/changelog/3260.bugfix.rst
+++ b/changelog/3260.bugfix.rst
@@ -1,0 +1,1 @@
+``[tool:pytest]`` sections in ``*.cfg`` files passed by the ``-c`` option are now properly recognized.

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -110,6 +110,13 @@ class TestConfigCmdlineParsing(object):
         config = testdir.parseconfig("-c", "custom.cfg")
         assert config.getini("custom") == "1"
 
+        testdir.makefile(".cfg", custom_tool_pytest_section="""
+            [tool:pytest]
+            custom = 1
+        """)
+        config = testdir.parseconfig("-c", "custom_tool_pytest_section.cfg")
+        assert config.getini("custom") == "1"
+
     def test_absolute_win32_path(self, testdir):
         temp_cfg_file = testdir.makefile(".cfg", custom="""
             [pytest]


### PR DESCRIPTION
Fixes #3260 

Bugfix: When you pass option "-c custom_config.cfg" section [tool:pytest] is now parses. And print warning if there is [pytest] section.