### PR TITLE
Use `bytes` directly instead of `binary_type`

### DIFF
--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -402,12 +402,11 @@ def _saferepr(obj):
     JSON reprs.
 
     """
-    repr = py.io.saferepr(obj)
-    if isinstance(repr, six.text_type):
-        t = six.text_type
+    r = py.io.saferepr(obj)
+    if isinstance(r, six.text_type):
+        return r.replace(u"\n", u"\\n")
     else:
-        t = six.binary_type
-    return repr.replace(t("\n"), t("\\n"))
+        return r.replace(b"\n", b"\\n")
 
 
 from _pytest.assertion.util import format_explanation as _format_explanation  # noqa
@@ -446,10 +445,9 @@ def _should_repr_global_name(obj):
 def _format_boolop(explanations, is_or):
     explanation = "(" + (is_or and " or " or " and ").join(explanations) + ")"
     if isinstance(explanation, six.text_type):
-        t = six.text_type
+        return explanation.replace(u"%", u"%%")
     else:
-        t = six.binary_type
-    return explanation.replace(t("%"), t("%%"))
+        return explanation.replace(b"%", b"%%")
 
 
 def _call_reprcompare(ops, results, expls, each_obj):

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -187,9 +187,9 @@ def _diff_text(left, right, verbose=False):
         r = r.replace(r"\r", "\r")
         return r
 
-    if isinstance(left, six.binary_type):
+    if isinstance(left, bytes):
         left = escape_for_readable_diff(left)
-    if isinstance(right, six.binary_type):
+    if isinstance(right, bytes):
         right = escape_for_readable_diff(right)
     if not verbose:
         i = 0  # just in case left or right has zero length

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -12,7 +12,7 @@ from io import UnsupportedOperation
 import py
 import pytest
 import contextlib
-from six import binary_type, text_type
+from six import text_type
 from _pytest import capture
 from _pytest.capture import CaptureManager
 from _pytest.main import EXIT_NOTESTSCOLLECTED
@@ -24,12 +24,12 @@ needsosdup = pytest.mark.xfail("not hasattr(os, 'dup')")
 def tobytes(obj):
     if isinstance(obj, text_type):
         obj = obj.encode("UTF-8")
-    assert isinstance(obj, binary_type)
+    assert isinstance(obj, bytes)
     return obj
 
 
 def totext(obj):
-    if isinstance(obj, binary_type):
+    if isinstance(obj, bytes):
         obj = text_type(obj, "UTF-8")
     assert isinstance(obj, text_type)
     return obj


### PR DESCRIPTION
`bytes` is an alias for `str` in python2.6+