### PR TITLE
Actually deprecate long standing features

### DIFF
--- a/changelog/3616.deprecation.rst
+++ b/changelog/3616.deprecation.rst
@@ -9,3 +9,10 @@ The following accesses have been documented as deprecated for years, but are now
 
 * ``request.cached_setup``, this was the precursor of the setup/teardown mechanism available to fixtures. You can
   consult `funcarg comparision section in the docs <https://docs.pytest.org/en/latest/funcarg_compare.html>`_.
+
+* Using objects named ``"Class"`` as a way to customize the type of nodes that are collected in ``Collector``
+  subclasses has been deprecated. Users instead should use ``pytest_collect_make_item`` to customize node types during
+  collection.
+
+  This issue should affect only advanced plugins who create new collection types, so if you see this warning
+  message please contact the authors so they can change the code.

--- a/changelog/3616.deprecation.rst
+++ b/changelog/3616.deprecation.rst
@@ -6,3 +6,6 @@ The following accesses have been documented as deprecated for years, but are now
         usage of Function.Module is deprecated, please use pytest.Module instead
 
   Users should just ``import pytest`` and access those objects using the ``pytest`` module.
+
+* ``request.cached_setup``, this was the precursor of the setup/teardown mechanism available to fixtures. You can
+  consult `funcarg comparision section in the docs <https://docs.pytest.org/en/latest/funcarg_compare.html>`_.

--- a/changelog/3616.deprecation.rst
+++ b/changelog/3616.deprecation.rst
@@ -1,0 +1,8 @@
+The following accesses have been documented as deprecated for years, but are now actually emitting deprecation warnings.
+
+* Access of ``Module``, ``Function``, ``Class``, ``Instance``, ``File`` and ``Item`` through ``Node`` instances. Now
+  users will this warning::
+
+        usage of Function.Module is deprecated, please use pytest.Module instead
+
+  Users should just ``import pytest`` and access those objects using the ``pytest`` module.

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -14,7 +14,8 @@ Each file should be named like ``<ISSUE>.<TYPE>.rst``, where
 * ``feature``: new user facing features, like new command-line options and new behavior.
 * ``bugfix``: fixes a reported bug.
 * ``doc``: documentation improvement, like rewording an entire session or adding missing docs.
-* ``removal``: feature deprecation or removal.
+* ``deprecation``: feature deprecation.
+* ``removal``: feature removal.
 * ``vendor``: changes in packages vendored in pytest.
 * ``trivial``: fixing a small typo or internal change that might be noteworthy.
 

--- a/doc/en/historical-notes.rst
+++ b/doc/en/historical-notes.rst
@@ -175,3 +175,13 @@ Previous to version 2.4 to set a break point in code one needed to use ``pytest.
 This is no longer needed and one can use the native ``import pdb;pdb.set_trace()`` call directly.
 
 For more details see :ref:`breakpoints`.
+
+"compat" properties
+-------------------
+
+.. deprecated:: 3.9
+
+Access of ``Module``, ``Function``, ``Class``, ``Instance``, ``File`` and ``Item`` through ``Node`` instances have long
+been documented as deprecated, but started to emit warnings from pytest ``3.9`` and onward.
+
+Users should just ``import pytest`` and access those objects using the ``pytest`` module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,12 @@ template = "changelog/_template.rst"
 
   [[tool.towncrier.type]]
   directory = "removal"
