### PR TITLE
Use a.item() instead of deprecated np.asscalar(a)

### DIFF
--- a/changelog/4643.trivial.rst
+++ b/changelog/4643.trivial.rst
@@ -1,0 +1,3 @@
+Use ``a.item()`` instead of the deprecated ``np.asscalar(a)`` in ``pytest.approx``.
+
+``np.asscalar`` has been `deprecated <https://github.com/numpy/numpy/blob/master/doc/release/1.16.0-notes.rst#new-deprecations>`__ in ``numpy 1.16.``.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -150,10 +150,10 @@ class ApproxNumpy(ApproxBase):
 
         if np.isscalar(actual):
             for i in np.ndindex(self.expected.shape):
-                yield actual, np.asscalar(self.expected[i])
+                yield actual, self.expected[i].item()
         else:
             for i in np.ndindex(self.expected.shape):
-                yield np.asscalar(actual[i]), np.asscalar(self.expected[i])
+                yield actual[i].item(), self.expected[i].item()
 
 
 class ApproxMapping(ApproxBase):


### PR DESCRIPTION
`np.asscalar()` has been deprecated in numpy 1.16:

https://github.com/numpy/numpy/blob/master/doc/release/1.16.0-notes.rst#new-deprecations
