### PR TITLE
--lsof: suppress stderr

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -81,7 +81,11 @@ class LsofFdLeakChecker(object):
 
     def _exec_lsof(self):
         pid = os.getpid()
-        return subprocess.check_output(("lsof", "-Ffn0", "-p", str(pid))).decode()
+        # py3: use subprocess.DEVNULL directly.
+        with open(os.devnull, "wb") as devnull:
+            return subprocess.check_output(
+                ("lsof", "-Ffn0", "-p", str(pid)), stderr=devnull
+            ).decode()
 
     def _parse_lsof_output(self, out):
         def isopen(line):


### PR DESCRIPTION
This can spam a lot of warnings (per invocation), e.g.:

> lsof: WARNING: can't stat() nsfs file system /run/docker/netns/default
        Output information may be incomplete.

Or from Travis/MacOS:

> lsof: WARNING: can't stat() vmhgfs file system /Volumes/VMware Shared Folders
>       Output information may be incomplete.
>       assuming "dev=31000003" from mount table