### PR TITLE
Parametrizing scopes with autouse

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,6 +42,7 @@ Ceridwen
 Charles Cloud
 Charnjit SiNGH (CCSJ)
 Chris Lamb
+Chris NeJame
 Christian Boelsen
 Christian Theunert
 Christian Tismer

--- a/changelog/1552.feature.rst
+++ b/changelog/1552.feature.rst
@@ -1,0 +1,1 @@
+Parametrized fixtures with ``autouse`` now cause the reactivation of all fixtures of that scope for each param set, instead of just the fixtures that get activated after them.

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -381,10 +381,11 @@ shared across every fixture and test in the ``module``. The ``clear_data``
 fixture is responsible for emptying out the ``dict`` provided by ``data``, but
 will only happen once per ``class``. However, the ``data_value`` fixture is an
 autoparam fixture with a scope of ``class``, so that means it wants every
-fixture for the ``class`` to be run once per set of parameters. Since
+``class``-scoped fixture to be run once per set of parameters. Since
 ``clear_data`` has a scope of ``class``, it will also be executed once per param
-set. But since the ``data`` fixture has a scope of ``module``, it won't be
-impacted  by the parametrization, and will only be executed once.
+set declared by ``data_value``. But since the ``data`` fixture has a scope of
+``module``, it won't be impacted by the parametrization, and will only be
+executed once.
 
 The flow looks something like this:
 
@@ -408,7 +409,8 @@ The flow looks something like this:
                     └── add_data
                         └── test_was_cleared (function)
 
-Without autouse, the flow would look more like this:
+If we remove the autouse declaration from all fixtures, the flow would look more
+like this:
 
 .. code-block:: none
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -561,7 +561,7 @@ class FixtureRequest(FuncargnamesCompatAttr):
             param = funcitem.callspec.getparam(argname)
         except (AttributeError, ValueError):
             param = NOTSET
-            param_index = 0
+            param_index = "0"
             if fixturedef.params is not None:
                 frame = inspect.stack()[3]
                 frameinfo = inspect.getframeinfo(frame[0])
@@ -581,6 +581,36 @@ class FixtureRequest(FuncargnamesCompatAttr):
                     )
                 )
                 fail(msg)
+            else:
+                if hasattr(funcitem, "callspec"):
+                    # fixture can be impacted by any parametrization of the
+                    # scope
+                    param_fix_argnames = funcitem.callspec.indices.keys()
+                    relevant_fixture_names = []
+                    for name in param_fix_argnames:
+                        num = funcitem.callspec._arg2scopenum.get(name)
+                        fix_scope = scopes[num]
+                        if fix_scope == scope:
+                            # they share the same scope
+                            fm = fixturedef._fixturemanager
+                            if name not in fm._arg2fixturedefs.keys():
+                                # must be parametrized through
+                                # pytest.mark.parametrize, which means it should
+                                # be considered autouse
+                                relevant_fixture_names.append(name)
+                            elif fm._arg2fixturedefs[name][-1].is_autouse:
+                                # the fixture is autouse
+                                relevant_fixture_names.append(name)
+                    # keep them in order to keep param_index consistent
+                    relevant_fixture_names.sort()
+                    for name in relevant_fixture_names:
+                        # create a param_index that combines all the param_index
+                        # values of all the relevant parametrized fixtures so
+                        # the fixture will be executed again when stepping to
+                        # the next param set.
+                        pi = str(funcitem.callspec.indices.get(name, 0))
+                        param_index += pi
+            param_index = int(param_index)
         else:
             # indices might not be set if old-style metafunc.addcall() was used
             param_index = funcitem.callspec.indices.get(argname, 0)
@@ -894,6 +924,11 @@ class FixtureDef(object):
 
         hook = self._fixturemanager.session.gethookproxy(request.node.fspath)
         return hook.pytest_fixture_setup(fixturedef=self, request=request)
+
+    @property
+    def is_autouse(self):
+        autousenames = self._fixturemanager._getautousenames(self.baseid)
+        return self.argname in autousenames
 
     def __repr__(self):
         return "<FixtureDef name=%r scope=%r baseid=%r >" % (

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -613,7 +613,7 @@ class FixtureRequest(FuncargnamesCompatAttr):
 
         The effective ``param_index`` of a fixture will be used to determine
         whether or not the value of the fixture needs to be computed again, and
-        is based on the ``param_index`` values of the autouse, parameterized
+        is based on the ``param_index`` values of the autouse, parametrized
         fixtures of the same scope. If the fixture's effective ``param_index``
         does not match the one found in its ``cached_result``, or the fixture
         does not have a ``cached_result``, then the value of the fixture will be

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -4219,7 +4219,7 @@ class TestFixtureParametrizationAndAutouseUsages(object):
         """
         )
         reprec = testdir.inline_run()
-        reprec.assertoutcome(passed=2)
+        reprec.assertoutcome(passed=4)
 
     def test_scope_is_respected(self, testdir):
         """Test ensures the module level fixtures are still only run once when class is parametrized."""
@@ -4284,7 +4284,7 @@ class TestFixtureParametrizationAndAutouseUsages(object):
         """
         )
         reprec = testdir.inline_run()
-        reprec.assertoutcome(passed=2)
+        reprec.assertoutcome(passed=4)
 
     def test_nested_parametrization_of_different_scopes(self, testdir):
         testdir.makepyfile(
@@ -4321,13 +4321,9 @@ class TestFixtureParametrizationAndAutouseUsages(object):
                 def test_was_cleared(self, data, data_value_module, data_value_class):
                     assert data == [data_value_module, data_value_class]
 
+                def test_data_length(self, data, data_value_module, data_value_class):
+                    assert len(data) == 2
         """
         )
         reprec = testdir.inline_run()
-        reprec.assertoutcome(passed=2, failed=2)
-        reprec.stdout.fnmatch_lines(
-            """
-            E*assert ['a', 'x', 'y'] == ['a', 'y']
-            E*assert ['b', 'x', 'y'] == ['b', 'y']
-            """
-        )
+        reprec.assertoutcome(passed=4, failed=4)


### PR DESCRIPTION
Closes #1552 

Now, instead of only re-activating fixtures for a given scope if they occur after a parametrized fixture for the same scope that has ``autouse`` as ``True``, all fixtures of that scope will be re-activated.

For example, currently, given the following module:

```python
import pytest


@pytest.fixture(scope="class", autouse=True)
def before_param():
    print("in before_param")


class TestIt():

    @pytest.fixture(scope="class", autouse=True, params=["a", "b"])
    def param_fix(self, before_param, request):
        print("in param_fix")
        return request.param

    @pytest.fixture(scope="class", autouse=True)
    def other_fix(self, param_fix):
        print("in other_fix")

    def test_stuff(self, other_fix):
        assert True
```

You used to get the following flow:

```
test_module (module)
└── TestIt (class)
    └── before_param
        ├── param_fix["a"]
        |   └── other_fix
        |       └── test_stuff (function)
        └── param_fix["b"]
            └── other_fix
                └── test_stuff (function)
```

But now, you get this flow:

```
test_module (module)
└── TestIt (class)
    ├── before_param
    |   └── param_fix["a"]
    |       └── other_fix
    |           └── test_stuff (function)
    └── before_param
        └── param_fix["b"]
            └── other_fix
                └── test_stuff (function)
```