### PR TITLE
pytester: allow passing in stdin to run/popen

### DIFF
--- a/changelog/5059.feature.rst
+++ b/changelog/5059.feature.rst
@@ -1,0 +1,1 @@
+Standard input (stdin) can be given to pytester's ``Testdir.run()`` and ``Testdir.popen()``.

--- a/changelog/5059.trivial.rst
+++ b/changelog/5059.trivial.rst
@@ -1,0 +1,1 @@
+pytester's ``Testdir.popen()`` uses ``stdout`` and ``stderr`` via keyword arguments with defaults now (``subprocess.PIPE``).

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1034,7 +1034,14 @@ class Testdir(object):
             if colitem.name == name:
                 return colitem
 
-    def popen(self, cmdargs, stdout, stderr, stdin=CLOSE_STDIN, **kw):
+    def popen(
+        self,
+        cmdargs,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=CLOSE_STDIN,
+        **kw
+    ):
         """Invoke subprocess.Popen.
 
         This calls subprocess.Popen making sure the current working directory

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -36,8 +36,6 @@ IGNORE_PAM = [  # filenames added when obtaining details about the current user
     u"/var/lib/sss/mc/passwd"
 ]
 
-CLOSE_STDIN = object
-
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -474,6 +472,8 @@ class Testdir(object):
        the method using them so refer to them for details.
 
     """
+
+    CLOSE_STDIN = object
 
     class TimeoutExpired(Exception):
         pass
@@ -1059,7 +1059,7 @@ class Testdir(object):
         env["USERPROFILE"] = env["HOME"]
         kw["env"] = env
 
-        if stdin is CLOSE_STDIN:
+        if stdin is Testdir.CLOSE_STDIN:
             kw["stdin"] = subprocess.PIPE
         elif isinstance(stdin, bytes):
             kw["stdin"] = subprocess.PIPE
@@ -1067,7 +1067,7 @@ class Testdir(object):
             kw["stdin"] = stdin
 
         popen = subprocess.Popen(cmdargs, stdout=stdout, stderr=stderr, **kw)
-        if stdin is CLOSE_STDIN:
+        if stdin is Testdir.CLOSE_STDIN:
             popen.stdin.close()
         elif isinstance(stdin, bytes):
             popen.stdin.write(stdin)
@@ -1093,7 +1093,7 @@ class Testdir(object):
         __tracebackhide__ = True
 
         timeout = kwargs.pop("timeout", None)
-        stdin = kwargs.pop("stdin", CLOSE_STDIN)
+        stdin = kwargs.pop("stdin", Testdir.CLOSE_STDIN)
         raise_on_kwargs(kwargs)
 
         popen_kwargs = {"stdin": stdin}

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1096,10 +1096,6 @@ class Testdir(object):
         stdin = kwargs.pop("stdin", Testdir.CLOSE_STDIN)
         raise_on_kwargs(kwargs)
 
-        popen_kwargs = {"stdin": stdin}
-        if isinstance(stdin, bytes):
-            popen_kwargs["stdin"] = subprocess.PIPE
-
         cmdargs = [
             str(arg) if isinstance(arg, py.path.local) else arg for arg in cmdargs
         ]
@@ -1113,13 +1109,12 @@ class Testdir(object):
             now = time.time()
             popen = self.popen(
                 cmdargs,
+                stdin=stdin,
                 stdout=f1,
                 stderr=f2,
                 close_fds=(sys.platform != "win32"),
-                **popen_kwargs
             )
             if isinstance(stdin, bytes):
-                popen.stdin.write(stdin)
                 popen.stdin.close()
 
             def handle_timeout():

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -4,6 +4,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import subprocess
 import sys
 import time
 
@@ -482,3 +483,60 @@ def test_pytester_addopts(request, monkeypatch):
         testdir.finalize()
 
     assert os.environ["PYTEST_ADDOPTS"] == "--orig-unused"
+
+
+def test_run_stdin(testdir):
+    with pytest.raises(testdir.TimeoutExpired):
+        testdir.run(
+            sys.executable,
+            "-c",
+            "import sys; print(sys.stdin.read())",
+            stdin=subprocess.PIPE,
+            timeout=0.1,
+        )
+
+    with pytest.raises(testdir.TimeoutExpired):
+        result = testdir.run(
+            sys.executable,
+            "-c",
+            "import sys, time; time.sleep(1); print(sys.stdin.read())",
+            stdin=b"input\n2ndline",
+            timeout=0.1,
+        )
+
+    result = testdir.run(
+        sys.executable,
+        "-c",
+        "import sys; print(sys.stdin.read())",
+        stdin=b"input\n2ndline",
+    )
+    assert result.stdout.lines == ["input", "2ndline"]
+    assert result.stderr.str() == ""
+    assert result.ret == 0
+
+
+def test_popen_stdin_pipe(testdir):
+    proc = testdir.popen(
+        [sys.executable, "-c", "import sys; print(sys.stdin.read())"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.PIPE,
+    )
+    stdin = b"input\n2ndline"
+    stdout, stderr = proc.communicate(input=stdin)
+    assert stdout.decode("utf8").splitlines() == ["input", "2ndline"]
+    assert stderr == b""
+    assert proc.returncode == 0
+
+
+def test_popen_stdin_bytes(testdir):
+    proc = testdir.popen(
+        [sys.executable, "-c", "import sys; print(sys.stdin.read())"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=b"input\n2ndline",
+    )
+    stdout, stderr = proc.communicate()
+    assert stdout.decode("utf8").splitlines() == ["input", "2ndline"]
+    assert stderr == b""
+    assert proc.returncode == 0

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -540,3 +540,22 @@ def test_popen_stdin_bytes(testdir):
     assert stdout.decode("utf8").splitlines() == ["input", "2ndline"]
     assert stderr == b""
     assert proc.returncode == 0
+
+
+def test_popen_default_stdin_stderr_and_stdin_None(testdir):
+    # stdout, stderr default to pipes,
+    # stdin can be None to not close the pipe, avoiding
+    # "ValueError: flush of closed file" with `communicate()`.
+    p1 = testdir.makepyfile(
+        """
+        import sys
+        print(sys.stdin.read())  # empty
+        print('stdout')
+        sys.stderr.write('stderr')
+        """
+    )
+    proc = testdir.popen([sys.executable, str(p1)], stdin=None)
+    stdout, stderr = proc.communicate(b"ignored")
+    assert stdout.splitlines() == [b"", b"stdout"]
+    assert stderr.splitlines() == [b"stderr"]
+    assert proc.returncode == 0

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -490,7 +490,7 @@ def test_run_stdin(testdir):
         testdir.run(
             sys.executable,
             "-c",
-            "import sys; print(sys.stdin.read())",
+            "import sys, time; time.sleep(1); print(sys.stdin.read())",
             stdin=subprocess.PIPE,
             timeout=0.1,
         )


### PR DESCRIPTION
This makes it more flexible to use `testdir.run` / `testdir.popen`.