### PR TITLE
Make pytest.skip work in doctest

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -222,6 +222,7 @@ Steffen Allner
 Stephan Obermann
 Sven-Hendrik Haase
 Tadek Teleżyński
+Takafumi Arakaki
 Tarcisio Fischer
 Tareq Alayan
 Ted Xiao

--- a/changelog/4911.feature.rst
+++ b/changelog/4911.feature.rst
@@ -1,0 +1,1 @@
+Doctest can be now skipped dynamically with `pytest.skip`.

--- a/changelog/4911.feature.rst
+++ b/changelog/4911.feature.rst
@@ -1,1 +1,1 @@
-Doctest can be now skipped dynamically with `pytest.skip`.
+Doctests can be skipped now dynamically using ``pytest.skip()``.

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -15,6 +15,7 @@ from _pytest._code.code import ReprFileLocation
 from _pytest._code.code import TerminalRepr
 from _pytest.compat import safe_getattr
 from _pytest.fixtures import FixtureRequest
+from _pytest.outcomes import Skipped
 
 DOCTEST_REPORT_CHOICE_NONE = "none"
 DOCTEST_REPORT_CHOICE_CDIFF = "cdiff"
@@ -153,6 +154,8 @@ def _init_runner_class():
                 raise failure
 
         def report_unexpected_exception(self, out, test, example, exc_info):
+            if isinstance(exc_info[1], Skipped):
+                raise exc_info[1]
             failure = doctest.UnexpectedException(test, example, exc_info)
             if self.continue_on_failure:
                 out.append(failure)

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -81,7 +81,7 @@ def skip(msg="", **kwargs):
 
     This function should be called only during testing (setup, call or teardown) or
     during collection by using the ``allow_module_level`` flag.  This function can
-    be called in doctest as well.
+    be called in doctests as well.
 
     :kwarg bool allow_module_level: allows this function to be called at
         module level, skipping the rest of the module. Default to False.

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -80,7 +80,8 @@ def skip(msg="", **kwargs):
     Skip an executing test with the given message.
 
     This function should be called only during testing (setup, call or teardown) or
-    during collection by using the ``allow_module_level`` flag.
+    during collection by using the ``allow_module_level`` flag.  This function can
+    be called in doctest as well.
 
     :kwarg bool allow_module_level: allows this function to be called at
         module level, skipping the rest of the module. Default to False.
@@ -89,6 +90,9 @@ def skip(msg="", **kwargs):
         It is better to use the :ref:`pytest.mark.skipif ref` marker when possible to declare a test to be
         skipped under certain conditions like mismatching platforms or
         dependencies.
+        Similarly, use ``# doctest: +SKIP`` directive (see `doctest.SKIP
+        <https://docs.python.org/3/library/doctest.html#doctest.SKIP>`_)
+        to skip a doctest statically.
     """
     __tracebackhide__ = True
     allow_module_level = kwargs.pop("allow_module_level", False)

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -90,7 +90,7 @@ def skip(msg="", **kwargs):
         It is better to use the :ref:`pytest.mark.skipif ref` marker when possible to declare a test to be
         skipped under certain conditions like mismatching platforms or
         dependencies.
-        Similarly, use ``# doctest: +SKIP`` directive (see `doctest.SKIP
+        Similarly, use the ``# doctest: +SKIP`` directive (see `doctest.SKIP
         <https://docs.python.org/3/library/doctest.html#doctest.SKIP>`_)
         to skip a doctest statically.
     """

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -188,6 +188,18 @@ class TestDoctests(object):
             ]
         )
 
+    def test_doctest_skip(self, testdir):
+        testdir.maketxtfile(
+            """
+            >>> 1
+            1
+            >>> import pytest
+            >>> pytest.skip("")
+        """
+        )
+        result = testdir.runpytest("--doctest-modules")
+        result.stdout.fnmatch_lines(["*1 skipped*"])
+
     def test_docstring_partial_context_around_error(self, testdir):
         """Test that we show some context before the actual line of a failing
         doctest.


### PR DESCRIPTION
As discussed in https://github.com/pytest-dev/pytest/issues/4911#issuecomment-471992106, it would be nice if doctest can be conditionally skipped.  It seems that just adding three lines is enough (close #4911).  All this patch does is throwing `Skipped` instead of `UnexpectedException` if the original exception is `Skipped`.

I'll add tests and docs if this direction looks OK.

---

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- ~Target the `master` branch for bug fixes, documentation updates and trivial changes.~
- [x] Target the `features` branch for new features and removals/deprecations.
- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS` in alphabetical order;
