### PR TITLE
Assertion rewrite breaks for objects that reimplement `__getattr__`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,6 +24,7 @@ Andy Freeland
 Anthon van der Neut
 Anthony Shaw
 Anthony Sottile
+Anton Lodder
 Antony Lee
 Armin Rigo
 Aron Coyle

--- a/changelog/4631.bugfix.rst
+++ b/changelog/4631.bugfix.rst
@@ -1,0 +1,1 @@
+Don't rewrite assertion when ``__getattr__`` is broken

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -525,7 +525,13 @@ def _format_assertmsg(obj):
 
 
 def _should_repr_global_name(obj):
-    return not hasattr(obj, "__name__") and not callable(obj)
+    if callable(obj):
+        return False
+
+    try:
+        return not hasattr(obj, "__name__")
+    except Exception:
+        return True
 
 
 def _format_boolop(explanations, is_or):

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -180,6 +180,27 @@ class TestAssertionRewrite(object):
 
         assert getmsg(f, {"cls": X}) == "assert cls == 42"
 
+    def test_dont_rewrite_if_hasattr_fails(self):
+        class Y(object):
+            """ A class whos getattr fails, but not with `AttributeError` """
+
+            def __getattr__(self, attribute_name):
+                raise KeyError()
+
+            def __repr__(self):
+                return "Y"
+
+            def __init__(self):
+                self.foo = 3
+
+        def f():
+            assert cls().foo == 2  # noqa
+
+        message = getmsg(f, {"cls": Y})
+        assert "assert 3 == 2" in message
+        assert "+  where 3 = Y.foo" in message
+        assert "+    where Y = cls()" in message
+
     def test_assert_already_has_message(self):
         def f():
             assert False, "something bad!"


### PR DESCRIPTION
This fix addresses #4631.

