### PR TITLE
Simplify tox to avoid repetition

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist =
     {py27,py36}-{pexpect,xdist,trial,numpy,pluggymaster}
     py27-nobyte
     doctesting
-    py35-freeze
+    py36-freeze
     docs
 
 [testenv]
@@ -56,12 +56,11 @@ deps =
     hypothesis>=3.5.2
 changedir=testing
 commands =
-    pytest -n1 -ra {posargs:.}
+    pytest -n8 -ra {posargs:.}
 
 [testenv:py36-xdist]
 deps = {[testenv:py27-xdist]deps}
-commands =
-    pytest -n3 -ra {posargs:testing}
+commands = {[testenv:py27-xdist]commands}
 
 [testenv:py27-pexpect]
 changedir = testing
@@ -71,11 +70,10 @@ commands =
     pytest -ra test_pdb.py test_terminal.py test_unittest.py
 
 [testenv:py36-pexpect]
-changedir = testing
-platform = linux|darwin
+changedir = {[testenv:py27-pexpect]changedir}
+platform = {[testenv:py27-pexpect]platform}
 deps = {[testenv:py27-pexpect]deps}
-commands =
-    pytest -ra test_pdb.py test_terminal.py test_unittest.py
+commands = {[testenv:py27-pexpect]commands}
 
 [testenv:py27-nobyte]
 deps =
@@ -95,18 +93,16 @@ commands =
 
 [testenv:py36-trial]
 deps = {[testenv:py27-trial]deps}
-commands =
-    pytest -ra {posargs:testing/test_unittest.py}
+commands = {[testenv:py27-trial]commands}
 
 [testenv:py27-numpy]
-deps=numpy
+deps = numpy
 commands=
   pytest -ra {posargs:testing/python/approx.py}
 
 [testenv:py36-numpy]
-deps=numpy
-commands=
-  pytest -ra {posargs:testing/python/approx.py}
+deps = {[testenv:py27-numpy]deps}
+commands = {[testenv:py27-numpy]commands}
 
 [testenv:py27-pluggymaster]
 setenv=
@@ -115,12 +111,9 @@ deps =
     {[testenv]deps}
     git+https://github.com/pytest-dev/pluggy.git@master
 
-[testenv:py35-pluggymaster]
-setenv=
-    _PYTEST_SETUP_SKIP_PLUGGY_DEP=1
-deps =
-    {[testenv:py27-pluggymaster]deps}
-    git+https://github.com/pytest-dev/pluggy.git@master
+[testenv:py36-pluggymaster]
+setenv = {[testenv:py27-pluggymaster]setenv}
+deps = {[testenv:py27-pluggymaster]deps}
 
 [testenv:docs]
 skipsdist = True
@@ -176,7 +169,7 @@ changedir = testing
 commands =
     {envpython} {envbindir}/py.test-jython -ra {posargs}
 
-[testenv:py35-freeze]
+[testenv:py36-freeze]
 changedir = testing/freeze
 deps = pyinstaller
 commands =
@@ -199,7 +192,6 @@ commands =
 [pytest]
 minversion = 2.0
 plugins = pytester
-#--pyargs --doctest-modules --ignore=.tox
 addopts = -ra -p pytester --ignore=testing/cx_freeze
 rsyncdirs = tox.ini pytest.py _pytest testing
 python_files = test_*.py *_test.py testing/*/*.py


### PR DESCRIPTION
Also took the opportunity to:

* Use more cores for py*-xdist environments
* Update freeze test to use py36
