### PR TITLE
doc: fix HOWTORELEASE.rst

### DIFF
--- a/HOWTORELEASE.rst
+++ b/HOWTORELEASE.rst
@@ -46,5 +46,3 @@ taking a lot of time to make a new one.
    * testing-in-python@lists.idyll.org (only major/minor releases)
 
    And announce it on `Twitter <https://twitter.com/>`_ with the ``#pytest`` hashtag.
-
-#. After a minor/major release, merge ``release-X.Y.Z`` into ``master`` and push (or open a PR).


### PR DESCRIPTION
Remove last step, because it was merged already before (changed in
77cad3c4).

[ci skip]