### PR TITLE
4371: Update --collect-only to display test descriptions when ran in verbose

### DIFF
--- a/changelog/4371.feature.rst
+++ b/changelog/4371.feature.rst
@@ -1,0 +1,1 @@
+Updated the ``--collect-only`` option to display test descriptions when ran using ``--verbose``.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -611,6 +611,10 @@ class TerminalReporter(object):
                     continue
                 indent = (len(stack) - 1) * "  "
                 self._tw.line("%s%s" % (indent, col))
+                if self.config.option.verbose >= 1:
+                    if hasattr(col, "_obj") and col._obj.__doc__:
+                        for line in col._obj.__doc__.strip().splitlines():
+                            self._tw.line("%s%s" % (indent + "  ", line.strip()))
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_sessionfinish(self, exitstatus):

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -276,6 +276,18 @@ class TestCollectonly(object):
         result = testdir.runpytest("--collect-only", "-rs")
         result.stdout.fnmatch_lines(["*ERROR collecting*"])
 
+    def test_collectonly_display_test_description(self, testdir):
+        testdir.makepyfile(
+            """
+            def test_with_description():
+                \""" This test has a description.
+                \"""
+                assert True
+        """
+        )
+        result = testdir.runpytest("--collect-only", "--verbose")
+        result.stdout.fnmatch_lines(["    This test has a description."])
+
     def test_collectonly_failed_module(self, testdir):
         testdir.makepyfile("""raise ValueError(0)""")
         result = testdir.runpytest("--collect-only")


### PR DESCRIPTION
This implements #4371 by updating --collect-only to display test descriptions when running in verbose mode.

Example output:
```
plugins: xdist-1.23.0, forked-0.2, env-0.6.2, hypothesis-3.73.4
collected 2 items
<Module example_description.py>
  Module containing tests.
  <Function test_a>
    This test has a description
  <Function test_b>
    This test has one docstring line.
    and a second one.

======================== no tests ran in 0.03 seconds =========================

(test_env) C:\Users\User\Desktop\pytest>
```
