### PR TITLE
Toggle JUnit behavior with INI option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -118,6 +118,7 @@ Jonas Obrist
 Jordan Guymon
 Jordan Moldow
 Jordan Speicher
+Joseph Hunkeler
 Joshua Bronson
 Jurko Gospodnetić
 Justyna Janczyszyn

--- a/changelog/3547.bugfix.rst
+++ b/changelog/3547.bugfix.rst
@@ -1,1 +1,2 @@
-``--junitxml`` emits XML data compatible with Jenkins xUnit schemas via ``junit_family`` INI config option
+``--junitxml`` can emit XML compatible with Jenkins xUnit.
+``junit_family`` INI option accepts ``legacy|xunit1``, which produces old style output, and ``xunit2`` that conforms more strictly to https://github.com/jenkinsci/xunit-plugin/blob/xunit-2.3.2/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd

--- a/changelog/3547.bugfix.rst
+++ b/changelog/3547.bugfix.rst
@@ -1,0 +1,1 @@
+``--junitxml`` emits XML data compatible with JUnit's offical schema releases.

--- a/changelog/3547.bugfix.rst
+++ b/changelog/3547.bugfix.rst
@@ -1,1 +1,1 @@
-``--junitxml`` emits XML data compatible with JUnit's offical schema releases.
+``--junitxml`` emits XML data compatible with Jenkins xUnit schemas via ``junit_family`` INI config option

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -78,14 +78,14 @@ def merge_family(left, right):
 
 families = {}
 families["_base"] = {"testcase": ["classname", "name"]}
-families["_base_old"] = {"testcase": ["file", "line", "url"]}
+families["_base_legacy"] = {"testcase": ["file", "line", "url"]}
 
-# xUnit 1.x inherits old attributes
+# xUnit 1.x inherits legacy attributes
 families["xunit1"] = families["_base"].copy()
-merge_family(families["xunit1"], families["_base_old"])
+merge_family(families["xunit1"], families["_base_legacy"])
 
-# Alias "old" to xUnit 1.x
-families["old"] = families["xunit1"]
+# Alias "legacy" to xUnit 1.x
+families["legacy"] = families["xunit1"]
 
 # xUnit 2.x uses strict base attributes
 families["xunit2"] = families["_base"]
@@ -144,8 +144,8 @@ class _NodeReporter(object):
         self.attrs = attrs
         self.attrs.update(existing_attrs)  # restore any user-defined attributes
 
-        # Preserve old testcase behavior
-        if self.family == "old":
+        # Preserve legacy testcase behavior
+        if self.family == "legacy":
             return
 
         # Purge attributes not permitted by this test family
@@ -354,7 +354,9 @@ def pytest_addoption(parser):
         default="total",
     )  # choices=['total', 'call'])
     parser.addini(
-        "junit_family", "Emit XML for schema: one of old|xunit1|xunit2", default="old"
+        "junit_family",
+        "Emit XML for schema: one of legacy|xunit1|xunit2",
+        default="legacy",
     )
 
 
@@ -397,7 +399,13 @@ def mangle_test_address(address):
 
 class LogXML(object):
     def __init__(
-        self, logfile, prefix, suite_name="pytest", logging="no", report_duration="total", family="old"
+        self,
+        logfile,
+        prefix,
+        suite_name="pytest",
+        logging="no",
+        report_duration="total",
+        family="legacy",
     ):
         logfile = os.path.expanduser(os.path.expandvars(logfile))
         self.logfile = os.path.normpath(os.path.abspath(logfile))

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -107,20 +107,14 @@ class _NodeReporter(object):
         classnames = names[:-1]
         if self.xml.prefix:
             classnames.insert(0, self.xml.prefix)
-        attrs = {
-            "classname": ".".join(classnames),
-            "name": bin_xml_escape(names[-1]),
-            "file": testreport.location[0],
-        }
-        if testreport.location[1] is not None:
-            attrs["line"] = testreport.location[1]
+        attrs = {"classname": ".".join(classnames), "name": bin_xml_escape(names[-1])}
         if hasattr(testreport, "url"):
             attrs["url"] = testreport.url
         self.attrs = attrs
         self.attrs.update(existing_attrs)  # restore any user-defined attributes
 
     def to_xml(self):
-        testcase = Junit.testcase(time=self.duration, **self.attrs)
+        testcase = Junit.testcase(time="%.3f" % self.duration, **self.attrs)
         testcase.append(self.make_properties_node())
         for node in self.nodes:
             testcase.append(node)
@@ -545,7 +539,7 @@ class LogXML(object):
                 name=self.suite_name,
                 errors=self.stats["error"],
                 failures=self.stats["failure"],
