### PR TITLE
Fix usages of "verbose" option

### DIFF
--- a/changelog/4975.bugfix.rst
+++ b/changelog/4975.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the interpretation of ``-qq`` option where it was being considered as ``-v`` instead.

--- a/doc/en/builtin.rst
+++ b/doc/en/builtin.rst
@@ -55,7 +55,7 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
         Example::
 
             def test_foo(pytestconfig):
-                if pytestconfig.getoption("verbose"):
+                if pytestconfig.getoption("verbose") > 0:
                     ...
     record_property
         Add an extra properties the calling test.

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -151,7 +151,7 @@ def assertrepr_compare(config, op, left, right):
                 elif type(left) == type(right) and (isdatacls(left) or isattrs(left)):
                     type_fn = (isdatacls, isattrs)
                     explanation = _compare_eq_cls(left, right, verbose, type_fn)
-                elif verbose:
+                elif verbose > 0:
                     explanation = _compare_eq_verbose(left, right)
                 if isiterable(left) and isiterable(right):
                     expl = _compare_eq_iterable(left, right, verbose)
@@ -175,8 +175,8 @@ def assertrepr_compare(config, op, left, right):
     return [summary] + explanation
 
 
-def _diff_text(left, right, verbose=False):
-    """Return the explanation for the diff between text or bytes
+def _diff_text(left, right, verbose=0):
+    """Return the explanation for the diff between text or bytes.
 
     Unless --verbose is used this will skip leading and trailing
     characters which are identical to keep the diff minimal.
@@ -202,7 +202,7 @@ def _diff_text(left, right, verbose=False):
         left = escape_for_readable_diff(left)
     if isinstance(right, bytes):
         right = escape_for_readable_diff(right)
-    if not verbose:
+    if verbose < 1:
         i = 0  # just in case left or right has zero length
         for i in range(min(len(left), len(right))):
             if left[i] != right[i]:
@@ -250,7 +250,7 @@ def _compare_eq_verbose(left, right):
     return explanation
 
 
-def _compare_eq_iterable(left, right, verbose=False):
+def _compare_eq_iterable(left, right, verbose=0):
     if not verbose:
         return [u"Use -v to get the full diff"]
     # dynamic import to speedup pytest
@@ -273,7 +273,7 @@ def _compare_eq_iterable(left, right, verbose=False):
     return explanation
 
 
-def _compare_eq_sequence(left, right, verbose=False):
+def _compare_eq_sequence(left, right, verbose=0):
     explanation = []
     for i in range(min(len(left), len(right))):
         if left[i] != right[i]:
@@ -292,7 +292,7 @@ def _compare_eq_sequence(left, right, verbose=False):
     return explanation
 
 
-def _compare_eq_set(left, right, verbose=False):
+def _compare_eq_set(left, right, verbose=0):
     explanation = []
     diff_left = left - right
     diff_right = right - left
@@ -307,7 +307,7 @@ def _compare_eq_set(left, right, verbose=False):
     return explanation
 
 
-def _compare_eq_dict(left, right, verbose=False):
+def _compare_eq_dict(left, right, verbose=0):
     explanation = []
     common = set(left).intersection(set(right))
     same = {k: left[k] for k in common if left[k] == right[k]}
@@ -368,7 +368,7 @@ def _compare_eq_cls(left, right, verbose, type_fns):
     return explanation
 
 
-def _notin_text(term, text, verbose=False):
+def _notin_text(term, text, verbose=0):
     index = text.find(term)
     head = text[:index]
     tail = text[index + len(term) :]

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -340,7 +340,7 @@ def cache(request):
 
 def pytest_report_header(config):
     """Display cachedir with --cache-show and if non-default."""
-    if config.option.verbose or config.getini("cache_dir") != ".pytest_cache":
+    if config.option.verbose > 0 or config.getini("cache_dir") != ".pytest_cache":
         cachedir = config.cache._cachedir
         # TODO: evaluate generating upward relative paths
         # starting with .., ../.. if sensible

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1065,7 +1065,7 @@ def pytestconfig(request):
     Example::
 
         def test_foo(pytestconfig):
-            if pytestconfig.getoption("verbose"):
+            if pytestconfig.getoption("verbose") > 0:
                 ...
 
     """

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -389,7 +389,7 @@ class LoggingPlugin(object):
         self._config = config
 
         # enable verbose output automatically if live logging is enabled
-        if self._log_cli_enabled() and not config.getoption("verbose"):
+        if self._log_cli_enabled() and config.getoption("verbose") < 1:
             config.option.verbose = 1
 
         self.print_logs = get_option_ini(config, "log_print")

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -25,15 +25,14 @@ DistInfo = collections.namedtuple("DistInfo", ["project_name", "version"])
 
 
 class Option(object):
-    def __init__(self, verbose=False, fulltrace=False):
-        self.verbose = verbose
+    def __init__(self, verbosity=0, fulltrace=False):
+        self.verbosity = verbosity
         self.fulltrace = fulltrace
 
     @property
     def args(self):
         values = []
-        if self.verbose:
-            values.append("-v")
+        values.append("--verbosity=%d" % self.verbosity)
         if self.fulltrace:
             values.append("--fulltrace")
         return values
@@ -41,9 +40,9 @@ class Option(object):
 
 @pytest.fixture(
     params=[
-        Option(verbose=False),
-        Option(verbose=True),
-        Option(verbose=-1),
+        Option(verbosity=0),
+        Option(verbosity=1),
+        Option(verbosity=-1),
         Option(fulltrace=True),
     ],
     ids=["default", "verbose", "quiet", "fulltrace"],
@@ -87,7 +86,7 @@ class TestTerminal(object):
         """
         )
         result = testdir.runpytest(*option.args)
-        if option.verbose:
+        if option.verbosity > 0:
             result.stdout.fnmatch_lines(
                 [
                     "*test_pass_skip_fail.py::test_ok PASS*",
@@ -95,8 +94,10 @@ class TestTerminal(object):
                     "*test_pass_skip_fail.py::test_func FAIL*",
                 ]
             )
-        else:
+        elif option.verbosity == 0:
             result.stdout.fnmatch_lines(["*test_pass_skip_fail.py .sF*"])
+        else:
+            result.stdout.fnmatch_lines([".sF*"])
         result.stdout.fnmatch_lines(
             ["    def test_func():", ">       assert 0", "E       assert 0"]
         )


### PR DESCRIPTION
With `-qq` `bool(config.getoption("verbose"))` is True; it needs to be
checked for `> 0`.

Found via `rg 'if .*verbose[^<>=]*$' `.