### PR TITLE
Escape whitespace only strings when diffing them on failed assertions

### DIFF
--- a/_pytest/assertion/util.py
+++ b/_pytest/assertion/util.py
@@ -172,9 +172,9 @@ def _diff_text(left, right, verbose=False):
     from difflib import ndiff
     explanation = []
 
-    def to_unicode_text(binary_text):
+    def escape_for_readable_diff(binary_text):
         """
-        This ensures that the internal string is always valid unicode, converting any bytes safely to valid unicode.
+        Ensures that the internal string is always valid unicode, converting any bytes safely to valid unicode.
         This is done using repr() which then needs post-processing to fix the encompassing quotes and un-escape
         newlines and carriage returns (#429).
         """
@@ -184,9 +184,9 @@ def _diff_text(left, right, verbose=False):
         return r
 
     if isinstance(left, six.binary_type):
-        left = to_unicode_text(left)
+        left = escape_for_readable_diff(left)
     if isinstance(right, six.binary_type):
-        right = to_unicode_text(right)
+        right = escape_for_readable_diff(right)
     if not verbose:
         i = 0  # just in case left or right has zero length
         for i in range(min(len(left), len(right))):

--- a/_pytest/assertion/util.py
+++ b/_pytest/assertion/util.py
@@ -171,10 +171,22 @@ def _diff_text(left, right, verbose=False):
     """
     from difflib import ndiff
     explanation = []
+
+    def to_unicode_text(binary_text):
+        """
+        This ensures that the internal string is always valid unicode, converting any bytes safely to valid unicode.
+        This is done using repr() which then needs post-processing to fix the encompassing quotes and un-escape
+        newlines and carriage returns (#429).
+        """
+        r = six.text_type(repr(binary_text)[1:-1])
+        r = r.replace(r'\n', '\n')
+        r = r.replace(r'\r', '\r')
+        return r
+
     if isinstance(left, six.binary_type):
-        left = u(repr(left)[1:-1]).replace(r'\n', '\n')
+        left = to_unicode_text(left)
     if isinstance(right, six.binary_type):
-        right = u(repr(right)[1:-1]).replace(r'\n', '\n')
+        right = to_unicode_text(right)
     if not verbose:
         i = 0  # just in case left or right has zero length
         for i in range(min(len(left), len(right))):
@@ -197,6 +209,10 @@ def _diff_text(left, right, verbose=False):
                 left = left[:-i]
                 right = right[:-i]
     keepends = True
+    if left.isspace() or right.isspace():
+        left = repr(str(left))
+        right = repr(str(right))
+        explanation += [u'Strings contain only whitespace, escaping them using repr()']
     explanation += [line.strip('\n')
                     for line in ndiff(left.splitlines(keepends),
                                       right.splitlines(keepends))]

--- a/changelog/3443.bugfix.rst
+++ b/changelog/3443.bugfix.rst
@@ -1,0 +1,1 @@
+When showing diffs of failed assertions where the contents contain only whitespace, escape them using ``repr()`` first to make it easy to spot the differences.

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -746,6 +746,18 @@ def test_reprcompare_notin(mock_config):
     assert detail == ["'foo' is contained here:", '  aaafoobbb', '?    +++']
 
 
+def test_reprcompare_whitespaces(mock_config):
+    detail = plugin.pytest_assertrepr_compare(
+        mock_config, '==', '\r\n', '\n')
+    assert detail == [
+        r"'\r\n' == '\n'",
+        r"Strings contain only whitespace, escaping them using repr()",
+        r"- '\r\n'",
+        r"?  --",
+        r"+ '\n'",
+    ]
+
+
 def test_pytest_assertrepr_compare_integration(testdir):
     testdir.makepyfile("""
         def test_hello():


### PR DESCRIPTION
Fix #3443

Here's how it looks:

```

    def test_stuff():
        a = u'\r\n'
>       assert a == u'\n'
E       AssertionError: assert '\r\n' == '\n'
E         Strings contain only whitespace, escaping them using repr()
E         - '\r\n'
E         ?  --
E         + '\n'

.tmp\test_rn.py:4: AssertionError
```
