### PR TITLE
cacheprovider: do not write README/.gitignore to existing dir

### DIFF
--- a/changelog/4393.bugfix.rst
+++ b/changelog/4393.bugfix.rst
@@ -1,0 +1,1 @@
+Do not create ``.gitignore``/``README.md`` files in existing cache directories.

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -108,6 +108,10 @@ class Cache(object):
         """
         path = self._getvaluepath(key)
         try:
+            if path.parent.is_dir():
+                cache_dir_exists_already = True
+            else:
+                cache_dir_exists_already = self._cachedir.exists()
             path.parent.mkdir(exist_ok=True, parents=True)
         except (IOError, OSError):
             self.warn("could not create cache path {path}", path=path)
@@ -119,6 +123,7 @@ class Cache(object):
         else:
             with f:
                 json.dump(value, f, indent=2, sort_keys=True)
+            if not cache_dir_exists_already:
                 self._ensure_supporting_files()
 
     def _ensure_supporting_files(self):
@@ -128,8 +133,10 @@ class Cache(object):
             if not readme_path.is_file():
                 readme_path.write_text(README_CONTENT)
 
-            msg = u"# created by pytest automatically, do not change\n*"
-            self._cachedir.joinpath(".gitignore").write_text(msg, encoding="UTF-8")
+            gitignore_path = self._cachedir.joinpath(".gitignore")
+            if not gitignore_path.is_file():
+                msg = u"# Created by pytest automatically.\n*"
+                gitignore_path.write_text(msg, encoding="UTF-8")
 
 
 class LFPlugin(object):

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -899,5 +899,28 @@ def test_gitignore(testdir):
     config = testdir.parseconfig()
     cache = Cache.for_config(config)
     cache.set("foo", "bar")
-    msg = "# created by pytest automatically, do not change\n*"
-    assert cache._cachedir.joinpath(".gitignore").read_text(encoding="UTF-8") == msg
+    msg = "# Created by pytest automatically.\n*"
+    gitignore_path = cache._cachedir.joinpath(".gitignore")
+    assert gitignore_path.read_text(encoding="UTF-8") == msg
+
+    # Does not overwrite existing/custom one.
+    gitignore_path.write_text("")
+    cache.set("something", "else")
+    assert gitignore_path.read_text(encoding="UTF-8") == ""
+
+
+def test_does_not_create_boilerplate_in_existing_dirs(testdir):
+    from _pytest.cacheprovider import Cache
+
+    testdir.makeini(
+        """
+        [pytest]
+        cache_dir = .
+        """
+    )
+    config = testdir.parseconfig()
+    cache = Cache.for_config(config)
+    cache.set("foo", "bar")
+
+    assert not os.path.exists(".gitignore")
+    assert not os.path.exists("README.md")

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -904,9 +904,9 @@ def test_gitignore(testdir):
     assert gitignore_path.read_text(encoding="UTF-8") == msg
 
     # Does not overwrite existing/custom one.
-    gitignore_path.write_text("")
+    gitignore_path.write_text(u"custom")
     cache.set("something", "else")
-    assert gitignore_path.read_text(encoding="UTF-8") == ""
+    assert gitignore_path.read_text(encoding="UTF-8") == "custom"
 
 
 def test_does_not_create_boilerplate_in_existing_dirs(testdir):
@@ -922,5 +922,6 @@ def test_does_not_create_boilerplate_in_existing_dirs(testdir):
     cache = Cache.for_config(config)
     cache.set("foo", "bar")
 
+    assert os.path.isdir("v")  # cache contents
     assert not os.path.exists(".gitignore")
     assert not os.path.exists("README.md")


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/issues/4393.

It will not "upgrade" existing dirs anymore - not sure if we want to keep this behavior?!
Could be achieved with more logic, but certainly `cache_dir = .` should be skipped etc.