### PR TITLE
Attempt to fix test_request_garbage on Windows

### DIFF
--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -630,7 +630,7 @@ class TestRequestBasic(object):
             """
             import sys
             import pytest
-            from _pytest.compat import safe_str
+            from _pytest.fixtures import PseudoFixtureDef
             import gc
 
             @pytest.fixture(autouse=True)
@@ -647,7 +647,7 @@ class TestRequestBasic(object):
 
                     gc.collect()
                     leaked_types = sum(1 for _ in gc.garbage
-                                       if 'PseudoFixtureDef' in safe_str(_))
+                                       if isinstance(_, PseudoFixtureDef))
 
                     gc.garbage[:] = []
 


### PR DESCRIPTION
~~Related to #3564~~

~~At least avoid breaking AppVeyor on Windows until we can get to the bottom of why this test is flaky.~~

Fix #3564

Initially I marked the test as flaky, but taking another look at the traceback I think I found a proper fix.