### PR TITLE
Fix pytest.org links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,23 +66,23 @@ To execute it::
     ========================== 1 failed in 0.04 seconds ===========================
 
 
-Due to ``pytest``'s detailed assertion introspection, only plain ``assert`` statements are used. See `getting-started <http://docs.pytest.org/en/latest/getting-started.html#our-first-test-run>`_ for more examples.
+Due to ``pytest``'s detailed assertion introspection, only plain ``assert`` statements are used. See `getting-started <https://docs.pytest.org/en/latest/getting-started.html#our-first-test-run>`_ for more examples.
 
 
 Features
 --------
 
-- Detailed info on failing `assert statements <http://docs.pytest.org/en/latest/assert.html>`_ (no need to remember ``self.assert*`` names);
+- Detailed info on failing `assert statements <https://docs.pytest.org/en/latest/assert.html>`_ (no need to remember ``self.assert*`` names);
 
 - `Auto-discovery
-  <http://docs.pytest.org/en/latest/goodpractices.html#python-test-discovery>`_
+  <https://docs.pytest.org/en/latest/goodpractices.html#python-test-discovery>`_
   of test modules and functions;
 
-- `Modular fixtures <http://docs.pytest.org/en/latest/fixture.html>`_ for
+- `Modular fixtures <https://docs.pytest.org/en/latest/fixture.html>`_ for
   managing small or parametrized long-lived test resources;
 
-- Can run `unittest <http://docs.pytest.org/en/latest/unittest.html>`_ (or trial),
-  `nose <http://docs.pytest.org/en/latest/nose.html>`_ test suites out of the box;
+- Can run `unittest <https://docs.pytest.org/en/latest/unittest.html>`_ (or trial),
+  `nose <https://docs.pytest.org/en/latest/nose.html>`_ test suites out of the box;
 
 - Python 2.7, Python 3.4+, PyPy 2.3, Jython 2.5 (untested);
 
@@ -92,7 +92,7 @@ Features
 Documentation
 -------------
 
-For full documentation, including installation, tutorials and PDF documents, please see http://docs.pytest.org.
+For full documentation, including installation, tutorials and PDF documents, please see https://docs.pytest.org/en/latest/.
 
 
 Bugs/Requests
@@ -104,7 +104,7 @@ Please use the `GitHub issue tracker <https://github.com/pytest-dev/pytest/issue
 Changelog
 ---------
 
-Consult the `Changelog <http://docs.pytest.org/en/latest/changelog.html>`__ page for fixes and enhancements of each version.
+Consult the `Changelog <https://docs.pytest.org/en/latest/changelog.html>`__ page for fixes and enhancements of each version.
 
 
 License

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: http://docs.pytest.org/en/latest/_static/pytest1.png
-   :target: http://docs.pytest.org
+.. image:: https://docs.pytest.org/en/latest/_static/pytest1.png
+   :target: https://docs.pytest.org/en/latest/
    :align: center
    :alt: pytest
 

--- a/doc/en/funcarg_compare.rst
+++ b/doc/en/funcarg_compare.rst
@@ -7,7 +7,7 @@ pytest-2.3: reasoning for fixture/funcarg evolution
 
 **Target audience**: Reading this document requires basic knowledge of
 python testing, xUnit setup methods and the (previous) basic pytest
-funcarg mechanism, see http://pytest.org/2.2.4/funcargs.html
+funcarg mechanism, see https://docs.pytest.org/en/latest/historical-notes.html#funcargs-and-pytest-funcarg.
 If you are new to pytest, then you can simply ignore this
 section and read the other sections.
 

--- a/scripts/release.minor.rst
+++ b/scripts/release.minor.rst
@@ -9,7 +9,7 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    https://doc.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/latest/changelog.html
 
 For complete documentation, please visit:
 

--- a/scripts/release.minor.rst
+++ b/scripts/release.minor.rst
@@ -9,11 +9,11 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    http://doc.pytest.org/en/latest/changelog.html
+    https://doc.pytest.org/en/latest/changelog.html
 
 For complete documentation, please visit:
 
