### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,13 +6,13 @@
 ------
 
 .. image:: https://img.shields.io/pypi/v/pytest.svg
-    :target: https://pypi.python.org/pypi/pytest
+    :target: https://pypi.org/project/pytest/
 
 .. image:: https://anaconda.org/conda-forge/pytest/badges/version.svg
     :target: https://anaconda.org/conda-forge/pytest
 
 .. image:: https://img.shields.io/pypi/pyversions/pytest.svg
-    :target: https://pypi.python.org/pypi/pytest
+    :target: https://pypi.org/project/pytest/
 
 .. image:: https://img.shields.io/coveralls/pytest-dev/pytest/master.svg
     :target: https://coveralls.io/r/pytest-dev/pytest

--- a/changelog/3431.trivial.rst
+++ b/changelog/3431.trivial.rst
@@ -1,0 +1,1 @@
+Update all pypi.python.org URLs to pypi.org.

--- a/doc/en/_templates/links.html
+++ b/doc/en/_templates/links.html
@@ -1,6 +1,6 @@
 <h3>Useful Links</h3>
 <ul>
-  <li><a href="https://pypi.python.org/pypi/pytest">pytest @ PyPI</a></li>
+  <li><a href="https://pypi.org/project/pytest/">pytest @ PyPI</a></li>
   <li><a href="https://github.com/pytest-dev/pytest/">pytest @ GitHub</a></li>
   <li><a href="http://plugincompat.herokuapp.com/">3rd party plugins</a></li>
   <li><a href="https://github.com/pytest-dev/pytest/issues">Issue Tracker</a></li>

--- a/doc/en/announce/release-2.3.5.rst
+++ b/doc/en/announce/release-2.3.5.rst
@@ -14,7 +14,7 @@ few interesting new plugins saw the light last month:
 
 And several others like pytest-django saw maintenance releases.
 For a more complete list, check out 
-https://pypi.python.org/pypi?%3Aaction=search&term=pytest&submit=search.
+https://pypi.org/search/?q=pytest
 
 For general information see:
 

--- a/doc/en/announce/release-2.4.0.rst
+++ b/doc/en/announce/release-2.4.0.rst
@@ -23,14 +23,14 @@ a full list of details.  A few feature highlights:
   called if the corresponding setup method succeeded.
 
 - integrate tab-completion on command line options if you
-  have `argcomplete <http://pypi.python.org/pypi/argcomplete>`_ 
+  have `argcomplete <https://pypi.org/project/argcomplete/>`_ 
   configured.
 
 - allow boolean expression directly with skipif/xfail
   if a "reason" is also specified.
 
 - a new hook ``pytest_load_initial_conftests`` allows plugins like
-  `pytest-django <http://pypi.python.org/pypi/pytest-django>`_ to
+  `pytest-django <https://pypi.org/project/pytest-django/>`_ to
   influence the environment before conftest files import ``django``.
 
 - reporting: color the last line red or green depending if

--- a/doc/en/development_guide.rst
+++ b/doc/en/development_guide.rst
@@ -10,7 +10,7 @@ Code Style
 ----------
 
 * `PEP-8 <https://www.python.org/dev/peps/pep-0008>`_
-* `flake8 <https://pypi.python.org/pypi/flake8>`_ for quality checks
+* `flake8 <https://pypi.org/project/flake8/>`_ for quality checks
 * `invoke <http://www.pyinvoke.org/>`_ to automate development tasks
 
 

--- a/doc/en/example/nonpython.rst
+++ b/doc/en/example/nonpython.rst
@@ -10,7 +10,7 @@ A basic example for specifying tests in Yaml files
 --------------------------------------------------------------
 
 .. _`pytest-yamlwsgi`: http://bitbucket.org/aafshar/pytest-yamlwsgi/src/tip/pytest_yamlwsgi.py
-.. _`PyYAML`: http://pypi.python.org/pypi/PyYAML/
+.. _`PyYAML`: https://pypi.org/project/PyYAML/
 
 Here is an example ``conftest.py`` (extracted from Ali Afshnars special purpose `pytest-yamlwsgi`_ plugin).   This ``conftest.py`` will  collect ``test*.yml`` files and will execute the yaml-formatted content as custom tests:
 

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -160,7 +160,7 @@ together with the actual data, instead of listing them separately.
 A quick port of "testscenarios"
 ------------------------------------
 
