### PR TITLE
_getconftestmodules: use functools.lru_cache

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -214,7 +214,7 @@ class PytestPluginManager(PluginManager):
         self._conftest_plugins = set()
 
         # state related to local conftest plugins
-        self._path2confmods = {}
+        self._dirpath2confmods = {}
         self._conftestpath2mod = {}
         self._confcutdir = None
         self._noconftest = False
@@ -385,31 +385,35 @@ class PytestPluginManager(PluginManager):
                 if x.check(dir=1):
                     self._getconftestmodules(x)
 
+    @lru_cache(maxsize=128)
     def _getconftestmodules(self, path):
         if self._noconftest:
             return []
 
-        try:
-            return self._path2confmods[path]
-        except KeyError:
-            if path.isfile():
-                directory = path.dirpath()
-            else:
-                directory = path
-            # XXX these days we may rather want to use config.rootdir
-            # and allow users to opt into looking into the rootdir parent
-            # directories instead of requiring to specify confcutdir
-            clist = []
-            for parent in directory.realpath().parts():
-                if self._confcutdir and self._confcutdir.relto(parent):
-                    continue
-                conftestpath = parent.join("conftest.py")
-                if conftestpath.isfile():
-                    mod = self._importconftest(conftestpath)
-                    clist.append(mod)
+        if path.isfile():
+            directory = path.dirpath()
+        else:
+            directory = path
 
-            self._path2confmods[path] = clist
-            return clist
+        if six.PY2:  # py2 is not using lru_cache.
+            try:
+                return self._dirpath2confmods[directory]
+            except KeyError:
+                pass
+
+        # XXX these days we may rather want to use config.rootdir
+        # and allow users to opt into looking into the rootdir parent
+        # directories instead of requiring to specify confcutdir
+        clist = []
+        for parent in directory.realpath().parts():
+            if self._confcutdir and self._confcutdir.relto(parent):
+                continue
+            conftestpath = parent.join("conftest.py")
+            if conftestpath.isfile():
+                mod = self._importconftest(conftestpath)
+                clist.append(mod)
+        self._dirpath2confmods[directory] = clist
+        return clist
 
     def _rget_with_confmod(self, name, path):
         modules = self._getconftestmodules(path)
@@ -450,8 +454,8 @@ class PytestPluginManager(PluginManager):
             self._conftest_plugins.add(mod)
             self._conftestpath2mod[conftestpath] = mod
             dirpath = conftestpath.dirpath()
-            if dirpath in self._path2confmods:
-                for path, mods in self._path2confmods.items():
+            if dirpath in self._dirpath2confmods:
+                for path, mods in self._dirpath2confmods.items():
                     if path and path.relto(dirpath) or path == dirpath:
                         assert mod not in mods
                         mods.append(mod)
@@ -902,7 +906,6 @@ class Config(object):
             assert type is None
             return value
 
-    @lru_cache(maxsize=None)
     def _getconftest_pathlist(self, name, path):
         try:
             mod, relroots = self.pluginmanager._rget_with_confmod(name, path)

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -49,14 +49,14 @@ class TestConftestValueAccessGlobal(object):
 
     def test_immediate_initialiation_and_incremental_are_the_same(self, basedir):
         conftest = PytestPluginManager()
-        len(conftest._path2confmods)
+        len(conftest._dirpath2confmods)
         conftest._getconftestmodules(basedir)
-        snap1 = len(conftest._path2confmods)
-        # assert len(conftest._path2confmods) == snap1 + 1
+        snap1 = len(conftest._dirpath2confmods)
+        # assert len(conftest._dirpath2confmods) == snap1 + 1
         conftest._getconftestmodules(basedir.join("adir"))
-        assert len(conftest._path2confmods) == snap1 + 1
+        assert len(conftest._dirpath2confmods) == snap1 + 1
         conftest._getconftestmodules(basedir.join("b"))
-        assert len(conftest._path2confmods) == snap1 + 2
+        assert len(conftest._dirpath2confmods) == snap1 + 2
 
     def test_value_access_not_existing(self, basedir):
         conftest = ConftestWithSetinitial(basedir)


### PR DESCRIPTION
Also renames `_path2confmods` to `_dirpath2confmods` for clarity (it is
expected to be a dirpath in `_importconftest`).

Merges master to avoid conflict with 63691f56 (which should have been done on features probably).