### PR TITLE
TerminalWriter: write "collecting" msg only once every 0.5s

### DIFF
--- a/changelog/4225.feature.rst
+++ b/changelog/4225.feature.rst
@@ -1,0 +1,3 @@
+Improve performance with collection reporting in non-quiet mode with terminals.
+
+The "collecting …" message is only printed/updated every 0.5s.


### PR DESCRIPTION
Running `pytest -k doesnotmatch` on pytest's own tests takes ~3s with
Kitty terminal for me, but only ~1s with `-q`.
It also is faster with urxvt, but still takes 2.2s there.

This patch only calls `report_collect` every 0.1s, which is good enough
for reporting collection progress, and improves the time with both Kitty
and urxvt to ~1.2s for me.

TODO:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.