### PR TITLE
Upgrade pre-commit/pre-commit-hooks to 2.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         additional_dependencies: [black==18.9b0]
         language_version: python3
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.4.0-1
+    rev: v2.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer


### PR DESCRIPTION
I've seen some issues with pre-commit-hooks<2.x though I think they only affect python2? not sure -- but either way this upgrade passes: https://github.com/pre-commit/pre-commit-hooks/issues/328