### PR TITLE
_getconftestmodules: avoid isfile()/dirpath()

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -387,13 +387,13 @@ class PytestPluginManager(PluginManager):
         if self._noconftest:
             return []
 
-        if path.isfile():
-            directory = path.dirpath()
-        else:
-            directory = path
         try:
-            return self._path2confmods[directory]
+            return self._path2confmods[path]
         except KeyError:
+            if path.isfile():
+                directory = path.dirpath()
+            else:
+                directory = path
             # XXX these days we may rather want to use config.rootdir
             # and allow users to opt into looking into the rootdir parent
             # directories instead of requiring to specify confcutdir
@@ -406,7 +406,7 @@ class PytestPluginManager(PluginManager):
                     mod = self._importconftest(conftestpath)
                     clist.append(mod)
 
-            self._path2confmods[directory] = clist
+            self._path2confmods[path] = clist
             return clist
 
     def _rget_with_confmod(self, name, path):


### PR DESCRIPTION
Ref: https://github.com/pytest-dev/pytest/issues/2206#issuecomment-432623646

I cannot see a real difference myself with clock time (1.2s vs 1.15s with some project and `-k doesnotmatch`), but I think it makes sense anyway, and might help with the above comment.

For pytest itself:
new: 1 loop, best of 5: 1.73 sec per loop
old: 1 loop, best of 5: 1.61 sec per loop

However, pytest itself displays "2287 deselected in 1.06 seconds" vs "2287 deselected in 1.22 seconds".