### PR TITLE
Allow DontReadFromInput to produce iterator without error.

### DIFF
--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -560,7 +560,7 @@ class SysCaptureBinary(SysCapture):
         return res
 
 
-class DontReadFromInput(object):
+class DontReadFromInput(six.Iterator):
     """Temporary stub class.  Ideally when stdin is accessed, the
     capturing should be turned off, with possibly all data captured
     so far sent to the screen.  This should be configurable, though,

--- a/_pytest/capture.py
+++ b/_pytest/capture.py
@@ -574,7 +574,10 @@ class DontReadFromInput(object):
         raise IOError("reading from stdin while output is captured")
     readline = read
     readlines = read
-    __iter__ = read
+    __next__ = read
+
+    def __iter__(self):
+        return self
 
     def fileno(self):
         raise UnsupportedOperation("redirected stdin is pseudofile, "

--- a/_pytest/logging.py
+++ b/_pytest/logging.py
@@ -292,8 +292,7 @@ def caplog(request):
     * caplog.text()          -> string containing formatted log output
     * caplog.records()       -> list of logging.LogRecord instances
     * caplog.record_tuples() -> list of (logger_name, level, message) tuples
-    * caplog.clear()         -> clear captured records and formatted log output
-                                string
+    * caplog.clear()         -> clear captured records and formatted log output string
     """
     result = LogCaptureFixture(request.node)
     yield result

--- a/changelog/3314.bugfix.rst
+++ b/changelog/3314.bugfix.rst
@@ -1,0 +1,3 @@
+During test collection, when stdin is not allowed to be read, the
+``DontReadFromStdin`` object still allow itself to be iterable and
+resolved to an iterator without crashing.

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -751,7 +751,8 @@ def test_dontreadfrominput():
     assert not f.isatty()
     pytest.raises(IOError, f.read)
     pytest.raises(IOError, f.readlines)
-    pytest.raises(IOError, iter, f)
+    iter_f = iter(f)
+    pytest.raises(IOError, next, iter_f)
     pytest.raises(UnsupportedOperation, f.fileno)
     f.close()  # just for completeness
 
@@ -764,7 +765,8 @@ def test_dontreadfrominput_buffer_python3():
     assert not fb.isatty()
     pytest.raises(IOError, fb.read)
     pytest.raises(IOError, fb.readlines)
-    pytest.raises(IOError, iter, fb)
+    iter_f = iter(f)
+    pytest.raises(IOError, next, iter_f)
     pytest.raises(ValueError, fb.fileno)
     f.close()  # just for completeness
 


### PR DESCRIPTION
Fixes #3314.