### PR TITLE
Use safe_str() to format warning message about unicode in Python 2

### DIFF
--- a/changelog/3691.bugfix.rst
+++ b/changelog/3691.bugfix.rst
@@ -1,0 +1,2 @@
+Python 2: safely format warning message about passing unicode strings to ``warnings.warn``, which may cause
+surprising ``MemoryError`` exception when monkey patching ``warnings.warn`` itself.

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -123,7 +123,7 @@ def warning_record_to_str(warning_message):
     if unicode_warning:
         warnings.warn(
             "Warning is using unicode non convertible to ascii, "
-            "converting to a safe representation:\n  %s" % msg,
+            "converting to a safe representation:\n  {!r}".format(compat.safe_str(msg)),
             UnicodeWarning,
         )
     return msg

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ envlist =
 
 [testenv]
 commands =
-    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest --lsof
+    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest --lsof {posargs}
     coverage: coverage combine
     coverage: coverage report
 passenv = USER USERNAME COVERAGE_* TRAVIS
@@ -41,7 +41,7 @@ deps =
     py27: mock
     nose
 commands =
-    pytest -n auto --runpytest=subprocess
+    pytest -n auto --runpytest=subprocess {posargs}
 
 
 [testenv:linting]
@@ -58,7 +58,7 @@ deps =
     hypothesis>=3.56
     {env:_PYTEST_TOX_EXTRA_DEP:}
 commands =
-    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n auto
+    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n auto {posargs}
 
 [testenv:py36-xdist]
 # NOTE: copied from above due to https://github.com/tox-dev/tox/issues/706.


### PR DESCRIPTION
Fix #3691

