### PR TITLE
PYTEST_DISABLE_PLUGIN_AUTOLOAD: allow 0 to enable it explicitly

### DIFF
--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -878,8 +878,8 @@ Contains comma-separated list of modules that should be loaded as plugins:
 PYTEST_DISABLE_PLUGIN_AUTOLOAD
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When set, disables plugin auto-loading through setuptools entrypoints. Only explicitly specified plugins will be
-loaded.
+Set to "1" to disable plugin auto-loading through setuptools entrypoints.
+Only explicitly specified plugins will be loaded then.
 
 PYTEST_CURRENT_TEST
 ~~~~~~~~~~~~~~~~~~~

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -757,7 +757,7 @@ class Config(object):
 
         self.pluginmanager.rewrite_hook = hook
 
-        if os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
+        if bool(int(os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "0"))):
             # We don't autoload from setuptools entry points, no need to continue.
             return
 
@@ -786,7 +786,7 @@ class Config(object):
         self._checkversion()
         self._consider_importhook(args)
         self.pluginmanager.consider_preparse(args)
-        if not os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
+        if not bool(int(os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "0"))):
             # Don't autoload from setuptools entry point. Only explicitly specified
             # plugins are going to be loaded.
             self.pluginmanager.load_setuptools_entrypoints("pytest11")

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -160,7 +160,7 @@ def showhelp(config):
     vars = [
         ("PYTEST_ADDOPTS", "extra command line options"),
         ("PYTEST_PLUGINS", "comma-separated plugins to load during startup"),
-        ("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "set to disable plugin auto-loading"),
+        ("PYTEST_DISABLE_PLUGIN_AUTOLOAD", 'set to "1" to disable plugin auto-loading'),
         ("PYTEST_DEBUG", "set to enable debug tracing of pytest's internals"),
     ]
     for name, help in vars:


### PR DESCRIPTION
This assumes that only "1" was used previously to enable it.