### PR TITLE
fixes for flake8 3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: doc/en/example/py2py3/test_py2.py
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 18.6b4
+    rev: 18.9b0
     hooks:
     -   id: black
         args: [--safe, --quiet]
@@ -13,7 +13,7 @@ repos:
         additional_dependencies: [black==18.9b0]
         language_version: python3
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -27,17 +27,17 @@ repos:
     -   id: flake8
         language_version: python3
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.3.3
+    rev: v1.3.5
     hooks:
     -   id: reorder-python-imports
         args: ['--application-directories=.:src']
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.10.1
+    rev: v1.11.1
     hooks:
     -   id: pyupgrade
         args: [--keep-percent-format]
 -   repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.1.0
+    rev: v1.2.0
     hooks:
     -   id: rst-backticks
 -   repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,9 @@ repos:
     -   id: debug-statements
         exclude: _pytest/debugging.py
         language_version: python3
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.0
+    hooks:
     -   id: flake8
         language_version: python3
 -   repo: https://github.com/asottile/reorder_python_imports

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -437,7 +437,7 @@ class PytestPluginManager(PluginManager):
                     and not self._using_pyargs
                 ):
                     from _pytest.deprecated import (
-                        PYTEST_PLUGINS_FROM_NON_TOP_LEVEL_CONFTEST
+                        PYTEST_PLUGINS_FROM_NON_TOP_LEVEL_CONFTEST,
                     )
 
                     fail(

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -307,8 +307,8 @@ class FuncFixtureInfo(object):
     # fixture names specified via usefixtures and via autouse=True in fixture
     # definitions.
     initialnames = attr.ib(type=tuple)
-    names_closure = attr.ib()  # type: List[str]
-    name2fixturedefs = attr.ib()  # type: List[str, List[FixtureDef]]
+    names_closure = attr.ib()  # List[str]
+    name2fixturedefs = attr.ib()  # List[str, List[FixtureDef]]
 
     def prune_dependency_tree(self):
         """Recompute names_closure from initialnames and name2fixturedefs

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -217,7 +217,7 @@ class LogCaptureFixture(object):
         """Creates a new funcarg."""
         self._item = item
         # dict of log name -> log level
-        self._initial_log_levels = {}  # type: Dict[str, int]
+        self._initial_log_levels = {}  # Dict[str, int]
 
     def _finalize(self):
         """Finalizes the fixture.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -143,9 +143,9 @@ class Mark(object):
     #: name of the mark
     name = attr.ib(type=str)
     #: positional arguments of the mark decorator
-    args = attr.ib()  # type: List[object]
+    args = attr.ib()  # List[object]
     #: keyword arguments of the mark decorator
-    kwargs = attr.ib()  # type: Dict[str, object]
+    kwargs = attr.ib()  # Dict[str, object]
 
     def combined_with(self, other):
         """

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -204,7 +204,7 @@ class CallInfo(object):
     """ Result/Exception info a function invocation. """
 
     _result = attr.ib()
-    # type: Optional[ExceptionInfo]
+    # Optional[ExceptionInfo]
     excinfo = attr.ib()
     start = attr.ib()
     stop = attr.ib()


### PR DESCRIPTION
I opted to _remove_ the PEP 484 type comment annotations for now since we're not linting for mypy

Also upgraded the pre-commit hooks since `virtualenv` has been released fixing the weird `black` issue that was happening before