### PR TITLE
Exclude durations that are 0.00 seconds long.

### DIFF
--- a/changelog/4063.trivial.rst
+++ b/changelog/4063.trivial.rst
@@ -1,1 +1,1 @@
-Exclude 0.00 second entries from ``--duration`` output.
+Exclude 0.00 second entries from ``--duration`` output unless ``-vv`` is passed on the command-line.

--- a/changelog/4063.trivial.rst
+++ b/changelog/4063.trivial.rst
@@ -1,0 +1,1 @@
+Exclude 0.00 second entries from ``--duration`` output.

--- a/doc/en/usage.rst
+++ b/doc/en/usage.rst
@@ -269,6 +269,7 @@ To get a list of the slowest 10 test durations::
 
     pytest --durations=10
 
+By default, pytest will not show test durations that are too small (<0.01s) unless ``-vv`` is passed on the command-line.
 
 Creating JUnitXML format files
 ----------------------------------------------------

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -51,6 +51,7 @@ def pytest_terminal_summary(terminalreporter):
 
     for rep in dlist:
         if verbose < 2 and rep.duration < 0.01:
+            tr.write_line("0.00 durations hidden.  Use -vv to show these durations.")
             break
         nodeid = rep.nodeid.replace("::()::", "::")
         tr.write_line("%02.2fs %-8s %s" % (rep.duration, rep.when, nodeid))

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -30,6 +30,7 @@ def pytest_addoption(parser):
 
 def pytest_terminal_summary(terminalreporter):
     durations = terminalreporter.config.option.durations
+    verbose = terminalreporter.config.getvalue("verbose")
     if durations is None:
         return
     tr = terminalreporter
@@ -49,6 +50,8 @@ def pytest_terminal_summary(terminalreporter):
         dlist = dlist[:durations]
 
     for rep in dlist:
+        if verbose < 2 and rep.duration < 0.01:
+            break
         nodeid = rep.nodeid.replace("::()::", "::")
         tr.write_line("%02.2fs %-8s %s" % (rep.duration, rep.when, nodeid))
 

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -50,7 +50,7 @@ def pytest_terminal_summary(terminalreporter):
         dlist = dlist[:durations]
 
     for rep in dlist:
-        if verbose < 2 and rep.duration < 0.01:
+        if verbose < 2 and rep.duration < 0.005:
             tr.write_line("0.00 durations hidden.  Use -vv to show these durations.")
             break
         nodeid = rep.nodeid.replace("::()::", "::")

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -51,7 +51,8 @@ def pytest_terminal_summary(terminalreporter):
 
     for rep in dlist:
         if verbose < 2 and rep.duration < 0.005:
-            tr.write_line("0.00 durations hidden.  Use -vv to show these durations.")
+            tr.write_line("")
+            tr.write_line("(0.00 durations hidden.  Use -vv to show these durations.)")
             break
         nodeid = rep.nodeid.replace("::()::", "::")
         tr.write_line("%02.2fs %-8s %s" % (rep.duration, rep.when, nodeid))

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -818,6 +818,10 @@ class TestDurations(object):
         result.stdout.fnmatch_lines_random(
             ["*durations*", "*call*test_3*", "*call*test_2*"]
         )
+        assert "test_something" not in result.stdout.str()
+        result.stdout.fnmatch_lines(
+            ["(0.00 durations hidden.  Use -vv to show these durations.)"]
+        )
 
     def test_calls_show_2(self, testdir):
         testdir.makepyfile(self.source)


### PR DESCRIPTION
Implements #4063 by excluding 0.00 second long durations from the --durations output unless -vv is used.