### PR TITLE
Change -ra to show errors and failures last, instead of first

### DIFF
--- a/changelog/4532.feature.rst
+++ b/changelog/4532.feature.rst
@@ -1,0 +1,3 @@
+``-ra`` now will show errors and failures last, instead of as the first items in the summary.
+
+This makes it easier to obtain a list of errors and failures to run tests selectively.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -167,7 +167,7 @@ def getreportopt(config):
             if char not in reportopts and char != "a":
                 reportopts += char
             elif char == "a":
-                reportopts = "fEsxXw"
+                reportopts = "sxXwEf"
     return reportopts
 
 

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -875,11 +875,22 @@ def test_reportchars_all(testdir):
             pass
         def test_4():
             pytest.skip("four")
+        @pytest.fixture
+        def fail():
+            assert 0
+        def test_5(fail):
+            pass
     """
     )
     result = testdir.runpytest("-ra")
     result.stdout.fnmatch_lines(
-        ["FAIL*test_1*", "SKIP*four*", "XFAIL*test_2*", "XPASS*test_3*"]
+        [
+            "SKIP*four*",
+            "XFAIL*test_2*",
+            "XPASS*test_3*",
+            "ERROR*test_5*",
+            "FAIL*test_1*",
+        ]
     )
 
 


### PR DESCRIPTION
Often in large test suites (like pytest's), the -ra summary is very useful
to obtain a list of failures so we can execute each test at once to fix them.

Problem is the default shows errors and failures first, which leads to a lot
of scrolling to get to them.
