### PR TITLE
Miscellaneous improvements to approx()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,9 @@ Bug Fixes
 - `#3695 <https://github.com/pytest-dev/pytest/issues/3695>`_: Fix ``ApproxNumpy`` initialisation argument mixup, ``abs`` and ``rel`` tolerances were flipped causing strange comparsion results.
   Add tests to check ``abs`` and ``rel`` tolerances for ``np.array`` and test for expecting ``nan`` with ``np.array()``
 
+- `#3712  <https://github.com/pytest-dev/pytest/issues/3712>`_: Correctly represent the dimensions of an numpy array when calling ``repr()`` on ``approx()``.
+
+- `#3473  <https://github.com/pytest-dev/pytest/issues/3473>`_: Raise immediately if ``approx()`` is given an expected value of a type it doesn't understand (e.g. strings, nested dicts, etc.)
 
 - `#980 <https://github.com/pytest-dev/pytest/issues/980>`_: Fix truncated locals output in verbose mode.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,9 +54,6 @@ Bug Fixes
 - `#3695 <https://github.com/pytest-dev/pytest/issues/3695>`_: Fix ``ApproxNumpy`` initialisation argument mixup, ``abs`` and ``rel`` tolerances were flipped causing strange comparsion results.
   Add tests to check ``abs`` and ``rel`` tolerances for ``np.array`` and test for expecting ``nan`` with ``np.array()``
 
-- `#3712  <https://github.com/pytest-dev/pytest/issues/3712>`_: Correctly represent the dimensions of an numpy array when calling ``repr()`` on ``approx()``.
-
-- `#3473  <https://github.com/pytest-dev/pytest/issues/3473>`_: Raise immediately if ``approx()`` is given an expected value of a type it doesn't understand (e.g. strings, nested dicts, etc.)
 
 - `#980 <https://github.com/pytest-dev/pytest/issues/980>`_: Fix truncated locals output in verbose mode.
 

--- a/changelog/3473.bugfix.rst
+++ b/changelog/3473.bugfix.rst
@@ -1,0 +1,1 @@
+Raise immediately if ``approx()`` is given an expected value of a type it doesn't understand (e.g. strings, nested dicts, etc.).

--- a/changelog/3712.bugfix.rst
+++ b/changelog/3712.bugfix.rst
@@ -1,0 +1,1 @@
+Correctly represent the dimensions of an numpy array when calling ``repr()`` on ``approx()``.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -34,9 +34,9 @@ def _cmp_raises_type_error(self, other):
 
 
 def _non_numeric_type_error(value, at):
