### PR TITLE
Fixes #4064 by correcting the documentation for unit-tests

### DIFF
--- a/changelog/4064.doc.rst
+++ b/changelog/4064.doc.rst
@@ -1,0 +1,1 @@
+According to unittest.rst, setUpModule and tearDownModule were not implemented, but it turns out they are. So updated the documentation for unittest.

--- a/doc/en/unittest.rst
+++ b/doc/en/unittest.rst
@@ -22,16 +22,15 @@ Almost all ``unittest`` features are supported:
 
 * ``@unittest.skip`` style decorators;
 * ``setUp/tearDown``;
-* ``setUpClass/tearDownClass()``;
+* ``setUpClass/tearDownClass``;
+* ``setUpModule/tearDownModule``;
 
 .. _`load_tests protocol`: https://docs.python.org/3/library/unittest.html#load-tests-protocol
-.. _`setUpModule/tearDownModule`: https://docs.python.org/3/library/unittest.html#setupmodule-and-teardownmodule
 .. _`subtests`: https://docs.python.org/3/library/unittest.html#distinguishing-test-iterations-using-subtests
 
 Up to this point pytest does not have support for the following features:
 
 * `load_tests protocol`_;
-* `setUpModule/tearDownModule`_;
 * `subtests`_;
 
 Benefits out of the box


### PR DESCRIPTION
Updated `unittest.rst` with the correct documentation.