-.. _`test scenarios`: http://pypi.python.org/pypi/testscenarios/
+.. _`test scenarios`: https://pypi.org/project/testscenarios/
 
 Here is a quick port to run tests configured with `test scenarios`_,
 an add-on from Robert Collins for the standard unittest framework. We

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -108,7 +108,7 @@ the command line arguments before they get processed:
             num = max(multiprocessing.cpu_count() / 2, 1)
             args[:] = ["-n", str(num)] + args
 
-If you have the `xdist plugin <https://pypi.python.org/pypi/pytest-xdist>`_ installed
+If you have the `xdist plugin <https://pypi.org/project/pytest-xdist/>`_ installed
 you will now always perform test runs using a number
 of subprocesses close to your CPU. Running in an empty
 directory with the above conftest.py::
@@ -778,7 +778,7 @@ which test got stuck, for example if pytest was run in quiet mode (``-q``) or yo
 output. This is particularly a problem if the problem helps only sporadically, the famous "flaky" kind of tests.
 
 ``pytest`` sets a ``PYTEST_CURRENT_TEST`` environment variable when running tests, which can be inspected
-by process monitoring utilities or libraries like `psutil <https://pypi.python.org/pypi/psutil>`_ to discover which
+by process monitoring utilities or libraries like `psutil <https://pypi.org/project/psutil/>`_ to discover which
 test got stuck if necessary:
 
 .. code-block:: python

--- a/doc/en/faq.rst
+++ b/doc/en/faq.rst
@@ -30,14 +30,14 @@ and does not handle Deferreds returned from a test in pytest style.
 If you are using trial's unittest.TestCase chances are that you can
 just run your tests even if you return Deferreds.  In addition,
 there also is a dedicated `pytest-twisted
-<http://pypi.python.org/pypi/pytest-twisted>`_ plugin which allows you to
+<https://pypi.org/project/pytest-twisted/>`_ plugin which allows you to
 return deferreds from pytest-style tests, allowing the use of
 :ref:`fixtures` and other features.
 
 how does pytest work with Django?
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-In 2012, some work is going into the `pytest-django plugin <http://pypi.python.org/pypi/pytest-django>`_.  It substitutes the usage of Django's
+In 2012, some work is going into the `pytest-django plugin <https://pypi.org/project/pytest-django/>`_.  It substitutes the usage of Django's
 ``manage.py test`` and allows the use of all pytest features_ most of which
 are not available from Django directly.
 

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -154,7 +154,7 @@ This makes use of the automatic caching mechanisms of pytest.
 Another good approach is by adding the data files in the ``tests`` folder.
 There are also community plugins available to help managing this aspect of 
 testing, e.g. `pytest-datadir <https://github.com/gabrielcnr/pytest-datadir>`__ 
-and `pytest-datafiles <https://pypi.python.org/pypi/pytest-datafiles>`__. 
+and `pytest-datafiles <https://pypi.org/project/pytest-datafiles/>`__. 
 
 .. _smtpshared:
 

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -5,10 +5,10 @@ Installation and Getting Started
 
 **Platforms**: Unix/Posix and Windows
 
-**PyPI package name**: `pytest <http://pypi.python.org/pypi/pytest>`_
+**PyPI package name**: `pytest <https://pypi.org/project/pytest/>`_
 
-**Dependencies**: `py <http://pypi.python.org/pypi/py>`_,
-`colorama (Windows) <http://pypi.python.org/pypi/colorama>`_,
+**Dependencies**: `py <https://pypi.org/project/py/>`_,
+`colorama (Windows) <https://pypi.org/project/colorama/>`_,
 
 **Documentation as PDF**: `download latest <https://media.readthedocs.org/pdf/pytest/latest/pytest.pdf>`_
 

--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -168,9 +168,9 @@ Note that this layout also works in conjunction with the ``src`` layout mentione
     to avoid surprises such as a test module getting imported twice.
 
 
-.. _`virtualenv`: http://pypi.python.org/pypi/virtualenv
+.. _`virtualenv`: https://pypi.org/project/virtualenv/
 .. _`buildout`: http://www.buildout.org/
-.. _pip: http://pypi.python.org/pypi/pip
+.. _pip: https://pypi.org/project/pip/
 
 .. _`use tox`:
 
@@ -205,7 +205,7 @@ Integrating with setuptools / ``python setup.py test`` / ``pytest-runner``
 --------------------------------------------------------------------------
 
 You can integrate test runs into your setuptools based project
-with the `pytest-runner <https://pypi.python.org/pypi/pytest-runner>`_ plugin.
+with the `pytest-runner <https://pypi.org/project/pytest-runner/>`_ plugin.
 
 Add this to ``setup.py`` file:
 

