### PR TITLE
Remove cached_setup and Metafunc.addcall

### DIFF
--- a/changelog/3083.removal.rst
+++ b/changelog/3083.removal.rst
@@ -1,0 +1,3 @@
+Remove ``Metafunc.addcall``. This was the predecessor mechanism to ``@pytest.mark.parametrize``.
+
+See our `docs <https://docs.pytest.org/en/latest/deprecations.html#metafunc-addcall>`__ on information on how to update your code.

--- a/changelog/4489.removal.rst
+++ b/changelog/4489.removal.rst
@@ -1,0 +1,3 @@
+Removed ``request.cached_setup``. This was the predecessor mechanism to modern fixtures.
+
+See our `docs <https://docs.pytest.org/en/latest/deprecations.html#cached-setup>`__ on information on how to update your code.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -168,13 +168,6 @@ Defining ``pytest_plugins`` is now deprecated in non-top-level conftest.py
 files because they will activate referenced plugins *globally*, which is surprising because for all other pytest
 features ``conftest.py`` files are only *active* for tests at or below it.
 
-Metafunc.addcall
-~~~~~~~~~~~~~~~~
-
-.. deprecated:: 3.3
-
-:meth:`_pytest.python.Metafunc.addcall` was a precursor to the current parametrized mechanism. Users should use
-:meth:`_pytest.python.Metafunc.parametrize` instead.
 
 marks in ``pytest.mark.parametrize``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -273,6 +266,30 @@ Removed Features
 
 As stated in our :ref:`backwards-compatibility` policy, deprecated features are removed only in major releases after
 an appropriate period of deprecation has passed.
+
+Metafunc.addcall
+~~~~~~~~~~~~~~~~
+
+*Removed in version 4.0.*
+
+:meth:`_pytest.python.Metafunc.addcall` was a precursor to the current parametrized mechanism. Users should use
+:meth:`_pytest.python.Metafunc.parametrize` instead.
+
+Example:
+
+.. code-block:: python
+
+    def pytest_generate_tests(metafunc):
+        metafunc.addcall({"i": 1}, id="1")
+        metafunc.addcall({"i": 2}, id="2")
+
+Becomes:
+
+.. code-block:: python
+
+    def pytest_generate_tests(metafunc):
+        metafunc.parametrize("i", [1, 2], ids=["1", "2"])
+
 
 ``cached_setup``
 ~~~~~~~~~~~~~~~~

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -49,41 +49,6 @@ Becomes:
         exec("assert(1, 2)")  # exec is used to avoid a top-level warning
 
 
-
-``cached_setup``
-~~~~~~~~~~~~~~~~
-
-.. deprecated:: 3.9
-
-``request.cached_setup`` was the precursor of the setup/teardown mechanism available to fixtures.
-
-Example:
-
-.. code-block:: python
-
-    @pytest.fixture
-    def db_session():
-        return request.cached_setup(
-            setup=Session.create, teardown=lambda session: session.close(), scope="module"
-        )
-
-This should be updated to make use of standard fixture mechanisms:
-
-.. code-block:: python
-
-    @pytest.fixture(scope="module")
-    def db_session():
-        session = Session.create()
-        yield session
-        session.close()
-
-
-You can consult `funcarg comparison section in the docs <https://docs.pytest.org/en/latest/funcarg_compare.html>`_ for
-more information.
-
-This has been documented as deprecated for years, but only now we are actually emitting deprecation warnings.
-
-
 Using ``Class`` in custom Collectors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -308,6 +273,39 @@ Removed Features
 
 As stated in our :ref:`backwards-compatibility` policy, deprecated features are removed only in major releases after
 an appropriate period of deprecation has passed.
+
+``cached_setup``
+~~~~~~~~~~~~~~~~
+
+*Removed in version 4.0.*
+
+``request.cached_setup`` was the precursor of the setup/teardown mechanism available to fixtures.
+
+Example:
+
+.. code-block:: python
+
+    @pytest.fixture
+    def db_session():
+        return request.cached_setup(
+            setup=Session.create, teardown=lambda session: session.close(), scope="module"
+        )
+
+This should be updated to make use of standard fixture mechanisms:
+
+.. code-block:: python
+
+    @pytest.fixture(scope="module")
+    def db_session():
+        session = Session.create()
+        yield session
+        session.close()
+
+
+You can consult `funcarg comparison section in the docs <https://docs.pytest.org/en/latest/funcarg_compare.html>`_ for
+more information.
+
+This has been documented as deprecated for years, but only now we are actually emitting deprecation warnings.
 
 ``yield`` tests
 ~~~~~~~~~~~~~~~

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -91,11 +91,6 @@ COLLECTOR_MAKEITEM = RemovedInPytest4Warning(
     "pycollector makeitem was removed as it is an accidentially leaked internal api"
 )
 
