### PR TITLE
Add reference docs for pytest_sessionstart/finish and update their docstrings

### DIFF
--- a/_pytest/hookspec.py
+++ b/_pytest/hookspec.py
@@ -413,14 +413,15 @@ def pytest_fixture_post_finalizer(fixturedef, request):
 
 
 def pytest_sessionstart(session):
-    """ before session.main() is called.
+    """ called after the ``Session`` object has been created and before performing collection
+    and entering the run test loop.
 
     :param _pytest.main.Session session: the pytest session object
     """
 
 
 def pytest_sessionfinish(session, exitstatus):
-    """ whole test run finishes.
+    """ called after whole test run finished, right before returning the exit status to the system.
 
     :param _pytest.main.Session session: the pytest session object
     :param int exitstatus: the status which pytest will return to the system

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -527,6 +527,8 @@ Initialization hooks called for plugins and ``conftest.py`` files.
 .. autofunction:: pytest_addhooks
 .. autofunction:: pytest_configure
 .. autofunction:: pytest_unconfigure
+.. autofunction:: pytest_sessionstart
+.. autofunction:: pytest_sessionfinish
 
 Test running hooks
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
And TIL once upon a time there was a `Session.main()` function. 😛 