-  name = "Deprecations and Removals"
+  name = "Removals"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "deprecation"
+  name = "Deprecations"
   showcontent = true
 
   [[tool.towncrier.type]]

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -479,6 +479,11 @@ class FixtureRequest(FuncargnamesCompatAttr):
             or ``session`` indicating the caching lifecycle of the resource.
         :arg extrakey: added to internal caching key of (funcargname, scope).
         """
+        msg = (
+            "cached_setup is deprecated and will be removed in a future release. "
+            "Use standard fixture functions instead."
+        )
+        warnings.warn(RemovedInPytest4Warning(msg), stacklevel=2)
         if not hasattr(self.config, "_setupcache"):
             self.config._setupcache = {}  # XXX weakref?
         cachekey = (self.fixturename, self._getscopeitem(scope), extrakey)

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -11,6 +11,7 @@ import _pytest._code
 from _pytest.compat import getfslineno
 
 from _pytest.mark.structures import NodeKeywords, MarkInfo
+from _pytest.warning_types import RemovedInPytest4Warning
 
 SEP = "/"
 
@@ -61,11 +62,13 @@ class _CompatProperty(object):
         if obj is None:
             return self
 
-        # TODO: reenable in the features branch
-        # warnings.warn(
-        #     "usage of {owner!r}.{name} is deprecated, please use pytest.{name} instead".format(
-        #         name=self.name, owner=type(owner).__name__),
-        #     PendingDeprecationWarning, stacklevel=2)
+        warnings.warn(
+            "usage of {owner}.{name} is deprecated, please use pytest.{name} instead".format(
+                name=self.name, owner=owner.__name__
+            ),
+            RemovedInPytest4Warning,
+            stacklevel=2,
+        )
         return getattr(__import__("pytest"), self.name)
 
 

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -130,10 +130,13 @@ class Node(object):
             return getattr(__import__("pytest"), name)
         else:
             cls = getattr(self, name)
-            # TODO: reenable in the features branch
-            # warnings.warn("use of node.%s is deprecated, "
-            #    "use pytest_pycollect_makeitem(...) to create custom "
-            #    "collection nodes" % name, category=DeprecationWarning)
+            msg = (
+                'use of special named "%s" objects in collectors of type "%s" to '
+                "customize the created nodes is deprecated. "
+                "Use pytest_pycollect_makeitem(...) to create custom "
+                "collection nodes instead." % (name, type(self).__name__)
+            )
+            self.warn(RemovedInPytest4Warning(msg))
         return cls
 
     def __repr__(self):

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -800,7 +800,7 @@ class Generator(FunctionMixin, PyCollector):
                     "%r generated tests with non-unique name %r" % (self, name)
                 )
             seen[name] = True
-            values.append(self.Function(name, self, args=args, callobj=call))
+            values.append(Function(name, self, args=args, callobj=call))
         self.warn(deprecated.YIELD_TESTS)
         return values
 

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -68,6 +68,36 @@ def test_cached_setup_deprecation(testdir):
     )
 
 
+def test_custom_class_deprecation(testdir):
+    testdir.makeconftest(
+        """
+        import pytest
+
+        class MyModule(pytest.Module):
+
+            class Class(pytest.Class):
+                pass
+
+        def pytest_pycollect_makemodule(path, parent):
+            return MyModule(path, parent)
+    """
+    )
+    testdir.makepyfile(
+        """
+        class Test:
+            def test_foo(self):
+                pass
+    """
+    )
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(
+        [
+            '*test_custom_class_deprecation.py:1:*"Class" objects in collectors of type "MyModule*',
+            "*1 passed, 1 warnings in*",
+        ]
+    )
+
+
 @pytest.mark.filterwarnings("default")
 def test_funcarg_prefix_deprecation(testdir):
     testdir.makepyfile(

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -47,6 +47,27 @@ def test_compat_properties_deprecation(testdir):
     )
 
 
+def test_cached_setup_deprecation(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        @pytest.fixture
+        def fix(request):
+            return request.cached_setup(lambda: 1)
+
+        def test_foo(fix):
+            assert fix == 1
+    """
+    )
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(
+        [
+            "*test_cached_setup_deprecation.py:4:*cached_setup is deprecated*",
+            "*1 passed, 1 warnings in*",
+        ]
+    )
+
+
 @pytest.mark.filterwarnings("default")
 def test_funcarg_prefix_deprecation(testdir):
     testdir.makepyfile(

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -30,6 +30,23 @@ def test_yield_tests_deprecation(testdir):
     assert result.stdout.str().count("yield tests are deprecated") == 2
 
 
+def test_compat_properties_deprecation(testdir):
+    testdir.makepyfile(
+        """
+        def test_foo(request):
+            print(request.node.Module)
+    """
+    )
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(
+        [
+            "*test_compat_properties_deprecation.py:2:*usage of Function.Module is deprecated, "
+            "please use pytest.Module instead*",
+            "*1 passed, 1 warnings in*",
+        ]
+    )
+
+
 @pytest.mark.filterwarnings("default")
 def test_funcarg_prefix_deprecation(testdir):
     testdir.makepyfile(

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -977,6 +977,7 @@ class TestRequestCachedSetup(object):
         )
         reprec.assertoutcome(passed=4)
 
+    @pytest.mark.filterwarnings("ignore:cached_setup is deprecated")
     def test_request_cachedsetup_extrakey(self, testdir):
         item1 = testdir.getitem("def test_func(): pass")
         req1 = fixtures.FixtureRequest(item1)
@@ -994,6 +995,7 @@ class TestRequestCachedSetup(object):
         assert ret1 == ret1b
         assert ret2 == ret2b
 
+    @pytest.mark.filterwarnings("ignore:cached_setup is deprecated")
     def test_request_cachedsetup_cache_deletion(self, testdir):
         item1 = testdir.getitem("def test_func(): pass")
         req1 = fixtures.FixtureRequest(item1)


### PR DESCRIPTION
This issues proper warnings for:

* Compatible properties
* `cached_setup`
* Using special named objects to customize node objects during class creation.

This fixes #3616. It also supports a new type of changelog entry, "deprecations", so we can show `Deprecations` separated from `Removals`.

@RonnyPfannschmidt are other features you remember of that we should issue deprecation warnings? Would love to add to them as well.

Also it follows that we should not merge #3898, as now we have a proper way to turn the warnings into errors in pytest-4.0, to effectively remove them in 4.1. 👍 