### PR TITLE
setup.cfg: use existing [tool:pytest] (ignoring [pytest])

### DIFF
--- a/changelog/5008.feature.rst
+++ b/changelog/5008.feature.rst
@@ -1,0 +1,3 @@
+If a ``setup.cfg`` file contains ``[tool:pytest]`` and also the no longer supported ``[pytest]`` section, pytest will use ``[tool:pytest]`` ignoring ``[pytest]``. Previously it would unconditionally error out.
+
+This makes it simpler for plugins to support old pytest versions.

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -33,7 +33,12 @@ def getcfg(args, config=None):
                 p = base.join(inibasename)
                 if exists(p):
                     iniconfig = py.iniconfig.IniConfig(p)
-                    if "pytest" in iniconfig.sections:
+                    if (
+                        inibasename == "setup.cfg"
+                        and "tool:pytest" in iniconfig.sections
+                    ):
+                        return base, p, iniconfig["tool:pytest"]
+                    elif "pytest" in iniconfig.sections:
                         if inibasename == "setup.cfg" and config is not None:
 
                             fail(
@@ -41,11 +46,6 @@ def getcfg(args, config=None):
                                 pytrace=False,
                             )
                         return base, p, iniconfig["pytest"]
-                    if (
-                        inibasename == "setup.cfg"
-                        and "tool:pytest" in iniconfig.sections
-                    ):
-                        return base, p, iniconfig["tool:pytest"]
                     elif inibasename == "pytest.ini":
                         # allowed to be empty
                         return base, p, {}

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -46,6 +46,22 @@ class TestParseIni(object):
         """correctly handle zero length arguments (a la pytest '')"""
         getcfg([""])
 
+    def test_setupcfg_uses_toolpytest_with_pytest(self, testdir):
+        p1 = testdir.makepyfile("def test(): pass")
+        testdir.makefile(
+            ".cfg",
+            setup="""
+                [tool:pytest]
+                testpaths=%s
+                [pytest]
+                testpaths=ignored
+        """
+            % p1.basename,
+        )
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines(["*, inifile: setup.cfg, *", "* 1 passed in *"])
+        assert result.ret == 0
+
     def test_append_parse_args(self, testdir, tmpdir, monkeypatch):
         monkeypatch.setenv("PYTEST_ADDOPTS", '--color no -rs --tb="short"')
         tmpdir.join("pytest.ini").write(


### PR DESCRIPTION
Helps with migrating existing plugins, e.g. https://github.com/astropy/pytest-openfiles/pull/20.