### PR TITLE
tox.ini: passenv: COVERAGE_*

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest --lsof
     coverage: coverage combine
     coverage: coverage report
-passenv = USER USERNAME
+passenv = USER USERNAME COVERAGE_*
 setenv =
     # configuration if a user runs tox with a "coverage" factor, for example "tox -e py36-coverage"
     coverage: _PYTEST_TOX_COVERAGE_RUN=coverage run -m
@@ -41,7 +41,6 @@ deps =
     pytest-xdist>=1.13
     py27: mock
     nose
-passenv = USER USERNAME TRAVIS
 commands =
     pytest -n auto --runpytest=subprocess
 
@@ -59,7 +58,6 @@ deps =
     nose
     hypothesis>=3.56
     {env:_PYTEST_TOX_EXTRA_DEP:}
-passenv = USER USERNAME TRAVIS
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n auto
 
@@ -99,7 +97,6 @@ changedir=testing
 setenv =
     {[testenv]setenv}
     PYTHONDONTWRITEBYTECODE=1
-passenv = USER USERNAME TRAVIS
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n auto {posargs:.}
 


### PR DESCRIPTION
This is required to pass through COVERAGE_PROCESS_START etc.