### PR TITLE
Fix assertion rewriter crash if cwd changes mid-testing

### DIFF
--- a/changelog/3973.bugfix.rst
+++ b/changelog/3973.bugfix.rst
@@ -1,0 +1,1 @@
+Fix crash of the assertion rewriter if a test changed the current working directory without restoring it afterwards.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -199,7 +199,11 @@ class AssertionRewritingHook(object):
 
         # For matching the name it must be as if it was a filename.
         parts[-1] = parts[-1] + ".py"
-        fn_pypath = py.path.local(os.path.sep.join(parts))
+        try:
+            fn_pypath = py.path.local(os.path.sep.join(parts))
+        except EnvironmentError:
+            return False
+
         for pat in self.fnpats:
             # if the pattern contains subdirectories ("tests/**.py" for example) we can't bail out based
             # on the name alone because we need to match against the full path

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -23,7 +23,7 @@ except ImportError:  # pragma: no cover
     # Only available in Python 3.4+ or as a backport
     enum = None
 
-__all__ = ["Path"]
+__all__ = ["Path", "PurePath"]
 
 _PY3 = sys.version_info > (3, 0)
 _PY2 = not _PY3
@@ -42,9 +42,9 @@ PY36 = sys.version_info[:2] >= (3, 6)
 MODULE_NOT_FOUND_ERROR = "ModuleNotFoundError" if PY36 else "ImportError"
 
 if PY36:
-    from pathlib import Path
+    from pathlib import Path, PurePath
 else:
-    from pathlib2 import Path
+    from pathlib2 import Path, PurePath
 
 
 if _PY3:
@@ -54,6 +54,14 @@ else:
     # those raise DeprecationWarnings in Python >=3.7
     from collections import MutableMapping as MappingMixin  # noqa
     from collections import Mapping, Sequence  # noqa
+
+
+if sys.version_info >= (3, 4):
+    from importlib.util import spec_from_file_location
+else:
+
+    def spec_from_file_location(*_, **__):
+        return None
 
 
 def _format_args(func):

--- a/src/_pytest/paths.py
+++ b/src/_pytest/paths.py
@@ -31,6 +31,10 @@ def fnmatch_ex(pattern, path):
 
     This algorithm was ported to keep backward-compatibility with existing settings which assume paths match according
     this logic.
+    
+    References:
+    * https://bugs.python.org/issue29249
+    * https://bugs.python.org/issue34731
     """
     path = PurePath(path)
     iswin32 = sys.platform.startswith("win")

--- a/src/_pytest/paths.py
+++ b/src/_pytest/paths.py
@@ -31,7 +31,7 @@ def fnmatch_ex(pattern, path):
 
     This algorithm was ported to keep backward-compatibility with existing settings which assume paths match according
     this logic.
-    
+
     References:
     * https://bugs.python.org/issue29249
     * https://bugs.python.org/issue34731

--- a/src/_pytest/paths.py
+++ b/src/_pytest/paths.py
@@ -1,5 +1,11 @@
-from .compat import Path
-from os.path import expanduser, expandvars, isabs
+from os.path import expanduser, expandvars, isabs, sep
+from posixpath import sep as posix_sep
+import fnmatch
+import sys
+
+import six
+
+from .compat import Path, PurePath
 
 
 def resolve_from_str(input, root):
@@ -11,3 +17,32 @@ def resolve_from_str(input, root):
         return Path(input)
     else:
         return root.joinpath(input)
+
+
+def fnmatch_ex(pattern, path):
+    """FNMatcher port from py.path.common which works with PurePath() instances.
+
+    The difference between this algorithm and PurePath.match() is that the latter matches "**" glob expressions
+    for each part of the path, while this algorithm uses the whole path instead.
+
+    For example:
+        "tests/foo/bar/doc/test_foo.py" matches pattern "tests/**/doc/test*.py" with this algorithm, but not with
+        PurePath.match().
+
+    This algorithm was ported to keep backward-compatibility with existing settings which assume paths match according
+    this logic.
+    """
+    path = PurePath(path)
+    iswin32 = sys.platform.startswith("win")
+
+    if iswin32 and sep not in pattern and posix_sep in pattern:
+        # Running on Windows, the pattern has no Windows path separators,
+        # and the pattern has one or more Posix path separators. Replace
+        # the Posix path separators with the Windows path separator.
+        pattern = pattern.replace(posix_sep, sep)
+
+    if sep not in pattern:
+        name = path.name
+    else:
+        name = six.text_type(path)
+    return fnmatch.fnmatch(name, pattern)

--- a/testing/test_paths.py
+++ b/testing/test_paths.py
@@ -1,0 +1,69 @@
+import sys
+
+import py
+
+import pytest
+
+from _pytest.paths import fnmatch_ex
+
+
+class TestPort:
+    """Test that our port of py.common.FNMatcher (fnmatch_ex) produces the same results as the
+    original py.path.local.fnmatch method.
+    """
+
+    @pytest.fixture(params=["pathlib", "py.path"])
+    def match(self, request):
+        if request.param == "py.path":
+
+            def match_(pattern, path):
+                return py.path.local(path).fnmatch(pattern)
+
+        else:
+            assert request.param == "pathlib"
+
+            def match_(pattern, path):
+                return fnmatch_ex(pattern, path)
+
+        return match_
+
+    if sys.platform == "win32":
+        drv1 = "c:"
+        drv2 = "d:"
+    else:
+        drv1 = "/c"
+        drv2 = "/d"
+
+    @pytest.mark.parametrize(
+        "pattern, path",
+        [
+            ("*.py", "foo.py"),
+            ("*.py", "bar/foo.py"),
+            ("test_*.py", "foo/test_foo.py"),
+            ("tests/*.py", "tests/foo.py"),
+            (drv1 + "/*.py", drv1 + "/foo.py"),
+            (drv1 + "/foo/*.py", drv1 + "/foo/foo.py"),
+            ("tests/**/test*.py", "tests/foo/test_foo.py"),
+            ("tests/**/doc/test*.py", "tests/foo/bar/doc/test_foo.py"),
+            ("tests/**/doc/**/test*.py", "tests/foo/doc/bar/test_foo.py"),
+        ],
+    )
+    def test_matching(self, match, pattern, path):
+        assert match(pattern, path)
+
+    @pytest.mark.parametrize(
+        "pattern, path",
+        [
+            ("*.py", "foo.pyc"),
+            ("*.py", "foo/foo.pyc"),
+            ("tests/*.py", "foo/foo.py"),
+            (drv1 + "/*.py", drv2 + "/foo.py"),
+            (drv1 + "/foo/*.py", drv2 + "/foo/foo.py"),
+            ("tests/**/test*.py", "tests/foo.py"),
+            ("tests/**/test*.py", "foo/test_foo.py"),
+            ("tests/**/doc/test*.py", "tests/foo/bar/doc/foo.py"),
+            ("tests/**/doc/test*.py", "tests/foo/bar/test_foo.py"),
+        ],
+    )
+    def test_not_matching(self, match, pattern, path):
+        assert not match(pattern, path)


### PR DESCRIPTION
Unfortunately we need to get a `py.path.local` object to perform the fnmatch
operation, it is different from the standard `fnmatch` module because it
implements its own custom logic. So we need to use `py.path` to perform
the fnmatch for backward compatibility reasons.

Ideally we should be able to use a "pure path" in `pathlib` terms (a path
not bound to the file system), but we don't have those in pylib.

Fix #3973

