### PR TITLE
pytester: do not use outer plugins

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -503,6 +503,7 @@ class Testdir(object):
         self.test_tmproot = tmpdir_factory.mktemp("tmp-" + name, numbered=True)
         os.environ["PYTEST_DEBUG_TEMPROOT"] = str(self.test_tmproot)
         os.environ.pop("TOX_ENV_DIR", None)  # Ensure that it is not used for caching.
+        os.environ.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
         self.plugins = []
         self._cwd_snapshot = CwdSnapshot()
         self._sys_path_snapshot = SysPathsSnapshot()

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -511,6 +511,7 @@ def test_options_on_small_file_do_not_blow_up(testdir):
 
 def test_preparse_ordering_with_setuptools(testdir, monkeypatch):
     pkg_resources = pytest.importorskip("pkg_resources")
+    monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
 
     def my_iter(name):
         assert name == "pytest11"
@@ -548,6 +549,7 @@ def test_preparse_ordering_with_setuptools(testdir, monkeypatch):
 
 def test_setuptools_importerror_issue1479(testdir, monkeypatch):
     pkg_resources = pytest.importorskip("pkg_resources")
+    monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
 
     def my_iter(name):
         assert name == "pytest11"
@@ -576,6 +578,7 @@ def test_setuptools_importerror_issue1479(testdir, monkeypatch):
 @pytest.mark.parametrize("block_it", [True, False])
 def test_plugin_preparse_prevents_setuptools_loading(testdir, monkeypatch, block_it):
     pkg_resources = pytest.importorskip("pkg_resources")
+    monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
 
     plugin_module_placeholder = object()
 

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -6,14 +6,19 @@ import pytest
 from _pytest.main import EXIT_NOTESTSCOLLECTED
 
 
-def test_version(testdir, pytestconfig):
+@pytest.mark.parametrize("disable_plugin_autoload", (True, False))
+def test_version(disable_plugin_autoload, testdir, pytestconfig, monkeypatch):
+    if not disable_plugin_autoload:
+        monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
     result = testdir.runpytest("--version")
     assert result.ret == 0
-    # p = py.path.local(py.__file__).dirpath()
     result.stderr.fnmatch_lines(
         ["*pytest*{}*imported from*".format(pytest.__version__)]
     )
-    if pytestconfig.pluginmanager.list_plugin_distinfo():
+    if (
+        not disable_plugin_autoload
+        and pytestconfig.pluginmanager.list_plugin_distinfo()
+    ):
         result.stderr.fnmatch_lines(["*setuptools registered plugins:", "*at*"])
 
 

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1046,7 +1046,9 @@ def test_random_report_log_xdist(testdir):
             assert i != 22
     """
     )
-    _, dom = runandparse(testdir, "-n2")
+    # XXX: why does "-p xdist" work here, but xdist.plugin is required with
+    # other tests (to recognize the pytest_configure hook in there)?!
+    _, dom = runandparse(testdir, "-p xdist -n2")
     suite_node = dom.find_first_by_tag("testsuite")
     failed = []
     for case_node in suite_node.find_by_tag("testcase"):

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -616,7 +616,9 @@ class TestTerminalFunctional(object):
         if not pytestconfig.pluginmanager.get_plugin("xdist"):
             pytest.skip("xdist plugin not installed")
 
-        result = testdir.runpytest(p1, "-v", "-n 1", SHOW_PYTEST_WARNINGS_ARG)
+        result = testdir.runpytest(
+            p1, "-v", "-p", "xdist.plugin", "-n 1", SHOW_PYTEST_WARNINGS_ARG
+        )
         result.stdout.fnmatch_lines(["*FAIL*test_verbose_reporting.py::test_fail*"])
         assert result.ret == 1
 
@@ -1333,7 +1335,7 @@ class TestProgressOutputStyle(object):
 
     def test_xdist_normal(self, many_tests_files, testdir):
         pytest.importorskip("xdist")
-        output = testdir.runpytest("-n2")
+        output = testdir.runpytest("-p", "xdist.plugin", "-n2")
         output.stdout.re_match_lines([r"\.{20} \s+ \[100%\]"])
 
     def test_xdist_normal_count(self, many_tests_files, testdir):
@@ -1344,12 +1346,12 @@ class TestProgressOutputStyle(object):
             console_output_style = count
         """
         )
-        output = testdir.runpytest("-n2")
+        output = testdir.runpytest("-p", "xdist.plugin", "-n2")
         output.stdout.re_match_lines([r"\.{20} \s+ \[20/20\]"])
 
     def test_xdist_verbose(self, many_tests_files, testdir):
         pytest.importorskip("xdist")
-        output = testdir.runpytest("-n2", "-v")
+        output = testdir.runpytest("-p", "xdist.plugin", "-n2", "-v")
         output.stdout.re_match_lines_random(
             [
                 r"\[gw\d\] \[\s*\d+%\] PASSED test_bar.py::test_bar\[1\]",
@@ -1444,5 +1446,5 @@ class TestProgressWithTeardown(object):
 
     def test_xdist_normal(self, many_files, testdir):
         pytest.importorskip("xdist")
-        output = testdir.runpytest("-n2")
+        output = testdir.runpytest("-p", "xdist.plugin", "-n2")
         output.stdout.re_match_lines([r"[\.E]{40} \s+ \[100%\]"])


### PR DESCRIPTION
Sets PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 by default.

Fixes https://github.com/pytest-dev/pytest/issues/4351.