### PR TITLE
Use more flexible `language_version: python3`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,13 @@ repos:
     hooks:
     -   id: black
         args: [--safe, --quiet]
-        language_version: python3.6
+        language_version: python3
 -   repo: https://github.com/asottile/blacken-docs
     rev: v0.2.0
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==18.6b4]
-        language_version: python3.6
+        language_version: python3
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.3.0
     hooks:
@@ -37,7 +37,6 @@ repos:
         files: ^(CHANGELOG.rst|HOWTORELEASE.rst|README.rst|changelog/.*)$
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]
-        python_version: python3.6
     -   id: changelogs-rst
         name: changelog files must end in .rst
         entry: ./scripts/fail


### PR DESCRIPTION
More and more are hitting this now that brew moved to python3.7.  Here's a few reports:

- https://github.com/pytest-dev/pytest/issues/3833#issuecomment-414195025
- https://github.com/pytest-dev/pytest/pull/3838#issuecomment-414214293

Note that this is what upstream `black` does in their configuration: https://github.com/ambv/black/pull/430