### PR TITLE
Add pytest_before_assert hook.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -200,6 +200,7 @@ Raphael Pierzina
 Raquel Alegre
 Ravi Chandra
 Roberto Polli
+Robert Schweizer
 Roland Puntaier
 Romain Dorgueil
 Roman Bolshakov

--- a/changelog/4047.feature.rst
+++ b/changelog/4047.feature.rst
@@ -1,0 +1,1 @@
+Add pytest_before_assert hook to run before any assertion.

--- a/doc/en/assert.rst
+++ b/doc/en/assert.rst
@@ -252,6 +252,33 @@ the conftest file:
 .. _assert-details:
 .. _`assert introspection`:
 
+Collecting information about passing assertions
+-----------------------------------------------
+
+The ``pytest_assertrepr_compare`` hook only runs for failing assertions. Information
+about passing assertions can be collected with the ``pytest_before_assert`` hook.
+
+.. autofunction:: _pytest.hookspec.pytest_before_assert
+   :noindex:
+
+For example, to report every encountered assertion, the following hook
+needs to be added to :ref:`conftest.py <conftest.py>`::
+
+    # content of conftest.py
+    def pytest_before_assert():
+        print("Before-assert hook is executed.")
+
+now, given this test module::
+
+    # content of test_sample.py
+    def test_answer():
+        assert 1 == 1
+
+the following stdout is captured, e.g. in an HTML report::
+
+    ----------------------------- Captured stdout call -----------------------------
+    Before-assert hook is executed.
+
 Assertion introspection details
 -------------------------------
 

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -651,9 +651,10 @@ test execution:
 
 .. autofunction:: pytest_runtest_logreport
 
-You can also use this hook to customize assertion representation for some
-types:
+You can also use these hooks to output assertion information or customize
+assertion representation for some types:
 
+.. autofunction:: pytest_before_assert
 .. autofunction:: pytest_assertrepr_compare
 
 

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -102,12 +102,14 @@ def pytest_collection(session):
 
 
 def pytest_runtest_setup(item):
-    """Setup the pytest_assertrepr_compare hook
+    """Setup the pytest_assertrepr_compare and pytest_before_assert hooks.
 
-    The newinterpret and rewrite modules will use util._reprcompare if
-    it exists to use custom reporting via the
-    pytest_assertrepr_compare hook.  This sets up this custom
-    comparison for the test.
+    The rewrite module will use util._reprcompare and util._before_assert
+    if they exist to enable custom reporting. Comparison representation is
+    customized via the pytest_assertrepr_compare hook. Before every assert,
+    the pytest_before_assert hook is run.
+
+    This sets up the custom assert hooks for the test.
     """
 
     def callbinrepr(op, left, right):
@@ -137,11 +139,16 @@ def pytest_runtest_setup(item):
                     res = res.replace("%", "%%")
                 return res
 
+    def call_before_assert():
+        item.ihook.pytest_before_assert(config=item.config)
+
     util._reprcompare = callbinrepr
+    util._before_assert = call_before_assert
 
 
 def pytest_runtest_teardown(item):
     util._reprcompare = None
+    util._before_assert = None
 
 
 def pytest_sessionfinish(session):

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -545,6 +545,11 @@ def _call_reprcompare(ops, results, expls, each_obj):
     return expl
 
 
+def _call_before_assert():
+    if util._before_assert is not None:
+        util._before_assert()
+
+
 unary_map = {ast.Not: "not %s", ast.Invert: "~%s", ast.USub: "-%s", ast.UAdd: "+%s"}
 
 binop_map = {
@@ -833,6 +838,8 @@ class AssertionRewriter(ast.NodeVisitor):
         self.stack = []
         self.on_failure = []
         self.push_format_context()
+        # Run before assert hook.
+        self.statements.append(ast.Expr(self.helper("call_before_assert")))
         # Rewrite assert into a bunch of statements.
         top_condition, explanation = self.visit(assert_.test)
         # If in a test module, check if directly asserting None, in order to warn [Issue #3191]

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -16,6 +16,7 @@ from _pytest._io.saferepr import saferepr
 # loaded and in turn call the hooks defined here as part of the
 # DebugInterpreter.
 _reprcompare = None
+_before_assert = None
 
 
 # the re-encoding is needed for python2 repr

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -446,6 +446,13 @@ def pytest_assertrepr_compare(config, op, left, right):
     """
 
 
+def pytest_before_assert(config):
+    """ called before every assertion is evaluated.
+
+    :param _pytest.config.Config config: pytest config object
+    """
+
+
 # -------------------------------------------------------------------------
 # hooks for influencing reporting (invoked from _pytest_terminal)
 # -------------------------------------------------------------------------


### PR DESCRIPTION
This hook will run before every assert, in contrast to the
pytest_assertrepr_compare hook which only runs for failing asserts.

As of now, no parameters are passed to the hook.

We use this hook to print the assertion code of passed assertions to
collect test evidence. This is done using inspect::

    inspect.stack()[7].code_context[0].strip()

Signed-off-by: Schweizer, Robert <rschweizer@definiens.com>

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs (you can delete this text from the final description, this is
just a guideline):

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](/changelog/README.rst) for details.
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [x] Target the `features` branch for new features and removals/deprecations.
- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS` in alphabetical order;
