### PR TITLE
Handle missing space with -p

### DIFF
--- a/changelog/3532.bugfix.rst
+++ b/changelog/3532.bugfix.rst
@@ -1,0 +1,1 @@
+``-p`` now accepts its argument without a space between the value, for example ``-pmyplugin``.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -470,9 +470,20 @@ class PytestPluginManager(PluginManager):
     #
 
     def consider_preparse(self, args):
-        for opt1, opt2 in zip(args, args[1:]):
-            if opt1 == "-p":
-                self.consider_pluginarg(opt2)
+        i = 0
+        n = len(args)
+        while i < n:
+            opt = args[i]
+            i += 1
+            if isinstance(opt, six.string_types):
+                if opt == "-p":
+                    parg = args[i]
+                    i += 1
+                elif opt.startswith("-p"):
+                    parg = opt[2:]
+                else:
+                    continue
+                self.consider_pluginarg(parg)
 
     def consider_pluginarg(self, arg):
         if arg.startswith("no:"):
@@ -507,7 +518,7 @@ class PytestPluginManager(PluginManager):
         # "terminal" or "capture".  Those plugins are registered under their
         # basename for historic purposes but must be imported with the
         # _pytest prefix.
-        assert isinstance(modname, (six.text_type, str)), (
+        assert isinstance(modname, six.string_types), (
             "module name as text required, got %r" % modname
         )
         modname = str(modname)

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -323,6 +323,12 @@ class TestPytestPluginManagerBootstrapming(object):
             ImportError, lambda: pytestpm.consider_preparse(["xyz", "-p", "hello123"])
         )
 
+        # Handles -p without space (#3532).
+        with pytest.raises(ImportError) as excinfo:
+            pytestpm.consider_preparse(["-phello123"])
+        assert '"hello123"' in excinfo.value.args[0]
+        pytestpm.consider_preparse(["-pno:hello123"])
+
     def test_plugin_prevent_register(self, pytestpm):
         pytestpm.consider_preparse(["xyz", "-p", "no:abc"])
         l1 = pytestpm.get_plugins()


### PR DESCRIPTION
This still does not use an actual argument parser, which only gets
instantiated below, and it does not appear to make sense instantiating
it just for this pre-parsing it seems.

`-p` without the required value is being handled before already though,
so it could potentially be passed down from somewhere already?!

Fixes https://github.com/pytest-dev/pytest/issues/3532.