-METAFUNC_ADD_CALL = RemovedInPytest4Warning(
-    "Metafunc.addcall is deprecated and scheduled to be removed in pytest 4.0.\n"
-    "Please use Metafunc.parametrize instead."
-)
-
 PYTEST_PLUGINS_FROM_NON_TOP_LEVEL_CONFTEST = RemovedInPytest4Warning(
     "Defining pytest_plugins in a non-top-level conftest is deprecated, "
     "because it affects the entire directory tree in a non-explicit way.\n"

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -24,11 +24,6 @@ MAIN_STR_ARGS = RemovedInPytest4Warning(
 
 YIELD_TESTS = "yield tests were removed in pytest 4.0 - {name} will be ignored"
 
-CACHED_SETUP = RemovedInPytest4Warning(
-    "cached_setup is deprecated and will be removed in a future release. "
-    "Use standard fixture functions instead."
-)
-
 FUNCARG_PREFIX = UnformattedWarning(
     RemovedInPytest4Warning,
     '{name}: declaring fixtures using "pytest_funcarg__" prefix is deprecated '

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -568,8 +568,7 @@ class FixtureRequest(FuncargnamesCompatAttr):
                 )
                 fail(msg, pytrace=False)
         else:
-            # indices might not be set if old-style metafunc.addcall() was used
-            param_index = funcitem.callspec.indices.get(argname, 0)
+            param_index = funcitem.callspec.indices[argname]
             # if a parametrize invocation set a scope it will override
             # the static scope defined with the fixture function
             paramscopenum = funcitem.callspec._arg2scopenum.get(argname)

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -469,43 +469,6 @@ class FixtureRequest(FuncargnamesCompatAttr):
             if argname not in item.funcargs:
                 item.funcargs[argname] = self.getfixturevalue(argname)
 
-    def cached_setup(self, setup, teardown=None, scope="module", extrakey=None):
-        """ (deprecated) Return a testing resource managed by ``setup`` &
-        ``teardown`` calls.  ``scope`` and ``extrakey`` determine when the
-        ``teardown`` function will be called so that subsequent calls to
-        ``setup`` would recreate the resource.  With pytest-2.3 you often
-        do not need ``cached_setup()`` as you can directly declare a scope
-        on a fixture function and register a finalizer through
-        ``request.addfinalizer()``.
-
-        :arg teardown: function receiving a previously setup resource.
-        :arg setup: a no-argument function creating a resource.
-        :arg scope: a string value out of ``function``, ``class``, ``module``
-            or ``session`` indicating the caching lifecycle of the resource.
-        :arg extrakey: added to internal caching key of (funcargname, scope).
-        """
-        from _pytest.deprecated import CACHED_SETUP
-
-        warnings.warn(CACHED_SETUP, stacklevel=2)
-        if not hasattr(self.config, "_setupcache"):
-            self.config._setupcache = {}  # XXX weakref?
-        cachekey = (self.fixturename, self._getscopeitem(scope), extrakey)
-        cache = self.config._setupcache
-        try:
-            val = cache[cachekey]
-        except KeyError:
-            self._check_scope(self.fixturename, self.scope, scope)
-            val = setup()
-            cache[cachekey] = val
-            if teardown is not None:
-
-                def finalizer():
-                    del cache[cachekey]
-                    teardown(val)
-
-                self._addfinalizer(finalizer, scope=scope)
-        return val
-
     def getfixturevalue(self, argname):
         """ Dynamically run a named fixture function.
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1022,48 +1022,6 @@ class Metafunc(fixtures.FuncargnamesCompatAttr):
                         pytrace=False,
                     )
 
-    def addcall(self, funcargs=None, id=NOTSET, param=NOTSET):
-        """ Add a new call to the underlying test function during the collection phase of a test run.
-
-        .. deprecated:: 3.3
-
-            Use :meth:`parametrize` instead.
-
-        Note that request.addcall() is called during the test collection phase prior and
-        independently to actual test execution.  You should only use addcall()
-        if you need to specify multiple arguments of a test function.
-
-        :arg funcargs: argument keyword dictionary used when invoking
-            the test function.
-
-        :arg id: used for reporting and identification purposes.  If you
-            don't supply an `id` an automatic unique id will be generated.
-
-        :arg param: a parameter which will be exposed to a later fixture function
-            invocation through the ``request.param`` attribute.
-        """
-        warnings.warn(deprecated.METAFUNC_ADD_CALL, stacklevel=2)
-
-        assert funcargs is None or isinstance(funcargs, dict)
-        if funcargs is not None:
-            for name in funcargs:
-                if name not in self.fixturenames:
-                    fail("funcarg %r not used in this function." % name)
-        else:
-            funcargs = {}
-        if id is None:
-            raise ValueError("id=None not allowed")
-        if id is NOTSET:
-            id = len(self._calls)
-        id = str(id)
-        if id in self._ids:
-            raise ValueError("duplicate id %r" % id)
-        self._ids.add(id)
-
-        cs = CallSpec2(self)
-        cs.setall(funcargs, id, param)
-        self._calls.append(cs)
-
 
 def _find_parametrized_scope(argnames, arg2fixturedefs, indirect):
     """Find the most appropriate scope for a parametrized call based on its arguments.

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -299,7 +299,7 @@ class TestGeneralUsage(object):
             """
             import pytest
             def pytest_generate_tests(metafunc):
-                metafunc.addcall({'x': 3}, id='hello-123')
+                metafunc.parametrize('x', [3], ids=['hello-123'])
             def pytest_runtest_setup(item):
                 print(item.keywords)
                 if 'hello-123' in item.keywords:
@@ -316,8 +316,7 @@ class TestGeneralUsage(object):
         p = testdir.makepyfile(
             """
             def pytest_generate_tests(metafunc):
-                metafunc.addcall({'i': 1}, id="1")
-                metafunc.addcall({'i': 2}, id="2")
+                metafunc.parametrize('i', [1, 2], ids=["1", "2"])
             def test_func(i):
                 pass
         """

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -10,27 +10,6 @@ from _pytest.warnings import SHOW_PYTEST_WARNINGS_ARG
 pytestmark = pytest.mark.pytester_example_path("deprecated")
 
 
-def test_cached_setup_deprecation(testdir):
-    testdir.makepyfile(
-        """
-        import pytest
-        @pytest.fixture
-        def fix(request):
-            return request.cached_setup(lambda: 1)
-
-        def test_foo(fix):
-            assert fix == 1
-    """
-    )
-    result = testdir.runpytest(SHOW_PYTEST_WARNINGS_ARG)
-    result.stdout.fnmatch_lines(
-        [
-            "*test_cached_setup_deprecation.py:4:*cached_setup is deprecated*",
-            "*1 passed, 1 warnings in*",
-        ]
-    )
-
-
 def test_funcarg_prefix_deprecation(testdir):
     testdir.makepyfile(
         """

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -105,23 +105,6 @@ def test_resultlog_is_deprecated(testdir):
     )
 
 
-def test_metafunc_addcall_deprecated(testdir):
-    testdir.makepyfile(
-        """
-        def pytest_generate_tests(metafunc):
-            metafunc.addcall({'i': 1})
-            metafunc.addcall({'i': 2})
-        def test_func(i):
-            pass
-    """
-    )
-    res = testdir.runpytest("-s", SHOW_PYTEST_WARNINGS_ARG)
-    assert res.ret == 0
-    res.stdout.fnmatch_lines(
-        ["*Metafunc.addcall is deprecated*", "*2 passed, 2 warnings*"]
-    )
-
-
 def test_terminal_reporter_writer_attr(pytestconfig):
     """Check that TerminalReporter._tw is also available as 'writer' (#2984)
     This attribute is planned to be deprecated in 3.4.


### PR DESCRIPTION
Removed `request.cached_setup` and `Metafunc.addcall`.

Fix #4489, #3083

A note: I had to remove some tests because `Metafunc.addcall` can combine arguments in multiple levels of `pytest_generate_tests` hooks, while `Metafunc.parametrize` specifically has a check against that. For example:

```python
    def test_generate_plugin_and_module(self, testdir):
        testdir.makeconftest(
            """
            def pytest_generate_tests(metafunc):
                assert "arg1" in metafunc.fixturenames
                metafunc.addcall(id="world", param=(2,100))
        """
        )
        p = testdir.makepyfile(
            """
            def pytest_generate_tests(metafunc):
                metafunc.addcall(param=(1,1), id="hello")

            import pytest
            @pytest.fixture
            def arg1(request):
                return request.param[0]
            @pytest.fixture
            def arg2(request):
                return request.param[1]

            class TestClass(object):
                def test_myfunc(self, arg1, arg2):
                    assert arg1 == arg2
        """
        )
        result = testdir.runpytest("-v", p, SHOW_PYTEST_WARNINGS_ARG)
        result.stdout.fnmatch_lines(
            [
                "*test_myfunc*hello*PASS*",
                "*test_myfunc*world*FAIL*",
                "*1 failed, 1 passed*",
            ]
        )
```

When converted to use `metafunc.parametrize`:

```python
    def test_generate_plugin_and_module(self, testdir):
        testdir.makeconftest(
            """
            def pytest_generate_tests(metafunc):
                assert "arg1" in metafunc.fixturenames
                metafunc.parametrize('arg1, arg2', [(2, 100)], ids=["world"])
        """
        )
        p = testdir.makepyfile(
            """
            def pytest_generate_tests(metafunc):
                metafunc.parametrize('arg1, arg2', [(1, 1)], ids=["hello"])    

            class TestClass(object):
                def test_myfunc(self, arg1, arg2):
                    assert arg1 == arg2
        """
        )
        result = testdir.runpytest("-v", p, SHOW_PYTEST_WARNINGS_ARG)
        result.stdout.fnmatch_lines(
            [
                "*test_myfunc*hello*PASS*",
                "*test_myfunc*world*FAIL*",
                "*1 failed, 1 passed*",
            ]
        )
```

We get this error:

```
ValueError: duplicate 'arg1'
```

I think this is fine, as users who might still rely on `cached_setup`'s behavior would have probably complain by now.