### PR TITLE
Revert change of Callinfo.result default value

### DIFF
--- a/changelog/3554.bugfix
+++ b/changelog/3554.bugfix
@@ -1,1 +1,0 @@
-Allow ``CallInfo`` to have an unfinished state represented by having a ``None`` value in the ``result`` attribute.

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -194,7 +194,6 @@ class CallInfo(object):
         #: "teardown", "memocollect"
         self.when = when
         self.start = time()
-        self.result = None
         try:
             self.result = func()
         except KeyboardInterrupt:

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -473,7 +473,7 @@ def test_callinfo():
     assert "result" in repr(ci)
     ci = runner.CallInfo(lambda: 0 / 0, "123")
     assert ci.when == "123"
-    assert ci.result is None
+    assert not hasattr(ci, "result")
     assert ci.excinfo
     assert "exc" in repr(ci)
 


### PR DESCRIPTION
As discussed in #3560, this should not go to master because this breaks
the API.

Reverts commits:

1a7dcd73cf38f07ccaa4bd19c476750a1c678cbc
198e993969ddf9ecb137150760565fccc773f11c

Follow up of https://github.com/pytest-dev/pytest/pull/3560#pullrequestreview-127388483