### PR TITLE
Prefer unittest.mock before mock

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -157,6 +157,7 @@ Oleg Sushchenko
 Oliver Bestwalter
 Omar Kohl
 Omer Hadari
+Ondřej Súkup
 Patrick Hayes
 Paweł Adamczak
 Pedro Algarvio

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1,7 +1,11 @@
 from __future__ import absolute_import, division, print_function
 import os
 import sys
-import mock
+
+try:
+    import mock
+except ImportError:
+    import unittest.mock as mock
 import pytest
 from _pytest.mark import (
     MarkGenerator as Mark,


### PR DESCRIPTION
From Python 3.3 is mock part of python standard library in unittest namespace

- [x] Add yourself to `AUTHORS` in alphabetical order;
