### PR TITLE
Use functools.lru_cache with _getconftest_pathlist

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1,6 +1,7 @@
 """ command line options, ini-file and conftest.py processing. """
 from __future__ import absolute_import, division, print_function
 import argparse
+import functools
 import inspect
 import shlex
 import types
@@ -893,6 +894,7 @@ class Config(object):
             assert type is None
             return value
 
+    @functools.lru_cache(maxsize=None)
     def _getconftest_pathlist(self, name, path):
         try:
             mod, relroots = self.pluginmanager._rget_with_confmod(name, path)

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -894,7 +894,6 @@ class Config(object):
             assert type is None
             return value
 
-    @functools.lru_cache(maxsize=None)
     def _getconftest_pathlist(self, name, path):
         try:
             mod, relroots = self.pluginmanager._rget_with_confmod(name, path)
@@ -908,6 +907,10 @@ class Config(object):
                 relroot = modpath.join(relroot, abs=True)
             values.append(relroot)
         return values
+
+    if six.PY3:
+        # once we drop Python 2, please change this to use the normal decorator syntax (#4227)
+        _getconftest_pathlist = functools.lru_cache(maxsize=None)(_getconftest_pathlist)
 
     def _get_override_ini_value(self, name):
         value = None


### PR DESCRIPTION
For pytest's own suite the `cache_info()` looks as follows:

    > session.config._getconftest_pathlist.cache_info()
    CacheInfo(hits=231, misses=19, maxsize=None, currsize=19)

While it does not really make a difference for me this might help with
larger test suites / the case mentioned in
https://github.com/pytest-dev/pytest/issues/2206#issuecomment-432623646.

/cc @boxed 