### PR TITLE
no-capture in sample code demo'ing plugin

### DIFF
--- a/doc/en/writing_plugins.rst
+++ b/doc/en/writing_plugins.rst
@@ -85,8 +85,8 @@ sub directory but not for other directories::
 
 Here is how you might run it::
 
-     pytest test_flat.py   # will not show "setting up"
-     pytest a/test_sub.py  # will show "setting up"
+     pytest test_flat.py --capture=no  # will not show "setting up"
+     pytest a/test_sub.py --capture=no  # will show "setting up"
 
 .. note::
     If you have ``conftest.py`` files which do not reside in a


### PR DESCRIPTION
I think the current comment `will show "setting up"` here will be wrong by default (the print output will be captured). Would it be better for this sample code to say no-capture so the print statement actually shows up when users run it?