### PR TITLE
pytester: unset PYTEST_ADDOPTS

### DIFF
--- a/changelog/4851.bugfix.rst
+++ b/changelog/4851.bugfix.rst
@@ -1,0 +1,1 @@
+pytester unsets ``PYTEST_ADDOPTS`` now to not use outer options with ``testdir.runpytest()``.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -509,6 +509,7 @@ class Testdir(object):
         self.test_tmproot = tmpdir_factory.mktemp("tmp-" + name, numbered=True)
         os.environ["PYTEST_DEBUG_TEMPROOT"] = str(self.test_tmproot)
         os.environ.pop("TOX_ENV_DIR", None)  # Ensure that it is not used for caching.
+        os.environ.pop("PYTEST_ADDOPTS", None)  # Do not use outer options.
         self.plugins = []
         self._cwd_snapshot = CwdSnapshot()
         self._sys_path_snapshot = SysPathsSnapshot()


### PR DESCRIPTION
Pulled out of https://github.com/pytest-dev/pytest/pull/4851, which needs fixes for pytest's own tests.