### PR TITLE
Rename "junit_time" to "junit_duration_report" option

### DIFF
--- a/changelog/4483.feature.rst
+++ b/changelog/4483.feature.rst
@@ -1,4 +1,4 @@
-Added ini parameter ``junit_time`` to optionally report test call durations, excluding setup and teardown times.
+Added ini parameter ``junit_duration_report`` to optionally report test call durations, excluding setup and teardown times.
 
 The JUnit XML specification and the default pytest behavior is to include setup and teardown times in the test duration
 report. You can include just the call durations instead (excluding setup and teardown) by adding this to your ``pytest.ini`` file:
@@ -6,4 +6,4 @@ report. You can include just the call durations instead (excluding setup and tea
 .. code-block:: ini
 
     [pytest]
-    junit_time = call
+    junit_duration_report = call

--- a/doc/en/usage.rst
+++ b/doc/en/usage.rst
@@ -301,12 +301,12 @@ should report total test execution times, including setup and teardown
 (`1 <http://windyroad.com.au/dl/Open%20Source/JUnit.xsd>`_, `2
 <https://www.ibm.com/support/knowledgecenter/en/SSQ2R2_14.1.0/com.ibm.rsar.analysis.codereview.cobol.doc/topics/cac_useresults_junit.html>`_).
 It is the default pytest behavior. To report just call durations
-instead, configure the ``junit_time`` option like this:
+instead, configure the ``junit_duration_report`` option like this:
 
 .. code-block:: ini
 
     [pytest]
-    junit_time = call
+    junit_duration_report = call
 
 .. _record_property example:
 

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -324,7 +324,9 @@ def pytest_addoption(parser):
         default="no",
     )  # choices=['no', 'stdout', 'stderr'])
     parser.addini(
-        "junit_time", "Duration time to report: one of total|call", default="total"
+        "junit_duration_report",
+        "Duration time to report: one of total|call",
+        default="total",
     )  # choices=['total', 'call'])
 
 
@@ -337,7 +339,7 @@ def pytest_configure(config):
             config.option.junitprefix,
             config.getini("junit_suite_name"),
             config.getini("junit_logging"),
-            config.getini("junit_time"),
+            config.getini("junit_duration_report"),
         )
         config.pluginmanager.register(config._xml)
 

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -153,7 +153,7 @@ class TestPython(object):
         val = tnode["time"]
         assert round(float(val), 2) >= 0.03
 
-    def test_call_time(self, testdir):
+    def test_junit_duration_report(self, testdir):
         testdir.makepyfile(
             """
             import time, pytest
@@ -165,7 +165,7 @@ class TestPython(object):
                 time.sleep(0.1)
         """
         )
-        result, dom = runandparse(testdir, "-o", "junit_time=call")
+        result, dom = runandparse(testdir, "-o", "junit_duration_report=call")
         node = dom.find_first_by_tag("testsuite")
         tnode = node.find_first_by_tag("testcase")
         val = tnode["time"]


### PR DESCRIPTION
Just realized while reading the changelog that "junit_time" is not a very good
name, so I decided to open this PR renaming it to "junit_duration_report" which
I believe conveys the meaning of the option better

cc @aparamon

Follow up to #4529