### PR TITLE
ci: Travis: disable cache by default, only for pre-commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,9 @@ jobs:
     - env: TOXENV=py36-xdist
       python: '3.6'
     - env: TOXENV=linting,docs,doctesting PYTEST_COVERAGE=1
+      cache:
+        directories:
+          - $HOME/.cache/pre-commit
 
     - stage: deploy
       python: '3.6'
@@ -144,7 +147,4 @@ notifications:
     skip_join: true
   email:
     - pytest-commit@python.org
-cache:
-    directories:
-        - $HOME/.cache/pip
-        - $HOME/.cache/pre-commit
+cache: false


### PR DESCRIPTION
For pip the usual http caching should be good enough.
This keeps the cache for pre-commit with the linting env for now.

Ref: https://github.com/pytest-dev/pytest/issues/3502

Timings:

1. Ran for 28 min 24 sec, Total time 1 hr 15 min 36 sec
2. Ran for 25 min 3 sec, Total time 1 hr 9 min 18 sec