### PR TITLE
Add config to pytest_report_teststatus

### DIFF
--- a/changelog/4688.feature.rst
+++ b/changelog/4688.feature.rst
@@ -1,0 +1,1 @@
+``pytest_report_teststatus`` hook now can also receive a ``config`` parameter.

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -481,8 +481,10 @@ def pytest_report_collectionfinish(config, startdir, items):
 
 
 @hookspec(firstresult=True)
-def pytest_report_teststatus(report):
+def pytest_report_teststatus(report, config):
     """ return result-category, shortletter and verbose word for reporting.
+
+    :param _pytest.config.Config config: pytest config object
 
     Stops at first non-None result, see :ref:`firstresult` """
 

--- a/src/_pytest/resultlog.py
+++ b/src/_pytest/resultlog.py
@@ -66,7 +66,9 @@ class ResultLog(object):
     def pytest_runtest_logreport(self, report):
         if report.when != "call" and report.passed:
             return
-        res = self.config.hook.pytest_report_teststatus(report=report)
+        res = self.config.hook.pytest_report_teststatus(
+            report=report, config=self.config
+        )
         code = res[1]
         if code == "x":
             longrepr = str(report.longrepr)

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -363,7 +363,7 @@ class TerminalReporter(object):
 
     def pytest_runtest_logreport(self, report):
         rep = report
-        res = self.config.hook.pytest_report_teststatus(report=rep)
+        res = self.config.hook.pytest_report_teststatus(report=rep, config=self.config)
         category, letter, word = res
         if isinstance(word, tuple):
             word, markup = word


### PR DESCRIPTION
Now that `pytest.config` is deprecated, this allows users to access the config object and avoid "hacks" such as https://github.com/hackebrot/pytest-emoji/pull/4