### PR TITLE
.coveragerc: fix include for pypy

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,8 @@ include =
   testing/*
   */lib/python*/site-packages/_pytest/*
   */lib/python*/site-packages/pytest.py
+  */pypy*/site-packages/_pytest/*
+  */pypy*/site-packages/pytest.py
   *\Lib\site-packages\_pytest\*
   *\Lib\site-packages\pytest.py
 parallel = 1
@@ -12,4 +14,5 @@ branch = 1
 [paths]
 source = src/
   */lib/python*/site-packages/
+  */pypy*/site-packages/
   *\Lib\site-packages\


### PR DESCRIPTION
PyPy uses "site-packages" directly.