### PR TITLE
debugging: make pytest_configure re-entrant

### DIFF
--- a/changelog/4287.bugfix.rst
+++ b/changelog/4287.bugfix.rst
@@ -1,0 +1,1 @@
+Fix nested usage of debugging plugin (pdb), e.g. with pytester's ``testdir.runpytest``.

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -784,3 +784,30 @@ class TestTraceOption:
         assert "1 passed" in rest
         assert "reading from stdin while output" not in rest
         TestPDB.flush(child)
+
+
+def test_trace_after_runpytest(testdir):
+    """Test that debugging's pytest_configure is re-entrant."""
+    p1 = testdir.makepyfile(
+        """
+        from _pytest.debugging import pytestPDB
+
+        def test_outer(testdir):
+            from _pytest.debugging import pytestPDB
+
+            assert len(pytestPDB._saved) == 1
+
+            testdir.runpytest("-k test_inner")
+
+            __import__('pdb').set_trace()
+
+        def test_inner(testdir):
+            assert len(pytestPDB._saved) == 2
+    """
+    )
+    child = testdir.spawn_pytest("-p pytester %s -k test_outer" % p1)
+    child.expect(r"\(Pdb")
+    child.sendline("c")
+    rest = child.read().decode("utf8")
+    TestPDB.flush(child)
+    assert child.exitstatus == 0, rest


### PR DESCRIPTION
Causes:

    E             def test_1(testdir):
    E                 testdir.runpytest()
    E         >       __import__('pdb').set_trace()
    E
    E         ../../test_trace_after_runpytest.py:3:
    E         …/Vcs/pytest/src/_pytest/debugging.py:81: in set_trace
    E             tw = _pytest.config.create_terminal_writer(cls._config)
    E
    E         config = None, args = (), kwargs = {}, tw = <py._io.terminalwriter.TerminalWriter object at 0x7f1097088160>
    E
    E             def create_terminal_writer(config, *args, **kwargs):
    E                 """Create a TerminalWriter instance configured according to the options
    E                 in the config object. Every code which requires a TerminalWriter object
    E                 and has access to a config object should use this function.
    E                 """
    E                 tw = py.io.TerminalWriter(*args, **kwargs)
    E         >       if config.option.color == "yes":
    E         E       AttributeError: 'NoneType' object has no attribute 'option'

Appears to be related to `pytest_unconfigure` being called then, and this appears to be an inline run.