-    at_str = "at {}".format(at) if at else ""
+    at_str = " at {}".format(at) if at else ""
     return TypeError(
-        "cannot make approximate comparisons to non-numeric values: {!r} ".format(
+        "cannot make approximate comparisons to non-numeric values: {!r} {}".format(
             value, at_str
         )
     )

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -104,8 +104,6 @@ class ApproxNumpy(ApproxBase):
     """
 
     def __repr__(self):
-        import numpy as np
-
         def recursive_map(f, x):
             if isinstance(x, list):
                 return list(recursive_map(f, xi) for xi in x)

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -82,14 +82,18 @@ class ApproxNumpy(ApproxBase):
     """
 
     def __repr__(self):
-        # It might be nice to rewrite this function to account for the
-        # shape of the array...
         import numpy as np
 
-        list_scalars = []
-        for x in np.ndindex(self.expected.shape):
-            list_scalars.append(self._approx_scalar(np.asscalar(self.expected[x])))
+        def recursive_map(f, x):
+            if isinstance(x, list):
+                return list(recursive_map(f, xi) for xi in x)
+            else:
+                return f(x)
 
+        list_scalars = recursive_map(
+                self._approx_scalar,
+                self.expected.tolist())
+                
         return "approx({!r})".format(list_scalars)
 
     if sys.version_info[0] == 2:

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -173,7 +173,7 @@ class ApproxMapping(ApproxBase):
         for x in self.expected.values():
             if isinstance(x, type(self.expected)):
                 raise TypeError(
-                    "pytest.approx() does not support nested dictionaries, e.g. {}".format(
+                    "pytest.approx() does not support nested dictionaries, e.g. {!r}".format(
                         self.expected
                     )
                 )
@@ -207,7 +207,7 @@ class ApproxSequence(ApproxBase):
         for x in self.expected:
             if isinstance(x, type(self.expected)):
                 raise TypeError(
-                    "pytest.approx() does not support nested data structures, e.g. {}".format(
+                    "pytest.approx() does not support nested data structures, e.g. {!r}".format(
                         self.expected
                     )
                 )

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -101,20 +101,20 @@ class ApproxBase(object):
         pass
 
 
+def recursive_map(f, x):
+    if isinstance(x, list):
+        return list(recursive_map(f, xi) for xi in x)
+    else:
+        return f(x)
+
+
 class ApproxNumpy(ApproxBase):
     """
     Perform approximate comparisons where the expected value is numpy array.
     """
 
     def __repr__(self):
-        def recursive_map(f, x):
-            if isinstance(x, list):
-                return list(recursive_map(f, xi) for xi in x)
-            else:
-                return f(x)
-
         list_scalars = recursive_map(self._approx_scalar, self.expected.tolist())
-
         return "approx({!r})".format(list_scalars)
 
     if sys.version_info[0] == 2:

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -78,7 +78,7 @@ class ApproxBase(object):
 
 class ApproxNumpy(ApproxBase):
     """
-    Perform approximate comparisons for numpy arrays.
+    Perform approximate comparisons where the expected value is numpy array.
     """
 
     def __repr__(self):
@@ -132,8 +132,8 @@ class ApproxNumpy(ApproxBase):
 
 class ApproxMapping(ApproxBase):
     """
-    Perform approximate comparisons for mappings where the values are numbers
-    (the keys can be anything).
+    Perform approximate comparisons where the expected value is a mapping with 
+    numeric values (the keys can be anything).
     """
 
     def __repr__(self):
@@ -154,7 +154,8 @@ class ApproxMapping(ApproxBase):
 
 class ApproxSequence(ApproxBase):
     """
-    Perform approximate comparisons for sequences of numbers.
+    Perform approximate comparisons where the expected value is a sequence of 
+    numbers.
     """
 
     def __repr__(self):
@@ -176,7 +177,7 @@ class ApproxSequence(ApproxBase):
 
 class ApproxScalar(ApproxBase):
     """
-    Perform approximate comparisons for single numbers only.
+    Perform approximate comparisons where the expected value is a single number.
     """
 
     DEFAULT_ABSOLUTE_TOLERANCE = 1e-12
@@ -290,6 +291,9 @@ class ApproxScalar(ApproxBase):
 
 
 class ApproxDecimal(ApproxScalar):
+    """
+    Perform approximate comparisons where the expected value is a decimal.
+    """
     from decimal import Decimal
 
     DEFAULT_ABSOLUTE_TOLERANCE = Decimal("1e-12")

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -31,8 +31,13 @@ def _cmp_raises_type_error(self, other):
         "Comparison operators other than == and != not supported by approx objects"
     )
 
+
 def _non_numeric_type_error(value):
-    return TypeError("cannot make approximate comparisons to non-numeric values, e.g. {}".format(value))
+    return TypeError(
+        "cannot make approximate comparisons to non-numeric values, e.g. {}".format(
+            value
+        )
+    )
 
 
 # builtin pytest.approx helper
@@ -85,10 +90,10 @@ class ApproxBase(object):
         """
         Raise a TypeError if the expected value is not a valid type.
         """
-        # This is only a concern if the expected value is a sequence.  In every 
-        # other case, the approx() function ensures that the expected value has 
-        # a numeric type.  For this reason, the default is to do nothing.  The 
-        # classes that deal with sequences should reimplement this method to 
+        # This is only a concern if the expected value is a sequence.  In every
+        # other case, the approx() function ensures that the expected value has
+        # a numeric type.  For this reason, the default is to do nothing.  The
+        # classes that deal with sequences should reimplement this method to
         # raise if there are any non-numeric elements in the sequence.
         pass
 
@@ -107,10 +112,8 @@ class ApproxNumpy(ApproxBase):
             else:
                 return f(x)
 
-        list_scalars = recursive_map(
-                self._approx_scalar,
-                self.expected.tolist())
-                
+        list_scalars = recursive_map(self._approx_scalar, self.expected.tolist())
+
         return "approx({!r})".format(list_scalars)
 
     if sys.version_info[0] == 2:
@@ -149,7 +152,7 @@ class ApproxNumpy(ApproxBase):
 
 class ApproxMapping(ApproxBase):
     """
-    Perform approximate comparisons where the expected value is a mapping with 
+    Perform approximate comparisons where the expected value is a mapping with
     numeric values (the keys can be anything).
     """
 
@@ -171,14 +174,18 @@ class ApproxMapping(ApproxBase):
     def _check_type(self):
         for x in self.expected.values():
             if isinstance(x, type(self.expected)):
-                raise TypeError("pytest.approx() does not support nested dictionaries, e.g. {}".format(self.expected))
+                raise TypeError(
+                    "pytest.approx() does not support nested dictionaries, e.g. {}".format(
+                        self.expected
+                    )
+                )
             elif not isinstance(x, Number):
                 raise _non_numeric_type_error(self.expected)
 
 
 class ApproxSequence(ApproxBase):
     """
-    Perform approximate comparisons where the expected value is a sequence of 
+    Perform approximate comparisons where the expected value is a sequence of
     numbers.
     """
 
@@ -201,7 +208,11 @@ class ApproxSequence(ApproxBase):
     def _check_type(self):
         for x in self.expected:
             if isinstance(x, type(self.expected)):
-                raise TypeError("pytest.approx() does not support nested data structures, e.g. {}".format(self.expected))
+                raise TypeError(
+                    "pytest.approx() does not support nested data structures, e.g. {}".format(
+                        self.expected
+                    )
+                )
             elif not isinstance(x, Number):
                 raise _non_numeric_type_error(self.expected)
 
@@ -325,6 +336,7 @@ class ApproxDecimal(ApproxScalar):
     """
     Perform approximate comparisons where the expected value is a decimal.
     """
+
     DEFAULT_ABSOLUTE_TOLERANCE = Decimal("1e-12")
     DEFAULT_RELATIVE_TOLERANCE = Decimal("1e-6")
 
@@ -485,17 +497,17 @@ def approx(expected, rel=None, abs=None, nan_ok=False):
     # Delegate the comparison to a class that knows how to deal with the type
     # of the expected value (e.g. int, float, list, dict, numpy.array, etc).
     #
-    # The primary responsibility of these classes is to implement ``__eq__()`` 
-    # and ``__repr__()``.  The former is used to actually check if some 
-    # "actual" value is equivalent to the given expected value within the 
-    # allowed tolerance.  The latter is used to show the user the expected 
+    # The primary responsibility of these classes is to implement ``__eq__()``
+    # and ``__repr__()``.  The former is used to actually check if some
+    # "actual" value is equivalent to the given expected value within the
+    # allowed tolerance.  The latter is used to show the user the expected
     # value and tolerance, in the case that a test failed.
     #
-    # The actual logic for making approximate comparisons can be found in 
-    # ApproxScalar, which is used to compare individual numbers.  All of the 
-    # other Approx classes eventually delegate to this class.  The ApproxBase 
-    # class provides some convenient methods and overloads, but isn't really 
-    # essential. 
+    # The actual logic for making approximate comparisons can be found in
+    # ApproxScalar, which is used to compare individual numbers.  All of the
+    # other Approx classes eventually delegate to this class.  The ApproxBase
+    # class provides some convenient methods and overloads, but isn't really
+    # essential.
 
     if isinstance(expected, Decimal):
         cls = ApproxDecimal

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -531,17 +531,11 @@ def _is_numpy_array(obj):
     Return true if the given object is a numpy array.  Make a special effort to
     avoid importing numpy unless it's really necessary.
     """
-    import inspect
+    import sys
 
-    for cls in inspect.getmro(type(obj)):
-        if cls.__module__ == "numpy":
-            try:
-                import numpy as np
-
-                return isinstance(obj, np.ndarray)
-            except ImportError:
-                pass
-
+    np = sys.modules.get("numpy")
+    if np is not None:
+        return isinstance(obj, np.ndarray)
     return False
 
 

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -34,7 +34,7 @@ def _cmp_raises_type_error(self, other):
 
 def _non_numeric_type_error(value):
     return TypeError(
-        "cannot make approximate comparisons to non-numeric values, e.g. {}".format(
+        "cannot make approximate comparisons to non-numeric values, e.g. {!r}".format(
             value
         )
     )
@@ -506,6 +506,8 @@ def approx(expected, rel=None, abs=None, nan_ok=False):
     # other Approx classes eventually delegate to this class.  The ApproxBase
     # class provides some convenient methods and overloads, but isn't really
     # essential.
+
+    __tracebackhide__ = True
 
     if isinstance(expected, Decimal):
         cls = ApproxDecimal

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -101,9 +101,9 @@ class ApproxBase(object):
         pass
 
 
-def recursive_map(f, x):
+def _recursive_list_map(f, x):
     if isinstance(x, list):
-        return list(recursive_map(f, xi) for xi in x)
+        return list(_recursive_list_map(f, xi) for xi in x)
     else:
         return f(x)
 
@@ -114,7 +114,7 @@ class ApproxNumpy(ApproxBase):
     """
 
     def __repr__(self):
-        list_scalars = recursive_map(self._approx_scalar, self.expected.tolist())
+        list_scalars = _recursive_list_map(self._approx_scalar, self.expected.tolist())
         return "approx({!r})".format(list_scalars)
 
     if sys.version_info[0] == 2:

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -59,17 +59,19 @@ class TestApprox(object):
             ),
         )
 
