### PR TITLE
Fix MacOS py37 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,11 @@ jobs:
       env: TOXENV=py37
       before_install:
         - brew update
+        # remove c++ include files because upgrading python as of 2018-10-23, also
+        # attempts to upgrade gcc, and it fails because the include files already
+        # exist. removing the include files is one of the solutions recommended by brew
+        # this workaround might not be necessary in the future
+        - rm '/usr/local/include/c++'
         - brew upgrade python
         - brew unlink python
         - brew link python


### PR DESCRIPTION

This has been failing as of 2018-10-23 while installing gcc with
this message:

```
	==> Installing numpy dependency: gcc
	==> Downloading https://homebrew.bintray.com/bottles/gcc-8.2.0.high_sierra.bottl
	######################################################################## 100.0%
	==> Pouring gcc-8.2.0.high_sierra.bottle.1.tar.gz
	Error: The `brew link` step did not complete successfully
	The formula built, but is not symlinked into /usr/local
	Could not symlink include/c++
	Target /usr/local/include/c++
	already exists. You may want to remove it:
	  rm '/usr/local/include/c++'
	To force the link and overwrite all conflicting files:
	  brew link --overwrite gcc
	To list all files that would be deleted:
	  brew link --overwrite --dry-run gcc
	Possible conflicting files are:
	/usr/local/include/c++ -> /usr/local/Caskroom/oclint/0.13.1,17.4.0/oclint-0.13.1/include/c++

```

Example failure: https://travis-ci.org/pytest-dev/pytest/jobs/444989259