### PR TITLE
Fix "ValueError: Plugin already registered" exceptions when running in build directories that symlink to actual source.

### DIFF
--- a/changelog/526.bugfix.rst
+++ b/changelog/526.bugfix.rst
@@ -1,0 +1,1 @@
+Fix "ValueError: Plugin already registered" exceptions when running in build directories that symlink to actual source.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -408,7 +408,7 @@ class PytestPluginManager(PluginManager):
                 continue
             conftestpath = parent.join("conftest.py")
             if conftestpath.isfile():
-                mod = self._importconftest(conftestpath)
+                mod = self._importconftest(conftestpath.realpath())
                 clist.append(mod)
         self._dirpath2confmods[directory] = clist
         return clist

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -408,6 +408,9 @@ class PytestPluginManager(PluginManager):
                 continue
             conftestpath = parent.join("conftest.py")
             if conftestpath.isfile():
+                # Use realpath to avoid loading the same conftest twice
+                # with build systems that create build directories containing
+                # symlinks to actual files.
                 mod = self._importconftest(conftestpath.realpath())
                 clist.append(mod)
         self._dirpath2confmods[directory] = clist


### PR DESCRIPTION
Some build systems (e.g. bazel) create build directories that have original source files symlinked and not copied or hardlinked.

This confused pytest which tried to refer to a conftest file by realpath in some cases and with symlink path in others, leading to "ValueError: Plugin already registered"  exception. This PR fixes that.