### PR TITLE
Display the filename when encountering `SyntaxWarning`.

### DIFF
--- a/changelog/4152.bugfix.rst
+++ b/changelog/4152.bugfix.rst
@@ -1,0 +1,1 @@
+Display the filename when encountering ``SyntaxWarning``.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -398,7 +398,7 @@ def _rewrite_test(config, fn):
             finally:
                 del state._indecode
     try:
-        tree = ast.parse(source)
+        tree = ast.parse(source, filename=fn.strpath)
     except SyntaxError:
         # Let this pop up again in the real import.
         state.trace("failed to parse: %r" % (fn,))


### PR DESCRIPTION
Resolves #4152 

Couldn't think of a way to test this without implementation / version specific code 🤷‍♂️ -- at least the commit message contains the reproduction

### before

```console
$ cd t && rm -rf __pycache__ && pytest t.py -q -c /dev/null; cd ..
.                                                                        [100%]
=============================== warnings summary ===============================
<unknown>:2: DeprecationWarning: invalid escape sequence \.

-- Docs: https://docs.pytest.org/en/latest/warnings.html
1 passed, 1 warnings in 0.01 seconds

```

### after

```console
$ cd t && rm -rf __pycache__ && pytest t.py -q -c /dev/null; cd ..
.                                                                        [100%]
=============================== warnings summary ===============================
/tmp/pytest/t/t.py:2: DeprecationWarning: invalid escape sequence \.
  '\.wat'

-- Docs: https://docs.pytest.org/en/latest/warnings.html
1 passed, 1 warnings in 0.01 seconds
```
