### PR TITLE
fix #4400 - rearrange the handling of yield test warnings/errors

### DIFF
--- a/changelog/4400.bugfix.rst
+++ b/changelog/4400.bugfix.rst
@@ -1,0 +1,1 @@
+Rearrange warning handling for the yield test errors so the opt-out in 4.0.x correctly works.

--- a/testing/test_session.py
+++ b/testing/test_session.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import pytest
 from _pytest.main import EXIT_NOTESTSCOLLECTED
+from _pytest.warnings import SHOW_PYTEST_WARNINGS_ARG
 
 
 class SessionTests(object):
@@ -77,7 +78,8 @@ class SessionTests(object):
             """
             def test_1():
                 yield None
-        """
+        """,
+            SHOW_PYTEST_WARNINGS_ARG,
         )
         failures = reprec.getfailedcollections()
         out = failures[0].longrepr.reprcrash.message


### PR DESCRIPTION
.