### PR TITLE
bugfix in ApproxNumpy initialisation, use keywords for arguments to fix

### DIFF
--- a/changelog/3695.bugfix.rst
+++ b/changelog/3695.bugfix.rst
@@ -1,1 +1,1 @@
-Fix ApproxNumpy initialisation argument mixup. abs rel tolerances were previously flipped
+Fix ``ApproxNumpy`` initialisation argument mixup, ``abs`` and ``rel`` tolerances were flipped causing strange comparsion results.

--- a/changelog/3695.bugfix.rst
+++ b/changelog/3695.bugfix.rst
@@ -1,1 +1,2 @@
 Fix ``ApproxNumpy`` initialisation argument mixup, ``abs`` and ``rel`` tolerances were flipped causing strange comparsion results.
+Add tests to check ``abs`` and ``rel`` tolerances for ``np.array`` and test for expecting ``nan`` with ``np.array()``

--- a/changelog/3695.bugfix.rst
+++ b/changelog/3695.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ApproxNumpy initialisation argument mixup. abs rel tolerances were previously flipped

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -211,7 +211,7 @@ class ApproxScalar(ApproxBase):
         the pre-specified tolerance.
         """
         if _is_numpy_array(actual):
-            return all(a == self for a in actual)
+            return all(a == self for a in actual.flat)
 
         # Short-circuit exact equality.
         if actual == self.expected:

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -211,9 +211,7 @@ class ApproxScalar(ApproxBase):
         the pre-specified tolerance.
         """
         if _is_numpy_array(actual):
-            import numpy as np
-
-            return np.all(abs(self.expected - actual) <= self.tolerance)
+            return all(a == self for a in actual)
 
         # Short-circuit exact equality.
         if actual == self.expected:

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -211,10 +211,9 @@ class ApproxScalar(ApproxBase):
         the pre-specified tolerance.
         """
         if _is_numpy_array(actual):
-            return (
-                ApproxNumpy(actual, rel=self.rel, abs=self.abs, nan_ok=self.nan_ok)
-                == self.expected
-            )
+            import numpy as np
+
+            return np.all(abs(self.expected - actual) <= self.tolerance)
 
         # Short-circuit exact equality.
         if actual == self.expected:

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -211,7 +211,10 @@ class ApproxScalar(ApproxBase):
         the pre-specified tolerance.
         """
         if _is_numpy_array(actual):
-            return ApproxNumpy(actual, self.abs, self.rel, self.nan_ok) == self.expected
+            return (
+                ApproxNumpy(actual, rel=self.rel, abs=self.abs, nan_ok=self.nan_ok)
+                == self.expected
+            )
 
         # Short-circuit exact equality.
         if actual == self.expected:

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -390,6 +390,20 @@ class TestApprox(object):
             assert op(np.array(a), approx(x, nan_ok=True))
             assert op(a, approx(np.array(x), nan_ok=True))
 
+    def test_numpy_expecting_inf(self):
+        np = pytest.importorskip("numpy")
+        examples = [
+            (eq, inf, inf),
+            (eq, -inf, -inf),
+            (ne, inf, -inf),
+            (ne, 0.0, inf),
+            (ne, nan, inf),
+        ]
+        for op, a, x in examples:
+            assert op(np.array(a), approx(x))
+            assert op(a, approx(np.array(x)))
+            assert op(np.array(a), approx(np.array(x)))
+
     def test_numpy_array_wrong_shape(self):
         np = pytest.importorskip("numpy")
 

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -346,15 +346,22 @@ class TestApprox(object):
         """
         quick check that numpy rel/abs args are handled correctly
         for comparison against an np.array
+        - 3.6.4 would approx both actual / expected if np.array
+         regardless of which value was passed to approx()
+         Means tolerance could be calculated against bad test return
         """
         np = pytest.importorskip("numpy")
         expected = 100
         actual = 99
         assert actual != pytest.approx(expected, abs=0.1, rel=0)
         assert np.array(actual) != pytest.approx(expected, abs=0.1, rel=0)
+        assert actual != pytest.approx(np.array(expected), abs=0.1, rel=0)
+        assert np.array(actual) != pytest.approx(np.array(expected), abs=0.1, rel=0)
 
         assert actual == pytest.approx(expected, abs=0, rel=0.01)
-        assert np.array(actual) == pytest.approx(expected, abs=0, rel=0.1)
+        assert np.array(actual) == pytest.approx(expected, abs=0, rel=0.01)
+        assert actual == pytest.approx(np.array(expected), abs=0, rel=0.01)
+        assert np.array(actual) == pytest.approx(np.array(expected), abs=0, rel=0.01)
 
     def test_numpy_array_wrong_shape(self):
         np = pytest.importorskip("numpy")

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -342,6 +342,20 @@ class TestApprox(object):
         assert actual == approx(list(expected), rel=5e-7, abs=0)
         assert actual != approx(list(expected), rel=5e-8, abs=0)
 
+    def test_numpy_tolerance_args(self):
+        """
+        quick check that numpy rel/abs args are handled correctly
+        for comparison against an np.array
+        """
+        np = pytest.importorskip("numpy")
+        expected = 100
+        actual = 99
+        assert actual != pytest.approx(expected, abs=0.1, rel=0)
+        assert np.array(actual) != pytest.approx(expected, abs=0.1, rel=0)
+
+        assert actual == pytest.approx(expected, abs=0, rel=0.01)
+        assert np.array(actual) == pytest.approx(expected, abs=0, rel=0.1)
+
     def test_numpy_array_wrong_shape(self):
         np = pytest.importorskip("numpy")
 


### PR DESCRIPTION
With respect to #3695 , flip the arguments in the initialization and also use keywords so it's more obvious and less likely to happen in future.  

Can add tests along the lines of the code in #3695 if desired but it seems like an obvious typo fix