### PR TITLE
Refactor direct fixture call warning to avoid incompatibility with plugins

### DIFF
--- a/changelog/3747.bugfix.rst
+++ b/changelog/3747.bugfix.rst
@@ -1,0 +1,1 @@
+Fix compatibility problem with plugins and the the warning code issued by fixture functions when they are called directly.

--- a/changelog/3747.bugfix.rst
+++ b/changelog/3747.bugfix.rst
@@ -1,1 +1,1 @@
-Fix compatibility problem with plugins and the the warning code issued by fixture functions when they are called directly.
+Fix compatibility problem with plugins and the warning code issued by fixture functions when they are called directly.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -249,6 +249,21 @@ def get_real_func(obj):
     return obj
 
 
+def get_real_method(obj, holder):
+    """
+    Attempts to obtain the real function object that might be wrapping ``obj``, while at the same time
+    returning a bound method to ``holder`` if the original object was a bound method.
+    """
+    try:
+        is_method = hasattr(obj, "__func__")
+        obj = get_real_func(obj)
+    except Exception:
+        return obj
+    if is_method and hasattr(obj, "__get__") and callable(obj.__get__):
+        obj = obj.__get__(holder)
+    return obj
+
+
 def getfslineno(obj):
     # xxx let decorators etc specify a sane ordering
     obj = get_real_func(obj)

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -267,7 +267,6 @@ def test_pytest_plugins_in_non_top_level_conftest_deprecated_no_false_positives(
     )
 
 
-# @pytest.mark.skipif(six.PY2, reason="We issue the warning in Python 3 only")
 def test_call_fixture_function_deprecated():
     """Check if a warning is raised if a fixture function is called directly (#3661)"""
 

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -1470,10 +1470,9 @@ class TestFixtureManagerParseFactories(object):
                     print (faclist)
                     assert len(faclist) == 3
 
-                    kwargs = {'__being_called_by_pytest': True}
-                    assert faclist[0].func(item._request, **kwargs) == "conftest"
-                    assert faclist[1].func(item._request, **kwargs) == "module"
-                    assert faclist[2].func(item._request, **kwargs) == "class"
+                    assert faclist[0].func(item._request) == "conftest"
+                    assert faclist[1].func(item._request) == "module"
+                    assert faclist[2].func(item._request) == "class"
         """
         )
         reprec = testdir.inline_run("-s")


### PR DESCRIPTION
This refactors the code so we have the real function object right during
collection. This avoids having to unwrap it later and lose attached information
such as "async" functions.

I've tested this with `pytest-asyncio` and it fixes https://github.com/pytest-dev/pytest-asyncio/issues/89.

Fix #3747, Fix #3720
Fix https://github.com/pytest-dev/pytest-asyncio/issues/89