### PR TITLE
Fix logging usage in hooks pytest_sessionstart/finish

### DIFF
--- a/changelog/3340.bugfix.rst
+++ b/changelog/3340.bugfix.rst
@@ -1,0 +1,1 @@
+Fix logging messages not shown in hooks ``pytest_sessionstart()`` and ``pytest_sessionfinish()``.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -497,6 +497,29 @@ class LoggingPlugin(object):
         with self._runtest_for(None, "finish"):
             yield
 
+    @pytest.hookimpl(hookwrapper=True, tryfirst=True)
+    def pytest_sessionfinish(self):
+        with self.live_logs_context():
+            if self.log_cli_handler:
+                self.log_cli_handler.set_when("sessionfinish")
+            if self.log_file_handler is not None:
+                with catching_logs(self.log_file_handler, level=self.log_file_level):
+                    yield
+            else:
+                yield
+
+    @pytest.hookimpl(hookwrapper=True, tryfirst=True)
+    def pytest_sessionstart(self):
+        self._setup_cli_logging()
+        with self.live_logs_context():
+            if self.log_cli_handler:
+                self.log_cli_handler.set_when("sessionstart")
+            if self.log_file_handler is not None:
+                with catching_logs(self.log_file_handler, level=self.log_file_level):
+                    yield
+            else:
+                yield
+
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtestloop(self, session):
         """Runs all collected test items."""


### PR DESCRIPTION
Fix issue #3340: missing logging on some hooks

Add logging capture for `pytest_sessionstart()` and `pytest_sessionfinish()`

I didn't find anywhere this could be documented; these hooks aren't well documented and this just restores a normal behavior.