### PR TITLE
Add support for `pytest.approx` comparisons between array and scalar

### DIFF
--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -88,12 +88,14 @@ class ApproxNumpy(ApproxBase):
     def __eq__(self, actual):
         import numpy as np
 
-        try:
-            actual = np.asarray(actual)
-        except:  # noqa
-            raise TypeError("cannot compare '{0}' to numpy.ndarray".format(actual))
+        if not np.isscalar(actual):
+            try:
+                actual = np.asarray(actual)
+            except:  # noqa
+                raise TypeError("cannot compare '{0}' to numpy.ndarray".format(actual))
 
-        if not np.isscalar(self.expected) and actual.shape != self.expected.shape:
+        if (not np.isscalar(self.expected) and not np.isscalar(actual)
+                and actual.shape != self.expected.shape):
             return False
 
         return ApproxBase.__eq__(self, actual)
@@ -108,6 +110,9 @@ class ApproxNumpy(ApproxBase):
         if np.isscalar(self.expected):
             for i in np.ndindex(actual.shape):
                 yield actual[i], self.expected
+        elif np.isscalar(actual):
+            for i in np.ndindex(self.expected.shape):
+                yield actual, self.expected[i]
         else:
             for i in np.ndindex(self.expected.shape):
                 yield actual[i], self.expected[i]

--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -76,8 +76,10 @@ class ApproxNumpy(ApproxBase):
     def __repr__(self):
         # It might be nice to rewrite this function to account for the
         # shape of the array...
+        import numpy as np
+
         return "approx({0!r})".format(list(
-            self._approx_scalar(x) for x in self.expected))
+            self._approx_scalar(x) for x in np.asarray(self.expected)))
 
     if sys.version_info[0] == 2:
         __cmp__ = _cmp_raises_type_error
@@ -100,9 +102,11 @@ class ApproxNumpy(ApproxBase):
     def _yield_comparisons(self, actual):
         import numpy as np
 
-        # We can be sure that `actual` is a numpy array, because it's
-        # casted in `__eq__` before being passed to `ApproxBase.__eq__`,
-        # which is the only method that calls this one.
+        # For both `actual` and `self.expected`, they can independently be
+        # either a `numpy.array` or a scalar (but both can't be scalar,
+        # in this case an `ApproxScalar` is used).
+        # They are treated in `__eq__` before being passed to
+        # `ApproxBase.__eq__`, which is the only method that calls this one.
 
         if np.isscalar(self.expected):
             for i in np.ndindex(actual.shape):

--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -31,9 +31,9 @@ class ApproxBase(object):
     or sequences of numbers.
     """
 
-    # Tell numpy to use our `__eq__` operator instead of its when left side in a numpy array but right side is
-    # an instance of ApproxBase
+    # Tell numpy to use our `__eq__` operator instead of its
     __array_ufunc__ = None
+    __array_priority__ = 100
 
     def __init__(self, expected, rel=None, abs=None, nan_ok=False):
         self.expected = expected
@@ -73,9 +73,6 @@ class ApproxNumpy(ApproxBase):
     Perform approximate comparisons for numpy arrays.
     """
 
-    # Tell numpy to use our `__eq__` operator instead of its.
-    __array_priority__ = 100
-
     def __repr__(self):
         # It might be nice to rewrite this function to account for the
         # shape of the array...
@@ -109,13 +106,13 @@ class ApproxNumpy(ApproxBase):
 
         if np.isscalar(self.expected):
             for i in np.ndindex(actual.shape):
-                yield actual[i], self.expected
+                yield np.asscalar(actual[i]), self.expected
         elif np.isscalar(actual):
             for i in np.ndindex(self.expected.shape):
-                yield actual, self.expected[i]
+                yield actual, np.asscalar(self.expected[i])
         else:
             for i in np.ndindex(self.expected.shape):
-                yield actual[i], self.expected[i]
+                yield np.asscalar(actual[i]), np.asscalar(self.expected[i])
 
 
 class ApproxMapping(ApproxBase):
