### PR TITLE
Doc update - recommend use venv instead of virtualenv

### DIFF
--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -8,7 +8,7 @@ Install package with pip
 -------------------------------------------------
 
 For development, we recommend you use venv_ for virtual environments 
-(or virtualenv_ for Python 2.7 and 3.4) and 
+(or virtualenv_ for Python 2.7) and 
 pip_ for installing your application and any dependencies, 
 as well as the ``pytest`` package itself. 
 This ensures your code and dependencies are isolated from your system Python installation.

--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -7,10 +7,11 @@ Good Integration Practices
 Install package with pip
 -------------------------------------------------
 
-For development, we recommend you use venv_ for virtual environments and pip_
-for installing your application and any dependencies
-as well as the ``pytest`` package itself. This ensures your code and
-dependencies are isolated from the system Python installation.
+For development, we recommend you use venv_ for virtual environments 
+(or virtualenv_ for Python 2.7) and 
+pip_ for installing your application and any dependencies, 
+as well as the ``pytest`` package itself. 
+This ensures your code and dependencies are isolated from your system Python installation.
 
 Next, place a ``setup.py`` file in the root of your package with the following minimum content::
 

--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -7,10 +7,10 @@ Good Integration Practices
 Install package with pip
 -------------------------------------------------
 
-For development, we recommend you use venv_ for virtual environments 
-(or virtualenv_ for Python 2.7) and 
-pip_ for installing your application and any dependencies, 
-as well as the ``pytest`` package itself. 
+For development, we recommend you use venv_ for virtual environments
+(or virtualenv_ for Python 2.7) and
+pip_ for installing your application and any dependencies,
+as well as the ``pytest`` package itself.
 This ensures your code and dependencies are isolated from your system Python installation.
 
 Next, place a ``setup.py`` file in the root of your package with the following minimum content::

--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -7,12 +7,12 @@ Good Integration Practices
 Install package with pip
 -------------------------------------------------
 
-For development, we recommend to use virtualenv_ environments and pip_
+For development, we recommend you use venv_ for virtual environments and pip_
 for installing your application and any dependencies
 as well as the ``pytest`` package itself. This ensures your code and
 dependencies are isolated from the system Python installation.
 
-First you need to place a ``setup.py`` file in the root of your package with the following minimum content::
+Next, place a ``setup.py`` file in the root of your package with the following minimum content::
 
     from setuptools import setup, find_packages
 

--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -8,7 +8,7 @@ Install package with pip
 -------------------------------------------------
 
 For development, we recommend you use venv_ for virtual environments 
-(or virtualenv_ for Python 2.7) and 
+(or virtualenv_ for Python 2.7 and 3.4) and 
 pip_ for installing your application and any dependencies, 
 as well as the ``pytest`` package itself. 
 This ensures your code and dependencies are isolated from your system Python installation.

--- a/doc/en/links.inc
+++ b/doc/en/links.inc
@@ -15,6 +15,7 @@
 .. _`distribute`: https://pypi.org/project/distribute/
 .. _`pip`: https://pypi.org/project/pip/
 .. _`venv`: https://docs.python.org/3/library/venv.html/
+.. _`virtualenv`: https://pypi.org/project/virtualenv/
 .. _hudson: http://hudson-ci.org/
 .. _jenkins: http://jenkins-ci.org/
 .. _tox: http://testrun.org/tox


### PR DESCRIPTION
Recommend use venv instead of virtualenv

From the Python docs:
"Changed in version 3.5: The use of venv is now recommended for creating virtual environments."
-https://docs.python.org/3/library/venv.html