### PR TITLE
Fix for bug #4038 to the teardown_exact method

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Anatoly Bubenkoff
 Anders Hovmöller
 Andras Tim
 Andreas Zeidler
+Andrew Robbins
 Andrzej Ostrowski
 Andy Freeland
 Anthon van der Neut

--- a/changelog/4038.bugfix.rst
+++ b/changelog/4038.bugfix.rst
@@ -1,0 +1,5 @@
+Changes teardown behavior for parameterized fixtures as follows:
+
+1. Teardown code will be called from within the pytest_runtest_teardown hook.
+2. If a fixture is parameterized and the next item requires the next index, all lower scoped fixtures are torn down.
+3. If a fixture of equal scope needs to be torn down and the next item requires the next index, all fixtures that were setup after the fixture are torn down, but not fixtures of equal scope that were set up earlier.

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -335,9 +335,44 @@ class SetupState(object):
             self._teardown_with_finalization(key)
         assert not self._finalizers
 
+    def _callfinalizer(self,colitem,finalizer_index):
+        exc = None
+        fin = self._finalizers[colitem].pop(finalizer_index)
+        try:
+            fin()
+        except TEST_OUTCOM:
+            if exc is None:
+                exc = sys.exc_info()
+        if exc:
+            six.reaise(*exc)
+
+    def _teardown_to_finalizer(self,colitem_index,finalizer_index):
+        colitem = self.stack[colitem_index]
+        finalizer = self._finalizers[colitem][finalizer_index]
+        while self.stack[colitem_index+1:] != []:
+            self._pop_and_teardown()
+        while finalizer in self._finalizers[colitem]:
+            self._callfinalizer(colitem,finalizer_index)
+        if len(self._finalizers[colitem]) == 0:
+            self._teardown_with_finalization(colitem)
+
     def teardown_exact(self, item, nextitem):
-        needed_collectors = nextitem and nextitem.listchain() or []
-        self._teardown_towards(needed_collectors)
+        for colitem_index in range(len(item.listchain())-1,-1,-1):
+            colitem = item.listchain()[colitem_index]
+            if nextitem is None:
+                self.teardown_all()
+                break
+            elif colitem not in nextitem.listchain():
+                while colitem in self.stack:
+                    self._pop_and_teardown()
+            elif colitem in self._finalizers.keys():
+                for finalizer_index in range(len(self._finalizers[colitem])-1,-1,-1):
+                    finalizer = self._finalizers[colitem][finalizer_index]
+                    finalizer_fix_name = finalizer.keywords['request'].fixturename
+                    if finalizer_fix_name not in nextitem.fixturenames:
+                        self._teardown_to_finalizer(colitem_index,finalizer_index)
+                    elif finalizer_fix_name in nextitem.fixturenames and item.callspec.indices[finalizer_fix_name] != nextitem.callspec.indices[finalizer_fix_name]:
+                        self._teardown_to_finalizer(colitem_index,finalizer_index)
 
     def _teardown_towards(self, needed_collectors):
         exc = None


### PR DESCRIPTION
Changes the teardown behavior so that teardown code is called from within the pytest_runtest_teardown hook rather than from within the pytest_runtest_setup hook when a fixture of scope higher than function has been parameterized.

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](/changelog/README.rst) for details.
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [x] Add yourself to `AUTHORS` in alphabetical order;