### PR TITLE
Add unittest2 testing to trial environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -83,6 +83,7 @@ commands =
 deps =
     {[testenv]deps}
     twisted
+    unittest2
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest {posargs:testing/test_unittest.py}
 


### PR DESCRIPTION
Just noticed that `test_usefixtures_marker_on_unittest` is parametrized
for unittest2, but no environment ever installed that library.

