### PR TITLE
Remove pytest_funcarg__ prefix support for defining fixtures

### DIFF
--- a/changelog/4543.removal.rst
+++ b/changelog/4543.removal.rst
@@ -1,0 +1,3 @@
+Remove support to define fixtures using the ``pytest_funcarg__`` prefix. Use the ``@pytest.fixture`` decorator instead.
+
+See our `docs <https://docs.pytest.org/en/latest/deprecations.html#pytest-funcarg-prefix>`__ on information on how to update your code.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -237,26 +237,6 @@ By passing a string, users expect that pytest will interpret that command-line u
 on (for example ``bash`` or ``Powershell``), but this is very hard/impossible to do in a portable way.
 
 
-``pytest_funcarg__`` prefix
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. deprecated:: 3.0
-
-In very early pytest versions fixtures could be defined using the ``pytest_funcarg__`` prefix:
-
-.. code-block:: python
-
-    def pytest_funcarg__data():
-        return SomeData()
-
-Switch over to the ``@pytest.fixture`` decorator:
-
-.. code-block:: python
-
-    @pytest.fixture
-    def data():
-        return SomeData()
-
 [pytest] section in setup.cfg files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -294,6 +274,27 @@ collection.
 
 This issue should affect only advanced plugins who create new collection types, so if you see this warning
 message please contact the authors so they can change the code.
+
+``pytest_funcarg__`` prefix
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+*Removed in version 4.0.*
+
+In very early pytest versions fixtures could be defined using the ``pytest_funcarg__`` prefix:
+
+.. code-block:: python
+
+    def pytest_funcarg__data():
+        return SomeData()
+
+Switch over to the ``@pytest.fixture`` decorator:
+
+.. code-block:: python
+
+    @pytest.fixture
+    def data():
+        return SomeData()
+
 
 Metafunc.addcall
 ~~~~~~~~~~~~~~~~

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -261,8 +261,8 @@ class PytestPluginManager(PluginManager):
         # (see issue #1073)
         if not name.startswith("pytest_"):
             return
-        # ignore some historic special names which can not be hooks anyway
-        if name == "pytest_plugins" or name.startswith("pytest_funcarg__"):
+        # ignore names which can not be hooks
+        if name == "pytest_plugins":
             return
 
         method = getattr(plugin, name)

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -24,12 +24,6 @@ MAIN_STR_ARGS = RemovedInPytest4Warning(
 
 YIELD_TESTS = "yield tests were removed in pytest 4.0 - {name} will be ignored"
 
-FUNCARG_PREFIX = UnformattedWarning(
-    RemovedInPytest4Warning,
-    '{name}: declaring fixtures using "pytest_funcarg__" prefix is deprecated '
-    "and scheduled to be removed in pytest 4.0.  "
-    "Please remove the prefix and use the @pytest.fixture decorator instead.",
-)
 
 FIXTURE_FUNCTION_CALL = UnformattedWarning(
     RemovedInPytest4Warning,

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -10,28 +10,6 @@ from _pytest.warnings import SHOW_PYTEST_WARNINGS_ARG
 pytestmark = pytest.mark.pytester_example_path("deprecated")
 
 
-def test_funcarg_prefix_deprecation(testdir):
-    testdir.makepyfile(
-        """
-        def pytest_funcarg__value():
-            return 10
-
-        def test_funcarg_prefix(value):
-            assert value == 10
-    """
-    )
-    result = testdir.runpytest("-ra", SHOW_PYTEST_WARNINGS_ARG)
-    result.stdout.fnmatch_lines(
-        [
-            (
-                "*test_funcarg_prefix_deprecation.py:1: *pytest_funcarg__value: "
-                'declaring fixtures using "pytest_funcarg__" prefix is deprecated*'
-            ),
-            "*1 passed*",
-        ]
-    )
-
-
 @pytest.mark.filterwarnings("default")
 def test_pytest_setup_cfg_deprecated(testdir):
     testdir.makefile(

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -627,25 +627,6 @@ class TestRequestBasic(object):
         print(ss.stack)
         assert teardownlist == [1]
 
-    def test_mark_as_fixture_with_prefix_and_decorator_fails(self, testdir):
-        testdir.makeconftest(
-            """
-            import pytest
-
-            @pytest.fixture
-            def pytest_funcarg__marked_with_prefix_and_decorator():
-                pass
-        """
-        )
-        result = testdir.runpytest_subprocess()
-        assert result.ret != 0
-        result.stdout.fnmatch_lines(
-            [
-                "*AssertionError: fixtures cannot have*@pytest.fixture*",
-                "*pytest_funcarg__marked_with_prefix_and_decorator*",
-            ]
-        )
-
     def test_request_addfinalizer_failing_setup(self, testdir):
         testdir.makepyfile(
             """


### PR DESCRIPTION
Fix #4543
