### PR TITLE
Add additional project urls to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,10 @@ def main():
             'write_to': '_pytest/_version.py',
         },
         url='http://pytest.org',
+        project_urls={
+            'Source': 'https://github.com/pytest-dev/pytest',
+            'Tracker': 'https://github.com/pytest-dev/pytest/issues',
+        },
         license='MIT license',
         platforms=['unix', 'linux', 'osx', 'cygwin', 'win32'],
         author=(


### PR DESCRIPTION
According to:

https://packaging.python.org/tutorials/distributing-packages/#project-urls

Those URLs are displayed in the project page in Warehouse (new PyPI).

From [this article](https://lwn.net/SubscriberLink/751458/81b2759e7025d6b9/):

> ... and support for multiple project URLs (e.g., for a homepage and a repo) on a project's PyPI page.