### PR TITLE
Correct cmdclass for doc: Good Integration Practices

### DIFF
--- a/changelog/3870.doc.rst
+++ b/changelog/3870.doc.rst
@@ -1,0 +1,1 @@
+correct documentation for setuptools integration

--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -291,7 +291,7 @@ your own setuptools Test command for invoking pytest.
     setup(
         # ...,
         tests_require=["pytest"],
-        cmdclass={"test": PyTest},
+        cmdclass={"pytest": PyTest},
     )
 
 Now if you run::


### PR DESCRIPTION
Addressing #3870 

If you follow the guide to this point, the correct key for `cmdclass` will be the canonical name 'pytest' rather than the alias 'test' created in setup.cfg.