### PR TITLE
Simplify 'obj' property definition in PyobjMixin

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -243,25 +243,24 @@ class PyobjMixin(PyobjContext):
     def __init__(self, *k, **kw):
         super(PyobjMixin, self).__init__(*k, **kw)
 
-    def obj():
-        def fget(self):
-            obj = getattr(self, "_obj", None)
-            if obj is None:
-                self._obj = obj = self._getobj()
-                # XXX evil hack
-                # used to avoid Instance collector marker duplication
-                if self._ALLOW_MARKERS:
-                    self.own_markers.extend(get_unpacked_marks(self.obj))
-            return obj
+    @property
+    def obj(self):
+        """underlying python object"""
+        obj = getattr(self, "_obj", None)
+        if obj is None:
+            self._obj = obj = self._getobj()
+            # XXX evil hack
+            # used to avoid Instance collector marker duplication
+            if self._ALLOW_MARKERS:
+                self.own_markers.extend(get_unpacked_marks(self.obj))
+        return obj
 
-        def fset(self, value):
-            self._obj = value
-
-        return property(fget, fset, None, "underlying python object")
-
-    obj = obj()
+    @obj.setter
+    def obj(self, value):
+        self._obj = value
 
     def _getobj(self):
+        """Gets the underlying python object. May be overwritten by subclasses."""
         return getattr(self.parent.obj, self.name)
 
     def getmodpath(self, stopatmodule=True, includemodule=False):

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -245,7 +245,7 @@ class PyobjMixin(PyobjContext):
 
     @property
     def obj(self):
-        """underlying python object"""
+        """Underlying Python object."""
         obj = getattr(self, "_obj", None)
         if obj is None:
             self._obj = obj = self._getobj()
@@ -260,7 +260,7 @@ class PyobjMixin(PyobjContext):
         self._obj = value
 
     def _getobj(self):
-        """Gets the underlying python object. May be overwritten by subclasses."""
+        """Gets the underlying Python object. May be overwritten by subclasses."""
         return getattr(self.parent.obj, self.name)
 
     def getmodpath(self, stopatmodule=True, includemodule=False):


### PR DESCRIPTION
This uses modern property definition syntax, declaring both getter
and setter as obj() functions. That definition has always bothered me a little. 🙃 

It was defined this way so the getter and setter wouldn't be a part of the API. The modern property declaration also has the same characteristics.