### PR TITLE
#3290 improve monkeypatch

### DIFF
--- a/_pytest/monkeypatch.py
+++ b/_pytest/monkeypatch.py
@@ -110,6 +110,21 @@ class MonkeyPatch(object):
 
     @contextmanager
     def context(self):
+        """
+        Context manager that returns a new :class:`MonkeyPatch` object which
+        undoes any patching done inside the ``with`` block upon exit:
+
+        .. code-block:: python
+
+            import functools
+            def test_partial(monkeypatch):
+                with monkeypatch.context() as m:
+                    m.setattr(functools, "partial", 3)
+
+        Useful in situations where it is desired to undo some patches before the test ends,
+        such as mocking ``stdlib`` functions that might break pytest itself if mocked (for examples
+        of this see `#3290 <https://github.com/pytest-dev/pytest/issues/3290>`_.
+        """
         m = MonkeyPatch()
         try:
             yield m

--- a/_pytest/monkeypatch.py
+++ b/_pytest/monkeypatch.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 import re
+from contextlib import contextmanager
+
 import six
 from _pytest.fixtures import fixture
 
@@ -105,6 +107,14 @@ class MonkeyPatch(object):
         self._setitem = []
         self._cwd = None
         self._savesyspath = None
+
+    @contextmanager
+    def context(self):
+        m = MonkeyPatch()
+        try:
+            yield m
+        finally:
+            m.undo()
 
     def setattr(self, target, name, value=notset, raising=True):
         """ Set attribute value on target, memorizing the old value.

--- a/changelog/3290.bugfix
+++ b/changelog/3290.bugfix
@@ -1,2 +1,0 @@
-Improved `monkeypatch` to support some form of with statement. Now you can use `with monkeypatch.context() as m:`
-construction to avoid damage of Pytest.

--- a/changelog/3290.bugfix
+++ b/changelog/3290.bugfix
@@ -1,0 +1,2 @@
+Improved `monkeypatch` to support some form of with statement. Now you can use `with monkeypatch.context() as m:`
+construction to avoid damage of Pytest.

--- a/changelog/3290.feature
+++ b/changelog/3290.feature
@@ -1,0 +1,2 @@
+``monkeypatch`` now supports a ``context()`` function which acts as a context manager which undoes all patching done
+within the ``with`` block.

--- a/doc/en/monkeypatch.rst
+++ b/doc/en/monkeypatch.rst
@@ -62,16 +62,20 @@ so that any attempts within tests to create http requests will fail.
     unavoidable, passing ``--tb=native``, ``--assert=plain`` and ``--capture=no`` might 
     help although there's no guarantee.
 
-    To avoid damage of pytest from patching python stdlib functions use ``with``
-    construction::
+.. note::
 
-        # content of test_module.py
+    Mind that patching ``stdlib`` functions and some third-party libraries used by pytest
+    might break pytest itself, therefore in those cases it is recommended to use
+    :meth:`MonkeyPatch.context` to limit the patching to the block you want tested:
 
+    .. code-block:: python
         import functools
         def test_partial(monkeypatch):
             with monkeypatch.context() as m:
                 m.setattr(functools, "partial", 3)
                 assert functools.partial == 3
+
+    See issue `#3290 <https://github.com/pytest-dev/pytest/issues/3290>`_ for details.
     
 
 .. currentmodule:: _pytest.monkeypatch

--- a/doc/en/monkeypatch.rst
+++ b/doc/en/monkeypatch.rst
@@ -69,6 +69,7 @@ so that any attempts within tests to create http requests will fail.
     :meth:`MonkeyPatch.context` to limit the patching to the block you want tested:
 
     .. code-block:: python
+
         import functools
         def test_partial(monkeypatch):
             with monkeypatch.context() as m:

--- a/doc/en/monkeypatch.rst
+++ b/doc/en/monkeypatch.rst
@@ -61,6 +61,17 @@ so that any attempts within tests to create http requests will fail.
     ``compile``, etc., because it might break pytest's internals. If that's
     unavoidable, passing ``--tb=native``, ``--assert=plain`` and ``--capture=no`` might 
     help although there's no guarantee.
+
+    To avoid damage of pytest from patching python stdlib functions use ``with``
+    construction::
+
+        # content of test_module.py
+
+        import functools
+        def test_partial(monkeypatch):
+            with monkeypatch.context() as m:
+                m.setattr(functools, "partial", 3)
+                assert functools.partial == 3
     
 
 .. currentmodule:: _pytest.monkeypatch

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -327,3 +327,16 @@ def test_issue1338_name_resolving():
         monkeypatch.delattr('requests.sessions.Session.request')
     finally:
         monkeypatch.undo()
+
+
+def test_context(testdir):
+    testdir.makepyfile("""
+    import functools
+    def test_partial(monkeypatch):
+        with monkeypatch.context() as m:
+            m.setattr(functools, "partial", 3)
+            assert functools.partial == 3
+    """)
+
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines("*1 passed*")

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -329,14 +329,13 @@ def test_issue1338_name_resolving():
         monkeypatch.undo()
 
 
-def test_context(testdir):
-    testdir.makepyfile("""
-    import functools
-    def test_partial(monkeypatch):
-        with monkeypatch.context() as m:
-            m.setattr(functools, "partial", 3)
-            assert functools.partial == 3
-    """)
+def test_context():
+    monkeypatch = MonkeyPatch()
 
-    result = testdir.runpytest()
-    result.stdout.fnmatch_lines("*1 passed*")
+    import functools
+    import inspect
+
+    with monkeypatch.context() as m:
+        m.setattr(functools, "partial", 3)
+        assert not inspect.isclass(functools.partial)
+    assert inspect.isclass(functools.partial)


### PR DESCRIPTION
Fixes #3290.

```
To handle #2180, we could just import open and other builtins explicitly at the module level of rewrite.py to shield us from users tampering with it.
```
I added to `rewrite.py` (not in this PR)
```
from builtins import open
```
but it has no effect :(