### PR TITLE
coverage: use run.include, remove --ignore-errors, send TOXENV as name to codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,10 @@
 [run]
-source = pytest,_pytest,testing/
+source = .
 parallel = 1
 branch = 1
+
+[report]
+include = src/*, testing/*
 
 [paths]
 source = src/

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,9 @@ branch = 1
 include = src/*, testing/*
 
 [paths]
-source = src/
-  .tox/*/lib/python*/site-packages/
-  .tox\*\Lib\site-packages\
+source = src/_pytest
+  .tox/*/lib/python*/site-packages/_pytest/
+  .tox\*\Lib\site-packages\pytest\
+source_pytest_py = src/pytest.py
+  .tox/*/lib/python*/site-packages/pytest.py
+  .tox\*\Lib\site-packages\pytest.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,15 +1,15 @@
 [run]
-source = .
+include =
+  src/*
+  testing/*
+  .tox/*/lib/python*/site-packages/_pytest/*
+  .tox/*/lib/python*/site-packages/pytest.py
+  .tox\*\Lib\site-packages\_pytest\*
+  .tox\*\Lib\site-packages\pytest.py
 parallel = 1
 branch = 1
 
-[report]
-include = src/*, testing/*
-
 [paths]
-source = src/_pytest
-  .tox/*/lib/python*/site-packages/_pytest/
-  .tox\*\Lib\site-packages\pytest\
-source_pytest_py = src/pytest.py
-  .tox/*/lib/python*/site-packages/pytest.py
-  .tox\*\Lib\site-packages\pytest.py
+source = src/
+  .tox/*/lib/python*/site-packages/
+  .tox\*\Lib\site-packages\

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,8 +103,8 @@ after_success:
       # Add last TOXENV to $PATH.
       PATH="$PWD/.tox/${TOXENV##*,}/bin:$PATH"
       coverage combine
-      coverage xml --ignore-errors
-      coverage report -m --ignore-errors
+      coverage xml
+      coverage report -m
       bash <(curl -s https://codecov.io/bash) -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml -F $TRAVIS_OS_NAME
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ after_success:
       coverage combine
       coverage xml
       coverage report -m
-      bash <(curl -s https://codecov.io/bash) -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml -F $TRAVIS_OS_NAME
+      bash <(curl -s https://codecov.io/bash) -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml -F $TRAVIS_OS_NAME -n $TOXENV
     fi
 
 notifications:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,3 +120,4 @@ jobs:
     condition: eq(variables['PYTEST_COVERAGE'], '1')
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
+      PYTEST_CODECOV_NAME: $(tox.env)

--- a/scripts/upload-coverage.bat
+++ b/scripts/upload-coverage.bat
@@ -8,8 +8,8 @@ if "%PYTEST_COVERAGE%" == "1" (
     )
     python -m pip install codecov
     coverage combine
-    coverage xml --ignore-errors
-    coverage report -m --ignore-errors
+    coverage xml
+    coverage report -m
     scripts\retry codecov --required -X gcov pycov search -f coverage.xml --flags windows
 ) else (
     echo Skipping coverage upload, PYTEST_COVERAGE=%PYTEST_COVERAGE%

--- a/scripts/upload-coverage.bat
+++ b/scripts/upload-coverage.bat
@@ -10,7 +10,7 @@ if "%PYTEST_COVERAGE%" == "1" (
     coverage combine
     coverage xml
     coverage report -m
-    scripts\retry codecov --required -X gcov pycov search -f coverage.xml --flags windows
+    scripts\retry codecov --required -X gcov pycov search -f coverage.xml --flags windows --name %PYTEST_CODECOV_NAME%
 ) else (
     echo Skipping coverage upload, PYTEST_COVERAGE=%PYTEST_COVERAGE%
 )


### PR DESCRIPTION
This appears to improve performance - ~4s with `tox -e py37-coverage --
testing/test_collection.py`.