### PR TITLE
Docs: modules implementing pytest_cmdline_parse can be early-loaded

### DIFF
--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -99,7 +99,8 @@ def pytest_cmdline_parse(pluginmanager, args):
     Stops at first non-None result, see :ref:`firstresult`
 
     .. note::
-        This hook will not be called for ``conftest.py`` files, only for setuptools plugins.
+        This hook will not be called for ``conftest.py`` files, only for setuptools plugins or
+        modules which implement this hook and are early-loaded with the ``-p`` flag.
 
     :param _pytest.config.PytestPluginManager pluginmanager: pytest plugin manager
     :param list[str] args: list of arguments passed on the command line


### PR DESCRIPTION
Related to #4974
