### PR TITLE
Fix typo in the Changelog for `get_closest_marker`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1022,7 +1022,7 @@ Features
 - Revamp the internals of the ``pytest.mark`` implementation with correct per
   node handling which fixes a number of long standing bugs caused by the old
   design. This introduces new ``Node.iter_markers(name)`` and
-  ``Node.get_closest_mark(name)`` APIs. Users are **strongly encouraged** to
+  ``Node.get_closest_marker(name)`` APIs. Users are **strongly encouraged** to
   read the `reasons for the revamp in the docs
   <https://docs.pytest.org/en/latest/mark.html#marker-revamp-and-iteration>`_,
   or jump over to details about `updating existing code to use the new APIs


### PR DESCRIPTION
Hej! I was looking for a changelog entry for `Node.get_closest_marker` and found out that it mentioned like `Node.get_closest_mark`. This PR fixes this typo