### PR TITLE
[WIP] revisit style with terminal reporting

### DIFF
--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -773,14 +773,10 @@ class FormattedExcinfo:
             extraline = None
 
         last = traceback[-1]
-        crashentry = traceback.getcrashentry()
         entries = []
         for index, entry in enumerate(traceback):
             einfo = (last == entry) and excinfo or None
             reprentry = self.repr_traceback_entry(entry, einfo)
-
-            # Store this for toterminal.
-            reprentry._is_crashentry = entry == crashentry
 
             entries.append(reprentry)
         return ReprTraceback(entries, extraline, style=self.style)
@@ -968,8 +964,6 @@ class ReprEntryNative(TerminalRepr):
 
 
 class ReprEntry(TerminalRepr):
-    _is_crashentry = None
-
     def __init__(self, lines, reprfuncargs, reprlocals, filelocrepr, style):
         self.lines = lines
         self.reprfuncargs = reprfuncargs
@@ -982,9 +976,7 @@ class ReprEntry(TerminalRepr):
             self.reprfileloc.toterminal(tw, style="short")
             for line in self.lines:
                 is_error = line.startswith("E   ")
-                red = is_error
-                bold = is_error or self._is_crashentry
-                tw.line(line, bold=bold, red=red)
+                tw.line(line, bold=is_error, red=is_error)
             return
 
         if self.reprfuncargs:
@@ -1021,7 +1013,7 @@ class ReprFileLocation(TerminalRepr):
             msg = msg[:i]
         bold = style != "short"
         tw.write("%s" % self.path, bold=bold)
-        tw.line(":%s: %s" % (self.lineno, msg))
+        tw.line(":{}: {}".format(self.lineno, msg))
 
 
 class ReprLocals(TerminalRepr):

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -609,7 +609,7 @@ class TerminalReporter:
 
         if self.config.getoption("collectonly"):
             if self.stats.get("failed"):
-                self._tw.sep("!", "collection failures")
+                self.write_sep("!", "collection failures")
                 for rep in self.stats.get("failed"):
                     rep.toterminal(self._tw)
 
@@ -807,7 +807,7 @@ class TerminalReporter:
             if showcapture != "all" and showcapture not in secname:
                 continue
             if "teardown" in secname:
-                self._tw.sep("-", secname)
+                self.write_sep("-", secname)
                 if content[-1:] == "\n":
                     content = content[:-1]
                 self._tw.line(content)
@@ -858,7 +858,7 @@ class TerminalReporter:
         for secname, content in rep.sections:
             if showcapture != "all" and showcapture not in secname:
                 continue
-            self._tw.sep("-", secname)
+            self.write_sep("-", secname)
             if content[-1:] == "\n":
                 content = content[:-1]
             self._tw.line(content)


### PR DESCRIPTION
1. use less bold/red with location representation

## Using `--tb=short` before:

![less-bold-before](https://user-images.githubusercontent.com/9766/55685299-b9275b80-5954-11e9-9763-b4b4ff7f353c.png)

## After:

![less-bold-after](https://user-images.githubusercontent.com/9766/55685298-b9275b80-5954-11e9-833f-704bfae88c7f.png)

TODO:

- [ ] tests
- [ ] changelog