### PR TITLE
Add support for logging in collection-phase

### DIFF
--- a/changelog/3964.rst
+++ b/changelog/3964.rst
@@ -1,2 +1,2 @@
-Log messages generated in the collection phase are now shown when
-live-logging is enabled.
+Log messages generated in the collection phase are shown when
+live-logging is enabled and/or when they are logged to a file.

--- a/changelog/3964.rst
+++ b/changelog/3964.rst
@@ -1,0 +1,2 @@
+Log messages generated in the collection phase are now shown when
+live-logging is enabled.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -436,7 +436,7 @@ class LoggingPlugin(object):
 
             if self.log_file_handler is not None:
                 with catching_logs(self.log_file_handler, level=self.log_file_level):
-                    yield  # run all the tests
+                    yield
             else:
                 yield
 

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -908,3 +908,23 @@ def test_live_logging_suspends_capture(has_capture_manager, request):
     else:
         assert MockCaptureManager.calls == []
     assert out_file.getvalue() == "\nsome message\n"
+
+
+def test_collection_live_logging(testdir):
+    testdir.makepyfile(
+        """
+        import logging
+
+        logging.getLogger().info("Normal message")
+    """
+    )
+
+    result = testdir.runpytest("--log-cli-level=INFO")
+    result.stdout.fnmatch_lines(
+        [
+            "collecting*",
+            "*--- live log collection ---*",
+            "*Normal message*",
+            "collected 0 items",
+        ]
+    )


### PR DESCRIPTION
The logging plugin does not output log messages generated during the
collection-phase when live-logging is enabled. This fixes this.
    
Fixes #3964

