### PR TITLE
Update documentation to indicate a fixture can be invoked more than once in it's scope.

### DIFF
--- a/changelog/4058.doc.rst
+++ b/changelog/4058.doc.rst
@@ -1,0 +1,1 @@
+Update fixture documentation to specify that a fixture can be invoked twice in the scope it's defined for.

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -259,6 +259,11 @@ instance, you can simply declare it:
 
 Finally, the ``class`` scope will invoke the fixture once per test *class*.
 
+.. note::
+
+    Pytest will only cache one instance of a fixture at a time.
+    This means that when using a parametrized fixture, it may need to be invoked more than once in the scope it's defined for.
+
 
 ``package`` scope (experimental)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -262,7 +262,7 @@ Finally, the ``class`` scope will invoke the fixture once per test *class*.
 .. note::
 
     Pytest will only cache one instance of a fixture at a time.
-    This means that when using a parametrized fixture, it may need to be invoked more than once in the scope it's defined for.
+    This means that when using a parametrized fixture, pytest may invoke a fixture more than once in the given scope.
 
 
 ``package`` scope (experimental)


### PR DESCRIPTION
Closes #4058 by updating the documentation to reference that a scope can be invoked more than once in the scope it's defined for.
