### PR TITLE
Remove dangerous sys.path manipulations in test_pluginmanager

### DIFF
--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -228,11 +228,15 @@ def test_syspath_prepend(mp):
 
 
 def test_syspath_prepend_double_undo(mp):
-    mp.syspath_prepend("hello world")
-    mp.undo()
-    sys.path.append("more hello world")
-    mp.undo()
-    assert sys.path[-1] == "more hello world"
+    old_syspath = sys.path[:]
+    try:
+        mp.syspath_prepend("hello world")
+        mp.undo()
+        sys.path.append("more hello world")
+        mp.undo()
+        assert sys.path[-1] == "more hello world"
+    finally:
+        sys.path[:] = old_syspath
 
 
 def test_chdir_with_path_local(mp, tmpdir):

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -25,7 +25,6 @@ class TestPytestPluginInteractions(object):
         )
         conf = testdir.makeconftest(
             """
-            import sys ; sys.path.insert(0, '.')
             import newhooks
             def pytest_addhooks(pluginmanager):
                 pluginmanager.addhooks(newhooks)
@@ -263,8 +262,7 @@ class TestPytestPluginManager(object):
         mod.pytest_plugins = "pytest_a"
         aplugin = testdir.makepyfile(pytest_a="#")
         reprec = testdir.make_hook_recorder(pytestpm)
-        # syspath.prepend(aplugin.dirpath())
-        sys.path.insert(0, str(aplugin.dirpath()))
+        testdir.syspathinsert(aplugin.dirpath())
         pytestpm.consider_module(mod)
         call = reprec.getcall(pytestpm.hook.pytest_plugin_registered.name)
         assert call.plugin.__name__ == "pytest_a"

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -215,57 +215,6 @@ class TestInlineRunModulesCleanup(object):
         assert imported.data == 42
 
 
-def test_inline_run_clean_sys_paths(testdir):
-    def test_sys_path_change_cleanup(self, testdir):
-        test_path1 = testdir.tmpdir.join("boink1").strpath
-        test_path2 = testdir.tmpdir.join("boink2").strpath
-        test_path3 = testdir.tmpdir.join("boink3").strpath
-        sys.path.append(test_path1)
-        sys.meta_path.append(test_path1)
-        original_path = list(sys.path)
-        original_meta_path = list(sys.meta_path)
-        test_mod = testdir.makepyfile(
-            """
-            import sys
-            sys.path.append({:test_path2})
-            sys.meta_path.append({:test_path2})
-            def test_foo():
-                sys.path.append({:test_path3})
-                sys.meta_path.append({:test_path3})""".format(
-                locals()
-            )
-        )
-        testdir.inline_run(str(test_mod))
-        assert sys.path == original_path
-        assert sys.meta_path == original_meta_path
-
-    def spy_factory(self):
-        class SysPathsSnapshotSpy(object):
-            instances = []
-
-            def __init__(self):
-                SysPathsSnapshotSpy.instances.append(self)
-                self._spy_restore_count = 0
-                self.__snapshot = SysPathsSnapshot()
-
-            def restore(self):
-                self._spy_restore_count += 1
-                return self.__snapshot.restore()
-
-        return SysPathsSnapshotSpy
-
-    def test_inline_run_taking_and_restoring_a_sys_paths_snapshot(
-        self, testdir, monkeypatch
-    ):
-        spy_factory = self.spy_factory()
-        monkeypatch.setattr(pytester, "SysPathsSnapshot", spy_factory)
-        test_mod = testdir.makepyfile("def test_foo(): pass")
-        testdir.inline_run(str(test_mod))
-        assert len(spy_factory.instances) == 1
-        spy = spy_factory.instances[0]
-        assert spy._spy_restore_count == 1
-
-
 def test_assert_outcomes_after_pytest_error(testdir):
     testdir.makepyfile("def test_foo(): assert True")
 


### PR DESCRIPTION
Noticed these while working in something else

