### PR TITLE
Silence usage of `reduce` warning in python 2

### DIFF
--- a/changelog/3609.trivial.rst
+++ b/changelog/3609.trivial.rst
@@ -1,0 +1,1 @@
+Silence usage of ``reduce`` warning in python 2

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -1,13 +1,14 @@
 import inspect
 import warnings
 from collections import namedtuple
+from functools import reduce
 from operator import attrgetter
 
 import attr
 
 from ..deprecated import MARK_PARAMETERSET_UNPACKING, MARK_INFO_ATTRIBUTE
 from ..compat import NOTSET, getfslineno, MappingMixin
-from six.moves import map, reduce
+from six.moves import map
 
 
 EMPTY_PARAMETERSET_OPTION = "empty_parameter_set_mark"


### PR DESCRIPTION
[`functools.reduce` was added in python2.6 to aid in porting](https://docs.python.org/2/library/functools.html#functools.reduce)
