### PR TITLE
Added warning when "[pytest]" section is used in a ".cfg" file passed with "-c"

### DIFF
--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -1251,7 +1251,7 @@ def getcfg(args, warnfunc=None):
         This parameter should be removed when pytest
         adopts standard deprecation warnings (#1804).
     """
-    from _pytest.deprecated import SETUP_CFG_PYTEST
+    from _pytest.deprecated import CFG_PYTEST_SECTION
     inibasenames = ["pytest.ini", "tox.ini", "setup.cfg"]
     args = [x for x in args if not str(x).startswith("-")]
     if not args:
@@ -1265,7 +1265,7 @@ def getcfg(args, warnfunc=None):
                     iniconfig = py.iniconfig.IniConfig(p)
                     if 'pytest' in iniconfig.sections:
                         if inibasename == 'setup.cfg' and warnfunc:
-                            warnfunc('C1', SETUP_CFG_PYTEST)
+                            warnfunc('C1', CFG_PYTEST_SECTION.format(filename=inibasename))
                         return base, p, iniconfig['pytest']
                     if inibasename == 'setup.cfg' and 'tool:pytest' in iniconfig.sections:
                         return base, p, iniconfig['tool:pytest']
@@ -1335,8 +1335,8 @@ def determine_setup(inifile, args, warnfunc=None, rootdir_cmd_arg=None):
             try:
                 inicfg = iniconfig[section]
                 if is_cfg_file and section == 'pytest' and warnfunc:
-                    from _pytest.deprecated import SETUP_CFG_PYTEST
-                    warnfunc('C1', SETUP_CFG_PYTEST.replace('setup.cfg', str(inifile)))
+                    from _pytest.deprecated import CFG_PYTEST_SECTION
+                    warnfunc('C1', CFG_PYTEST_SECTION.format(filename=str(inifile)))
                 break
             except KeyError:
                 inicfg = None

--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -1329,10 +1329,14 @@ def determine_setup(inifile, args, warnfunc=None, rootdir_cmd_arg=None):
     if inifile:
         iniconfig = py.iniconfig.IniConfig(inifile)
         is_cfg_file = str(inifile).endswith('.cfg')
+        # TODO: [pytest] section in *.cfg files is depricated. Need refactoring.
         sections = ['tool:pytest', 'pytest'] if is_cfg_file else ['pytest']
         for section in sections:
             try:
                 inicfg = iniconfig[section]
+                if is_cfg_file and section == 'pytest' and warnfunc:
+                    from _pytest.deprecated import SETUP_CFG_PYTEST
+                    warnfunc('C1', SETUP_CFG_PYTEST.replace('setup.cfg', str(inifile)))
                 break
             except KeyError:
                 inicfg = None

--- a/_pytest/deprecated.py
+++ b/_pytest/deprecated.py
@@ -22,7 +22,7 @@ FUNCARG_PREFIX = (
     'and scheduled to be removed in pytest 4.0.  '
     'Please remove the prefix and use the @pytest.fixture decorator instead.')
 
-SETUP_CFG_PYTEST = '[pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.'
+CFG_PYTEST_SECTION = '[pytest] section in {filename} files is deprecated, use [tool:pytest] instead.'
 
 GETFUNCARGVALUE = "use of getfuncargvalue is deprecated, use getfixturevalue"
 

--- a/changelog/3268.trivial
+++ b/changelog/3268.trivial
@@ -1,0 +1,1 @@
+Added warning when ``[pytest]`` section is used in a ``.cfg`` file passed with ``-c``

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -48,6 +48,15 @@ def test_pytest_setup_cfg_deprecated(testdir):
     result.stdout.fnmatch_lines(['*pytest*section in setup.cfg files is deprecated*use*tool:pytest*instead*'])
 
 
+def test_pytest_custom_cfg_deprecated(testdir):
+    testdir.makefile('.cfg', custom='''
+        [pytest]
+        addopts = --verbose
+    ''')
+    result = testdir.runpytest("-c", "custom.cfg")
+    result.stdout.fnmatch_lines(['*pytest*section in custom.cfg files is deprecated*use*tool:pytest*instead*'])
+
+
 def test_str_args_deprecated(tmpdir, testdir):
     """Deprecate passing strings to pytest.main(). Scheduled for removal in pytest-4.0."""
     from _pytest.main import EXIT_NOTESTSCOLLECTED


### PR DESCRIPTION
Fixes #3268 