### PR TITLE
Fix flake8: os imported, but unused

### DIFF
--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -1,7 +1,6 @@
 """ interactive debugging with PDB, the Python Debugger. """
 from __future__ import absolute_import, division, print_function
 
-import os
 import pdb
 import sys
 from doctest import UnexpectedException


### PR DESCRIPTION
Likely due to b6fa4e24.