### PR TITLE
Do not issue non-top-level conftest warning when --pyargs is used

### DIFF
--- a/changelog/4039.bugfix.rst
+++ b/changelog/4039.bugfix.rst
@@ -1,0 +1,2 @@
+No longer issue warnings about using ``pytest_plugins`` in non-top-level directories when using ``--pyargs``: the
+current ``--pyargs`` mechanism is not reliable and might give false negatives.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -351,6 +351,7 @@ class PytestPluginManager(PluginManager):
             else None
         )
         self._noconftest = namespace.noconftest
+        self._using_pyargs = namespace.pyargs
         testpaths = namespace.file_or_dir
         foundanchor = False
         for path in testpaths:
@@ -416,7 +417,11 @@ class PytestPluginManager(PluginManager):
                 _ensure_removed_sysmodule(conftestpath.purebasename)
             try:
                 mod = conftestpath.pyimport()
-                if hasattr(mod, "pytest_plugins") and self._configured:
+                if (
+                    hasattr(mod, "pytest_plugins")
+                    and self._configured
+                    and not self._using_pyargs
+                ):
                     from _pytest.deprecated import (
                         PYTEST_PLUGINS_FROM_NON_TOP_LEVEL_CONFTEST
                     )

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -178,21 +178,12 @@ def test_pytest_catchlog_deprecated(testdir, plugin):
 def test_pytest_plugins_in_non_top_level_conftest_deprecated(testdir):
     from _pytest.deprecated import PYTEST_PLUGINS_FROM_NON_TOP_LEVEL_CONFTEST
 
-    subdirectory = testdir.tmpdir.join("subdirectory")
-    subdirectory.mkdir()
-    # create the inner conftest with makeconftest and then move it to the subdirectory
-    testdir.makeconftest(
-        """
+    testdir.makepyfile(
+        **{
+            "subdirectory/conftest.py": """
         pytest_plugins=['capture']
     """
-    )
-    testdir.tmpdir.join("conftest.py").move(subdirectory.join("conftest.py"))
-    # make the top level conftest
-    testdir.makeconftest(
-        """
-        import warnings
-        warnings.filterwarnings('always', category=DeprecationWarning)
-    """
+        }
     )
     testdir.makepyfile(
         """

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -191,7 +191,7 @@ def test_pytest_plugins_in_non_top_level_conftest_deprecated(testdir):
             pass
     """
     )
-    res = testdir.runpytest_subprocess()
+    res = testdir.runpytest()
     assert res.ret == 0
     msg = str(PYTEST_PLUGINS_FROM_NON_TOP_LEVEL_CONFTEST).splitlines()[0]
     res.stdout.fnmatch_lines(
@@ -199,6 +199,34 @@ def test_pytest_plugins_in_non_top_level_conftest_deprecated(testdir):
             sep=os.sep, msg=msg
         )
     )
+
+
+@pytest.mark.parametrize("use_pyargs", [True, False])
+def test_pytest_plugins_in_non_top_level_conftest_deprecated_pyargs(
+    testdir, use_pyargs
+):
+    """When using --pyargs, do not emit the warning about non-top-level conftest warnings (#4039, #4044)"""
+    from _pytest.deprecated import PYTEST_PLUGINS_FROM_NON_TOP_LEVEL_CONFTEST
+
+    files = {
+        "src/pkg/__init__.py": "",
+        "src/pkg/conftest.py": "",
+        "src/pkg/test_root.py": "def test(): pass",
+        "src/pkg/sub/__init__.py": "",
+        "src/pkg/sub/conftest.py": "pytest_plugins=['capture']",
+        "src/pkg/sub/test_bar.py": "def test(): pass",
+    }
+    testdir.makepyfile(**files)
+    testdir.syspathinsert(testdir.tmpdir.join("src"))
+
+    args = ("--pyargs", "pkg") if use_pyargs else ()
+    res = testdir.runpytest(*args)
+    assert res.ret == 0
+    msg = str(PYTEST_PLUGINS_FROM_NON_TOP_LEVEL_CONFTEST).splitlines()[0]
+    if use_pyargs:
+        assert msg not in res.stdout.str()
+    else:
+        res.stdout.fnmatch_lines("*{msg}*".format(msg=msg))
 
 
 def test_pytest_plugins_in_non_top_level_conftest_deprecated_no_top_level_conftest(

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -30,6 +30,7 @@ def conftest_setinitial(conftest, args, confcutdir=None):
             self.file_or_dir = args
             self.confcutdir = str(confcutdir)
             self.noconftest = False
+            self.pyargs = False
 
     conftest._set_initial_conftests(Namespace())
 


### PR DESCRIPTION
Fix #4039