### PR TITLE
Fix bench/bench.py without args

### DIFF
--- a/bench/bench.py
+++ b/bench/bench.py
@@ -5,7 +5,7 @@ if __name__ == "__main__":
     import pytest  # NOQA
     import pstats
 
-    script = sys.argv[1:] if len(sys.argv) > 1 else "empty.py"
+    script = sys.argv[1:] if len(sys.argv) > 1 else ["empty.py"]
     stats = cProfile.run("pytest.cmdline.main(%r)" % script, "prof")
     p = pstats.Stats("prof")
     p.strip_dirs()


### PR DESCRIPTION
Fixes:

>   File "…/Vcs/pytest/src/_pytest/config/__init__.py", line 60, in main
>     config = _prepareconfig(args, plugins)
>   File "…/Vcs/pytest/src/_pytest/config/__init__.py", line 179, in _prepareconfig
>     raise TypeError(msg.format(args, type(args)))
> TypeError: `args` parameter expected to be a list or tuple of strings, got: 'empty.py' (type: <class 'str'>)