### PR TITLE
Issue a warning when a fixture named 'request' is collected

### DIFF
--- a/changelog/611.bugfix.rst
+++ b/changelog/611.bugfix.rst
@@ -1,0 +1,2 @@
+Naming a fixture ``request`` will now raise a warning: the ``request`` fixture is internal and
+should not be overwritten as it will lead to internal errors.

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -11,7 +11,11 @@ in case of warnings which need to format their messages.
 from __future__ import absolute_import, division, print_function
 
 
-from _pytest.warning_types import UnformattedWarning, RemovedInPytest4Warning
+from _pytest.warning_types import (
+    UnformattedWarning,
+    RemovedInPytest4Warning,
+    PytestDeprecationWarning,
+)
 
 
 MAIN_STR_ARGS = RemovedInPytest4Warning(
@@ -53,6 +57,10 @@ FIXTURE_FUNCTION_CALL = UnformattedWarning(
     'Fixture "{name}" called directly. Fixtures are not meant to be called directly, '
     "are created automatically when test functions request them as parameters. "
     "See https://docs.pytest.org/en/latest/fixture.html for more information.",
+)
+
+FIXTURE_NAMED_REQUEST = PytestDeprecationWarning(
+    "'request' is a reserved name for fixtures and will raise an error in future versions"
 )
 
 CFG_PYTEST_SECTION = UnformattedWarning(

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -32,7 +32,7 @@ from _pytest.compat import (
     get_real_method,
     _PytestWrapper,
 )
-from _pytest.deprecated import FIXTURE_FUNCTION_CALL
+from _pytest.deprecated import FIXTURE_FUNCTION_CALL, FIXTURE_NAMED_REQUEST
 from _pytest.outcomes import fail, TEST_OUTCOME
 
 FIXTURE_MSG = 'fixtures cannot have "pytest_funcarg__" prefix and be decorated with @pytest.fixture:\n{}'
@@ -1029,6 +1029,9 @@ class FixtureFunctionMarker(object):
 
         function = wrap_function_to_warning_if_called_directly(function, self)
 
+        name = self.name or function.__name__
+        if name == "request":
+            warnings.warn(FIXTURE_NAMED_REQUEST)
         function._pytestfixturefunction = self
         return function
 

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -4,6 +4,8 @@ import os
 
 import pytest
 
+pytestmark = pytest.mark.pytester_example_path("deprecated")
+
 
 @pytest.mark.filterwarnings("default")
 def test_yield_tests_deprecation(testdir):
@@ -392,3 +394,13 @@ def test_pycollector_makeitem_is_deprecated():
     with pytest.warns(RemovedInPytest4Warning):
         collector.makeitem("foo", "bar")
     assert collector.called
+
+
+def test_fixture_named_request(testdir):
+    testdir.copy_example()
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(
+        [
+            "*'request' is a reserved name for fixtures and will raise an error in future versions"
+        ]
+    )

--- a/testing/example_scripts/deprecated/test_fixture_named_request.py
+++ b/testing/example_scripts/deprecated/test_fixture_named_request.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.fixture
+def request():
+    pass
+
+
+def test():
+    pass


### PR DESCRIPTION
Fix #611

