### PR TITLE
Improve performance of ~3 of the slowest tests

### DIFF
--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -1371,7 +1371,7 @@ def test_exception_repr_extraction_error_on_recursion():
     def b(x):
         return a(numpy_like())
 
-    with pytest.raises(RecursionError) as excinfo:
+    with pytest.raises(RuntimeError) as excinfo:
         a(numpy_like())
 
     matcher = LineMatcher(str(excinfo.getrepr()).splitlines())
@@ -1395,6 +1395,6 @@ def test_no_recursion_index_on_recursion_error():
         def __getattr__(self, attr):
             return getattr(self, "_" + attr)
 
-    with pytest.raises(RecursionError) as excinfo:
+    with pytest.raises(RuntimeError) as excinfo:
         RecursionDepthError().trigger
     assert "maximum recursion" in str(excinfo.getrepr())

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -31,6 +31,14 @@ failsonjython = pytest.mark.xfail("sys.platform.startswith('java')")
 pytest_version_info = tuple(map(int, pytest.__version__.split(".")[:3]))
 
 
+@pytest.fixture
+def limited_recursion_depth():
+    before = sys.getrecursionlimit()
+    sys.setrecursionlimit(100)
+    yield
+    sys.setrecursionlimit(before)
+
+
 class TWMock(object):
     WRITE = object()
 
@@ -239,7 +247,7 @@ class TestTraceback_f_g_h(object):
                 raise RuntimeError("hello")
             f(n - 1)
 
-        excinfo = pytest.raises(RuntimeError, f, 100)
+        excinfo = pytest.raises(RuntimeError, f, 25)
         monkeypatch.delattr(excinfo.traceback.__class__, "recursionindex")
         repr = excinfo.getrepr()
         assert "RuntimeError: hello" in str(repr.reprcrash)
@@ -1341,11 +1349,13 @@ def test_cwd_deleted(testdir):
     assert "INTERNALERROR" not in result.stdout.str() + result.stderr.str()
 
 
+@pytest.mark.usefixtures("limited_recursion_depth")
 def test_exception_repr_extraction_error_on_recursion():
     """
     Ensure we can properly detect a recursion error even
     if some locals raise error on comparison (#2459).
     """
+    from _pytest.pytester import LineMatcher
 
     class numpy_like(object):
         def __eq__(self, other):
@@ -1361,40 +1371,30 @@ def test_exception_repr_extraction_error_on_recursion():
     def b(x):
         return a(numpy_like())
 
-    try:
+    with pytest.raises(RecursionError) as excinfo:
         a(numpy_like())
-    except:  # noqa
-        from _pytest._code.code import ExceptionInfo
-        from _pytest.pytester import LineMatcher
 
-        exc_info = ExceptionInfo()
-
-        matcher = LineMatcher(str(exc_info.getrepr()).splitlines())
-        matcher.fnmatch_lines(
-            [
-                "!!! Recursion error detected, but an error occurred locating the origin of recursion.",
-                "*The following exception happened*",
-                "*ValueError: The truth value of an array*",
-            ]
-        )
+    matcher = LineMatcher(str(excinfo.getrepr()).splitlines())
+    matcher.fnmatch_lines(
+        [
+            "!!! Recursion error detected, but an error occurred locating the origin of recursion.",
+            "*The following exception happened*",
+            "*ValueError: The truth value of an array*",
+        ]
+    )
 
 
+@pytest.mark.usefixtures("limited_recursion_depth")
 def test_no_recursion_index_on_recursion_error():
     """
     Ensure that we don't break in case we can't find the recursion index
     during a recursion error (#2486).
     """
-    try:
 
-        class RecursionDepthError(object):
-            def __getattr__(self, attr):
-                return getattr(self, "_" + attr)
+    class RecursionDepthError(object):
+        def __getattr__(self, attr):
+            return getattr(self, "_" + attr)
 
+    with pytest.raises(RecursionError) as excinfo:
         RecursionDepthError().trigger
-    except:  # noqa
-        from _pytest._code.code import ExceptionInfo
-
-        exc_info = ExceptionInfo()
-        assert "maximum recursion" in str(exc_info.getrepr())
-    else:
-        assert 0
+    assert "maximum recursion" in str(excinfo.getrepr())

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -34,7 +34,7 @@ pytest_version_info = tuple(map(int, pytest.__version__.split(".")[:3]))
 @pytest.fixture
 def limited_recursion_depth():
     before = sys.getrecursionlimit()
-    sys.setrecursionlimit(100)
+    sys.setrecursionlimit(150)
     yield
     sys.setrecursionlimit(before)
 

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -45,7 +45,7 @@ def test_change_level_undo(testdir):
             assert 0
     """
     )
-    result = testdir.runpytest_subprocess()
+    result = testdir.runpytest()
     result.stdout.fnmatch_lines(["*log from test1*", "*2 failed in *"])
     assert "log from test2" not in result.stdout.str()
 


### PR DESCRIPTION
cherry picked a few from `pytest testing/{subdir} --durations=5` and wanted to see what I could do to make them faster.

this saves ~11 seconds off of a test run (which isn't much but it's something!)

interesting to note that `runpytest_subprocess` adds about 500ms per invocation. (I guess we should avoid it if possible? @nicoddemus do you know if there's a reason why it was used for #3124?)