### PR TITLE
Emit warning on unknown marks via decorator

### DIFF
--- a/changelog/4826.feature.rst
+++ b/changelog/4826.feature.rst
@@ -1,0 +1,2 @@
+A warning is now emitted when unknown marks are used as a decorator.
+This is often due to a typo, which can lead to silently broken tests.

--- a/doc/en/mark.rst
+++ b/doc/en/mark.rst
@@ -31,7 +31,10 @@ which also serve as documentation.
 Raising errors on unknown marks
 -------------------------------
 
-Marks can be registered in ``pytest.ini`` like this:
+Unknown marks applied with the ``@pytest.mark.name_of_the_mark`` decorator
+will always emit a warning, in order to avoid silently doing something
+surprising due to mis-typed names.  You can disable the warning for custom
+marks by registering them in ``pytest.ini`` like this:
 
 .. code-block:: ini
 

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -147,8 +147,7 @@ def pytest_collection_modifyitems(items, config):
 
 def pytest_configure(config):
     config._old_mark_config = MARK_GEN._config
-    if config.option.strict:
-        MARK_GEN._config = config
+    MARK_GEN._config = config
 
     empty_parameterset = config.getini(EMPTY_PARAMETERSET_OPTION)
 

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -11,7 +11,7 @@ from ..compat import getfslineno
 from ..compat import MappingMixin
 from ..compat import NOTSET
 from _pytest.outcomes import fail
-from _pytest.warning_types import PytestWarning
+from _pytest.warning_types import UnknownMarkWarning
 
 EMPTY_PARAMETERSET_OPTION = "empty_parameter_set_mark"
 
@@ -294,10 +294,10 @@ class MarkGenerator(object):
             self._update_markers(name)
             if name not in self._markers:
                 warnings.warn(
-                    "Unknown mark %r.  You can register custom marks to avoid this "
-                    "warning, without risking typos that break your tests.  See "
-                    "https://docs.pytest.org/en/latest/mark.html for details." % name,
-                    PytestWarning,
+                    "Unknown pytest.mark.%s - is this a typo?  You can register "
+                    "custom marks to avoid this warning - for details, see "
+                    "https://docs.pytest.org/en/latest/mark.html" % name,
+                    UnknownMarkWarning,
                 )
                 if self._config.option.strict:
                     fail("{!r} not a registered marker".format(name), pytrace=False)

--- a/src/_pytest/warning_types.py
+++ b/src/_pytest/warning_types.py
@@ -9,6 +9,15 @@ class PytestWarning(UserWarning):
     """
 
 
+class UnknownMarkWarning(PytestWarning):
+    """
+    Bases: :class:`PytestWarning`.
+
+    Warning emitted on use of unknown markers.
+    See https://docs.pytest.org/en/latest/mark.html for details.
+    """
+
+
 class PytestDeprecationWarning(PytestWarning, DeprecationWarning):
     """
     Bases: :class:`pytest.PytestWarning`, :class:`DeprecationWarning`.

--- a/tox.ini
+++ b/tox.ini
@@ -168,6 +168,12 @@ filterwarnings =
 pytester_example_dir = testing/example_scripts
 markers =
     issue
+    nothing
+    foo
+    bar
+    baz
+    xyz
+    XYZ
 
 [flake8]
 max-line-length = 120

--- a/tox.ini
+++ b/tox.ini
@@ -165,15 +165,11 @@ filterwarnings =
     ignore::pytest.PytestExperimentalApiWarning
     # Do not cause SyntaxError for invalid escape sequences in py37.
     default:invalid escape sequence:DeprecationWarning
+    # ignore use of unregistered marks, because we use many to test the implementation
+    ignore::_pytest.warning_types.UnknownMarkWarning
 pytester_example_dir = testing/example_scripts
 markers =
     issue
-    nothing
-    foo
-    bar
-    baz
-    xyz
-    XYZ
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
Being an updated version of #4933.

One of the most common problems I see, and help debug, is typos in `@pytest.mark.whatever` decorators.  Just recently we've had #4639 and #4814, and I've read three sets of unrelated docs in the last week that explicitly point out the spelling of `mark.parametrize` (not `parameterize`!).

The `--strict` argument helps, but is clearly insufficient by default.  On the other hand, it can't be an error until a major version bump.  This PR emits a warning every time an unknown name is used as an attribute of `pytest.mark`, and therefore closes #4826.

TODO: tests, if people otherwise like the approach.