### PR TITLE
Use "dev" extras to simplify development

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -217,12 +217,18 @@ Here is a simple overview, with pytest-specific bits:
    If you need some help with Git, follow this quick start
    guide: https://git.wiki.kernel.org/index.php/QuickStart
 
-#. install pre-commit and install its hook on the pytest repo
+#. Create a virtual environment and install pytest in development mode::
+
+    $ python3 -m venv .env
+    $ source activate .env/bin/activate (on Linux)
+    $ .env\Scripts\activate (on Windows)
+    $ pip install -e .[dev]
+
+#. Install pre-commit hook on the pytest repo
 
     https://pre-commit.com/ is a framework for managing and maintaining multi-language pre-commit hooks
     pytest uses pre-commit to ensure code-style and code formatting is the same
 
-    $ pip install --user pre-commit
     $ pre-commit install
 
     Afterwards pre-commit will run whenever you commit.
@@ -245,15 +251,9 @@ Here is a simple overview, with pytest-specific bits:
    This command will run tests via the "tox" tool against Python 2.7 and 3.6
    and also perform "lint" coding-style checks.
 
-#. You can now edit your local working copy. Please follow PEP-8.
+#. You can now edit your local working copy.
 
    You can now make the changes you want and run the tests again as necessary.
-
-   If you have too much linting errors, try running::
-
-    $ tox -e fix-lint
-
-   To fix pep8 related errors.
 
    You can pass different options to ``tox``. For example, to run tests on Python 2.7 and pass options to pytest
    (e.g. enter pdb on failure) to pytest you can do::

--- a/HOWTORELEASE.rst
+++ b/HOWTORELEASE.rst
@@ -10,9 +10,9 @@ taking a lot of time to make a new one.
     pytest releases must be prepared on **Linux** because the docs and examples expect
     to be executed in that platform.
 
-#. Install development dependencies in a virtual environment with::
+#. Install and update development dependencies in a virtual environment with::
 
-    pip3 install -U -r tasks/requirements.txt
+    pip3 install -U .[dev]
 
 #. Create a branch ``release-X.Y.Z`` with the version for the release.
 

--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,12 @@ Changelog
 Consult the `Changelog <http://docs.pytest.org/en/latest/changelog.html>`__ page for fixes and enhancements of each version.
 
 
+Contributing
+------------
+
+Consult the `Contribution guide <https://docs.pytest.org/en/latest/contributing.html>`__ page.
+
+
 License
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 import os
 import sys
-import setuptools
+
 import pkg_resources
+import setuptools
 from setuptools import setup, Command
 
 classifiers = [
@@ -57,7 +58,9 @@ def get_environment_marker_support_level():
 
 
 def main():
-    extras_require = {}
+    extras_require = {
+        "dev": ["gitpython", "invoke", "pre-commit", "towncrier", "tox", "wheel"]
+    }
     install_requires = [
         "py>=1.5.0",
         "six>=1.10.0",

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
+import io
 import os
 import sys
 
 import pkg_resources
 import setuptools
-from setuptools import setup, Command
+from setuptools import setup
 
 classifiers = [
     "Development Status :: 6 - Mature",
@@ -20,8 +21,10 @@ classifiers = [
     for x in "2 2.7 3 3.4 3.5 3.6 3.7".split()
 ]
 
-with open("README.rst") as fd:
-    long_description = fd.read()
+
+def get_long_description():
+    with io.open("README.rst", encoding="UTF-8") as fd:
+        return fd.read()
 
 
 def get_environment_marker_support_level():
@@ -89,7 +92,7 @@ def main():
     setup(
         name="pytest",
         description="pytest: simple powerful testing with Python",
-        long_description=long_description,
+        long_description=get_long_description(),
         use_scm_version={"write_to": "src/_pytest/_version.py"},
         url="http://pytest.org",
         project_urls={
@@ -105,8 +108,6 @@ def main():
         entry_points={"console_scripts": ["pytest=pytest:main", "py.test=pytest:main"]},
         classifiers=classifiers,
         keywords="test unittest",
-        cmdclass={"test": PyTest},
-        # the following should be enabled for release
         setup_requires=["setuptools-scm"],
         package_dir={"": "src"},
         python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
@@ -116,25 +117,6 @@ def main():
         py_modules=["pytest"],
         zip_safe=False,
     )
-
-
-class PyTest(Command):
-    user_options = []
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        import subprocess
-
-        python_path = [x for x in os.environ.get("PYTHONPATH", "").split(":") if x]
-        python_path.insert(0, os.getcwd())
-        os.environ["PYTHONPATH"] = ":".join(python_path)
-        errno = subprocess.call([sys.executable, "pytest.py", "--ignore=doc"])
-        raise SystemExit(errno)
 
 
 if __name__ == "__main__":

--- a/tasks/requirements.txt
+++ b/tasks/requirements.txt
@@ -1,6 +1,0 @@
--e .
-gitpython
-invoke
-towncrier
-tox
-wheel

--- a/tox.ini
+++ b/tox.ini
@@ -150,14 +150,6 @@ commands =
     rm -rf /tmp/doc-exec*
     make regen
 
-[testenv:fix-lint]
-skipsdist = True
-usedevelop = True
-deps =
-    autopep8
-commands =
-    autopep8 --in-place -r --max-line-length=120 --exclude=test_source_multiline_block.py _pytest testing setup.py pytest.py
-
 [testenv:jython]
 changedir = testing
 commands =


### PR DESCRIPTION
This uses the `extra_requires` feature and recommends using `pip install -e .[dev]` for development. Also cleanup `setup.py` a bit.

**Note** for some reason `pip install -e .[dev]` is not working for me and I don't understand why:

```
(.env36) λ pip install -e .[dev]
Obtaining file:///C:/pytest
  Installing build dependencies ... done
  pytest 3.6.1.dev29+g1b16d649 does not provide the extra 'dev'
```

While `pip install -e .[testing]` with tox works just fine, even though the extras definition is identical: https://github.com/tox-dev/tox/blob/6edfab0f8a75124d453cb95a1cfe560d614e79d8/setup.py#L53-L60

Would appreciate any advice here.