### PR TITLE
Remove pytest.config example from skipping at module level docs

### DIFF
--- a/doc/en/skipping.rst
+++ b/doc/en/skipping.rst
@@ -58,18 +58,20 @@ by calling the ``pytest.skip(reason)`` function:
         if not valid_config():
             pytest.skip("unsupported configuration")
 
+The imperative method is useful when it is not possible to evaluate the skip condition
+during import time.
+
 It is also possible to skip the whole module using
 ``pytest.skip(reason, allow_module_level=True)`` at the module level:
 
 .. code-block:: python
 
+    import sys
     import pytest
 
-    if not pytest.config.getoption("--custom-flag"):
-        pytest.skip("--custom-flag is missing, skipping tests", allow_module_level=True)
+    if not sys.platform.startswith("win"):
+        pytest.skip("skipping windows-only tests", allow_module_level=True)
 
-The imperative method is useful when it is not possible to evaluate the skip condition
-during import time.
 
 **Reference**: :ref:`pytest.mark.skip ref`
 


### PR DESCRIPTION
Fix #4206 