### PR TITLE
Attempt to solve race-condition which corrupts .pyc files on Windows

### DIFF
--- a/changelog/3008.bugfix.rst
+++ b/changelog/3008.bugfix.rst
@@ -1,0 +1,1 @@
+A rare race-condition which might result in corrupted ``.pyc`` files on Windows has been hopefully solved.

--- a/changelog/3008.trivial.rst
+++ b/changelog/3008.trivial.rst
@@ -1,0 +1,1 @@
+``pytest`` now depends on the `python-atomicwrites <https://github.com/untitaker/python-atomicwrites>`_ library.

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ def main():
         'setuptools',
         'attrs>=17.4.0',
         'more-itertools>=4.0.0',
+        'atomicwrites>=1.0',
     ]
     # if _PYTEST_SETUP_SKIP_PLUGGY_DEP is set, skip installing pluggy;
     # used by tox.ini to test with pluggy master


### PR DESCRIPTION
This uses of the `atomicwrites` library.

This is very hard to create a reliable test for.

Fix #3008
