### PR TITLE
Use --show-diff-on-failure for pre-commit CI invocation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ skipsdist = True
 usedevelop = True
 basepython = python3.6
 deps = pre-commit
-commands = pre-commit run --all-files
+commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:py27-xdist]
 deps =


### PR DESCRIPTION
This is how `tox-dev/tox` invokes this and can often reduce the number of round trips for a PR by showing the changes in the output.