### PR TITLE
Allow tests to pass after 2038

### DIFF
--- a/changelog/4903.bugfix.rst
+++ b/changelog/4903.bugfix.rst
@@ -1,0 +1,1 @@
+Fix handling of mtime to work after year 2038

--- a/changelog/4903.bugfix.rst
+++ b/changelog/4903.bugfix.rst
@@ -1,1 +1,1 @@
-Fix handling of mtime to work after year 2038
+Use the correct modified time for years after 2038 in rewritten ``.pyc`` files.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -344,8 +344,10 @@ def _write_pyc(state, co, source_stat, pyc):
     try:
         with atomicwrites.atomic_write(pyc, mode="wb", overwrite=True) as fp:
             fp.write(imp.get_magic())
+            # as of now, bytecode header expects 32-bit numbers for size and mtime (#4903)
             mtime = int(source_stat.mtime) & 0xFFFFFFFF
             size = source_stat.size & 0xFFFFFFFF
+            # "<LL" stands for 2 unsigned longs, little-ending
             fp.write(struct.pack("<LL", mtime, size))
             fp.write(marshal.dumps(co))
     except EnvironmentError as e:

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -344,9 +344,9 @@ def _write_pyc(state, co, source_stat, pyc):
     try:
         with atomicwrites.atomic_write(pyc, mode="wb", overwrite=True) as fp:
             fp.write(imp.get_magic())
-            mtime = int(source_stat.mtime)
+            mtime = int(source_stat.mtime) & 0xFFFFFFFF
             size = source_stat.size & 0xFFFFFFFF
-            fp.write(struct.pack("<ll", mtime, size))
+            fp.write(struct.pack("<LL", mtime, size))
             fp.write(marshal.dumps(co))
     except EnvironmentError as e:
         state.trace("error writing pyc file at %s: errno=%s" % (pyc, e.errno))
@@ -441,7 +441,7 @@ def _read_pyc(source, pyc, trace=lambda x: None):
         if (
             len(data) != 12
             or data[:4] != imp.get_magic()
-            or struct.unpack("<ll", data[4:]) != (mtime, size)
+            or struct.unpack("<LL", data[4:]) != (mtime & 0xFFFFFFFF, size & 0xFFFFFFFF)
         ):
             trace("_read_pyc(%s): invalid or out of date pyc" % source)
             return None


### PR DESCRIPTION
- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [X] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Add yourself to `AUTHORS` in alphabetical order;


Without this change, the python-apache-libcloud tests failed
in the year 2039 with

```
     fp.write(struct.pack("<ll", mtime, size))
 E   error: 'l' format requires -2147483648 <= number <= 2147483647
```

Note: 2nd hunk is untested

modeled after https://github.com/python/cpython/pull/9892/files