### PR TITLE
Logging: Make pytest_runtest_logreport() hook available for logging

### DIFF
--- a/changelog/4810.bugfix.rst
+++ b/changelog/4810.bugfix.rst
@@ -1,0 +1,1 @@
+Logging messages inside ``pytest_runtest_logreport()`` are now properly captured and displayed.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -567,6 +567,11 @@ class LoggingPlugin(object):
         with self._runtest_for(None, "finish"):
             yield
 
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_logreport(self):
+        with self._runtest_for(None, "logreport"):
+            yield
+
     @pytest.hookimpl(hookwrapper=True, tryfirst=True)
     def pytest_sessionfinish(self):
         with self.live_logs_context():

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1004,6 +1004,40 @@ def test_log_in_hooks(testdir):
         assert "sessionfinish" in contents
 
 
+def test_log_in_runtest_logreport(testdir):
+    log_file = testdir.tmpdir.join("pytest.log").strpath
+
+    testdir.makeini(
+        """
+        [pytest]
+        log_file={}
+        log_file_level = INFO
+        log_cli=true
+        """.format(
+            log_file
+        )
+    )
+    testdir.makeconftest(
+        """
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def pytest_runtest_logreport(report):
+            logger.info("logreport")
+    """
+    )
+    testdir.makepyfile(
+        """
+            def test_first():
+                assert True
+        """
+    )
+    testdir.runpytest()
+    with open(log_file) as rfh:
+        contents = rfh.read()
+        assert contents.count("logreport") == 3
+
+
 def test_log_set_path(testdir):
     report_dir_base = testdir.tmpdir.strpath
 


### PR DESCRIPTION
Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>