-    def test_repr_0d_array(self, plus_minus):
+    def test_repr_nd_array(self, plus_minus):
+        # Make sure that arrays of all different dimensions are repr'd 
+        # correctly.
         np = pytest.importorskip("numpy")
-        np_array = np.array(5.)
-        assert approx(np_array) == 5.0
-        string_expected = "approx([5.0 {} 5.0e-06])".format(plus_minus)
-
-        assert repr(approx(np_array)) == string_expected
-
-        np_array = np.array([5.])
-        assert approx(np_array) == 5.0
-        assert repr(approx(np_array)) == string_expected
+        examples = [
+                (np.array(5.), 'approx(5.0 {pm} 5.0e-06)'),
+                (np.array([5.]), 'approx([5.0 {pm} 5.0e-06])'),
+                (np.array([[5.]]), 'approx([[5.0 {pm} 5.0e-06]])'),
+                (np.array([[5., 6.]]), 'approx([[5.0 {pm} 5.0e-06, 6.0 {pm} 6.0e-06]])'),
+                (np.array([[5.], [6.]]), 'approx([[5.0 {pm} 5.0e-06], [6.0 {pm} 6.0e-06]])'),
+        ]
+        for np_array, repr_string in examples:
+            assert repr(approx(np_array)) == repr_string.format(pm=plus_minus)
 
     def test_operator_overloading(self):
         assert 1 == approx(1, rel=1e-6, abs=1e-12)

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -444,7 +444,15 @@ class TestApprox(object):
         )
 
     @pytest.mark.parametrize(
-        "x", [None, "string", ["string"], [[1]], {"key": "string"}, {"key": {"key": 1}}]
+        "x",
+        [
+            pytest.param(None),
+            pytest.param("string"),
+            pytest.param(["string"], id="nested-str"),
+            pytest.param([[1]], id="nested-list"),
+            pytest.param({"key": "string"}, id="dict-with-string"),
+            pytest.param({"key": {"key": 1}}, id="nested-dict"),
+        ],
     )
     def test_expected_value_type_error(self, x):
         with pytest.raises(TypeError):

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -60,15 +60,18 @@ class TestApprox(object):
         )
 
     def test_repr_nd_array(self, plus_minus):
