### PR TITLE
Suppress ``IOError`` when closing the temporary file used for capturing streams in Python 2.7

### DIFF
--- a/changelog/2370.bugfix.rst
+++ b/changelog/2370.bugfix.rst
@@ -1,0 +1,1 @@
+Suppress ``IOError`` when closing the temporary file used for capturing streams in Python 2.7.

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1265,6 +1265,30 @@ def test_dontreadfrominput_has_encoding(testdir):
     reprec.assertoutcome(passed=1)
 
 
+def test_crash_on_closing_tmpfile_py27(testdir):
+    testdir.makepyfile('''
+        from __future__ import print_function
+        import time
+        import threading
+        import sys
+
+        def spam():
+            f = sys.stderr
+            while True:
+                print('.', end='', file=f)
+
+        def test_silly():
+            t = threading.Thread(target=spam)
+            t.daemon = True
+            t.start()
+            time.sleep(0.5)
+
+    ''')
+    result = testdir.runpytest_subprocess()
+    assert result.ret == 0
+    assert 'IOError' not in result.stdout.str()
+
+
 def test_pickling_and_unpickling_encoded_file():
     # See https://bitbucket.org/pytest-dev/pytest/pull-request/194
     # pickle.loads() raises infinite recursion if


### PR DESCRIPTION
Fix #2370
