### PR TITLE
Mention that `pytest_plugins` should not be used as module name

### DIFF
--- a/changelog/3899.doc.rst
+++ b/changelog/3899.doc.rst
@@ -1,0 +1,1 @@
+Add note to ``plugins.rst`` that ``pytest_plugins`` should not be used as a name for a user module containing plugins.

--- a/doc/en/plugins.rst
+++ b/doc/en/plugins.rst
@@ -86,6 +86,11 @@ which will import the specified module as a ``pytest`` plugin.
     :ref:`full explanation <requiring plugins in non-root conftests>`
     in the Writing plugins section.
 
+.. note::
+   The name ``pytest_plugins`` is reserved and should not be used as a
+   name for a custom plugin module.
+
+
 .. _`findpluginname`:
 
 Finding out which plugins are active


### PR DESCRIPTION
- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.

---

As discussed in #3899 