### PR TITLE
tests: install pexpect via testing extra always

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - TOXENV=py27-nobyte-numpy-xdist PYTEST_COVERAGE=1
     - TOXENV=py27-pluggymaster-xdist
     # Specialized factors for py37.
-    - TOXENV=py37-pexpect,py37-trial
+    - TOXENV=py37-trial
     - TOXENV=py37-pluggymaster-xdist
     - TOXENV=py37-freeze
 
@@ -64,7 +64,7 @@ jobs:
       if: type = cron
 
     - stage: baseline
-      env: TOXENV=py27-pexpect,py27-trial
+      env: TOXENV=py27-trial
     - env: TOXENV=py37-numpy-xdist
     - env: TOXENV=linting,docs,doctesting
       python: '3.7'

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ def main():
                 "argcomplete",
                 "hypothesis>=3.56",
                 "nose",
+                "pexpect;sys_platform!='win32'",
                 "requests",
                 "mock;python_version=='2.7'",
             ],

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist =
     py38
     pypy
     pypy3
-    {py27,py37}-{pexpect,xdist,trial,numpy,pluggymaster}
+    {py27,py37}-{xdist,trial,numpy,pluggymaster}
     py27-nobyte-xdist
     doctesting
     py37-freeze
@@ -37,14 +37,10 @@ setenv =
 
     nobyte: PYTHONDONTWRITEBYTECODE=1
 
-    pexpect: _PYTEST_TOX_PLATFORM=linux|darwin
-    pexpect: _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_DEFAULT_POSARGS:testing/test_pdb.py testing/test_terminal.py testing/test_unittest.py}
-
     xdist: _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_DEFAULT_POSARGS:-n auto}
 extras = testing
 deps =
     numpy: numpy
-    pexpect: pexpect
     xdist: pytest-xdist>=1.13
     {env:_PYTEST_TOX_EXTRA_DEP:}
 platform = {env:_PYTEST_TOX_PLATFORM:.*}


### PR DESCRIPTION
This removes the pexpect tox factor.