### PR TITLE
Multiple colors with terminal summary_stats

### DIFF
--- a/changelog/5061.feature.rst
+++ b/changelog/5061.feature.rst
@@ -1,0 +1,1 @@
+Use multiple colors with terminal summary statistics.

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -193,7 +193,7 @@ class TestPDB:
         )
         child = testdir.spawn_pytest("-rs --pdb %s" % p1)
         child.expect("Skipping also with pdb active")
-        child.expect("1 skipped in")
+        child.expect_exact("= \x1b[33m\x1b[1m1 skipped\x1b[0m\x1b[33m in")
         child.sendeof()
         self.flush(child)
 
@@ -221,7 +221,7 @@ class TestPDB:
         child.sendeof()
         rest = child.read().decode("utf8")
         assert "Exit: Quitting debugger" in rest
-        assert "= 1 failed in" in rest
+        assert "= \x1b[31m\x1b[1m1 failed\x1b[0m\x1b[31m in" in rest
         assert "def test_1" not in rest
         assert "get rekt" not in rest
         self.flush(child)
@@ -703,7 +703,7 @@ class TestPDB:
             assert "> PDB continue (IO-capturing resumed) >" in rest
         else:
             assert "> PDB continue >" in rest
-        assert "1 passed in" in rest
+        assert "= \x1b[32m\x1b[1m1 passed\x1b[0m\x1b[32m in" in rest
 
     def test_pdb_used_outside_test(self, testdir):
         p1 = testdir.makepyfile(
@@ -1019,7 +1019,7 @@ class TestTraceOption:
         child.sendline("q")
         child.expect_exact("Exit: Quitting debugger")
         rest = child.read().decode("utf8")
-        assert "2 passed in" in rest
+        assert "= \x1b[32m\x1b[1m2 passed\x1b[0m\x1b[32m in" in rest
         assert "reading from stdin while output" not in rest
         # Only printed once - not on stderr.
         assert "Exit: Quitting debugger" not in child.before.decode("utf8")
@@ -1130,7 +1130,7 @@ def test_pdb_suspends_fixture_capturing(testdir, fixture):
 
     TestPDB.flush(child)
     assert child.exitstatus == 0
-    assert "= 1 passed in " in rest
+    assert "= \x1b[32m\x1b[1m1 passed\x1b[0m\x1b[32m in" in rest
     assert "> PDB continue (IO-capturing resumed for fixture %s) >" % (fixture) in rest
 
 


### PR DESCRIPTION
Ref: https://github.com/pytest-dev/pytest/issues/5060

This is quite a hack, and should probably go with better support in py itself, or some more generic wrapping.

![55671348-86675f80-588f-11e9-9997-b6efed19514a](https://user-images.githubusercontent.com/9766/55838709-a617b580-5b25-11e9-8da4-25751a1102be.png)

TODO:

- [x] (adjust) tests
- [x] changelog