### PR TITLE
Inject width via pylib to argparse formatter

### DIFF
--- a/changelog/5056.trivial.rst
+++ b/changelog/5056.trivial.rst
@@ -1,0 +1,1 @@
+The HelpFormatter uses ``py.io.get_terminal_width`` for better width detection.

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -405,6 +405,12 @@ class DropShorterLongHelpFormatter(argparse.HelpFormatter):
     - cache result on action object as this is called at least 2 times
     """
 
+    def __init__(self, *args, **kwargs):
+        """Use more accurate terminal width via pylib."""
+        if "width" not in kwargs:
+            kwargs["width"] = py.io.get_terminal_width()
+        super().__init__(*args, **kwargs)
+
     def _format_action_invocation(self, action):
         orgstr = argparse.HelpFormatter._format_action_invocation(self, action)
         if orgstr and orgstr[0] != "-":  # only optional arguments

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1194,6 +1194,21 @@ def test_help_and_version_after_argument_error(testdir):
     assert result.ret == ExitCode.USAGE_ERROR
 
 
+def test_help_formatter_uses_py_get_terminal_width(testdir, monkeypatch):
+    from _pytest.config.argparsing import DropShorterLongHelpFormatter
+
+    monkeypatch.setenv("COLUMNS", "90")
+    formatter = DropShorterLongHelpFormatter("prog")
+    assert formatter._width == 90
+
+    monkeypatch.setattr("py.io.get_terminal_width", lambda: 160)
+    formatter = DropShorterLongHelpFormatter("prog")
+    assert formatter._width == 160
+
+    formatter = DropShorterLongHelpFormatter("prog", width=42)
+    assert formatter._width == 42
+
+
 def test_config_does_not_load_blocked_plugin_from_args(testdir):
     """This tests that pytest's config setup handles "-p no:X"."""
     p = testdir.makepyfile("def test(capfd): pass")


### PR DESCRIPTION
`argparse.HelpFormatter` looks at `$COLUMNS` only, falling back to a default of 80.

`py.io.get_terminal_width()` is smarter there, and could even work better with https://github.com/pytest-dev/py/pull/219.

This ensures to use a consistent value for formatting the ini values etc.

1: https://github.com/pytest-dev/py/pull/219

TODO:

- [x] changelog
- [x] coverage