### PR TITLE
Fix typo in docstring

### DIFF
--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -219,8 +219,8 @@ class MonkeyPatch(object):
         self.setitem(os.environ, name, value)
 
     def delenv(self, name, raising=True):
-        """ Delete ``name`` from the environment. Raise KeyError it does not
-        exist.
+        """ Delete ``name`` from the environment. Raise KeyError if it does
+        not exist.
 
         If ``raising`` is set to False, no exception will be raised if the
         environment variable is missing.


### PR DESCRIPTION
Trivial typo fix in docstring.

Many thanks for everyone's awesome work on `pytest`! I use it every day and could not imagine what my workflow would be without it. Your work is hugely appreciated!