### PR TITLE
Resolve symlinks for args

### DIFF
--- a/changelog/4108.bugfix.rst
+++ b/changelog/4108.bugfix.rst
@@ -1,0 +1,5 @@
+Resolve symbolic links for args.
+
+This fixes running ``pytest tests/test_foo.py::test_bar``, where ``tests``
+is a symlink to ``project/app/tests``:
+previously ``project/app/conftest.py`` would be ignored for fixtures then.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1175,7 +1175,7 @@ class FixtureManager(object):
     def pytest_plugin_registered(self, plugin):
         nodeid = None
         try:
-            p = py.path.local(plugin.__file__)
+            p = py.path.local(plugin.__file__).realpath()
         except AttributeError:
             pass
         else:

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -490,7 +490,7 @@ class Session(nodes.FSCollector):
         from _pytest.python import Package
 
         names = self._parsearg(arg)
-        argpath = names.pop(0)
+        argpath = names.pop(0).realpath()
         paths = []
 
         root = self


### PR DESCRIPTION
This fixes runnings `pytest tests`, where `tests` is a symlink to
`project/app/tests`: previously `project/app/conftest.py` would be
ignored for fixtures then.