### PR TITLE
Fixes #4255 by adding to the doc that module names are not regex-escaped

### DIFF
--- a/changelog/4255.doc.rst
+++ b/changelog/4255.doc.rst
@@ -1,0 +1,1 @@
+Added missing documentation about the fact that module names passed to filter warnings are not regex-escaped.

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -117,6 +117,7 @@ Add warning filters to marked test items.
         A *warning specification string*, which is composed of contents of the tuple ``(action, message, category, module, lineno)``
         as specified in `The Warnings filter <https://docs.python.org/3/library/warnings.html#warning-filter>`_ section of
         the Python documentation, separated by ``":"``. Optional fields can be omitted.
+        Module names passed for filtering are not regex-escaped.
 
         For example:
 


### PR DESCRIPTION
Added the missing documentation to [filterwarnings](https://docs.pytest.org/en/latest/reference.html#pytest-mark-filterwarnings) section that module names passed are not regex-filtered. 