### PR TITLE
Import Mapping and Sequence from compat in python_api::approx

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -144,6 +144,7 @@ Michael Seifert
 Michal Wajszczuk
 Mihai Capotă
 Mike Lundy
+Miro Hrončok
 Nathaniel Waisbrot
 Ned Batchelder
 Neven Mundar

--- a/_pytest/compat.py
+++ b/_pytest/compat.py
@@ -40,11 +40,11 @@ MODULE_NOT_FOUND_ERROR = 'ModuleNotFoundError' if PY36 else 'ImportError'
 
 if _PY3:
     from collections.abc import MutableMapping as MappingMixin  # noqa
-    from collections.abc import Sequence  # noqa
+    from collections.abc import Mapping, Sequence  # noqa
 else:
     # those raise DeprecationWarnings in Python >=3.7
     from collections import MutableMapping as MappingMixin  # noqa
-    from collections import Sequence  # noqa
+    from collections import Mapping, Sequence  # noqa
 
 
 def _format_args(func):

--- a/_pytest/python_api.py
+++ b/_pytest/python_api.py
@@ -426,7 +426,7 @@ def approx(expected, rel=None, abs=None, nan_ok=False):
        __ https://docs.python.org/3/reference/datamodel.html#object.__ge__
     """
 
-    from collections import Mapping, Sequence
+    from _pytest.compat import Mapping, Sequence
     from _pytest.compat import STRING_TYPES as String
     from decimal import Decimal
 

--- a/changelog/3497.trivial.rst
+++ b/changelog/3497.trivial.rst
@@ -1,0 +1,5 @@
+Import ``Mapping`` and ``Sequence`` from ``_pytest.compat`` instead of directly
+from ``collections`` in ``python_api.py::approx``. Add ``Mapping`` to
+``_pytest.compat``, import it from ``collections`` on python 2, but from
+``collections.abc`` on Python 3 to avoid a ``DeprecationWarning`` on
+Python 3.7 or newer.


### PR DESCRIPTION
Related to https://github.com/pytest-dev/pytest/issues/3339

Fixes a DeprecationWarning on Python 3.7

Adds Mapping to compat