### PR TITLE
tox: add generic nobyte and numpy factors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,10 @@ env:
   matrix:
     - TOXENV=py27 PYTEST_COVERAGE=1
     # Specialized factors for py27.
-    - TOXENV=py27-nobyte PYTEST_COVERAGE=1
-    - TOXENV=py27-xdist PYTEST_COVERAGE=1
+    - TOXENV=py27-nobyte-numpy-xdist PYTEST_COVERAGE=1
     - TOXENV=py27-pluggymaster-xdist
     # Specialized factors for py37.
-    - TOXENV=py37-pexpect,py37-trial,py37-numpy
+    - TOXENV=py37-pexpect,py37-trial
     - TOXENV=py37-pluggymaster-xdist
     - TOXENV=py37-freeze
 
@@ -65,8 +64,8 @@ jobs:
       if: type = cron
 
     - stage: baseline
-      env: TOXENV=py27-pexpect,py27-trial,py27-numpy
-    - env: TOXENV=py37-xdist
+      env: TOXENV=py27-pexpect,py27-trial
+    - env: TOXENV=py37-numpy-xdist
     - env: TOXENV=linting,docs,doctesting
       python: '3.7'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,13 +21,9 @@ jobs:
         python.version: '2.7'
         tox.env: 'py27'
         PYTEST_COVERAGE: '1'
-      py27-xdist:
+      py27-nobyte-numpy-xdist:
         python.version: '2.7'
-        tox.env: 'py27-xdist'
-        PYTEST_COVERAGE: '1'
-      py27-numpy/nobyte:
-        python.version: '2.7'
-        tox.env: 'py27-numpy,py27-nobyte'
+        tox.env: 'py27-nobyte-numpy-xdist'
         PYTEST_COVERAGE: '1'
       py27-trial:
         python.version: '2.7'

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist =
     pypy
     pypy3
     {py27,py37}-{pexpect,xdist,trial,numpy,pluggymaster}
-    py27-nobyte
+    py27-nobyte-xdist
     doctesting
     py37-freeze
     docs
@@ -35,12 +35,15 @@ setenv =
     coverage: COVERAGE_FILE={toxinidir}/.coverage
     coverage: COVERAGE_PROCESS_START={toxinidir}/.coveragerc
 
+    nobyte: PYTHONDONTWRITEBYTECODE=1
+
     pexpect: _PYTEST_TOX_PLATFORM=linux|darwin
     pexpect: _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_DEFAULT_POSARGS:testing/test_pdb.py testing/test_terminal.py testing/test_unittest.py}
 
     xdist: _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_DEFAULT_POSARGS:-n auto}
 extras = testing
 deps =
+    numpy: numpy
     pexpect: pexpect
     xdist: pytest-xdist>=1.13
     {env:_PYTEST_TOX_EXTRA_DEP:}
@@ -61,18 +64,6 @@ basepython = python3
 deps = pre-commit>=1.11.0
 commands = pre-commit run --all-files --show-diff-on-failure
 
-[testenv:py27-nobyte]
-extras = testing
-deps =
-    {[testenv]deps}
-    pytest-xdist>=1.13
-distribute = true
-setenv =
-    {[testenv]setenv}
-    PYTHONDONTWRITEBYTECODE=1
-commands =
-    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest -n auto {posargs}
-
 [testenv:py27-trial]
 deps =
     {[testenv]deps}
@@ -84,17 +75,6 @@ commands =
 [testenv:py37-trial]
 deps = {[testenv:py27-trial]deps}
 commands = {[testenv:py27-trial]commands}
-
-[testenv:py27-numpy]
-deps =
-    {[testenv]deps}
-    numpy
-commands=
-  {env:_PYTEST_TOX_COVERAGE_RUN:} pytest {posargs:testing/python/approx.py}
-
-[testenv:py37-numpy]
-deps = {[testenv:py27-numpy]deps}
-commands = {[testenv:py27-numpy]commands}
 
 [testenv:py27-pluggymaster]
 setenv=


### PR DESCRIPTION
Remove `py27-nobyte` from tox.ini, which was using xdist already.
Therefore this also removes `py27-xdist` from Travis.

`py27-xdist` is still run on Azure.