### PR TITLE
Improve internal error messages

### DIFF
--- a/changelog/2293.feature.rst
+++ b/changelog/2293.feature.rst
@@ -1,0 +1,4 @@
+Improve usage errors messages by hiding internal details which can be distracting and noisy.
+
+This has the side effect that some error conditions that previously raised generic errors (such as
+``ValueError`` for unregistered marks) are now raising ``Failed`` exceptions.

--- a/changelog/2293.trivial.rst
+++ b/changelog/2293.trivial.rst
@@ -1,0 +1,1 @@
+The internal ``MarkerError`` exception has been removed.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -579,7 +579,7 @@ class FixtureRequest(FuncargnamesCompatAttr):
                     nodeid=funcitem.nodeid,
                     typename=type(funcitem).__name__,
                 )
-                fail(msg)
+                fail(msg, pytrace=False)
             if has_params:
                 frame = inspect.stack()[3]
                 frameinfo = inspect.getframeinfo(frame[0])
@@ -600,7 +600,7 @@ class FixtureRequest(FuncargnamesCompatAttr):
                         source_lineno,
                     )
                 )
-                fail(msg)
+                fail(msg, pytrace=False)
         else:
             # indices might not be set if old-style metafunc.addcall() was used
             param_index = funcitem.callspec.indices.get(argname, 0)
@@ -718,10 +718,11 @@ def scope2index(scope, descr, where=None):
     try:
         return scopes.index(scope)
     except ValueError:
