### PR TITLE
[WIP] Pytester: disable plugin autoload

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -500,6 +500,8 @@ class Testdir(object):
         mp.delenv("TOX_ENV_DIR", raising=False)
         # Discard outer pytest options.
         mp.delenv("PYTEST_ADDOPTS", raising=False)
+        # Do not load entrypoint plugins by default.
+        mp.setenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
 
     def __repr__(self):
         return "<Testdir %r>" % (self.tmpdir,)

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -790,6 +790,14 @@ class Testdir(object):
         items = [x.item for x in rec.getcalls("pytest_itemcollected")]
         return items, rec
 
+    def _get_isolated_env(self):
+        tmpdir = str(self.tmpdir)
+        return (
+            # Do not load user config.
+            ("HOME", tmpdir),
+            ("USERPROFILE", tmpdir),
+        )
+
     def inline_run(self, *args, **kwargs):
         """Run ``pytest.main()`` in-process, returning a HookRecorder.
 
@@ -811,8 +819,8 @@ class Testdir(object):
         try:
             # Do not load user config (during runs only).
             mp_run = MonkeyPatch()
-            mp_run.setenv("HOME", str(self.tmpdir))
-            mp_run.setenv("USERPROFILE", str(self.tmpdir))
+            for k, v in self._get_isolated_env():
+                mp_run.setenv(k, v)
             finalizers.append(mp_run.undo)
 
             # When running pytest inline any plugins active in the main test
@@ -1040,16 +1048,18 @@ class Testdir(object):
 
         You probably want to use :py:meth:`run` instead.
         """
-        env = os.environ.copy()
-        env_update = kw.get("env", {})
-        if "PYTHONPATH" not in env_update:
-            env_update["PYTHONPATH"] = os.pathsep.join(
-                filter(None, [os.getcwd(), env.get("PYTHONPATH", "")])
-            )
-        # Do not load user config.
-        env_update["HOME"] = str(self.tmpdir)
-        env_update["USERPROFILE"] = env["HOME"]
-        env.update(env_update)
+        if "env" in kw:
+            env = kw["env"]
+        else:
+            env = os.environ.copy()
+            env.update(self._get_isolated_env())
+
+            env_update = kw.pop("env_update", {})
+            if "PYTHONPATH" not in env_update:
+                env["PYTHONPATH"] = os.pathsep.join(
+                    filter(None, [os.getcwd(), env.get("PYTHONPATH", "")])
+                )
+            env.update(env_update)
 
         popen = subprocess.Popen(
             cmdargs, stdin=subprocess.PIPE, stdout=stdout, stderr=stderr, env=env, **kw

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1044,12 +1044,22 @@ class Testdir(object):
         """Invoke subprocess.Popen.
 
         This calls subprocess.Popen, making sure the current working directory
-        is in the PYTHONPATH.
+        is in the PYTHONPATH by default.
+
+        Optional keyword arguments:
+
+        :param env: OS environment to be used as is (no PYTHONPATH adjustment,
+                    nor isolation for HOME etc).
+        :param env_update: OS environment values to update the current
+                           environment with.
+                           PYTHONPATH gets adjusted if not passed in explicitly.
 
         You probably want to use :py:meth:`run` instead.
         """
         if "env" in kw:
-            env = kw["env"]
+            env = kw.pop("env")
+            if "env_update" in kw:
+                raise ValueError("env and env_update are mutually exclusive")
         else:
             env = os.environ.copy()
             env.update(self._get_isolated_env())

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1035,26 +1035,26 @@ class Testdir(object):
     def popen(self, cmdargs, stdout, stderr, **kw):
         """Invoke subprocess.Popen.
 
-        This calls subprocess.Popen making sure the current working directory
+        This calls subprocess.Popen, making sure the current working directory
         is in the PYTHONPATH.
 
         You probably want to use :py:meth:`run` instead.
-
         """
         env = os.environ.copy()
-        env["PYTHONPATH"] = os.pathsep.join(
-            filter(None, [os.getcwd(), env.get("PYTHONPATH", "")])
-        )
+        env_update = kw.get("env", {})
+        if "PYTHONPATH" not in env_update:
+            env_update["PYTHONPATH"] = os.pathsep.join(
+                filter(None, [os.getcwd(), env.get("PYTHONPATH", "")])
+            )
         # Do not load user config.
-        env["HOME"] = str(self.tmpdir)
-        env["USERPROFILE"] = env["HOME"]
-        kw["env"] = env
+        env_update["HOME"] = str(self.tmpdir)
+        env_update["USERPROFILE"] = env["HOME"]
+        env.update(env_update)
 
         popen = subprocess.Popen(
-            cmdargs, stdin=subprocess.PIPE, stdout=stdout, stderr=stderr, **kw
+            cmdargs, stdin=subprocess.PIPE, stdout=stdout, stderr=stderr, env=env, **kw
         )
         popen.stdin.close()
-
         return popen
 
     def run(self, *cmdargs, **kwargs):

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -157,6 +157,7 @@ class TestGeneralUsage(object):
 
         monkeypatch.setattr(pkg_resources, "iter_entry_points", my_iter)
         params = ("-p", "mycov") if load_cov_early else ()
+        testdir.monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
         testdir.runpytest_inprocess(*params)
         if load_cov_early:
             assert loaded == ["mycov", "myplugin1", "myplugin2"]

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -155,7 +155,7 @@ class TestImportHookInstallation(object):
     @pytest.mark.parametrize("mode", ["plain", "rewrite"])
     @pytest.mark.parametrize("plugin_state", ["development", "installed"])
     def test_installed_plugin_rewrite(self, testdir, mode, plugin_state, monkeypatch):
-        monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
+        monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
         # Make sure the hook is installed early enough so that plugins
         # installed via setuptools are rewritten.
         testdir.tmpdir.join("hampkg").ensure(dir=1)

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -7,6 +7,7 @@ from _pytest.main import EXIT_NOTESTSCOLLECTED
 
 
 def test_version(testdir, pytestconfig):
+    testdir.monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
     result = testdir.runpytest("--version")
     assert result.ret == 0
     # p = py.path.local(py.__file__).dirpath()

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -568,6 +568,7 @@ class TestTerminalFunctional(object):
         assert result.ret == 0
 
     def test_header_trailer_info(self, testdir, request):
+        testdir.monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
         testdir.makepyfile(
             """
             def test_passes():
@@ -677,6 +678,7 @@ class TestTerminalFunctional(object):
     def test_verbose_reporting_xdist(self, verbose_testfile, testdir, pytestconfig):
         if not pytestconfig.pluginmanager.get_plugin("xdist"):
             pytest.skip("xdist plugin not installed")
+        testdir.monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
 
         result = testdir.runpytest(
             verbose_testfile, "-v", "-n 1", "-Walways::pytest.PytestWarning"


### PR DESCRIPTION
Includes / based on https://github.com/pytest-dev/pytest/pull/4902.

Makes it easier to use pytest-randomly etc with pytest's tests itself (https://github.com/pytest-dev/pytest/issues/4351).