### PR TITLE
Minor grammar fixes in pytest.mark.xfail docs

### DIFF
--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -199,16 +199,18 @@ Marks a test function as *expected to fail*.
 .. py:function:: pytest.mark.xfail(condition=None, *, reason=None, raises=None, run=True, strict=False)
 
     :type condition: bool or str
-    :param condition: ``True/False`` if the condition should be marked as xfail or a :ref:`condition string <string conditions>`.
+    :param condition:
+        Condition for marking the test function as xfail (``True/False`` or a
+        :ref:`condition string <string conditions>`).
     :keyword str reason: Reason why the test function is marked as xfail.
     :keyword Exception raises: Exception subclass expected to be raised by the test function; other exceptions will fail the test.
     :keyword bool run:
         If the test function should actually be executed. If ``False``, the function will always xfail and will
-        not be executed (useful a function is segfaulting).
+        not be executed (useful if a function is segfaulting).
     :keyword bool strict:
         * If ``False`` (the default) the function will be shown in the terminal output as ``xfailed`` if it fails
           and as ``xpass`` if it passes. In both cases this will not cause the test suite to fail as a whole. This
-          is particularly useful to mark *flaky* tests (tests that random at fail) to be tackled later.
+          is particularly useful to mark *flaky* tests (tests that fail at random) to be tackled later.
         * If ``True``, the function will be shown in the terminal output as ``xfailed`` if it fails, but if it
           unexpectedly passes then it will **fail** the test suite. This is particularly useful to mark functions
           that are always failing and there should be a clear indication if they unexpectedly start to pass (for example


### PR DESCRIPTION
Self-explanatory