### PR TITLE
Remove unneeded 2nd _setup_cli_logging call

### DIFF
--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -430,10 +430,6 @@ class LoggingPlugin(object):
 
     @pytest.hookimpl(hookwrapper=True, tryfirst=True)
     def pytest_collection(self):
-        # This has to be called before the first log message is logged,
-        # so we can access the terminal reporter plugin.
-        self._setup_cli_logging()
-
         with self.live_logs_context():
             if self.log_cli_handler:
                 self.log_cli_handler.set_when("collection")
@@ -513,6 +509,8 @@ class LoggingPlugin(object):
 
     @pytest.hookimpl(hookwrapper=True, tryfirst=True)
     def pytest_sessionstart(self):
+        # This has to be called before the first log message is logged,
+        # so we can access the terminal reporter plugin.
         self._setup_cli_logging()
         with self.live_logs_context():
             if self.log_cli_handler:


### PR DESCRIPTION
During the review of #4204 it was not noticed that _setup_cli_logging
was already called in the collection phase (pytest_collection). After #4204 was merged
_setup_cli_logging is called in two hooks: pytest_collection and
pytest_sessionstart. However, it only makes sense to call _setup_cli_logging once
(in the first called hook of the logging plugin).

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs (you can delete this text from the final description, this is
just a guideline):

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Add yourself to `AUTHORS` in alphabetical order;
