### PR TITLE
Add documentation blurb for --strict

### DIFF
--- a/changelog/3549.doc.rst
+++ b/changelog/3549.doc.rst
@@ -1,0 +1,1 @@
+Add documentation for the ``--strict`` flag.

--- a/doc/en/mark.rst
+++ b/doc/en/mark.rst
@@ -50,11 +50,6 @@ should add ``--strict`` to ``addopts``:
         slow
         serial
 
-.. currentmodule:: _pytest.mark.structures
-.. autoclass:: Mark
-    :members:
-    :noindex:
-
 
 .. `marker-iteration`
 

--- a/doc/en/mark.rst
+++ b/doc/en/mark.rst
@@ -29,7 +29,8 @@ which also serve as documentation.
 Raising errors on unknown marks: --strict
 -----------------------------------------
 
-The ``--strict`` command-line flag can be used to raise errors when marks not registered in the ``pytest.ini`` file.
+When the ``--strict`` command-line flag is passed, any marks not registered in the ``pytest.ini`` file will trigger an error.
+
 Marks can be registered like this:
 
 .. code-block:: ini
@@ -39,7 +40,7 @@ Marks can be registered like this:
         slow
         serial
 
-This can be used to prevent users mistyping mark names by accident. Test suites that want to enforce that this
+This can be used to prevent users mistyping mark names by accident. Test suites that want to enforce this
 should add ``--strict`` to ``addopts``:
 
 .. code-block:: ini

--- a/doc/en/mark.rst
+++ b/doc/en/mark.rst
@@ -26,6 +26,30 @@ which also serve as documentation.
     :ref:`fixtures <fixtures>`.
 
 
+Raising errors on unknown marks: --strict
+-----------------------------------------
+
+The ``--strict`` command-line flag can be used to raise errors when marks not registered in the ``pytest.ini`` file.
+Marks can be registered like this:
+
+.. code-block:: ini
+
+    [pytest]
+    markers =
+        slow
+        serial
+
+This can be used to prevent users mistyping mark names by accident. Test suites that want to enforce that this
+should add ``--strict`` to ``addopts``:
+
+.. code-block:: ini
+
+    [pytest]
+    addopts = --strict
+    markers =
+        slow
+        serial
+
 .. currentmodule:: _pytest.mark.structures
 .. autoclass:: Mark
     :members:


### PR DESCRIPTION
Also remove Mark api from mark.rst: Feels out of place in there, plus the reference documentation already contains the reference API to all mark-related classes.

Fix #3459
