### PR TITLE
Deprecate the 'message' parameter of pytest.raises

### DIFF
--- a/changelog/3974.deprecation.rst
+++ b/changelog/3974.deprecation.rst
@@ -1,0 +1,8 @@
+Passing the ``message`` parameter of ``pytest.raises`` now issues a ``DeprecationWarning``.
+
+It is a common mistake to think this parameter will match the exception message, while in fact
+it only serves to provide a custom message in case the ``pytest.raises`` check fails. To avoid this
+mistake and because it is believed to be little used, pytest is deprecating it without providing
+an alternative for the moment.
+
+If you have concerns about this, please comment on `issue #3974 <https://github.com/pytest-dev/pytest/issues/3974>`__.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -14,6 +14,19 @@ Below is a complete list of all pytest features which are considered deprecated.
 :class:`_pytest.warning_types.PytestWarning` or subclasses, which can be filtered using
 :ref:`standard warning filters <warnings>`.
 
+``"message"`` parameter of ``pytest.raises``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 4.1
+
+It is a common mistake to think this parameter will match the exception message, while in fact
+it only serves to provide a custom message in case the ``pytest.raises`` check fails. To avoid this
+mistake and because it is believed to be little used, pytest is deprecating it without providing
+an alternative for the moment.
+
+If you have concerns about this, please comment on `issue #3974 <https://github.com/pytest-dev/pytest/issues/3974>`__.
+
+
 ``pytest.config`` global
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -51,6 +51,13 @@ GETFUNCARGVALUE = RemovedInPytest4Warning(
     "getfuncargvalue is deprecated, use getfixturevalue"
 )
 
+RAISES_MESSAGE_PARAMETER = PytestDeprecationWarning(
+    "The 'message' parameter is deprecated.\n"
+    "(did you mean to use `match='some regex'` to check the exception message?)\n"
+    "Please comment on https://github.com/pytest-dev/pytest/issues/3974 "
+    "if you have concerns about removal of this parameter."
+)
+
 RESULT_LOG = PytestDeprecationWarning(
     "--result-log is deprecated and scheduled for removal in pytest 5.0.\n"
     "See https://docs.pytest.org/en/latest/deprecations.html#result-log-result-log for more information."

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -136,6 +136,12 @@ def test_pytest_catchlog_deprecated(testdir, plugin):
     )
 
 
+def test_raises_message_argument_deprecated():
+    with pytest.warns(pytest.PytestDeprecationWarning):
+        with pytest.raises(RuntimeError, message="foobar"):
+            raise RuntimeError
+
+
 def test_pytest_plugins_in_non_top_level_conftest_deprecated(testdir):
     from _pytest.deprecated import PYTEST_PLUGINS_FROM_NON_TOP_LEVEL_CONFTEST
 

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -121,8 +121,9 @@ class TestRaises(object):
     def test_custom_raise_message(self):
         message = "TEST_MESSAGE"
         try:
-            with pytest.raises(ValueError, message=message):
-                pass
+            with pytest.warns(PytestDeprecationWarning):
+                with pytest.raises(ValueError, message=message):
+                    pass
         except pytest.raises.Exception as e:
             assert e.msg == message
         else:

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -280,7 +280,7 @@ def test_assert_outcomes_after_pytest_error(testdir):
     testdir.makepyfile("def test_foo(): assert True")
 
     result = testdir.runpytest("--unexpected-argument")
-    with pytest.raises(ValueError, message="Pytest terminal report not found"):
+    with pytest.raises(ValueError, match="Pytest terminal report not found"):
         result.assert_outcomes(passed=0)
 
 


### PR DESCRIPTION
Fix #3974
