### PR TITLE
Write rewritten code using file.write(marshal.dumps())

### DIFF
--- a/_pytest/assertion/rewrite.py
+++ b/_pytest/assertion/rewrite.py
@@ -265,10 +265,7 @@ def _write_pyc(state, co, source_stat, pyc):
             mtime = int(source_stat.mtime)
             size = source_stat.size & 0xFFFFFFFF
             fp.write(struct.pack("<ll", mtime, size))
-            if six.PY2:
-                marshal.dump(co, fp.file)
-            else:
-                marshal.dump(co, fp)
+            fp.write(marshal.dumps(co))
     except EnvironmentError as e:
         state.trace("error writing pyc file at %s: errno=%s" % (pyc, e.errno))
         # we ignore any failure to write the cache file

--- a/changelog/3503.bugfix.rst
+++ b/changelog/3503.bugfix.rst
@@ -1,0 +1,1 @@
+Fix assertion rewriter compatibility with libraries that monkey patch ``file`` objects.


### PR DESCRIPTION
This works around the fact that some libraries might monkey patch
the file object, so the previous approach of marshal.dump(co, file)
breaks because file is not a built-in file object anymore.

Fix #3503

