### PR TITLE
Fix TypeError when first item in MarkInfo list of marks is a MarkDecorator instance

### DIFF
--- a/changelog/3501.bugfix.rst
+++ b/changelog/3501.bugfix.rst
@@ -1,0 +1,1 @@
+Allow to insert ``pytest.mark.NAME`` (``MarkDecorator``) objects at the start of an item's marks.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 from operator import attrgetter
 
 import attr
+import six
 
 from ..deprecated import MARK_PARAMETERSET_UNPACKING, MARK_INFO_ATTRIBUTE
 from ..compat import NOTSET, getfslineno, MappingMixin
@@ -282,12 +283,17 @@ class MarkInfo(object):
     """ Marking object created by :class:`MarkDecorator` instances. """
 
     _marks = attr.ib()
-    combined = attr.ib(
-        repr=False,
-        default=attr.Factory(
-            lambda self: reduce(Mark.combined_with, self._marks), takes_self=True
-        ),
-    )
+    combined = attr.ib(repr=False)
+
+    @combined.default
+    def _combined_default(self):
+        if six.PY2:
+            marks = [
+                (x.mark if isinstance(x, MarkDecorator) else x) for x in self._marks
+            ]
+        else:
+            marks = self._marks
+        return reduce(Mark.combined_with, marks)
 
     name = alias("combined.name", warning=MARK_INFO_ATTRIBUTE)
     args = alias("combined.args", warning=MARK_INFO_ATTRIBUTE)

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -136,6 +136,16 @@ class TestMark(object):
         assert "reason" not in g.some.kwargs
         assert g.some.kwargs["reason2"] == "456"
 
+    @ignore_markinfo
+    def test_pytest_mark_decorator_first_item(self):
+        """Check that inserting a MarkDecorator as the first element of MarkInfo works (#3501)"""
+        from _pytest.mark.structures import MarkInfo, Mark
+
+        mark_info = MarkInfo(
+            [pytest.mark.slow(3), Mark(name="slow", args=(1,), kwargs={})]
+        )
+        assert mark_info.args == (3, 1)
+
 
 def test_marked_class_run_twice(testdir, request):
     """Test fails file is run twice that contains marked class.


### PR DESCRIPTION
Not sure I like the fix, but the current state of things of working on Python 3 and failing on Python 2 is not optimal either. 🤔 

Fix #3501