### PR TITLE
Code block: :: missing and 4 spaces instead of 5

### DIFF
--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -12,12 +12,11 @@ for installing your application and any dependencies
 as well as the ``pytest`` package itself. This ensures your code and
 dependencies are isolated from the system Python installation.
 
-First you need to place a ``setup.py`` file in the root of your package with the following minimum content:
+First you need to place a ``setup.py`` file in the root of your package with the following minimum content::
 
-     from setuptools import setup, find_packages
+    from setuptools import setup, find_packages
 
-
-     setup(name="PACKAGENAME", packages=find_packages())
+    setup(name="PACKAGENAME", packages=find_packages())
 
 Where ``PACKAGENAME`` is the name of your package. You can then install your package in "editable" mode by running from the same directory::
 


### PR DESCRIPTION
Just a minor doc fix to recent PR #3865.

I just noticed the newly committed code block doesn't format as a code block without `::` in the paragraph before. Perhaps doesn't make a difference, but also corrected 5 spaces to 4 which seems standard.