### PR TITLE
Fix pytestmark syntax in reference.rst

### DIFF
--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -883,7 +883,7 @@ pytest_mark
 **Tutorial**: :ref:`scoped-marking`
 
 Can be declared at the **global** level in *test modules* to apply one or more :ref:`marks <marks ref>` to all
-test functions and methods. Can be either a single mark or a sequence of marks.
+test functions and methods. Can be either a single mark or a list of marks.
 
 .. code-block:: python
 
@@ -896,7 +896,7 @@ test functions and methods. Can be either a single mark or a sequence of marks.
 
     import pytest
 
-    pytestmark = (pytest.mark.integration, pytest.mark.slow)
+    pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
 PYTEST_DONT_REWRITE (module docstring)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
pytest 4.3.1 throws an error if `pytestmark` is set to a tuple of marks; it appears to insist on a list.



With `pytestmark = [pytest.mark.api, pytest.mark.good]`:

```
============================== test session starts ==============================
platform win32 -- Python 3.6.3, pytest-4.3.1, py-1.8.0, pluggy-0.9.0
rootdir: C:\Temp\git\sphobjinv, inifile: tox.ini
plugins: timeout-1.3.3
collected 48 items / 41 deselected / 7 selected

tests\test_api_good.py .......                                             [100%]

==================== 7 passed, 41 deselected in 0.15 seconds ====================
```


With `pytestmark = (pytest.mark.api, pytest.mark.good)`:
```
==================================== ERRORS =====================================
____________________ ERROR collecting tests/test_api_good.py ____________________
env\lib\site-packages\_pytest\runner.py:226: in from_call
    result = func()
env\lib\site-packages\_pytest\runner.py:289: in <lambda>
    call = CallInfo.from_call(lambda: list(collector.collect()), "collect")
env\lib\site-packages\_pytest\python.py:435: in collect
    self._inject_setup_module_fixture()
env\lib\site-packages\_pytest\python.py:447: in _inject_setup_module_fixture
    setup_module = _get_non_fixture_func(self.obj, "setUpModule")
env\lib\site-packages\_pytest\python.py:255: in obj
    self.own_markers.extend(get_unpacked_marks(self.obj))
env\lib\site-packages\_pytest\mark\structures.py:244: in get_unpacked_marks
    return normalize_mark_list(mark_list)
env\lib\site-packages\_pytest\mark\structures.py:259: in normalize_mark_list
    raise TypeError("got {!r} instead of Mark".format(mark))
E   TypeError: got (MarkDecorator(mark=Mark(name='api', args=(), kwargs={})), MarkDecorator(mark=Mark(name='good', args=(), kwargs={}))) instead of Mark
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!
==================== 19 deselected, 1 error in 0.27 seconds =====================
```
