### PR TITLE
Implement pytest.deprecated_call with pytest.warns

### DIFF
--- a/changelog/4012.bugfix.rst
+++ b/changelog/4012.bugfix.rst
@@ -1,1 +1,0 @@
-``pytest.warn`` will capture previously-warned warnings in python2.  Previously they were never raised.

--- a/changelog/4012.bugfix.rst
+++ b/changelog/4012.bugfix.rst
@@ -1,0 +1,1 @@
+``pytest.warn`` will capture previously-warned warnings in python2.  Previously they were never raised.

--- a/changelog/4102.bugfix.rst
+++ b/changelog/4102.bugfix.rst
@@ -1,0 +1,1 @@
+``pytest.warn`` will capture previously-warned warnings in Python 2. Previously they were never raised.

--- a/changelog/4102.feature.rst
+++ b/changelog/4102.feature.rst
@@ -1,1 +1,4 @@
 Reimplement ``pytest.deprecated_call`` using ``pytest.warns`` so it supports the ``match='...'`` keyword argument.
+
+This has the side effect that ``pytest.deprecated_call`` now raises ``pytest.fail.Exception`` instead
+of ``AssertionError``.

--- a/changelog/4102.feature.rst
+++ b/changelog/4102.feature.rst
@@ -1,0 +1,1 @@
+Reimplement ``pytest.deprecated_call`` using ``pytest.warns`` so it supports the ``match='...'`` keyword argument.

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -156,18 +156,18 @@ class WarningsRecorder(warnings.catch_warnings):
         if six.PY2:
 
             def warn(*args, **kwargs):
-                return self._warn(*args, **kwargs)
+                return self._saved_warn(*args, **kwargs)
 
-            warnings.warn, self._warn = warn, warnings.warn
+            warnings.warn, self._saved_warn = warn, warnings.warn
         return self
 
     def __exit__(self, *exc_info):
         if not self._entered:
             __tracebackhide__ = True
             raise RuntimeError("Cannot exit %r without entering first" % self)
-        # see above where `self.mp` is assigned
+        # see above where `self._saved_warn` is assigned
         if six.PY2:
-            warnings.warn = self._warn
+            warnings.warn = self._saved_warn
         super(WarningsRecorder, self).__exit__(*exc_info)
 
 

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -43,45 +43,10 @@ def deprecated_call(func=None, *args, **kwargs):
     in which case it will ensure calling ``func(*args, **kwargs)`` produces one of the warnings
     types above.
     """
-    if not func:
-        return _DeprecatedCallContext()
-    else:
-        __tracebackhide__ = True
-        with _DeprecatedCallContext():
-            return func(*args, **kwargs)
-
-
-class _DeprecatedCallContext(object):
-    """Implements the logic to capture deprecation warnings as a context manager."""
-
-    def __enter__(self):
-        self._captured_categories = []
-        self._old_warn = warnings.warn
-        self._old_warn_explicit = warnings.warn_explicit
-        warnings.warn_explicit = self._warn_explicit
-        warnings.warn = self._warn
-
-    def _warn_explicit(self, message, category, *args, **kwargs):
-        self._captured_categories.append(category)
-
-    def _warn(self, message, category=None, *args, **kwargs):
-        if isinstance(message, Warning):
-            self._captured_categories.append(message.__class__)
-        else:
-            self._captured_categories.append(category)
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        warnings.warn_explicit = self._old_warn_explicit
-        warnings.warn = self._old_warn
-
-        if exc_type is None:
-            deprecation_categories = (DeprecationWarning, PendingDeprecationWarning)
-            if not any(
-                issubclass(c, deprecation_categories) for c in self._captured_categories
-            ):
-                __tracebackhide__ = True
-                msg = "Did not produce DeprecationWarning or PendingDeprecationWarning"
-                raise AssertionError(msg)
+    __tracebackhide__ = True
+    if func is not None:
+        args = (func,) + args
+    return warns((DeprecationWarning, PendingDeprecationWarning), *args, **kwargs)
 
 
 def warns(expected_warning, *args, **kwargs):
@@ -116,6 +81,7 @@ def warns(expected_warning, *args, **kwargs):
         Failed: DID NOT WARN. No warnings of type ...UserWarning... was emitted...
 
     """
+    __tracebackhide__ = True
     match_expr = None
     if not args:
         if "match" in kwargs:

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -76,9 +76,8 @@ class TestDeprecatedCall(object):
             )
 
     def test_deprecated_call_raises(self):
-        with pytest.raises(AssertionError) as excinfo:
+        with pytest.raises(pytest.fail.Exception, match="No warnings of type"):
             pytest.deprecated_call(self.dep, 3, 5)
-        assert "Did not produce" in str(excinfo)
 
     def test_deprecated_call(self):
         pytest.deprecated_call(self.dep, 0, 5)
@@ -100,7 +99,7 @@ class TestDeprecatedCall(object):
         assert warn_explicit is warnings.warn_explicit
 
     def test_deprecated_explicit_call_raises(self):
-        with pytest.raises(AssertionError):
+        with pytest.raises(pytest.fail.Exception):
             pytest.deprecated_call(self.dep_explicit, 3)
 
     def test_deprecated_explicit_call(self):
@@ -116,8 +115,8 @@ class TestDeprecatedCall(object):
         def f():
             pass
 
-        msg = "Did not produce DeprecationWarning or PendingDeprecationWarning"
-        with pytest.raises(AssertionError, match=msg):
+        msg = "No warnings of type (.*DeprecationWarning.*, .*PendingDeprecationWarning.*)"
+        with pytest.raises(pytest.fail.Exception, match=msg):
             if mode == "call":
                 pytest.deprecated_call(f)
             else:
@@ -179,11 +178,19 @@ class TestDeprecatedCall(object):
             def f():
                 warnings.warn(warning("hi"))
 
-            with pytest.raises(AssertionError):
+            with pytest.raises(pytest.fail.Exception):
                 pytest.deprecated_call(f)
-            with pytest.raises(AssertionError):
+            with pytest.raises(pytest.fail.Exception):
                 with pytest.deprecated_call():
                     f()
+
+    def test_deprecated_call_supports_match(self):
+        with pytest.deprecated_call(match=r"must be \d+$"):
+            warnings.warn("value must be 42", DeprecationWarning)
+
+        with pytest.raises(pytest.fail.Exception):
+            with pytest.deprecated_call(match=r"must be \d+$"):
+                warnings.warn("this is not here", DeprecationWarning)
 
 
 class TestWarns(object):

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -350,3 +350,13 @@ class TestWarns(object):
             with pytest.warns(UserWarning, match=r"aaa"):
                 warnings.warn("bbbbbbbbbb", UserWarning)
                 warnings.warn("cccccccccc", UserWarning)
+
+    @pytest.mark.filterwarnings("ignore")
+    def test_can_capture_previously_warned(self):
+        def f():
+            warnings.warn(UserWarning("ohai"))
+            return 10
+
+        assert f() == 10
+        assert pytest.warns(UserWarning, f) == 10
+        assert pytest.warns(UserWarning, f) == 10


### PR DESCRIPTION
Resolves #4102

I'm targetting `features` because it changes the exception type and message.  Though it ~could be considered a bugfix by stretch and target `master` instead?

Edit: Resolves #2917