### PR TITLE
Add config to pytest_terminal_summary hook

### DIFF
--- a/changelog/4691.feature.rst
+++ b/changelog/4691.feature.rst
@@ -1,0 +1,1 @@
+``pytest_terminal_summary`` hook now can also receive a ``config`` parameter.

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -489,13 +489,14 @@ def pytest_report_teststatus(report, config):
     Stops at first non-None result, see :ref:`firstresult` """
 
 
-def pytest_terminal_summary(terminalreporter, exitstatus):
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
     """Add a section to terminal summary reporting.
 
     :param _pytest.terminal.TerminalReporter terminalreporter: the internal terminal reporter object
     :param int exitstatus: the exit status that will be reported back to the OS
+    :param _pytest.config.Config config: pytest config object
 
-    .. versionadded:: 3.5
+    .. versionadded:: 4.2
         The ``config`` parameter.
     """
 

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -633,7 +633,7 @@ class TerminalReporter(object):
         )
         if exitstatus in summary_exit_codes:
             self.config.hook.pytest_terminal_summary(
-                terminalreporter=self, exitstatus=exitstatus
+                terminalreporter=self, exitstatus=exitstatus, config=self.config
             )
         if exitstatus == EXIT_INTERRUPTED:
             self._report_keyboardinterrupt()


### PR DESCRIPTION
The docs stated that this hook got the 'config' parameter in 3.5, but the docs
were probably changed by mistake.

