### PR TITLE
setup.py: add "testing" extra requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,16 @@ def main():
         use_scm_version={"write_to": "src/_pytest/_version.py"},
         setup_requires=["setuptools-scm", "setuptools>=40.0"],
         package_dir={"": "src"},
+        # fmt: off
+        extras_require={
+            "testing": [
+                "hypothesis>=3.56",
+                "nose",
+                "requests",
+                "mock;python_version=='2.7'",
+            ],
+        },
+        # fmt: on
         install_requires=INSTALL_REQUIRES,
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,11 +28,8 @@ setenv =
     coverage: _PYTEST_TOX_EXTRA_DEP=coverage-enable-subprocess
     coverage: COVERAGE_FILE={toxinidir}/.coverage
     coverage: COVERAGE_PROCESS_START={toxinidir}/.coveragerc
+extras = testing
 deps =
-    hypothesis>=3.56
-    nose
-    {py27,pypy}: mock
-    requests
     {env:_PYTEST_TOX_EXTRA_DEP:}
 
 [testenv:py27-subprocess]
@@ -51,22 +48,19 @@ deps = pre-commit>=1.11.0
 commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:py27-xdist]
+extras = testing
 deps =
     pytest-xdist>=1.13
-    {py27,pypy}: mock
-    nose
-    hypothesis>=3.56
     {env:_PYTEST_TOX_EXTRA_DEP:}
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n auto {posargs}
 
 [testenv:py37-xdist]
 # NOTE: copied from above due to https://github.com/tox-dev/tox/issues/706.
+extras = testing
 deps =
     pytest-xdist>=1.13
     {py27,pypy}: mock
-    nose
-    hypothesis>=3.56
     {env:_PYTEST_TOX_EXTRA_DEP:}
 commands = {[testenv:py27-xdist]commands}
 
@@ -84,9 +78,9 @@ deps = {[testenv:py27-pexpect]deps}
 commands = {[testenv:py27-pexpect]commands}
 
 [testenv:py27-nobyte]
+extras = testing
 deps =
     pytest-xdist>=1.13
-    hypothesis>=3.56
     py27: mock
     {env:_PYTEST_TOX_EXTRA_DEP:}
 distribute = true


### PR DESCRIPTION
Use this in tox to stream-line base testing requirements.

Closes https://github.com/pytest-dev/pytest/issues/4410.