### PR TITLE
terminal: use pytest_collection_finish for reporting

### DIFF
--- a/changelog/5113.bugfix.rst
+++ b/changelog/5113.bugfix.rst
@@ -1,0 +1,1 @@
+Deselected items from plugins using ``pytest_collect_modifyitems`` as a hookwrapper are correctly reported now.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -554,10 +554,6 @@ class TerminalReporter(object):
             self.write_line(line)
 
     @pytest.hookimpl(trylast=True)
-    def pytest_collection_modifyitems(self):
-        self.report_collect(True)
-
-    @pytest.hookimpl(trylast=True)
     def pytest_sessionstart(self, session):
         self._session = session
         self._sessionstarttime = time.time()
@@ -609,6 +605,8 @@ class TerminalReporter(object):
         return result
 
     def pytest_collection_finish(self, session):
+        self.report_collect(True)
+
         if self.config.getoption("collectonly"):
             self._printcollecteditems(session.items)
 


### PR DESCRIPTION
This is required to report deselected items from other hookwrappers.