### PR TITLE
Fix flaky durations test

### DIFF
--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -808,7 +808,6 @@ class TestDurations(object):
         result.stdout.fnmatch_lines_random(
             ["*durations*", "*call*test_3*", "*call*test_2*"]
         )
-        assert "test_something" not in result.stdout.str()
         result.stdout.fnmatch_lines(
             ["(0.00 durations hidden.  Use -vv to show these durations.)"]
         )

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -494,6 +494,12 @@ class TestRequestBasic(object):
         reason="this method of test doesn't work on pypy",
     )
     def test_request_garbage(self, testdir):
+        try:
+            import xdist  # noqa
+        except ImportError:
+            pass
+        else:
+            pytest.xfail("this test is flaky when executed with xdist")
         testdir.makepyfile(
             """
             import sys


### PR DESCRIPTION
Unfortunately due to fluctuations in runtime "test_something"
might still appear in the final message.

Example failure:

https://ci.appveyor.com/project/pytestbot/pytest/builds/19494829/job/8lx847u0c78m63wf

