### PR TITLE
tox: split default posargs, use --lsof with single job only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ jobs:
 
     - stage: baseline
       env: TOXENV=py27-pexpect,py27-trial
-    - env: TOXENV=py37-numpy-xdist
+    - env: TOXENV=py37-lsof-numpy-xdist PYTEST_COVERAGE=1
     - env: TOXENV=linting,docs,doctesting
       python: '3.7'
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,12 +21,12 @@ envlist =
 
 [testenv]
 commands =
-    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest {posargs:{env:_PYTEST_TOX_DEFAULT_POSARGS}}
+    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest {posargs:{env:_PYTEST_TOX_DEFAULT_POSARGS:}}
     coverage: coverage combine
     coverage: coverage report
 passenv = USER USERNAME COVERAGE_* TRAVIS PYTEST_ADDOPTS
 setenv =
-    _PYTEST_TOX_DEFAULT_POSARGS=--lsof
+    _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_POSARGS_LSOF:} {env:_PYTEST_TOX_POSARGS_PEXPECT:} {env:_PYTEST_TOX_POSARGS_XDIST:}
 
     # Configuration to run with coverage similar to Travis/Appveyor, e.g.
     # "tox -e py37-coverage".
@@ -37,10 +37,12 @@ setenv =
 
     nobyte: PYTHONDONTWRITEBYTECODE=1
 
-    pexpect: _PYTEST_TOX_PLATFORM=linux|darwin
-    pexpect: _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_DEFAULT_POSARGS:testing/test_pdb.py testing/test_terminal.py testing/test_unittest.py}
+    lsof: _PYTEST_TOX_POSARGS_LSOF=--lsof
 
-    xdist: _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_DEFAULT_POSARGS:-n auto}
+    pexpect: _PYTEST_TOX_PLATFORM=linux|darwin
+    pexpect: _PYTEST_TOX_POSARGS_PEXPECT=testing/test_pdb.py testing/test_terminal.py testing/test_unittest.py
+
+    xdist: _PYTEST_TOX_POSARGS_XDIST=-n auto
 extras = testing
 deps =
     numpy: numpy


### PR DESCRIPTION
This is required for combining.