### PR TITLE
fixed a bunch of unicode bugs in pytester.py

### DIFF
--- a/changelog/3848.bugfix.rst
+++ b/changelog/3848.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bugs where unicode arguments could not be passed to testdir.runpytest on Python 2.x

--- a/changelog/3848.bugfix.rst
+++ b/changelog/3848.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bugs where unicode arguments could not be passed to testdir.runpytest on Python 2.x
+Fix bugs where unicode arguments could not be passed to ``testdir.runpytest`` on Python 2.

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -2,6 +2,8 @@ import six
 import warnings
 import argparse
 
+import py
+
 FILE_OR_DIR = "file_or_dir"
 
 
@@ -70,7 +72,8 @@ class Parser(object):
 
         self.optparser = self._getparser()
         try_argcomplete(self.optparser)
-        return self.optparser.parse_args([str(x) for x in args], namespace=namespace)
+        args = [str(x) if isinstance(x, py.path.local) else x for x in args]
+        return self.optparser.parse_args(args, namespace=namespace)
 
     def _getparser(self):
         from _pytest._argcomplete import filescompleter
@@ -106,7 +109,7 @@ class Parser(object):
         the remaining arguments unknown at this point.
         """
         optparser = self._getparser()
-        args = [str(x) for x in args]
+        args = [str(x) if isinstance(x, py.path.local) else x for x in args]
         return optparser.parse_known_args(args, namespace=namespace)
 
     def addini(self, name, help, type=None, default=None):

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -8,7 +8,7 @@ import _pytest.pytester as pytester
 from _pytest.pytester import HookRecorder
 from _pytest.pytester import CwdSnapshot, SysModulesSnapshot, SysPathsSnapshot
 from _pytest.config import PytestPluginManager
-from _pytest.main import EXIT_OK, EXIT_TESTSFAILED
+from _pytest.main import EXIT_OK, EXIT_TESTSFAILED, EXIT_NOTESTSCOLLECTED
 
 
 def test_make_hook_recorder(testdir):
@@ -396,3 +396,8 @@ class TestSysPathsSnapshot(object):
 def test_testdir_subprocess(testdir):
     testfile = testdir.makepyfile("def test_one(): pass")
     assert testdir.runpytest_subprocess(testfile).ret == 0
+
+    
+def test_unicode_args(testdir):
+    result = testdir.runpytest("-k", u"💩")
+    assert result.ret == EXIT_NOTESTSCOLLECTED

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -397,7 +397,7 @@ def test_testdir_subprocess(testdir):
     testfile = testdir.makepyfile("def test_one(): pass")
     assert testdir.runpytest_subprocess(testfile).ret == 0
 
-    
+
 def test_unicode_args(testdir):
     result = testdir.runpytest("-k", u"💩")
     assert result.ret == EXIT_NOTESTSCOLLECTED


### PR DESCRIPTION
CI for [my plugin](https://github.com/wimglenn/pytest-custom-report/pull/1) is failing on  2.7, but when checking in the code I don't think I'm doing anything wrong actually.  Look to me like the problem is in `pytester.py`, so trying to fix it there - don't randomly call str() on args which might be unicode objects (this seems to have been originally done to convert py.path.local instances to ordinary strings, but done a bit over-zealously).
