### PR TITLE
Use `isdir` instead of `exists`

### DIFF
--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -170,7 +170,7 @@ def _in_venv(path):
     """Attempts to detect if ``path`` is the root of a Virtual Environment by
     checking for the existence of the appropriate activate script"""
     bindir = path.join('Scripts' if sys.platform.startswith('win') else 'bin')
-    if not bindir.exists():
+    if not bindir.isdir():
         return False
     activates = ('activate', 'activate.csh', 'activate.fish',
                  'Activate', 'Activate.bat', 'Activate.ps1')

--- a/changelog/3241.bugfix.rst
+++ b/changelog/3241.bugfix.rst
@@ -1,2 +1,2 @@
-Refactor check of bindir from `exists` to `isdir`.
+Refactor check of bindir from ``exists`` to ``isdir`` regarding `#3241 <https://github.com/pytest-dev/pytest/issues/3241>`_.
 

--- a/changelog/3241.bugfix.rst
+++ b/changelog/3241.bugfix.rst
@@ -1,0 +1,2 @@
+Refactor check of bindir from `exists` to `isdir`.
+


### PR DESCRIPTION
As suggested in #3241 `exists` should rather be `isdir`. 

If we want a test here, pleas let me know. I actually tried to write a test against this but failed miserably - would anyone outline how to let `exist` fail but `isdir` pass in this specific case? 