### PR TITLE
Update pypi.python.org URLs to pypi.org

### DIFF
--- a/doc/en/announce/release-2.4.0.rst
+++ b/doc/en/announce/release-2.4.0.rst
@@ -23,7 +23,7 @@ a full list of details.  A few feature highlights:
   called if the corresponding setup method succeeded.
 
 - integrate tab-completion on command line options if you
-  have `argcomplete <http://pypi.python.org/pypi/argcomplete>`_
+  have `argcomplete <https://pypi.org/project/argcomplete/>`_
   configured.
 
 - allow boolean expression directly with skipif/xfail

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -154,7 +154,7 @@ This makes use of the automatic caching mechanisms of pytest.
 Another good approach is by adding the data files in the ``tests`` folder.
 There are also community plugins available to help managing this aspect of
 testing, e.g. `pytest-datadir <https://github.com/gabrielcnr/pytest-datadir>`__
-and `pytest-datafiles <https://pypi.python.org/pypi/pytest-datafiles>`__.
+and `pytest-datafiles <https://pypi.org/project/pytest-datafiles/>`__.
 
 .. _smtpshared:
 


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html