### PR TITLE
fix #4386 - handle uninitialized exceptioninfo in repr/str

### DIFF
--- a/changelog/4386.bugfix.rst
+++ b/changelog/4386.bugfix.rst
@@ -1,0 +1,1 @@
+Handle uninitialized exceptioninfo in repr/str.

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -425,7 +425,10 @@ class ExceptionInfo(object):
         self.traceback = _pytest._code.Traceback(self.tb, excinfo=ref(self))
 
     def __repr__(self):
-        return "<ExceptionInfo %s tblen=%d>" % (self.typename, len(self.traceback))
+        try:
+            return "<ExceptionInfo %s tblen=%d>" % (self.typename, len(self.traceback))
+        except AttributeError:
+            return "<ExceptionInfo uninitialized>"
 
     def exconly(self, tryshort=False):
         """ return the exception as a string
@@ -513,9 +516,13 @@ class ExceptionInfo(object):
         return fmt.repr_excinfo(self)
 
     def __str__(self):
-        entry = self.traceback[-1]
-        loc = ReprFileLocation(entry.path, entry.lineno + 1, self.exconly())
-        return str(loc)
+        try:
+            entry = self.traceback[-1]
+        except AttributeError:
+            return repr(self)
+        else:
+            loc = ReprFileLocation(entry.path, entry.lineno + 1, self.exconly())
+            return str(loc)
 
     def __unicode__(self):
         entry = self.traceback[-1]

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -33,6 +33,18 @@ class TestRaises(object):
         except pytest.raises.Exception:
             pass
 
+    def test_raises_repr_inflight(self):
+        with pytest.raises(RuntimeError) as excinfo:
+            # this test prints the inflight uninitialized object
+            # using repr and str as well as pprint to demonstrate
+            # it works
+            print(str(excinfo))
+            print(repr(excinfo))
+            import pprint
+
+            pprint.pprint(excinfo)
+            raise RuntimeError(1)
+
     def test_raises_as_contextmanager(self, testdir):
         testdir.makepyfile(
             """

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -34,7 +34,12 @@ class TestRaises(object):
             pass
 
     def test_raises_repr_inflight(self):
-        with pytest.raises(RuntimeError) as excinfo:
+        """Ensure repr() on an exception info inside a pytest.raises with block works (#4386)"""
+
+        class E(Exception):
+            pass
+
+        with pytest.raises(E) as excinfo:
             # this test prints the inflight uninitialized object
             # using repr and str as well as pprint to demonstrate
             # it works
@@ -43,7 +48,7 @@ class TestRaises(object):
             import pprint
 
             pprint.pprint(excinfo)
-            raise RuntimeError(1)
+            raise E()
 
     def test_raises_as_contextmanager(self, testdir):
         testdir.makepyfile(


### PR DESCRIPTION
this is a backport of the fixing strategy from #4438 