### PR TITLE
Fix tox spelling (all lower case).

### DIFF
--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -174,7 +174,7 @@ Note that this layout also works in conjunction with the ``src`` layout mentione
 
 .. _`use tox`:
 
-Tox
+tox
 ------
 
 For development, we recommend to use virtualenv_ environments and pip_
@@ -194,7 +194,7 @@ Once you are done with your work and want to make sure that your actual
 package passes all tests you may want to look into `tox`_, the
 virtualenv test automation tool and its `pytest support
 <https://tox.readthedocs.io/en/latest/example/pytest.html>`_.
-Tox helps you to setup virtualenv environments with pre-defined
+tox helps you to setup virtualenv environments with pre-defined
 dependencies and then executing a pre-configured test command with
 options.  It will run tests against the installed package and not
 against your source code checkout, helping to detect packaging

--- a/doc/en/nose.rst
+++ b/doc/en/nose.rst
@@ -58,7 +58,7 @@ Unsupported idioms / known issues
   You may find yourself wanting to do this if you ran ``python setup.py install``
   to set up your project, as opposed to ``python setup.py develop`` or any of
   the package manager equivalents.  Installing with develop in a
-  virtual environment like Tox is recommended over this pattern.
+  virtual environment like tox is recommended over this pattern.
 
 - nose-style doctests are not collected and executed correctly,
   also doctest fixtures don't work.


### PR DESCRIPTION
This is a mini-mini fix, so no changelog entry or anything else is necessary, I guess.