### PR TITLE
Use sphinx removed in extension in the documentation

### DIFF
--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -42,10 +42,11 @@ todo_include_todos = 1
 extensions = [
     "pygments_pytest",
     "sphinx.ext.autodoc",
-    "sphinx.ext.todo",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    "sphinx_removed_in",
     "sphinxcontrib_trio",
 ]
 

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -423,6 +423,24 @@ Users should just ``import pytest`` and access those objects using the ``pytest`
 
 This has been documented as deprecated for years, but only now we are actually emitting deprecation warnings.
 
+``Node.get_marker``
+~~~~~~~~~~~~~~~~~~~
+
+.. versionremoved:: 4.0
+
+As part of a large :ref:`marker-revamp`, :meth:`_pytest.nodes.Node.get_marker` is deprecated. See
+:ref:`the documentation <update marker code>` on tips on how to update your code.
+
+
+``somefunction.markname``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionremoved:: 4.0
+
+As part of a large :ref:`marker-revamp` we already deprecated using ``MarkInfo``
+the only correct way to get markers of an element is via ``node.iter_markers(name)``.
+
+
 ``pytest_namespace``
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -491,21 +509,3 @@ Removed all ``py.test-X*`` entry points. The versioned, suffixed entry points
 were never documented and a leftover from a pre-virtualenv era. These entry
 points also created broken entry points in wheels, so removing them also
 removes a source of confusion for users.
-
-
-``Node.get_marker``
-~~~~~~~~~~~~~~~~~~~
-
-.. versionremoved:: 4.0
-
-As part of a large :ref:`marker-revamp`, :meth:`_pytest.nodes.Node.get_marker` is deprecated. See
-:ref:`the documentation <update marker code>` on tips on how to update your code.
-
-
-``somefunction.markname``
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionremoved:: 4.0
-
-As part of a large :ref:`marker-revamp` we already deprecated using ``MarkInfo``
-the only correct way to get markers of an element is via ``node.iter_markers(name)``.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -101,7 +101,7 @@ an appropriate period of deprecation has passed.
 Using ``Class`` in custom Collectors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 4.0.*
+.. versionremoved:: 4.0
 
 Using objects named ``"Class"`` as a way to customize the type of nodes that are collected in ``Collector``
 subclasses has been deprecated. Users instead should use ``pytest_pycollect_makeitem`` to customize node types during
@@ -114,7 +114,7 @@ message please contact the authors so they can change the code.
 marks in ``pytest.mark.parametrize``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 4.0.*
+.. versionremoved:: 4.0
 
 Applying marks to values of a ``pytest.mark.parametrize`` call is now deprecated. For example:
 
@@ -162,7 +162,7 @@ To update the code, use ``pytest.param``:
 ``pytest_funcarg__`` prefix
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 4.0.*
+.. versionremoved:: 4.0
 
 In very early pytest versions fixtures could be defined using the ``pytest_funcarg__`` prefix:
 
@@ -184,7 +184,7 @@ Switch over to the ``@pytest.fixture`` decorator:
 [pytest] section in setup.cfg files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 4.0.*
+.. versionremoved:: 4.0
 
 ``[pytest]`` sections in ``setup.cfg`` files should now be named ``[tool:pytest]``
 to avoid conflicts with other distutils commands.
@@ -193,7 +193,7 @@ to avoid conflicts with other distutils commands.
 Metafunc.addcall
 ~~~~~~~~~~~~~~~~
 
-*Removed in version 4.0.*
+.. versionremoved:: 4.0
 
 :meth:`_pytest.python.Metafunc.addcall` was a precursor to the current parametrized mechanism. Users should use
 :meth:`_pytest.python.Metafunc.parametrize` instead.
@@ -217,7 +217,7 @@ Becomes:
 ``cached_setup``
 ~~~~~~~~~~~~~~~~
 
-*Removed in version 4.0.*
+.. versionremoved:: 4.0
 
 ``request.cached_setup`` was the precursor of the setup/teardown mechanism available to fixtures.
 
@@ -249,7 +249,7 @@ more information.
 pytest_plugins in non-top-level conftest files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 4.0.*
+.. versionremoved:: 4.0
 
 Defining ``pytest_plugins`` is now deprecated in non-top-level conftest.py
 files because they will activate referenced plugins *globally*, which is surprising because for all other pytest
@@ -259,7 +259,7 @@ features ``conftest.py`` files are only *active* for tests at or below it.
 ``Config.warn`` and ``Node.warn``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 4.0.*
+.. versionremoved:: 4.0
 
 Those methods were part of the internal pytest warnings system, but since ``3.8`` pytest is using the builtin warning
 system for its own warnings, so those two functions are now deprecated.
@@ -286,7 +286,7 @@ Becomes:
 record_xml_property
 ~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 4.0.*
+.. versionremoved:: 4.0
 
 The ``record_xml_property`` fixture is now deprecated in favor of the more generic ``record_property``, which
 can be used by other consumers (for example ``pytest-html``) to obtain custom information about the test run.
@@ -309,7 +309,7 @@ Change to:
 Passing command-line string to ``pytest.main()``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 4.0.*
+.. versionremoved:: 4.0
 
 Passing a command-line string to ``pytest.main()`` is deprecated:
 
@@ -331,7 +331,7 @@ on (for example ``bash`` or ``Powershell``), but this is very hard/impossible to
 Calling fixtures directly
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 4.0.*
+.. versionremoved:: 4.0
 
 Calling a fixture function directly, as opposed to request them in a test function, is deprecated.
 
@@ -384,7 +384,7 @@ with the ``name`` parameter:
 ``yield`` tests
 ~~~~~~~~~~~~~~~
 
-*Removed in version 4.0.*
+.. versionremoved:: 4.0
 
 pytest supported ``yield``-style tests, where a test function actually ``yield`` functions and values
 that are then turned into proper test methods. Example:
@@ -412,7 +412,7 @@ This form of test function doesn't support fixtures properly, and users should s
 Internal classes accessed through ``Node``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 4.0.*
+.. versionremoved:: 4.0
 
 Access of ``Module``, ``Function``, ``Class``, ``Instance``, ``File`` and ``Item`` through ``Node`` instances now issue
 this warning::
@@ -426,7 +426,7 @@ This has been documented as deprecated for years, but only now we are actually e
 ``pytest_namespace``
 ~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 4.0.*
+.. versionremoved:: 4.0
 
 This hook is deprecated because it greatly complicates the pytest internals regarding configuration and initialization, making some
 bug fixes and refactorings impossible.
@@ -461,7 +461,7 @@ As a stopgap measure, plugin authors may still inject their names into pytest's 
 Reinterpretation mode (``--assert=reinterp``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 3.0.*
+.. versionremoved:: 3.0
 
 Reinterpretation mode has now been removed and only plain and rewrite
 mode are available, consequently the ``--assert=reinterp`` option is
@@ -473,7 +473,7 @@ explicitly turn on assertion rewriting for those files.
 Removed command-line options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 3.0.*
+.. versionremoved:: 3.0
 
 The following deprecated commandline options were removed:
 
@@ -485,7 +485,7 @@ The following deprecated commandline options were removed:
 py.test-X* entry points
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 3.0.*
+.. versionremoved:: 3.0
 
 Removed all ``py.test-X*`` entry points. The versioned, suffixed entry points
 were never documented and a leftover from a pre-virtualenv era. These entry
@@ -496,7 +496,7 @@ removes a source of confusion for users.
 ``Node.get_marker``
 ~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 4.0*
+.. versionremoved:: 4.0
 
 As part of a large :ref:`marker-revamp`, :meth:`_pytest.nodes.Node.get_marker` is deprecated. See
 :ref:`the documentation <update marker code>` on tips on how to update your code.
@@ -505,7 +505,7 @@ As part of a large :ref:`marker-revamp`, :meth:`_pytest.nodes.Node.get_marker` i
 ``somefunction.markname``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 4.0*
+.. versionremoved:: 4.0
 
 As part of a large :ref:`marker-revamp` we already deprecated using ``MarkInfo``
 the only correct way to get markers of an element is via ``node.iter_markers(name)``.

--- a/doc/en/requirements.txt
+++ b/doc/en/requirements.txt
@@ -1,3 +1,4 @@
 pygments-pytest>=1.1.0
 sphinx>=1.8.2
 sphinxcontrib-trio
+sphinx-removed-in>=0.1.3


### PR DESCRIPTION
Fix https://github.com/pytest-dev/pytest/issues/4568

This is blocked by https://github.com/MrSenko/sphinx-removed-in/pull/1:

---

```
λ tox -re docs
docs create: C:\Users\bruno\pytest\.tox\docs
docs installdeps: -rC:\Users\bruno\pytest/doc/en/requirements.txt
ERROR: invocation failed (exit code 1), logfile: C:\Users\bruno\pytest\.tox\docs\log\docs-1.log
ERROR: actionid: docs
msg: getenv
cmdargs: "'C:\\Users\\bruno\\pytest\\.tox\\docs\\Scripts\\python.EXE' -m pip install '-rC:\\Users\\bruno\\pytest/doc/en/requirements.txt'"

