### PR TITLE
Fix for bug #4038 to the teardown_exact method attempt 2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Anatoly Bubenkoff
 Anders Hovmöller
 Andras Tim
 Andreas Zeidler
+Andrew Robbins
 Andrzej Ostrowski
 Andy Freeland
 Anthon van der Neut

--- a/changelog/4038.bugfix.rst
+++ b/changelog/4038.bugfix.rst
@@ -1,0 +1,5 @@
+Changes teardown behavior for parameterized fixtures as follows:
+
+1. Teardown code will be called from within the pytest_runtest_teardown hook.
+2. If a fixture is parameterized and the next item requires the next index, all lower scoped fixtures are torn down.
+3. If a fixture of equal scope needs to be torn down and the next item requires the next index, all fixtures that were setup after the fixture are torn down, but not fixtures of equal scope that were set up earlier.

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -371,8 +371,13 @@ class SetupState(object):
                     finalizer_fix_name = finalizer.keywords['request'].fixturename
                     if finalizer_fix_name not in nextitem.fixturenames:
                         self._teardown_to_finalizer(colitem_index,finalizer_index)
-                    elif finalizer_fix_name in nextitem.fixturenames and item.callspec.indices[finalizer_fix_name] != nextitem.callspec.indices[finalizer_fix_name]:
-                        self._teardown_to_finalizer(colitem_index,finalizer_index)
+                    elif finalizer_fix_name in nextitem.fixturenames:
+                        if not hasattr(item,'callspec') and not hasattr(item,'callspec'):
+                            pass
+                        if ( hasattr(item,'callspec') and not hasattr(item,'callspec') ) or \
+                           ( not hasattr(item,'callspec') and hasattr(item,'callspec') ) or \
+                           ( item.callspec.indices[finalizer_fix_name] != nextitem.callspec.indices[finalizer_fix_name] ):
+                            self._teardown_to_finalizer(colitem_index,finalizer_index)
 
     def _teardown_towards(self, needed_collectors):
         exc = None


### PR DESCRIPTION
Changes the teardown behavior so that teardown code is called from within the pytest_runtest_teardown hook rather than from within the pytest_runtest_setup hook when a fixture of scope higher than function has been parameterized.

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](/changelog/README.rst) for details.
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [x] Add yourself to `AUTHORS` in alphabetical order;