### PR TITLE
Use -n auto now that xdist behaves well in Travis and AppVeyor

### DIFF
--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -211,9 +211,6 @@ class TestMetafunc(object):
     @hypothesis.settings(
         deadline=400.0
     )  # very close to std deadline and CI boxes are not reliable in CPU power
-    @pytest.mark.xfail(
-        sys.platform.startswith("win32"), reason="flaky #3707", strict=False
-    )
     def test_idval_hypothesis(self, value):
         from _pytest.python import _idval
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,8 +40,9 @@ deps =
     pytest-xdist>=1.13
     mock
     nose
+passenv = USER USERNAME TRAVIS
 commands =
-    pytest -n3 -ra --runpytest=subprocess {posargs:testing}
+    pytest -n auto -ra --runpytest=subprocess {posargs:testing}
 
 
 [testenv:linting]
@@ -58,8 +59,9 @@ deps =
     hypothesis>=3.56
     {env:_PYTEST_TOX_EXTRA_DEP:}
 whitelist_externals = env
+passenv = USER USERNAME TRAVIS
 commands =
-    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n8 -ra {posargs:testing}
+    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n auto -ra {posargs:testing}
 
 [testenv:py36-xdist]
 deps = {[testenv:py27-xdist]deps}
@@ -93,8 +95,9 @@ setenv =
     {[testenv]setenv}
     PYTHONDONTWRITEBYTECODE=1
 whitelist_externals = env
+passenv = USER USERNAME TRAVIS
 commands =
-    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n3 -ra {posargs:.}
+    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n auto -ra {posargs:.}
 
 [testenv:py27-trial]
 deps =


### PR DESCRIPTION
This hopefully fixes the flaky test_idval_hypothesis on AppVeyor

Fix #3707
