### PR TITLE
Show deprecation message when running under Python 2.7 and 3.4

### DIFF
--- a/changelog/4627.feature.rst
+++ b/changelog/4627.feature.rst
@@ -1,0 +1,2 @@
+Display a message at the end of the test session when running under Python 2.7 and 3.4 that pytest 5.0 will no longer
+support those Python versions.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -649,6 +649,7 @@ class TerminalReporter(object):
         self.summary_passes()
         # Display any extra warnings from teardown here (if any).
         self.summary_warnings()
+        self.summary_deprecated_python()
 
     def pytest_keyboard_interrupt(self, excinfo):
         self._keyboardinterrupt_memo = excinfo.getrepr(funcargs=True)
@@ -769,6 +770,20 @@ class TerminalReporter(object):
                         msg = self._getfailureheadline(rep)
                         self.write_sep("_", msg)
                         self._outrep_summary(rep)
+
+    def summary_deprecated_python(self):
+        if sys.version_info[:2] <= (3, 4) and self.verbosity >= 0:
+            self.write_sep("=", "deprecated python version", yellow=True, bold=False)
+            using_version = ".".join(str(x) for x in sys.version_info[:3])
+            self.line(
+                "You are using Python {}, which will no longer be supported in pytest 5.0".format(
+                    using_version
+                ),
+                yellow=True,
+                bold=False,
+            )
+            self.line("For more information, please read:")
+            self.line("  https://docs.pytest.org/en/latest/py27-py34-deprecation.html")
 
     def print_teardown_sections(self, rep):
         showcapture = self.config.option.showcapture

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -854,7 +854,9 @@ class TestDurations(object):
         result = testdir.runpytest("--durations=2")
         assert result.ret == 0
         lines = result.stdout.get_lines_after("*slowest*durations*")
-        assert "4 passed" in lines[2]
+        # account for the "deprecated python version" header
+        index = 2 if sys.version_info[:2] > (3, 4) else 6
+        assert "4 passed" in lines[index]
 
     def test_calls_showall(self, testdir):
         testdir.makepyfile(self.source)

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import sys
 
 import pytest
 from _pytest.warnings import SHOW_PYTEST_WARNINGS_ARG
@@ -219,3 +220,21 @@ def test_fixture_named_request(testdir):
             "*'request' is a reserved name for fixtures and will raise an error in future versions"
         ]
     )
+
+
+def test_python_deprecation(testdir):
+    result = testdir.runpytest()
+    python_ver = ".".join(str(x) for x in sys.version_info[:3])
+    msg = "You are using Python {}, which will no longer be supported in pytest 5.0".format(
+        python_ver
+    )
+    if sys.version_info[:2] <= (3, 4):
+        result.stdout.fnmatch_lines(
+            [
+                msg,
+                "For more information, please read:",
+                "  https://docs.pytest.org/en/latest/py27-py34-deprecation.html",
+            ]
+        )
+    else:
+        assert msg not in result.stdout.str()


### PR DESCRIPTION
Output:

```
testing\deprecated_test.py .                                             [100%]

========================== deprecated python version ==========================
You are using Python 2.7.15, which will no longer be supported in pytest 5.0
For more information, please read:
  https://docs.pytest.org/en/latest/py27-py34-deprecation.html
=================== 1 passed, 14 deselected in 0.13 seconds ===================
```

Fix #4627
