### PR TITLE
Pass TRAVIS env var to test environments [skip appveyor]

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest --lsof
     coverage: coverage combine
     coverage: coverage report
-passenv = USER USERNAME COVERAGE_*
+passenv = USER USERNAME COVERAGE_* TRAVIS
 setenv =
     # configuration if a user runs tox with a "coverage" factor, for example "tox -e py36-coverage"
     coverage: _PYTEST_TOX_COVERAGE_RUN=coverage run -m


### PR DESCRIPTION
xdist has a workaround inplace for Travis so "-n auto" works.

Fix #4162
