### PR TITLE
Reenable pypy now that scandir can be installed without a compiler

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
   - TOXENV: "py35"
   - TOXENV: "py36"
   - TOXENV: "py37"
-#  - TOXENV: "pypy" reenable when we are able to provide a scandir wheel or build scandir
+  - TOXENV: "pypy"
   - TOXENV: "py27-pexpect"
   - TOXENV: "py27-xdist"
   - TOXENV: "py27-trial"


### PR DESCRIPTION
Ref: benhoyt/scandir#105
Ref: #3111