-                skips=self.stats["skipped"],
+                skipped=self.stats["skipped"],
                 tests=numtests,
                 time="%.3f" % suite_time_delta,
             ).unicode(indent=0)

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -145,9 +145,8 @@ class _NodeReporter(object):
         if self.family == "xunit1":
             return
 
-        # Purge attributes not permitted by this test family
-        # This includes custom attributes, because they are not valid here.
-        # TODO: Convert invalid attributes to properties to preserve "something"
+        # Filter out attributes not permitted by this test family.
+        # Including custom attributes because they are not valid here.
         temp_attrs = {}
         for key in self.attrs.keys():
             if key in families[self.family]["testcase"]:

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -309,6 +309,9 @@ def pytest_addoption(parser):
         "Duration time to report: one of total|call",
         default="total",
     )  # choices=['total', 'call'])
+    parser.addini(
+        "junit_family", "Emit XML for schema: one of old|xunit1|xunit2", default="old"
+    )
 
 
 def pytest_configure(config):
@@ -321,6 +324,7 @@ def pytest_configure(config):
             config.getini("junit_suite_name"),
             config.getini("junit_logging"),
             config.getini("junit_duration_report"),
+            config.getini("junit_family"),
         )
         config.pluginmanager.register(config._xml)
 

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -311,7 +311,7 @@ def record_xml_attribute(request):
     attr_func = add_attr_noop
     xml = getattr(request.config, "_xml", None)
 
