### PR TITLE
docs: deprecation.rst: Add missing arguments to example code

### DIFF
--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -243,7 +243,7 @@ This form of test function doesn't support fixtures properly, and users should s
 .. code-block:: python
 
     @pytest.mark.parametrize("x, y", [(2, 4), (3, 9)])
-    def test_squared():
+    def test_squared(x, y):
         assert x ** x == y
 
 


### PR DESCRIPTION

https://github.com/pytest-dev/pytest/blob/c27c8f41a881cf719e2f12f14c4a9331c8f79e8a/doc/en/deprecations.rst#L241-L247

In the proposed new style using `@pytest.mark.parametrize`,
the example function signature missed the actual arguments.
Add the missing arguments.

