### PR TITLE
#3374 If path name is very long then pytest will split name for several lines

### DIFF
--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -218,7 +218,7 @@ class TerminalReporter(object):
             self._tw.line()
             self._tw.write(fspath + " ")
             width = self._tw.fullwidth - self._tw.chars_on_current_line
-            if 0 < width < 10:
+            if 0 < width < 10 or self._tw.chars_on_current_line % self._screen_width > self._screen_width - 10:
                 self._tw.line()
             elif width < 0:
                 self.is_fspath_extra_width = True
@@ -383,6 +383,7 @@ class TerminalReporter(object):
         msg = self._get_progress_information_message()
         if self.is_fspath_extra_width:
             fill = ' ' * (self._tw.fullwidth - self._tw.chars_on_current_line % self._screen_width - len(msg) - 1)
+            self.is_fspath_extra_width = False
         else:
             fill = ' ' * (self._tw.fullwidth - self._tw.chars_on_current_line - len(msg) - 1)
         self.write(fill + msg, cyan=True)

--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -215,7 +215,16 @@ class TerminalReporter(object):
             self.currentfspath = fspath
             fspath = self.startdir.bestrelpath(fspath)
             self._tw.line()
-            self._tw.write(fspath + " ")
+            if len(fspath) > (self._tw.fullwidth - self._tw.chars_on_current_line - 10):
+                line = self._tw.fullwidth - self._tw.chars_on_current_line - 10
+                while len(fspath) > 0:
+                    self._tw.write(fspath[:line] + " ")
+                    fspath = fspath[line:]
+                    if not fspath:
+                        break
+                    self._tw.line()
+            else:
+                self._tw.write(fspath + " ")
         self._tw.write(res)
 
     def write_ensure_prefix(self, prefix, extra="", **kwargs):

--- a/changelog/3374.feature
+++ b/changelog/3374.feature
@@ -1,0 +1,1 @@
+If path name is very long then pytest will split name for several lines.

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1063,29 +1063,6 @@ class TestProgress(object):
             """,
         )
 
-    @pytest.fixture
-    def many_tests_files_long_names(self, testdir):
-        testdir.makepyfile(
-            test_bar_with_very_long_name_bar_with_very_long_name_bar_with_very_long_name_with_very_long_name="""
-                import pytest
-                @pytest.mark.parametrize('i', range(10))
-                def test_bar(i):
-                    pass
-            """,
-            test_foo_with_very_long_name_foo_with_very_long_name_foo_with_very_long_name_with_very_long_name="""
-                import pytest
-                @pytest.mark.parametrize('i', range(5))
-                def test_foo(i):
-                    pass
-            """,
-            test_fooba_with_very_long_name_foobar_with_very_long_name_foobar_with_very_long_name_with_very_long_name="""
-                import pytest
-                @pytest.mark.parametrize('i', range(5))
-                def test_foobar(i):
-                    pass
-            """,
-        )
-
     def test_zero_tests_collected(self, testdir):
         """Some plugins (testmon for example) might issue pytest_runtest_logreport without any tests being
         actually collected (#2971)."""
@@ -1110,17 +1087,6 @@ class TestProgress(object):
             r'test_bar.py \.{10} \s+ \[ 50%\]',
             r'test_foo.py \.{5} \s+ \[ 75%\]',
             r'test_foobar.py \.{5} \s+ \[100%\]',
-        ])
-
-    def test_normal_long_names(self, many_tests_files_long_names, testdir):
-        output = testdir.runpytest()
-        output.stdout.fnmatch_lines([
-            '*test_bar_with*',
-            '*long_name.py* 50%]',
-            '*test_foo_with*',
-            '*long_name.py* 75%]',
-            '*test_fooba_with*',
-            '*long_name.py*100%]',
         ])
 
     def test_verbose(self, many_tests_files, testdir):

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1063,6 +1063,29 @@ class TestProgress(object):
             """,
         )
 
+    @pytest.fixture
+    def many_tests_files_long_names(self, testdir):
+        testdir.makepyfile(
+            test_bar_with_very_long_name_bar_with_very_long_name_bar_with_very_long_name_with_very_long_name="""
+                import pytest
+                @pytest.mark.parametrize('i', range(10))
+                def test_bar(i):
+                    pass
+            """,
+            test_foo_with_very_long_name_foo_with_very_long_name_foo_with_very_long_name_with_very_long_name="""
+                import pytest
+                @pytest.mark.parametrize('i', range(5))
+                def test_foo(i):
+                    pass
+            """,
+            test_fooba_with_very_long_name_foobar_with_very_long_name_foobar_with_very_long_name_with_very_long_name="""
+                import pytest
+                @pytest.mark.parametrize('i', range(5))
+                def test_foobar(i):
+                    pass
+            """,
+        )
+
     def test_zero_tests_collected(self, testdir):
         """Some plugins (testmon for example) might issue pytest_runtest_logreport without any tests being
         actually collected (#2971)."""
@@ -1087,6 +1110,17 @@ class TestProgress(object):
             r'test_bar.py \.{10} \s+ \[ 50%\]',
             r'test_foo.py \.{5} \s+ \[ 75%\]',
             r'test_foobar.py \.{5} \s+ \[100%\]',
+        ])
+
+    def test_normal_long_names(self, many_tests_files_long_names, testdir):
+        output = testdir.runpytest()
+        output.stdout.fnmatch_lines([
+            '*test_bar_with*',
+            '*long_name.py* 50%]',
+            '*test_foo_with*',
+            '*long_name.py* 75%]',
+            '*test_fooba_with*',
+            '*long_name.py*100%]',
         ])
 
     def test_verbose(self, many_tests_files, testdir):


### PR DESCRIPTION
Fixes #3374

Long names:

![selection_023](https://user-images.githubusercontent.com/9434344/38578894-f3788908-3d0d-11e8-8597-b1ae91a6f865.png)

Long name full line:
![selection_025](https://user-images.githubusercontent.com/9434344/38578915-01ccc0c8-3d0e-11e8-8091-cca760d07609.png)

Long name full line + 1 letter:
![selection_026](https://user-images.githubusercontent.com/9434344/38578937-0c514e74-3d0e-11e8-9175-93403cd191da.png)

Very beautiful when progress prints in every line but it is a problem with progress count: it counts only after run a test (after report write a dot), so, there is a problem:
![selection_024](https://user-images.githubusercontent.com/9434344/38578991-47ea50c0-3d0e-11e8-8bda-876c4ba741ee.png)
