### PR TITLE
Skip the "test" stage when making a release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: python
 stages:
 - baseline
-- test
+- name: test
+  if: repo = pytest-dev/pytest AND tag IS NOT present
 - name: deploy
   if: repo = pytest-dev/pytest AND tag IS present
 python:


### PR DESCRIPTION
Given that our guidelines demand that the CI have already passed, it seems
wasteful to run all those jobs again for the exact same commit.

As discussed in https://github.com/pytest-dev/pytest/pull/3906#issuecomment-417094481,
this will skip the "test" stage when building a tag for deployment.

