### PR TITLE
LoggingPlugin: Support to customize log_file from hook

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Allan Feldman
 Aly Sivji
 Anatoly Bubenkoff
 Anders Hovmöller
+Andras Mitzki
 Andras Tim
 Andrea Cimatoribus
 Andreas Zeidler

--- a/changelog/4707.feature.rst
+++ b/changelog/4707.feature.rst
@@ -1,0 +1,1 @@
+With the help of new ``set_log_path()`` method there is a way to set ``log_file`` paths from hooks.

--- a/doc/en/logging.rst
+++ b/doc/en/logging.rst
@@ -198,6 +198,9 @@ option names are:
 * ``log_file_format``
 * ``log_file_date_format``
 
+You can call ``set_log_path()`` to customize the log_file path dynamically. This functionality
+is considered **experimental**.
+
 .. _log_release_notes:
 
 Release notes


### PR DESCRIPTION
First of all thanks to @thisch who allowed to make this PR possible.

Without this patch there was only one static way to customize log_file path: --log-file starter option.
This patch allows to customize log_file value also from hooks, which helps to create log-files dynamically even for each testcases.
