### PR TITLE
Run docs, doctesting and linting in the same job to save some CI time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ env:
     - TOXENV=py36-numpy
     - TOXENV=py36-pluggymaster PYTEST_NO_COVERAGE=1
     - TOXENV=py27-nobyte
-    - TOXENV=doctesting
-    - TOXENV=docs PYTEST_NO_COVERAGE=1
 
 jobs:
   include:
@@ -61,7 +59,7 @@ jobs:
       env: TOXENV=py27
     - env: TOXENV=py34
     - env: TOXENV=py36
-    - env: TOXENV=linting PYTEST_NO_COVERAGE=1
+    - env: TOXENV=linting,docs,doctesting PYTEST_NO_COVERAGE=1
 
     - stage: deploy
       python: '3.6'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-  - TOXENV: "linting"
+  - TOXENV: "linting,docs,doctesting"
     PYTEST_NO_COVERAGE: "1"
   - TOXENV: "py27"
   - TOXENV: "py34"
@@ -20,10 +20,7 @@ environment:
   - TOXENV: "py36-pluggymaster"
     PYTEST_NO_COVERAGE: "1"
   - TOXENV: "py27-nobyte"
-  - TOXENV: "doctesting"
   - TOXENV: "py36-freeze"
-    PYTEST_NO_COVERAGE: "1"
-  - TOXENV: "docs"
     PYTEST_NO_COVERAGE: "1"
 
 install:


### PR DESCRIPTION
Docs also checks the documentation for syntax failures, so it should
part of the baseline to bail out early.
