### PR TITLE
Avoid possible infinite recursion when writing pyc files in assert rewrite

### DIFF
--- a/changelog/3506.bugfix.rst
+++ b/changelog/3506.bugfix.rst
@@ -1,0 +1,1 @@
+Fix possible infinite recursion when writing ``.pyc`` files.


### PR DESCRIPTION
What happens is that atomic_write on Python 2.7 on Windows will try
to convert the paths to unicode, but this triggers the import of
the encoding module for the file system codec, which in turn triggers
the rewrite, which in turn again tries to import the module, and so on.

This short-circuits the cases where we try to import another file when
writing a pyc file; I don't expect this to affect anything because
the only modules that could be affected are those imported by
atomic_writes.

The fix has been tested in an actual repository showing the problem: https://github.com/Pylons/pyramid-cookiecutter-starter/pull/56

Fix #3506

