### PR TITLE
Logging done late enough might happen when capture already stopped.

### DIFF
--- a/changelog/4487.bugfix.rst
+++ b/changelog/4487.bugfix.rst
@@ -1,0 +1,1 @@
+During teardown of the python process, and on rare occasions, capture attributes can be ``None`` while trying to resume global capture.

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -117,7 +117,10 @@ class CaptureManager(object):
             self._global_capturing = None
 
     def resume_global_capture(self):
-        self._global_capturing.resume_capturing()
+        # During teardown of the python process, and on rare occasions, capture
+        # attributes can be `None` while trying to resume global capture.
+        if self._global_capturing is not None:
+            self._global_capturing.resume_capturing()
 
     def suspend_global_capture(self, in_=False):
         cap = getattr(self, "_global_capturing", None)


### PR DESCRIPTION
```
22:56:26,997 [pytestsalt.utils:206 ][INFO    ][1024] Stopping process psutil.Process(pid=1228, name='/home/vampas/.d', started='22:55:17') and respective children: [psutil.Process(pid=1245, name='/home/vampas/.d', started='22:55:18'), psut
il.Process(pid=1262, name='/home/vampas/.d', started='22:55:19'), psutil.Process(pid=1263, name='/home/vampas/.d', started='22:55:19')]                                                                                                        
Error in atexit._run_exitfuncs:                                                                                                                                                                                                                
Traceback (most recent call last):                                                                                                                                                                                                             
  File "/home/vampas/.dotfiles/.ext/pyenv/versions/3.5.4/lib/python3.5/logging/__init__.py", line 861, in handle                                                                                                                               
    self.emit(record)                                                                                                                                                                                                                          
  File "/home/vampas/.dotfiles/.ext/pyenv/versions/3.5.4/envs/Salt-3.5.4-Develop/lib/python3.5/site-packages/_pytest/logging.py", line 625, in emit                                                                                            
    logging.StreamHandler.emit(self, record)
  File "/home/vampas/.dotfiles/.ext/pyenv/versions/3.5.4/lib/python3.5/contextlib.py", line 66, in __exit__
    next(self.gen)
  File "/home/vampas/.dotfiles/.ext/pyenv/versions/3.5.4/envs/Salt-3.5.4-Develop/lib/python3.5/site-packages/_pytest/capture.py", line 167, in global_and_fixture_disabled
    self.resume_global_capture()
  File "/home/vampas/.dotfiles/.ext/pyenv/versions/3.5.4/envs/Salt-3.5.4-Develop/lib/python3.5/site-packages/_pytest/capture.py", line 120, in resume_global_capture
    self._global_capturing.resume_capturing()
AttributeError: 'NoneType' object has no attribute 'resume_capturing'
```
- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.