### PR TITLE
.coveragerc: use globs with includes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,15 +1,15 @@
 [run]
 include =
-  src/*
+  */src/*
   testing/*
-  .tox/*/lib/python*/site-packages/_pytest/*
-  .tox/*/lib/python*/site-packages/pytest.py
-  .tox\*\Lib\site-packages\_pytest\*
-  .tox\*\Lib\site-packages\pytest.py
+  */lib/python*/site-packages/_pytest/*
+  */lib/python*/site-packages/pytest.py
+  *\Lib\site-packages\_pytest\*
+  *\Lib\site-packages\pytest.py
 parallel = 1
 branch = 1
 
 [paths]
 source = src/
-  .tox/*/lib/python*/site-packages/
-  .tox\*\Lib\site-packages\
+  */lib/python*/site-packages/
+  *\Lib\site-packages\


### PR DESCRIPTION
Apparently this causes missing coverage with pdb/pexpect tests.

Ref: https://github.com/pytest-dev/pytest/pull/4865#issuecomment-468735403