### PR TITLE
Temporarily disable `linting` env in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - TOXENV: "linting"
-    PYTEST_NO_COVERAGE: "1"
   - TOXENV: "py27"
   - TOXENV: "py34"
   - TOXENV: "py35"


### PR DESCRIPTION
broken in #4089

will revert after `virtualenv` releases with upgrade `pip` which _should_ fix the installation issue