### PR TITLE
Remove stale CHANGELOG entries

### DIFF
--- a/changelog/1478.feature
+++ b/changelog/1478.feature
@@ -1,1 +1,0 @@
-New ``--show-capture`` command-line option that allows to specify how to display captured output when tests fail: ``no``, ``stdout``, ``stderr``, ``log`` or ``all`` (the default).

--- a/changelog/1642.feature.rst
+++ b/changelog/1642.feature.rst
@@ -1,1 +1,0 @@
-New ``--rootdir`` command-line option to override the rules for discovering the root directory. See `customize <https://docs.pytest.org/en/latest/customize.html>`_ in the documentation for details.

--- a/changelog/1713.doc.rst
+++ b/changelog/1713.doc.rst
@@ -1,1 +1,0 @@
-Added a `reference <https://docs.pytest.org/en/latest/reference.html>`_ page to the docs.

--- a/changelog/2370.bugfix.rst
+++ b/changelog/2370.bugfix.rst
@@ -1,1 +1,0 @@
-Suppress ``IOError`` when closing the temporary file used for capturing streams in Python 2.7.

--- a/changelog/2405.feature.rst
+++ b/changelog/2405.feature.rst
@@ -1,1 +1,0 @@
-Fixtures are now instantiated based on their scopes, with higher-scoped fixtures (such as ``session``) being instantiated first than lower-scoped fixtures (such as ``function``). The relative order of fixtures of the same scope is kept unchanged, based in their declaration order and their dependencies.

--- a/changelog/2770.feature
+++ b/changelog/2770.feature
@@ -1,2 +1,0 @@
-``record_xml_property`` renamed to ``record_property`` and is now compatible with xdist, markers and any reporter.
-``record_xml_property`` name is now deprecated.

--- a/changelog/2770.removal.rst
+++ b/changelog/2770.removal.rst
@@ -1,1 +1,0 @@
-``record_xml_property`` fixture is now deprecated in favor of the more generic ``record_property``.

--- a/changelog/3034.feature
+++ b/changelog/3034.feature
@@ -1,1 +1,0 @@
-New ``--nf``, ``--new-first`` options: run new tests first followed by the rest of the tests, in both cases tests are also sorted by the file modified time, with more recent files coming first.

--- a/changelog/3084.removal
+++ b/changelog/3084.removal
@@ -1,1 +1,0 @@
-Defining ``pytest_plugins`` is now deprecated in non-top-level conftest.py files, because they "leak" to the entire directory tree.

--- a/changelog/3139.feature
+++ b/changelog/3139.feature
@@ -1,1 +1,0 @@
-New ``--last-failed-no-failures`` command-line option that allows to specify the behavior of the cache plugin's ```--last-failed`` feature when no tests failed in the last run (or no cache was found): ``none`` or ``all`` (the default).

--- a/changelog/3149.feature
+++ b/changelog/3149.feature
@@ -1,1 +1,0 @@
-New ``--doctest-continue-on-failure`` command-line option to enable doctests to show multiple failures for each snippet, instead of stopping at the first failure.

