### PR TITLE
3245: Add doc to norecursedirs in tox.ini

### DIFF
--- a/changelog/3245.trivial.rst
+++ b/changelog/3245.trivial.rst
@@ -1,0 +1,1 @@
+Added ``doc`` to norecursedirs in tox.ini

--- a/tox.ini
+++ b/tox.ini
@@ -204,7 +204,7 @@ rsyncdirs = tox.ini pytest.py _pytest testing
 python_files = test_*.py *_test.py testing/*/*.py
 python_classes = Test Acceptance
 python_functions = test
-norecursedirs = .tox ja .hg cx_freeze_source
+norecursedirs = .tox ja .hg cx_freeze_source doc
 xfail_strict=true
 filterwarnings =
     error


### PR DESCRIPTION
Resolve the test failures that are caused by calling `pytest` against the root directory due to the inclusion of running tests in the doc directory.