### PR TITLE
Fix #3297 where caplog.clear() did not clear text, just records

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -105,6 +105,7 @@ Kale Kundert
 Katarzyna Jachim
 Kevin Cox
 Kodi B. Arfer
+Kostis Anagnostopoulos
 Lawrence Mitchell
 Lee Kamentsky
 Lev Maximov

--- a/_pytest/logging.py
+++ b/_pytest/logging.py
@@ -176,6 +176,10 @@ class LogCaptureHandler(logging.StreamHandler):
         self.records.append(record)
         logging.StreamHandler.emit(self, record)
 
+    def reset(self):
+        self.records = []
+        self.stream = py.io.TextIO()
+
 
 class LogCaptureFixture(object):
     """Provides access and control of log capturing."""
@@ -197,6 +201,9 @@ class LogCaptureFixture(object):
 
     @property
     def handler(self):
+        """
+        :rtype: LogCaptureHandler
+        """
         return self._item.catch_log_handler
 
     def get_records(self, when):
@@ -239,8 +246,8 @@ class LogCaptureFixture(object):
         return [(r.name, r.levelno, r.getMessage()) for r in self.records]
 
     def clear(self):
-        """Reset the list of log records."""
-        self.handler.records = []
+        """Reset the list of log records and the captured log text."""
+        self.handler.reset()
 
     def set_level(self, level, logger=None):
         """Sets the level for capturing of logs. The level will be restored to its previous value at the end of
@@ -285,6 +292,8 @@ def caplog(request):
     * caplog.text()          -> string containing formatted log output
     * caplog.records()       -> list of logging.LogRecord instances
     * caplog.record_tuples() -> list of (logger_name, level, message) tuples
+    * caplog.clear()         -> clear captured records and formatted log output
+                                string
     """
     result = LogCaptureFixture(request.node)
     yield result

--- a/changelog/3297.bugfix.rst
+++ b/changelog/3297.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``clear()`` method on ``caplog`` fixture which cleared ``records``,
+but not the ``text`` property.

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -95,8 +95,10 @@ def test_clear(caplog):
     caplog.set_level(logging.INFO)
     logger.info(u'bū')
     assert len(caplog.records)
+    assert caplog.text
     caplog.clear()
     assert not len(caplog.records)
+    assert not caplog.text
 
 
 @pytest.fixture


### PR DESCRIPTION
Fix #3297 where ``caplog.clear()`` did not clear text, just records.  
Fix by @thisch that re-installs a new ``StringIO`` on the handler as suggested in https://stackoverflow.com/questions/4330812/how-do-i-clear-a-stringio-object#4330829
+ Actually work delegated to a new `reset()` method on the handler, used also on `caplog` construction .
+ Added TC demonstrating failure.