### PR TITLE
Suggest targetting features for minor releases

### DIFF
--- a/HOWTORELEASE.rst
+++ b/HOWTORELEASE.rst
@@ -24,7 +24,14 @@ taking a lot of time to make a new one.
 
    This will generate a commit with all the changes ready for pushing.
 
-#. Open a PR for this branch targeting ``master``.
+#. Open a PR for this branch:
+
+   * **patch releases**: target ``master``;
+
+   * **minor releases**: target ``features``;
+
+   The reasoning here is to get the smallest diff possible of what will be effectively released,
+   making review easier.
 
 #. After all tests pass and the PR has been approved, publish to PyPI by pushing the tag::
 
@@ -33,7 +40,7 @@ taking a lot of time to make a new one.
 
    Wait for the deploy to complete, then make sure it is `available on PyPI <https://pypi.org/project/pytest>`_.
 
-#. Merge the PR into ``master``.
+#. Merge the PR. For **minor releases**, also open a new PR merging ``features`` back to ``master``.
 
 #. Send an email announcement with the contents from::
 


### PR DESCRIPTION
This way we get just the small diff for review of what will be actually
be released, instead of the entire history between the last two minor
versions (say 4.0 to 4.1).

I don't think this needs a CHANGELOG entry as is an internal doc.