-    http://docs.pytest.org
+    https://docs.pytest.org/en/latest/
 
 As usual, you can upgrade from pypi via:
 

--- a/scripts/release.patch.rst
+++ b/scripts/release.patch.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://doc.pytest.org/en/latest/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/scripts/release.patch.rst
+++ b/scripts/release.patch.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ def main():
         description="pytest: simple powerful testing with Python",
         long_description=long_description,
         use_scm_version={"write_to": "src/_pytest/_version.py"},
-        url="http://pytest.org",
+        url="https://docs.pytest.org/en/latest/",
         project_urls={
             "Source": "https://github.com/pytest-dev/pytest",
             "Tracker": "https://github.com/pytest-dev/pytest/issues",

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -173,13 +173,14 @@ def pytest_configure(config):
         "or a list of tuples of values if argnames specifies multiple names. "
         "Example: @parametrize('arg1', [1,2]) would lead to two calls of the "
         "decorated test function, one with arg1=1 and another with arg1=2."
-        "see http://pytest.org/latest/parametrize.html for more info and "
-        "examples.",
+        "see https://docs.pytest.org/en/latest/parametrize.html for more info "
+        "and examples.",
     )
     config.addinivalue_line(
         "markers",
         "usefixtures(fixturename1, fixturename2, ...): mark tests as needing "
-        "all of the specified fixtures. see http://pytest.org/latest/fixture.html#usefixtures ",
+        "all of the specified fixtures. see "
+        "https://docs.pytest.org/en/latest/fixture.html#usefixtures ",
     )
 
 

--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -51,7 +51,7 @@ def pytest_configure(config):
         "results in a True value.  Evaluation happens within the "
         "module global context. Example: skipif('sys.platform == \"win32\"') "
         "skips the test if we are on the win32 platform. see "
-        "http://pytest.org/latest/skipping.html",
+        "https://docs.pytest.org/en/latest/skipping.html",
     )
     config.addinivalue_line(
         "markers",
@@ -61,7 +61,7 @@ def pytest_configure(config):
         "and run=False if you don't even want to execute the test function. "
         "If only specific exception(s) are expected, you can list them in "
         "raises, and if the test fails in other ways, it will be reported as "
-        "a true failure. See http://pytest.org/latest/skipping.html",
+        "a true failure. See https://docs.pytest.org/en/latest/skipping.html",
     )
 
 

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -691,7 +691,7 @@ class TerminalReporter(object):
                     indented = "\n".join("  " + x for x in lines)
                     self._tw.line(indented)
                 self._tw.line()
-            self._tw.line("-- Docs: http://doc.pytest.org/en/latest/warnings.html")
+            self._tw.line("-- Docs: https://docs.pytest.org/en/latest/warnings.html")
 
     def summary_passes(self):
         if self.config.option.tbstyle != "no":

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -53,7 +53,7 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers",
         "filterwarnings(warning): add a warning filter to the given test. "
-        "see http://pytest.org/latest/warnings.html#pytest-mark-filterwarnings ",
+        "see https://docs.pytest.org/en/latest/warnings.html#pytest-mark-filterwarnings ",
     )
 
 

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -116,7 +116,7 @@ def test_resultlog_is_deprecated(testdir):
     result.stdout.fnmatch_lines(
         [
             "*--result-log is deprecated and scheduled for removal in pytest 4.0*",
-            "*See https://docs.pytest.org/*/usage.html#creating-resultlog-format-files for more information*",
+            "*See https://docs.pytest.org/en/latest/usage.html#creating-resultlog-format-files for more information*",
         ]
     )
 


### PR DESCRIPTION
I corrected various versions of links to `pytest.org` for consistency, to use https, fix 404s, and save redirects.

All URLs should now begin with `https://docs.pytest.org/en/latest/`.

Please note that the project description on GitHub uses the URL `http://pytest.org/`, but I can't fix that one.