### PR TITLE
Require funcsigs>=1.0 on Python 2.7

### DIFF
--- a/changelog/4815.trivial.rst
+++ b/changelog/4815.trivial.rst
@@ -1,0 +1,1 @@
+``funcsigs>=1.0`` is now required for Python 2.7.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ INSTALL_REQUIRES = [
     'more-itertools>=4.0.0,<6.0.0;python_version<="2.7"',
     'more-itertools>=4.0.0;python_version>"2.7"',
     "atomicwrites>=1.0",
-    'funcsigs;python_version<"3.0"',
+    'funcsigs>=1.0;python_version<"3.0"',
     'pathlib2>=2.2.0;python_version<"3.6"',
     'colorama;sys_platform=="win32"',
 ]


### PR DESCRIPTION
Fix #4815

