### PR TITLE
WIP: No more call node - prepare constructor cleanup

### DIFF
--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -121,3 +121,10 @@ PYTEST_ENSURETEMP = RemovedInPytest4Warning(
     "pytest/tmpdir_factory.ensuretemp is deprecated, \n"
     "please use the tmp_path fixture or tmp_path_factory.mktemp"
 )
+
+
+NODE_CONSTRUCTION = UnformattedWarning(
+    RemovedInPytest4Warning,
+    "creating a node via {klass}(...) is deprecated, \n"
+    "please use {klass}.from_parent(...) or {klass}.legacy_object(...)",
+)

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -86,9 +86,9 @@ def pytest_collect_file(path, parent):
     config = parent.config
     if path.ext == ".py":
         if config.option.doctestmodules and not _is_setup_py(config, path, parent):
-            return DoctestModule(path, parent)
+            return DoctestModule.legacy_object(path, parent)
     elif _is_doctest(config, path, parent):
-        return DoctestTextfile(path, parent)
+        return DoctestTextfile.legacy_object(path, parent)
 
 
 def _is_setup_py(config, path, parent):
@@ -332,7 +332,7 @@ class DoctestTextfile(pytest.Module):
         parser = doctest.DocTestParser()
         test = parser.get_doctest(text, globs, name, filename, 0)
         if test.examples:
-            yield DoctestItem(test.name, self, runner, test)
+            yield DoctestItem.legacy_object(test.name, self, runner, test)
 
 
 def _check_all_skipped(test):

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -11,6 +11,7 @@ import six
 
 import _pytest._code
 from _pytest.compat import getfslineno
+from _pytest.deprecated import NODE_CONSTRUCTION
 from _pytest.mark.structures import MarkInfo
 from _pytest.mark.structures import NodeKeywords
 from _pytest.outcomes import fail
@@ -72,7 +73,17 @@ class _CompatProperty(object):
         return getattr(__import__("pytest"), self.name)
 
 
-class Node(object):
+class NodeMeta(type):
+    def __call__(self, *k, **kw):
+        warnings.warn(NODE_CONSTRUCTION.format(klass=self.__name__), stacklevel=2)
+        return super(NodeMeta, self).__call__(*k, **kw)
+
+    def legacy_object(self, *k, **kw):
+        # todo: alternative implementation
+        return super(NodeMeta, self).__call__(*k, **kw)
+
+
+class Node(six.with_metaclass(NodeMeta)):
     """ base class for Collector and Item the test collection tree.
     Collector subclasses have children, Items are terminal nodes."""
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -186,8 +186,8 @@ def path_matches_patterns(path, patterns):
 
 def pytest_pycollect_makemodule(path, parent):
     if path.basename == "__init__.py":
-        return Package(path, parent)
-    return Module(path, parent)
+        return Package.legacy_object(path, parent)
+    return Module.legacy_object(path, parent)
 
 
 @hookimpl(hookwrapper=True)
@@ -200,7 +200,7 @@ def pytest_pycollect_makeitem(collector, name, obj):
     if safe_isclass(obj):
         if collector.istestclass(obj, name):
             Class = collector._getcustomclass("Class")
-            outcome.force_result(Class(name, parent=collector))
+            outcome.force_result(Class.legacy_object(name, parent=collector))
     elif collector.istestfunction(obj, name):
         # mock seems to store unbound methods (issue473), normalize it
         obj = getattr(obj, "__func__", obj)
@@ -390,7 +390,9 @@ class PyCollector(PyobjMixin, nodes.Collector):
         transfer_markers(funcobj, cls, module)
         fm = self.session._fixturemanager
 
-        definition = FunctionDefinition(name=name, parent=self, callobj=funcobj)
+        definition = FunctionDefinition.legacy_object(
+            name=name, parent=self, callobj=funcobj
+        )
         fixtureinfo = fm.getfixtureinfo(definition, funcobj, cls)
 
         metafunc = Metafunc(
@@ -410,7 +412,7 @@ class PyCollector(PyobjMixin, nodes.Collector):
 
         Function = self._getcustomclass("Function")
         if not metafunc._calls:
-            yield Function(name, parent=self, fixtureinfo=fixtureinfo)
+            yield Function.legacy_object(name, parent=self, fixtureinfo=fixtureinfo)
         else:
             # add funcargs() as fixturedefs to fixtureinfo.arg2fixturedefs
             fixtures.add_funcarg_pseudo_fixture_def(self, metafunc, fm)
@@ -422,7 +424,7 @@ class PyCollector(PyobjMixin, nodes.Collector):
 
             for callspec in metafunc._calls:
                 subname = "%s[%s]" % (name, callspec.id)
-                yield Function(
+                yield Function.legacy_object(
                     name=subname,
                     parent=self,
                     callspec=callspec,
@@ -635,7 +637,7 @@ class Class(PyCollector):
                 )
             )
             return []
-        return [self._getcustomclass("Instance")(name="()", parent=self)]
+        return [self._getcustomclass("Instance").legacy_object(name="()", parent=self)]
 
     def setup(self):
         setup_class = _get_xunit_func(self.obj, "setup_class")


### PR DESCRIPTION
in order for pytest to clean up the constructors of the node types we need to introduce a way to switch to named constructors and shifting towards the api slowly as we enable a different api layout