### PR TITLE
Do not swallow outcomes.Exit in assertrepr_compare

### DIFF
--- a/changelog/4978.bugfix.rst
+++ b/changelog/4978.bugfix.rst
@@ -1,0 +1,1 @@
+``outcomes.Exit`` is not swallowed in ``assertrepr_compare`` anymore.

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -11,6 +11,7 @@ import six
 
 import _pytest.assertion as plugin
 import pytest
+from _pytest import outcomes
 from _pytest.assertion import truncate
 from _pytest.assertion import util
 
@@ -1305,3 +1306,13 @@ def test_issue_1944(testdir):
         "AttributeError: 'Module' object has no attribute '_obj'"
         not in result.stdout.str()
     )
+
+
+def test_exit_from_assertrepr_compare(monkeypatch):
+    def raise_exit(obj):
+        outcomes.exit("Quitting debugger")
+
+    monkeypatch.setattr(util, "istext", raise_exit)
+
+    with pytest.raises(outcomes.Exit, match="Quitting debugger"):
+        callequal(1, 1)


### PR DESCRIPTION
It is annoying if `q` does not work.