### PR TITLE
[WIP] Allow developers of plugins and pytest to use code objects

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 
 import codecs
 import gc
+import inspect
 import os
 import platform
 import re
@@ -583,6 +584,19 @@ class Testdir(object):
     def makepyfile(self, *args, **kwargs):
         """Shortcut for .makefile() with a .py extension."""
         return self._makefile(".py", args, kwargs)
+
+    def makepyfilefunc(self, func, *args, **kwargs):
+        """Make Python file from function"""
+        source = inspect.getsourcelines(func)[0][1:]
+        # Calculate whitespace from function and remove it.
+        pad = 0
+        for c in source[0]:
+            if c == ' ':
+                pad += 1
+            else:
+                break
+        unpadded_source = ''.join([line[pad:] for line in source])
+        return self.makepyfile(unpadded_source)
 
     def maketxtfile(self, *args, **kwargs):
         """Shortcut for .makefile() with a .txt extension."""

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -140,6 +140,17 @@ def test_makepyfile_utf8(testdir):
     assert u"mixed_encoding = u'São Paulo'".encode("utf-8") in p.read("rb")
 
 
+def test_makepyfilefunc(testdir):
+    """Test makepyfilefunc against an inline function declaration"""
+    def tests():
+        def test_foo():
+            assert True
+    
+    test_mod = testdir.makepyfilefunc(tests)
+    result = testdir.inline_run(str(test_mod))
+    assert result.ret == EXIT_OK
+
+
 class TestInlineRunModulesCleanup(object):
     def test_inline_run_test_module_not_cleaned_up(self, testdir):
         test_mod = testdir.makepyfile("def test_foo(): assert True")


### PR DESCRIPTION
Opening early since this probably deserves discussion..

When developing PyTest plugins, having to write the tests in string literals is tricky and loses out on syntax highlighting etc. 
This change proposes adding a helper function where a function can be declared and the source code within the function will be written to the temporary test file instead.

e.g.

```python
def test_makepyfilefunc(testdir):
    """Test makepyfilefunc against an inline function declaration"""
    def tests():
        def test_foo():
            assert True
    
    test_mod = testdir.makepyfilefunc(tests)
    result = testdir.inline_run(str(test_mod))
    assert result.ret == EXIT_OK
```


- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](/changelog/README.rst) for details.
- [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Add yourself to `AUTHORS` in alphabetical order;
