### PR TITLE
pdb: improve msg about output capturing with set_trace

### DIFF
--- a/changelog/4277.trivial.rst
+++ b/changelog/4277.trivial.rst
@@ -1,0 +1,4 @@
+pdb: improve message about output capturing with ``set_trace``.
+
+Do not display "IO-capturing turned off/on" when ``-s`` is used to avoid
+confusion.

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -102,6 +102,9 @@ class CaptureManager(object):
 
     # Global capturing control
 
+    def is_globally_capturing(self):
+        return self._method != "no"
+
     def start_global_capturing(self):
         assert self._global_capturing is None
         self._global_capturing = self._getcapture(self._method)

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -80,7 +80,10 @@ class pytestPDB(object):
                 capman.suspend_global_capture(in_=True)
             tw = _pytest.config.create_terminal_writer(cls._config)
             tw.line()
-            tw.sep(">", "PDB set_trace (IO-capturing turned off)")
+            if capman and capman.is_globally_capturing():
+                tw.sep(">", "PDB set_trace (IO-capturing turned off)")
+            else:
+                tw.sep(">", "PDB set_trace")
 
             class _PdbWrapper(cls._pdb_cls, object):
                 _pytest_capman = capman
@@ -91,7 +94,10 @@ class pytestPDB(object):
                     if self._pytest_capman:
                         tw = _pytest.config.create_terminal_writer(cls._config)
                         tw.line()
-                        tw.sep(">", "PDB continue (IO-capturing resumed)")
+                        if self._pytest_capman.is_globally_capturing():
+                            tw.sep(">", "PDB continue (IO-capturing resumed)")
+                        else:
+                            tw.sep(">", "PDB continue")
                         self._pytest_capman.resume_global_capture()
                     cls._pluginmanager.hook.pytest_leave_pdb(
                         config=cls._config, pdb=self

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -518,6 +518,22 @@ class TestPDB(object):
         assert "1 failed" in rest
         self.flush(child)
 
+    def test_pdb_without_capture(self, testdir):
+        p1 = testdir.makepyfile(
+            """
+            import pytest
+            def test_1():
+                pytest.set_trace()
+        """
+        )
+        child = testdir.spawn_pytest("-s %s" % p1)
+        child.expect(r">>> PDB set_trace >>>")
+        child.expect("Pdb")
+        child.sendline("c")
+        child.expect(r">>> PDB continue >>>")
+        child.expect("1 passed")
+        self.flush(child)
+
     def test_pdb_used_outside_test(self, testdir):
         p1 = testdir.makepyfile(
             """


### PR DESCRIPTION
Do not display "IO-capturing turned off/on" when ``-s`` is used to avoid
confusion.

TODO:

- [x] (trivial) changelog entry