### PR TITLE
tests: fix test_raises_exception_looks_iterable

### DIFF
--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -190,7 +190,8 @@ class TestRaises(object):
             pass
 
         with pytest.raises(
-            Failed, match="DID NOT RAISE <class 'raises.ClassLooksIterableException'>"
+            Failed,
+            match=r"DID NOT RAISE <class 'raises(\..*)*ClassLooksIterableException'>",
         ):
             pytest.raises(ClassLooksIterableException, lambda: None)
 


### PR DESCRIPTION
Started to fail on py37-xdist between
https://travis-ci.org/pytest-dev/pytest/jobs/465498973 and
https://travis-ci.org/pytest-dev/pytest/jobs/465792343, but could not
find a diff in versions (from the tox header), and both commits failed
locally.