### PR TITLE
Revert patching of breakpointhook as it appears to do nothing

### DIFF
--- a/changelog/4028.trivial.rst
+++ b/changelog/4028.trivial.rst
@@ -1,0 +1,1 @@
+Revert patching of ``sys.breakpointhook`` since it appears to do nothing.

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -2,17 +2,9 @@
 from __future__ import absolute_import, division, print_function
 import pdb
 import sys
-import os
 from doctest import UnexpectedException
 
 from _pytest.config import hookimpl
-
-try:
-    from builtins import breakpoint  # noqa
-
-    SUPPORTS_BREAKPOINT_BUILTIN = True
-except ImportError:
-    SUPPORTS_BREAKPOINT_BUILTIN = False
 
 
 def pytest_addoption(parser):
@@ -51,20 +43,12 @@ def pytest_configure(config):
     if config.getvalue("usepdb"):
         config.pluginmanager.register(PdbInvoke(), "pdbinvoke")
 
-    # Use custom Pdb class set_trace instead of default Pdb on breakpoint() call
-    if SUPPORTS_BREAKPOINT_BUILTIN:
-        _environ_pythonbreakpoint = os.environ.get("PYTHONBREAKPOINT", "")
-        if _environ_pythonbreakpoint == "":
-            sys.breakpointhook = pytestPDB.set_trace
-
     old = (pdb.set_trace, pytestPDB._pluginmanager)
 
     def fin():
         pdb.set_trace, pytestPDB._pluginmanager = old
         pytestPDB._config = None
         pytestPDB._pdb_cls = pdb.Pdb
-        if SUPPORTS_BREAKPOINT_BUILTIN:
-            sys.breakpointhook = sys.__breakpointhook__
 
     pdb.set_trace = pytestPDB.set_trace
     pytestPDB._pluginmanager = config.pluginmanager

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -4,8 +4,14 @@ import platform
 import os
 
 import _pytest._code
-from _pytest.debugging import SUPPORTS_BREAKPOINT_BUILTIN
 import pytest
+
+try:
+    breakpoint
+except NameError:
+    SUPPORTS_BREAKPOINT_BUILTIN = False
+else:
+    SUPPORTS_BREAKPOINT_BUILTIN = True
 
 
 _ENVIRON_PYTHONBREAKPOINT = os.environ.get("PYTHONBREAKPOINT", "")


### PR DESCRIPTION
Resolves #4027

I noticed this code while working on [future-breakpoint](https://github.com/asottile/breakpoint).

Here's the tests with that installed under python2.7:

```
=========================== short test summary info ============================
FAIL testing/test_pdb.py::TestDebuggingBreakpoints::()::test_supports_breakpoint_module_global
===================== 1 failed, 41 passed in 17.26 seconds =====================
```