--- a/changelog/3156.feature
+++ b/changelog/3156.feature
@@ -1,1 +1,0 @@
-Captured log messages are added to the ``<system-out>`` tag in the generated junit xml file if the ``junit_logging`` ini option is set to ``system-out``. If the value of this ini option is ``system-err`, the logs are written to ``<system-err>``. The default value for ``junit_logging`` is ``no``, meaning captured logs are not written to the output file. 

--- a/changelog/3189.feature
+++ b/changelog/3189.feature
@@ -1,1 +1,0 @@
-Allow the logging plugin to handle ``pytest_runtest_logstart`` and ``pytest_runtest_logfinish`` hooks when live logs are enabled.

--- a/changelog/3190.feature
+++ b/changelog/3190.feature
@@ -1,1 +1,0 @@
-Passing `--log-cli-level` in the command-line now automatically activates live logging.

--- a/changelog/3198.feature.rst
+++ b/changelog/3198.feature.rst
@@ -1,1 +1,0 @@
-Add command line option ``--deselect`` to allow deselection of individual tests at collection time.

--- a/changelog/3204.feature
+++ b/changelog/3204.feature
@@ -1,1 +1,0 @@
-Captured logs are printed before entering pdb.

--- a/changelog/3213.feature
+++ b/changelog/3213.feature
@@ -1,1 +1,0 @@
-Deselected item count is now shown before tests are run, e.g. ``collected X items / Y deselected``.

--- a/changelog/3228.trivial.rst
+++ b/changelog/3228.trivial.rst
@@ -1,1 +1,0 @@
-Change minimum requirement of ``attrs`` to ``17.4.0``.

--- a/changelog/3236.feature.rst
+++ b/changelog/3236.feature.rst
@@ -1,1 +1,0 @@
-The builtin module ``platform`` is now available for use in expressions in ``pytest.mark``.

--- a/changelog/3245.trivial.rst
+++ b/changelog/3245.trivial.rst
@@ -1,1 +1,0 @@
-Renamed example directories so all tests pass when ran from the base directory.

--- a/changelog/3246.trival.rst
+++ b/changelog/3246.trival.rst
@@ -1,1 +1,0 @@
-Remove usage of deprecated ``metafunc.addcall`` in our own tests.

--- a/changelog/3250.trivial.rst
+++ b/changelog/3250.trivial.rst
@@ -1,1 +1,0 @@
-Internal ``mark.py`` module has been turned into a package.

--- a/changelog/3255.feature.rst
+++ b/changelog/3255.feature.rst
@@ -1,1 +1,0 @@
-The *short test summary info* section now is displayed after tracebacks and warnings in the terminal.

--- a/changelog/3265.trivial.rst
+++ b/changelog/3265.trivial.rst
@@ -1,1 +1,0 @@
-``pytest`` now depends on the `more_itertools <https://github.com/erikrose/more-itertools>`_ package.

--- a/changelog/3268.trivial
+++ b/changelog/3268.trivial
@@ -1,1 +1,0 @@
-Added warning when ``[pytest]`` section is used in a ``.cfg`` file passed with ``-c``

--- a/changelog/3291.trivial.rst
+++ b/changelog/3291.trivial.rst
@@ -1,1 +1,0 @@
-``nodeids`` can now be passed explicitly to ``FSCollector`` and ``Node`` constructors.

--- a/changelog/3292.trivial.rst
+++ b/changelog/3292.trivial.rst
@@ -1,1 +1,0 @@
-Internal refactoring of ``FormattedExcinfo`` to use ``attrs`` facilities and remove old support code for legacy Python versions.

--- a/changelog/3296.feature
+++ b/changelog/3296.feature
@@ -1,1 +1,0 @@
-New ``--verbosity`` flag to set verbosity level explicitly.

--- a/changelog/3296.trivial
+++ b/changelog/3296.trivial
@@ -1,1 +1,0 @@
-Refactoring to unify how verbosity is handled internally.

--- a/changelog/3297.bugfix.rst
+++ b/changelog/3297.bugfix.rst
@@ -1,2 +1,0 @@
-Fixed ``clear()`` method on ``caplog`` fixture which cleared ``records``,
-but not the ``text`` property.

--- a/changelog/3304.trivial
+++ b/changelog/3304.trivial
@@ -1,1 +1,0 @@
-Internal refactoring to better integrate with argparse.

--- a/changelog/3308.trivial.rst
+++ b/changelog/3308.trivial.rst
@@ -1,1 +1,0 @@
-Fix a python example when calling a fixture in doc/en/usage.rst

--- a/changelog/3312.feature
+++ b/changelog/3312.feature
@@ -1,1 +1,0 @@
-``pytest.approx`` now accepts comparing a numpy array with a scalar.

--- a/changelog/3314.bugfix.rst
+++ b/changelog/3314.bugfix.rst
@@ -1,3 +1,0 @@
-During test collection, when stdin is not allowed to be read, the
-``DontReadFromStdin`` object still allow itself to be iterable and
-resolved to an iterator without crashing.


### PR DESCRIPTION
Those were not removed in the last release because of a bug in
towncrier; I was about to fallback to don't use the .rst extension
for entries but just noticed that this was fixed in towncrier 17.8.0
so it should no longer be a problem.

