### PR TITLE
tests: fix tests that require PYTEST_DISABLE_PLUGIN_AUTOLOAD to be unset

### DIFF
--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -153,7 +153,8 @@ class TestImportHookInstallation(object):
 
     @pytest.mark.parametrize("mode", ["plain", "rewrite"])
     @pytest.mark.parametrize("plugin_state", ["development", "installed"])
-    def test_installed_plugin_rewrite(self, testdir, mode, plugin_state):
+    def test_installed_plugin_rewrite(self, testdir, mode, plugin_state, monkeypatch):
+        monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
         # Make sure the hook is installed early enough so that plugins
         # installed via setuptools are rewritten.
         testdir.tmpdir.join("hampkg").ensure(dir=1)

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -511,6 +511,7 @@ def test_options_on_small_file_do_not_blow_up(testdir):
 
 def test_preparse_ordering_with_setuptools(testdir, monkeypatch):
     pkg_resources = pytest.importorskip("pkg_resources")
+    monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
 
     def my_iter(name):
         assert name == "pytest11"
@@ -548,6 +549,7 @@ def test_preparse_ordering_with_setuptools(testdir, monkeypatch):
 
 def test_setuptools_importerror_issue1479(testdir, monkeypatch):
     pkg_resources = pytest.importorskip("pkg_resources")
+    monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
 
     def my_iter(name):
         assert name == "pytest11"
@@ -576,6 +578,7 @@ def test_setuptools_importerror_issue1479(testdir, monkeypatch):
 @pytest.mark.parametrize("block_it", [True, False])
 def test_plugin_preparse_prevents_setuptools_loading(testdir, monkeypatch, block_it):
     pkg_resources = pytest.importorskip("pkg_resources")
+    monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
 
     plugin_module_placeholder = object()
 

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1032,12 +1032,13 @@ def test_record_attribute(testdir):
     )
 
 
-def test_random_report_log_xdist(testdir):
+def test_random_report_log_xdist(testdir, monkeypatch):
     """xdist calls pytest_runtest_logreport as they are executed by the slaves,
     with nodes from several nodes overlapping, so junitxml must cope with that
     to produce correct reports. #1064
     """
     pytest.importorskip("xdist")
+    monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
     testdir.makepyfile(
         """
         import pytest, time

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1331,13 +1331,15 @@ class TestProgressOutputStyle(object):
             ]
         )
 
-    def test_xdist_normal(self, many_tests_files, testdir):
+    def test_xdist_normal(self, many_tests_files, testdir, monkeypatch):
         pytest.importorskip("xdist")
+        monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
         output = testdir.runpytest("-n2")
         output.stdout.re_match_lines([r"\.{20} \s+ \[100%\]"])
 
-    def test_xdist_normal_count(self, many_tests_files, testdir):
+    def test_xdist_normal_count(self, many_tests_files, testdir, monkeypatch):
         pytest.importorskip("xdist")
+        monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
         testdir.makeini(
             """
             [pytest]
@@ -1347,8 +1349,9 @@ class TestProgressOutputStyle(object):
         output = testdir.runpytest("-n2")
         output.stdout.re_match_lines([r"\.{20} \s+ \[20/20\]"])
 
-    def test_xdist_verbose(self, many_tests_files, testdir):
+    def test_xdist_verbose(self, many_tests_files, testdir, monkeypatch):
         pytest.importorskip("xdist")
+        monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
         output = testdir.runpytest("-n2", "-v")
         output.stdout.re_match_lines_random(
             [
@@ -1442,7 +1445,8 @@ class TestProgressWithTeardown(object):
             ]
         )
 
-    def test_xdist_normal(self, many_files, testdir):
+    def test_xdist_normal(self, many_files, testdir, monkeypatch):
         pytest.importorskip("xdist")
+        monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
         output = testdir.runpytest("-n2")
         output.stdout.re_match_lines([r"[\.E]{40} \s+ \[100%\]"])


### PR DESCRIPTION
Fix pytest's own tests with PYTEST_DISABLE_PLUGIN_AUTOLOAD=1.