### PR TITLE
3348: raise error on unknown arguments to raises

### DIFF
--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -597,6 +597,10 @@ def raises(expected_exception, *args, **kwargs):
             message = kwargs.pop("message")
         if "match" in kwargs:
             match_expr = kwargs.pop("match")
+        if len(kwargs.keys()) > 0:
+            msg = 'Unexpected keyword arguments passed to pytest.raises: '
+            msg += ', '.join(kwargs.keys())
+            raise TypeError(msg)
         return RaisesContext(expected_exception, message, match_expr)
     elif isinstance(args[0], str):
         code, = args

--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -597,7 +597,7 @@ def raises(expected_exception, *args, **kwargs):
             message = kwargs.pop("message")
         if "match" in kwargs:
             match_expr = kwargs.pop("match")
-        if len(kwargs.keys()) > 0:
+        if kwargs:
             msg = 'Unexpected keyword arguments passed to pytest.raises: '
             msg += ', '.join(kwargs.keys())
             raise TypeError(msg)

--- a/changelog/3348.bugfix.rst
+++ b/changelog/3348.bugfix.rst
@@ -1,0 +1,1 @@
+Updated `pytest.raises` to raise a TypeError when an invalid keyword argument is passed.

--- a/changelog/3348.bugfix.rst
+++ b/changelog/3348.bugfix.rst
@@ -1,1 +1,1 @@
-Updated `pytest.raises` to raise a TypeError when an invalid keyword argument is passed.
+``pytest.raises`` now raises ``TypeError`` when receiving an unknown keyword argument.

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -61,6 +61,11 @@ class TestRaises(object):
         with pytest.raises(TypeError):
             pytest.raises('wrong', lambda: None)
 
+    def test_invalid_arguments_to_raises(self):
+        with pytest.raises(TypeError, match='unknown'):
+            with pytest.raises(TypeError, unknown='bogus'):
+                raise ValueError()
+
     def test_tuple(self):
         with pytest.raises((KeyError, ValueError)):
             raise KeyError('oops')

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -113,7 +113,7 @@ class TestDeprecatedCall(object):
             pass
 
         msg = 'Did not produce DeprecationWarning or PendingDeprecationWarning'
-        with pytest.raises(AssertionError, matches=msg):
+        with pytest.raises(AssertionError, match=msg):
             if mode == 'call':
                 pytest.deprecated_call(f)
             else:


### PR DESCRIPTION
Per https://github.com/pytest-dev/pytest/issues/3348, I've gone ahead and updated pytest.raises to raise a TypeError if an invalid keyword argument is passed.

In addition, I fixed an issue of a test case in pytest that was passing an invalid keyword argument to pytest.raises.