### PR TITLE
consider_preparse: remove leading space

### DIFF
--- a/changelog/4766.bugfix.rst
+++ b/changelog/4766.bugfix.rst
@@ -1,0 +1,1 @@
+Handle ``-p no:fooplugin`` when passed as single argument.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -480,7 +480,7 @@ class PytestPluginManager(PluginManager):
                     parg = args[i]
                     i += 1
                 elif opt.startswith("-p"):
-                    parg = opt[2:]
+                    parg = opt[2:].lstrip()
                 else:
                     continue
                 self.consider_pluginarg(parg)

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -312,6 +312,7 @@ class TestPytestPluginManagerBootstrapming(object):
             pytestpm.consider_preparse(["-phello123"])
         assert '"hello123"' in excinfo.value.args[0]
         pytestpm.consider_preparse(["-pno:hello123"])
+        pytestpm.consider_preparse(["-p no:hello123"])
 
     def test_plugin_prevent_register(self, pytestpm):
         pytestpm.consider_preparse(["xyz", "-p", "no:abc"])


### PR DESCRIPTION
This handles "-p no:sugar" passed in as single arg via
`testdir.runpytest`.

Ref: https://github.com/Frozenball/pytest-sugar/issues/167