### PR TITLE
Detect `pytest_` prefixed hooks

### DIFF
--- a/_pytest/config.py
+++ b/_pytest/config.py
@@ -177,7 +177,7 @@ class PytestPluginManager(PluginManager):
     """
 
     def __init__(self):
-        super(PytestPluginManager, self).__init__("pytest", implprefix="pytest_")
+        super(PytestPluginManager, self).__init__("pytest")
         self._conftest_plugins = set()
 
         # state related to local conftest plugins
@@ -231,6 +231,11 @@ class PytestPluginManager(PluginManager):
 
         method = getattr(plugin, name)
         opts = super(PytestPluginManager, self).parse_hookimpl_opts(plugin, name)
+
+        # collect unmarked hooks as long as they have the `pytest_' prefix
+        if opts is None and name.startswith("pytest_"):
+            opts = {}
+
         if opts is not None:
             for name in ("tryfirst", "trylast", "optionalhook", "hookwrapper"):
                 opts.setdefault(name, hasattr(method, name))

--- a/changelog/3487.trivial.rst
+++ b/changelog/3487.trivial.rst
@@ -1,0 +1,3 @@
+Detect `pytest_` prefixed hooks using the internal plugin
+manager since ``pluggy`` is deprecating the ``implprefix``
+argument to ``PluginManager``.


### PR DESCRIPTION
`pluggy` is deprecating the `implprefix` argument in the next major
release so implement this detection in our derived plugin manager.

Relates to pytest-dev/pluggy#145