### PR TITLE
Reset reference to failed test frame before each test executes

### DIFF
--- a/_pytest/runner.py
+++ b/_pytest/runner.py
@@ -105,6 +105,7 @@ def pytest_runtest_setup(item):
 
 def pytest_runtest_call(item):
     _update_current_test_var(item, 'call')
+    sys.last_type, sys.last_value, sys.last_traceback = (None, None, None)
     try:
         item.runtest()
     except Exception:
@@ -114,7 +115,7 @@ def pytest_runtest_call(item):
         sys.last_type = type
         sys.last_value = value
         sys.last_traceback = tb
-        del tb  # Get rid of it in this namespace
+        del type, value, tb  # Get rid of these in this frame
         raise
 
 

--- a/changelog/2798.bugfix.rst
+++ b/changelog/2798.bugfix.rst
@@ -1,0 +1,3 @@
+Reset ``sys.last_type``, ``sys.last_value`` and ``sys.last_traceback`` before each test executes. Those attributes
+are added by pytest during the test run to aid debugging, but were never reset so they would create a leaking
+reference to the last failing test's frame which in turn could never be reclaimed by the garbage collector.


### PR DESCRIPTION
Fixes #2798. Not entirely because I was not able to remove the cyclic references which seem to be caused by the traceback objects being kept around; those cycles will be eventually be claimed by the garbage collector, at least (with the previous code that was not even possible).