### PR TITLE
Fix #3539: reload module with assertion rewrite import hook

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -93,6 +93,7 @@ Hui Wang (coldnight)
 Ian Bicking
 Ian Lesperance
 Ionuț Turturică
+Iwan Briquemont
 Jaap Broekhuizen
 Jan Balster
 Janne Vanhala

--- a/changelog/3539.bugfix.rst
+++ b/changelog/3539.bugfix.rst
@@ -1,0 +1,1 @@
+Fix reload on assertion rewritten modules.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -269,17 +269,17 @@ class AssertionRewritingHook(object):
         )
 
     def load_module(self, name):
-        # If there is an existing module object named 'fullname' in
-        # sys.modules, the loader must use that existing module. (Otherwise,
-        # the reload() builtin will not work correctly.)
-        if name in sys.modules:
-            return sys.modules[name]
-
         co, pyc = self.modules.pop(name)
-        # I wish I could just call imp.load_compiled here, but __file__ has to
-        # be set properly. In Python 3.2+, this all would be handled correctly
-        # by load_compiled.
-        mod = sys.modules[name] = imp.new_module(name)
+        if name in sys.modules:
+            # If there is an existing module object named 'fullname' in
+            # sys.modules, the loader must use that existing module. (Otherwise,
+            # the reload() builtin will not work correctly.)
+            mod = sys.modules[name]
+        else:
+            # I wish I could just call imp.load_compiled here, but __file__ has to
+            # be set properly. In Python 3.2+, this all would be handled correctly
+            # by load_compiled.
+            mod = sys.modules[name] = imp.new_module(name)
         try:
             mod.__file__ = co.co_filename
             # Normally, this attribute is 3.2+.


### PR DESCRIPTION
The current reload hook did not reload code of already imported modules.
See https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module

Fix #3539