### PR TITLE
Fix 2 DeprecationWarnings about invalid escape seq

### DIFF
--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -497,7 +497,7 @@ def _is_numpy_array(obj):
 
 
 def raises(expected_exception, *args, **kwargs):
-    """
+    r"""
     Assert that a code block/function call raises ``expected_exception``
     and raise a failure exception otherwise.
 

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -85,7 +85,7 @@ class _DeprecatedCallContext(object):
 
 
 def warns(expected_warning, *args, **kwargs):
-    """Assert that code raises a particular class of warning.
+    r"""Assert that code raises a particular class of warning.
 
     Specifically, the parameter ``expected_warning`` can be a warning class or
     sequence of warning classes, and the inside the ``with`` block must issue a warning of that class or


### PR DESCRIPTION
Currently I get greeted on each test run with this:

```
py36 runtests: commands[0] | coverage run --parallel -m pytest
/Users/hynek/Projects/attrs/.tox/py36/lib/python3.6/site.py:165: DeprecationWarning: 'U' mode is deprecated
  f = open(fullname, "rU")
/Users/hynek/Projects/attrs/.tox/py36/lib/python3.6/site-packages/_pytest/assertion/rewrite.py:6: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
/Users/hynek/Projects/attrs/.tox/py36/lib/python3.6/site-packages/_pytest/recwarn.py:118: DeprecationWarning: invalid escape sequence \d
  """
/Users/hynek/Projects/attrs/.tox/py36/lib/python3.6/site-packages/_pytest/python_api.py:604: DeprecationWarning: invalid escape sequence \d
```

The imp warning is probably more complicated but the other two warnings are fixed by this PR.

I don’t think it warrants a newsfragment? I can add one tho if you wish.