### PR TITLE
Fix #3533: properly escape raw XML object

### DIFF
--- a/changelog/3533.bugfix.rst
+++ b/changelog/3533.bugfix.rst
@@ -1,0 +1,1 @@
+Fix unescaped XML raw objects in JUnit report for skipped tests

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -221,12 +221,14 @@ class _NodeReporter(object):
         else:
             filename, lineno, skipreason = report.longrepr
             if skipreason.startswith("Skipped: "):
-                skipreason = bin_xml_escape(skipreason[9:])
+                skipreason = skipreason[9:]
+            details = "%s:%s: %s" % (filename, lineno, skipreason)
+
             self.append(
                 Junit.skipped(
-                    "%s:%s: %s" % (filename, lineno, skipreason),
+                    bin_xml_escape(details),
                     type="pytest.skip",
-                    message=skipreason,
+                    message=bin_xml_escape(skipreason),
                 )
             )
             self.write_captured_output(report)

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1222,3 +1222,19 @@ def test_set_suite_name(testdir, suite_name):
     assert result.ret == 0
     node = dom.find_first_by_tag("testsuite")
     node.assert_attr(name=expected)
+
+
+def test_escaped_skipreason_issue3533(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        @pytest.mark.skip(reason='1 <> 2')
+        def test_skip():
+            pass
+    """
+    )
+    _, dom = runandparse(testdir)
+    node = dom.find_first_by_tag("testcase")
+    snode = node.find_first_by_tag("skipped")
+    assert "1 <> 2" in snode.text
+    snode.assert_attr(message="1 <> 2")


### PR DESCRIPTION
Using string formatting with the raw escaped object lead to string evaluation
resulting in "<py._xmlgen.raw object>" in skipped test Junit report

Format the unescaped string first, then use the XML escape method as a last step.


