### PR TITLE
Fix traceback reporting for exceptions with `__cause__` cycles.

### DIFF
--- a/changelog/3804.bugfix.rst
+++ b/changelog/3804.bugfix.rst
@@ -1,0 +1,1 @@
+Fix traceback reporting for exceptions with ``__cause__`` cycles.

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -719,7 +719,9 @@ class FormattedExcinfo(object):
             repr_chain = []
             e = excinfo.value
             descr = None
-            while e is not None:
+            seen = set()
+            while e is not None and id(e) not in seen:
+                seen.add(id(e))
                 if excinfo:
                     reprtraceback = self.repr_traceback(excinfo)
                     reprcrash = excinfo._getreprcrash()


### PR DESCRIPTION
Resolves #3804