### PR TITLE
Raise `TypeError` for `with raises(..., match=<non-None falsey value>)`.

### DIFF
--- a/changelog/4538.bugfix.rst
+++ b/changelog/4538.bugfix.rst
@@ -1,0 +1,1 @@
+Raise ``TypeError`` for ``with raises(..., match=<non-None falsey value>)``.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -716,6 +716,6 @@ class RaisesContext(object):
         suppress_exception = issubclass(self.excinfo.type, self.expected_exception)
         if sys.version_info[0] == 2 and suppress_exception:
             sys.exc_clear()
-        if self.match_expr and suppress_exception:
+        if self.match_expr is not None and suppress_exception:
             self.excinfo.match(self.match_expr)
         return suppress_exception

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -37,6 +37,11 @@ class TestRaises(object):
         except pytest.raises.Exception:
             pass
 
+    def test_raises_falsey_type_error(self):
+        with pytest.raises(TypeError):
+            with pytest.raises(AssertionError, match=0):
+                raise AssertionError("ohai")
+
     def test_raises_repr_inflight(self):
         """Ensure repr() on an exception info inside a pytest.raises with block works (#4386)"""
 


### PR DESCRIPTION
See #4538 