### PR TITLE
Deprecate pytest namespace

### DIFF
--- a/changelog/2639.removal.rst
+++ b/changelog/2639.removal.rst
@@ -1,0 +1,3 @@
+``pytest_namespace`` has been deprecated.
+
+Plugins who need this feature are suggested to import ``pytest`` and set attributes explicitly during ``pytest_configure``.

--- a/changelog/2639.removal.rst
+++ b/changelog/2639.removal.rst
@@ -1,3 +1,4 @@
 ``pytest_namespace`` has been deprecated.
 
-Plugins who need this feature are suggested to import ``pytest`` and set attributes explicitly during ``pytest_configure``.
+See the documentation for ``pytest_namespace`` hook for suggestions on how to deal
+with this in plugins which use this functionality.

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ def main():
     # if _PYTEST_SETUP_SKIP_PLUGGY_DEP is set, skip installing pluggy;
     # used by tox.ini to test with pluggy master
     if "_PYTEST_SETUP_SKIP_PLUGGY_DEP" not in os.environ:
-        install_requires.append("pluggy>=0.5,<0.8")
+        install_requires.append("pluggy>=0.7")
     environment_marker_support_level = get_environment_marker_support_level()
     if environment_marker_support_level >= 2:
         install_requires.append('funcsigs;python_version<"3.0"')

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -71,3 +71,7 @@ PYTEST_PLUGINS_FROM_NON_TOP_LEVEL_CONFTEST = RemovedInPytest4Warning(
     "because it affects the entire directory tree in a non-explicit way.\n"
     "Please move it to the top level conftest file instead."
 )
+
+PYTEST_NAMESPACE = RemovedInPytest4Warning(
+    "pytest_namespace is deprecated and will be removed soon"
+)

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -42,8 +42,15 @@ def pytest_namespace():
     .. warning::
         This hook has been **deprecated** and will be removed in pytest 4.0.
 
-        Plugins who need this feature are suggested
-        to import ``pytest`` and set attributes explicitly during ``pytest_configure``.
+        Plugins whose users depend on the current namespace functionality should prepare to migrate to a
+        namespace they actually own.
+
+        To support the migration its suggested to trigger ``DeprecationWarnings`` for objects they put into the
+        pytest namespace.
+
+        An stopgap measure to avoid the warning is to monkeypatch the ``pytest`` module, but just as the
+        ``pytest_namespace`` hook this should be seen as a temporary measure to be removed in future versions after
+        an appropriate transition period.
     """
 
 

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -1,6 +1,7 @@
 """ hook specifications for pytest plugins, invoked from main.py and builtin plugins.  """
 
 from pluggy import HookspecMarker
+from .deprecated import RemovedInPytest4Warning
 
 hookspec = HookspecMarker("pytest")
 
@@ -22,10 +23,14 @@ def pytest_addhooks(pluginmanager):
     """
 
 
-@hookspec(historic=True)
+@hookspec(
+    historic=True,
+    warn_on_impl=RemovedInPytest4Warning(
+        "pytest_namespace is deprecated and will be removed soon"
+    ),
+)
 def pytest_namespace():
     """
-    (**Deprecated**) this hook causes direct monkeypatching on pytest, its use is strongly discouraged
     return dict of name->object to be made globally available in
     the pytest namespace.
 
@@ -33,6 +38,12 @@ def pytest_namespace():
 
     .. note::
         This hook is incompatible with ``hookwrapper=True``.
+
+    .. warning::
+        This hook has been **deprecated** and will be removed in pytest 4.0.
+
+        Plugins who need this feature are suggested
+        to import ``pytest`` and set attributes explicitly during ``pytest_configure``.
     """
 
 

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -1,7 +1,8 @@
 """ hook specifications for pytest plugins, invoked from main.py and builtin plugins.  """
 
 from pluggy import HookspecMarker
-from .deprecated import RemovedInPytest4Warning
+from .deprecated import PYTEST_NAMESPACE
+
 
 hookspec = HookspecMarker("pytest")
 
@@ -23,12 +24,7 @@ def pytest_addhooks(pluginmanager):
     """
 
 
-@hookspec(
-    historic=True,
-    warn_on_impl=RemovedInPytest4Warning(
-        "pytest_namespace is deprecated and will be removed soon"
-    ),
-)
+@hookspec(historic=True, warn_on_impl=PYTEST_NAMESPACE)
 def pytest_namespace():
     """
     return dict of name->object to be made globally available in

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -66,6 +66,7 @@ class TestPytestPluginInteractions(object):
         result = testdir.runpython(p)
         assert result.ret == 0
 
+    @pytest.mark.filterwarnings("ignore:pytest_namespace is deprecated")
     def test_do_ext_namespace(self, testdir):
         testdir.makeconftest(
             """


### PR DESCRIPTION
This is based on #3732, so it is better to review after that PR gets merged.

Fix #2639