### PR TITLE
Use packaging/pkg_resources to check minversion

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -158,6 +158,7 @@ Michael Droettboom
 Michael Seifert
 Michal Wajszczuk
 Mihai Capotă
+Mike Hoyle (hoylemd)
 Mike Lundy
 Miro Hrončok
 Nathaniel Waisbrot

--- a/changelog/4315.trivial.rst
+++ b/changelog/4315.trivial.rst
@@ -1,0 +1,1 @@
+Use ``pkg_resources.parse_version`` instead of ``LooseVersion`` in minversion check.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -11,10 +11,10 @@ import shlex
 import sys
 import types
 import warnings
-from distutils.version import LooseVersion
 
 import py
 import six
+from pkg_resources import parse_version
 from pluggy import HookimplMarker
 from pluggy import HookspecMarker
 from pluggy import PluginManager
@@ -822,7 +822,7 @@ class Config(object):
 
         minver = self.inicfg.get("minversion", None)
         if minver:
-            if LooseVersion(minver) > LooseVersion(pytest.__version__):
+            if parse_version(minver) > parse_version(pytest.__version__):
                 raise pytest.UsageError(
                     "%s:%d: requires pytest-%s, actual pytest-%s'"
                     % (


### PR DESCRIPTION
Checklist:
- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [x] Add yourself to `AUTHORS` in alphabetical order;

---

Fix #4315

Tasks from The issue:
- [x] use packaging or pkg_ressources
- [ ] add a acceptance-test

I couldn't figure out the best way to add an acceptance test, but I found that `testing/test_config.py::TestParseIni.test_tox_ini_wrong_version` was already checking the behaviour.  I tried to add a 'right version' test by copying that one and changing the minver in the generated ini to 3.0, but whenever I ran it I'd be getting errors about reading from stdin.  I couldn't figure out what was causing the errors, so I just moved on.

note: I tested this with python 3.7, *not* 3.6 - it was pretty easy to get that to work. Easier than setting 3.6 up in my dev environment at least.  I assume CI will do 3.6, so we'll still have all the coverage and I don't anticipate any issues cropping up.