### PR TITLE
Attempt to fix flaky test on Python 2

### DIFF
--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -523,6 +523,7 @@ class TestRequestBasic(object):
         testdir.makepyfile("""
             import sys
             import pytest
+            from _pytest.compat import safe_str
             import gc
 
             @pytest.fixture(autouse=True)
@@ -539,7 +540,7 @@ class TestRequestBasic(object):
 
                     gc.collect()
                     leaked_types = sum(1 for _ in gc.garbage
-                                    if 'PseudoFixtureDef' in str(_))
+                                       if 'PseudoFixtureDef' in safe_str(_))
 
                     gc.garbage[:] = []
 


### PR DESCRIPTION
This test sometimes fails on AppVeyor with:

```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.0 = <listiterator object at 0x0549DC50>
    leaked_types = sum(1 for _ in gc.garbage
>                   if 'PseudoFixtureDef' in str(_))
E   UnicodeEncodeError: 'ascii' codec can't encode character u'\u263a' in position 23: ordinal not in range(128)
test_request_garbage.py:19: UnicodeEncodeError
====================== 1 passed, 1 error in 1.39 seconds ======================
```

Use our internal "safe_repr" function to handle Encode errors: who knows
what objects are in garbage after all.

Example of a recent failure: https://ci.appveyor.com/project/pytestbot/pytest/build/1.0.4327/job/yfunwupo1bo3rvdc