### PR TITLE
Increase required verbosity level for debug output

### DIFF
--- a/changelog/4159.feature.rst
+++ b/changelog/4159.feature.rst
@@ -1,0 +1,3 @@
+For test-suites containing test classes, the information about the subclassed
+module is now output only if a higher verbosity level is specified (at least
+"-vv").

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -676,7 +676,9 @@ class TerminalReporter(object):
 
         if fspath:
             res = mkrel(nodeid).replace("::()", "")  # parens-normalization
-            if nodeid.split("::")[0] != fspath.replace("\\", nodes.SEP):
+            if self.verbosity >= 2 and nodeid.split("::")[0] != fspath.replace(
+                "\\", nodes.SEP
+            ):
                 res += " <- " + self.startdir.bestrelpath(fspath)
         else:
             res = "[location]"

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -760,8 +760,8 @@ class TestInvocationVariants(object):
         if hasattr(py.path.local, "mksymlinkto"):
             result.stdout.fnmatch_lines(
                 [
-                    "lib/foo/bar/test_bar.py::test_bar <- local/lib/foo/bar/test_bar.py PASSED*",
-                    "lib/foo/bar/test_bar.py::test_other <- local/lib/foo/bar/test_bar.py PASSED*",
+                    "lib/foo/bar/test_bar.py::test_bar PASSED*",
+                    "lib/foo/bar/test_bar.py::test_other PASSED*",
                     "*2 passed*",
                 ]
             )

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -154,7 +154,7 @@ class TestTerminal(object):
         )
         result = testdir.runpytest(p2)
         result.stdout.fnmatch_lines(["*test_p2.py .*", "*1 passed*"])
-        result = testdir.runpytest("-v", p2)
+        result = testdir.runpytest("-vv", p2)
         result.stdout.fnmatch_lines(
             ["*test_p2.py::TestMore::test_p1* <- *test_p1.py*PASSED*"]
         )
@@ -170,7 +170,7 @@ class TestTerminal(object):
                 """
             )
         )
-        result = testdir.runpytest("-v")
+        result = testdir.runpytest("-vv")
         assert result.ret == 0
         result.stdout.fnmatch_lines(["*a123/test_hello123.py*PASS*"])
         assert " <- " not in result.stdout.str()


### PR DESCRIPTION
To show the subclassed file in legacy test suits in the runtest output
you have to set the verbosity level to at least "-vv" now.

Closes #3211

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs (you can delete this text from the final description, this is
just a guideline):

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [x] Target the `features` branch for new features and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Add yourself to `AUTHORS` in alphabetical order;
