### PR TITLE
Improve error message when it is not possible to determine a function's signature

### DIFF
--- a/changelog/4026.bugfix.rst
+++ b/changelog/4026.bugfix.rst
@@ -1,0 +1,1 @@
+Improve error message when it is not possible to determine a function's signature.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 import py
 
 import _pytest
-from _pytest.outcomes import TEST_OUTCOME
+from _pytest.outcomes import TEST_OUTCOME, fail
 from six import text_type
 import six
 
@@ -131,9 +131,17 @@ def getfuncargnames(function, is_method=False, cls=None):
     # ordered mapping of parameter names to Parameter instances.  This
     # creates a tuple of the names of the parameters that don't have
     # defaults.
+    try:
+        parameters = signature(function).parameters
+    except (ValueError, TypeError) as e:
+        fail(
+            "Could not determine arguments of {!r}: {}".format(function, e),
+            pytrace=False,
+        )
+
     arg_names = tuple(
         p.name
-        for p in signature(function).parameters.values()
+        for p in parameters.values()
         if (
             p.kind is Parameter.POSITIONAL_OR_KEYWORD
             or p.kind is Parameter.KEYWORD_ONLY

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -952,3 +952,23 @@ def test_collect_init_tests(testdir):
             "*<Function 'test_foo'>",
         ]
     )
+
+
+def test_collect_invalid_signature_message(testdir):
+    """Check that we issue a proper message when we can't determine the signature of a test
+    function (#4026).
+    """
+    testdir.makepyfile(
+        """
+        import pytest
+
+        class TestCase:
+            @pytest.fixture
+            def fix():
+                pass
+    """
+    )
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(
+        ["Could not determine arguments of *.fix *: invalid method signature"]
+    )


### PR DESCRIPTION
This is an improvement as it at least indicates which is the problematic function:

```
============================================= ERRORS ==============================================
__________________________________ ERROR collecting test-foo.py ___________________________________
Could not determine arguments of <bound method TestCase.fix of <test-foo.TestCase object at 0x000001A6AA687908>>: invalid method signature
!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
===================================== 1 error in 0.10 seconds =====================================
```

Fix #4026

