### PR TITLE
Fix TypeError in report_collect with _collect_report_last_write

### DIFF
--- a/changelog/4329.bugfix.rst
+++ b/changelog/4329.bugfix.rst
@@ -1,0 +1,1 @@
+Fix TypeError in report_collect with _collect_report_last_write.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -497,7 +497,10 @@ class TerminalReporter(object):
         if not final:
             # Only write "collecting" report every 0.5s.
             t = time.time()
-            if self._collect_report_last_write > t - 0.5:
+            if (
+                self._collect_report_last_write is not None
+                and self._collect_report_last_write > t - 0.5
+            ):
                 return
             self._collect_report_last_write = t
 


### PR DESCRIPTION
`_collect_report_last_write` might be None, when `pytest_collection` was
not called before.  Not sure if this indicates another problem, but it
can be reproduced with `testing/test_collection.py::TestCollector::()::test_getcustomfile_roundtrip`.

Fixes https://github.com/pytest-dev/pytest/issues/4329