### PR TITLE
Only consider actual functions when collecting hooks

### DIFF
--- a/changelog/3775.bugfix.rst
+++ b/changelog/3775.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where importing modules or other objects with prefix ``pytest_`` prefix would raise a ``PluginValidationError``.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1,6 +1,7 @@
 """ command line options, ini-file and conftest.py processing. """
 from __future__ import absolute_import, division, print_function
 import argparse
+import inspect
 import shlex
 import traceback
 import types
@@ -251,6 +252,10 @@ class PytestPluginManager(PluginManager):
 
         method = getattr(plugin, name)
         opts = super(PytestPluginManager, self).parse_hookimpl_opts(plugin, name)
+
+        # consider only actual functions for hooks (#3775)
+        if not inspect.isroutine(method):
+            return
 
         # collect unmarked hooks as long as they have the `pytest_' prefix
         if opts is None and name.startswith("pytest_"):

--- a/testing/example_scripts/config/collect_pytest_prefix/conftest.py
+++ b/testing/example_scripts/config/collect_pytest_prefix/conftest.py
@@ -1,0 +1,2 @@
+class pytest_something(object):
+    pass

--- a/testing/example_scripts/config/collect_pytest_prefix/test_foo.py
+++ b/testing/example_scripts/config/collect_pytest_prefix/test_foo.py
@@ -1,0 +1,2 @@
+def test_foo():
+    pass

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -745,6 +745,24 @@ def test_get_plugin_specs_as_list():
     assert _get_plugin_specs_as_list(("foo", "bar")) == ["foo", "bar"]
 
 
+def test_collect_pytest_prefix_bug_integration(testdir):
+    """Integration test for issue #3775"""
+    p = testdir.copy_example("config/collect_pytest_prefix")
+    result = testdir.runpytest(p)
+    result.stdout.fnmatch_lines("* 1 passed *")
+
+
+def test_collect_pytest_prefix_bug(pytestconfig):
+    """Ensure we collect only actual functions from conftest files (#3775)"""
+
+    class Dummy(object):
+        class pytest_something(object):
+            pass
+
+    pm = pytestconfig.pluginmanager
+    assert pm.parse_hookimpl_opts(Dummy(), "pytest_something") is None
+
+
 class TestWarning(object):
     def test_warn_config(self, testdir):
         testdir.makeconftest(


### PR DESCRIPTION
Fix #3775

