### PR TITLE
Let approx() work on more generic sequences

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -163,6 +163,7 @@ Miro Hrončok
 Nathaniel Waisbrot
 Ned Batchelder
 Neven Mundar
+Nicholas Devenish
 Niclas Olofsson
 Nicolas Delaby
 Oleg Pidsadnyi

--- a/changelog/4327.bugfix.rst
+++ b/changelog/4327.bugfix.rst
@@ -1,1 +1,1 @@
-Loosen the definition of what ``approx`` considers a sequence
+``approx`` again works with more generic containers, more precisely instances of ``Iterable`` and ``Sized`` instead of more restrictive ``Sequence``.

--- a/changelog/4327.bugfix.rst
+++ b/changelog/4327.bugfix.rst
@@ -1,0 +1,1 @@
+Loosen the definition of what ``approx`` considers a sequence

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -45,11 +45,11 @@ MODULE_NOT_FOUND_ERROR = "ModuleNotFoundError" if PY36 else "ImportError"
 
 if _PY3:
     from collections.abc import MutableMapping as MappingMixin
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterable, Mapping, Sequence, Sized
 else:
     # those raise DeprecationWarnings in Python >=3.7
     from collections import MutableMapping as MappingMixin  # noqa
-    from collections import Mapping, Sequence  # noqa
+    from collections import Iterable, Mapping, Sequence, Sized  # noqa
 
 
 if sys.version_info >= (3, 4):

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -11,8 +11,9 @@ from six.moves import zip
 
 import _pytest._code
 from _pytest.compat import isclass
+from _pytest.compat import Iterable
 from _pytest.compat import Mapping
-from _pytest.compat import Sequence
+from _pytest.compat import Sized
 from _pytest.compat import STRING_TYPES
 from _pytest.outcomes import fail
 
@@ -182,7 +183,7 @@ class ApproxMapping(ApproxBase):
                 raise _non_numeric_type_error(self.expected, at="key={!r}".format(key))
 
 
-class ApproxSequence(ApproxBase):
+class ApproxSequencelike(ApproxBase):
     """
     Perform approximate comparisons where the expected value is a sequence of
     numbers.
@@ -518,10 +519,14 @@ def approx(expected, rel=None, abs=None, nan_ok=False):
         cls = ApproxScalar
     elif isinstance(expected, Mapping):
         cls = ApproxMapping
-    elif isinstance(expected, Sequence) and not isinstance(expected, STRING_TYPES):
-        cls = ApproxSequence
     elif _is_numpy_array(expected):
         cls = ApproxNumpy
+    elif (
+        isinstance(expected, Iterable)
+        and isinstance(expected, Sized)
+        and not isinstance(expected, STRING_TYPES)
+    ):
+        cls = ApproxSequencelike
     else:
         raise _non_numeric_type_error(expected, at=None)
 

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -497,12 +497,13 @@ class TestApprox(object):
         assert approx(expected, rel=5e-7, abs=0) == actual
         assert approx(expected, rel=5e-8, abs=0) != actual
 
-    def test_generic_iterable_sized_object(self):
-        class newIterable(object):
+    def test_generic_sized_iterable_object(self):
+        class MySizedIterable(object):
             def __iter__(self):
                 return iter([1, 2, 3, 4])
 
             def __len__(self):
                 return 4
 
-        assert [1, 2, 3, 4] == approx(newIterable())
+        expected = MySizedIterable()
+        assert [1, 2, 3, 4] == approx(expected)

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -496,3 +496,13 @@ class TestApprox(object):
         assert actual != approx(expected, rel=5e-8, abs=0)
         assert approx(expected, rel=5e-7, abs=0) == actual
         assert approx(expected, rel=5e-8, abs=0) != actual
+
+    def test_generic_iterable_sized_object(self):
+        class newIterable(object):
+            def __iter__(self):
+                return iter([1, 2, 3, 4])
+
+            def __len__(self):
+                return 4
+
+        assert [1, 2, 3, 4] == approx(newIterable())


### PR DESCRIPTION
### My Problem
approx() was updated in 9f3122fe to work better with numpy arrays, however at the same time the requirements were tightened from requiring an `Iterable` to requiring a `Sequence` - the former being
tested only on [interface](https://github.com/python/cpython/blob/f19447994983902aa88362d8fffe645f1ea2f2aa/Lib/_collections_abc.py#L252-L256), while the latter requires subclassing or [registration](https://github.com/python/cpython/blob/f19447994983902aa88362d8fffe645f1ea2f2aa/Lib/_collections_abc.py#L926-L929) with the abc.

This broke our code which uses many custom containers (though it wasn't apparent to us that things were broken until the Scalar testing was tightened in cd2085ee718fb297537638bb33a70fc781ea450f). For various (mainly political) reasons it's hard to change our code for pytest, and in any case I believe this benefits from a broader solution.

### This Patch
Since the ApproxSequence only used `__iter__` and `__len__` anyway, this patch reduces the requirement to only what's used, and allows unregistered Sequence-like containers to be used. Since numpy arrays qualify for the new criteria, I've reordered the checks so that generic sequences are checked for after numpy arrays (which would also work if numpy every made the arrays officially sequences)

### This Code

I know the new test doesn't look as neat as the old one, but thought it better to start out explicit rather than making e.g. a new custom `Sequencelike` abc which implements `__subclasshook__ `. `Sequence` can't be removed from `compat.py` because is also used for testing in https://github.com/pytest-dev/pytest/blob/176d27440ce04d26d9d6a2dd590a5f2cb39f4fa2/src/_pytest/assertion/util.py#L113-L114 and I haven't investigated whether it's also appropriate to loosen that. I'm happy to do that work if people would require.

I've categorised the `changelog` as `bugfix` for now. Also, have followed instructions but unsure if this is large enough to qualify for the step:
- Add yourself to `AUTHORS` in alphabetical order;
