### PR TITLE
wrap_session: restore old behavior for initstate=1

### DIFF
--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -214,10 +214,13 @@ def wrap_session(config, doit):
         except (KeyboardInterrupt, exit.Exception):
             excinfo = _pytest._code.ExceptionInfo.from_current()
             exitstatus = EXIT_INTERRUPTED
-            if initstate <= 2 and isinstance(excinfo.value, exit.Exception):
-                sys.stderr.write("{}: {}\n".format(excinfo.typename, excinfo.value.msg))
+            if isinstance(excinfo.value, exit.Exception):
                 if excinfo.value.returncode is not None:
                     exitstatus = excinfo.value.returncode
+                if initstate < 2:
+                    sys.stderr.write(
+                        "{}: {}\n".format(excinfo.typename, excinfo.value.msg)
+                    )
             config.hook.pytest_keyboard_interrupt(excinfo=excinfo)
             session.exitstatus = exitstatus
         except:  # noqa

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1015,7 +1015,8 @@ class TestTraceOption:
         rest = child.read().decode("utf8")
         assert "2 passed in" in rest
         assert "reading from stdin while output" not in rest
-        assert "Exit: Quitting debugger" in child.before.decode("utf8")
+        # Only printed once - not on stderr.
+        assert "Exit: Quitting debugger" not in child.before.decode("utf8")
         TestPDB.flush(child)
 
 

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -580,7 +580,23 @@ def test_pytest_exit_returncode(testdir):
     """
     )
     result = testdir.runpytest()
+    result.stdout.fnmatch_lines(["*! *Exit: some exit msg !*"])
+    assert result.stderr.lines == [""]
     assert result.ret == 99
+
+    # It prints to stderr also in case of exit during pytest_sessionstart.
+    testdir.makeconftest(
+        """
+        import pytest
+
+        def pytest_sessionstart():
+            pytest.exit("during_sessionstart", 98)
+        """
+    )
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(["*! *Exit: during_sessionstart !*"])
+    assert result.stderr.lines == ["Exit: during_sessionstart", ""]
+    assert result.ret == 98
 
 
 def test_pytest_fail_notrace_runtest(testdir):


### PR DESCRIPTION
The condition for `initstate <= 2` was always True, after https://github.com/pytest-dev/pytest/pull/4145.

/cc @cacoze

No changelog.