### PR TITLE
Fix `raises(..., "code(string)")` frame filename.

### DIFF
--- a/changelog/4435.bugfix.rst
+++ b/changelog/4435.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``raises(..., 'code(string)')`` frame filename.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -679,7 +679,7 @@ def raises(expected_exception, *args, **kwargs):
         loc.update(kwargs)
         # print "raises frame scope: %r" % frame.f_locals
         try:
-            code = _pytest._code.Source(code).compile()
+            code = _pytest._code.Source(code).compile(_genframe=frame)
             six.exec_(code, frame.f_globals, loc)
             # XXX didn't mean f_globals == f_locals something special?
             #     this is destroyed here ...

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -17,6 +17,10 @@ class TestRaises(object):
     def test_raises_exec(self):
         pytest.raises(ValueError, "a,x = []")
 
+    def test_raises_exec_correct_filename(self):
+        excinfo = pytest.raises(ValueError, 'int("s")')
+        assert __file__ in excinfo.traceback[-1].path
+
     def test_raises_syntax_error(self):
         pytest.raises(SyntaxError, "qwe qwe qwe")
 


### PR DESCRIPTION
### example

```python
import pytest

def test():
    pytest.raises(TypeError, 'int("s")')
```

### before

```
============================= test session starts ==============================
platform linux -- Python 3.6.6, pytest-4.0.1.dev42+g23e44479, py-1.7.1.dev3+gb9da2ed6, pluggy-0.8.0
rootdir: /home/asottile/workspace/pygments-pytest, inifile:
collected 1 item                                                               

t.py F                                                                   [100%]

=================================== FAILURES ===================================
_____________________________________ test _____________________________________

    def test():
>       pytest.raises(TypeError, 'int("s")')

t.py:4: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   int("s")
E   ValueError: invalid literal for int() with base 10: 's'

<0-codegen /home/asottile/workspace/pygments-pytest/venv/lib/python3.6/site-packages/_pytest/python_api.py:682>:1: ValueError
=========================== 1 failed in 0.03 seconds ===========================
```

### after

```
============================= test session starts ==============================
platform linux -- Python 3.6.6, pytest-4.0.1.dev42+g23e44479, py-1.7.1.dev3+gb9da2ed6, pluggy-0.8.0
rootdir: /home/asottile/workspace/pygments-pytest, inifile:
collected 1 item                                                               

t.py F                                                                   [100%]

=================================== FAILURES ===================================
_____________________________________ test _____________________________________

    def test():
>       pytest.raises(TypeError, 'int("s")')

t.py:4: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   int("s")
E   ValueError: invalid literal for int() with base 10: 's'

<0-codegen /home/asottile/workspace/pygments-pytest/t.py:4>:1: ValueError
=========================== 1 failed in 0.04 seconds ===========================
```