### PR TITLE
Move handling of duplicate files

### DIFF
--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -278,15 +278,6 @@ def pytest_ignore_collect(path, config):
     if _in_venv(path) and not allow_in_venv:
         return True
 
-    # Skip duplicate paths.
-    keepduplicates = config.getoption("keepduplicates")
-    duplicate_paths = config.pluginmanager._duplicatepaths
-    if not keepduplicates:
-        if path in duplicate_paths:
-            return True
-        else:
-            duplicate_paths.add(path)
-
     return False
 
 
@@ -556,6 +547,16 @@ class Session(nodes.FSCollector):
         if not self.isinitpath(path):
             if ihook.pytest_ignore_collect(path=path, config=self.config):
                 return ()
+
+        # Skip duplicate paths.
+        keepduplicates = self.config.getoption("keepduplicates")
+        if not keepduplicates:
+            duplicate_paths = self.config.pluginmanager._duplicatepaths
+            if path in duplicate_paths:
+                return ()
+            else:
+                duplicate_paths.add(path)
+
         return ihook.pytest_collect_file(path=path, parent=self)
 
     def _recurse(self, path):

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -554,15 +554,6 @@ class Package(Module):
         return path in self.session._initialpaths
 
     def collect(self):
-        # XXX: HACK!
-        # Before starting to collect any files from this package we need
-        # to cleanup the duplicate paths added by the session's collect().
-        # Proper fix is to not track these as duplicates in the first place.
-        for path in list(self.session.config.pluginmanager._duplicatepaths):
-            # if path.parts()[:len(self.fspath.dirpath().parts())] == self.fspath.dirpath().parts():
-            if path.dirname.startswith(self.name):
-                self.session.config.pluginmanager._duplicatepaths.remove(path)
-
         this_path = self.fspath.dirpath()
         init_module = this_path.join("__init__.py")
         if init_module.check(file=1) and path_matches_patterns(

--- a/testing/test_session.py
+++ b/testing/test_session.py
@@ -218,7 +218,7 @@ class TestNewSession(SessionTests):
         started = reprec.getcalls("pytest_collectstart")
         finished = reprec.getreports("pytest_collectreport")
         assert len(started) == len(finished)
-        assert len(started) == 7  # XXX extra TopCollector
+        assert len(started) == 8
         colfail = [x for x in finished if x.failed]
         assert len(colfail) == 1
 


### PR DESCRIPTION
This removes the hack added in
https://github.com/pytest-dev/pytest/pull/3802.

This also improves performance a bit with the test case for #4237:
Before: 7.95s
After: 7.51s