### PR TITLE
Swallow warnings during anonymous compilation of source

### DIFF
--- a/changelog/4260.bugfix.rst
+++ b/changelog/4260.bugfix.rst
@@ -1,0 +1,1 @@
+Swallow warnings during anonymous compilation of source.

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -14,8 +14,6 @@ from bisect import bisect_right
 import py
 import six
 
-cpy_compile = compile
-
 
 class Source(object):
     """ an immutable object holding a source code fragment,
@@ -161,7 +159,7 @@ class Source(object):
                 filename = base + "%r %s:%d>" % (filename, fn, lineno)
         source = "\n".join(self.lines) + "\n"
         try:
-            co = cpy_compile(source, filename, mode, flag)
+            co = compile(source, filename, mode, flag)
         except SyntaxError:
             ex = sys.exc_info()[1]
             # re-represent syntax errors from parsing python strings
@@ -195,7 +193,7 @@ def compile_(source, filename=None, mode="exec", flags=0, dont_inherit=0):
     """
     if isinstance(source, ast.AST):
         # XXX should Source support having AST?
-        return cpy_compile(source, filename, mode, flags, dont_inherit)
+        return compile(source, filename, mode, flags, dont_inherit)
     _genframe = sys._getframe(1)  # the caller
     s = Source(source)
     co = s.compile(filename, mode, flags, _genframe=_genframe)
@@ -290,7 +288,7 @@ def get_statement_startend2(lineno, node):
 def getstatementrange_ast(lineno, source, assertion=False, astnode=None):
     if astnode is None:
         content = str(source)
-        astnode = compile(content, "source", "exec", 1024)  # 1024 for AST
+        astnode = compile(content, "source", "exec", _AST_FLAG)
 
     start, end = get_statement_startend2(lineno, astnode)
     # we need to correct the end:

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -8,6 +8,7 @@ import linecache
 import sys
 import textwrap
 import tokenize
+import warnings
 from ast import PyCF_ONLY_AST as _AST_FLAG
 from bisect import bisect_right
 
@@ -288,7 +289,11 @@ def get_statement_startend2(lineno, node):
 def getstatementrange_ast(lineno, source, assertion=False, astnode=None):
     if astnode is None:
         content = str(source)
-        astnode = compile(content, "source", "exec", _AST_FLAG)
+        # See #4260:
+        # don't produce duplicate warnings when compiling source to find ast
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            astnode = compile(content, "source", "exec", _AST_FLAG)
 
     start, end = get_statement_startend2(lineno, astnode)
     # we need to correct the end:


### PR DESCRIPTION
Resolves #4260 

For the same reasons as [this](https://github.com/pytest-dev/pytest/pull/4153#issuecomment-429675418) it's difficult to write a future-proof regression test for this.

Here's what I used locally to verify this though:

```python
import pytest


@pytest.mark.xfail
def test_xfail():
    assert False

def test():
    '\d'
```

### before

```
$ rm -rf __pycache__/ && pytest -Wonce t.py
============================= test session starts ==============================
platform linux -- Python 3.6.6, pytest-3.9.4.dev5+ge6e40db9, py-1.7.0, pluggy-0.8.0
rootdir: /tmp/pytest, inifile: tox.ini
collected 2 items                                                              

t.py x.                                                                  [100%]
=========================== short test summary info ============================
XFAIL t.py::test_xfail

=============================== warnings summary ===============================
t.py:9
  /tmp/pytest/t.py:9: DeprecationWarning: invalid escape sequence \d
    '\d'

t.py::test_xfail
  source:9: DeprecationWarning: invalid escape sequence \d

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============== 1 passed, 1 xfailed, 2 warnings in 0.05 seconds ================
```

### after

```
$ rm -rf __pycache__/ && pytest -Wonce t.py
============================= test session starts ==============================
platform linux -- Python 3.6.6, pytest-3.9.4.dev5+ge6e40db9, py-1.7.0, pluggy-0.8.0
rootdir: /tmp/pytest, inifile: tox.ini
collected 2 items                                                              

t.py x.                                                                  [100%]
=========================== short test summary info ============================
XFAIL t.py::test_xfail

=============================== warnings summary ===============================
t.py:9
  /tmp/pytest/t.py:9: DeprecationWarning: invalid escape sequence \d
    '\d'

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============== 1 passed, 1 xfailed, 1 warnings in 0.05 seconds ================
```