### PR TITLE
Travis: use TOXENV=linting for linting stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,12 +62,7 @@ jobs:
           repo: pytest-dev/pytest
     - stage: linting
       python: '3.6'
-      env:
-      install:
-      - pip install pre-commit
-      - pre-commit install-hooks
-      script:
-      - pre-commit run --all-files
+      env: TOXENV=linting
 
 script: tox --recreate
 


### PR DESCRIPTION
This will run it with `--show-diff-on-failure` then, and helps to keep
it in line / in a central place.

See https://travis-ci.org/pytest-dev/pytest/jobs/420595379 for an example failure.

Appveyor uses TOXENV=linting already.