### PR TITLE
Remove warning about #568 from documentation

### DIFF
--- a/changelog/3845.trivial.rst
+++ b/changelog/3845.trivial.rst
@@ -1,2 +1,2 @@
-Remove a reference to issue #568 from the documentation, which has since been
+Remove a reference to issue `#568 <https://github.com/pytest-dev/pytest/issues/568>`_ from the documentation, which has since been
 fixed.

--- a/changelog/3845.trivial.rst
+++ b/changelog/3845.trivial.rst
@@ -1,0 +1,2 @@
+Remove a reference to issue #568 from the documentation, which has since been
+fixed.

--- a/doc/en/skipping.rst
+++ b/doc/en/skipping.rst
@@ -136,12 +136,6 @@ You can use the ``skipif`` marker (as any other marker) on classes::
 If the condition is ``True``, this marker will produce a skip result for
 each of the test methods of that class.
 
-.. warning::
-
-   The use of ``skipif`` on classes that use inheritance is strongly
-   discouraged. `A Known bug <https://github.com/pytest-dev/pytest/issues/568>`_
-   in pytest's markers may cause unexpected behavior in super classes.
-
 If you want to skip all test functions of a module, you may use
 the ``pytestmark`` name on the global level:
 


### PR DESCRIPTION
The documentation (https://docs.pytest.org/en/latest/skipping.html) references
issue #568, which has since been fixed.