### PR TITLE
tox: fix/improve posargs with pexpect factor(s)  [ci skip]

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ deps =
     pexpect
     {env:_PYTEST_TOX_EXTRA_DEP:}
 commands =
-    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest testing/test_pdb.py testing/test_terminal.py testing/test_unittest.py {posargs}
+    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest {posargs:testing/test_pdb.py testing/test_terminal.py testing/test_unittest.py}
 
 [testenv:py37-pexpect]
 platform = {[testenv:py27-pexpect]platform}


### PR DESCRIPTION
Taken out of https://github.com/pytest-dev/pytest/pull/4347.