### PR TITLE
Add links to the deprecations docs for the "removal" changelog entries

### DIFF
--- a/changelog/3079.removal.rst
+++ b/changelog/3079.removal.rst
@@ -1,1 +1,3 @@
-Remove support for yield tests - they are fundamentally broken since collection and test execution were separated.
+Remove support for yield tests - they are fundamentally broken because they don't support fixtures properly since collection and test execution were separated.
+
+See our `docs <https://docs.pytest.org/en/latest/deprecations.html#yield-tests>`__ on information on how to update your code.

--- a/changelog/3616.removal.rst
+++ b/changelog/3616.removal.rst
@@ -1,1 +1,3 @@
-Remove the deprecated compat properties for node.Class/Function/Module - use pytest... now.
+Remove the deprecated compat properties for ``node.Class/Function/Module`` - use ``pytest.Class/Function/Module`` now.
+
+See our `docs <https://docs.pytest.org/en/latest/deprecations.html#internal-classes-accessed-through-node>`__ on information on how to update your code.

--- a/changelog/4421.removal.rst
+++ b/changelog/4421.removal.rst
@@ -1,1 +1,3 @@
-Remove the implementation of the pytest_namespace hook.
+Remove the implementation of the ``pytest_namespace`` hook.
+
+See our `docs <https://docs.pytest.org/en/latest/deprecations.html#pytest-namespace>`__ on information on how to update your code.


### PR DESCRIPTION
I think this makes all the difference when users need to read the CHANGELOG. 👍 