### PR TITLE
Exclude empty reports for passed tests

### DIFF
--- a/changelog/4040.trivial.rst
+++ b/changelog/4040.trivial.rst
@@ -1,0 +1,1 @@
+Exclude empty reports for passed tests when ``-rP`` option is used.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -745,9 +745,10 @@ class TerminalReporter(object):
                     return
                 self.write_sep("=", "PASSES")
                 for rep in reports:
-                    msg = self._getfailureheadline(rep)
-                    self.write_sep("_", msg)
-                    self._outrep_summary(rep)
+                    if rep.sections:
+                        msg = self._getfailureheadline(rep)
+                        self.write_sep("_", msg)
+                        self._outrep_summary(rep)
 
     def print_teardown_sections(self, rep):
         showcapture = self.config.option.showcapture

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -681,14 +681,22 @@ def test_pass_reporting_on_fail(testdir):
 def test_pass_output_reporting(testdir):
     testdir.makepyfile(
         """
-        def test_pass_output():
+        def test_pass_has_output():
             print("Four score and seven years ago...")
+        def test_pass_no_output():
+            pass
     """
     )
     result = testdir.runpytest()
-    assert "Four score and seven years ago..." not in result.stdout.str()
+    s = result.stdout.str()
+    assert "test_pass_has_output" not in s
+    assert "Four score and seven years ago..." not in s
+    assert "test_pass_no_output" not in s
     result = testdir.runpytest("-rP")
-    result.stdout.fnmatch_lines(["Four score and seven years ago..."])
+    result.stdout.fnmatch_lines(
+        ["*test_pass_has_output*", "Four score and seven years ago..."]
+    )
+    assert "test_pass_no_output" not in result.stdout.str()
 
 
 def test_color_yes(testdir):


### PR DESCRIPTION
A check is added to avoid empty reports with headline only when `-r P` option is used.