### PR TITLE
Fix formatting for plugin loading in conftest

### DIFF
--- a/doc/en/plugins.rst
+++ b/doc/en/plugins.rst
@@ -69,16 +69,14 @@ You may also discover more plugins through a `pytest- pypi.python.org search`_.
 Requiring/Loading plugins in a test module or conftest file
 -----------------------------------------------------------
 
-You can require plugins in a test module or a conftest file like this::
+You can require plugins in a test module or a conftest file like this:
 
-    pytest_plugins = "myapp.testsupport.myplugin",
+.. code-block:: python
+
+    pytest_plugins = ("myapp.testsupport.myplugin",)
 
 When the test module or conftest plugin is loaded the specified plugins
 will be loaded as well.
-
-    pytest_plugins = "myapp.testsupport.myplugin"
-
-which will import the specified module as a ``pytest`` plugin.
 
 .. note::
     Requiring plugins using a ``pytest_plugins`` variable in non-root


### PR DESCRIPTION
## what I did

- The text in this section looked redundant so I removed the extra bits
- I think changed the code to be a code block, then `blacken-docs` did the rest

## comparison

(ignore the font differences, one is in a VM one is out)

### before

![](https://i.fluffy.cc/Lc2dMxFScshLrcN9tN7JsT5lvn5prCxT.png)

### after

![](https://i.fluffy.cc/z3QR5MmCtcHm6d4SzDcPwhq9mCvCXHg8.png)