### PR TITLE
don`t parse compat properties as fixtures

### DIFF
--- a/changelog/2701.bugfix.rst
+++ b/changelog/2701.bugfix.rst
@@ -1,0 +1,1 @@
+avoid "RemovedInPytest4Warning: usage of Session... is deprecated, please use pytest... instead" warnings.:w

--- a/changelog/2701.bugfix.rst
+++ b/changelog/2701.bugfix.rst
@@ -1,1 +1,1 @@
-avoid "RemovedInPytest4Warning: usage of Session... is deprecated, please use pytest... instead" warnings.:w
+Fix false ``RemovedInPytest4Warning: usage of Session... is deprecated, please use pytest`` warnings.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1193,6 +1193,7 @@ class FixtureManager(object):
                 nodeid = p.dirpath().relto(self.config.rootdir)
                 if p.sep != nodes.SEP:
                     nodeid = nodeid.replace(p.sep, nodes.SEP)
+
         self.parsefactories(plugin, nodeid)
 
     def _getautousenames(self, nodeid):
@@ -1297,11 +1298,18 @@ class FixtureManager(object):
             nodeid = node_or_obj.nodeid
         if holderobj in self._holderobjseen:
             return
+
+        from _pytest.nodes import _CompatProperty
+
         self._holderobjseen.add(holderobj)
         autousenames = []
         for name in dir(holderobj):
             # The attribute can be an arbitrary descriptor, so the attribute
             # access below can raise. safe_getatt() ignores such exceptions.
+            maybe_property = safe_getattr(type(holderobj), name, None)
+            if isinstance(maybe_property, _CompatProperty):
+                # deprecated
+                continue
             obj = safe_getattr(holderobj, name, None)
             marker = getfixturemarker(obj)
             # fixture functions have a pytest_funcarg__ prefix (pre-2.3 style)


### PR DESCRIPTION
Fix #2701 

its tricky to trigger those warnings under normal circumstances as they happen before pytest hooks into the warnings system

`python -W always -m pytest testing/test_tmpdir.py --collectonly` could be used to trigger them for example on the cli
