### PR TITLE
Clarify docs on --strict marks

### DIFF
--- a/doc/en/mark.rst
+++ b/doc/en/mark.rst
@@ -29,9 +29,11 @@ which also serve as documentation.
 Raising errors on unknown marks: --strict
 -----------------------------------------
 
-When the ``--strict`` command-line flag is passed, any marks not registered in the ``pytest.ini`` file will trigger an error.
+When the ``--strict`` command-line flag is passed, any unknown marks applied
+with the ``@pytest.mark.name_of_the_mark`` decorator will trigger an error.
+Marks defined or added by pytest or by a plugin will not trigger an error.
 
-Marks can be registered like this:
+Marks can be registered in ``pytest.ini`` like this:
 
 .. code-block:: ini
 

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -1226,8 +1226,11 @@ passed multiple times. The expected format is ``name=value``. For example::
 
 .. confval:: markers
 
-    List of markers that are allowed in test functions, enforced when ``--strict`` command-line argument is used.
-    You can use a marker name per line, indented from the option name.
+    When the ``--strict`` command-line argument is used, only known markers -
+    defined in code by core pytest or some plugin - are allowed.
+    You can list additional markers in this setting to add them to the whitelist.
+
+    You can list one marker name per line, indented from the option name.
 
     .. code-block:: ini
 


### PR DESCRIPTION
I've been looking into the behaviour of unknown marks today, and discovered that the docs for the `--strict` option are a bit misleading:  even with `--strict`, you don't need to list marks in `pytest.ini` if they come from pytest or are added by a plugin.  IMO this is the right thing to do, as `--strict` is really to catch typos, so I've just fixed the docs.