### PR TITLE
fix #3631 - don't store legacy markinfo when its impossible

### DIFF
--- a/changelog/3631.bugfix.rst
+++ b/changelog/3631.bugfix.rst
@@ -1,0 +1,1 @@
+No longer raise AttributeError when legacy marks can't be stored.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -259,7 +259,7 @@ def store_legacy_markinfo(func, mark):
     if holder is None:
         holder = MarkInfo.for_mark(mark)
         setattr(func, mark.name, holder)
-    else:
+    elif isinstance(holder, MarkInfo):
         holder.add_mark(mark)
 
 

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -63,6 +63,19 @@ class TestMark(object):
         mark.hello(f)
         assert f.hello
 
+    def test_mark_legacy_ignore_fail(self):
+        def add_attribute(func):
+            func.foo = 1
+            return func
+
+        @pytest.mark.foo
+        @add_attribute
+        def test_fun():
+            pass
+
+        assert test_fun.foo == 1
+        assert test_fun.pytestmark
+
     @ignore_markinfo
     def test_pytest_mark_keywords(self):
         mark = Mark()


### PR DESCRIPTION
.