-        # Make sure that arrays of all different dimensions are repr'd 
+        # Make sure that arrays of all different dimensions are repr'd
         # correctly.
         np = pytest.importorskip("numpy")
         examples = [
-                (np.array(5.), 'approx(5.0 {pm} 5.0e-06)'),
-                (np.array([5.]), 'approx([5.0 {pm} 5.0e-06])'),
-                (np.array([[5.]]), 'approx([[5.0 {pm} 5.0e-06]])'),
-                (np.array([[5., 6.]]), 'approx([[5.0 {pm} 5.0e-06, 6.0 {pm} 6.0e-06]])'),
-                (np.array([[5.], [6.]]), 'approx([[5.0 {pm} 5.0e-06], [6.0 {pm} 6.0e-06]])'),
+            (np.array(5.), "approx(5.0 {pm} 5.0e-06)"),
+            (np.array([5.]), "approx([5.0 {pm} 5.0e-06])"),
+            (np.array([[5.]]), "approx([[5.0 {pm} 5.0e-06]])"),
+            (np.array([[5., 6.]]), "approx([[5.0 {pm} 5.0e-06, 6.0 {pm} 6.0e-06]])"),
+            (
+                np.array([[5.], [6.]]),
+                "approx([[5.0 {pm} 5.0e-06], [6.0 {pm} 6.0e-06]])",
+            ),
         ]
         for np_array, repr_string in examples:
             assert repr(approx(np_array)) == repr_string.format(pm=plus_minus)
