### PR TITLE
logging: close log_file_handler

### DIFF
--- a/changelog/4988.bugfix.rst
+++ b/changelog/4988.bugfix.rst
@@ -1,0 +1,1 @@
+Close logging's file handler explicitly when the session finishes.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -577,8 +577,15 @@ class LoggingPlugin(object):
             if self.log_cli_handler:
                 self.log_cli_handler.set_when("sessionfinish")
             if self.log_file_handler is not None:
-                with catching_logs(self.log_file_handler, level=self.log_file_level):
-                    yield
+                try:
+                    with catching_logs(
+                        self.log_file_handler, level=self.log_file_level
+                    ):
+                        yield
+                finally:
+                    # Close the FileHandler explicitly.
+                    # (logging.shutdown might have lost the weakref?!)
+                    self.log_file_handler.close()
             else:
                 yield
 


### PR DESCRIPTION
See https://github.com/pytest-dev/pytest/pull/4981/commits/92ffe42b45973bce478f25bb8acbb5e8e791aafa / #4981 for more information.

TODO:

- [x] changelog
- [ ] test

It means that coverage with src/_pytest/capture.py is likely not flaky anymore, but decreases - it was only accidentally covered.