### PR TITLE
terminal summary: display passes after warnings

### DIFF
--- a/changelog/5108.feature.rst
+++ b/changelog/5108.feature.rst
@@ -1,0 +1,1 @@
+The short test summary is displayed after passes with output (``-rP``).

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -684,9 +684,9 @@ class TerminalReporter(object):
         self.summary_errors()
         self.summary_failures()
         self.summary_warnings()
+        self.summary_passes()
         yield
         self.short_test_summary()
-        self.summary_passes()
         # Display any extra warnings from teardown here (if any).
         self.summary_warnings()
 

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -769,11 +769,19 @@ def test_pass_output_reporting(testdir):
     assert "test_pass_has_output" not in s
     assert "Four score and seven years ago..." not in s
     assert "test_pass_no_output" not in s
-    result = testdir.runpytest("-rP")
+    result = testdir.runpytest("-rPp")
     result.stdout.fnmatch_lines(
-        ["*test_pass_has_output*", "Four score and seven years ago..."]
+        [
+            "*= PASSES =*",
+            "*_ test_pass_has_output _*",
+            "*- Captured stdout call -*",
+            "Four score and seven years ago...",
+            "*= short test summary info =*",
+            "PASSED test_pass_output_reporting.py::test_pass_has_output",
+            "PASSED test_pass_output_reporting.py::test_pass_no_output",
+            "*= 2 passed in *",
+        ]
     )
-    assert "test_pass_no_output" not in result.stdout.str()
 
 
 def test_color_yes(testdir):


### PR DESCRIPTION
This displays passes (with output, `-rP`) before the short summary, and
before any other output from other plugins also.

TODO:

- [x] changelog, test