### PR TITLE
Fix request.fixturenames to return fixtures created dynamically

### DIFF
--- a/changelog/3057.bugfix.rst
+++ b/changelog/3057.bugfix.rst
@@ -1,0 +1,1 @@
+``request.fixturenames`` now correctly returns the name of fixtures created by ``request.getfixturevalue()``.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -359,8 +359,10 @@ class FixtureRequest(FuncargnamesCompatAttr):
 
     @property
     def fixturenames(self):
-        # backward incompatible note: now a readonly property
-        return list(self._pyfuncitem._fixtureinfo.names_closure)
+        """names of all active fixtures in this request"""
+        result = list(self._pyfuncitem._fixtureinfo.names_closure)
+        result.extend(set(self._fixture_defs).difference(result))
+        return result
 
     @property
     def node(self):

--- a/testing/example_scripts/fixtures/test_getfixturevalue_dynamic.py
+++ b/testing/example_scripts/fixtures/test_getfixturevalue_dynamic.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+@pytest.fixture
+def dynamic():
+    pass
+
+
+@pytest.fixture
+def a(request):
+    request.getfixturevalue("dynamic")
+
+
+@pytest.fixture
+def b(a):
+    pass
+
+
+def test(b, request):
+    assert request.fixturenames == ["b", "request", "a", "dynamic"]

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -756,6 +756,12 @@ class TestRequestBasic(object):
         reprec = testdir.inline_run()
         reprec.assertoutcome(passed=1)
 
+    def test_request_fixturenames_dynamic_fixture(self, testdir):
+        """Regression test for #3057"""
+        testdir.copy_example("fixtures/test_getfixturevalue_dynamic.py")
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines("*1 passed*")
+
     def test_funcargnames_compatattr(self, testdir):
         testdir.makepyfile(
             """


### PR DESCRIPTION
Fix #3057
