### PR TITLE
pytester: testdir: set $HOME to tmpdir

### DIFF
--- a/changelog/4941.feature.rst
+++ b/changelog/4941.feature.rst
@@ -1,0 +1,3 @@
+``pytester``'s ``Testdir`` sets ``$HOME`` and ``$USERPROFILE`` to the temporary directory.
+
+This ensures to not load configuration files from the real user's home directory.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -469,6 +469,8 @@ class Testdir(object):
         os.environ["PYTEST_DEBUG_TEMPROOT"] = str(self.test_tmproot)
         os.environ.pop("TOX_ENV_DIR", None)  # Ensure that it is not used for caching.
         os.environ.pop("PYTEST_ADDOPTS", None)  # Do not use outer options.
+        os.environ["HOME"] = str(self.tmpdir)  # Do not load user config.
+        os.environ["USERPROFILE"] = os.environ["HOME"]
         self.plugins = []
         self._cwd_snapshot = CwdSnapshot()
         self._sys_path_snapshot = SysPathsSnapshot()

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -816,16 +816,12 @@ def test_invalid_xml_escape():
         assert chr(i) == bin_xml_escape(unichr(i)).uniobj
 
 
-def test_logxml_path_expansion(tmpdir, monkeypatch):
+def test_logxml_path_expansion(tmpdir):
     home_tilde = py.path.local(os.path.expanduser("~")).join("test.xml")
-
     xml_tilde = LogXML("~%stest.xml" % tmpdir.sep, None)
     assert xml_tilde.logfile == home_tilde
 
-    # this is here for when $HOME is not set correct
-    monkeypatch.setenv("HOME", str(tmpdir))
     home_var = os.path.normpath(os.path.expandvars("$HOME/test.xml"))
-
     xml_var = LogXML("$HOME%stest.xml" % tmpdir.sep, None)
     assert xml_var.logfile == home_var
 

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -470,9 +470,6 @@ class TestPDB(object):
                 '''
         """
         )
-        # Prevent ~/.pdbrc etc to output anything.
-        monkeypatch.setenv("HOME", str(testdir))
-
         child = testdir.spawn_pytest("--doctest-modules --pdb %s" % p1)
         child.expect("Pdb")
 


### PR DESCRIPTION
This avoids loading user configuration, which might interfere with test
results, e.g. a `~/.pdbrc.py` with pdb++.

TODO:

- [x] changelog