-        raise ValueError(
-            "{} {}has an unsupported scope value '{}'".format(
+        fail(
+            "{} {}got an unexpected scope value '{}'".format(
                 descr, "from {} ".format(where) if where else "", scope
-            )
+            ),
+            pytrace=False,
         )
 
 
@@ -854,7 +855,9 @@ class FixtureDef(object):
         self.argname = argname
         self.scope = scope
         self.scopenum = scope2index(
-            scope or "function", descr="fixture {}".format(func.__name__), where=baseid
+            scope or "function",
+            descr="Fixture '{}'".format(func.__name__),
+            where=baseid,
         )
         self.params = params
         self.argnames = getfuncargnames(func, is_method=unittest)

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -24,11 +24,6 @@ __all__ = [
 ]
 
 
-class MarkerError(Exception):
-
-    """Error in use of a pytest marker/attribute."""
-
-
 def param(*values, **kw):
     """Specify a parameter in `pytest.mark.parametrize`_ calls or
     :ref:`parametrized fixtures <fixture-parametrize-marks>`.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -315,7 +315,7 @@ def _marked(func, mark):
     return any(mark == info.combined for info in func_mark)
 
 
-@attr.s
+@attr.s(repr=False)
 class MarkInfo(object):
     """ Marking object created by :class:`MarkDecorator` instances. """
 

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -6,6 +6,7 @@ from operator import attrgetter
 
 import attr
 
+from _pytest.outcomes import fail
 from ..deprecated import MARK_PARAMETERSET_UNPACKING, MARK_INFO_ATTRIBUTE
 from ..compat import NOTSET, getfslineno, MappingMixin
 from six.moves import map
@@ -393,7 +394,7 @@ class MarkGenerator(object):
             x = marker.split("(", 1)[0]
             values.add(x)
         if name not in self._markers:
-            raise AttributeError("%r not a registered marker" % (name,))
+            fail("{!r} not a registered marker".format(name), pytrace=False)
 
 
 MARK_GEN = MarkGenerator()

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -9,6 +9,7 @@ import attr
 import _pytest
 import _pytest._code
 from _pytest.compat import getfslineno
+from _pytest.outcomes import fail
 
 from _pytest.mark.structures import NodeKeywords, MarkInfo
 
@@ -346,6 +347,9 @@ class Node(object):
         pass
 
     def _repr_failure_py(self, excinfo, style=None):
+        if excinfo.errisinstance(fail.Exception):
+            if not excinfo.value.pytrace:
+                return six.text_type(excinfo.value)
         fm = self.session._fixturemanager
         if excinfo.errisinstance(fm.FixtureLookupError):
             return excinfo.value.formatrepr()

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -1217,8 +1217,7 @@ class TestFixtureUsages(object):
         result = testdir.runpytest_inprocess()
         result.stdout.fnmatch_lines(
             (
-                "*ValueError: fixture badscope from test_invalid_scope.py has an unsupported"
-                " scope value 'functions'"
+                "*Fixture 'badscope' from test_invalid_scope.py got an unexpected scope value 'functions'"
             )
         )
 
@@ -3607,16 +3606,15 @@ class TestParameterizedSubRequest(object):
         )
         result = testdir.runpytest()
         result.stdout.fnmatch_lines(
-            """
-            E*Failed: The requested fixture has no parameter defined for test:
-            E*    test_call_from_fixture.py::test_foo
-            E*
-            E*Requested fixture 'fix_with_param' defined in:
-            E*test_call_from_fixture.py:4
-            E*Requested here:
-            E*test_call_from_fixture.py:9
-            *1 error*
-            """
+            [
+                "The requested fixture has no parameter defined for test:",
+                "    test_call_from_fixture.py::test_foo",
+                "Requested fixture 'fix_with_param' defined in:",
+                "test_call_from_fixture.py:4",
+                "Requested here:",
+                "test_call_from_fixture.py:9",
+                "*1 error in*",
+            ]
         )
 
     def test_call_from_test(self, testdir):
@@ -3634,16 +3632,15 @@ class TestParameterizedSubRequest(object):
         )
         result = testdir.runpytest()
         result.stdout.fnmatch_lines(
-            """
-            E*Failed: The requested fixture has no parameter defined for test:
-            E*    test_call_from_test.py::test_foo
-            E*
-            E*Requested fixture 'fix_with_param' defined in:
-            E*test_call_from_test.py:4
-            E*Requested here:
-            E*test_call_from_test.py:8
-            *1 failed*
-            """
+            [
+                "The requested fixture has no parameter defined for test:",
+                "    test_call_from_test.py::test_foo",
+                "Requested fixture 'fix_with_param' defined in:",
+                "test_call_from_test.py:4",
+                "Requested here:",
+                "test_call_from_test.py:8",
+                "*1 failed*",
+            ]
         )
 
     def test_external_fixture(self, testdir):
@@ -3665,16 +3662,16 @@ class TestParameterizedSubRequest(object):
         )
         result = testdir.runpytest()
         result.stdout.fnmatch_lines(
-            """
-            E*Failed: The requested fixture has no parameter defined for test:
-            E*    test_external_fixture.py::test_foo
-            E*
-            E*Requested fixture 'fix_with_param' defined in:
-            E*conftest.py:4
-            E*Requested here:
-            E*test_external_fixture.py:2
-            *1 failed*
-            """
+            [
+                "The requested fixture has no parameter defined for test:",
+                "    test_external_fixture.py::test_foo",
+                "",
+                "Requested fixture 'fix_with_param' defined in:",
+                "conftest.py:4",
+                "Requested here:",
+                "test_external_fixture.py:2",
+                "*1 failed*",
+            ]
         )
 
     def test_non_relative_path(self, testdir):
@@ -3709,16 +3706,16 @@ class TestParameterizedSubRequest(object):
         testdir.syspathinsert(fixdir)
         result = testdir.runpytest()
         result.stdout.fnmatch_lines(
-            """
-            E*Failed: The requested fixture has no parameter defined for test:
-            E*    test_foos.py::test_foo
-            E*
-            E*Requested fixture 'fix_with_param' defined in:
-            E*fix.py:4
-            E*Requested here:
-            E*test_foos.py:4
-            *1 failed*
-            """
+            [
+                "The requested fixture has no parameter defined for test:",
+                "    test_foos.py::test_foo",
+                "",
+                "Requested fixture 'fix_with_param' defined in:",
+                "*fix.py:4",
+                "Requested here:",
+                "test_foos.py:4",
+                "*1 failed*",
+            ]
         )
 
 

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -247,7 +247,7 @@ def test_marker_without_description(testdir):
     )
     ftdir = testdir.mkdir("ft1_dummy")
     testdir.tmpdir.join("conftest.py").move(ftdir.join("conftest.py"))
-    rec = testdir.runpytest_subprocess("--strict")
+    rec = testdir.runpytest("--strict")
     rec.assert_outcomes()
 
 
@@ -302,7 +302,7 @@ def test_strict_prohibits_unregistered_markers(testdir):
     )
     result = testdir.runpytest("--strict")
     assert result.ret != 0
-    result.stdout.fnmatch_lines(["*unregisteredmark*not*registered*"])
+    result.stdout.fnmatch_lines(["'unregisteredmark' not a registered marker"])
 
 
 @pytest.mark.parametrize(

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -570,7 +570,8 @@ def test_pytest_exit_msg(testdir):
     result.stderr.fnmatch_lines(["Exit: oh noes"])
 
 
-def test_pytest_fail_notrace(testdir):
+def test_pytest_fail_notrace_runtest(testdir):
+    """Test pytest.fail(..., pytrace=False) does not show tracebacks during test run."""
     testdir.makepyfile(
         """
         import pytest
@@ -583,6 +584,21 @@ def test_pytest_fail_notrace(testdir):
     result = testdir.runpytest()
     result.stdout.fnmatch_lines(["world", "hello"])
     assert "def teardown_function" not in result.stdout.str()
+
+
+def test_pytest_fail_notrace_collection(testdir):
+    """Test pytest.fail(..., pytrace=False) does not show tracebacks during collection."""
+    testdir.makepyfile(
+        """
+        import pytest
+        def some_internal_function():
+            pytest.fail("hello", pytrace=False)
+        some_internal_function()
+    """
+    )
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(["hello"])
+    assert "def some_internal_function()" not in result.stdout.str()
 
 
 @pytest.mark.parametrize("str_prefix", ["u", ""])


### PR DESCRIPTION
Currently some usage errors produce very ugly traceback with pytest's internals. For example, mistyping the `scope` of a fixture produces this:

```
============================================= ERRORS ==============================================
_____________________________ ERROR collecting test-scope-mismatch.py _____________________________
src\_pytest\fixtures.py:699: in scope2index
    return scopes.index(scope)
E   ValueError: 'modu' is not in list

During handling of the above exception, another exception occurred:
src\_pytest\runner.py:201: in __init__
    self.result = func()
src\_pytest\runner.py:265: in <lambda>
    call = CallInfo(lambda: list(collector.collect()), "collect")
src\_pytest\python.py:475: in collect
    self.session._fixturemanager.parsefactories(self)
src\_pytest\fixtures.py:1321: in parsefactories
    ids=marker.ids,
src\_pytest\fixtures.py:837: in __init__
    scope or "function", descr="fixture {}".format(func.__name__), where=baseid
src\_pytest\fixtures.py:703: in scope2index
    descr, "from {} ".format(where) if where else "", scope
E   ValueError: fixture fix from test-scope-mismatch.py has an unsupported scope value 'modu'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
===================================== 1 error in 0.16 seconds =====================================
```

This PR handles a specific of exception type (here `UsageError` for demonstration) so it shows only the exception message instead of the entire traceback. This way we can raise that exception on errors that we know are usage problems and where displaying the entire traceback is not helpful in general. With this PR the error above produces this:

```
============================================= ERRORS ==============================================
_____________________________ ERROR collecting test-scope-mismatch.py _____________________________
fixture fix from test-scope-mismatch.py has an unsupported scope value 'modu'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
===================================== 1 error in 0.07 seconds =====================================
```

Which is definitely nicer.

Questions for discussion:

1. Is this approach sound?
2. Should we use `UsageError` or create a new type of exception? Should it be public so plugins can use it too?
3. Comments about verbosity handling done here?

Refs: #2293, #3867, #2535, #3332

--- 

EDIT: in the end we don't need a new exception, we just have to use `pytest.fail(..., pytrace=False)` instead of general exceptions and make sure we also treat `Failed` exceptions during collection.

Fixes #2293, Fixes #3867 

I will resolve #3332 in a separate PR.
