### PR TITLE
monkeypatch.syspath_prepend: call fixup_namespace_packages

### DIFF
--- a/changelog/4980.feature.rst
+++ b/changelog/4980.feature.rst
@@ -1,0 +1,1 @@
+``monkeypatch.syspath_prepend`` calls ``pkg_resources.fixup_namespace_packages`` to handle namespace packages better.

--- a/changelog/4980.feature.rst
+++ b/changelog/4980.feature.rst
@@ -1,1 +1,1 @@
-``monkeypatch.syspath_prepend`` calls ``pkg_resources.fixup_namespace_packages`` to handle namespace packages better.
+Namespace packages are handled better with ``monkeypatch.syspath_prepend`` and ``testdir.syspathinsert`` (via ``pkg_resources.fixup_namespace_packages``).

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -262,9 +262,14 @@ class MonkeyPatch(object):
 
     def syspath_prepend(self, path):
         """ Prepend ``path`` to ``sys.path`` list of import locations. """
+        from pkg_resources import fixup_namespace_packages
+
         if self._savesyspath is None:
             self._savesyspath = sys.path[:]
         sys.path.insert(0, str(path))
+
+        # https://github.com/pypa/setuptools/blob/d8b901bc/docs/pkg_resources.txt#L162-L171
+        fixup_namespace_packages(str(path))
 
     def chdir(self, path):
         """ Change the current working directory to the specified path.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -593,11 +593,16 @@ class Testdir(object):
 
         This is undone automatically when this object dies at the end of each
         test.
-
         """
+        from pkg_resources import fixup_namespace_packages
+
         if path is None:
             path = self.tmpdir
-        sys.path.insert(0, str(path))
+
+        dirname = str(path)
+        sys.path.insert(0, dirname)
+        fixup_namespace_packages(dirname)
+
         # a call to syspathinsert() usually means that the caller wants to
         # import some dynamically created files, thus with python3 we
         # invalidate its import caches

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -611,12 +611,10 @@ class Testdir(object):
     def _possibly_invalidate_import_caches(self):
         # invalidate caches if we can (py33 and above)
         try:
-            import importlib
+            from importlib import invalidate_caches
         except ImportError:
-            pass
-        else:
-            if hasattr(importlib, "invalidate_caches"):
-                importlib.invalidate_caches()
+            return
+        invalidate_caches()
 
     def mkdir(self, name):
         """Create a new (sub)directory."""

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -34,8 +34,6 @@ class TestModule(object):
         )
 
     def test_import_prepend_append(self, testdir, monkeypatch):
-        syspath = list(sys.path)
-        monkeypatch.setattr(sys, "path", syspath)
         root1 = testdir.mkdir("root1")
         root2 = testdir.mkdir("root2")
         root1.ensure("x456.py")

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1335,7 +1335,7 @@ class TestEarlyRewriteBailout(object):
         # Setup conditions for py's fspath trying to import pathlib on py34
         # always (previously triggered via xdist only).
         # Ref: https://github.com/pytest-dev/py/pull/207
-        monkeypatch.setattr(sys, "path", [""] + sys.path)
+        monkeypatch.syspath_prepend("")
         monkeypatch.delitem(sys.modules, "pathlib", raising=False)
 
         testdir.makepyfile(

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -4,7 +4,6 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import re
 import sys
 import types
 
@@ -165,10 +164,10 @@ def test_importplugin_error_message(testdir, pytestpm):
     with pytest.raises(ImportError) as excinfo:
         pytestpm.import_plugin("qwe")
 
-    expected_message = '.*Error importing plugin "qwe": Not possible to import: .'
-    expected_traceback = ".*in test_traceback"
-    assert re.match(expected_message, str(excinfo.value))
-    assert re.match(expected_traceback, str(excinfo.traceback[-1]))
+    assert str(excinfo.value).endswith(
+        'Error importing plugin "qwe": Not possible to import: ☺'
+    )
+    assert "in test_traceback" in str(excinfo.traceback[-1])
 
 
 class TestPytestPluginManager(object):


### PR DESCRIPTION
Without the patch the test fails as follows:

            # Prepending should call fixup_namespace_packages.
            monkeypatch.syspath_prepend("world")
    >       import ns_pkg.world
    E       ModuleNotFoundError: No module named 'ns_pkg.world'