### PR TITLE
Fix 4680 - `tmp_path` and `tmpdir` now share the same temporary directory

### DIFF
--- a/changelog/4680.bugfix.rst
+++ b/changelog/4680.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure the ``tmpdir`` and the ``tmp_path`` fixtures are the same folder.

--- a/changelog/4681.bugfix.rst
+++ b/changelog/4681.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure ``tmp_path`` is always a real path.

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -167,7 +167,7 @@ def _mk_tmp(request, factory):
 
 
 @pytest.fixture
-def tmpdir(request, tmpdir_factory):
+def tmpdir(tmp_path):
     """Return a temporary directory path object
     which is unique to each test function invocation,
     created as a sub directory of the base temporary
@@ -176,7 +176,7 @@ def tmpdir(request, tmpdir_factory):
 
     .. _`py.path.local`: https://py.readthedocs.io/en/latest/path.html
     """
-    return _mk_tmp(request, tmpdir_factory)
+    return py.path.local(tmp_path)
 
 
 @pytest.fixture

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -61,11 +61,11 @@ class TempPathFactory(object):
         """ return base temporary directory. """
         if self._basetemp is None:
             if self._given_basetemp is not None:
-                basetemp = self._given_basetemp
+                basetemp = self._given_basetemp.resolve()
                 ensure_reset_dir(basetemp)
             else:
                 from_env = os.environ.get("PYTEST_DEBUG_TEMPROOT")
-                temproot = Path(from_env or tempfile.gettempdir())
+                temproot = Path(from_env or tempfile.gettempdir()).resolve()
                 user = get_user() or "unknown"
                 # use a sub-directory in the temproot to speed-up
                 # make_numbered_dir() call

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -61,8 +61,9 @@ class TempPathFactory(object):
         """ return base temporary directory. """
         if self._basetemp is None:
             if self._given_basetemp is not None:
-                basetemp = self._given_basetemp.resolve()
+                basetemp = self._given_basetemp
                 ensure_reset_dir(basetemp)
+                basetemp = basetemp.resolve()
             else:
                 from_env = os.environ.get("PYTEST_DEBUG_TEMPROOT")
                 temproot = Path(from_env or tempfile.gettempdir()).resolve()

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -739,7 +739,7 @@ class TestRequestBasic(object):
             def test_function(request, farg):
                 assert set(get_public_names(request.fixturenames)) == \
                        set(["tmpdir", "sarg", "arg1", "request", "farg",
-                            "tmpdir_factory"])
+                            "tmp_path", "tmp_path_factory"])
         """
         )
         reprec = testdir.inline_run()

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -337,3 +337,7 @@ def attempt_symlink_to(path, to_path):
         Path(path).symlink_to(Path(to_path))
     except OSError:
         pytest.skip("could not create symbolic link")
+
+
+def test_tmpdir_equals_tmp_path(tmpdir, tmp_path):
+    assert Path(tmpdir) == tmp_path


### PR DESCRIPTION
Fixes #4680 