### PR TITLE
cache_dir: use $TOX_ENV_DIR/ prefix if set

### DIFF
--- a/changelog/4270.feature.rst
+++ b/changelog/4270.feature.rst
@@ -1,0 +1,3 @@
+The ``cache_dir`` option uses ``$TOX_ENV_DIR`` as prefix (if set in the environment).
+
+This uses a different cache per tox environment by default.

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -9,6 +9,7 @@ from __future__ import division
 from __future__ import print_function
 
 import json
+import os
 from collections import OrderedDict
 
 import attr
@@ -275,7 +276,10 @@ def pytest_addoption(parser):
         dest="cacheclear",
         help="remove all cache contents at start of test run.",
     )
-    parser.addini("cache_dir", default=".pytest_cache", help="cache directory path.")
+    cache_dir_default = ".pytest_cache"
+    if "TOX_ENV_DIR" in os.environ:
+        cache_dir_default = os.path.join(os.environ["TOX_ENV_DIR"], cache_dir_default)
+    parser.addini("cache_dir", default=cache_dir_default, help="cache directory path.")
     group.addoption(
         "--lfnf",
         "--last-failed-no-failures",


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/issues/4270

"rst" pre-commit hook fails:

> ERROR changelog/4270.feature.rst:1 Unknown interpreted text role "confval".

I think we should fix it to allow for our own roles etc.  /cc @asottile 