### PR TITLE
Fix typo in caplog fixture documentation: Issue #3406

### DIFF
--- a/_pytest/logging.py
+++ b/_pytest/logging.py
@@ -289,9 +289,9 @@ def caplog(request):
 
     Captured logs are available through the following methods::
 
-    * caplog.text()          -> string containing formatted log output
-    * caplog.records()       -> list of logging.LogRecord instances
-    * caplog.record_tuples() -> list of (logger_name, level, message) tuples
+    * caplog.text            -> string containing formatted log output
+    * caplog.records         -> list of logging.LogRecord instances
+    * caplog.record_tuples   -> list of (logger_name, level, message) tuples
     * caplog.clear()         -> clear captured records and formatted log output string
     """
     result = LogCaptureFixture(request.node)

--- a/changelog/3406.doc.rst
+++ b/changelog/3406.doc.rst
@@ -1,0 +1,1 @@
+Fix typo in `caplog` fixture documentation, which incorrectly identified certain attributes as methods.

--- a/changelog/3406.doc.rst
+++ b/changelog/3406.doc.rst
@@ -1,1 +1,1 @@
-Fix typo in `caplog` fixture documentation, which incorrectly identified certain attributes as methods.
+Fix typo in ``caplog`` fixture documentation, which incorrectly identified certain attributes as methods.

--- a/doc/en/builtin.rst
+++ b/doc/en/builtin.rst
@@ -77,9 +77,9 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
         
         Captured logs are available through the following methods::
         
-        * caplog.text()          -> string containing formatted log output
-        * caplog.records()       -> list of logging.LogRecord instances
-        * caplog.record_tuples() -> list of (logger_name, level, message) tuples
+        * caplog.text            -> string containing formatted log output
+        * caplog.records         -> list of logging.LogRecord instances
+        * caplog.record_tuples   -> list of (logger_name, level, message) tuples
         * caplog.clear()         -> clear captured records and formatted log output string
     monkeypatch
         The returned ``monkeypatch`` fixture provides these


### PR DESCRIPTION
Updated the caplog fixture documentation per the bug found in issue #3406 .