### PR TITLE
Correct code blocks in docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,8 @@ repos:
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]
         python_version: python3.6
+    -   id: rst-backticks
+        name: rst ``code`` is two backticks
+        entry: ' `[^`]+[^_]`([^_]|$)'
+        language: pygrep
+        types: [rst]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -72,7 +72,7 @@ Bug Fixes
   raises an exception. (`#3569
   <https://github.com/pytest-dev/pytest/issues/3569>`_)
 
-- Fix encoding error with `print` statements in doctests (`#3583
+- Fix encoding error with ``print`` statements in doctests (`#3583
   <https://github.com/pytest-dev/pytest/issues/3583>`_)
 
 
@@ -345,7 +345,7 @@ Features
   ``pytest_runtest_logfinish`` hooks when live logs are enabled. (`#3189
   <https://github.com/pytest-dev/pytest/issues/3189>`_)
 
-- Passing `--log-cli-level` in the command-line now automatically activates
+- Passing ``--log-cli-level`` in the command-line now automatically activates
   live logging. (`#3190 <https://github.com/pytest-dev/pytest/issues/3190>`_)
 
 - Add command line option ``--deselect`` to allow deselection of individual
@@ -697,8 +697,8 @@ Trivial/Internal Changes
 - Code cleanup. (`#3015 <https://github.com/pytest-dev/pytest/issues/3015>`_,
   `#3021 <https://github.com/pytest-dev/pytest/issues/3021>`_)
 
-- Clean up code by replacing imports and references of `_ast` to `ast`. (`#3018
-  <https://github.com/pytest-dev/pytest/issues/3018>`_)
+- Clean up code by replacing imports and references of ``_ast`` to ``ast``.
+  (`#3018 <https://github.com/pytest-dev/pytest/issues/3018>`_)
 
 
 Pytest 3.3.1 (2017-12-05)
@@ -1026,7 +1026,7 @@ Pytest 3.2.2 (2017-09-06)
 Bug Fixes
 ---------
 
-- Calling the deprecated `request.getfuncargvalue()` now shows the source of
+- Calling the deprecated ``request.getfuncargvalue()`` now shows the source of
   the call. (`#2681 <https://github.com/pytest-dev/pytest/issues/2681>`_)
 
 - Allow tests declared as ``@staticmethod`` to use fixtures. (`#2699
@@ -1048,10 +1048,10 @@ Improved Documentation
   ``pytest.mark.MARKER_NAME.__call__`` (`#2604
   <https://github.com/pytest-dev/pytest/issues/2604>`_)
 
-- In one of the simple examples, use `pytest_collection_modifyitems()` to skip
+- In one of the simple examples, use ``pytest_collection_modifyitems()`` to skip
   tests based on a command-line option, allowing its sharing while preventing a
-  user error when acessing `pytest.config` before the argument parsing. (`#2653
-  <https://github.com/pytest-dev/pytest/issues/2653>`_)
+  user error when acessing ``pytest.config`` before the argument parsing.
+  (`#2653 <https://github.com/pytest-dev/pytest/issues/2653>`_)
 
 
 Trivial/Internal Changes
@@ -1129,7 +1129,7 @@ Features
   from parent classes or modules. (`#2516 <https://github.com/pytest-
   dev/pytest/issues/2516>`_)
 
-- Collection ignores local virtualenvs by default; `--collect-in-virtualenv`
+- Collection ignores local virtualenvs by default; ``--collect-in-virtualenv``
   overrides this behavior. (`#2518 <https://github.com/pytest-
   dev/pytest/issues/2518>`_)
 

--- a/doc/en/announce/release-2.9.0.rst
+++ b/doc/en/announce/release-2.9.0.rst
@@ -124,7 +124,7 @@ The py.test Development Team
   Thanks `@biern`_ for the PR.
 
 * Fix `traceback style docs`_ to describe all of the available options
-  (auto/long/short/line/native/no), with `auto` being the default since v2.6.
+  (auto/long/short/line/native/no), with ``auto`` being the default since v2.6.
   Thanks `@hackebrot`_ for the PR.
 
 * Fix (`#1422`_): junit record_xml_property doesn't allow multiple records

--- a/doc/en/example/markers.rst
+++ b/doc/en/example/markers.rst
@@ -299,10 +299,10 @@ Skip and xfail marks can also be applied in this way, see :ref:`skip/xfail with 
 .. note::
 
     If the data you are parametrizing happen to be single callables, you need to be careful
-    when marking these items. `pytest.mark.xfail(my_func)` won't work because it's also the
+    when marking these items. ``pytest.mark.xfail(my_func)`` won't work because it's also the
     signature of a function being decorated. To resolve this ambiguity, you need to pass a
     reason argument:
-    `pytest.mark.xfail(func_bar, reason="Issue#7")`.
+    ``pytest.mark.xfail(func_bar, reason="Issue#7")``.
 
 
 .. _`adding a custom marker from a plugin`:

--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -187,7 +187,7 @@ You can then install your package in "editable" mode::
      pip install -e .
 
 which lets you change your source code (both tests and application) and rerun tests at will.
-This is similar to running `python setup.py develop` or `conda develop` in that it installs
+This is similar to running ``python setup.py develop`` or ``conda develop`` in that it installs
 your package using a symlink to your development code.
 
 Once you are done with your work and want to make sure that your actual

--- a/doc/en/mark.rst
+++ b/doc/en/mark.rst
@@ -52,8 +52,6 @@ should add ``--strict`` to ``addopts``:
         serial
 
 
-.. `marker-iteration`
-
 Marker revamp and iteration
 ---------------------------
 


### PR DESCRIPTION
I know I make this mistake all the time, let's see if pre-commit can't help prevent it :)

if this pygrep hook works well for pytest, I'm eventually planning to collect up a bunch of them and put them in a more centralized place.  I have a few that I've copied from project-to-project myself and feel it would better to share!