### PR TITLE
ci: codecov: remove flags completely for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ after_success:
       coverage combine
       coverage xml
       coverage report -m
-      bash <(curl -s https://codecov.io/bash) -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml -F $TRAVIS_OS_NAME -n $TOXENV
+      bash <(curl -s https://codecov.io/bash) -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml -n $TOXENV
     fi
 
 notifications:

--- a/scripts/upload-coverage.bat
+++ b/scripts/upload-coverage.bat
@@ -10,7 +10,7 @@ if "%PYTEST_COVERAGE%" == "1" (
     coverage combine
     coverage xml
     coverage report -m
-    scripts\retry codecov --required -X gcov pycov search -f coverage.xml --flags windows --name %PYTEST_CODECOV_NAME%
+    scripts\retry codecov --required -X gcov pycov search -f coverage.xml --name %PYTEST_CODECOV_NAME%
 ) else (
     echo Skipping coverage upload, PYTEST_COVERAGE=%PYTEST_COVERAGE%
 )


### PR DESCRIPTION
This appears to be one of the reasons for timeouts on their backend.