### PR TITLE
Fix issue #3372

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -188,6 +188,7 @@ Tareq Alayan
 Ted Xiao
 Thomas Grainger
 Thomas Hisch
+Tim Strazny
 Tom Dalton
 Tom Viner
 Trevor Bekolay

--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -2,6 +2,7 @@ import math
 import sys
 
 import py
+from six import binary_type, text_type
 from six.moves import zip, filterfalse
 from more_itertools.more import always_iterable
 
@@ -584,11 +585,11 @@ def raises(expected_exception, *args, **kwargs):
 
     """
     __tracebackhide__ = True
-    if not isclass(expected_exception) or not issubclass(expected_exception, BaseException):
-        for exc in filterfalse(isclass, always_iterable(expected_exception)):
-            msg = ("exceptions must be old-style classes or"
-                   " derived from BaseException, not %s")
-            raise TypeError(msg % type(exc))
+    base_type = (type, text_type, binary_type)
+    for exc in filterfalse(isclass, always_iterable(expected_exception, base_type)):
+        msg = ("exceptions must be old-style classes or"
+                " derived from BaseException, not %s")
+        raise TypeError(msg % type(exc))
 
     message = "DID NOT RAISE {0}".format(expected_exception)
     match_expr = None

--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -584,10 +584,11 @@ def raises(expected_exception, *args, **kwargs):
 
     """
     __tracebackhide__ = True
-    for exc in filterfalse(isclass, always_iterable(expected_exception)):
-        msg = ("exceptions must be old-style classes or"
-               " derived from BaseException, not %s")
-        raise TypeError(msg % type(exc))
+    if not issubclass(expected_exception, BaseException):
+        for exc in filterfalse(isclass, always_iterable(expected_exception)):
+            msg = ("exceptions must be old-style classes or"
+                   " derived from BaseException, not %s")
+            raise TypeError(msg % type(exc))
 
     message = "DID NOT RAISE {0}".format(expected_exception)
     match_expr = None

--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -584,7 +584,7 @@ def raises(expected_exception, *args, **kwargs):
 
     """
     __tracebackhide__ = True
-    if not issubclass(expected_exception, BaseException):
+    if not isclass(expected_exception) or not issubclass(expected_exception, BaseException):
         for exc in filterfalse(isclass, always_iterable(expected_exception)):
             msg = ("exceptions must be old-style classes or"
                    " derived from BaseException, not %s")

--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -588,7 +588,7 @@ def raises(expected_exception, *args, **kwargs):
     base_type = (type, text_type, binary_type)
     for exc in filterfalse(isclass, always_iterable(expected_exception, base_type)):
         msg = ("exceptions must be old-style classes or"
-                " derived from BaseException, not %s")
+               " derived from BaseException, not %s")
         raise TypeError(msg % type(exc))
 
     message = "DID NOT RAISE {0}".format(expected_exception)

--- a/changelog/3372.bugfix.rst
+++ b/changelog/3372.bugfix.rst
@@ -1,0 +1,1 @@
+``pytest.raises`` now works with exception classes that look like iterables.

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -1,3 +1,4 @@
+from _pytest.outcomes import Failed
 import pytest
 import sys
 
@@ -147,3 +148,20 @@ class TestRaises(object):
         with pytest.raises(ValueError):
             with pytest.raises(IndexError, match='nomatch'):
                 int('asdf')
+
+    def test_raises_exception_looks_iterable(self):
+        from six import add_metaclass
+
+        class Meta(type(object)):
+            def __getitem__(self, item):
+                return 1/0
+
+            def __len__(self):
+                return 1
+
+        @add_metaclass(Meta)
+        class ClassLooksIterableException(Exception):
+            pass
+
+        with pytest.raises(Failed, match="DID NOT RAISE <class 'raises.ClassLooksIterableException'>"):
+            pytest.raises(ClassLooksIterableException, lambda: None)


### PR DESCRIPTION
Add bugfix and test for #3372: Exception classes may have a type that looks iterable which caused problems with ``pytest.raises``.

Unfortunately, I wasn't able to use ``base_type`` as proposed by Ronny: ``pytest.raises`` is passed an exception **class** and I didn't find a way around calling ``issubclass``.

Only tested in py3.6.

----
Not a regular contributer, so I hope everything is up to speed and in accordance with your guidelines.