### PR TITLE
Travis: fix MacOS py37 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,6 @@ jobs:
       env: TOXENV=py37
       before_install:
         - brew update
-        # remove c++ include files because upgrading python as of 2018-10-23, also
-        # attempts to upgrade gcc, and it fails because the include files already
-        # exist. removing the include files is one of the solutions recommended by brew
-        # this workaround might not be necessary in the future
-        - rm '/usr/local/include/c++'
         - brew upgrade python
         - brew unlink python
         - brew link python


### PR DESCRIPTION
This reverts commit 28dbffdaf26519c79c86df67347ef09c31abf6ae.

Appears to be not necessary anymore:
https://travis-ci.org/pytest-dev/pytest/jobs/452598885#L906

[skip appveyor]