### PR TITLE
logging: del item.catch_log_handler only in teardown

### DIFF
--- a/changelog/3998.bugfix.rst
+++ b/changelog/3998.bugfix.rst
@@ -1,0 +1,1 @@
+Fix caplog's catch_log_handler not being available with --pdb

--- a/changelog/3998.bugfix.rst
+++ b/changelog/3998.bugfix.rst
@@ -1,1 +1,1 @@
-Fix caplog's catch_log_handler not being available with --pdb
+Fix issue that prevented some caplog properties (for example ``record_tuples``) from being available when entering the debugger with ``--pdb``.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -445,8 +445,8 @@ class LoggingPlugin(object):
             try:
                 yield  # run test
             finally:
-                del item.catch_log_handler
                 if when == "teardown":
+                    del item.catch_log_handler
                     del item.catch_log_handlers
 
             if self.print_logs:

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -397,6 +397,24 @@ class TestPDB(object):
         child.read()
         self.flush(child)
 
+    def test_pdb_with_caplog_on_pdb_invocation(self, testdir):
+        p1 = testdir.makepyfile(
+            """
+            def test_1(capsys, caplog):
+                import logging
+                logging.getLogger(__name__).warning("some_warning")
+                assert 0
+        """
+        )
+        child = testdir.spawn_pytest("--pdb %s" % str(p1))
+        child.send("caplog.record_tuples\n")
+        child.expect_exact(
+            "[('test_pdb_with_caplog_on_pdb_invocation', 30, 'some_warning')]"
+        )
+        child.sendeof()
+        child.read()
+        self.flush(child)
+
     def test_set_trace_capturing_afterwards(self, testdir):
         p1 = testdir.makepyfile(
             """


### PR DESCRIPTION
Without this caplog.record_tuples etc is not available when using
`--pdb`.

Maybe related to https://github.com/pytest-dev/pytest/issues/3099.