### PR TITLE
Bugfix: monkeypatch.delattr handles class descriptors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,6 +48,7 @@ Christian Boelsen
 Christian Theunert
 Christian Tismer
 Christopher Gilling
+Christopher Dignam
 CrazyMerlyn
 Cyrus Maden
 Dhiren Serai

--- a/changelog/4536.bugfix.rst
+++ b/changelog/4536.bugfix.rst
@@ -1,0 +1,1 @@
+monkeypatch.delattr handles class descriptors like staticmethod/classmethod

--- a/changelog/4536.bugfix.rst
+++ b/changelog/4536.bugfix.rst
@@ -1,1 +1,1 @@
-monkeypatch.delattr handles class descriptors like staticmethod/classmethod
+``monkeypatch.delattr`` handles class descriptors like ``staticmethod``/``classmethod``.

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -181,6 +181,8 @@ class MonkeyPatch(object):
         attribute is missing.
         """
         __tracebackhide__ = True
+        import inspect
+
         if name is notset:
             if not isinstance(target, six.string_types):
                 raise TypeError(
@@ -194,7 +196,11 @@ class MonkeyPatch(object):
             if raising:
                 raise AttributeError(name)
         else:
-            self._setattr.append((target, name, getattr(target, name, notset)))
+            oldval = getattr(target, name, notset)
+            # avoid class descriptors like staticmethod/classmethod
+            if inspect.isclass(target):
+                oldval = target.__dict__.get(name, notset)
+            self._setattr.append((target, name, oldval))
             delattr(target, name)
 
     def setitem(self, dic, name, value):

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -197,7 +197,7 @@ class MonkeyPatch(object):
                 raise AttributeError(name)
         else:
             oldval = getattr(target, name, notset)
-            # avoid class descriptors like staticmethod/classmethod
+            # Avoid class descriptors like staticmethod/classmethod.
             if inspect.isclass(target):
                 oldval = target.__dict__.get(name, notset)
             self._setattr.append((target, name, oldval))

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -391,6 +391,33 @@ def test_issue156_undo_staticmethod(Sample):
     assert Sample.hello()
 
 
+def test_undo_class_descriptors_delattr():
+    class SampleParent(object):
+        @classmethod
+        def hello(_cls):
+            pass
+
+        @staticmethod
+        def world():
+            pass
+
+    class SampleChild(SampleParent):
+        pass
+
+    monkeypatch = MonkeyPatch()
+
+    original_hello = SampleChild.hello
+    original_world = SampleChild.world
+    monkeypatch.delattr(SampleParent, "hello")
+    monkeypatch.delattr(SampleParent, "world")
+    assert getattr(SampleParent, "hello", None) is None
+    assert getattr(SampleParent, "world", None) is None
+
+    monkeypatch.undo()
+    assert original_hello == SampleChild.hello
+    assert original_world == SampleChild.world
+
+
 def test_issue1338_name_resolving():
     pytest.importorskip("requests")
     monkeypatch = MonkeyPatch()


### PR DESCRIPTION
Correct monkeypatch.delattr to match the correct behavior of monkeypatch.setattr when changing class descriptors.

Issue: https://github.com/pytest-dev/pytest/issues/4536
