### PR TITLE
change collections.abc import to fix deprecation warnings on python 3.7

### DIFF
--- a/_pytest/assertion/util.py
+++ b/_pytest/assertion/util.py
@@ -5,7 +5,11 @@ import pprint
 import _pytest._code
 import py
 import six
-from collections import Sequence
+import sys
+if sys.version_info >= (3, 4):
+    from collections.abc import Sequence
+else:
+    from collections import Sequence
 
 u = six.text_type
 

--- a/_pytest/assertion/util.py
+++ b/_pytest/assertion/util.py
@@ -5,11 +5,7 @@ import pprint
 import _pytest._code
 import py
 import six
-import sys
-if sys.version_info >= (3, 4):
-    from collections.abc import Sequence
-else:
-    from collections import Sequence
+from ..compat import Sequence
 
 u = six.text_type
 

--- a/_pytest/compat.py
+++ b/_pytest/compat.py
@@ -38,6 +38,14 @@ PY35 = sys.version_info[:2] >= (3, 5)
 PY36 = sys.version_info[:2] >= (3, 6)
 MODULE_NOT_FOUND_ERROR = 'ModuleNotFoundError' if PY36 else 'ImportError'
 
+if _PY2:
+    # those raise DeprecationWarnings in Python >=3.7
+    from collections.abc import MutableMapping as MappingMixin  # noqa
+    from collections.abc import Sequence  # noqa
+else:
+    from collections import MutableMapping as MappingMixin  # noqa
+    from collections import Sequence  # noqa
+
 
 def _format_args(func):
     return str(signature(func))

--- a/_pytest/compat.py
+++ b/_pytest/compat.py
@@ -38,11 +38,11 @@ PY35 = sys.version_info[:2] >= (3, 5)
 PY36 = sys.version_info[:2] >= (3, 6)
 MODULE_NOT_FOUND_ERROR = 'ModuleNotFoundError' if PY36 else 'ImportError'
 
-if _PY2:
-    # those raise DeprecationWarnings in Python >=3.7
+if _PY3:
     from collections.abc import MutableMapping as MappingMixin  # noqa
     from collections.abc import Sequence  # noqa
 else:
+    # those raise DeprecationWarnings in Python >=3.7
     from collections import MutableMapping as MappingMixin  # noqa
     from collections import Sequence  # noqa
 

--- a/_pytest/mark/structures.py
+++ b/_pytest/mark/structures.py
@@ -1,4 +1,9 @@
-from collections import namedtuple, MutableMapping as MappingMixin
+import sys
+if sys.version_info >= (3, 4):
+    from collections.abc import MutableMapping as MappingMixin
+else:
+    from collections import MutableMapping as MappingMixin
+from collections import namedtuple
 import warnings
 from operator import attrgetter
 import inspect

--- a/_pytest/mark/structures.py
+++ b/_pytest/mark/structures.py
@@ -1,18 +1,13 @@
-import sys
-if sys.version_info >= (3, 4):
-    from collections.abc import MutableMapping as MappingMixin
-else:
-    from collections import MutableMapping as MappingMixin
-from collections import namedtuple
-import warnings
-from operator import attrgetter
 import inspect
+import warnings
+from collections import namedtuple
+from operator import attrgetter
 
 import attr
-from ..deprecated import MARK_PARAMETERSET_UNPACKING
-from ..compat import NOTSET, getfslineno
 from six.moves import map
 
+from ..compat import NOTSET, getfslineno, MappingMixin
+from ..deprecated import MARK_PARAMETERSET_UNPACKING
 
 EMPTY_PARAMETERSET_OPTION = "empty_parameter_set_mark"
 

--- a/changelog/3339.trivial
+++ b/changelog/3339.trivial
@@ -1,0 +1,1 @@
+Import some modules from ``collections`` instead of ``collections.abc`` as the former modules trigger ``DeprecationWarning`` in Python 3.7.


### PR DESCRIPTION
This fixes the deprecation warnings from Python 3.7 related to importing abcs from the collections module, mentioned in issue #3339 

I couldn't fix the same for using the deprecated ``imp`` module, there's a bit too much wizardry going on with it in _pytest/assertion/rewrite.py ...
