### PR TITLE
Show XFail reason as part of JUnitXML message field

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -208,6 +208,7 @@ Ross Lawley
 Russel Winder
 Ryan Wooden
 Samuel Dion-Girardeau
+Samuel Searles-Bryant
 Samuele Pedroni
 Sankt Petersbug
 Segev Finer

--- a/changelog/4907.feature.rst
+++ b/changelog/4907.feature.rst
@@ -1,0 +1,1 @@
+Show XFail reason as part of JUnitXML message field.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -252,7 +252,14 @@ class _NodeReporter(object):
 
     def append_skipped(self, report):
         if hasattr(report, "wasxfail"):
-            self._add_simple(Junit.skipped, "expected test failure", report.wasxfail)
+            xfailreason = report.wasxfail
+            if xfailreason.startswith("reason: "):
+                xfailreason = xfailreason[8:]
+            self.append(
+                Junit.skipped(
+                    "", type="pytest.xfail", message=bin_xml_escape(xfailreason)
+                )
+            )
         else:
             filename, lineno, skipreason = report.longrepr
             if skipreason.startswith("Skipped: "):

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -485,8 +485,26 @@ class TestPython(object):
         tnode = node.find_first_by_tag("testcase")
         tnode.assert_attr(classname="test_xfailure_function", name="test_xfail")
         fnode = tnode.find_first_by_tag("skipped")
-        fnode.assert_attr(message="expected test failure")
+        fnode.assert_attr(type="pytest.xfail", message="42")
         # assert "ValueError" in fnode.toxml()
+
+    def test_xfailure_marker(self, testdir):
+        testdir.makepyfile(
+            """
+            import pytest
+            @pytest.mark.xfail(reason="42")
+            def test_xfail():
+                assert False
+        """
+        )
+        result, dom = runandparse(testdir)
+        assert not result.ret
+        node = dom.find_first_by_tag("testsuite")
+        node.assert_attr(skipped=1, tests=1)
+        tnode = node.find_first_by_tag("testcase")
+        tnode.assert_attr(classname="test_xfailure_marker", name="test_xfail")
+        fnode = tnode.find_first_by_tag("skipped")
+        fnode.assert_attr(type="pytest.xfail", message="42")
 
     def test_xfail_captures_output_once(self, testdir):
         testdir.makepyfile(


### PR DESCRIPTION
Fixes #4907
