### PR TITLE
Remove workaround for docstrings for py38+

### DIFF
--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -68,38 +68,16 @@ def getmsg(f, extra_ns=None, must_pass=False):
             pytest.fail("function didn't raise at all")
 
 
-def adjust_body_for_new_docstring_in_module_node(m):
-    """Module docstrings in 3.8 are part of Module node.
-    This was briefly in 3.7 as well but got reverted in beta 5.
-
-    It's not in the body so we remove it so the following body items have
-    the same indexes on all Python versions:
-
-    TODO:
-
-    We have a complicated sys.version_info if in here to ease testing on
-    various Python 3.7 versions, but we should remove the 3.7 check after
-    3.7 is released as stable to make this check more straightforward.
-    """
-    if sys.version_info < (3, 8) and not (
-        (3, 7) <= sys.version_info <= (3, 7, 0, "beta", 4)
-    ):
-        assert len(m.body) > 1
-        assert isinstance(m.body[0], ast.Expr)
-        assert isinstance(m.body[0].value, ast.Str)
-        del m.body[0]
-
-
 class TestAssertionRewrite(object):
     def test_place_initial_imports(self):
         s = """'Doc string'\nother = stuff"""
         m = rewrite(s)
-        adjust_body_for_new_docstring_in_module_node(m)
-        for imp in m.body[0:2]:
+        assert isinstance(m.body[0], ast.Expr)
+        for imp in m.body[1:3]:
             assert isinstance(imp, ast.Import)
             assert imp.lineno == 2
             assert imp.col_offset == 0
-        assert isinstance(m.body[2], ast.Assign)
+        assert isinstance(m.body[3], ast.Assign)
         s = """from __future__ import division\nother_stuff"""
         m = rewrite(s)
         assert isinstance(m.body[0], ast.ImportFrom)
@@ -110,24 +88,24 @@ class TestAssertionRewrite(object):
         assert isinstance(m.body[3], ast.Expr)
         s = """'doc string'\nfrom __future__ import division"""
         m = rewrite(s)
-        adjust_body_for_new_docstring_in_module_node(m)
-        assert isinstance(m.body[0], ast.ImportFrom)
-        for imp in m.body[1:3]:
+        assert isinstance(m.body[0], ast.Expr)
+        assert isinstance(m.body[1], ast.ImportFrom)
+        for imp in m.body[2:4]:
             assert isinstance(imp, ast.Import)
             assert imp.lineno == 2
             assert imp.col_offset == 0
         s = """'doc string'\nfrom __future__ import division\nother"""
         m = rewrite(s)
-        adjust_body_for_new_docstring_in_module_node(m)
-        assert isinstance(m.body[0], ast.ImportFrom)
-        for imp in m.body[1:3]:
+        assert isinstance(m.body[0], ast.Expr)
+        assert isinstance(m.body[1], ast.ImportFrom)
+        for imp in m.body[2:4]:
             assert isinstance(imp, ast.Import)
             assert imp.lineno == 3
             assert imp.col_offset == 0
-        assert isinstance(m.body[3], ast.Expr)
+        assert isinstance(m.body[4], ast.Expr)
         s = """from . import relative\nother_stuff"""
         m = rewrite(s)
-        for imp in m.body[0:2]:
+        for imp in m.body[:2]:
             assert isinstance(imp, ast.Import)
             assert imp.lineno == 1
             assert imp.col_offset == 0
@@ -136,9 +114,8 @@ class TestAssertionRewrite(object):
     def test_dont_rewrite(self):
         s = """'PYTEST_DONT_REWRITE'\nassert 14"""
         m = rewrite(s)
-        adjust_body_for_new_docstring_in_module_node(m)
-        assert len(m.body) == 1
-        assert m.body[0].msg is None
+        assert len(m.body) == 2
+        assert m.body[1].msg is None
 
     def test_dont_rewrite_plugin(self, testdir):
         contents = {


### PR DESCRIPTION
test-only changes for #4716 


```
$ pytest testing/test_assertrewrite.py 
============================ test session starts ============================
platform darwin -- Python 3.8.0a1+, pytest-4.2.1.dev15+ga9457345, py-1.7.0, pluggy-0.8.1
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/asottile/workspace/cpython/pytest/.hypothesis/examples')
rootdir: /Users/asottile/workspace/cpython/pytest, inifile: tox.ini
plugins: hypothesis-4.5.1
collected 66 items                                                          

testing/test_assertrewrite.py ....................................... [ 59%]
....s..ssss................                                           [100%]
========================== short test summary info ==========================
SKIPPED [1] testing/test_assertrewrite.py:866: python 2 only
SKIPPED [1] testing/test_assertrewrite.py:915: condition: sys.version_info[0] >= 3
SKIPPED [1] testing/test_assertrewrite.py:924: condition: sys.version_info[0] >= 3
SKIPPED [1] testing/test_assertrewrite.py:935: condition: sys.version_info[0] >= 3
SKIPPED [1] testing/test_assertrewrite.py:946: condition: sys.version_info[0] >= 3

=================== 61 passed, 5 skipped in 6.76 seconds ====================
```