### PR TITLE
Fix line offsets with `ScopeMismatch` errors

### DIFF
--- a/changelog/4928.bugfix.rst
+++ b/changelog/4928.bugfix.rst
@@ -1,0 +1,1 @@
+Fix line offsets with ``ScopeMismatch`` errors.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -612,7 +612,7 @@ class FixtureRequest(FuncargnamesCompatAttr):
             fs, lineno = getfslineno(factory)
             p = self._pyfuncitem.session.fspath.bestrelpath(fs)
             args = _format_args(factory)
-            lines.append("%s:%d:  def %s%s" % (p, lineno, factory.__name__, args))
+            lines.append("%s:%d:  def %s%s" % (p, lineno + 1, factory.__name__, args))
         return lines
 
     def _getscopeitem(self, scope):

--- a/testing/python/fixture.py
+++ b/testing/python/fixture.py
@@ -992,8 +992,8 @@ class TestFixtureUsages(object):
         result.stdout.fnmatch_lines(
             [
                 "*ScopeMismatch*involved factories*",
-                "* def arg2*",
-                "* def arg1*",
+                "test_receives_funcargs_scope_mismatch.py:6:  def arg2(arg1)",
+                "test_receives_funcargs_scope_mismatch.py:2:  def arg1()",
                 "*1 error*",
             ]
         )


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/issues/4928.