### PR TITLE
Add a conftest to prefer faster tests

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,0 +1,26 @@
+def pytest_collection_modifyitems(config, items):
+    """Prefer faster tests."""
+    fast_items = []
+    slow_items = []
+    neutral_items = []
+
+    slow_fixturenames = ("testdir",)
+
+    for item in items:
+        try:
+            fixtures = item.fixturenames
+        except AttributeError:
+            # doctest at least
+            # (https://github.com/pytest-dev/pytest/issues/5070)
+            neutral_items.append(item)
+        else:
+            if any(x for x in fixtures if x in slow_fixturenames):
+                slow_items.append(item)
+            else:
+                marker = item.get_closest_marker("slow")
+                if marker:
+                    slow_items.append(item)
+                else:
+                    fast_items.append(item)
+
+    items[:] = fast_items + neutral_items + slow_items

--- a/testing/test_modimport.py
+++ b/testing/test_modimport.py
@@ -6,6 +6,8 @@ import py
 import _pytest
 import pytest
 
+pytestmark = pytest.mark.slow
+
 MODSET = [
     x
     for x in py.path.local(_pytest.__file__).dirpath().visit("*.py")

--- a/tox.ini
+++ b/tox.ini
@@ -171,6 +171,7 @@ filterwarnings =
 pytester_example_dir = testing/example_scripts
 markers =
     issue
+    slow
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
This uses pytest_collection_modifyitems for pytest's own tests to order
them, preferring faster ones via quick'n'dirty heuristics only for now.