### PR TITLE
Mention omission of fixtures with leading '_', closes #3398

### DIFF
--- a/_pytest/helpconfig.py
+++ b/_pytest/helpconfig.py
@@ -138,7 +138,8 @@ def showhelp(config):
     tw.line("to see available markers type: pytest --markers")
     tw.line("to see available fixtures type: pytest --fixtures")
     tw.line("(shown according to specified file_or_dir or current dir "
-            "if not specified)")
+            "if not specified; fixtures with leading '_' are only shown "
+            "with the '-v' option")
 
     for warningreport in reporter.stats.get('warnings', []):
         tw.line("warning : " + warningreport.message, red=True)

--- a/_pytest/python.py
+++ b/_pytest/python.py
@@ -75,7 +75,8 @@ def pytest_addoption(parser):
     group = parser.getgroup("general")
     group.addoption('--fixtures', '--funcargs',
                     action="store_true", dest="showfixtures", default=False,
-                    help="show available fixtures, sorted by plugin appearance")
+                    help="show available fixtures, sorted by plugin appearance "
+                    "(fixtures with leading '_' are only shown with '-v')")
     group.addoption(
         '--fixtures-per-test',
         action="store_true",

--- a/changelog/3398.trivial.rst
+++ b/changelog/3398.trivial.rst
@@ -1,0 +1,1 @@
+Mention in documentation and CLI help that fixtures with leading ``_`` are printed by ``pytest --fixtures`` only if the ``-v`` option is added.

--- a/doc/en/builtin.rst
+++ b/doc/en/builtin.rst
@@ -12,7 +12,7 @@ For information on plugin hooks and objects, see :ref:`plugins`.
 
 For information on the ``pytest.mark`` mechanism, see :ref:`mark`.
 
-For information about fixtures, see :ref:`fixtures`. To see a complete list of available fixtures, type::
+For information about fixtures, see :ref:`fixtures`. To see a complete list of available fixtures (add ``-v`` to also see fixtures with leading ``_``), type ::
 
     $ pytest -q --fixtures
     cache

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -111,11 +111,11 @@ with a list of available function arguments.
 
 .. note::
 
-    You can always issue::
+    You can always issue ::
 
         pytest --fixtures test_simplefactory.py
 
-    to see available fixtures.
+    to see available fixtures (fixtures with leading ``_`` are only shown if you add the ``-v`` option).
 
 Fixtures: a prime example of dependency injection
 ---------------------------------------------------
@@ -141,7 +141,7 @@ automatically gets discovered by pytest. The discovery of
 fixture functions starts at test classes, then test modules, then
 ``conftest.py`` files and finally builtin and third party plugins.
 
-You can also use the ``conftest.py`` file to implement 
+You can also use the ``conftest.py`` file to implement
 :ref:`local per-directory plugins <conftest.py plugins>`.
 
 Sharing test data

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -166,6 +166,8 @@ Find out what kind of builtin :ref:`pytest fixtures <fixtures>` exist with the c
 
     pytest --fixtures   # shows builtin and custom fixtures
 
+Note that this command omits fixtures with leading ``_`` unless the ``-v`` option is added.
+
 Continue reading
 -------------------------------------
 

--- a/doc/en/test/plugin/terminal.rst
+++ b/doc/en/test/plugin/terminal.rst
@@ -23,7 +23,7 @@ command line options
 ``--full-trace``
     don't cut any tracebacks (default is to cut).
 ``--fixtures``
-    show available function arguments, sorted by plugin
+    show available fixtures, sorted by plugin appearance (fixtures with leading ``_`` are only shown with '-v')
 
 Start improving this plugin in 30 seconds
 =========================================


### PR DESCRIPTION
I've added the corresponding text in a number of places, basically the ones that a text search for `--fixtures` brought up.
I didn't change the printout of `FixtureLookupError`, that would IMO be too much spamming and would have required changes to the tests.