### PR TITLE
[blocked] #3224 allow to use file:line number

### DIFF
--- a/_pytest/main.py
+++ b/_pytest/main.py
@@ -393,8 +393,6 @@ class Session(nodes.FSCollector):
                     items_list = []
                     items_list.extend(self.genitems(node))
                     if self.file_line:
-                        # print('ITEM', items_list[1].location)
-                        # items_list = [item for item in items_list if self.select_by_function_name in item.name]
                         items_list = self._find_nearest_test_function(items_list)
                     self.items.extend(items_list)
             return items
@@ -476,10 +474,6 @@ class Session(nodes.FSCollector):
         if self.config.option.pyargs:
             parts[0] = self._tryconvertpyarg(parts[0])
         relpath = parts[0].replace("/", os.sep)
-
-        # if match:
-        #     relpath = ''.join(relpath.split(':')[:-1])
-        #     self.line = match.group("line")
         path = self.config.invocation_dir.join(relpath, abs=True)
         if not path.check():
             try:
@@ -539,7 +533,6 @@ class Session(nodes.FSCollector):
             mid = (lo+hi)//2
             midval = items[mid].location[1]
             next_to_midval = items[mid+1].location[1] if len(items) > mid + 1 else items[mid].location[1]
-            print('LO', lo, hi, midval, self.file_line)
             if line not in list(range(midval, next_to_midval)):
                 if midval < line:
                     lo = mid+1

--- a/changelog/3224.feature
+++ b/changelog/3224.feature
@@ -1,0 +1,1 @@
+Allowed test selection by file:line_number. For example, you can run ``pytest tests/test_foo.py:5`` and Pytest will find a nearest test.

--- a/doc/en/usage.rst
+++ b/doc/en/usage.rst
@@ -96,6 +96,14 @@ Another example specifying a test method in the command line::
 
     pytest test_mod.py::TestClass::test_method
 
+**Run tests by line number**
+
+::
+
+    pytest test_mod.py:5
+
+Will search nearest test to this line and run only this test.
+
 **Run tests by marker expressions**
 
 ::

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -705,10 +705,10 @@ class TestCollectLineOption(object):
         p = testdir.makepyfile(test_1="""
         def test_01():
             assert 1
-            
+
         def test_02():
             assert 1
-        
+
         def test_03():
             assert 1
         """)
@@ -723,11 +723,11 @@ class TestCollectLineOption(object):
         import pytest
         def test_01():
             assert 1
-            
+
         @pytest.mark.parametrize('x', [1, 2])
         def test_02(x):
             assert 1
-        
+
         def test_03():
             assert 1
         """)
@@ -743,10 +743,10 @@ class TestCollectLineOption(object):
         class TestLine:
             def test_01(self):
                 assert 1
-    
+
             def test_02(self):
                 assert 1
-    
+
             def test_03(self):
                 assert 1
         """)
@@ -762,11 +762,11 @@ class TestCollectLineOption(object):
         class TestLine:
             def test_01(self):
                 assert 1
-    
+
             @pytest.mark.parametrize('x', [1, 2])
             def test_02(self, x):
                 assert 1
-    
+
             def test_03(self):
                 assert 1
         """)

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -773,24 +773,44 @@ class TestCollectLineOption(object):
         result = testdir.runpytest("{}:{}".format(p, line), "-v")
         result.stdout.fnmatch_lines("*test_1.py::TestLine::test_02[1*")
         result.stdout.fnmatch_lines("*test_1.py::TestLine::test_02[2*")
-        assert "test_1.py::test_01" not in result.stdout.str()
-        assert "test_1.py::test_03" not in result.stdout.str()
+        assert "test_1.py::TestLine::test_01" not in result.stdout.str()
+        assert "test_1.py::TestLine::test_03" not in result.stdout.str()
 
-    def test_collect_line_no_test_found(self, testdir):
+    def test_collect_line_boundary_values_min(self, testdir):
         p = testdir.makepyfile(test_1="""
         import pytest
         class TestLine:
             def test_01(self):
                 assert 1
 
-            def test_02(self, x):
+            def test_02(self):
                 assert 1
 
             def test_03(self):
                 assert 1
         """)
-        result = testdir.runpytest("{}:{}".format(p, 1), "-v")
-        result.stderr.fnmatch_lines("*No test found near line 1*")
+        result = testdir.runpytest("{}:{}".format(p, 0), "-v")
+        result.stdout.fnmatch_lines("*test_1.py::TestLine::test_01*")
+        assert "test_1.py::test_02" not in result.stdout.str()
+        assert "test_1.py::test_03" not in result.stdout.str()
+
+    def test_collect_line_boundary_values_max(self, testdir):
+        p = testdir.makepyfile(test_1="""
+        import pytest
+        class TestLine:
+            def test_01(self):
+                assert 1
+
+            def test_02(self):
+                assert 1
+
+            def test_03(self):
+                assert 1
+        """)
+        result = testdir.runpytest("{}:{}".format(p, 1000), "-v")
+        result.stdout.fnmatch_lines("*test_1.py::TestLine::test_03*")
+        assert "test_1.py::test_01" not in result.stdout.str()
+        assert "test_1.py::test_02" not in result.stdout.str()
 
     @pytest.mark.parametrize("line", [9, 10, 11])
     def test_collect_line_not_test(self, testdir, line):


### PR DESCRIPTION
Allowed test selection by file:line_number. For example, you can run ``pytest tests/test_foo.py:5`` and Pytest will find a nearest test.
Fixes #3224 

Problems:
Pytest collects all tests in file but run only one test (or several if parametrize):

$ cat tests/test_1.py
```
1  def test_01():
2      assert 1
3
4
5  def test_02():
6      assert 1
7
8
9  def test_03():
10     assert 1
```
pytest tests/test_1.py:6 -v
```
================================================================================= test session starts ==================================================================================
platform linux -- Python 3.6.4, pytest-3.4.2.dev130+gc95f3316, py-1.5.2, pluggy-0.6.0 -- /home/feuillemorte/github/pytest-dev/pytest/pytest_3224/env/bin/python
cachedir: .pytest_cache
rootdir: /home/feuillemorte/github/pytest-dev/pytest/pytest_3224, inifile: tox.ini
collected 3 items                                                                                                                                                                      

tests/test_1.py::test_02 PASSED                                                                                                                                                  [100%]

=============================================================================== 1 passed in 0.01 seconds ===============================================================================
``` 