### PR TITLE
Add option to disable plugin auto-loading

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -207,6 +207,7 @@ Tzu-ping Chung
 Vasily Kuznetsov
 Victor Uriarte
 Vidar T. Fauske
+Virgil Dupras
 Vitaly Lashmanov
 Vlad Dragos
 Wil Cooley

--- a/changelog/3784.feature.rst
+++ b/changelog/3784.feature.rst
@@ -1,0 +1,1 @@
+Add option to disable plugin auto-loading.

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -866,6 +866,11 @@ Contains comma-separated list of modules that should be loaded as plugins:
 
     export PYTEST_PLUGINS=mymodule.plugin,xdist
 
+PYTEST_DISABLE_PLUGIN_AUTOLOAD
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When set, disables plugin auto-loading through setuptools entrypoints. Only explicitly specified plugins will be
+loaded.
 
 PYTEST_CURRENT_TEST
 ~~~~~~~~~~~~~~~~~~~

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -701,6 +701,10 @@ class Config(object):
 
         self.pluginmanager.rewrite_hook = hook
 
+        if os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
+            # We don't autoload from setuptools entry points, no need to continue.
+            return
+
         # 'RECORD' available for plugins installed normally (pip install)
         # 'SOURCES.txt' available for plugins installed in dev mode (pip install -e)
         # for installed plugins 'SOURCES.txt' returns an empty list, and vice-versa
@@ -726,7 +730,10 @@ class Config(object):
         self._checkversion()
         self._consider_importhook(args)
         self.pluginmanager.consider_preparse(args)
-        self.pluginmanager.load_setuptools_entrypoints("pytest11")
+        if not os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
+            # Don't autoload from setuptools entry point. Only explicitly specified
+            # plugins are going to be loaded.
+            self.pluginmanager.load_setuptools_entrypoints("pytest11")
         self.pluginmanager.consider_env()
         self.known_args_namespace = ns = self._parser.parse_known_args(
             args, namespace=copy.copy(self.option)

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -156,6 +156,7 @@ def showhelp(config):
     vars = [
         ("PYTEST_ADDOPTS", "extra command line options"),
         ("PYTEST_PLUGINS", "comma-separated plugins to load during startup"),
+        ("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "set to disable plugin auto-loading"),
         ("PYTEST_DEBUG", "set to enable debug tracing of pytest's internals"),
     ]
     for name, help in vars:


### PR DESCRIPTION
If `PYTEST_DISABLE_PLUGIN_AUTOLOAD` is set, disable auto-loading of
plugins through setuptools entrypoints. Only plugins that have been
explicitly specified are loaded.

ref #3784.
