### PR TITLE
Remove dead-code related to yield tests

### DIFF
--- a/changelog/4829.trivial.rst
+++ b/changelog/4829.trivial.rst
@@ -1,0 +1,1 @@
+Some left-over internal code related to ``yield`` tests has been removed.

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -209,17 +209,12 @@ def _test_pytest_function(pyfuncitem):
     _pdb = pytestPDB._init_pdb()
     testfunction = pyfuncitem.obj
     pyfuncitem.obj = _pdb.runcall
-    if pyfuncitem._isyieldedfunction():
-        arg_list = list(pyfuncitem._args)
-        arg_list.insert(0, testfunction)
-        pyfuncitem._args = tuple(arg_list)
-    else:
-        if "func" in pyfuncitem._fixtureinfo.argnames:
-            raise ValueError("--trace can't be used with a fixture named func!")
-        pyfuncitem.funcargs["func"] = testfunction
-        new_list = list(pyfuncitem._fixtureinfo.argnames)
-        new_list.append("func")
-        pyfuncitem._fixtureinfo.argnames = tuple(new_list)
+    if "func" in pyfuncitem._fixtureinfo.argnames:
+        raise ValueError("--trace can't be used with a fixture named func!")
+    pyfuncitem.funcargs["func"] = testfunction
+    new_list = list(pyfuncitem._fixtureinfo.argnames)
+    new_list.append("func")
+    pyfuncitem._fixtureinfo.argnames = tuple(new_list)
 
 
 def _enter_pdb(node, excinfo, rep):

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -209,7 +209,7 @@ def _test_pytest_function(pyfuncitem):
     _pdb = pytestPDB._init_pdb()
     testfunction = pyfuncitem.obj
     pyfuncitem.obj = _pdb.runcall
-    if "func" in pyfuncitem._fixtureinfo.argnames:
+    if "func" in pyfuncitem._fixtureinfo.argnames:  # noqa
         raise ValueError("--trace can't be used with a fixture named func!")
     pyfuncitem.funcargs["func"] = testfunction
     new_list = list(pyfuncitem._fixtureinfo.argnames)

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1414,11 +1414,6 @@ class Function(FunctionMixin, nodes.Item, fixtures.FuncargnamesCompatAttr):
 
     def _initrequest(self):
         self.funcargs = {}
-        if hasattr(self, "callspec"):
-            callspec = self.callspec
-            assert not callspec.funcargs
-            if hasattr(callspec, "param"):
-                self.param = callspec.param
         self._request = fixtures.FixtureRequest(self)
 
     @property


### PR DESCRIPTION
Just noticed some code that no longer is needed when we removed yield-tests

