### PR TITLE
Fix '--show-capture=no' capture teardown logs

### DIFF
--- a/changelog/3816.bugfix.rst
+++ b/changelog/3816.bugfix.rst
@@ -1,1 +1,1 @@
-Fix ``--show-capture=no`` option still capture teardown logs.
+Fix bug where ``--show-capture=no`` option would still show logs printed during fixture teardown.

--- a/changelog/3816.bugfix.rst
+++ b/changelog/3816.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``--show-capture=no`` option still capture teardown logs.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -706,7 +706,12 @@ class TerminalReporter(object):
                     self._outrep_summary(rep)
 
     def print_teardown_sections(self, rep):
+        showcapture = self.config.option.showcapture
+        if showcapture == "no":
+            return
         for secname, content in rep.sections:
+            if showcapture != "all" and showcapture not in secname:
+                continue
             if "teardown" in secname:
                 self._tw.sep("-", secname)
                 if content[-1:] == "\n":


### PR DESCRIPTION
Add a check before printing teardown logs.

'print_teardown_sections' method does not check '--show-capture' option
value, and teardown logs are always printed.

Resolves: #3816