### PR TITLE
codecov: use only linux/windows/osx flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ after_success:
       coverage combine
       coverage xml --ignore-errors
       coverage report -m --ignore-errors
-      bash <(curl -s https://codecov.io/bash) -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml -F "${TOXENV//-/,},linux"
+      bash <(curl -s https://codecov.io/bash) -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml -F $TRAVIS_OS_NAME
     fi
 
 notifications:

--- a/scripts/upload-coverage.bat
+++ b/scripts/upload-coverage.bat
@@ -5,7 +5,7 @@ if not defined PYTEST_NO_COVERAGE (
     C:\Python36\Scripts\coverage combine
     C:\Python36\Scripts\coverage xml --ignore-errors
     C:\Python36\Scripts\coverage report -m --ignore-errors
-    scripts\appveyor-retry C:\Python36\Scripts\codecov --required -X gcov pycov search -f coverage.xml --flags %TOXENV:-= % windows
+    scripts\appveyor-retry C:\Python36\Scripts\codecov --required -X gcov pycov search -f coverage.xml --flags windows
 ) else (
     echo Skipping coverage upload, PYTEST_NO_COVERAGE is set
 )


### PR DESCRIPTION
Using many flags are a reason for timeouts on their backend, and we do
not really need those.