### PR TITLE
Remove some extraneous `# noqa` comments

### DIFF
--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -41,8 +41,8 @@ PY36 = sys.version_info[:2] >= (3, 6)
 MODULE_NOT_FOUND_ERROR = "ModuleNotFoundError" if PY36 else "ImportError"
 
 if _PY3:
-    from collections.abc import MutableMapping as MappingMixin  # noqa
-    from collections.abc import Mapping, Sequence  # noqa
+    from collections.abc import MutableMapping as MappingMixin
+    from collections.abc import Mapping, Sequence
 else:
     # those raise DeprecationWarnings in Python >=3.7
     from collections import MutableMapping as MappingMixin  # noqa

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -71,7 +71,7 @@ def main(args=None, plugins=None):
         return 4
 
 
-class cmdline(object):  # NOQA compatibility namespace
+class cmdline(object):  # compatibility namespace
     main = staticmethod(main)
 
 

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -941,7 +941,7 @@ class TestAssertionRewriteHookDetails(object):
             e = IOError()
             e.errno = 10
             raise e
-            yield  # noqa
+            yield
 
         monkeypatch.setattr(atomicwrites, "atomic_write", atomic_write_failed)
         assert not _write_pyc(state, [1], source_path.stat(), pycpath)

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -364,10 +364,7 @@ class TestSysPathsSnapshot(object):
         original = list(sys_path)
         original_other = list(getattr(sys, other_path_type))
         snapshot = SysPathsSnapshot()
-        transformation = {
-            "source": (0, 1, 2, 3, 4, 5),
-            "target": (6, 2, 9, 7, 5, 8),
-        }  # noqa: E201
+        transformation = {"source": (0, 1, 2, 3, 4, 5), "target": (6, 2, 9, 7, 5, 8)}
         assert sys_path == [self.path(x) for x in transformation["source"]]
         sys_path[1] = self.path(6)
         sys_path[3] = self.path(7)


### PR DESCRIPTION
This was partially automated with https://github.com/asottile/yesqa

_with a few caveats_:
- it was run under python2 (chosen arbitrarily, when run under python3 other
  things were changed)
- I used `git checkout -p` to revert the removal of `noqa` comments from
  `cmp()` lines.