### PR TITLE
Fix infinite recursion collection bug with pytest_ignore_collect hook

### DIFF
--- a/changelog/3771.bugfix.rst
+++ b/changelog/3771.bugfix.rst
@@ -1,0 +1,1 @@
+Fix infinite recursion during collection if a ``pytest_ignore_collect`` returns ``False`` instead of ``None``.

--- a/testing/example_scripts/collect/package_infinite_recursion/conftest.py
+++ b/testing/example_scripts/collect/package_infinite_recursion/conftest.py
@@ -1,0 +1,2 @@
+def pytest_ignore_collect(path):
+    return False

--- a/testing/example_scripts/collect/package_infinite_recursion/tests/test_basic.py
+++ b/testing/example_scripts/collect/package_infinite_recursion/tests/test_basic.py
@@ -1,0 +1,2 @@
+def test():
+    pass

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -1577,3 +1577,9 @@ def test_keep_duplicates(testdir):
     )
     result = testdir.runpytest("--keep-duplicates", a.strpath, a.strpath)
     result.stdout.fnmatch_lines(["*collected 2 item*"])
+
+
+def test_package_collection_infinite_recursion(testdir):
+    testdir.copy_example("collect/package_infinite_recursion")
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines("*1 passed*")


### PR DESCRIPTION
Adding an example for a bug we found at work. This blows up with:

```
.env36\lib\site-packages\pluggy\hooks.py:258: in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
.env36\lib\site-packages\pluggy\manager.py:67: in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
.env36\lib\site-packages\pluggy\manager.py:61: in <lambda>
    firstresult=hook.spec_opts.get('firstresult'),
src\_pytest\python.py:210: in pytest_collect_file
    return ihook.pytest_pycollect_makemodule(path=path, parent=parent)
.env36\lib\site-packages\pluggy\hooks.py:258: in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
.env36\lib\site-packages\pluggy\manager.py:67: in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
.env36\lib\site-packages\pluggy\manager.py:61: in <lambda>
    firstresult=hook.spec_opts.get('firstresult'),
src\_pytest\python.py:215: in pytest_pycollect_makemodule
    return Package(path, parent)
src\_pytest\python.py:552: in __init__
    self, fspath, parent=parent, config=config, session=session, nodeid=nodeid
src\_pytest\nodes.py:351: in __init__
    fspath = py.path.local(fspath)  # xxx only for test_resultlog.py?
.env36\lib\site-packages\py\_path\local.py:158: in __init__
    self.strpath = abspath(path)
w:\Miniconda\envs\py36\lib\ntpath.py:552: in abspath
    return normpath(path)
w:\Miniconda\envs\py36\lib\ntpath.py:494: in normpath
    prefix, path = splitdrive(path)
w:\Miniconda\envs\py36\lib\ntpath.py:142: in splitdrive
    if len(p) >= 2:
E   RecursionError: maximum recursion depth exceeded in comparison
!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!
```

The trigger is the `pytest_ignore_collect` hook returning `False`. If it returns `None`, everything works.

This is a regression because returning `False` from the hook worked up until `3.7.0`.

cc @kfasolin