### PR TITLE
Revert introduction of more_itertools on master

### DIFF
--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -2,8 +2,7 @@ import math
 import sys
 
 import py
-from six.moves import zip, filterfalse
-from more_itertools.more import always_iterable
+from six.moves import zip
 
 from _pytest.compat import isclass
 from _pytest.outcomes import fail
@@ -567,10 +566,14 @@ def raises(expected_exception, *args, **kwargs):
 
     """
     __tracebackhide__ = True
-    for exc in filterfalse(isclass, always_iterable(expected_exception)):
-        msg = ("exceptions must be old-style classes or"
-               " derived from BaseException, not %s")
-        raise TypeError(msg % type(exc))
+    msg = ("exceptions must be old-style classes or"
+           " derived from BaseException, not %s")
+    if isinstance(expected_exception, tuple):
+        for exc in expected_exception:
+            if not isclass(exc):
+                raise TypeError(msg % type(exc))
+    elif not isclass(expected_exception):
+        raise TypeError(msg % type(expected_exception))
 
     message = "DID NOT RAISE {0}".format(expected_exception)
     match_expr = None

--- a/changelog/3265.trivial.rst
+++ b/changelog/3265.trivial.rst
@@ -1,1 +1,0 @@
-``pytest`` now depends on the `more_itertools <https://github.com/erikrose/more-itertools>`_ package.

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ def main():
         'six>=1.10.0',
         'setuptools',
         'attrs>=17.2.0',
-        'more_itertools>=4.0.0',
     ]
     # if _PYTEST_SETUP_SKIP_PLUGGY_DEP is set, skip installing pluggy;
     # used by tox.ini to test with pluggy master


### PR DESCRIPTION
This was merged on master but really should be on features: we should not
add new dependencies in bug-fix releases

This reverts commits:

* cfaf3600c1d9ea2b45d9b801a47379304fd7e455
* 14a9b1ec838fc1b2bb530458757c0bb9a67f164d
