### PR TITLE
Upgrade sphinx doc requirements

### DIFF
--- a/doc/en/requirements.txt
+++ b/doc/en/requirements.txt
@@ -1,5 +1,3 @@
-pygments-pytest>=1.0.4
-# pinning sphinx to 1.4.* due to search issues with rtd:
-# https://github.com/rtfd/readthedocs-sphinx-ext/issues/25
-sphinx ==1.4.*
+pygments-pytest>=1.1.0
+sphinx>=1.8.2
 sphinxcontrib-trio


### PR DESCRIPTION
the upstream sphinx issue seems resolved.  I'll watch this carefully as it merges

I also bumped pygments-pytest to get improved `-q` coloring support