### PR TITLE
[WIP] classmethod and class-scoped fixtures (#3778)

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -667,7 +667,9 @@ class Testdir(object):
             example_path.copy(result)
             return result
         else:
-            raise LookupError("example is not found as a file or directory")
+            raise LookupError(
+                "example {} is not found as a file or directory".format(example_path)
+            )
 
     Session = Session
 

--- a/testing/example_scripts/fixtures/fill_fixtures/class_variable_auto_use.py
+++ b/testing/example_scripts/fixtures/fill_fixtures/class_variable_auto_use.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+class Test(object):
+    @classmethod
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(cls):
+        cls.url = "localhost:5000"
+
+    def test_url(self):
+        assert self.url == "localhost:5000"

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -371,6 +371,11 @@ class TestFillFixtures(object):
         result = testdir.runpytest()
         assert result.ret == 0
 
+    def test_class_variable_auto_use(self, testdir):
+        p = testdir.copy_example("class_variable_auto_use.py")
+        result = testdir.runpytest(p)
+        result.stdout.fnmatch_lines("* 1 passed *")
+
     def test_funcarg_lookup_error(self, testdir):
         testdir.makeconftest(
             """


### PR DESCRIPTION
Unfortunately I could not come up with a fix here.

The issue is that the fixture is declared as:

```python
@classmethod
@pytest.fixture(...)
def setup(cls): ...
```

When we "unwrap" the fixture to get to the underlying `setup` function, we lose the `classmethod` decoration; we would have to get the original `setup` function and somehow reapply the `@classmethod` decorator in order to get the class object as `cls` when we call the function later. I don't see any way to do this in a general manner.

After thinking about this issue I'm afraid the conclusion is that we have to pull back the warning about calling fixture functions directly: its intention was good but this has caused many more problems than we expected to be worth the trouble at this point.


xref: #3778 