### PR TITLE
Handle unittest.SkipTest exception with non-ascii characters

### DIFF
--- a/changelog/4669.bugfix.rst
+++ b/changelog/4669.bugfix.rst
@@ -1,0 +1,1 @@
+Correctly handle ``unittest.SkipTest`` exception containing non-ascii characters on Python 2.

--- a/src/_pytest/nose.py
+++ b/src/_pytest/nose.py
@@ -5,6 +5,8 @@ from __future__ import print_function
 
 import sys
 
+import six
+
 from _pytest import python
 from _pytest import runner
 from _pytest import unittest
@@ -24,7 +26,7 @@ def pytest_runtest_makereport(item, call):
     if call.excinfo and call.excinfo.errisinstance(get_skip_exceptions()):
         # let's substitute the excinfo with a pytest.skip one
         call2 = runner.CallInfo.from_call(
-            lambda: runner.skip(str(call.excinfo.value)), call.when
+            lambda: runner.skip(six.text_type(call.excinfo.value)), call.when
         )
         call.excinfo = call2.excinfo
 

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -366,3 +367,17 @@ def test_nottest_class_decorator(testdir):
     assert not reprec.getfailedcollections()
     calls = reprec.getreports("pytest_runtest_logreport")
     assert not calls
+
+
+def test_skip_test_with_unicode(testdir):
+    testdir.makepyfile(
+        """
+        # encoding: utf-8
+        import unittest
+        class TestClass():
+            def test_io(self):
+                raise unittest.SkipTest(u'😊')
+    """
+    )
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines("* 1 skipped *")


### PR DESCRIPTION
Fix #4669

