### PR TITLE
Add Testdir.__str__ to return str(self.tmpdir)

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -518,6 +518,9 @@ class Testdir(object):
     def __repr__(self):
         return "<Testdir %r>" % (self.tmpdir,)
 
+    def __str__(self):
+        return str(self.tmpdir)
+
     def finalize(self):
         """Clean up global state artifacts.
 


### PR DESCRIPTION
I just expected this with `monkeypatch.setenv("PYTHONPATH", str(testdir))`,
wondering why it was not picked up correctly.