### PR TITLE
Fix `ImportWarning` triggered by explicit relative imports

### DIFF
--- a/changelog/3061.bugfix.rst
+++ b/changelog/3061.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``ImportWarning`` triggered by explicit relative imports in assertion-rewritten package modules.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -45,6 +45,14 @@ else:
         return ast.Call(a, b, c, None, None)
 
 
+if sys.version_info >= (3, 4):
+    from importlib.util import spec_from_file_location
+else:
+
+    def spec_from_file_location(*_, **__):
+        return None
+
+
 class AssertionRewritingHook(object):
     """PEP302 Import hook which rewrites asserts."""
 
@@ -213,6 +221,8 @@ class AssertionRewritingHook(object):
             # Normally, this attribute is 3.2+.
             mod.__cached__ = pyc
             mod.__loader__ = self
+            # Normally, this attribute is 3.4+
+            mod.__spec__ = spec_from_file_location(name, co.co_filename, loader=self)
             py.builtin.exec_(co, mod.__dict__)
         except:  # noqa
             if name in sys.modules:


### PR DESCRIPTION
Resolves #3061 