### PR TITLE
Fix scope determination with indirect parameters

### DIFF
--- a/changelog/3941.bugfix.rst
+++ b/changelog/3941.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where indirect parametrization would consider the scope of all fixtures used by the test function to determine the parametrization scope, and not only the scope of the fixtures being parametrized.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1141,13 +1141,18 @@ def _find_parametrized_scope(argnames, arg2fixturedefs, indirect):
     """
     from _pytest.fixtures import scopes
 
-    indirect_as_list = isinstance(indirect, (list, tuple))
-    all_arguments_are_fixtures = (
-        indirect is True or indirect_as_list and len(indirect) == argnames
-    )
+    if isinstance(indirect, (list, tuple)):
+        all_arguments_are_fixtures = len(indirect) == len(argnames)
+    else:
+        all_arguments_are_fixtures = bool(indirect)
+
     if all_arguments_are_fixtures:
         fixturedefs = arg2fixturedefs or {}
-        used_scopes = [fixturedef[0].scope for name, fixturedef in fixturedefs.items()]
+        used_scopes = [
+            fixturedef[0].scope
+            for name, fixturedef in fixturedefs.items()
+            if name in argnames
+        ]
         if used_scopes:
             # Takes the most narrow scope from used fixtures
             for scope in reversed(scopes):


### PR DESCRIPTION
Fix #3941
