### PR TITLE
 Deprecate calling fixture functions directly

### DIFF
--- a/changelog/3661.removal.rst
+++ b/changelog/3661.removal.rst
@@ -1,0 +1,3 @@
+Calling a fixture function directly, as opposed to request them in a test function, now issues a ``RemovedInPytest4Warning``. It will be changed into an error in pytest ``4.0``.
+
+This is a great source of confusion to new users, which will often call the fixture functions and request them from test functions interchangeably, which breaks the fixture resolution model.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -84,6 +84,7 @@ def iscoroutinefunction(func):
 
 
 def getlocation(function, curdir):
+    function = get_real_func(function)
     fn = py.path.local(inspect.getfile(function))
     lineno = function.__code__.co_firstlineno
     if fn.relto(curdir):

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -22,6 +22,12 @@ FUNCARG_PREFIX = (
     "Please remove the prefix and use the @pytest.fixture decorator instead."
 )
 
+FIXTURE_FUNCTION_CALL = (
+    "Fixture {name} called directly. Fixtures are not meant to be called directly, "
+    "are created automatically when test functions request them as parameters. "
+    "See https://docs.pytest.org/en/latest/fixture.html for more information."
+)
+
 CFG_PYTEST_SECTION = (
     "[pytest] section in {filename} files is deprecated, use [tool:pytest] instead."
 )

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -669,6 +669,11 @@ class Testdir(object):
         else:
             raise LookupError("example is not found as a file or directory")
 
+    def run_example(self, name=None, *pytest_args):
+        """Runs the given example and returns the results of the run"""
+        p = self.copy_example(name)
+        return self.runpytest(p, *pytest_args)
+
     Session = Session
 
     def getnode(self, config, arg):

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -669,11 +669,6 @@ class Testdir(object):
         else:
             raise LookupError("example is not found as a file or directory")
 
-    def run_example(self, name=None, *pytest_args):
-        """Runs the given example and returns the results of the run"""
-        p = self.copy_example(name)
-        return self.runpytest(p, *pytest_args)
-
     Session = Session
 
     def getnode(self, config, arg):

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import, division, print_function
+
+
 import pytest
 
 
@@ -263,3 +265,15 @@ def test_pytest_plugins_in_non_top_level_conftest_deprecated_no_false_positives(
         str(PYTEST_PLUGINS_FROM_NON_TOP_LEVEL_CONFTEST).splitlines()[0]
         not in res.stderr.str()
     )
+
+
+# @pytest.mark.skipif(six.PY2, reason="We issue the warning in Python 3 only")
+def test_call_fixture_function_deprecated():
+    """Check if a warning is raised if a fixture function is called directly (#3661)"""
+
+    @pytest.fixture
+    def fix():
+        return 1
+
+    with pytest.deprecated_call():
+        assert fix() == 1

--- a/testing/example_scripts/tmpdir/tmpdir_fixture.py
+++ b/testing/example_scripts/tmpdir/tmpdir_fixture.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.mark.parametrize("a", [r"qwe/\abc"])
+def test_fixture(tmpdir, a):
+    tmpdir.check(dir=1)
+    assert tmpdir.listdir() == []

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -1456,6 +1456,7 @@ class TestFixtureManagerParseFactories(object):
         testdir.makepyfile(
             """
             import pytest
+            import six
 
             @pytest.fixture
             def hello(request):
@@ -1468,9 +1469,11 @@ class TestFixtureManagerParseFactories(object):
                     faclist = fm.getfixturedefs("hello", item.nodeid)
                     print (faclist)
                     assert len(faclist) == 3
-                    assert faclist[0].func(item._request) == "conftest"
-                    assert faclist[1].func(item._request) == "module"
-                    assert faclist[2].func(item._request) == "class"
+
+                    kwargs = {'__being_called_by_pytest': True}
+                    assert faclist[0].func(item._request, **kwargs) == "conftest"
+                    assert faclist[1].func(item._request, **kwargs) == "module"
+                    assert faclist[2].func(item._request, **kwargs) == "class"
         """
         )
         reprec = testdir.inline_run("-s")

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -212,6 +212,9 @@ class TestMetafunc(object):
     @hypothesis.settings(
         deadline=400.0
     )  # very close to std deadline and CI boxes are not reliable in CPU power
