### PR TITLE
tox.ini: pexpect: use posargs; cleanup posargs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ envlist =
 
 [testenv]
 commands =
-    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest --lsof -ra {posargs:testing}
+    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest --lsof
     coverage: coverage combine
     coverage: coverage report
 passenv = USER USERNAME
@@ -43,7 +43,7 @@ deps =
     nose
 passenv = USER USERNAME TRAVIS
 commands =
-    pytest -n auto -ra --runpytest=subprocess {posargs:testing}
+    pytest -n auto --runpytest=subprocess
 
 
 [testenv:linting]
@@ -61,7 +61,7 @@ deps =
     {env:_PYTEST_TOX_EXTRA_DEP:}
 passenv = USER USERNAME TRAVIS
 commands =
-    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n auto -ra {posargs:testing}
+    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n auto
 
 [testenv:py36-xdist]
 # NOTE: copied from above due to https://github.com/tox-dev/tox/issues/706.
@@ -80,7 +80,7 @@ deps =
     pexpect
     {env:_PYTEST_TOX_EXTRA_DEP:}
 commands =
-    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -ra test_pdb.py test_terminal.py test_unittest.py
+    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest test_pdb.py test_terminal.py test_unittest.py {posargs}
 
 [testenv:py36-pexpect]
 changedir = {[testenv:py27-pexpect]changedir}
@@ -101,14 +101,14 @@ setenv =
     PYTHONDONTWRITEBYTECODE=1
 passenv = USER USERNAME TRAVIS
 commands =
-    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n auto -ra {posargs:.}
+    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n auto {posargs:.}
 
 [testenv:py27-trial]
 deps =
     twisted
     {env:_PYTEST_TOX_EXTRA_DEP:}
 commands =
-    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -ra {posargs:testing/test_unittest.py}
+    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest {posargs:testing/test_unittest.py}
 
 [testenv:py36-trial]
 deps = {[testenv:py27-trial]deps}
@@ -119,7 +119,7 @@ deps =
     numpy
     {env:_PYTEST_TOX_EXTRA_DEP:}
 commands=
-  {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -ra {posargs:testing/python/approx.py}
+  {env:_PYTEST_TOX_COVERAGE_RUN:} pytest {posargs:testing/python/approx.py}
 
 [testenv:py36-numpy]
 deps = {[testenv:py27-numpy]deps}
@@ -154,7 +154,7 @@ deps =
     PyYAML
     {env:_PYTEST_TOX_EXTRA_DEP:}
 commands =
-    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -ra doc/en
+    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest doc/en
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest --doctest-modules --pyargs _pytest
 
 [testenv:regen]
@@ -175,7 +175,7 @@ commands =
 [testenv:jython]
 changedir = testing
 commands =
-    {envpython} {envbindir}/py.test-jython -ra {posargs}
+    {envpython} {envbindir}/py.test-jython {posargs}
 
 [testenv:py36-freeze]
 changedir = testing/freeze


### PR DESCRIPTION
- no need for {posargs:testing} really
- remove `-ra`, used with addopts already