### PR TITLE
Errors in parametrize id functions now propagate the error instead of issuing a warning

### DIFF
--- a/changelog/2169.removal.rst
+++ b/changelog/2169.removal.rst
@@ -1,0 +1,1 @@
+``pytest.mark.parametrize``: in previous versions, errors raised by id functions were suppressed and changed into warnings. Now the exceptions are propagated, along with a pytest message informing the node, parameter value and index where the exception occurred.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -45,7 +45,6 @@ from _pytest.mark.structures import transfer_markers
 from _pytest.outcomes import fail
 from _pytest.pathlib import parts
 from _pytest.warning_types import PytestWarning
-from _pytest.warning_types import RemovedInPytest4Warning
 
 
 def pyobj_property(name):
@@ -1059,13 +1058,11 @@ def _idval(val, argname, idx, idfn, item, config):
             s = idfn(val)
         except Exception as e:
             # See issue https://github.com/pytest-dev/pytest/issues/2169
-            msg = (
-                "While trying to determine id of parameter {} at position "
-                "{} the following exception was raised:\n".format(argname, idx)
-            )
+            msg = "{}: error raised while trying to determine id of parameter '{}' at position {}\n"
+            msg = msg.format(item.nodeid, argname, idx)
+            # we only append the exception type and message because on Python 2 reraise does nothing
             msg += "  {}: {}\n".format(type(e).__name__, e)
-            msg += "This warning will be an error error in pytest-4.0."
-            item.warn(RemovedInPytest4Warning(msg))
+            six.raise_from(ValueError(msg), e)
         if s:
             return ascii_escaped(s)
 

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -393,7 +393,6 @@ class TestMetafunc(object):
         )
         assert result == ["a-a0", "a-a1", "a-a2"]
 
-    @pytest.mark.filterwarnings("default")
     def test_parametrize_ids_exception(self, testdir):
         """
         :param testdir: the instance of Testdir class, a temporary
@@ -411,14 +410,11 @@ class TestMetafunc(object):
                     pass
             """
         )
-        result = testdir.runpytest("--collect-only", SHOW_PYTEST_WARNINGS_ARG)
+        result = testdir.runpytest()
         result.stdout.fnmatch_lines(
             [
-                "<Module test_parametrize_ids_exception.py>",
-                "  <Function test_foo[a]>",
-                "  <Function test_foo[b]>",
-                "*test_parametrize_ids_exception.py:6: *parameter arg at position 0*",
-                "*test_parametrize_ids_exception.py:6: *parameter arg at position 1*",
+                "*test_foo: error raised while trying to determine id of parameter 'arg' at position 0",
+                "*Exception: bad ids",
             ]
         )
 


### PR DESCRIPTION
Fix #2169
