### PR TITLE
config: fix consider_preparse with missing argument to -p

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -481,7 +481,10 @@ class PytestPluginManager(PluginManager):
             i += 1
             if isinstance(opt, six.string_types):
                 if opt == "-p":
-                    parg = args[i]
+                    try:
+                        parg = args[i]
+                    except IndexError:
+                        return
                     i += 1
                 elif opt.startswith("-p"):
                     parg = opt[2:]

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -313,6 +313,9 @@ class TestPytestPluginManagerBootstrapming(object):
         assert '"hello123"' in excinfo.value.args[0]
         pytestpm.consider_preparse(["-pno:hello123"])
 
+        # Handles -p without following arg (when used without argparse).
+        pytestpm.consider_preparse(["-p"])
+
     def test_plugin_prevent_register(self, pytestpm):
         pytestpm.consider_preparse(["xyz", "-p", "no:abc"])
         l1 = pytestpm.get_plugins()


### PR DESCRIPTION
This is only required after/with 415899d4 - otherwise argparse ensures
there is an argument already.