### PR TITLE
Fix #3751

### DIFF
--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -505,8 +505,9 @@ class Session(nodes.FSCollector):
                             root = self._node_cache[pkginit]
                         else:
                             col = root._collectfile(pkginit)
-                            if col and isinstance(col, Package):
-                                root = col[0]
+                            if col:
+                                if isinstance(col[0], Package):
+                                    root = col[0]
                                 self._node_cache[root.fspath] = root
 
         # If it's a directory argument, recurse and look for any Subpackages.

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -639,9 +639,9 @@ class Test_getinitialnodes(object):
 
     def test_pkgfile(self, testdir):
         """Verify nesting when a module is within a package.
-	The parent chain should match: Module<x.py> -> Package<subdir> -> Session.
-        Session's parent should always be None.
-	"""
+        The parent chain should match: Module<x.py> -> Package<subdir> -> Session.
+            Session's parent should always be None.
+        """
         tmpdir = testdir.tmpdir
         subdir = tmpdir.join("subdir")
         x = subdir.ensure("x.py")
@@ -649,8 +649,11 @@ class Test_getinitialnodes(object):
         with subdir.as_cwd():
             config = testdir.parseconfigure(x)
         col = testdir.getnode(config, x)
-        assert isinstance(col, pytest.Module)
         assert col.name == "x.py"
+        assert isinstance(col, pytest.Module)
+        assert isinstance(col.parent, pytest.Package)
+        assert isinstance(col.parent.parent, pytest.Session)
+        # session is batman (has no parents)
         assert col.parent.parent.parent is None
         for col in col.listchain():
             assert col.config is config

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -647,7 +647,7 @@ class Test_getinitialnodes(object):
         col = testdir.getnode(config, x)
         assert isinstance(col, pytest.Module)
         assert col.name == "x.py"
-        assert col.parent.parent is None
+        assert col.parent.parent.parent is None
         for col in col.listchain():
             assert col.config is config
 

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -638,6 +638,10 @@ class Test_getinitialnodes(object):
             assert col.config is config
 
     def test_pkgfile(self, testdir):
+        """Verify nesting when a module is within a package.
+	The parent chain should match: Module<x.py> -> Package<subdir> -> Session.
+        Session's parent should always be None.
+	"""
         tmpdir = testdir.tmpdir
         subdir = tmpdir.join("subdir")
         x = subdir.ensure("x.py")


### PR DESCRIPTION
The previous fix would basically bypass the if block because the return value would always be a list.