### PR TITLE
Ensure that node ids are printable

### DIFF
--- a/changelog/4397.bugfix.rst
+++ b/changelog/4397.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure that node ids are printable.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -185,6 +185,9 @@ def get_default_arg_names(function):
 _non_printable_ascii_translate_table = {
     i: u"\\x{:02x}".format(i) for i in range(128) if i not in range(32, 127)
 }
+_non_printable_ascii_translate_table.update(
+    {ord("\t"): u"\\t", ord("\r"): u"\\r", ord("\n"): u"\\n"}
+)
 
 
 def _translate_non_printable(s):

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -8,6 +8,7 @@ import attr
 import six
 from six.moves import map
 
+from ..compat import ascii_escaped
 from ..compat import getfslineno
 from ..compat import MappingMixin
 from ..compat import NOTSET
@@ -77,6 +78,7 @@ class ParameterSet(namedtuple("ParameterSet", "values, marks, id")):
                 raise TypeError(
                     "Expected id to be a string, got {}: {!r}".format(type(id_), id_)
                 )
+            id_ = ascii_escaped(id_)
         return cls(values, marks, id_)
 
     @classmethod

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -5,6 +5,7 @@ from functools import reduce
 from operator import attrgetter
 
 import attr
+import six
 from six.moves import map
 
 from ..compat import getfslineno
@@ -70,10 +71,12 @@ class ParameterSet(namedtuple("ParameterSet", "values, marks, id")):
         else:
             assert isinstance(marks, (tuple, list, set))
 
-        def param_extract_id(id=None):
-            return id
-
-        id_ = param_extract_id(**kw)
+        id_ = kw.pop("id", None)
+        if id_ is not None:
+            if not isinstance(id_, six.string_types):
+                raise TypeError(
+                    "Expected id to be a string, got {}: {!r}".format(type(id_), id_)
+                )
         return cls(values, marks, id_)
 
     @classmethod

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -394,6 +394,18 @@ class TestMetafunc(object):
         )
         assert result == ["\\x00-1", "\\x05-2", "\\x00-3", "\\x05-4"]
 
+    def test_idmaker_manual_ids_must_be_printable(self):
+        from _pytest.python import idmaker
+
+        result = idmaker(
+            ("s",),
+            [
+                pytest.param("x00", id="hello \x00"),
+                pytest.param("x05", id="hello \x05"),
+            ],
+        )
+        assert result == ["hello \\x00", "hello \\x05"]
+
     def test_idmaker_enum(self):
         from _pytest.python import idmaker
 

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -390,9 +390,11 @@ class TestMetafunc(object):
                 pytest.param("\x05", 2),
                 pytest.param(b"\x00", 3),
                 pytest.param(b"\x05", 4),
+                pytest.param("\t", 5),
+                pytest.param(b"\t", 6),
             ],
         )
-        assert result == ["\\x00-1", "\\x05-2", "\\x00-3", "\\x05-4"]
+        assert result == ["\\x00-1", "\\x05-2", "\\x00-3", "\\x05-4", "\\t-5", "\\t-6"]
 
     def test_idmaker_manual_ids_must_be_printable(self):
         from _pytest.python import idmaker

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -5,20 +5,21 @@ from __future__ import print_function
 import os
 import sys
 
+import six
+
+import pytest
+from _pytest.mark import EMPTY_PARAMETERSET_OPTION
+from _pytest.mark import MarkGenerator as Mark
+from _pytest.mark import ParameterSet
+from _pytest.mark import transfer_markers
+from _pytest.nodes import Collector
+from _pytest.nodes import Node
 from _pytest.warnings import SHOW_PYTEST_WARNINGS_ARG
 
 try:
     import mock
 except ImportError:
     import unittest.mock as mock
-import pytest
-from _pytest.mark import (
-    MarkGenerator as Mark,
-    ParameterSet,
-    transfer_markers,
-    EMPTY_PARAMETERSET_OPTION,
-)
-from _pytest.nodes import Node, Collector
 
 ignore_markinfo = pytest.mark.filterwarnings(
     "ignore:MarkInfo objects:pytest.RemovedInPytest4Warning"
@@ -1252,3 +1253,18 @@ def test_markers_from_parametrize(testdir):
 
     result = testdir.runpytest(SHOW_PYTEST_WARNINGS_ARG)
     result.assert_outcomes(passed=4)
+
+
+def test_pytest_param_id_requires_string():
+    with pytest.raises(TypeError) as excinfo:
+        pytest.param(id=True)
+    msg, = excinfo.value.args
+    if six.PY2:
+        assert msg == "Expected id to be a string, got <type 'bool'>: True"
+    else:
+        assert msg == "Expected id to be a string, got <class 'bool'>: True"
+
+
+@pytest.mark.parametrize("s", (None, "hello world"))
+def test_pytest_param_id_allows_none_or_string(s):
+    assert pytest.param(id=s)


### PR DESCRIPTION
Resolves #4397 

targeting `features`:
- *require* that `param(id=...)` is a string
- alter the `id=...` on construction when manually passed to enforce printability
- changes the ids of parametrized bytestrings that weren't printable