### PR TITLE
Call pytest_report_collectionfinish hook when --collect-only is passed

### DIFF
--- a/changelog/2895.bugfix.rst
+++ b/changelog/2895.bugfix.rst
@@ -1,0 +1,1 @@
+The ``pytest_report_collectionfinish`` hook now is also called with ``--collect-only``.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -574,18 +574,19 @@ class TerminalReporter(object):
         return lines
 
     def pytest_collection_finish(self, session):
-        if self.config.option.collectonly:
+        if self.config.getoption("collectonly"):
             self._printcollecteditems(session.items)
-            if self.stats.get("failed"):
-                self._tw.sep("!", "collection failures")
-                for rep in self.stats.get("failed"):
-                    rep.toterminal(self._tw)
-                return 1
-            return 0
+
         lines = self.config.hook.pytest_report_collectionfinish(
             config=self.config, startdir=self.startdir, items=session.items
         )
         self._write_report_lines_from_hooks(lines)
+
+        if self.config.getoption("collectonly"):
+            if self.stats.get("failed"):
+                self._tw.sep("!", "collection failures")
+                for rep in self.stats.get("failed"):
+                    rep.toterminal(self._tw)
 
     def _printcollecteditems(self, items):
         # to print out items and their parent collectors

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -649,7 +649,10 @@ class TestTerminalFunctional(object):
         assert "===" not in s
         assert "passed" not in s
 
-    def test_report_collectionfinish_hook(self, testdir):
+    @pytest.mark.parametrize(
+        "params", [(), ("--collect-only",)], ids=["no-params", "collect-only"]
+    )
+    def test_report_collectionfinish_hook(self, testdir, params):
         testdir.makeconftest(
             """
             def pytest_report_collectionfinish(config, startdir, items):
@@ -664,7 +667,7 @@ class TestTerminalFunctional(object):
                 pass
         """
         )
-        result = testdir.runpytest()
+        result = testdir.runpytest(*params)
         result.stdout.fnmatch_lines(["collected 3 items", "hello from hook: 3 items"])
 
 


### PR DESCRIPTION
Fix #2895
