### PR TITLE
tox: py37-freeze: use --no-use-pep517 for PyInstaller

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -166,7 +166,9 @@ commands =
 
 [testenv:py37-freeze]
 changedir = testing/freeze
+# Disable PEP 517 with pip, which does not work with PyInstaller currently.
 deps =
+    --no-use-pep517
     pyinstaller
 commands =
     {envpython} create_executable.py


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/issues/4750.