### PR TITLE
Color the setup ERROR red

### DIFF
--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -786,8 +786,7 @@ class TerminalReporter(object):
                     self.write_line(line)
                 else:
                     msg = self._getfailureheadline(rep)
-                    markup = {"red": True, "bold": True}
-                    self.write_sep("_", msg, **markup)
+                    self.write_sep("_", msg, red=True, bold=True)
                     self._outrep_summary(rep)
                     for report in self.getreports(""):
                         if report.nodeid == rep.nodeid and report.when == "teardown":
@@ -808,7 +807,7 @@ class TerminalReporter(object):
                     msg = "ERROR at setup of " + msg
                 elif rep.when == "teardown":
                     msg = "ERROR at teardown of " + msg
-                self.write_sep("_", msg)
+                self.write_sep("_", msg, red=True, bold=True)
                 self._outrep_summary(rep)
 
     def _outrep_summary(self, rep):


### PR DESCRIPTION
Very minor consistency improvement.  The bar demonstrating an "ERROR" for a test is now colored bold-red.

Top is before, bottom is after:

![](https://i.fluffy.cc/8q0g1g5BvPBVGD6kltsgSTnRvXw20wtQ.png)