### PR TITLE
Add the junit_log_passing_tests ini flag to skip logging output for passing tests.

### DIFF
--- a/changelog/4559.feature.rst
+++ b/changelog/4559.feature.rst
@@ -1,0 +1,1 @@
+Added the ``junit_log_passing_tests`` ini value which can be used to enable and disable logging passing test output in the Junit XML file.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -166,6 +166,9 @@ class _NodeReporter(object):
         self.append(node)
 
     def write_captured_output(self, report):
+        if not self.xml.log_passing_tests and report.passed:
+            return
+
         content_out = report.capstdout
         content_log = report.caplog
         content_err = report.capstderr
@@ -355,6 +358,12 @@ def pytest_addoption(parser):
         default="no",
     )  # choices=['no', 'stdout', 'stderr'])
     parser.addini(
+        "junit_log_passing_tests",
+        "Capture log information for passing tests to JUnit report: ",
+        type="bool",
+        default=True,
+    )
+    parser.addini(
         "junit_duration_report",
         "Duration time to report: one of total|call",
         default="total",
@@ -377,6 +386,7 @@ def pytest_configure(config):
             config.getini("junit_logging"),
             config.getini("junit_duration_report"),
             config.getini("junit_family"),
+            config.getini("junit_log_passing_tests"),
         )
         config.pluginmanager.register(config._xml)
 
@@ -412,12 +422,14 @@ class LogXML(object):
         logging="no",
         report_duration="total",
         family="xunit1",
+        log_passing_tests=True,
     ):
         logfile = os.path.expanduser(os.path.expandvars(logfile))
         self.logfile = os.path.normpath(os.path.abspath(logfile))
         self.prefix = prefix
         self.suite_name = suite_name
         self.logging = logging
+        self.log_passing_tests = log_passing_tests
         self.report_duration = report_duration
         self.family = family
         self.stats = dict.fromkeys(["error", "passed", "failure", "skipped"], 0)

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1245,3 +1245,30 @@ def test_escaped_skipreason_issue3533(testdir):
     snode = node.find_first_by_tag("skipped")
     assert "1 <> 2" in snode.text
     snode.assert_attr(message="1 <> 2")
+
+
+def test_logging_passing_tests_disabled_does_not_log_test_output(testdir):
+    testdir.makeini(
+        """
+        [pytest]
+        junit_log_passing_tests=False
+        junit_logging=system-out
+    """
+    )
+    testdir.makepyfile(
+        """
+        import pytest
+        import logging
+        import sys
+
+        def test_func():
+            sys.stdout.write('This is stdout')
+            sys.stderr.write('This is stderr')
+            logging.warning('hello')
+    """
+    )
+    result, dom = runandparse(testdir)
+    assert result.ret == 0
+    node = dom.find_first_by_tag("testcase")
+    assert len(node.find_by_tag("system-err")) == 0
+    assert len(node.find_by_tag("system-out")) == 0


### PR DESCRIPTION
Closes #4559 by adding the junit_log_passing_tests ini flag which can be turned off to disable logging test output and logging for passing tests in the junit XML report.