### PR TITLE
Use correct spelling for "more-itertools"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -136,7 +136,7 @@ Trivial/Internal Changes
 - Internal ``mark.py`` module has been turned into a package. (`#3250
   <https://github.com/pytest-dev/pytest/issues/3250>`_)
 
-- ``pytest`` now depends on the `more_itertools
+- ``pytest`` now depends on the `more-itertools
   <https://github.com/erikrose/more-itertools>`_ package. (`#3265
   <https://github.com/pytest-dev/pytest/issues/3265>`_)
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ def main():
         'six>=1.10.0',
         'setuptools',
         'attrs>=17.4.0',
-        'more_itertools>=4.0.0',
+        'more-itertools>=4.0.0',
     ]
     # if _PYTEST_SETUP_SKIP_PLUGGY_DEP is set, skip installing pluggy;
     # used by tox.ini to test with pluggy master

--- a/tox.ini
+++ b/tox.ini
@@ -128,7 +128,7 @@ usedevelop = True
 changedir = doc/en
 deps =
     attrs
-    more_itertools
+    more-itertools
     PyYAML
     sphinx
     sphinxcontrib-trio


### PR DESCRIPTION
Correct the requirement `more_itertools` to `more-itertools`.  Pip does not differentiate between `-` and `_` but Conda does.