### PR TITLE
 Remove MarkInfo

### DIFF
--- a/changelog/4546.removal.rst
+++ b/changelog/4546.removal.rst
@@ -1,0 +1,3 @@
+Remove ``Node.get_marker(name)`` the return value was not usable for more than a existence check.
+
+Use ``Node.get_closest_marker(name)`` as a replacement.

--- a/changelog/891.removal.rst
+++ b/changelog/891.removal.rst
@@ -1,0 +1,1 @@
+Remove ``testfunction.markername`` attributes - use ``Node.iter_markers(name=None)`` to iterate them.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -77,13 +77,7 @@ Becomes:
 
 
 
-``Node.get_marker``
-~~~~~~~~~~~~~~~~~~~
 
-.. deprecated:: 3.6
-
-As part of a large :ref:`marker-revamp`, :meth:`_pytest.nodes.Node.get_marker` is deprecated. See
-:ref:`the documentation <update marker code>` on tips on how to update your code.
 
 
 Result log (``--result-log``)
@@ -497,3 +491,21 @@ Removed all ``py.test-X*`` entry points. The versioned, suffixed entry points
 were never documented and a leftover from a pre-virtualenv era. These entry
 points also created broken entry points in wheels, so removing them also
 removes a source of confusion for users.
+
+
+``Node.get_marker``
+~~~~~~~~~~~~~~~~~~~
+
+*removed in version 4.1*
+
+As part of a large :ref:`marker-revamp`, :meth:`_pytest.nodes.Node.get_marker` is deprecated. See
+:ref:`the documentation <update marker code>` on tips on how to update your code.
+
+
+``somefunction.markname``
+~~~~~~~~~~~~~~~~~~~~~
+
+* Removed in version 4.1
+
+As part of a large :ref:`marker-revamp` we already deprecated using ``MarkInfo``
+the only correct way to get markers of an element is via ``node.iter_markers([name]``.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -496,16 +496,16 @@ removes a source of confusion for users.
 ``Node.get_marker``
 ~~~~~~~~~~~~~~~~~~~
 
-*removed in version 4.1*
+*Removed in version 4.0*
 
 As part of a large :ref:`marker-revamp`, :meth:`_pytest.nodes.Node.get_marker` is deprecated. See
 :ref:`the documentation <update marker code>` on tips on how to update your code.
 
 
 ``somefunction.markname``
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Removed in version 4.1
+*Removed in version 4.0*
 
 As part of a large :ref:`marker-revamp` we already deprecated using ``MarkInfo``
-the only correct way to get markers of an element is via ``node.iter_markers([name]``.
+the only correct way to get markers of an element is via ``node.iter_markers(name)``.

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -724,13 +724,6 @@ MarkGenerator
     :members:
 
 
-MarkInfo
-~~~~~~~~
-
-.. autoclass:: _pytest.mark.MarkInfo
-    :members:
-
-
 Mark
 ~~~~
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -268,10 +268,10 @@ class PytestPluginManager(PluginManager):
         # collect unmarked hooks as long as they have the `pytest_' prefix
         if opts is None and name.startswith("pytest_"):
             opts = {}
-
         if opts is not None:
             # TODO: DeprecationWarning, people should use hookimpl
             known_marks = {m.name for m in getattr(method, "pytestmark", [])}
+
             for name in ("tryfirst", "trylast", "optionalhook", "hookwrapper"):
 
                 opts.setdefault(name, hasattr(method, name) or name in known_marks)
@@ -283,10 +283,15 @@ class PytestPluginManager(PluginManager):
         )
         if opts is None:
             method = getattr(module_or_class, name)
+
             if name.startswith("pytest_"):
+                # todo: deprecate hookspec hacks
+                known_marks = {m.name for m in getattr(method, "pytestmark", [])}
                 opts = {
-                    "firstresult": hasattr(method, "firstresult"),
-                    "historic": hasattr(method, "historic"),
+                    "firstresult": hasattr(method, "firstresult")
+                    or "firstresult" in known_marks,
+                    "historic": hasattr(method, "historic")
+                    or "historic" in known_marks,
                 }
         return opts
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -270,6 +270,7 @@ class PytestPluginManager(PluginManager):
             opts = {}
         if opts is not None:
             # TODO: DeprecationWarning, people should use hookimpl
+            # https://github.com/pytest-dev/pytest/issues/4562
             known_marks = {m.name for m in getattr(method, "pytestmark", [])}
 
             for name in ("tryfirst", "trylast", "optionalhook", "hookwrapper"):
@@ -286,6 +287,7 @@ class PytestPluginManager(PluginManager):
 
             if name.startswith("pytest_"):
                 # todo: deprecate hookspec hacks
+                # https://github.com/pytest-dev/pytest/issues/4562
                 known_marks = {m.name for m in getattr(method, "pytestmark", [])}
                 opts = {
                     "firstresult": hasattr(method, "firstresult")

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -270,8 +270,11 @@ class PytestPluginManager(PluginManager):
             opts = {}
 
         if opts is not None:
+            # TODO: DeprecationWarning, people should use hookimpl
+            known_marks = {m.name for m in getattr(method, "pytestmark", [])}
             for name in ("tryfirst", "trylast", "optionalhook", "hookwrapper"):
-                opts.setdefault(name, hasattr(method, name))
+
+                opts.setdefault(name, hasattr(method, name) or name in known_marks)
         return opts
 
     def parse_hookspec_opts(self, module_or_class, name):

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1207,19 +1207,20 @@ class FixtureManager(object):
             if faclist:
                 fixturedef = faclist[-1]
                 if fixturedef.params is not None:
-                    parametrize_func = getattr(metafunc.function, "parametrize", None)
-                    if parametrize_func is not None:
-                        parametrize_func = parametrize_func.combined
-                    func_params = getattr(parametrize_func, "args", [[None]])
-                    func_kwargs = getattr(parametrize_func, "kwargs", {})
-                    # skip directly parametrized arguments
-                    if "argnames" in func_kwargs:
-                        argnames = parametrize_func.kwargs["argnames"]
+                    markers = list(metafunc.definition.iter_markers("parametrize"))
+                    for parametrize_mark in markers:
+                        if "argnames" in parametrize_mark.kwargs:
+                            argnames = parametrize_mark.kwargs["argnames"]
+                        else:
+                            argnames = parametrize_mark.args[0]
+
+                        if not isinstance(argnames, (tuple, list)):
+                            argnames = [
+                                x.strip() for x in argnames.split(",") if x.strip()
+                            ]
+                        if argname in argnames:
+                            break
                     else:
-                        argnames = func_params[0]
-                    if not isinstance(argnames, (tuple, list)):
-                        argnames = [x.strip() for x in argnames.split(",") if x.strip()]
-                    if argname not in func_params and argname not in argnames:
                         metafunc.parametrize(
                             argname,
                             fixturedef.params,

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -11,19 +11,10 @@ from .structures import Mark
 from .structures import MARK_GEN
 from .structures import MarkDecorator
 from .structures import MarkGenerator
-from .structures import MarkInfo
 from .structures import ParameterSet
-from .structures import transfer_markers
 from _pytest.config import UsageError
 
-__all__ = [
-    "Mark",
-    "MarkInfo",
-    "MarkDecorator",
-    "MarkGenerator",
-    "transfer_markers",
-    "get_empty_parameterset_mark",
-]
+__all__ = ["Mark", "MarkDecorator", "MarkGenerator", "get_empty_parameterset_mark"]
 
 
 def param(*values, **kw):

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -10,7 +10,6 @@ import six
 
 import _pytest._code
 from _pytest.compat import getfslineno
-from _pytest.mark.structures import MarkInfo
 from _pytest.mark.structures import NodeKeywords
 from _pytest.outcomes import fail
 
@@ -210,20 +209,6 @@ class Node(object):
         :param name: name to filter by
         """
         return next(self.iter_markers(name=name), default)
-
-    def get_marker(self, name):
-        """ get a marker object from this node or None if
-        the node doesn't have a marker with that name.
-
-        .. deprecated:: 3.6
-            This function has been deprecated in favor of
-            :meth:`Node.get_closest_marker <_pytest.nodes.Node.get_closest_marker>` and
-            :meth:`Node.iter_markers <_pytest.nodes.Node.iter_markers>`, see :ref:`update marker code`
-            for more details.
-        """
-        markers = list(self.iter_markers(name=name))
-        if markers:
-            return MarkInfo(markers)
 
     def listextrakeywords(self):
         """ Return a set of all extra keywords in self and any parents."""

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1290,6 +1290,8 @@ class Function(FunctionMixin, nodes.Item, fixtures.FuncargnamesCompatAttr):
             self.keywords.update(keywords)
 
         # todo: this is a hell of a hack
+        # https://github.com/pytest-dev/pytest/issues/4569
+
         self.keywords.update(
             dict.fromkeys(
                 [

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -14,8 +14,6 @@ from _pytest.outcomes import skip
 from _pytest.outcomes import xfail
 from _pytest.python import Class
 from _pytest.python import Function
-from _pytest.python import Module
-from _pytest.python import transfer_markers
 
 
 def pytest_pycollect_makeitem(collector, name, obj):
@@ -54,14 +52,12 @@ class UnitTestCase(Class):
             return
         self.session._fixturemanager.parsefactories(self, unittest=True)
         loader = TestLoader()
-        module = self.getparent(Module).obj
         foundsomething = False
         for name in loader.getTestCaseNames(self.obj):
             x = getattr(self.obj, name)
             if not getattr(x, "__test__", True):
                 continue
             funcobj = getimfunc(x)
-            transfer_markers(funcobj, cls, module)
             yield TestCaseFunction(name, parent=self, callobj=funcobj)
             foundsomething = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -121,6 +121,7 @@ setenv=
 setenv = {[testenv:py27-pluggymaster]setenv}
 
 [testenv:docs]
+basepython = python3
 skipsdist = True
 usedevelop = True
 changedir = doc/en


### PR DESCRIPTION
this removes marker info in various ways

a) no more legacy marker objects on functions (this has surprising effects)
b) keywords are changes in a backward incompatible way as markerinfo goes away
c) plugin hook parsing needs an additional compatibility hack, i registered #4562
d) mark finding got a bit tighter to sort out mistakes in prior normalization
e) gruesome bugs in parameterize and fixture handling have been resolved by switching from attributes to definition markers

fixes https://github.com/pytest-dev/pytest/issues/3515
fixes https://github.com/pytest-dev/pytest/issues/3537 (removes legacy marker transfer which triggers the error)
fixes https://github.com/pytest-dev/pytest/issues/891
fixes #4546 