### PR TITLE
Show full repr with assert a==b and -vv

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -176,6 +176,7 @@ Oliver Bestwalter
 Omar Kohl
 Omer Hadari
 Ondřej Súkup
+Oscar Benjamin
 Patrick Hayes
 Paweł Adamczak
 Pedro Algarvio

--- a/changelog/2256.bugfix.rst
+++ b/changelog/2256.bugfix.rst
@@ -1,0 +1,1 @@
+Show full repr with ``assert a==b`` and ``-vv``.

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -151,6 +151,8 @@ def assertrepr_compare(config, op, left, right):
                 elif type(left) == type(right) and (isdatacls(left) or isattrs(left)):
                     type_fn = (isdatacls, isattrs)
                     explanation = _compare_eq_cls(left, right, verbose, type_fn)
+                elif verbose:
+                    explanation = _compare_eq_verbose(left, right)
                 if isiterable(left) and isiterable(right):
                     expl = _compare_eq_iterable(left, right, verbose)
                     if explanation is not None:
@@ -233,6 +235,18 @@ def _diff_text(left, right, verbose=False):
         line.strip("\n")
         for line in ndiff(left.splitlines(keepends), right.splitlines(keepends))
     ]
+    return explanation
+
+
+def _compare_eq_verbose(left, right):
+    keepends = True
+    left_lines = repr(left).splitlines(keepends)
+    right_lines = repr(right).splitlines(keepends)
+
+    explanation = []
+    explanation += [u"-" + line for line in left_lines]
+    explanation += [u"+" + line for line in right_lines]
+
     return explanation
 
 

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -488,6 +488,30 @@ class TestAssert_reprcompare(object):
         expl = callequal([(1, 2)], [])
         assert len(expl) > 1
 
+    def test_repr_verbose(self):
+        class Nums:
+            def __init__(self, nums):
+                self.nums = nums
+
+            def __repr__(self):
+                return str(self.nums)
+
+        list_x = list(range(5000))
+        list_y = list(range(5000))
+        list_y[len(list_y) // 2] = 3
+        nums_x = Nums(list_x)
+        nums_y = Nums(list_y)
+
+        assert callequal(nums_x, nums_y) is None
+
+        expl = callequal(nums_x, nums_y, verbose=1)
+        assert "-" + repr(nums_x) in expl
+        assert "+" + repr(nums_y) in expl
+
+        expl = callequal(nums_x, nums_y, verbose=2)
+        assert "-" + repr(nums_x) in expl
+        assert "+" + repr(nums_y) in expl
+
     def test_list_bad_repr(self):
         class A(object):
             def __repr__(self):


### PR DESCRIPTION
Fixes #2256 

Adds a new explanation handler to show reprs of arbitrary objects. The handler shows the full `repr` in test failure output for `assert x==y` when `-vv` is given on the command line.

Here's a test case:
```python
class Nums:
    def __init__(self, nums):
        self.nums = nums
    def __repr__(self):
        return str(self.nums)

def test_f():
    x = list(range(5000))
    y = list(range(5000))
    y[len(y)//2] = 3
    x = Nums(x)
    y = Nums(y)
    assert x == y
```

Running on master this gives:
```terminal
$ pytest test_f.py -vv
==================================================================== test session starts =====================================================================
platform darwin -- Python 3.7.1, pytest-4.0.3.dev19+ge8152207, py-1.7.0, pluggy-0.8.0 -- /Users/enojb/current/sympy/venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/enojb/current/sympy/pytest, inifile: tox.ini
plugins: xdist-1.24.1, forked-0.2, doctestplus-0.3.0.dev0
collected 1 item                                                                                                                                             

test_f.py::test_f FAILED                                                                                                                               [100%]

========================================================================== FAILURES ==========================================================================
___________________________________________________________________________ test_f ___________________________________________________________________________

    def test_f():
        x = list(range(5000))
        y = list(range(5000))
        y[len(y)//2] = 3
        x = Nums(x)
        y = Nums(y)
>       assert x == y
E       assert [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,...4980, 4981, 4982, 4983, 4984, 4985, 4986, 4987, 4988, 4989, 4990, 4991, 4992, 4993, 4994, 4995, 4996, 4997, 4998, 4999] == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,...4980, 4981, 4982, 4983, 4984, 4985, 4986, 4987, 4988, 4989, 4990, 4991, 4992, 4993, 4994, 4995, 4996, 4997, 4998, 4999]

test_f.py:13: AssertionError
================================================================== short test summary info ===================================================================
FAIL test_f.py::test_f
================================================================== 1 failed in 0.09 seconds ==================================================================
```

With this patch there is a short output given by:
```terminal
$ pytest test_f.py -v
==================================================================== test session starts =====================================================================
platform darwin -- Python 3.7.1, pytest-4.0.3.dev19+ge8152207, py-1.7.0, pluggy-0.8.0 -- /Users/enojb/current/sympy/venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/enojb/current/sympy/pytest, inifile: tox.ini
plugins: xdist-1.24.1, forked-0.2, doctestplus-0.3.0.dev0
collected 1 item                                                                                                                                             

test_f.py::test_f FAILED                                                                                                                               [100%]

========================================================================== FAILURES ==========================================================================
___________________________________________________________________________ test_f ___________________________________________________________________________

    def test_f():
        x = list(range(5000))
        y = list(range(5000))
        y[len(y)//2] = 3
        x = Nums(x)
        y = Nums(y)
>       assert x == y
E       AssertionError: assert [0, 1, 2, 3, ...7, 4998, 4999] == [0, 1, 2, 3, 4...7, 4998, 4999]
E         -[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136...
E         
E         ...Full output truncated (2 lines hidden), use '-vv' to show

test_f.py:13: AssertionError
================================================================== short test summary info ===================================================================
FAIL test_f.py::test_f
================================================================== 1 failed in 0.10 seconds ==================================================================
```

Running with `-vv` shows the whole `repr` (which is very long so I won't paste it here).

