### PR TITLE
deselect_by_keyword: skip without expression

### DIFF
--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -100,6 +100,9 @@ pytest_cmdline_main.tryfirst = True
 
 def deselect_by_keyword(items, config):
     keywordexpr = config.option.keyword.lstrip()
+    if not keywordexpr:
+        return
+
     if keywordexpr.startswith("-"):
         keywordexpr = "not " + keywordexpr[1:]
     selectuntil = False


### PR DESCRIPTION
There is no need to iterate over all items always, if `-k` is not
specified.