### PR TITLE
TerminalReporter.rewrite to handle lines longer than terminal width

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -194,6 +194,7 @@ Stefan Zimmermann
 Stefano Taschini
 Steffen Allner
 Stephan Obermann
+Stephen Rauch
 Tadek Teleżyński
 Tarcisio Fischer
 Tareq Alayan

--- a/changelog/3896.bugfix.rst
+++ b/changelog/3896.bugfix.rst
@@ -1,0 +1,1 @@
+Better handle rewrite lines wider than the terminal.  EG: xdist with 16+ cores and 1k+ testcases will no longer scroll manically while gathering testcases.


### PR DESCRIPTION
If `TerminalReporter.rewrite` is passed a line wider than the terminal, the result is that the terminal will scroll with each update.  I ran into this while using xdist and 16 threads and 1k+ test cases.  During the gathering of the test cases, the terminal did some unwanted scrolling.

This change will take advantage of terminals that can do vertical scrolling to clean up the display in these cases.