-    if xml.family != "xunit1":
+    if xml is not None and xml.family != "xunit1":
         request.node.warn(
             PytestWarning(
                 "record_xml_attribute is incompatible with junit_family: "

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -71,7 +71,7 @@ def merge_family(left, right):
     for kl, vl in left.items():
         for kr, vr in right.items():
             if not isinstance(vl, list):
-                raise NotImplementedError(type(vl))
+                raise TypeError(type(vl))
             result[kl] = vl + vr
     left.update(result)
 

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -107,7 +107,7 @@ class TestPython(object):
         result, dom = runandparse(testdir)
         assert result.ret
         node = dom.find_first_by_tag("testsuite")
-        node.assert_attr(name="pytest", errors=0, failures=1, skips=2, tests=5)
+        node.assert_attr(name="pytest", errors=0, failures=1, skipped=2, tests=5)
 
     def test_summing_simple_with_errors(self, testdir):
         testdir.makepyfile(
@@ -133,7 +133,7 @@ class TestPython(object):
         result, dom = runandparse(testdir)
         assert result.ret
         node = dom.find_first_by_tag("testsuite")
-        node.assert_attr(name="pytest", errors=1, failures=2, skips=1, tests=5)
+        node.assert_attr(name="pytest", errors=1, failures=2, skipped=1, tests=5)
 
     def test_timing_function(self, testdir):
         testdir.makepyfile(
@@ -201,12 +201,7 @@ class TestPython(object):
         node = dom.find_first_by_tag("testsuite")
         node.assert_attr(errors=1, tests=1)
         tnode = node.find_first_by_tag("testcase")
-        tnode.assert_attr(
-            file="test_setup_error.py",
-            line="5",
-            classname="test_setup_error",
-            name="test_function",
-        )
+        tnode.assert_attr(classname="test_setup_error", name="test_function")
         fnode = tnode.find_first_by_tag("error")
         fnode.assert_attr(message="test setup failure")
         assert "ValueError" in fnode.toxml()
@@ -228,12 +223,7 @@ class TestPython(object):
         assert result.ret
         node = dom.find_first_by_tag("testsuite")
         tnode = node.find_first_by_tag("testcase")
-        tnode.assert_attr(
-            file="test_teardown_error.py",
-            line="6",
-            classname="test_teardown_error",
-            name="test_function",
-        )
+        tnode.assert_attr(classname="test_teardown_error", name="test_function")
         fnode = tnode.find_first_by_tag("error")
         fnode.assert_attr(message="test teardown failure")
         assert "ValueError" in fnode.toxml()
@@ -274,14 +264,9 @@ class TestPython(object):
         result, dom = runandparse(testdir)
         assert result.ret == 0
         node = dom.find_first_by_tag("testsuite")
-        node.assert_attr(skips=1)
+        node.assert_attr(skipped=1)
         tnode = node.find_first_by_tag("testcase")
-        tnode.assert_attr(
-            file="test_skip_contains_name_reason.py",
-            line="1",
-            classname="test_skip_contains_name_reason",
-            name="test_skip",
-        )
+        tnode.assert_attr(classname="test_skip_contains_name_reason", name="test_skip")
         snode = tnode.find_first_by_tag("skipped")
         snode.assert_attr(type="pytest.skip", message="hello23")
 
@@ -297,13 +282,10 @@ class TestPython(object):
         result, dom = runandparse(testdir)
         assert result.ret == 0
         node = dom.find_first_by_tag("testsuite")
-        node.assert_attr(skips=1)
+        node.assert_attr(skipped=1)
         tnode = node.find_first_by_tag("testcase")
         tnode.assert_attr(
-            file="test_mark_skip_contains_name_reason.py",
-            line="1",
-            classname="test_mark_skip_contains_name_reason",
-            name="test_skip",
+            classname="test_mark_skip_contains_name_reason", name="test_skip"
         )
         snode = tnode.find_first_by_tag("skipped")
         snode.assert_attr(type="pytest.skip", message="hello24")
@@ -321,13 +303,10 @@ class TestPython(object):
         result, dom = runandparse(testdir)
         assert result.ret == 0
         node = dom.find_first_by_tag("testsuite")
-        node.assert_attr(skips=1)
+        node.assert_attr(skipped=1)
         tnode = node.find_first_by_tag("testcase")
         tnode.assert_attr(
-            file="test_mark_skipif_contains_name_reason.py",
-            line="2",
-            classname="test_mark_skipif_contains_name_reason",
-            name="test_skip",
+            classname="test_mark_skipif_contains_name_reason", name="test_skip"
         )
         snode = tnode.find_first_by_tag("skipped")
         snode.assert_attr(type="pytest.skip", message="hello25")
@@ -360,10 +339,7 @@ class TestPython(object):
         node.assert_attr(failures=1)
         tnode = node.find_first_by_tag("testcase")
         tnode.assert_attr(
-            file="test_classname_instance.py",
-            line="1",
-            classname="test_classname_instance.TestClass",
-            name="test_method",
+            classname="test_classname_instance.TestClass", name="test_method"
         )
 
     def test_classname_nested_dir(self, testdir):
@@ -374,12 +350,7 @@ class TestPython(object):
         node = dom.find_first_by_tag("testsuite")
         node.assert_attr(failures=1)
         tnode = node.find_first_by_tag("testcase")
-        tnode.assert_attr(
-            file=os.path.join("sub", "test_hello.py"),
-            line="0",
-            classname="sub.test_hello",
-            name="test_func",
-        )
+        tnode.assert_attr(classname="sub.test_hello", name="test_func")
 
     def test_internal_error(self, testdir):
         testdir.makeconftest("def pytest_runtest_protocol(): 0 / 0")
@@ -415,12 +386,7 @@ class TestPython(object):
         node = dom.find_first_by_tag("testsuite")
         node.assert_attr(failures=1, tests=1)
         tnode = node.find_first_by_tag("testcase")
-        tnode.assert_attr(
-            file="test_failure_function.py",
-            line="3",
-            classname="test_failure_function",
-            name="test_fail",
-        )
+        tnode.assert_attr(classname="test_failure_function", name="test_fail")
         fnode = tnode.find_first_by_tag("failure")
         fnode.assert_attr(message="ValueError: 42")
         assert "ValueError" in fnode.toxml()
@@ -477,10 +443,7 @@ class TestPython(object):
 
             tnode = node.find_nth_by_tag("testcase", index)
             tnode.assert_attr(
-                file="test_failure_escape.py",
-                line="1",
-                classname="test_failure_escape",
-                name="test_func[%s]" % char,
+                classname="test_failure_escape", name="test_func[%s]" % char
             )
             sysout = tnode.find_first_by_tag("system-out")
             text = sysout.text
@@ -501,18 +464,10 @@ class TestPython(object):
         node = dom.find_first_by_tag("testsuite")
         node.assert_attr(failures=1, tests=2)
         tnode = node.find_first_by_tag("testcase")
-        tnode.assert_attr(
-            file="test_junit_prefixing.py",
-            line="0",
-            classname="xyz.test_junit_prefixing",
-            name="test_func",
-        )
+        tnode.assert_attr(classname="xyz.test_junit_prefixing", name="test_func")
         tnode = node.find_nth_by_tag("testcase", 1)
         tnode.assert_attr(
-            file="test_junit_prefixing.py",
-            line="3",
-            classname="xyz.test_junit_prefixing.TestHello",
-            name="test_hello",
+            classname="xyz.test_junit_prefixing.TestHello", name="test_hello"
         )
 
     def test_xfailure_function(self, testdir):
@@ -526,14 +481,9 @@ class TestPython(object):
         result, dom = runandparse(testdir)
         assert not result.ret
         node = dom.find_first_by_tag("testsuite")
-        node.assert_attr(skips=1, tests=1)
+        node.assert_attr(skipped=1, tests=1)
         tnode = node.find_first_by_tag("testcase")
-        tnode.assert_attr(
-            file="test_xfailure_function.py",
-            line="1",
-            classname="test_xfailure_function",
-            name="test_xfail",
-        )
+        tnode.assert_attr(classname="test_xfailure_function", name="test_xfail")
         fnode = tnode.find_first_by_tag("skipped")
         fnode.assert_attr(message="expected test failure")
         # assert "ValueError" in fnode.toxml()
@@ -569,14 +519,9 @@ class TestPython(object):
         result, dom = runandparse(testdir)
         # assert result.ret
         node = dom.find_first_by_tag("testsuite")
-        node.assert_attr(skips=0, tests=1)
+        node.assert_attr(skipped=0, tests=1)
         tnode = node.find_first_by_tag("testcase")
-        tnode.assert_attr(
-            file="test_xfailure_xpass.py",
-            line="1",
-            classname="test_xfailure_xpass",
-            name="test_xpass",
-        )
+        tnode.assert_attr(classname="test_xfailure_xpass", name="test_xpass")
 
     def test_xfailure_xpass_strict(self, testdir):
         testdir.makepyfile(
@@ -590,14 +535,9 @@ class TestPython(object):
         result, dom = runandparse(testdir)
         # assert result.ret
         node = dom.find_first_by_tag("testsuite")
-        node.assert_attr(skips=0, tests=1)
+        node.assert_attr(skipped=0, tests=1)
         tnode = node.find_first_by_tag("testcase")
-        tnode.assert_attr(
-            file="test_xfailure_xpass_strict.py",
-            line="1",
-            classname="test_xfailure_xpass_strict",
-            name="test_xpass",
-        )
+        tnode.assert_attr(classname="test_xfailure_xpass_strict", name="test_xpass")
         fnode = tnode.find_first_by_tag("failure")
         fnode.assert_attr(message="[XPASS(strict)] This needs to fail!")
 
@@ -608,8 +548,6 @@ class TestPython(object):
         node = dom.find_first_by_tag("testsuite")
         node.assert_attr(errors=1, tests=1)
         tnode = node.find_first_by_tag("testcase")
-        tnode.assert_attr(file="test_collect_error.py", name="test_collect_error")
-        assert tnode["line"] is None
         fnode = tnode.find_first_by_tag("error")
         fnode.assert_attr(message="collection failure")
         assert "SyntaxError" in fnode.toxml()
@@ -792,7 +730,7 @@ class TestNonPython(object):
         result, dom = runandparse(testdir)
         assert result.ret
         node = dom.find_first_by_tag("testsuite")
-        node.assert_attr(errors=0, failures=1, skips=0, tests=1)
+        node.assert_attr(errors=0, failures=1, skipped=0, tests=1)
         tnode = node.find_first_by_tag("testcase")
         tnode.assert_attr(name="myfile.xyz")
         fnode = tnode.find_first_by_tag("failure")
@@ -1155,20 +1093,18 @@ def test_fancy_items_regression(testdir):
 
     assert "INTERNALERROR" not in result.stdout.str()
 
-    items = sorted(
-        "%(classname)s %(name)s %(file)s" % x for x in dom.find_by_tag("testcase")
-    )
+    items = sorted("%(classname)s %(name)s" % x for x in dom.find_by_tag("testcase"))
     import pprint
 
     pprint.pprint(items)
     assert items == [
-        u"conftest a conftest.py",
-        u"conftest a conftest.py",
-        u"conftest b conftest.py",
-        u"test_fancy_items_regression a test_fancy_items_regression.py",
-        u"test_fancy_items_regression a test_fancy_items_regression.py",
-        u"test_fancy_items_regression b test_fancy_items_regression.py",
-        u"test_fancy_items_regression test_pass" u" test_fancy_items_regression.py",
+        u"conftest a",
+        u"conftest a",
+        u"conftest b",
+        u"test_fancy_items_regression a",
+        u"test_fancy_items_regression a",
+        u"test_fancy_items_regression b",
+        u"test_fancy_items_regression test_pass",
     ]
 
 


### PR DESCRIPTION
Continuation of #4493 
cc: @nicoddemus @RonnyPfannschmidt 

Known issues so far:

1) A few failing tests
2) Debugging output needs to be removed
3) There's no good way to inform either `_NodeReporter` or `LogXML` about which family they should choose. Not without horrifically breaking either of them.
4) Use of module-global variable

Note:
Despite the tests failing this _does_ emit different/corrected XML for the selected `junit_family=[(old|xunit1),xunit2]`.