### PR TITLE
[WIP] tests: harden test_cmdline_python_package_symlink

### DIFF
--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -738,8 +738,8 @@ class TestInvocationVariants(object):
         assert result.ret == 0
         result.stdout.fnmatch_lines(
             [
-                "*lib/foo/bar/test_bar.py::test_bar*PASSED*",
-                "*lib/foo/bar/test_bar.py::test_other*PASSED*",
+                "*lib/foo/bar/test_bar.py::test_bar PASSED*",
+                "*lib/foo/bar/test_bar.py::test_other PASSED*",
                 "*2 passed*",
             ]
         )

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -688,8 +688,6 @@ class TestInvocationVariants(object):
                 pytest.skip(six.text_type(e.args[0]))
         monkeypatch.delenv("PYTHONDONTWRITEBYTECODE", raising=False)
 
-        search_path = ["lib", os.path.join("local", "lib")]
-
         dirname = "lib"
         d = testdir.mkdir(dirname)
         foo = d.mkdir("foo")
@@ -728,8 +726,9 @@ class TestInvocationVariants(object):
                 dirs += (cur,)
             return os.pathsep.join(str(p) for p in dirs)
 
+        search_path = ["lib", os.path.join("local", "lib")]
         monkeypatch.setenv("PYTHONPATH", join_pythonpath(*search_path))
-        for p in search_path:
+        for p in reversed(search_path):
             monkeypatch.syspath_prepend(p)
 
         # module picked up in symlink-ed directory:


### PR DESCRIPTION
This tests that symlinks are not resolved there currently.

Relevant for when I've worked on https://github.com/pytest-dev/pytest/pull/4108.