@@ -442,7 +445,7 @@ class TestApprox(object):
         )
 
     @pytest.mark.parametrize(
-            'x', [None, 'string', ['string'], [[1]], {'key': 'string'}, {'key': {'key': 1}}]
+        "x", [None, "string", ["string"], [[1]], {"key": "string"}, {"key": {"key": 1}}]
     )
     def test_expected_value_type_error(self, x):
         with pytest.raises(TypeError):

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -442,6 +442,13 @@ class TestApprox(object):
         )
 
     @pytest.mark.parametrize(
+            'x', [None, 'string', ['string'], [[1]], {'key': 'string'}, {'key': {'key': 1}}]
+    )
+    def test_expected_value_type_error(self, x):
+        with pytest.raises(TypeError):
+            approx(x)
+
+    @pytest.mark.parametrize(
         "op",
         [
             pytest.param(operator.le, id="<="),

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -59,22 +59,21 @@ class TestApprox(object):
             ),
         )
 
-    def test_repr_nd_array(self, plus_minus):
-        # Make sure that arrays of all different dimensions are repr'd
-        # correctly.
+    @pytest.mark.parametrize(
+        "value, repr_string",
+        [
+            (5., "approx(5.0 {pm} 5.0e-06)"),
+            ([5.], "approx([5.0 {pm} 5.0e-06])"),
+            ([[5.]], "approx([[5.0 {pm} 5.0e-06]])"),
+            ([[5., 6.]], "approx([[5.0 {pm} 5.0e-06, 6.0 {pm} 6.0e-06]])"),
+            ([[5.], [6.]], "approx([[5.0 {pm} 5.0e-06], [6.0 {pm} 6.0e-06]])"),
+        ],
+    )
+    def test_repr_nd_array(self, plus_minus, value, repr_string):
+        """Make sure that arrays of all different dimensions are repr'd correctly."""
         np = pytest.importorskip("numpy")
-        examples = [
-            (np.array(5.), "approx(5.0 {pm} 5.0e-06)"),
-            (np.array([5.]), "approx([5.0 {pm} 5.0e-06])"),
-            (np.array([[5.]]), "approx([[5.0 {pm} 5.0e-06]])"),
-            (np.array([[5., 6.]]), "approx([[5.0 {pm} 5.0e-06, 6.0 {pm} 6.0e-06]])"),
-            (
-                np.array([[5.], [6.]]),
-                "approx([[5.0 {pm} 5.0e-06], [6.0 {pm} 6.0e-06]])",
-            ),
-        ]
-        for np_array, repr_string in examples:
-            assert repr(approx(np_array)) == repr_string.format(pm=plus_minus)
+        np_array = np.array(value)
+        assert repr(approx(np_array)) == repr_string.format(pm=plus_minus)
 
     def test_operator_overloading(self):
         assert 1 == approx(1, rel=1e-6, abs=1e-12)


### PR DESCRIPTION
This PR fixes a couple small issues with ``approx()``:

- Change the output of ``repr(approx(np.array(...)))`` to reflect the dimension of the array being compared.  For example, ``repr(approx([[1, 2], [3, 4]]))`` would look something like ``approx([[1±..., 2±...], [3±..., 4±...]])`` rather than ``approx([1±..., 2±..., 3±..., 4±...])``.  This was supposed to fix #3712, but it turns out that #3615 already fixed it.  Still, I think it's nice to have a more accurate repr.
- Check for type errors as soon as the approx object is instantiated, rather than waiting until a comparison is made.  Fixes #3473.  This includes very clear error messages if the user tries to use nested dictionaries or lists, since people seem to assume that this will work.  (And maybe it should, but that's a different discussion.)
- Improve some comments.
