### PR TITLE
3491 - Fixed a bug where stdout and stderr were logged twice by junitxml for xfail tests.

### DIFF
--- a/_pytest/junitxml.py
+++ b/_pytest/junitxml.py
@@ -224,7 +224,7 @@ class _NodeReporter(object):
                 Junit.skipped("%s:%s: %s" % (filename, lineno, skipreason),
                               type="pytest.skip",
                               message=skipreason))
-        self.write_captured_output(report)
+            self.write_captured_output(report)
 
     def finalize(self):
         data = self.to_xml().unicode(indent=0)

--- a/changelog/3491.bugfix.rst
+++ b/changelog/3491.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where stdout and stderr were logged twice by junitxml.

--- a/changelog/3491.bugfix.rst
+++ b/changelog/3491.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed a bug where stdout and stderr were logged twice by junitxml.
+Fixed a bug where stdout and stderr were logged twice by junitxml when a test was marked xfail.

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -458,6 +458,23 @@ class TestPython(object):
         fnode.assert_attr(message="expected test failure")
         # assert "ValueError" in fnode.toxml()
 
+    def test_xfail_captures_output_once(self, testdir):
+        testdir.makepyfile("""
+            import sys
+            import pytest
+
+            @pytest.mark.xfail()
+            def test_fail():
+                sys.stdout.write('XFAIL This is stdout')
+                sys.stderr.write('XFAIL This is stderr')
+                assert 0
+        """)
+        result, dom = runandparse(testdir)
+        node = dom.find_first_by_tag("testsuite")
+        tnode = node.find_first_by_tag("testcase")
+        assert len(tnode.find_by_tag('system-err')) == 1
+        assert len(tnode.find_by_tag('system-out')) == 1
+    
     def test_xfailure_xpass(self, testdir):
         testdir.makepyfile("""
             import pytest

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -474,7 +474,7 @@ class TestPython(object):
         tnode = node.find_first_by_tag("testcase")
         assert len(tnode.find_by_tag('system-err')) == 1
         assert len(tnode.find_by_tag('system-out')) == 1
-    
+
     def test_xfailure_xpass(self, testdir):
         testdir.makepyfile("""
             import pytest


### PR DESCRIPTION
Before this commit. stdout and stderr were being logged twice in the junitxml report.

This change fixes the issue so that stdout and stderr are now only logged once:

```
<?xml version="1.0" encoding="utf-8"?>
<testsuite errors="0" failures="0" name="pytest" skips="1" tests="1" time="0.062">
	<testcase classname="test" file="test.py" line="3" name="test_fail" time="0.0">
	<skipped message="expected test failure"></skipped>
	<system-out>XFAIL This is stdout
	</system-out>
	<system-err>XFAIL This is stderr
	</system-err>
	</testcase>
</testsuite>
```