### PR TITLE
Fix encoding error with `print` statements in doctests

### DIFF
--- a/changelog/3583.bugfix.rst
+++ b/changelog/3583.bugfix.rst
@@ -1,0 +1,1 @@
+Fix encoding error with `print` statements in doctests

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -505,7 +505,7 @@ def _fix_spoof_python2(runner, encoding):
 
         def getvalue(self):
             result = _SpoofOut.getvalue(self)
-            if encoding:
+            if encoding and isinstance(result, bytes):
                 result = result.decode(encoding)
             return result
 

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -655,6 +655,22 @@ class TestDoctests(object):
         result = testdir.runpytest(p, "--doctest-modules")
         result.stdout.fnmatch_lines(["* 1 passed *"])
 
+    def test_print_unicode_value(self, testdir):
+        """
+        Test case for issue 3583: Printing Unicode in doctest under Python 2.7
+        doesn't work
+        """
+        p = testdir.maketxtfile(
+            test_print_unicode_value=r"""
+            Here is a doctest::
+
+                >>> print(u'\xE5\xE9\xEE\xF8\xFC')
+                åéîøü
+        """
+        )
+        result = testdir.runpytest(p)
+        result.stdout.fnmatch_lines(["* 1 passed *"])
+
     def test_reportinfo(self, testdir):
         """
         Test case to make sure that DoctestItem.reportinfo() returns lineno.


### PR DESCRIPTION
This fixes #3583.  This fix was suggested by Stack Overflow user phd in
<https://stackoverflow.com/a/50863820/744178>.