### PR TITLE
Bug fix #3593 - approx repr in a 0-d numpy array

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -126,6 +126,7 @@ Maik Figura
 Mandeep Bhutani
 Manuel Krebber
 Marc Schlaich
+Marcelo Duarte Trevisani
 Marcin Bachry
 Mark Abramowitz
 Markus Unterwaditzer

--- a/changelog/3593.bugfix.rst
+++ b/changelog/3593.bugfix.rst
@@ -1,0 +1,5 @@
+If the user pass as a expected value a numpy array created like
+numpy.array(5); it will creates an array with one element without shape,
+when used with approx it will raise an error for the `repr`
+'TypeError: iteration over a 0-d array'. With this PR pytest will iterate
+properly in the numpy array even with 0 dimension.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -86,9 +86,11 @@ class ApproxNumpy(ApproxBase):
         # shape of the array...
         import numpy as np
 
-        return "approx({!r})".format(
-            list(self._approx_scalar(x) for x in np.asarray(self.expected))
-        )
+        list_scalars = []
+        for x in np.ndindex(self.expected.shape):
+            list_scalars.append(self._approx_scalar(np.asscalar(self.expected[x])))
+
+        return "approx({!r})".format(list_scalars)
 
     if sys.version_info[0] == 2:
         __cmp__ = _cmp_raises_type_error

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -27,8 +27,11 @@ class MyDocTestRunner(doctest.DocTestRunner):
 
 class TestApprox(object):
 
-    def test_repr_string(self):
-        plus_minus = u"\u00b1" if sys.version_info[0] > 2 else u"+-"
+    @pytest.fixture
+    def plus_minus(self):
+        return u"\u00b1" if sys.version_info[0] > 2 else u"+-"
+
+    def test_repr_string(self, plus_minus):
         tol1, tol2, infr = "1.0e-06", "2.0e-06", "inf"
         assert repr(approx(1.0)) == "1.0 {pm} {tol1}".format(pm=plus_minus, tol1=tol1)
         assert (
@@ -60,6 +63,18 @@ class TestApprox(object):
                 pm=plus_minus, tol1=tol1, tol2=tol2
             ),
         )
+
+    def test_repr_0d_array(self, plus_minus):
+        np = pytest.importorskip("numpy")
+        np_array = np.array(5.)
+        assert approx(np_array) == 5.0
+        string_expected = "approx([5.0 {} 5.0e-06])".format(plus_minus)
+
+        assert repr(approx(np_array)) == string_expected
+
+        np_array = np.array([5.])
+        assert approx(np_array) == 5.0
+        assert repr(approx(np_array)) == string_expected
 
     def test_operator_overloading(self):
         assert 1 == approx(1, rel=1e-6, abs=1e-12)


### PR DESCRIPTION
If the user pass as a expected value a numpy array created like
numpy.array(5); it will creates an array with one element without shape,
when used with approx it will raise an error
'TypeError: iteration over a 0-d array'

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs (you can delete this text from the final description, this is
just a guideline):

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](/changelog/README.rst) for details.
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [x] Target the `features` branch for new features and removals/deprecations.
- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS` in alphabetical order;
