### PR TITLE
goodpractices - needs __init__.py for easy invocation

### DIFF
--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -68,6 +68,7 @@ to keep tests separate from actual application code (often a good idea)::
         app.py
         view.py
     tests/
+        __init__.py
         test_app.py
         test_view.py
         ...


### PR DESCRIPTION
The tests folder must be a package in order to simply run `pytest` and for it to simply work, as the docs imply. Without this, pytest does not add the current directory to PYTHONPATH, and so seems to mysteriously fail.

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs (you can delete this text from the final description, this is
just a guideline):

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [x] Target the `features` branch for new features and removals/deprecations.
- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS` in alphabetical order;
