### PR TITLE
Fix typo in plugin list example

### DIFF
--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -845,7 +845,7 @@ Contains comma-separated list of modules that should be loaded as plugins:
 
 .. code-block:: bash
 
-    export PYTEST_PLUGINS=mymodule.plugin,xdisst
+    export PYTEST_PLUGINS=mymodule.plugin,xdist
 
 
 PYTEST_CURRENT_TEST


### PR DESCRIPTION
Small typo `xdisst` -> `xdist` in the documentation for the `PYTEST_PLUGINS` env variable.

I thought this was too small to warrant an issue + changelog, but I'll be happy to do those if requested.