### PR TITLE
pytester: LineMatcher: assert lines

### DIFF
--- a/changelog/4931.feature.rst
+++ b/changelog/4931.feature.rst
@@ -1,0 +1,1 @@
+pytester's ``LineMatcher`` asserts that the passed lines are a sequence.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -25,6 +25,7 @@ from _pytest.assertion.rewrite import AssertionRewritingHook
 from _pytest.capture import MultiCapture
 from _pytest.capture import SysCapture
 from _pytest.compat import safe_str
+from _pytest.compat import Sequence
 from _pytest.main import EXIT_INTERRUPTED
 from _pytest.main import EXIT_OK
 from _pytest.main import Session
@@ -1325,6 +1326,7 @@ class LineMatcher(object):
             will be logged to stdout when a match occurs
 
         """
+        assert isinstance(lines2, Sequence)
         lines2 = self._getlines(lines2)
         lines1 = self.lines[:]
         nextline = None

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -17,6 +17,7 @@ from _pytest.main import EXIT_OK
 from _pytest.main import EXIT_TESTSFAILED
 from _pytest.pytester import CwdSnapshot
 from _pytest.pytester import HookRecorder
+from _pytest.pytester import LineMatcher
 from _pytest.pytester import SysModulesSnapshot
 from _pytest.pytester import SysPathsSnapshot
 
@@ -453,3 +454,18 @@ def test_testdir_run_timeout_expires(testdir):
     )
     with pytest.raises(testdir.TimeoutExpired):
         testdir.runpytest_subprocess(testfile, timeout=1)
+
+
+def test_linematcher_with_nonlist():
+    """Test LineMatcher with regard to passing in a set (accidentally)."""
+    lm = LineMatcher([])
+
+    with pytest.raises(AssertionError):
+        lm.fnmatch_lines(set())
+    with pytest.raises(AssertionError):
+        lm.fnmatch_lines({})
+    lm.fnmatch_lines([])
+    lm.fnmatch_lines(())
+
+    assert lm._getlines({}) == {}
+    assert lm._getlines(set()) == set()


### PR DESCRIPTION
This can be helpful when passing a set accidentally.