### PR TITLE
Fix reference to py36-freeze in travis and appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ jobs:
       python: 'pypy-5.4'
     - env: TOXENV=py35
       python: '3.5'
-    - env: TOXENV=py35-freeze
-      python: '3.5'
+    - env: TOXENV=py36-freeze
+      python: '3.6'
     - env: TOXENV=py37
       python: 'nightly'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ environment:
   - TOXENV: "py36-pluggymaster"
   - TOXENV: "py27-nobyte"
   - TOXENV: "doctesting"
-  - TOXENV: "py35-freeze"
+  - TOXENV: "py36-freeze"
   - TOXENV: "docs"
 
 install:


### PR DESCRIPTION
Travis and AppVeyor were executing "py35-freeze", which does not actually
exist in tox.ini.