+    @pytest.mark.xfail(
+        sys.platform.startswith("win32"), reason="flaky #3707", strict=False
+    )
     def test_idval_hypothesis(self, value):
         from _pytest.python import _idval
 

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -12,7 +12,6 @@ from _pytest.assertion import truncate
 PY3 = sys.version_info >= (3, 0)
 
 
-@pytest.fixture
 def mock_config():
     class Config(object):
         verbose = False
@@ -768,15 +767,15 @@ def test_rewritten(testdir):
     assert testdir.runpytest().ret == 0
 
 
-def test_reprcompare_notin(mock_config):
-    detail = plugin.pytest_assertrepr_compare(
-        mock_config, "not in", "foo", "aaafoobbb"
-    )[1:]
+def test_reprcompare_notin():
+    config = mock_config()
+    detail = plugin.pytest_assertrepr_compare(config, "not in", "foo", "aaafoobbb")[1:]
     assert detail == ["'foo' is contained here:", "  aaafoobbb", "?    +++"]
 
 
-def test_reprcompare_whitespaces(mock_config):
-    detail = plugin.pytest_assertrepr_compare(mock_config, "==", "\r\n", "\n")
+def test_reprcompare_whitespaces():
+    config = mock_config()
+    detail = plugin.pytest_assertrepr_compare(config, "==", "\r\n", "\n")
     assert detail == [
         r"'\r\n' == '\n'",
         r"Strings contain only whitespace, escaping them using repr()",

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -10,9 +10,7 @@ from _pytest.main import EXIT_NOTESTSCOLLECTED, EXIT_USAGEERROR
 
 @pytest.fixture(scope="module", params=["global", "inpackage"])
 def basedir(request, tmpdir_factory):
-    from _pytest.tmpdir import tmpdir
-
-    tmpdir = tmpdir(request, tmpdir_factory)
+    tmpdir = tmpdir_factory.mktemp("basedir", numbered=True)
     tmpdir.ensure("adir/conftest.py").write("a=1 ; Directory = 3")
     tmpdir.ensure("adir/b/conftest.py").write("b=2 ; a = 1.5")
     if request.param == "inpackage":

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -3,35 +3,10 @@ import sys
 import py
 import pytest
 
-from _pytest.tmpdir import tmpdir
 
-
-def test_funcarg(testdir):
-    testdir.makepyfile(
-        """
-            def pytest_generate_tests(metafunc):
-                metafunc.addcall(id='a')
-                metafunc.addcall(id='b')
-            def test_func(tmpdir): pass
-    """
-    )
-    from _pytest.tmpdir import TempdirFactory
-
-    reprec = testdir.inline_run()
-    calls = reprec.getcalls("pytest_runtest_setup")
-    item = calls[0].item
-    config = item.config
-    tmpdirhandler = TempdirFactory(config)
-    item._initrequest()
-    p = tmpdir(item._request, tmpdirhandler)
-    assert p.check()
-    bn = p.basename.strip("0123456789")
-    assert bn.endswith("test_func_a_")
-    item.name = "qwe/\\abc"
-    p = tmpdir(item._request, tmpdirhandler)
-    assert p.check()
-    bn = p.basename.strip("0123456789")
-    assert bn == "qwe__abc"
+def test_tmpdir_fixture(testdir):
+    results = testdir.run_example("tmpdir/tmpdir_fixture.py")
+    results.stdout.fnmatch_lines("*1 passed*")
 
 
 def test_ensuretemp(recwarn):

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -5,7 +5,8 @@ import pytest
 
 
 def test_tmpdir_fixture(testdir):
-    results = testdir.run_example("tmpdir/tmpdir_fixture.py")
+    p = testdir.copy_example("tmpdir/tmpdir_fixture.py")
+    results = testdir.runpytest(p)
     results.stdout.fnmatch_lines("*1 passed*")
 
 


### PR DESCRIPTION
The 3 first commits are small refactorings that I felt doing while implementing the actual task, so I recommend reading the commits separately.

I had to use a "wrapper" around the original fixture function to issue a warning, and one difficulty I had was to make this work reliably in Python 2 because `@itertools.wraps` doesn't preserve the signature. I believe this is fine though, because we probably will drop Python 2 by the time we release `4.0`.

Surprisingly, we had a few tests in our test suite which did call fixture functions directly, I just fixed those while keeping the same semantics.


Fix #3661