--- a/doc/en/links.inc
+++ b/doc/en/links.inc
@@ -7,14 +7,14 @@
 .. _`reStructured Text`: http://docutils.sourceforge.net
 .. _`Python debugger`: http://docs.python.org/lib/module-pdb.html
 .. _nose: https://nose.readthedocs.io/en/latest/
-.. _pytest: http://pypi.python.org/pypi/pytest
+.. _pytest: https://pypi.org/project/pytest/
 .. _mercurial: http://mercurial.selenic.com/wiki/
-.. _`setuptools`: http://pypi.python.org/pypi/setuptools
+.. _`setuptools`: https://pypi.org/project/setuptools/
 .. _`easy_install`:
 .. _`distribute docs`:
-.. _`distribute`: http://pypi.python.org/pypi/distribute
-.. _`pip`: http://pypi.python.org/pypi/pip
-.. _`virtualenv`: http://pypi.python.org/pypi/virtualenv
+.. _`distribute`: https://pypi.org/project/distribute/
+.. _`pip`: https://pypi.org/project/pip/
+.. _`virtualenv`: https://pypi.org/project/virtualenv/
 .. _hudson: http://hudson-ci.org/
 .. _jenkins: http://jenkins-ci.org/
 .. _tox: http://testrun.org/tox

--- a/doc/en/plugins.rst
+++ b/doc/en/plugins.rst
@@ -20,39 +20,39 @@ Here is a little annotated list for some popular plugins:
 
 .. _`django`: https://www.djangoproject.com/
 
-* `pytest-django <http://pypi.python.org/pypi/pytest-django>`_: write tests
+* `pytest-django <https://pypi.org/project/pytest-django/>`_: write tests
   for `django`_ apps, using pytest integration.
 
-* `pytest-twisted <http://pypi.python.org/pypi/pytest-twisted>`_: write tests
+* `pytest-twisted <https://pypi.org/project/pytest-twisted/>`_: write tests
   for `twisted <http://twistedmatrix.com>`_ apps, starting a reactor and
   processing deferreds from test functions.
 
-* `pytest-cov <http://pypi.python.org/pypi/pytest-cov>`_:
+* `pytest-cov <https://pypi.org/project/pytest-cov/>`_:
   coverage reporting, compatible with distributed testing
 
-* `pytest-xdist <http://pypi.python.org/pypi/pytest-xdist>`_:
+* `pytest-xdist <https://pypi.org/project/pytest-xdist/>`_:
   to distribute tests to CPUs and remote hosts, to run in boxed
   mode which allows to survive segmentation faults, to run in
   looponfailing mode, automatically re-running failing tests
   on file changes.
 
-* `pytest-instafail <http://pypi.python.org/pypi/pytest-instafail>`_:
+* `pytest-instafail <https://pypi.org/project/pytest-instafail/>`_:
   to report failures while the test run is happening.
 
-* `pytest-bdd <http://pypi.python.org/pypi/pytest-bdd>`_ and
-  `pytest-konira <http://pypi.python.org/pypi/pytest-konira>`_
+* `pytest-bdd <https://pypi.org/project/pytest-bdd/>`_ and
+  `pytest-konira <https://pypi.org/project/pytest-konira/>`_
   to write tests using behaviour-driven testing.
 
-* `pytest-timeout <http://pypi.python.org/pypi/pytest-timeout>`_:
+* `pytest-timeout <https://pypi.org/project/pytest-timeout/>`_:
   to timeout tests based on function marks or global definitions.
 
-* `pytest-pep8 <http://pypi.python.org/pypi/pytest-pep8>`_:
+* `pytest-pep8 <https://pypi.org/project/pytest-pep8/>`_:
   a ``--pep8`` option to enable PEP8 compliance checking.
 
-* `pytest-flakes <https://pypi.python.org/pypi/pytest-flakes>`_:
+* `pytest-flakes <https://pypi.org/project/pytest-flakes/>`_:
   check source code with pyflakes.
 
-* `oejskit <http://pypi.python.org/pypi/oejskit>`_:
+* `oejskit <https://pypi.org/project/oejskit/>`_:
   a plugin to run javascript unittests in live browsers.
 
 To see a complete list of all plugins with their latest testing
@@ -61,7 +61,7 @@ status against different pytest and Python versions, please visit
 
 You may also discover more plugins through a `pytest- pypi.python.org search`_.
 
-.. _`pytest- pypi.python.org search`: http://pypi.python.org/pypi?%3Aaction=search&term=pytest-&submit=search
+.. _`pytest- pypi.python.org search`: https://pypi.org/search/?q=pytest-
 
 
 .. _`available installable plugins`:

