### PR TITLE
UnicodeEncodeError on source files containing non-ascii characters

### DIFF
--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -337,7 +337,7 @@ def get_statement_startend2(lineno, node):
 
 def getstatementrange_ast(lineno, source, assertion=False, astnode=None):
     if astnode is None:
-        content = str(source)
+        content = unicode(source)
         astnode = compile(content, "source", "exec", 1024)  # 1024 for AST
 
     start, end = get_statement_startend2(lineno, astnode)

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -337,7 +337,10 @@ def get_statement_startend2(lineno, node):
 
 def getstatementrange_ast(lineno, source, assertion=False, astnode=None):
     if astnode is None:
-        content = unicode(source)
+        if six.PY2:
+            content = unicode(source)
+        else:
+            content = str(source)
         astnode = compile(content, "source", "exec", 1024)  # 1024 for AST
 
     start, end = get_statement_startend2(lineno, astnode)


### PR DESCRIPTION
This PR fixes an issue I had when running tests that:
1) Fail, and
2) Contain non-ascii characters (e.g. accented characters)

Here's an example of such a test (`test_bug.py`):
```
# coding=utf-8
def test__bug():
    a = 'é'
    assert False
```

Running this test outputs the following:
```shell
test_env ❯ pytest tests/test_bug.py
===================================================================================================================================================================== test session starts ======================================================================================================================================================================
platform darwin -- Python 2.7.14, pytest-3.8.2, py-1.5.2, pluggy-0.7.1
Django settings: settings.test (from ini file)
rootdir: /Users/spgingras/test_sample, inifile: pytest.ini
plugins: teamcity-messages-1.21, xdist-1.23.0, random-0.2, mock-1.10.0, forked-0.2, env-0.6.2, django-3.4.2, cov-2.5.1, pyfakefs-3.4.3, celery-4.1.1
collected 1 item                                                                                                                                                                                                                                                                                                                                               

tests/test_bug.py 
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/main.py", line 178, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/main.py", line 215, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/hooks.py", line 258, in __call__
INTERNALERROR>     return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/manager.py", line 67, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/manager.py", line 61, in <lambda>
INTERNALERROR>     firstresult=hook.spec_opts.get('firstresult'),
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/callers.py", line 201, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/callers.py", line 77, in get_result
INTERNALERROR>     _reraise(*ex)  # noqa
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/callers.py", line 180, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/main.py", line 236, in pytest_runtestloop
INTERNALERROR>     item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/hooks.py", line 258, in __call__
INTERNALERROR>     return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/manager.py", line 67, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/manager.py", line 61, in <lambda>
INTERNALERROR>     firstresult=hook.spec_opts.get('firstresult'),
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/callers.py", line 201, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/callers.py", line 77, in get_result
INTERNALERROR>     _reraise(*ex)  # noqa
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/callers.py", line 180, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/runner.py", line 66, in pytest_runtest_protocol
INTERNALERROR>     runtestprotocol(item, nextitem=nextitem)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/runner.py", line 81, in runtestprotocol
INTERNALERROR>     reports.append(call_and_report(item, "call", log))
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/runner.py", line 163, in call_and_report
INTERNALERROR>     report = hook.pytest_runtest_makereport(item=item, call=call)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/hooks.py", line 258, in __call__
INTERNALERROR>     return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/manager.py", line 67, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/manager.py", line 61, in <lambda>
INTERNALERROR>     firstresult=hook.spec_opts.get('firstresult'),
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/callers.py", line 196, in _multicall
INTERNALERROR>     gen.send(outcome)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/skipping.py", line 123, in pytest_runtest_makereport
INTERNALERROR>     rep = outcome.get_result()
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/callers.py", line 77, in get_result
INTERNALERROR>     _reraise(*ex)  # noqa
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/pluggy/callers.py", line 180, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/runner.py", line 240, in pytest_runtest_makereport
INTERNALERROR>     longrepr = item.repr_failure(excinfo)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/python.py", line 774, in repr_failure
INTERNALERROR>     return self._repr_failure_py(excinfo, style=style)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/python.py", line 767, in _repr_failure_py
INTERNALERROR>     return super(FunctionMixin, self)._repr_failure_py(excinfo, style=style)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/nodes.py", line 388, in _repr_failure_py
INTERNALERROR>     truncate_locals=truncate_locals,
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/_code/code.py", line 480, in getrepr
INTERNALERROR>     return fmt.repr_excinfo(self)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/_code/code.py", line 715, in repr_excinfo
INTERNALERROR>     reprtraceback = self.repr_traceback(excinfo)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/_code/code.py", line 672, in repr_traceback
INTERNALERROR>     reprentry = self.repr_traceback_entry(entry, einfo)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/_code/code.py", line 617, in repr_traceback_entry
INTERNALERROR>     source = self._getentrysource(entry)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/_code/code.py", line 537, in _getentrysource
INTERNALERROR>     source = entry.getsource(self.astcache)
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/_code/code.py", line 222, in getsource
INTERNALERROR>     self.lineno, source, astnode=astnode
INTERNALERROR>   File "/Users/spgingras/.virtualenvs/test_env/lib/python2.7/site-packages/_pytest/_code/source.py", line 340, in getstatementrange_ast
INTERNALERROR>     content = str(source)
INTERNALERROR> UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 41: ordinal not in range(128)

================================================================================================================================================================= no tests ran in 0.82 seconds =================================================================================================================================================================
```

Aside from the obvious stacktrace, you can see that pytest reported that 0 tests ran.

With my fix:
```shell
test_env ❯ pytest tests/test_bug.py
===================================================================================================================================================================== test session starts ======================================================================================================================================================================
platform darwin -- Python 2.7.14, pytest-3.8.2, py-1.5.2, pluggy-0.7.1
Django settings: settings.test (from ini file)
rootdir: /Users/spgingras/test_sample, inifile: pytest.ini
plugins: teamcity-messages-1.21, xdist-1.23.0, random-0.2, mock-1.10.0, forked-0.2, env-0.6.2, django-3.4.2, cov-2.5.1, pyfakefs-3.4.3, celery-4.1.1
collected 1 item                                                                                                                                                                                                                                                                                                                                               

tests/test_bug.py F                                                                                                                                                                                                                                                                                                                                 [100%]

=========================================================================================================================================================================== FAILURES ===========================================================================================================================================================================
__________________________________________________________________________________________________________________________________________________________________________ test__bug ___________________________________________________________________________________________________________________________________________________________________________

    def test__bug():
        a = 'é'
>       assert False
E       assert False

tests/test_bug.py:4: AssertionError
=================================================================================================================================================================== 1 failed in 0.80 seconds ===================================================================================================================================================================
```

I'm not sure if or how I should write a test for this particular case. Any help is appreciated.