### PR TITLE
add FixtureManager to docs

### DIFF
--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -496,6 +496,14 @@ tmpdir_factory
 .. automethod:: TempdirFactory.mktemp
 .. automethod:: TempdirFactory.getbasetemp
 
+FixtureManager
+~~~~~~~~~~~~~~
+
+.. currentmodule:: _pytest.fixtures
+
+.. autoclass:: _pytest.fixtures.FixtureManager
+    :members:
+
 
 .. _`hook-reference`:
 


### PR DESCRIPTION
Fixes #3420.

@nicoddemus encouraged me to submit a PR, but please understand I have not been able to render the docs locally to verify that this documentation links / finds the class correctly (error in third party docs extension).

Commits from maintainers can be done on that fork, as well as I'm happy to move it to another location on the docs etc.  Thanks for `pytest`, the learning curve was totally worth it :heart:
