### PR TITLE
Small tweaks to the changelog entries

### DIFF
--- a/changelog/2220.bugfix.rst
+++ b/changelog/2220.bugfix.rst
@@ -1,3 +1,1 @@
-Fix a bug where fixtures overriden by direct parameters (for example parametrization) were being instantiated
-even if they were not being used by a test.
-
+Fix a bug where fixtures overriden by direct parameters (for example parametrization) were being instantiated even if they were not being used by a test.

--- a/changelog/2220.bugfix.rst
+++ b/changelog/2220.bugfix.rst
@@ -1,3 +1,3 @@
-In case a (direct) parameter of a test overrides some fixture upon which the
-test depends indirectly, do the pruning of the fixture dependency tree. That
-is, recompute the full set of fixtures the test function needs.
+Fix a bug where fixtures overriden by direct parameters (for example parametrization) were being instantiated
+even if they were not being used by a test.
+

--- a/changelog/3576.feature.rst
+++ b/changelog/3576.feature.rst
@@ -1,1 +1,1 @@
-``Node.add_marker`` now supports an append=True/False to determine whether the mark comes last (default) or first.
+``Node.add_marker`` now supports an ``append=True/False`` parameter to determine whether the mark comes last (default) or first.

--- a/changelog/3610.feature.rst
+++ b/changelog/3610.feature.rst
@@ -1,1 +1,1 @@
-Added the `--trace` option to enter the debugger at the start of a test.
+New ``--trace`` option to enter the debugger at the start of a test.

--- a/changelog/3623.feature.rst
+++ b/changelog/3623.feature.rst
@@ -1,1 +1,1 @@
-introduce ``pytester.copy_example`` as helper to do acceptance tests against examples from the project
+Introduce ``pytester.copy_example`` as helper to do acceptance tests against examples from the project.

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -26,7 +26,7 @@ changelog using that instead.
 
 If you are not sure what issue type to use, don't hesitate to ask in your PR.
 
-Note that the ``towncrier`` tool will automatically
-reflow your text, so it will work best if you stick to a single paragraph, but multiple sentences and links are OK
-and encouraged. You can install ``towncrier`` and then run ``towncrier --draft``
+``towncrier`` preserves multiple paragraphs and formatting (code blocks, lists, and so on), but for entries
+other than ``features`` it is usually better to stick to a single paragraph to keep it concise. You can install
+``towncrier`` and then run ``towncrier --draft``
 if you want to get a preview of how your change will look in the final release notes.

--- a/changelog/_template.rst
+++ b/changelog/_template.rst
@@ -14,7 +14,7 @@
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category]|dictsort(by='value') %}
 {% set issue_joiner = joiner(', ') %}
-- {{ text }}{% if category != 'vendor' %} ({% for value in values|sort %}{{ issue_joiner() }}`{{ value }} <https://github.com/pytest-dev/pytest/issues/{{ value[1:] }}>`_{% endfor %}){% endif %}
+- {% for value in values|sort %}{{ issue_joiner() }}`{{ value }} <https://github.com/pytest-dev/pytest/issues/{{ value[1:] }}>`_{% endfor %}: {{ text }}
 
 
 {% endfor %}


### PR DESCRIPTION
Some small tweaks on the text I noticed while reviewing the changelog for the upcoming 3.7 release.

Also pushed a tweak to our changelog rendering: now it writes the issue link first:

```
- `#3623 <https://github.com/pytest-dev/pytest/issues/3623>`_: Introduce ``pytester.copy_example`` as helper to do acceptance tests against examples from the project.
```

I want to be able to use a new feature from towncrier 18.6 which no longer wraps lines automatically, which allows us to use multi-line entries, including coding samples which can be very handy for new features. The issue link at the end was a problem because it did appear right after the line in a multi-line string.

Here's a local draft I did of dummy issues using this feature:

```rst
- `#3665 <https://github.com/pytest-dev/pytest/issues/3665>`_: Dummy entry just to demonstrate multi-paragraph changelog entry:

      * Some change
      * Another change.

  And now an example:

      .. code-block:: python

          def somecode():
              pass


- `#3666 <https://github.com/pytest-dev/pytest/issues/3666>`_: Some other entry.

      .. code-block:: python

          def somecode():
              pass
```

I generated the docs locally and it looks good.