### PR TITLE
Travis: move faster builds to baseline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,13 @@ install:
   - pip install --upgrade --pre tox
 env:
   matrix:
+    - TOXENV=py27
     # Specialized factors for py27.
-    - TOXENV=py27-pexpect,py27-trial,py27-numpy
     - TOXENV=py27-nobyte
     - TOXENV=py27-xdist
     - TOXENV=py27-pluggymaster PYTEST_NO_COVERAGE=1
     # Specialized factors for py37.
     - TOXENV=py37-pexpect,py37-trial,py37-numpy
-    - TOXENV=py37-xdist
     - TOXENV=py37-pluggymaster PYTEST_NO_COVERAGE=1
     - TOXENV=py37-freeze PYTEST_NO_COVERAGE=1
 
@@ -30,8 +29,12 @@ jobs:
     - env: TOXENV=pypy PYTEST_NO_COVERAGE=1
       python: 'pypy-5.4'
       dist: trusty
+    - env: TOXENV=py34
+      python: '3.4'
     - env: TOXENV=py35
       python: '3.5'
+    - env: TOXENV=py36
+      python: '3.6'
     - env: TOXENV=py37
     - &test-macos
       language: generic
@@ -50,11 +53,8 @@ jobs:
         - brew link python
 
     - stage: baseline
-      env: TOXENV=py27
-    - env: TOXENV=py34
-      python: '3.4'
-    - env: TOXENV=py36
-      python: '3.6'
+      env: TOXENV=py27-pexpect,py27-trial,py27-numpy
+    - env: TOXENV=py37-xdist
     - env: TOXENV=linting,docs,doctesting
       python: '3.7'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 environment:
   matrix:
+  - TOXENV: "py37-xdist"
+  - TOXENV: "py27-xdist"
   - TOXENV: "py27"
   - TOXENV: "py37"
   - TOXENV: "linting,docs,doctesting"
@@ -12,14 +14,12 @@ environment:
   - TOXENV: "py27-trial,py27-numpy,py27-nobyte"
   - TOXENV: "py27-pluggymaster"
     PYTEST_NO_COVERAGE: "1"
-  - TOXENV: "py27-xdist"
   # Specialized factors for py37.
   - TOXENV: "py37-trial,py37-numpy"
   - TOXENV: "py37-pluggymaster"
     PYTEST_NO_COVERAGE: "1"
   - TOXENV: "py37-freeze"
     PYTEST_NO_COVERAGE: "1"
-  - TOXENV: "py37-xdist"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
- use py27-pexpect,py27-trial,py27-numpy and py37-xdist in baseline,
  using pexpect there catches errors with pdb tests early, and
  py37-xdist is much faster than py37.
- move py34 and py36 out of baseline.