### PR TITLE
Ensure Monkeypatch setenv and delenv use bytes keys in Python 2

### DIFF
--- a/changelog/4056.bugfix.rst
+++ b/changelog/4056.bugfix.rst
@@ -1,0 +1,4 @@
+``MonkeyPatch.setenv`` and ``MonkeyPatch.delenv`` issue a warning if the environment variable name is not ``str`` on Python 2.
+
+In Python 2, adding ``unicode`` keys to ``os.environ`` causes problems with ``subprocess`` (and possible other modules),
+making this a subtle bug specially susceptible when used with ``from __future__ import unicode_literals``.

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -225,7 +225,15 @@ class MonkeyPatch(object):
         """ Set environment variable ``name`` to ``value``.  If ``prepend``
         is a character, read the current environment variable value
         and prepend the ``value`` adjoined with the ``prepend`` character."""
-        value = str(value)
+        if not isinstance(value, str):
+            warnings.warn(
+                pytest.PytestWarning(
+                    "Environment variable value {!r} should be str, converted to str implicitly".format(
+                        value
+                    )
+                )
+            )
+            value = str(value)
         if prepend and name in os.environ:
             value = value + prepend + os.environ[name]
         self._warn_if_env_name_is_not_str(name)

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -212,6 +212,8 @@ class WarningsChecker(WarningsRecorder):
     def __exit__(self, *exc_info):
         super(WarningsChecker, self).__exit__(*exc_info)
 
+        __tracebackhide__ = True
+
         # only check if we're not currently handling an exception
         if all(a is None for a in exc_info):
             if self.expected_warning is not None:

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -577,7 +577,7 @@ class TestInvocationVariants(object):
             return what
 
         empty_package = testdir.mkpydir("empty_package")
-        monkeypatch.setenv("PYTHONPATH", join_pythonpath(empty_package))
+        monkeypatch.setenv("PYTHONPATH", str(join_pythonpath(empty_package)))
         # the path which is not a package raises a warning on pypy;
         # no idea why only pypy and not normal python warn about it here
         with warnings.catch_warnings():
@@ -586,7 +586,7 @@ class TestInvocationVariants(object):
         assert result.ret == 0
         result.stdout.fnmatch_lines(["*2 passed*"])
 
-        monkeypatch.setenv("PYTHONPATH", join_pythonpath(testdir))
+        monkeypatch.setenv("PYTHONPATH", str(join_pythonpath(testdir)))
         result = testdir.runpytest("--pyargs", "tpkg.test_missing", syspathinsert=True)
         assert result.ret != 0
         result.stderr.fnmatch_lines(["*not*found*test_missing*"])

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -129,7 +129,7 @@ def test_source_strip_multiline():
 def test_syntaxerror_rerepresentation():
     ex = pytest.raises(SyntaxError, _pytest._code.compile, "xyz xyz")
     assert ex.value.lineno == 1
-    assert ex.value.offset in (4, 7)  # XXX pypy/jython versus cpython?
+    assert ex.value.offset in (4, 5, 7)  # XXX pypy/jython versus cpython?
     assert ex.value.text.strip(), "x x"
 
 

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -215,7 +215,7 @@ def test_cache_show(testdir):
 
 class TestLastFailed(object):
     def test_lastfailed_usecase(self, testdir, monkeypatch):
-        monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", 1)
+        monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", "1")
         p = testdir.makepyfile(
             """
             def test_1():
@@ -301,7 +301,7 @@ class TestLastFailed(object):
         assert "test_a.py" not in result.stdout.str()
 
     def test_lastfailed_difference_invocations(self, testdir, monkeypatch):
-        monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", 1)
+        monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", "1")
         testdir.makepyfile(
             test_a="""\
             def test_a1():
@@ -335,7 +335,7 @@ class TestLastFailed(object):
         result.stdout.fnmatch_lines(["*1 failed*1 desel*"])
 
     def test_lastfailed_usecase_splice(self, testdir, monkeypatch):
-        monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", 1)
+        monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", "1")
         testdir.makepyfile(
             """\
             def test_1():
@@ -474,8 +474,8 @@ class TestLastFailed(object):
         )
 
         def rlf(fail_import, fail_run):
-            monkeypatch.setenv("FAILIMPORT", fail_import)
-            monkeypatch.setenv("FAILTEST", fail_run)
+            monkeypatch.setenv("FAILIMPORT", str(fail_import))
+            monkeypatch.setenv("FAILTEST", str(fail_run))
 
             testdir.runpytest("-q")
             config = testdir.parseconfigure()
@@ -519,8 +519,8 @@ class TestLastFailed(object):
         )
 
         def rlf(fail_import, fail_run, args=()):
-            monkeypatch.setenv("FAILIMPORT", fail_import)
-            monkeypatch.setenv("FAILTEST", fail_run)
+            monkeypatch.setenv("FAILIMPORT", str(fail_import))
+            monkeypatch.setenv("FAILTEST", str(fail_run))
 
             result = testdir.runpytest("-q", "--lf", *args)
             config = testdir.parseconfigure()

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -850,7 +850,7 @@ def test_logxml_path_expansion(tmpdir, monkeypatch):
     assert xml_tilde.logfile == home_tilde
 
     # this is here for when $HOME is not set correct
-    monkeypatch.setenv("HOME", tmpdir)
+    monkeypatch.setenv("HOME", str(tmpdir))
     home_var = os.path.normpath(os.path.expandvars("$HOME/test.xml"))
 
     xml_var = LogXML("$HOME%stest.xml" % tmpdir.sep, None)


### PR DESCRIPTION
Fixes the bug described in https://github.com/tox-dev/tox/pull/1025#discussion_r221273830, which is more evident when using `unicode_literals`.

cc @gaborbernat