### PR TITLE
Remove terminal_reporter workaround from logging.py

### DIFF
--- a/changelog/4741.trivial.rst
+++ b/changelog/4741.trivial.rst
@@ -1,0 +1,2 @@
+Some verbosity related attributes of the TerminalReporter plugin are now
+read only properties.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -435,13 +435,6 @@ class LoggingPlugin(object):
             # terminal reporter is disabled e.g. by pytest-xdist.
             return
 
-        # FIXME don't set verbosity level and derived attributes of
-        # terminalwriter directly
-        terminal_reporter.verbosity = config.option.verbose
-        terminal_reporter.showheader = terminal_reporter.verbosity >= 0
-        terminal_reporter.showfspath = terminal_reporter.verbosity >= 0
-        terminal_reporter.showlongtestinfo = terminal_reporter.verbosity > 0
-
         capture_manager = config.pluginmanager.get_plugin("capturemanager")
         # if capturemanager plugin is disabled, live logging still works.
         log_cli_handler = _LiveLoggingStreamHandler(terminal_reporter, capture_manager)

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -222,12 +222,9 @@ class TerminalReporter(object):
         import _pytest.config
 
         self.config = config
-        self.verbosity = self.config.option.verbose
-        self.showheader = self.verbosity >= 0
-        self.showfspath = self.verbosity >= 0
-        self.showlongtestinfo = self.verbosity > 0
         self._numcollected = 0
         self._session = None
+        self._showfspath = None
 
         self.stats = {}
         self.startdir = py.path.local()
@@ -254,6 +251,28 @@ class TerminalReporter(object):
         if self.config.getoption("setupshow"):
             return False
         return self.config.getini("console_output_style") in ("progress", "count")
+
+    @property
+    def verbosity(self):
+        return self.config.option.verbose
+
+    @property
+    def showheader(self):
+        return self.verbosity >= 0
+
+    @property
+    def showfspath(self):
+        if self._showfspath is None:
+            return self.verbosity >= 0
+        return self._showfspath
+
+    @showfspath.setter
+    def showfspath(self, value):
+        self._showfspath = value
+
+    @property
+    def showlongtestinfo(self):
+        return self.verbosity > 0
 
     def hasopt(self, char):
         char = {"xfailed": "x", "skipped": "s"}.get(char, char)


### PR DESCRIPTION
The workaround was removed from the logging module by creating python
properties for verbosity related settings in the terminalreporter.

Closes: #4733

Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs (you can delete this text from the final description, this is
just a guideline):

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Add yourself to `AUTHORS` in alphabetical order;
