### PR TITLE
Split out list of essential plugins

### DIFF
--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -173,6 +173,7 @@ def getreportopt(config):
     return reportopts
 
 
+@pytest.hookimpl(trylast=True)  # after _pytest.runner
 def pytest_report_teststatus(report):
     if report.passed:
         letter = "."

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1205,20 +1205,12 @@ def test_config_does_not_load_blocked_plugin_from_args(testdir):
     [
         x
         for x in _pytest.config.default_plugins
-        if x
-        not in [
-            "fixtures",
-            "helpconfig",  # Provides -p.
-            "main",
-            "mark",
-            "python",
-            "runner",
-            "terminal",  # works in OK case (no output), but not with failures.
-        ]
+        if x not in _pytest.config.essential_plugins
     ],
 )
 def test_config_blocked_default_plugins(testdir, plugin):
     if plugin == "debugging":
+        # Fixed in xdist master (after 1.27.0).
         # https://github.com/pytest-dev/pytest-xdist/pull/422
         try:
             import xdist  # noqa: F401
@@ -1230,9 +1222,11 @@ def test_config_blocked_default_plugins(testdir, plugin):
     p = testdir.makepyfile("def test(): pass")
     result = testdir.runpytest(str(p), "-pno:%s" % plugin)
     assert result.ret == EXIT_OK
-    result.stdout.fnmatch_lines(["* 1 passed in *"])
+    if plugin != "terminal":
+        result.stdout.fnmatch_lines(["* 1 passed in *"])
 
-    p = testdir.makepyfile("def test(): assert 0")
-    result = testdir.runpytest(str(p), "-pno:%s" % plugin)
-    assert result.ret == EXIT_TESTSFAILED
-    result.stdout.fnmatch_lines(["* 1 failed in *"])
+    if plugin != "terminal":  # fails to report due to its options being used elsewhere.
+        p = testdir.makepyfile("def test(): assert 0")
+        result = testdir.runpytest(str(p), "-pno:%s" % plugin)
+        assert result.ret == EXIT_TESTSFAILED
+        result.stdout.fnmatch_lines(["* 1 failed in *"])

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -9,6 +9,7 @@ import types
 
 import pytest
 from _pytest.config import PytestPluginManager
+from _pytest.config.exceptions import UsageError
 from _pytest.main import EXIT_NOTESTSCOLLECTED
 from _pytest.main import Session
 
@@ -313,6 +314,9 @@ class TestPytestPluginManagerBootstrapming(object):
 
         # Handles -p without following arg (when used without argparse).
         pytestpm.consider_preparse(["-p"])
+
+        with pytest.raises(UsageError, match="^plugin main cannot be disabled$"):
+            pytestpm.consider_preparse(["-p", "no:main"])
 
     def test_plugin_prevent_register(self, pytestpm):
         pytestpm.consider_preparse(["xyz", "-p", "no:abc"])


### PR DESCRIPTION
No changelog, since this is meant to be internal/private?  (rename to `_essential_plugins` maybe?)