### PR TITLE
Improve pre-commit detection for changelog filenames

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,8 @@ repos:
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]
     -   id: changelogs-rst
-        name: changelog files must end in .rst
-        entry: ./scripts/fail
-        language: script
-        files: 'changelog/.*(?<!\.rst)$'
+        name: changelog filenames
+        language: fail
+        entry: 'changelog files must be named ####.(feature|bugfix|doc|removal|vendor|trivial).rst'
+        exclude: changelog/(\d+\.(feature|bugfix|doc|removal|vendor|trivial).rst|README.rst|_template.rst)
+        files: ^changelog/

--- a/changelog/3955.trivial.rst
+++ b/changelog/3955.trivial.rst
@@ -1,0 +1,1 @@
+Improve pre-commit detection for changelog filenames

--- a/scripts/fail
+++ b/scripts/fail
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-"""Used by .pre-commit-config.yaml"""
-import sys
-
-if __name__ == "__main__":
-    print(" ".join(sys.argv[1:]))
-    sys.exit(1)

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands =
 [testenv:linting]
 skip_install = True
 basepython = python3.6
-deps = pre-commit
+deps = pre-commit>=1.11.0
 commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:py27-xdist]
@@ -195,7 +195,7 @@ passenv = *
 deps =
     colorama
     gitpython
-    pre-commit
+    pre-commit>=1.11.0
     towncrier
     wheel
 commands = python scripts/release.py {posargs}


### PR DESCRIPTION
Resolves #3955

Before:

```console
$ pre-commit  run changelogs-rst --all-files
changelog filenames......................................................Failed
hookid: changelogs-rst

changelog files must be named ####.(feature|bugfix|doc|removal|vendor|trivial).rst

changelog/3251.feture.rst
```