### PR TITLE
Make --color more colorful

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -202,6 +202,7 @@ Stefan Zimmermann
 Stefano Taschini
 Steffen Allner
 Stephan Obermann
+Sven-Hendrik Haase
 Tadek Teleżyński
 Tarcisio Fischer
 Tareq Alayan

--- a/changelog/4188.feature.rst
+++ b/changelog/4188.feature.rst
@@ -1,0 +1,1 @@
+Make ``--color`` emit colorful dots when not running in verbose mode. Earlier, it would only colorize the test-by-test output if ``--verbose`` was also passed.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -263,7 +263,7 @@ class TerminalReporter(object):
         char = {"xfailed": "x", "skipped": "s"}.get(char, char)
         return char in self.reportchars
 
-    def write_fspath_result(self, nodeid, res):
+    def write_fspath_result(self, nodeid, res, **markup):
         fspath = self.config.rootdir.join(nodeid.split("::")[0])
         if fspath != self.currentfspath:
             if self.currentfspath is not None and self._show_progress_info:
@@ -272,7 +272,7 @@ class TerminalReporter(object):
             fspath = self.startdir.bestrelpath(fspath)
             self._tw.line()
             self._tw.write(fspath + " ")
-        self._tw.write(res)
+        self._tw.write(res, **markup)
 
     def write_ensure_prefix(self, prefix, extra="", **kwargs):
         if self.currentfspath != prefix:
@@ -386,22 +386,22 @@ class TerminalReporter(object):
             # probably passed setup/teardown
             return
         running_xdist = hasattr(rep, "node")
+        if markup is None:
+            if rep.passed:
+                markup = {"green": True}
+            elif rep.failed:
+                markup = {"red": True}
+            elif rep.skipped:
+                markup = {"yellow": True}
+            else:
+                markup = {}
         if self.verbosity <= 0:
             if not running_xdist and self.showfspath:
-                self.write_fspath_result(rep.nodeid, letter)
+                self.write_fspath_result(rep.nodeid, letter, **markup)
             else:
-                self._tw.write(letter)
+                self._tw.write(letter, **markup)
         else:
             self._progress_nodeids_reported.add(rep.nodeid)
-            if markup is None:
-                if rep.passed:
-                    markup = {"green": True}
-                elif rep.failed:
-                    markup = {"red": True}
-                elif rep.skipped:
-                    markup = {"yellow": True}
-                else:
-                    markup = {}
             line = self._locationline(rep.nodeid, *rep.location)
             if not running_xdist:
                 self.write_ensure_prefix(line, word, **markup)


### PR DESCRIPTION
- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [x] Target the `features` branch for new features and removals/deprecations.
- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS` in alphabetical order;

This patch makes `pytest --color yes` look like this in case `--verbose` is not passed. I always thought it was too bland before! The colored dots really make failures stand out. 
![2018-10-18-033332_1408x394_scrot](https://user-images.githubusercontent.com/1664/47125982-9d38dc00-d286-11e8-9c4a-4d165e86338b.png)
