### PR TITLE
Attempt to fix CI problems related to Hypothesis

### DIFF
--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -188,6 +188,7 @@ class TestMetafunc(object):
         assert metafunc._calls[3].id == "x1-b"
 
     @hypothesis.given(strategies.text() | strategies.binary())
+    @hypothesis.settings(deadline=400.0)  # very close to std deadline and CI boxes are not reliable in CPU power
     def test_idval_hypothesis(self, value):
         from _pytest.python import _idval
         escaped = _idval(value, 'a', 6, None)

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ envlist =
 commands = pytest --lsof -ra {posargs:testing}
 passenv = USER USERNAME
 deps =
-    hypothesis>=3.5.2
+    hypothesis>=3.56
     nose
     mock
     requests
@@ -53,7 +53,7 @@ deps =
     pytest-xdist>=1.13
     mock
     nose
-    hypothesis>=3.5.2
+    hypothesis>=3.56
 changedir=testing
 commands =
     pytest -n8 -ra {posargs:.}
@@ -78,7 +78,7 @@ commands = {[testenv:py27-pexpect]commands}
 [testenv:py27-nobyte]
 deps =
     pytest-xdist>=1.13
-    hypothesis>=3.5.2
+    hypothesis>=3.56
 distribute = true
 changedir=testing
 setenv =


### PR DESCRIPTION
* Increase hypothesis deadline

  The current deadline being reached is pretty close to the new default that will come out in
future hypothesis versions, which is generating a deprecation error
on CI.

  Using a loose deadline because CI boxes are not reliable in how much
CPU power they have available

* Use a more recent hypothesis version on CI

