### PR TITLE
tests: ensure cleanup with configs via get_config()

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -375,6 +375,15 @@ def testdir(request, tmpdir_factory):
     return Testdir(request, tmpdir_factory)
 
 
+@pytest.fixture
+def _config_for_test():
+    from _pytest.config import get_config
+
+    config = get_config()
+    yield config
+    config._ensure_unconfigure()  # cleanup, e.g. capman closing tmpfiles.
+
+
 rex_outcome = re.compile(r"(\d+) ([\w-]+)")
 
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -743,10 +743,8 @@ def test_notify_exception(testdir, capfd):
     assert not err
 
 
-def test_load_initial_conftest_last_ordering(testdir):
-    from _pytest.config import get_config
-
-    pm = get_config().pluginmanager
+def test_load_initial_conftest_last_ordering(testdir, _config_for_test):
+    pm = _config_for_test.pluginmanager
 
     class My(object):
         def pytest_load_initial_conftests(self):
@@ -1018,21 +1016,17 @@ class TestOverrideIniArgs(object):
             assert rootdir == tmpdir
             assert inifile is None
 
-    def test_addopts_before_initini(self, monkeypatch):
+    def test_addopts_before_initini(self, monkeypatch, _config_for_test):
         cache_dir = ".custom_cache"
         monkeypatch.setenv("PYTEST_ADDOPTS", "-o cache_dir=%s" % cache_dir)
-        from _pytest.config import get_config
-
-        config = get_config()
+        config = _config_for_test
         config._preparse([], addopts=True)
         assert config._override_ini == ["cache_dir=%s" % cache_dir]
 
-    def test_addopts_from_env_not_concatenated(self, monkeypatch):
+    def test_addopts_from_env_not_concatenated(self, monkeypatch, _config_for_test):
         """PYTEST_ADDOPTS should not take values from normal args (#4265)."""
-        from _pytest.config import get_config
-
         monkeypatch.setenv("PYTEST_ADDOPTS", "-o")
-        config = get_config()
+        config = _config_for_test
         with pytest.raises(UsageError) as excinfo:
             config._preparse(["cache_dir=ignored"], addopts=True)
         assert (
@@ -1057,11 +1051,9 @@ class TestOverrideIniArgs(object):
         )
         assert result.ret == _pytest.main.EXIT_USAGEERROR
 
-    def test_override_ini_does_not_contain_paths(self):
+    def test_override_ini_does_not_contain_paths(self, _config_for_test):
         """Check that -o no longer swallows all options after it (#3103)"""
-        from _pytest.config import get_config
-
-        config = get_config()
+        config = _config_for_test
         config._preparse(["-o", "cache_dir=/cache", "/some/test/path"])
         assert config._override_ini == ["cache_dir=/cache"]
 

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -9,7 +9,6 @@ import sys
 import types
 
 import pytest
-from _pytest.config import get_config
 from _pytest.config import PytestPluginManager
 from _pytest.main import EXIT_NOTESTSCOLLECTED
 from _pytest.main import Session
@@ -21,7 +20,7 @@ def pytestpm():
 
 
 class TestPytestPluginInteractions(object):
-    def test_addhooks_conftestplugin(self, testdir):
+    def test_addhooks_conftestplugin(self, testdir, _config_for_test):
         testdir.makepyfile(
             newhooks="""
             def pytest_myhook(xyz):
@@ -37,7 +36,7 @@ class TestPytestPluginInteractions(object):
                 return xyz + 1
         """
         )
-        config = get_config()
+        config = _config_for_test
         pm = config.pluginmanager
         pm.hook.pytest_addhooks.call_historic(
             kwargs=dict(pluginmanager=config.pluginmanager)
@@ -92,8 +91,8 @@ class TestPytestPluginInteractions(object):
         config.pluginmanager.register(A())
         assert len(values) == 2
 
-    def test_hook_tracing(self):
-        pytestpm = get_config().pluginmanager  # fully initialized with plugins
+    def test_hook_tracing(self, _config_for_test):
+        pytestpm = _config_for_test.pluginmanager  # fully initialized with plugins
         saveindent = []
 
         class api1(object):
@@ -202,8 +201,8 @@ class TestPytestPluginManager(object):
         assert pytestpm.get_plugin("pytest_p1").__name__ == "pytest_p1"
         assert pytestpm.get_plugin("pytest_p2").__name__ == "pytest_p2"
 
-    def test_consider_module_import_module(self, testdir):
-        pytestpm = get_config().pluginmanager
+    def test_consider_module_import_module(self, testdir, _config_for_test):
+        pytestpm = _config_for_test.pluginmanager
         mod = types.ModuleType("x")
         mod.pytest_plugins = "pytest_a"
         aplugin = testdir.makepyfile(pytest_a="#")


### PR DESCRIPTION
Also done in test_pluginmanager, although no resource warnings are
there at least.

Fixes https://github.com/pytest-dev/pytest/issues/4355.