### PR TITLE
Travis: run `pytest --help` for (stable) TTY coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,7 @@ before_script:
     fi
 
 script:
+  - python -c 'import sys; assert sys.stdout.isatty()'
   - tox --recreate
   # Add last TOXENV to $PATH.
   - PATH="$PWD/.tox/${TOXENV##*,}/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,14 +98,20 @@ before_script:
       export _PYTEST_TOX_EXTRA_DEP=coverage-enable-subprocess
     fi
 
-script: tox --recreate
+script:
+  - tox --recreate
+  # Add last TOXENV to $PATH.
+  - PATH="$PWD/.tox/${TOXENV##*,}/bin:$PATH"
+  - |
+    if [[ "$PYTEST_COVERAGE" = 1 ]]; then
+      which coverage
+      coverage run -m pytest --help
+    fi
 
 after_success:
   - |
     if [[ "$PYTEST_COVERAGE" = 1 ]]; then
       set -e
-      # Add last TOXENV to $PATH.
-      PATH="$PWD/.tox/${TOXENV##*,}/bin:$PATH"
       coverage combine
       coverage xml
       coverage report -m

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,13 +99,14 @@ before_script:
     fi
 
 script:
-  - python -c 'import sys; assert sys.stdout.isatty()'
   - tox --recreate
-  # Add last TOXENV to $PATH.
-  - PATH="$PWD/.tox/${TOXENV##*,}/bin:$PATH"
+
   - |
+    # Cover terminalreport for isatty.
+    # Add last TOXENV to $PATH (also used below).
+    PATH="$PWD/.tox/${TOXENV##*,}/bin:$PATH"
+    python -c 'import sys; assert sys.stdout.isatty()'
     if [[ "$PYTEST_COVERAGE" = 1 ]]; then
-      which coverage
       coverage run -m pytest --help
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,9 +106,9 @@ script:
     # Add last TOXENV to $PATH (also used below).
     PATH="$PWD/.tox/${TOXENV##*,}/bin:$PATH"
     python -c 'import sys; assert sys.stdout.isatty()'
-    if [[ "$PYTEST_COVERAGE" = 1 ]]; then
-      coverage run -m pytest --help
-    fi
+    # if [[ "$PYTEST_COVERAGE" = 1 ]]; then
+    #   coverage run -m pytest --help
+    # fi
 
 after_success:
   - |


### PR DESCRIPTION
According to https://codecov.io/gh/pytest-dev/pytest/pull/4881/changes
the "isatty" branches in _pytest/terminal.py are flaky.

This tries to fix it.

Maybe running it in a subprocess would also help, but it might be more about the outer term in the first place.

Travis should behave as a TTY AFAIK.