Collecting pygments-pytest>=1.1.0 (from -r C:\Users\bruno\pytest/doc/en/requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/49/3e/fc3a0102c4ae97430d34303c0963cc779e8a1c74a73fe6a04539665fdbb0/pygments_pytest-1.1.0-py2.py3-none-any.whl
Collecting sphinx>=1.8.2 (from -r C:\Users\bruno\pytest/doc/en/requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/ff/d5/3a8727d6f890b1ae45da72a55bf8449e9f2c535a444923b338c3f509f203/Sphinx-1.8.2-py2.py3-none-any.whl
Collecting sphinxcontrib-trio (from -r C:\Users\bruno\pytest/doc/en/requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/09/28/70870892f814a46db677872ba8da59936601d00f1109dc9359b122d3a8fc/sphinxcontrib_trio-1.0.1-py3-none-any.whl
Collecting sphinx-removed-in (from -r C:\Users\bruno\pytest/doc/en/requirements.txt (line 4))
  Using cached https://files.pythonhosted.org/packages/74/04/b6bcf18ddf8ac127b9f0c5dffd20542fdcfbf3db6b689947217bd46f4980/sphinx-removed-in-0.1.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\bruno\AppData\Local\Temp\pip-install-sqas3ip2\sphinx-removed-in\setup.py", line 5, in <module>
        __version__ = __import__('sphinx_removed_in').__version__
      File "C:\Users\bruno\AppData\Local\Temp\pip-install-sqas3ip2\sphinx-removed-in\sphinx_removed_in\__init__.py", line 1, in <module>
        from sphinx.locale import versionlabels
    ModuleNotFoundError: No module named 'sphinx'
```