### PR TITLE
Update kwarg for attr.ib to use 'converter' as 'convert' is due to be deprecated.

### DIFF
--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -31,7 +31,7 @@ class TempPathFactory(object):
         # using os.path.abspath() to get absolute path instead of resolve() as it
         # does not work the same in all platforms (see #4427)
         # Path.absolute() exists, but it is not public (see https://bugs.python.org/issue25012)
-        convert=attr.converters.optional(
+        converter=attr.converters.optional(
             lambda p: Path(os.path.abspath(six.text_type(p)))
         )
     )


### PR DESCRIPTION
The `attrs` package is in the process of deprecating the `convert` kwarg for `Atrribute` in favor of `converter` for consistency (see https://github.com/python-attrs/attrs/issues/307). Ironically this removal is stalled as `attrs` uses pytest, which of course fails when the `convert` kwarg is removed.

Support for both presently exists in `attrs>=15.2.0`.