### PR TITLE
CI: use py37 instead of py36 by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ stages:
 - name: deploy
   if: repo = pytest-dev/pytest AND tag IS present
 python:
-  - '3.6'
+  - '3.7'
 install:
   - pip install --upgrade --pre tox
 env:
@@ -18,10 +18,11 @@ env:
     - TOXENV=py27-nobyte
     - TOXENV=py27-xdist
     - TOXENV=py27-pluggymaster PYTEST_NO_COVERAGE=1
-    # Specialized factors for py36.
-    - TOXENV=py36-pexpect,py36-trial,py36-numpy
-    - TOXENV=py36-xdist
-    - TOXENV=py36-pluggymaster PYTEST_NO_COVERAGE=1
+    # Specialized factors for py37.
+    - TOXENV=py37-pexpect,py37-trial,py37-numpy
+    - TOXENV=py37-xdist
+    - TOXENV=py37-pluggymaster PYTEST_NO_COVERAGE=1
+    - TOXENV=py37-freeze PYTEST_NO_COVERAGE=1
 
 jobs:
   include:
@@ -31,10 +32,7 @@ jobs:
       dist: trusty
     - env: TOXENV=py35
       python: '3.5'
-    - env: TOXENV=py36-freeze PYTEST_NO_COVERAGE=1
-      python: '3.6'
     - env: TOXENV=py37
-      python: '3.7'
     - &test-macos
       language: generic
       os: osx
@@ -56,7 +54,9 @@ jobs:
     - env: TOXENV=py34
       python: '3.4'
     - env: TOXENV=py36
+      python: '3.6'
     - env: TOXENV=linting,docs,doctesting PYTEST_NO_COVERAGE=1
+      python: '3.7'
 
     - stage: deploy
       python: '3.6'

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -169,7 +169,7 @@ Short version
 #. Follow **PEP-8** for naming and `black <https://github.com/ambv/black>`_ for formatting.
 #. Tests are run using ``tox``::
 
-    tox -e linting,py27,py36
+    tox -e linting,py27,py37
 
    The test environments above are usually enough to cover most cases locally.
 
@@ -237,12 +237,12 @@ Here is a simple overview, with pytest-specific bits:
 
 #. Run all the tests
 
-   You need to have Python 2.7 and 3.6 available in your system.  Now
+   You need to have Python 2.7 and 3.7 available in your system.  Now
    running tests is as simple as issuing this command::
 
-    $ tox -e linting,py27,py36
+    $ tox -e linting,py27,py37
 
-   This command will run tests via the "tox" tool against Python 2.7 and 3.6
+   This command will run tests via the "tox" tool against Python 2.7 and 3.7
    and also perform "lint" coding-style checks.
 
 #. You can now edit your local working copy and run the tests again as necessary. Please follow PEP-8 for naming.
@@ -252,9 +252,9 @@ Here is a simple overview, with pytest-specific bits:
 
     $ tox -e py27 -- --pdb
 
-   Or to only run tests in a particular test module on Python 3.6::
+   Or to only run tests in a particular test module on Python 3.7::
 
-    $ tox -e py36 -- testing/test_config.py
+    $ tox -e py37 -- testing/test_config.py
 
 
    When committing, ``pre-commit`` will re-format the files if necessary.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,13 +14,13 @@ environment:
   - TOXENV: "py27-pluggymaster"
     PYTEST_NO_COVERAGE: "1"
   - TOXENV: "py27-xdist"
-  # Specialized factors for py36.
-  - TOXENV: "py36-trial,py36-numpy"
-  - TOXENV: "py36-pluggymaster"
+  # Specialized factors for py37.
+  - TOXENV: "py37-trial,py37-numpy"
+  - TOXENV: "py37-pluggymaster"
     PYTEST_NO_COVERAGE: "1"
-  - TOXENV: "py36-freeze"
+  - TOXENV: "py37-freeze"
     PYTEST_NO_COVERAGE: "1"
-  - TOXENV: "py36-xdist"
+  - TOXENV: "py37-xdist"
 
 matrix:
   fast_finish: true

--- a/tox.ini
+++ b/tox.ini
@@ -10,10 +10,10 @@ envlist =
     py36
     py37
     pypy
-    {py27,py36}-{pexpect,xdist,trial,numpy,pluggymaster}
+    {py27,py37}-{pexpect,xdist,trial,numpy,pluggymaster}
     py27-nobyte
     doctesting
-    py36-freeze
+    py37-freeze
     docs
 
 [testenv]
@@ -23,7 +23,7 @@ commands =
     coverage: coverage report
 passenv = USER USERNAME COVERAGE_* TRAVIS
 setenv =
-    # configuration if a user runs tox with a "coverage" factor, for example "tox -e py36-coverage"
+    # configuration if a user runs tox with a "coverage" factor, for example "tox -e py37-coverage"
     coverage: _PYTEST_TOX_COVERAGE_RUN=coverage run -m
     coverage: _PYTEST_TOX_EXTRA_DEP=coverage-enable-subprocess
     coverage: COVERAGE_FILE={toxinidir}/.coverage
@@ -60,7 +60,7 @@ deps =
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n auto {posargs}
 
-[testenv:py36-xdist]
+[testenv:py37-xdist]
 # NOTE: copied from above due to https://github.com/tox-dev/tox/issues/706.
 deps =
     pytest-xdist>=1.13
@@ -78,7 +78,7 @@ deps =
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest testing/test_pdb.py testing/test_terminal.py testing/test_unittest.py {posargs}
 
-[testenv:py36-pexpect]
+[testenv:py37-pexpect]
 platform = {[testenv:py27-pexpect]platform}
 deps = {[testenv:py27-pexpect]deps}
 commands = {[testenv:py27-pexpect]commands}
@@ -103,7 +103,7 @@ deps =
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest {posargs:testing/test_unittest.py}
 
-[testenv:py36-trial]
+[testenv:py37-trial]
 deps = {[testenv:py27-trial]deps}
 commands = {[testenv:py27-trial]commands}
 
@@ -114,7 +114,7 @@ deps =
 commands=
   {env:_PYTEST_TOX_COVERAGE_RUN:} pytest {posargs:testing/python/approx.py}
 
-[testenv:py36-numpy]
+[testenv:py37-numpy]
 deps = {[testenv:py27-numpy]deps}
 commands = {[testenv:py27-numpy]commands}
 
@@ -125,7 +125,7 @@ setenv=
     # NOTE: using env instead of "{[testenv]deps}", because of https://github.com/tox-dev/tox/issues/706.
     _PYTEST_TOX_EXTRA_DEP=git+https://github.com/pytest-dev/pluggy.git@master
 
-[testenv:py36-pluggymaster]
+[testenv:py37-pluggymaster]
 setenv = {[testenv:py27-pluggymaster]setenv}
 
 [testenv:docs]
@@ -170,7 +170,7 @@ changedir = testing
 commands =
     {envpython} {envbindir}/py.test-jython {posargs}
 
-[testenv:py36-freeze]
+[testenv:py37-freeze]
 changedir = testing/freeze
 deps =
     pyinstaller

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ commands =
 
 [testenv:linting]
 skip_install = True
-basepython = python3.6
+basepython = python3
 deps = pre-commit>=1.11.0
 commands = pre-commit run --all-files --show-diff-on-failure
 


### PR DESCRIPTION
Closes https://github.com/pytest-dev/pytest/issues/4370.