### PR TITLE
Fix handling of duplicate args with regard to Python packages

### DIFF
--- a/changelog/4310.bugfix.rst
+++ b/changelog/4310.bugfix.rst
@@ -1,0 +1,1 @@
+Fix duplicate collection due to multiple args matching the same packages.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -387,7 +387,6 @@ class Session(nodes.FSCollector):
         self._initialpaths = frozenset()
         # Keep track of any collected nodes in here, so we don't duplicate fixtures
         self._node_cache = {}
-        self._collect_seen_pkgdirs = set()
 
         self.config.pluginmanager.register(self, name="session")
 
@@ -505,7 +504,6 @@ class Session(nodes.FSCollector):
                 if parent.isdir():
                     pkginit = parent.join("__init__.py")
                     if pkginit.isfile():
-                        self._collect_seen_pkgdirs.add(parent)
                         if pkginit in self._node_cache:
                             root = self._node_cache[pkginit][0]
                         else:
@@ -531,12 +529,13 @@ class Session(nodes.FSCollector):
                 def filter_(f):
                     return f.check(file=1)
 
+            seen_dirs = set()
             for path in argpath.visit(
                 fil=filter_, rec=self._recurse, bf=True, sort=True
             ):
                 dirpath = path.dirpath()
-                if dirpath not in self._collect_seen_pkgdirs:
-                    self._collect_seen_pkgdirs.add(dirpath)
+                if dirpath not in seen_dirs:
+                    seen_dirs.add(dirpath)
                     pkginit = dirpath.join("__init__.py")
                     if pkginit.exists() and parts(pkginit.strpath).isdisjoint(paths):
                         for x in root._collectfile(pkginit):

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -18,7 +18,6 @@ from _pytest.config import directory_arg
 from _pytest.config import hookimpl
 from _pytest.config import UsageError
 from _pytest.outcomes import exit
-from _pytest.pathlib import parts
 from _pytest.runner import collect_one_node
 
 
@@ -489,7 +488,6 @@ class Session(nodes.FSCollector):
 
         names = self._parsearg(arg)
         argpath = names.pop(0).realpath()
-        paths = set()
         pkg_roots = {}
 
         root = self
@@ -539,21 +537,19 @@ class Session(nodes.FSCollector):
                 if dirpath not in seen_dirs:
                     seen_dirs.add(dirpath)
                     pkginit = dirpath.join("__init__.py")
-                    if pkginit.exists() and parts(pkginit.strpath).isdisjoint(paths):
+                    if pkginit.exists():
                         for x in collect_root._collectfile(pkginit):
                             yield x
                             if isinstance(x, Package):
                                 pkg_roots[dirpath] = x
-                            paths.add(x.fspath.dirpath())
 
-                if True or parts(path.strpath).isdisjoint(paths):
-                    for x in collect_root._collectfile(path):
-                        key = (type(x), x.fspath)
-                        if key in self._node_cache:
-                            yield self._node_cache[key]
-                        else:
-                            self._node_cache[key] = x
-                            yield x
+                for x in collect_root._collectfile(path):
+                    key = (type(x), x.fspath)
+                    if key in self._node_cache:
+                        yield self._node_cache[key]
+                    else:
+                        self._node_cache[key] = x
+                        yield x
         else:
             assert argpath.check(file=1)
 

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -978,6 +978,19 @@ def test_collect_init_tests(testdir):
             "<Package *",
             "  <Module '__init__.py'>",
             "    <Function 'test_init'>",
