### PR TITLE
Fix some issues related to "-p no:X" with default_plugins

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -762,7 +762,7 @@ class Config(object):
         by the importhook.
         """
         ns, unknown_args = self._parser.parse_known_and_unknown_args(args)
-        mode = ns.assertmode
+        mode = getattr(ns, "assertmode", "plain")
         if mode == "rewrite":
             try:
                 hook = _pytest.assertion.install_importhook(self)

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -548,7 +548,7 @@ class Session(nodes.FSCollector):
         # Start with a Session root, and delve to argpath item (dir or file)
         # and stack all Packages found on the way.
         # No point in finding packages when collecting doctests
-        if not self.config.option.doctestmodules:
+        if not self.config.getoption("doctestmodules", False):
             pm = self.config.pluginmanager
             for parent in reversed(argpath.parts()):
                 if pm._confcutdir and pm._confcutdir.relto(parent):

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -87,9 +87,9 @@ def runtestprotocol(item, log=True, nextitem=None):
     rep = call_and_report(item, "setup", log)
     reports = [rep]
     if rep.passed:
-        if item.config.option.setupshow:
+        if item.config.getoption("setupshow", False):
             show_test_item(item)
-        if not item.config.option.setuponly:
+        if not item.config.getoption("setuponly", False):
             reports.append(call_and_report(item, "call", log))
     reports.append(call_and_report(item, "teardown", log, nextitem=nextitem))
     # after all teardown hooks have been called
@@ -192,7 +192,7 @@ def call_runtest_hook(item, when, **kwds):
     hookname = "pytest_runtest_" + when
     ihook = getattr(item.ihook, hookname)
     reraise = (Exit,)
-    if not item.config.getvalue("usepdb"):
+    if not item.config.getoption("usepdb", False):
         reraise += (KeyboardInterrupt,)
     return CallInfo.from_call(
         lambda: ihook(item=item, **kwds), when=when, reraise=reraise

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -251,7 +251,7 @@ class TerminalReporter(object):
         if self.config.getoption("capture", "no") == "no":
             return False
         # do not show progress if we are showing fixture setup/teardown
-        if self.config.getoption("setupshow"):
+        if self.config.getoption("setupshow", False):
             return False
         return self.config.getini("console_output_style") in ("progress", "count")
 


### PR DESCRIPTION
This excludes some plugins for now, which are not trivial (but not impossible) to fix.

Some of them, e.g. "main" should be disallowed to be disabled though maybe?  (e.g. internal/core plugin versus interal default plugin)