### PR TITLE
pdb: trigger pytest_enter_pdb hook with post-mortem

### DIFF
--- a/changelog/4908.bugfix.rst
+++ b/changelog/4908.bugfix.rst
@@ -1,0 +1,1 @@
+The ``pytest_enter_pdb`` hook gets called with post-mortem (``--pdb``).

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -358,8 +358,7 @@ class CaptureFixture(object):
         self._captured_err = self.captureclass.EMPTY_BUFFER
 
     def _start(self):
-        # Start if not started yet
-        if getattr(self, "_capture", None) is None:
+        if self._capture is None:
             self._capture = MultiCapture(
                 out=True, err=True, in_=False, Capture=self.captureclass
             )
@@ -389,11 +388,13 @@ class CaptureFixture(object):
 
     def _suspend(self):
         """Suspends this fixture's own capturing temporarily."""
-        self._capture.suspend_capturing()
+        if self._capture is not None:
+            self._capture.suspend_capturing()
 
     def _resume(self):
         """Resumes this fixture's own capturing temporarily."""
-        self._capture.resume_capturing()
+        if self._capture is not None:
+            self._capture.resume_capturing()
 
     @contextlib.contextmanager
     def disabled(self):

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -744,7 +744,8 @@ class TestPDB(object):
             ["E   NameError: *xxx*", "*! *Exit: Quitting debugger !*"]  # due to EOF
         )
 
-    def test_enter_leave_pdb_hooks_are_called(self, testdir):
+    @pytest.mark.parametrize("post_mortem", (False, True))
+    def test_enter_leave_pdb_hooks_are_called(self, post_mortem, testdir):
         testdir.makeconftest(
             """
             mypdb = None
@@ -773,16 +774,25 @@ class TestPDB(object):
             """
             import pytest
 
-            def test_foo():
+            def test_set_trace():
                 pytest.set_trace()
+                assert 0
+
+            def test_post_mortem():
                 assert 0
         """
         )
-        child = testdir.spawn_pytest(str(p1))
+        if post_mortem:
+            child = testdir.spawn_pytest(str(p1) + " --pdb -s -k test_post_mortem")
+        else:
+            child = testdir.spawn_pytest(str(p1) + " -k test_set_trace")
         child.expect("enter_pdb_hook")
         child.sendline("c")
-        child.expect(r"PDB continue \(IO-capturing resumed\)")
-        child.expect("Captured stdout call")
+        if post_mortem:
+            child.expect(r"PDB continue")
+        else:
+            child.expect(r"PDB continue \(IO-capturing resumed\)")
+            child.expect("Captured stdout call")
         rest = child.read().decode("utf8")
         assert "leave_pdb_hook" in rest
         assert "1 failed" in rest


### PR DESCRIPTION
This is required for pytest-pdb to be called with `--pdb`.

TODO:

- [x] test
- [ ] ~~pass mode to hook, e.g. "post_mortem" in this case?~~ => later
- [ ] skip "Find last non-hidden frame" in non-postmortem mode?