### PR TITLE
No longer upload code coverage to coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,12 +93,6 @@ after_success:
       coverage xml --ignore-errors
       coverage report -m --ignore-errors
       bash <(curl -s https://codecov.io/bash) -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml -F "${TOXENV//-/,},linux"
-
-      # Coveralls does not support merged reports.
-      if [[ "$TOXENV" = py37 ]]; then
-        pip install coveralls
-        coveralls
-      fi
     fi
 
 notifications:


### PR DESCRIPTION
We have moved to codecov for awhile now, and uploading to coveralls is breaking
OS-X builds for py37 [1], so we might as well take this opportunity to drop
it.

[1] https://travis-ci.org/pytest-dev/pytest/jobs/442858038