+            "<Module 'tests/test_foo.py'>",
+            "  <Function 'test_foo'>",
+        ]
+    )
+    # XXX: Same as before, but different order.
+    result = testdir.runpytest(".", "tests", "--collect-only")
+    result.stdout.fnmatch_lines(
+        [
+            "collected 2 items",
+            "<Package *",
+            "  <Module '__init__.py'>",
+            "    <Function 'test_init'>",
+            "<Package *",
             "  <Module 'test_foo.py'>",
             "    <Function 'test_foo'>",
         ]

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -975,31 +975,34 @@ def test_collect_init_tests(testdir):
     result.stdout.fnmatch_lines(
         [
             "collected 2 items",
-            "<Package *",
+            "<Package */tests'>",
             "  <Module '__init__.py'>",
             "    <Function 'test_init'>",
-            "<Module 'tests/test_foo.py'>",
-            "  <Function 'test_foo'>",
+            "  <Module 'test_foo.py'>",
+            "    <Function 'test_foo'>",
         ]
     )
-    # XXX: Same as before, but different order.
+    # Same as before, but different order.
     result = testdir.runpytest(".", "tests", "--collect-only")
     result.stdout.fnmatch_lines(
         [
             "collected 2 items",
-            "<Package *",
+            "<Package */tests'>",
             "  <Module '__init__.py'>",
             "    <Function 'test_init'>",
-            "<Package *",
             "  <Module 'test_foo.py'>",
             "    <Function 'test_foo'>",
         ]
     )
     result = testdir.runpytest("./tests/test_foo.py", "--collect-only")
-    result.stdout.fnmatch_lines(["*<Module 'test_foo.py'>", "*<Function 'test_foo'>"])
+    result.stdout.fnmatch_lines(
+        ["<Package */tests'>", "  <Module 'test_foo.py'>", "    <Function 'test_foo'>"]
+    )
     assert "test_init" not in result.stdout.str()
     result = testdir.runpytest("./tests/__init__.py", "--collect-only")
-    result.stdout.fnmatch_lines(["*<Module '__init__.py'>", "*<Function 'test_init'>"])
+    result.stdout.fnmatch_lines(
+        ["<Package */tests'>", "  <Module '__init__.py'>", "    <Function 'test_init'>"]
+    )
     assert "test_foo" not in result.stdout.str()
 
 

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -951,19 +951,35 @@ def test_collect_init_tests(testdir):
     result = testdir.runpytest(p, "--collect-only")
     result.stdout.fnmatch_lines(
         [
-            "*<Module '__init__.py'>",
-            "*<Function 'test_init'>",
-            "*<Module 'test_foo.py'>",
-            "*<Function 'test_foo'>",
+            "collected 2 items",
+            "<Package *",
+            "  <Module '__init__.py'>",
+            "    <Function 'test_init'>",
+            "  <Module 'test_foo.py'>",
+            "    <Function 'test_foo'>",
         ]
     )
     result = testdir.runpytest("./tests", "--collect-only")
     result.stdout.fnmatch_lines(
         [
-            "*<Module '__init__.py'>",
-            "*<Function 'test_init'>",
-            "*<Module 'test_foo.py'>",
-            "*<Function 'test_foo'>",
+            "collected 2 items",
+            "<Package *",
+            "  <Module '__init__.py'>",
+            "    <Function 'test_init'>",
+            "  <Module 'test_foo.py'>",
+            "    <Function 'test_foo'>",
+        ]
+    )
+    # Ignores duplicates with "." and pkginit (#4310).
+    result = testdir.runpytest("./tests", ".", "--collect-only")
+    result.stdout.fnmatch_lines(
+        [
+            "collected 2 items",
+            "<Package *",
+            "  <Module '__init__.py'>",
+            "    <Function 'test_init'>",
+            "  <Module 'test_foo.py'>",
+            "    <Function 'test_foo'>",
         ]
     )
     result = testdir.runpytest("./tests/test_foo.py", "--collect-only")


### PR DESCRIPTION
Packages are collected twice.

Fails with:

    E       Failed: nomatch: 'collected 2 items'
    E           and: '==================================================================================== test session starts ====================================================================================='
    E           and: 'platform linux -- Python 3.6.6, pytest-3.10.1.dev18+g01c8fab1, py-1.7.0, pluggy-0.8.0'
    E           and: "hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('…/Vcs/pytest/.hypothesis/examples')"
    E           and: 'rootdir: /tmp/pytest-of-user/pytest-683/test_collect_init_tests0, inifile: pytest.ini'
    E           and: 'plugins: testmon-0.9.13, hypothesis-3.71.10'
    E       exact match: 'collected 2 items'
    E       fnmatch: '<Package *'
    E          with: "<Package '/tmp/pytest-of-user/pytest-683/test_collect_init_tests0/tests'>"
    E       nomatch: "  <Module '__init__.py'>"
    E           and: "  <Package '/tmp/pytest-of-user/pytest-683/test_collect_init_tests0/tests'>"
    E           and: "    <Module '__init__.py'>"
    E           and: "      <Function 'test_init'>"
    E           and: "    <Module 'test_foo.py'>"
    E           and: "      <Function 'test_foo'>"
    E           and: ''
    E           and: '================================================================================ no tests ran in 0.02 seconds ================================================================================'
    E           and: ''
    E       remains unmatched: "  <Module '__init__.py'>"

    …/Vcs/pytest/testing/test_collection.py:970: Failed

Found while looking into https://github.com/pytest-dev/pytest/issues/4310.