@@ -144,9 +141,6 @@ class ApproxSequence(ApproxBase):
     """
     Perform approximate comparisons for sequences of numbers.
     """
-
-    # Tell numpy to use our `__eq__` operator instead of its.
-    __array_priority__ = 100
 
     def __repr__(self):
         seq_type = type(self.expected)

--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -87,14 +87,15 @@ class ApproxNumpy(ApproxBase):
     def __eq__(self, actual):
         import numpy as np
 
+        # self.expected is supposed to always be an array here
+
         if not np.isscalar(actual):
             try:
                 actual = np.asarray(actual)
             except:  # noqa
                 raise TypeError("cannot compare '{0}' to numpy.ndarray".format(actual))
 
-        if (not np.isscalar(self.expected) and not np.isscalar(actual)
-                and actual.shape != self.expected.shape):
+        if not np.isscalar(actual) and actual.shape != self.expected.shape:
             return False
 
         return ApproxBase.__eq__(self, actual)
@@ -102,16 +103,11 @@ class ApproxNumpy(ApproxBase):
     def _yield_comparisons(self, actual):
         import numpy as np
 
-        # For both `actual` and `self.expected`, they can independently be
-        # either a `numpy.array` or a scalar (but both can't be scalar,
-        # in this case an `ApproxScalar` is used).
-        # They are treated in `__eq__` before being passed to
-        # `ApproxBase.__eq__`, which is the only method that calls this one.
+        # `actual` can either be a numpy array or a scalar, it is treated in
+        # `__eq__` before being passed to `ApproxBase.__eq__`, which is the
+        # only method that calls this one.
 
-        if np.isscalar(self.expected):
-            for i in np.ndindex(actual.shape):
-                yield np.asscalar(actual[i]), self.expected
-        elif np.isscalar(actual):
+        if np.isscalar(actual):
             for i in np.ndindex(self.expected.shape):
                 yield actual, np.asscalar(self.expected[i])
         else:
@@ -202,7 +198,7 @@ class ApproxScalar(ApproxBase):
         the pre-specified tolerance.
         """
         if _is_numpy_array(actual):
-            return actual == ApproxNumpy(self.expected, self.abs, self.rel, self.nan_ok)
+            return ApproxNumpy(actual, self.abs, self.rel, self.nan_ok) == self.expected
 
         # Short-circuit exact equality.
         if actual == self.expected:

--- a/changelog/3312.feature
+++ b/changelog/3312.feature
@@ -1,0 +1,1 @@
+``pytest.approx`` now accepts comparing a numpy array with a scalar.

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -391,3 +391,14 @@ class TestApprox(object):
         """
         with pytest.raises(TypeError):
             op(1, approx(1, rel=1e-6, abs=1e-12))
+
+    def test_numpy_array_with_scalar(self):
+        np = pytest.importorskip('numpy')
+
+        actual = np.array([1 + 1e-7, 1 - 1e-8])
+        expected = 1.0
+
+        assert actual == approx(expected, rel=5e-7, abs=0)
+        assert actual != approx(expected, rel=5e-8, abs=0)
+        assert approx(expected, rel=5e-7, abs=0) == actual
+        assert approx(expected, rel=5e-8, abs=0) != actual

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -402,3 +402,14 @@ class TestApprox(object):
         assert actual != approx(expected, rel=5e-8, abs=0)
         assert approx(expected, rel=5e-7, abs=0) == actual
         assert approx(expected, rel=5e-8, abs=0) != actual
+
+    def test_numpy_scalar_with_array(self):
+        np = pytest.importorskip('numpy')
+
+        actual = 1.0
+        expected = np.array([1 + 1e-7, 1 - 1e-8])
+
+        assert actual == approx(expected, rel=5e-7, abs=0)
+        assert actual != approx(expected, rel=5e-8, abs=0)
+        assert approx(expected, rel=5e-7, abs=0) == actual
+        assert approx(expected, rel=5e-8, abs=0) != actual


### PR DESCRIPTION
fixes #3312 