### PR TITLE
Fix recursion in pytest.approx() with arrays in numpy<1.13

### DIFF
--- a/changelog/3748.bugfix.rst
+++ b/changelog/3748.bugfix.rst
@@ -1,0 +1,1 @@
+Fix infinite recursion in ``pytest.approx`` with arrays in ``numpy<1.13``.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -211,7 +211,9 @@ class ApproxScalar(ApproxBase):
         the pre-specified tolerance.
         """
         if _is_numpy_array(actual):
-            return all(self == a for a in actual.flat)
+            # Call ``__eq__()`` manually to prevent infinite-recursion with
+            # numpy<1.13.  See #3748.
+            return all(self.__eq__(a) for a in actual.flat)
 
         # Short-circuit exact equality.
         if actual == self.expected:

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -211,7 +211,7 @@ class ApproxScalar(ApproxBase):
         the pre-specified tolerance.
         """
         if _is_numpy_array(actual):
-            return all(a == self for a in actual.flat)
+            return all(self == a for a in actual.flat)
 
         # Short-circuit exact equality.
         if actual == self.expected:


### PR DESCRIPTION
Fix #3748

cc @ironiccode @tigarmo

I tested this patch manually using this example from @tigarmo using `numpy 1.11`:

```python
def testApprox():
    from pytest import approx
    import numpy as np

    a = np.array([1, 2, 3])
    assert a == approx([1, 2, 3])
```

I did not add tests for this because it requires `numpy<1.13`. I thought it overkill to add another CI environment because of this.