### PR TITLE
coverage: use modules

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,9 @@
 [run]
-source = _pytest,testing
+source = pytest,_pytest,testing/
 parallel = 1
 branch = 1
+
+[paths]
+source = src/
+  .tox/*/lib/python*/site-packages/
+  .tox\*\Lib\site-packages\

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,11 +94,11 @@ after_success:
   - |
     if [[ "$PYTEST_NO_COVERAGE" != 1 ]]; then
       set -e
-      pip install codecov
+      pip install coverage
       coverage combine
       coverage xml --ignore-errors
       coverage report -m --ignore-errors
-      codecov --required -X gcov pycov search -f coverage.xml --flags ${TOXENV//-/ } linux
+      bash <(curl -s https://codecov.io/bash) -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml -F "${TOXENV//-/,},linux"
 
       # Coveralls does not support merged reports.
       if [[ "$TOXENV" = py37 ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ before_script:
     if [[ "$PYTEST_NO_COVERAGE" != 1 ]]; then
       export COVERAGE_FILE="$PWD/.coverage"
       export COVERAGE_PROCESS_START="$PWD/.coveragerc"
-      export _PYTEST_TOX_COVERAGE_RUN="coverage run --source {envsitepackagesdir}/_pytest/,{toxinidir}/testing -m"
+      export _PYTEST_TOX_COVERAGE_RUN="coverage run -m"
       export _PYTEST_TOX_EXTRA_DEP=coverage-enable-subprocess
     fi
 

--- a/scripts/prepare-coverage.bat
+++ b/scripts/prepare-coverage.bat
@@ -2,7 +2,7 @@ REM scripts called by AppVeyor to setup the environment variables to enable cove
 if not defined PYTEST_NO_COVERAGE (
     set "COVERAGE_FILE=%CD%\.coverage"
     set "COVERAGE_PROCESS_START=%CD%\.coveragerc"
-    set "_PYTEST_TOX_COVERAGE_RUN=coverage run --source {envsitepackagesdir}/_pytest/,{toxinidir}/testing -m"
+    set "_PYTEST_TOX_COVERAGE_RUN=coverage run -m"
     set "_PYTEST_TOX_EXTRA_DEP=coverage-enable-subprocess"
     echo Coverage setup completed
 ) else (

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ envlist =
 [testenv]
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest --lsof -ra {posargs:testing}
+    coverage: coverage combine
+    coverage: coverage report
 passenv = USER USERNAME
 setenv =
     # configuration if a user runs tox with a "coverage" factor, for example "tox -e py36-coverage"

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ envlist =
     docs
 
 [testenv]
-whitelist_externals = env
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest --lsof -ra {posargs:testing}
 passenv = USER USERNAME
@@ -58,7 +57,6 @@ deps =
     nose
     hypothesis>=3.56
     {env:_PYTEST_TOX_EXTRA_DEP:}
-whitelist_externals = env
 passenv = USER USERNAME TRAVIS
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n auto -ra {posargs:testing}
@@ -79,7 +77,6 @@ platform = linux|darwin
 deps =
     pexpect
     {env:_PYTEST_TOX_EXTRA_DEP:}
-whitelist_externals = env
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -ra test_pdb.py test_terminal.py test_unittest.py
 
@@ -100,7 +97,6 @@ changedir=testing
 setenv =
     {[testenv]setenv}
     PYTHONDONTWRITEBYTECODE=1
-whitelist_externals = env
 passenv = USER USERNAME TRAVIS
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n auto -ra {posargs:.}
@@ -109,7 +105,6 @@ commands =
 deps =
     twisted
     {env:_PYTEST_TOX_EXTRA_DEP:}
-whitelist_externals = env
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -ra {posargs:testing/test_unittest.py}
 
@@ -121,7 +116,6 @@ commands = {[testenv:py27-trial]commands}
 deps =
     numpy
     {env:_PYTEST_TOX_EXTRA_DEP:}
-whitelist_externals = env
 commands=
   {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -ra {posargs:testing/python/approx.py}
 
@@ -157,7 +151,6 @@ skipsdist = True
 deps =
     PyYAML
     {env:_PYTEST_TOX_EXTRA_DEP:}
-whitelist_externals = env
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -ra doc/en
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest --doctest-modules --pyargs _pytest


### PR DESCRIPTION
This should increase coverage for subprocesses, where `source` is used
only from the config file, but not the initial `--source` argument.