### PR TITLE
Fix collection of testpaths with `--pyargs`

### DIFF
--- a/changelog/4405.bugfix.rst
+++ b/changelog/4405.bugfix.rst
@@ -1,0 +1,1 @@
+Fix collection of testpaths with ``--pyargs``.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -852,10 +852,7 @@ class Config(object):
             )
             if not args:
                 if self.invocation_dir == self.rootdir:
-                    args = [
-                        str(self.invocation_dir.join(x, abs=True))
-                        for x in self.getini("testpaths")
-                    ]
+                    args = self.getini("testpaths")
                 if not args:
                     args = [str(self.invocation_dir)]
             self.args = args


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/issues/4405.