### PR TITLE
logging.py: Don't change log level of the root logger to bigger numeric value

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -105,6 +105,7 @@ Jurko Gospodnetić
 Justyna Janczyszyn
 Kale Kundert
 Katarzyna Jachim
+Katerina Koukiou
 Kevin Cox
 Kodi B. Arfer
 Lawrence Mitchell

--- a/_pytest/logging.py
+++ b/_pytest/logging.py
@@ -153,7 +153,7 @@ def catching_logs(handler, formatter=None, level=None):
         root_logger.addHandler(handler)
     if level is not None:
         orig_level = root_logger.level
-        root_logger.setLevel(level)
+        root_logger.setLevel(min(orig_level, level))
     try:
         yield handler
     finally:

--- a/changelog/3307.feature.rst
+++ b/changelog/3307.feature.rst
@@ -1,0 +1,3 @@
+pytest should not change the log level of the root logger when the
+``log-level`` parameter has greater numeric value than that of the level of
+the root logger.

--- a/changelog/3307.feature.rst
+++ b/changelog/3307.feature.rst
@@ -1,3 +1,3 @@
-pytest should not change the log level of the root logger when the
+pytest not longer changes the log level of the root logger when the
 ``log-level`` parameter has greater numeric value than that of the level of
-the root logger.
+the root logger, which makes it play better with custom logging configuration in user code.


### PR DESCRIPTION
When doing log capturing we need to temporary change the level of the root logger to be at least
of the log level that the handler used for log capturing has (log_level), so that we 'll be able to capture such  logs.

If root logger level has smaller numeric value than `log_level` parameter we should not enforce root logger level to `log_level` because we might miss important logs from root logger gathered by other handlers.