### PR TITLE
tests: add test_report_collect_after_half_a_second

### DIFF
--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -26,6 +26,8 @@ from _pytest.main import EXIT_OK
 from _pytest.main import EXIT_TESTSFAILED
 from _pytest.main import EXIT_USAGEERROR
 
+REPORT_COLLECTING_RESOLUTION = 0.5
+
 
 class MoreQuietAction(argparse.Action):
     """
@@ -512,7 +514,7 @@ class TerminalReporter(object):
             t = time.time()
             if (
                 self._collect_report_last_write is not None
-                and self._collect_report_last_write > t - 0.5
+                and self._collect_report_last_write > t - REPORT_COLLECTING_RESOLUTION
             ):
                 return
             self._collect_report_last_write = t

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -142,6 +142,31 @@ class TestTerminal(object):
         child.sendeof()
         child.kill(15)
 
+    def test_report_collect_after_half_a_second(self, testdir):
+        """Test for "collecting" being updated after 0.5s"""
+
+        testdir.makepyfile(
+            **{
+                "test1.py": """
+                import _pytest.terminal
+
+                _pytest.terminal.REPORT_COLLECTING_RESOLUTION = 0
+
+                def test_1():
+                    pass
+                    """,
+                "test2.py": "def test_2(): pass",
+            }
+        )
+
+        child = testdir.spawn_pytest("-v test1.py test2.py")
+        child.expect(r"collecting \.\.\.")
+        child.expect(r"collecting 1 item")
+        child.expect(r"collecting 2 items")
+        child.expect(r"collected 2 items")
+        rest = child.read().decode("utf8")
+        assert "2 passed in" in rest
+
     def test_itemreport_subclasses_show_subclassed_file(self, testdir):
         testdir.makepyfile(
             test_p1="""


### PR DESCRIPTION
This is meant for stable coverage with "collecting X item(s)".

I've thought about monkeypatching the duration from inside the first collected test, since the test is rather slow (1s).  Do you think that's a good idea?