--- a/doc/en/projects.rst
+++ b/doc/en/projects.rst
@@ -32,40 +32,40 @@ Here are some examples of projects using ``pytest`` (please send notes via :ref:
 * `PyPM <http://code.activestate.com/pypm/>`_ ActiveState's package manager
 * `Fom <http://packages.python.org/Fom/>`_ a fluid object mapper for FluidDB
 * `applib <https://github.com/ActiveState/applib>`_ cross-platform utilities
-* `six <http://pypi.python.org/pypi/six/>`_ Python 2 and 3 compatibility utilities
+* `six <https://pypi.org/project/six/>`_ Python 2 and 3 compatibility utilities
 * `pediapress <http://code.pediapress.com/wiki/wiki>`_ MediaWiki articles
-* `mwlib <http://pypi.python.org/pypi/mwlib>`_ mediawiki parser and utility library
+* `mwlib <https://pypi.org/project/mwlib/>`_ mediawiki parser and utility library
 * `The Translate Toolkit <http://translate.sourceforge.net/wiki/toolkit/index>`_ for localization and conversion
 * `execnet <http://codespeak.net/execnet>`_ rapid multi-Python deployment
 * `pylib <https://py.readthedocs.io>`_ cross-platform path, IO, dynamic code library
 * `Pacha <http://pacha.cafepais.com/>`_ configuration management in five minutes
-* `bbfreeze <http://pypi.python.org/pypi/bbfreeze>`_ create standalone executables from Python scripts
+* `bbfreeze <https://pypi.org/project/bbfreeze/>`_ create standalone executables from Python scripts
 * `pdb++ <http://bitbucket.org/antocuni/pdb>`_ a fancier version of PDB
 * `py-s3fuse <http://code.google.com/p/py-s3fuse/>`_ Amazon S3 FUSE based filesystem
 * `waskr <http://code.google.com/p/waskr/>`_ WSGI Stats Middleware
 * `guachi <http://code.google.com/p/guachi/>`_ global persistent configs for Python modules
-* `Circuits <http://pypi.python.org/pypi/circuits>`_ lightweight Event Driven Framework
+* `Circuits <https://pypi.org/project/circuits/>`_ lightweight Event Driven Framework
 * `pygtk-helpers <http://bitbucket.org/aafshar/pygtkhelpers-main/>`_ easy interaction with PyGTK
 * `QuantumCore <http://quantumcore.org/>`_ statusmessage and repoze openid plugin
 * `pydataportability <http://pydataportability.net/>`_ libraries for managing the open web
 * `XIST <http://www.livinglogic.de/Python/xist/>`_ extensible HTML/XML generator
-* `tiddlyweb <http://pypi.python.org/pypi/tiddlyweb>`_ optionally headless, extensible RESTful datastore
+* `tiddlyweb <https://pypi.org/project/tiddlyweb/>`_ optionally headless, extensible RESTful datastore
 * `fancycompleter <http://bitbucket.org/antocuni/fancycompleter/src>`_ for colorful tab-completion
 * `Paludis <http://paludis.exherbo.org/>`_ tools for Gentoo Paludis package manager
 * `Gerald <http://halfcooked.com/code/gerald/>`_ schema comparison tool
 * `abjad <http://code.google.com/p/abjad/>`_ Python API for Formalized Score control
 * `bu <http://packages.python.org/bu/>`_ a microscopic build system
 * `katcp <https://bitbucket.org/hodgestar/katcp>`_ Telescope communication protocol over Twisted
-* `kss plugin timer <http://pypi.python.org/pypi/kss.plugin.timer>`_
+* `kss plugin timer <https://pypi.org/project/kss.plugin.timer/>`_
 * `pyudev <https://pyudev.readthedocs.io/en/latest/tests/plugins.html>`_ a pure Python binding to the Linux library libudev
 * `pytest-localserver <https://bitbucket.org/pytest-dev/pytest-localserver/>`_ a plugin for pytest that provides an httpserver and smtpserver
-* `pytest-monkeyplus <http://pypi.python.org/pypi/pytest-monkeyplus/>`_ a plugin that extends monkeypatch
+* `pytest-monkeyplus <https://pypi.org/project/pytest-monkeyplus/>`_ a plugin that extends monkeypatch
 
 These projects help integrate ``pytest`` into other Python frameworks:
 
-* `pytest-django <http://pypi.python.org/pypi/pytest-django/>`_ for Django
+* `pytest-django <https://pypi.org/project/pytest-django/>`_ for Django
 * `zope.pytest <http://packages.python.org/zope.pytest/>`_ for Zope and Grok
-* `pytest_gae <http://pypi.python.org/pypi/pytest_gae/0.2.1>`_ for Google App Engine
+* `pytest_gae <https://pypi.org/project/pytest_gae/0.2.1/>`_ for Google App Engine
 * There is `some work <https://github.com/Kotti/Kotti/blob/master/kotti/testing.py>`_ underway for Kotti, a CMS built in Pyramid/Pylons
 
 

--- a/doc/en/proposals/parametrize_with_fixtures.rst
+++ b/doc/en/proposals/parametrize_with_fixtures.rst
@@ -118,7 +118,7 @@ all parameters marked as a fixture.
 
 .. note::
 
-    The `pytest-lazy-fixture <https://pypi.python.org/pypi/pytest-lazy-fixture>`_ plugin implements a very
+    The `pytest-lazy-fixture <https://pypi.org/project/pytest-lazy-fixture/>`_ plugin implements a very
     similar solution to the proposal below, make sure to check it out.
 
 .. code-block:: python

--- a/doc/en/test/plugin/cov.rst
+++ b/doc/en/test/plugin/cov.rst
@@ -21,7 +21,7 @@ The `pytest-cov`_ package may be installed with pip or easy_install::
     pip install pytest-cov
     easy_install pytest-cov
 
-.. _`pytest-cov`: http://pypi.python.org/pypi/pytest-cov/
+.. _`pytest-cov`: https://pypi.org/project/pytest-cov/
 
 
 Uninstallation

--- a/doc/en/test/plugin/oejskit.rst
+++ b/doc/en/test/plugin/oejskit.rst
@@ -7,6 +7,6 @@ The approach enables to write integration tests such that the JavaScript code is
 For more info and download please visit the `oejskit PyPI`_ page.
 
 .. _`oejskit`:
-.. _`oejskit PyPI`: http://pypi.python.org/pypi/oejskit
+.. _`oejskit PyPI`: https://pypi.org/project/oejskit/
 
 .. source link 'http://bitbucket.org/pedronis/js-infrastructure/src/tip/pytest_jstests.py',

--- a/doc/en/test/plugin/xdist.rst
+++ b/doc/en/test/plugin/xdist.rst
@@ -26,7 +26,7 @@ program source code to the remote place.  All test results
 are reported back and displayed to your local test session.
 You may specify different Python versions and interpreters.
 
-.. _`pytest-xdist`: http://pypi.python.org/pypi/pytest-xdist
+.. _`pytest-xdist`: https://pypi.org/project/pytest-xdist/
 
 Usage examples
 ---------------------

--- a/doc/en/unittest.rst
+++ b/doc/en/unittest.rst
@@ -46,9 +46,9 @@ in most cases without having to modify existing code:
 * :ref:`maxfail`;
 * :ref:`--pdb <pdb-option>` command-line option for debugging on test failures
   (see :ref:`note <pdb-unittest-note>` below);
-* Distribute tests to multiple CPUs using the `pytest-xdist <http://pypi.python.org/pypi/pytest-xdist>`_ plugin;
+* Distribute tests to multiple CPUs using the `pytest-xdist <https://pypi.org/project/pytest-xdist/>`_ plugin;
 * Use :ref:`plain assert-statements <assert>` instead of ``self.assert*`` functions (`unittest2pytest
-  <https://pypi.python.org/pypi/unittest2pytest/>`__ is immensely helpful in this);
+  <https://pypi.org/project/unittest2pytest/>`__ is immensely helpful in this);
 
 
 pytest features in ``unittest.TestCase`` subclasses

--- a/doc/en/usage.rst
+++ b/doc/en/usage.rst
@@ -407,7 +407,7 @@ Creating resultlog format files
     This option is rarely used and is scheduled for removal in 4.0.
 
     An alternative for users which still need similar functionality is to use the
-    `pytest-tap <https://pypi.python.org/pypi/pytest-tap>`_ plugin which provides
+    `pytest-tap <https://pypi.org/project/pytest-tap/>`_ plugin which provides
     a stream of test data.
 
     If you have any concerns, please don't hesitate to

--- a/doc/en/writing_plugins.rst
+++ b/doc/en/writing_plugins.rst
@@ -103,7 +103,7 @@ Here is how you might run it::
 Writing your own plugin
 -----------------------
 
-.. _`setuptools`: http://pypi.python.org/pypi/setuptools
+.. _`setuptools`: https://pypi.org/project/setuptools/
 
 If you want to write a plugin, there are many real-life examples
 you can copy from:


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html