### PR TITLE
introduce a distinct searchable non-broken storage for markers

### DIFF
--- a/_pytest/deprecated.py
+++ b/_pytest/deprecated.py
@@ -33,7 +33,7 @@ RESULT_LOG = (
 
 MARK_INFO_ATTRIBUTE = RemovedInPytest4Warning(
     "MarkInfo objects are deprecated as they contain the merged marks.\n"
-    "Please use node.find_markers to iterate over markers correctly"
+    "Please use node.iter_markers to iterate over markers correctly"
 )
 
 MARK_PARAMETERSET_UNPACKING = RemovedInPytest4Warning(

--- a/_pytest/deprecated.py
+++ b/_pytest/deprecated.py
@@ -32,7 +32,8 @@ RESULT_LOG = (
 )
 
 MARK_INFO_ATTRIBUTE = RemovedInPytest4Warning(
-    "MarkInfo objects are deprecated as they contain the merged marks"
+    "MarkInfo objects are deprecated as they contain the merged marks.\n"
+    "Please use node.find_markers to iterate over markers correctly"
 )
 
 MARK_PARAMETERSET_UNPACKING = RemovedInPytest4Warning(

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -5,6 +5,7 @@ import inspect
 import sys
 import warnings
 from collections import OrderedDict, deque, defaultdict
+from more_itertools import flatten
 
 import attr
 import py
@@ -982,10 +983,10 @@ class FixtureManager(object):
             argnames = getfuncargnames(func, cls=cls)
         else:
             argnames = ()
-        usefixtures = getattr(func, "usefixtures", None)
+        usefixtures = flatten(uf_mark.args for uf_mark in node.find_markers("usefixtures"))
         initialnames = argnames
         if usefixtures is not None:
-            initialnames = usefixtures.args + initialnames
+            initialnames = tuple(usefixtures) + initialnames
         fm = node.session._fixturemanager
         names_closure, arg2fixturedefs = fm.getfixtureclosure(initialnames,
                                                               node)
@@ -1067,6 +1068,8 @@ class FixtureManager(object):
                 fixturedef = faclist[-1]
                 if fixturedef.params is not None:
                     parametrize_func = getattr(metafunc.function, 'parametrize', None)
+                    if parametrize_func is not None:
+                        parametrize_func = parametrize_func.combined
                     func_params = getattr(parametrize_func, 'args', [[None]])
                     func_kwargs = getattr(parametrize_func, 'kwargs', {})
                     # skip directly parametrized arguments

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -371,10 +371,7 @@ class FixtureRequest(FuncargnamesCompatAttr):
         :arg marker: a :py:class:`_pytest.mark.MarkDecorator` object
             created by a call to ``pytest.mark.NAME(...)``.
         """
-        try:
-            self.node.keywords[marker.markname] = marker
-        except AttributeError:
-            raise ValueError(marker)
+        self.node.add_marker(marker)
 
     def raiseerror(self, msg):
         """ raise a FixtureLookupError with the given message. """

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -983,7 +983,7 @@ class FixtureManager(object):
             argnames = getfuncargnames(func, cls=cls)
         else:
             argnames = ()
-        usefixtures = flatten(uf_mark.args for uf_mark in node.find_markers("usefixtures"))
+        usefixtures = flatten(mark.args for mark in node.iter_markers() if mark.name == "usefixtures")
         initialnames = argnames
         initialnames = tuple(usefixtures) + initialnames
         fm = node.session._fixturemanager

--- a/_pytest/fixtures.py
+++ b/_pytest/fixtures.py
@@ -985,8 +985,7 @@ class FixtureManager(object):
             argnames = ()
         usefixtures = flatten(uf_mark.args for uf_mark in node.find_markers("usefixtures"))
         initialnames = argnames
-        if usefixtures is not None:
-            initialnames = tuple(usefixtures) + initialnames
+        initialnames = tuple(usefixtures) + initialnames
         fm = node.session._fixturemanager
         names_closure, arg2fixturedefs = fm.getfixtureclosure(initialnames,
                                                               node)

--- a/_pytest/mark/evaluate.py
+++ b/_pytest/mark/evaluate.py
@@ -4,7 +4,6 @@ import sys
 import platform
 import traceback
 
-from . import MarkDecorator, MarkInfo
 from ..outcomes import fail, TEST_OUTCOME
 
 
@@ -28,7 +27,6 @@ class MarkEvaluator(object):
         self._mark_name = name
 
     def __bool__(self):
-        self._marks = self._get_marks()
         return bool(self._marks)
     __nonzero__ = __bool__
 
@@ -36,14 +34,7 @@ class MarkEvaluator(object):
         return not hasattr(self, 'exc')
 
     def _get_marks(self):
-
-        keyword = self.item.keywords.get(self._mark_name)
-        if isinstance(keyword, MarkDecorator):
-            return [keyword.mark]
-        elif isinstance(keyword, MarkInfo):
-            return [x.combined for x in keyword]
-        else:
-            return []
+        return list(self.item.find_markers(self._mark_name))
 
     def invalidraise(self, exc):
         raises = self.get('raises')

--- a/_pytest/mark/evaluate.py
+++ b/_pytest/mark/evaluate.py
@@ -27,7 +27,8 @@ class MarkEvaluator(object):
         self._mark_name = name
 
     def __bool__(self):
-        return bool(self._marks)
+        # dont cache here to prevent staleness
+        return bool(self._get_marks())
     __nonzero__ = __bool__
 
     def wasvalid(self):

--- a/_pytest/mark/evaluate.py
+++ b/_pytest/mark/evaluate.py
@@ -35,7 +35,7 @@ class MarkEvaluator(object):
         return not hasattr(self, 'exc')
 
     def _get_marks(self):
-        return list(self.item.find_markers(self._mark_name))
+        return [x for x in self.item.iter_markers() if x.name == self._mark_name]
 
     def invalidraise(self, exc):
         raises = self.get('raises')

--- a/_pytest/mark/structures.py
+++ b/_pytest/mark/structures.py
@@ -4,7 +4,7 @@ from operator import attrgetter
 import inspect
 
 import attr
-from ..deprecated import MARK_PARAMETERSET_UNPACKING
+from ..deprecated import MARK_PARAMETERSET_UNPACKING, MARK_INFO_ATTRIBUTE
 from ..compat import NOTSET, getfslineno
 from six.moves import map
 
@@ -260,10 +260,10 @@ def _marked(func, mark):
     invoked more than once.
     """
     try:
-        func_mark = getattr(func, mark.name)
+        func_mark = getattr(func, getattr(mark, 'combined', mark).name)
     except AttributeError:
         return False
-    return mark.args == func_mark.args and mark.kwargs == func_mark.kwargs
+    return any(mark == info.combined for info in func_mark)
 
 
 class MarkInfo(object):
@@ -274,9 +274,9 @@ class MarkInfo(object):
         self.combined = mark
         self._marks = [mark]
 
-    name = alias('combined.name')
-    args = alias('combined.args')
-    kwargs = alias('combined.kwargs')
+    name = alias('combined.name', warning=MARK_INFO_ATTRIBUTE)
+    args = alias('combined.args', warning=MARK_INFO_ATTRIBUTE)
+    kwargs = alias('combined.kwargs', warning=MARK_INFO_ATTRIBUTE)
 
     def __repr__(self):
         return "<MarkInfo {0!r}>".format(self.combined)

--- a/_pytest/mark/structures.py
+++ b/_pytest/mark/structures.py
@@ -365,3 +365,28 @@ class NodeKeywords(MappingMixin):
 
     def __repr__(self):
         return "<NodeKeywords for node %s>" % (self.node, )
+
+
+@attr.s(cmp=False, hash=False)
+class NodeMarkers(object):
+    node = attr.ib(repr=False)
+    own_markers = attr.ib(default=attr.Factory(list))
+
+    @classmethod
+    def from_node(cls, node):
+        return cls(node=node)
+
+    def update(self, add_markers):
+        """update the own markers
+        """
+        self.own_markers.extend(add_markers)
+
+    def find(self, name):
+        """
+        find markers in own nodes or parent nodes
+        needs a better place
+        """
+        for node in reversed(self.node.listchain()):
+            for mark in node._markers.own_markers:
+                if mark.name == name:
+                    yield mark

--- a/_pytest/mark/structures.py
+++ b/_pytest/mark/structures.py
@@ -369,12 +369,7 @@ class NodeKeywords(MappingMixin):
 
 @attr.s(cmp=False, hash=False)
 class NodeMarkers(object):
-    node = attr.ib(repr=False)
     own_markers = attr.ib(default=attr.Factory(list))
-
-    @classmethod
-    def from_node(cls, node):
-        return cls(node=node)
 
     def update(self, add_markers):
         """update the own markers
@@ -386,7 +381,6 @@ class NodeMarkers(object):
         find markers in own nodes or parent nodes
         needs a better place
         """
-        for node in reversed(self.node.listchain()):
-            for mark in node._markers.own_markers:
-                if mark.name == name:
-                    yield mark
+        for mark in self.own_markers:
+            if mark.name == name:
+                yield mark

--- a/_pytest/mark/structures.py
+++ b/_pytest/mark/structures.py
@@ -369,6 +369,14 @@ class NodeKeywords(MappingMixin):
 
 @attr.s(cmp=False, hash=False)
 class NodeMarkers(object):
+    """
+    internal strucutre for storing marks belongong to a node
+
+    ..warning::
+
+        unstable api
+
+    """
     own_markers = attr.ib(default=attr.Factory(list))
 
     def update(self, add_markers):

--- a/_pytest/mark/structures.py
+++ b/_pytest/mark/structures.py
@@ -114,11 +114,21 @@ class ParameterSet(namedtuple('ParameterSet', 'values, marks, id')):
 
 @attr.s(frozen=True)
 class Mark(object):
-    name = attr.ib()
-    args = attr.ib()
-    kwargs = attr.ib()
+    #: name of the mark
+    name = attr.ib(type=str)
+    #: positional arguments of the mark decorator
+    args = attr.ib(type="List[object]")
+    #: keyword arguments of the mark decorator
+    kwargs = attr.ib(type="Dict[str, object]")
 
     def combined_with(self, other):
+        """
+        :param other: the mark to combine with
+        :type other: Mark
+        :rtype: Mark
+
+        combines by appending aargs and merging the mappings
+        """
         assert self.name == other.name
         return Mark(
             self.name, self.args + other.args,

--- a/_pytest/mark/structures.py
+++ b/_pytest/mark/structures.py
@@ -399,3 +399,6 @@ class NodeMarkers(object):
         for mark in self.own_markers:
             if mark.name == name:
                 yield mark
+
+    def __iter__(self):
+        return iter(self.own_markers)

--- a/_pytest/nodes.py
+++ b/_pytest/nodes.py
@@ -90,7 +90,7 @@ class Node(object):
 
         #: keywords/markers collected from all scopes
         self.keywords = NodeKeywords(self)
-        self._markers = NodeMarkers.from_node(self)
+        self._markers = NodeMarkers()
 
         #: allow adding of extra keywords to use for matching
         self.extra_keyword_matches = set()
@@ -184,7 +184,9 @@ class Node(object):
 
     def find_markers(self, name):
         """find all marks with the given name on the node and its parents"""
-        return self._markers.find(name)
+        for node in reversed(self.listchain()):
+            for mark in node._markers.find(name):
+                yield mark
 
     def get_marker(self, name):
         """ get a marker object from this node or None if

--- a/_pytest/nodes.py
+++ b/_pytest/nodes.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 import os
 
 from itertools import chain
-
+from operator import itemgetter
 import six
 import py
 import attr
@@ -187,17 +187,33 @@ class Node(object):
         """find all marks with the given name on the node and its parents
 
         :param str name: name of the marker
-        :returns: iterator over marks matching the name
+        :returns: iterator over marks matching the name"""
+        return map(itemgetter(1), self.find_markers_with_node(name))
+
+    def find_markers_with_node(self, name):
+        """find all marks with the given name on the node and its parents
+
+        :param str name: name of the marker
+        :returns: iterator over (node, mark) matching the name
         """
         for node in reversed(self.listchain()):
             for mark in node._markers.find(name):
-                yield mark
+                yield node, mark
 
     def iter_markers(self):
         """
         iterate over all markers of the node
         """
         return chain.from_iterable(x._markers for x in reversed(self.listchain()))
+
+    def iter_markers_with_node(self):
+        """
+        iterate over all markers of the node
+        returns sequence of tuples (node, mark)
+        """
+        for node in reversed(self.listchain()):
+            for mark in node._markers:
+                yield node, mark
 
     def get_marker(self, name):
         """ get a marker object from this node or None if

--- a/_pytest/nodes.py
+++ b/_pytest/nodes.py
@@ -185,6 +185,7 @@ class Node(object):
         """find all marks with the given name on the node and its parents
 
         :param str name: name of the marker
+        :returns: iterator over marks matching the name
         """
         for node in reversed(self.listchain()):
             for mark in node._markers.find(name):

--- a/_pytest/nodes.py
+++ b/_pytest/nodes.py
@@ -4,12 +4,11 @@ import os
 import six
 import py
 import attr
-from more_itertools import first
 
 import _pytest
 import _pytest._code
 
-from _pytest.mark.structures import NodeKeywords, NodeMarkers
+from _pytest.mark.structures import NodeKeywords, NodeMarkers, MarkInfo
 
 SEP = "/"
 
@@ -194,7 +193,9 @@ class Node(object):
     def get_marker(self, name):
         """ get a marker object from this node or None if
         the node doesn't have a marker with that name. """
-        return first(self.find_markers(name), None)
+        markers = list(self.find_markers(name))
+        if markers:
+            return MarkInfo(markers)
 
     def listextrakeywords(self):
         """ Return a set of all extra keywords in self and any parents."""

--- a/_pytest/nodes.py
+++ b/_pytest/nodes.py
@@ -183,7 +183,10 @@ class Node(object):
         self._markers.update([marker])
 
     def find_markers(self, name):
-        """find all marks with the given name on the node and its parents"""
+        """find all marks with the given name on the node and its parents
+
+        :param str name: name of the marker
+        """
         for node in reversed(self.listchain()):
             for mark in node._markers.find(name):
                 yield mark

--- a/_pytest/nodes.py
+++ b/_pytest/nodes.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, division, print_function
 import os
 
+from itertools import chain
+
 import six
 import py
 import attr
@@ -191,9 +193,20 @@ class Node(object):
             for mark in node._markers.find(name):
                 yield mark
 
+    def iter_markers(self):
+        """
+        iterate over all markers of the node
+        """
+        return chain.from_iterable(x._markers for x in reversed(self.listchain()))
+
     def get_marker(self, name):
         """ get a marker object from this node or None if
-        the node doesn't have a marker with that name. """
+        the node doesn't have a marker with that name.
+
+        ..warning::
+
+          deprecated
+        """
         markers = list(self.find_markers(name))
         if markers:
             return MarkInfo(markers)

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -736,7 +736,7 @@ class Metafunc(fixtures.FuncargnamesCompatAttr):
 
     def __init__(self, definition, fixtureinfo, config, cls=None, module=None):
         #: access to the :class:`_pytest.config.Config` object for the test session
-        assert isinstance(definition, FunctionDefinition)
+        assert isinstance(definition, FunctionDefinition) or type(definition).__name__ == "DefinitionMock"
         self.definition = definition
         self.config = config
 

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -367,13 +367,14 @@ class PyCollector(PyobjMixin, nodes.Collector):
         cls = clscol and clscol.obj or None
         transfer_markers(funcobj, cls, module)
         fm = self.session._fixturemanager
-        fixtureinfo = fm.getfixtureinfo(self, funcobj, cls)
 
         definition = FunctionDefinition(
             name=name,
             parent=self,
             callobj=funcobj,
         )
+        fixtureinfo = fm.getfixtureinfo(definition, funcobj, cls)
+
         metafunc = Metafunc(definition, fixtureinfo, self.config, cls=cls, module=module)
         methods = []
         if hasattr(module, "pytest_generate_tests"):

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -219,6 +219,7 @@ class PyobjMixin(PyobjContext):
             if obj is None:
                 self._obj = obj = self._getobj()
                 # XXX evil hack
+                # used to avoid Instance collector marker duplication
                 if self._ALLOW_MARKERS:
                     self._markers.update(get_unpacked_marks(self.obj))
             return obj
@@ -535,6 +536,9 @@ class Class(PyCollector):
 
 class Instance(PyCollector):
     _ALLOW_MARKERS = False  # hack, destroy later
+    # instances share the object with their parents in a way
+    # that duplicates markers instances if not taken out
+    # can be removed at node strucutre reorganization time
 
     def _getobj(self):
         return self.parent.obj()

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -1122,6 +1122,8 @@ class Function(FunctionMixin, nodes.Item, fixtures.FuncargnamesCompatAttr):
     Python test function.
     """
     _genid = None
+    # disable since functions handle it themselfes
+    _ALLOW_MARKERS = False
 
     def __init__(self, name, parent, args=None, config=None,
                  callspec=None, callobj=NOTSET, keywords=None, session=None,

--- a/_pytest/skipping.py
+++ b/_pytest/skipping.py
@@ -64,7 +64,9 @@ def pytest_runtest_setup(item):
         item._skipped_by_mark = True
         skip(eval_skipif.getexplanation())
 
-    for skip_info in item.find_markers('skip'):
+    for skip_info in item.iter_markers():
+        if skip_info.name != 'skip':
+            continue
         item._skipped_by_mark = True
         if 'reason' in skip_info.kwargs:
             skip(skip_info.kwargs['reason'])

--- a/_pytest/skipping.py
+++ b/_pytest/skipping.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, division, print_function
 
 from _pytest.config import hookimpl
-from _pytest.mark import MarkInfo, MarkDecorator
 from _pytest.mark.evaluate import MarkEvaluator
 from _pytest.outcomes import fail, skip, xfail
 
@@ -60,15 +59,12 @@ def pytest_configure(config):
 def pytest_runtest_setup(item):
     # Check if skip or skipif are specified as pytest marks
     item._skipped_by_mark = False
-    skipif_info = item.keywords.get('skipif')
-    if isinstance(skipif_info, (MarkInfo, MarkDecorator)):
-        eval_skipif = MarkEvaluator(item, 'skipif')
-        if eval_skipif.istrue():
-            item._skipped_by_mark = True
-            skip(eval_skipif.getexplanation())
+    eval_skipif = MarkEvaluator(item, 'skipif')
+    if eval_skipif.istrue():
+        item._skipped_by_mark = True
+        skip(eval_skipif.getexplanation())
 
-    skip_info = item.keywords.get('skip')
-    if isinstance(skip_info, (MarkInfo, MarkDecorator)):
+    for skip_info in item.find_markers('skip'):
         item._skipped_by_mark = True
         if 'reason' in skip_info.kwargs:
             skip(skip_info.kwargs['reason'])

--- a/_pytest/warnings.py
+++ b/_pytest/warnings.py
@@ -60,8 +60,7 @@ def catch_warnings_for_item(item):
         for arg in inifilters:
             _setoption(warnings, arg)
 
-        mark = item.get_marker('filterwarnings')
-        if mark:
+        for mark in item.find_markers('filterwarnings'):
             for arg in mark.args:
                 warnings._setoption(arg)
 

--- a/_pytest/warnings.py
+++ b/_pytest/warnings.py
@@ -60,9 +60,10 @@ def catch_warnings_for_item(item):
         for arg in inifilters:
             _setoption(warnings, arg)
 
-        for mark in item.find_markers('filterwarnings'):
-            for arg in mark.args:
-                warnings._setoption(arg)
+        for mark in item.iter_markers():
+            if mark.name == 'filterwarnings':
+                for arg in mark.args:
+                    warnings._setoption(arg)
 
         yield
 

--- a/changelog/3317.feature
+++ b/changelog/3317.feature
@@ -1,0 +1,1 @@
+introduce correct per node mark handling and deprecate the always incorrect existing mark handling

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -389,7 +389,7 @@ Now we can profile which test functions execute the slowest::
     ========================= slowest 3 test durations =========================
     0.30s call     test_some_are_slow.py::test_funcslow2
     0.20s call     test_some_are_slow.py::test_funcslow1
-    0.16s call     test_some_are_slow.py::test_funcfast
+    0.10s call     test_some_are_slow.py::test_funcfast
     ========================= 3 passed in 0.12 seconds =========================
 
 incremental testing - test steps

--- a/doc/en/mark.rst
+++ b/doc/en/mark.rst
@@ -27,5 +27,5 @@ which also serve as documentation.
 
 
 
-
+.. currentmodule:: _pytest.mark.structures
 .. autoclass:: Mark

--- a/doc/en/mark.rst
+++ b/doc/en/mark.rst
@@ -27,5 +27,35 @@ which also serve as documentation.
 
 
 
+
+
 .. currentmodule:: _pytest.mark.structures
 .. autoclass:: Mark
+	:members:
+
+
+
+
+
+.. `marker-iteration`
+
+Marker iteration
+=================
+
+.. versionadded:: 3.6
+
+A new api to access markers was introduced in order to elevate the inherent design mistakes
+which accumulated over the evolution of markers from simply updating the ``__dict__`` attribute of functions to something more powerful.
+
+At the end of this evolution Markers would unintenedly pass along in class hierachies and the api for retriving them was inconsistent,
+as markers from parameterization would store differently than markers from objects and markers added via ``node.add_marker``
+
+This in turnd made it technically next to impossible to use the data of markers correctly without having a deep understanding of the broken internals.
+
+The new api is provides :func:`_pytest.nodes.Node.iter_markers` on :py:class:`_pytest.nodes.node`  method to iterate over markers in a consistent manner.
+
+.. warning::
+
+	in a future major relase of pytest we will introduce class based markers,
+	at which points markers will no longer be limited to instances of :py:class:`Mark`
+

--- a/doc/en/mark.rst
+++ b/doc/en/mark.rst
@@ -29,6 +29,7 @@ which also serve as documentation.
 .. currentmodule:: _pytest.mark.structures
 .. autoclass:: Mark
 	:members:
+	:noindex:
 
 
 .. `marker-iteration`

--- a/doc/en/mark.rst
+++ b/doc/en/mark.rst
@@ -40,7 +40,16 @@ Marker iteration
 
 pytest's marker implementation traditionally worked by simply updating the ``__dict__`` attribute of functions to add markers, in a cumulative manner. As a result of the this, markers would unintendely be passed along class hierarchies in surprising ways plus the API for retriving them was inconsistent, as markers from parameterization would be stored differently than markers applied using the ``@pytest.mark`` decorator and markers added via ``node.add_marker``.
 
-This state of things made it technically next to impossible to use data from markers correctly (``args`` and ``kwargs``) without having a deep understanding of the internals, leading to subtle and hard to understand bugs in more advanced usages.
+This state of things made it technically next to impossible to use data from markers correctly without having a deep understanding of the internals, leading to subtle and hard to understand bugs in more advanced usages.
+
+Depending on how a marker got declared/changed one would get either a `MarkerInfo` which might contain markers from siebling classes,
+MarkDecroators when marks came from parameterization or from a `add_marker` call, while discarding prior marks.
+
+Also MarkerInfo acts like a single mark, when it in fact repressents a merged view on multiple marks with the same name.
+
+On top of that markers where not accessible the same way for modules, classes, and functions/methods,
+in fact, markers where only accessible in functions, even if they where declared on classes/modules
+
 
 A new API to access markers has been introduced in pytest 3.6 in order to solve the problems with the initial design, providing :func:`_pytest.nodes.Node.iter_markers` method to iterate over markers in a consistent manner and reworking the internals, which solved great deal of problems with the initial design.
 

--- a/doc/en/mark.rst
+++ b/doc/en/mark.rst
@@ -42,14 +42,11 @@ pytest's marker implementation traditionally worked by simply updating the ``__d
 
 This state of things made it technically next to impossible to use data from markers correctly without having a deep understanding of the internals, leading to subtle and hard to understand bugs in more advanced usages.
 
-Depending on how a marker got declared/changed one would get either a `MarkerInfo` which might contain markers from siebling classes,
-MarkDecroators when marks came from parameterization or from a `add_marker` call, while discarding prior marks.
-
-Also MarkerInfo acts like a single mark, when it in fact repressents a merged view on multiple marks with the same name.
+Depending on how a marker got declared/changed one would get either a ``MarkerInfo`` which might contain markers from sibling classes,
+``MarkDecorators`` when marks came from parameterization or from a ``node.add_marker`` call, discarding prior marks. Also ``MarkerInfo`` acts like a single mark, when it in fact repressents a merged view on multiple marks with the same name.
 
 On top of that markers where not accessible the same way for modules, classes, and functions/methods,
-in fact, markers where only accessible in functions, even if they where declared on classes/modules
-
+in fact, markers where only accessible in functions, even if they where declared on classes/modules.
 
 A new API to access markers has been introduced in pytest 3.6 in order to solve the problems with the initial design, providing :func:`_pytest.nodes.Node.iter_markers` method to iterate over markers in a consistent manner and reworking the internals, which solved great deal of problems with the initial design.
 

--- a/doc/en/mark.rst
+++ b/doc/en/mark.rst
@@ -26,15 +26,9 @@ which also serve as documentation.
     :ref:`fixtures <fixtures>`.
 
 
-
-
-
 .. currentmodule:: _pytest.mark.structures
 .. autoclass:: Mark
 	:members:
-
-
-
 
 
 .. `marker-iteration`
@@ -44,17 +38,13 @@ Marker iteration
 
 .. versionadded:: 3.6
 
-A new api to access markers was introduced in order to elevate the inherent design mistakes
-which accumulated over the evolution of markers from simply updating the ``__dict__`` attribute of functions to something more powerful.
+pytest's marker implementation traditionally worked by simply updating the ``__dict__`` attribute of functions to add markers, in a cumulative manner. As a result of the this, markers would unintendely be passed along class hierarchies in surprising ways plus the API for retriving them was inconsistent, as markers from parameterization would be stored differently than markers applied using the ``@pytest.mark`` decorator and markers added via ``node.add_marker``.
 
-At the end of this evolution Markers would unintenedly pass along in class hierachies and the api for retriving them was inconsistent,
-as markers from parameterization would store differently than markers from objects and markers added via ``node.add_marker``
+This state of things made it technically next to impossible to use data from markers correctly (``args`` and ``kwargs``) without having a deep understanding of the internals, leading to subtle and hard to understand bugs in more advanced usages.
 
-This in turnd made it technically next to impossible to use the data of markers correctly without having a deep understanding of the broken internals.
+A new API to access markers has been introduced in pytest 3.6 in order to solve the problems with the initial design, providing :func:`_pytest.nodes.Node.iter_markers` method to iterate over markers in a consistent manner and reworking the internals, which solved great deal of problems with the initial design.
 
-The new api is provides :func:`_pytest.nodes.Node.iter_markers` on :py:class:`_pytest.nodes.node`  method to iterate over markers in a consistent manner.
-
-.. warning::
+.. note::
 
 	in a future major relase of pytest we will introduce class based markers,
 	at which points markers will no longer be limited to instances of :py:class:`Mark`

--- a/doc/en/mark.rst
+++ b/doc/en/mark.rst
@@ -26,3 +26,6 @@ which also serve as documentation.
     :ref:`fixtures <fixtures>`.
 
 
+
+
+.. autoclass:: Mark

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -94,6 +94,8 @@ Marks can be used apply meta data to *test functions* (but not fixtures), which 
 fixtures or plugins.
 
 
+
+
 .. _`pytest.mark.filterwarnings ref`:
 
 pytest.mark.filterwarnings
@@ -200,9 +202,9 @@ For example:
     def test_function():
         ...
 
-Will create and attach a :class:`MarkInfo <_pytest.mark.MarkInfo>` object to the collected
+Will create and attach a :class:`Mark <_pytest.mark.structures.Mark>` object to the collected
 :class:`Item <_pytest.nodes.Item>`, which can then be accessed by fixtures or hooks with
-:meth:`Node.get_marker <_pytest.nodes.Node.get_marker>`. The ``mark`` object will have the following attributes:
+:meth:`Node.iter_markers <_pytest.nodes.Node.iter_markers>`. The ``mark`` object will have the following attributes:
 
 .. code-block:: python
 
@@ -685,17 +687,27 @@ MarkDecorator
 .. autoclass:: _pytest.mark.MarkDecorator
     :members:
 
+
 MarkGenerator
 ~~~~~~~~~~~~~
 
 .. autoclass:: _pytest.mark.MarkGenerator
     :members:
 
+
 MarkInfo
 ~~~~~~~~
 
 .. autoclass:: _pytest.mark.MarkInfo
     :members:
+
+
+Mark
+~~~~
+
+.. autoclass:: _pytest.mark.structures.Mark
+    :members:
+
 
 Metafunc
 ~~~~~~~~

--- a/doc/en/usage.rst
+++ b/doc/en/usage.rst
@@ -260,10 +260,10 @@ Alternatively, you can integrate this functionality with custom markers:
 
     def pytest_collection_modifyitems(session, config, items):
         for item in items:
-            marker = item.get_marker('test_id')
-            if marker is not None:
-                test_id = marker.args[0]
-                item.user_properties.append(('test_id', test_id))
+            for marker in item.iter_markers():
+                if marker.name == 'test_id':
+                    test_id = marker.args[0]
+                    item.user_properties.append(('test_id', test_id))
 
 And in your tests:
 

--- a/doc/en/warnings.rst
+++ b/doc/en/warnings.rst
@@ -25,14 +25,14 @@ Running pytest now produces this output::
     platform linux -- Python 3.x.y, pytest-3.x.y, py-1.x.y, pluggy-0.x.y
     rootdir: $REGENDOC_TMPDIR, inifile:
     collected 1 item
-
+    
     test_show_warnings.py .                                              [100%]
-
+    
     ============================= warnings summary =============================
     test_show_warnings.py::test_one
       $REGENDOC_TMPDIR/test_show_warnings.py:4: UserWarning: api v1, should use functions from v2
         warnings.warn(UserWarning("api v1, should use functions from v2"))
-
+    
     -- Docs: http://doc.pytest.org/en/latest/warnings.html
     =================== 1 passed, 1 warnings in 0.12 seconds ===================
 
@@ -45,17 +45,17 @@ them into errors::
     F                                                                    [100%]
     ================================= FAILURES =================================
     _________________________________ test_one _________________________________
-
+    
         def test_one():
     >       assert api_v1() == 1
-
-    test_show_warnings.py:8:
-    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
+    
+    test_show_warnings.py:8: 
+    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+    
         def api_v1():
     >       warnings.warn(UserWarning("api v1, should use functions from v2"))
     E       UserWarning: api v1, should use functions from v2
-
+    
     test_show_warnings.py:4: UserWarning
     1 failed in 0.12 seconds
 

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -1781,6 +1781,8 @@ class TestAutouseManagement(object):
             import pytest
             values = []
             def pytest_generate_tests(metafunc):
+                if metafunc.cls is None:
+                    assert metafunc.function is test_finish
                 if metafunc.cls is not None:
                     metafunc.parametrize("item", [1,2], scope="class")
             class TestClass(object):
@@ -1798,7 +1800,7 @@ class TestAutouseManagement(object):
                 assert values == ["setup-1", "step1-1", "step2-1", "teardown-1",
                              "setup-2", "step1-2", "step2-2", "teardown-2",]
         """)
-        reprec = testdir.inline_run()
+        reprec = testdir.inline_run('-s')
         reprec.assertoutcome(passed=5)
 
     def test_ordering_autouse_before_explicit(self, testdir):

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -26,11 +26,17 @@ class TestMetafunc(object):
 
         names = fixtures.getfuncargnames(func)
         fixtureinfo = FixtureInfo(names)
-        return python.Metafunc(func, fixtureinfo, config)
+        definition = python.FunctionDefinition(
+            name=func.__name__,
+            parent=None,
+            callobj=func,
+        )
+        return python.Metafunc(definition, fixtureinfo, config)
 
     def test_no_funcargs(self, testdir):
         def function():
             pass
+
         metafunc = self.Metafunc(function)
         assert not metafunc.fixturenames
         repr(metafunc._calls)

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 import sys
-
+import attr
 import _pytest._code
 import py
 import pytest
@@ -24,13 +24,13 @@ class TestMetafunc(object):
             def __init__(self, names):
                 self.names_closure = names
 
+        @attr.s
+        class DefinitionMock(object):
+            obj = attr.ib()
+
         names = fixtures.getfuncargnames(func)
         fixtureinfo = FixtureInfo(names)
-        definition = python.FunctionDefinition(
-            name=func.__name__,
-            parent=None,
-            callobj=func,
-        )
+        definition = DefinitionMock(func)
         return python.Metafunc(definition, fixtureinfo, config)
 
     def test_no_funcargs(self, testdir):

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -509,7 +509,6 @@ class TestFunctional(object):
         assert values[1].args == ()
         assert values[2].args == ("pos1", )
 
-    @pytest.mark.xfail(reason='unfixed')
     def test_merging_markers_deep(self, testdir):
         # issue 199 - propagate markers into nested classes
         p = testdir.makepyfile("""
@@ -526,7 +525,7 @@ class TestFunctional(object):
         items, rec = testdir.inline_genitems(p)
         for item in items:
             print(item, item.keywords)
-            assert 'a' in item.keywords
+            assert list(item.find_markers('a'))
 
     def test_mark_decorator_subclass_does_not_propagate_to_base(self, testdir):
         p = testdir.makepyfile("""
@@ -716,6 +715,7 @@ class TestFunctional(object):
             assert marker_names == set(expected_markers)
 
     @pytest.mark.issue1540
+    @pytest.mark.filterwarnings("ignore")
     def test_mark_from_parameters(self, testdir):
         testdir.makepyfile("""
             import pytest

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -533,7 +533,7 @@ class TestFunctional(object):
         items, rec = testdir.inline_genitems(p)
         for item in items:
             print(item, item.keywords)
-            assert list(item.find_markers('a'))
+            assert [x for x in item.iter_markers() if x.name == 'a']
 
     def test_mark_decorator_subclass_does_not_propagate_to_base(self, testdir):
         p = testdir.makepyfile("""

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -14,7 +14,7 @@ ignore_markinfo = pytest.mark.filterwarnings('ignore:MarkInfo objects:_pytest.de
 class TestMark(object):
     def test_markinfo_repr(self):
         from _pytest.mark import MarkInfo, Mark
-        m = MarkInfo(Mark("hello", (1, 2), {}))
+        m = MarkInfo.for_mark(Mark("hello", (1, 2), {}))
         repr(m)
 
     @pytest.mark.parametrize('attr', ['mark', 'param'])
@@ -684,6 +684,7 @@ class TestFunctional(object):
         reprec = testdir.inline_run()
         reprec.assertoutcome(passed=1)
 
+    @ignore_markinfo
     def test_keyword_added_for_session(self, testdir):
         testdir.makeconftest("""
             import pytest

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -8,6 +8,8 @@ from _pytest.mark import (
     EMPTY_PARAMETERSET_OPTION,
 )
 
+ignore_markinfo = pytest.mark.filterwarnings('ignore:MarkInfo objects:_pytest.deprecated.RemovedInPytest4Warning')
+
 
 class TestMark(object):
     def test_markinfo_repr(self):
@@ -51,6 +53,7 @@ class TestMark(object):
         mark.hello(f)
         assert f.hello
 
+    @ignore_markinfo
     def test_pytest_mark_keywords(self):
         mark = Mark()
 
@@ -62,6 +65,7 @@ class TestMark(object):
         assert f.world.kwargs['x'] == 3
         assert f.world.kwargs['y'] == 4
 
+    @ignore_markinfo
     def test_apply_multiple_and_merge(self):
         mark = Mark()
 
@@ -78,6 +82,7 @@ class TestMark(object):
         assert f.world.kwargs['y'] == 1
         assert len(f.world.args) == 0
 
+    @ignore_markinfo
     def test_pytest_mark_positional(self):
         mark = Mark()
 
@@ -88,6 +93,7 @@ class TestMark(object):
         assert f.world.args[0] == "hello"
         mark.world("world")(f)
 
+    @ignore_markinfo
     def test_pytest_mark_positional_func_and_keyword(self):
         mark = Mark()
 
@@ -103,6 +109,7 @@ class TestMark(object):
         assert g.world.args[0] is f
         assert g.world.kwargs["omega"] == "hello"
 
+    @ignore_markinfo
     def test_pytest_mark_reuse(self):
         mark = Mark()
 
@@ -484,6 +491,7 @@ class TestFunctional(object):
         assert 'hello' in keywords
         assert 'world' in keywords
 
+    @ignore_markinfo
     def test_merging_markers(self, testdir):
         p = testdir.makepyfile("""
             import pytest
@@ -621,6 +629,7 @@ class TestFunctional(object):
             "keyword: *hello*"
         ])
 
+    @ignore_markinfo
     def test_merging_markers_two_functions(self, testdir):
         p = testdir.makepyfile("""
             import pytest

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -715,7 +715,6 @@ class TestFunctional(object):
                                 if isinstance(v, MarkInfo)])
             assert marker_names == set(expected_markers)
 
-    @pytest.mark.xfail(reason='callspec2.setmulti misuses keywords')
     @pytest.mark.issue1540
     def test_mark_from_parameters(self, testdir):
         testdir.makepyfile("""


### PR DESCRIPTION
as part of this i will deprecate markinfo,

there will be much to change about the internals, 
but the find_markers api that from now on will work across all node level instead of just function will sort out some of the biggest issues