### PR TITLE
tox.ini: do not cause SyntaxWarning with py37  [ci skip]

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -219,6 +219,8 @@ filterwarnings =
     ignore:.*inspect.getargspec.*deprecated, use inspect.signature.*:DeprecationWarning
     # pytest's own futurewarnings
     ignore::pytest.PytestExperimentalApiWarning
+    # Do not cause SyntaxError for invalid escape sequences in py37.
+    default:invalid escape sequence:DeprecationWarning
 pytester_example_dir = testing/example_scripts
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
Do not cause a SyntaxError for something like:

> DeprecationWarning: invalid escape sequence \w

This was happening via pdb++ when it imported pygments (and that had no
compiled .pyc file).