### PR TITLE
unify cli verbosity handling

### DIFF
--- a/changelog/3296.feature
+++ b/changelog/3296.feature
@@ -1,0 +1,1 @@
+New ``--verbosity`` flag to set verbosity level explicitly.

--- a/changelog/3296.trivial
+++ b/changelog/3296.trivial
@@ -1,0 +1,1 @@
+Refactoring to unify how verbosity is handled internally.


### PR DESCRIPTION
based on https://github.com/pytest-dev/pytest/issues/3294#issuecomment-372190084

we really shouldnt have N options we post mortem hack together to determine verbosity
this change starts by unifying the data, we still need to handle deprecation/removal of config.quiet
