### PR TITLE
reportopts: A: put "Pp" in front

### DIFF
--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -170,7 +170,7 @@ def getreportopt(config):
         if char == "a":
             reportopts = "sxXwEf"
         elif char == "A":
-            reportopts = "sxXwEfpP"
+            reportopts = "PpsxXwEf"
             break
         elif char not in reportopts:
             reportopts += char

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -893,7 +893,7 @@ def test_getreportopt():
     assert getreportopt(config) == "sxXwEf"  # NOTE: "w" included!
 
     config.option.reportchars = "A"
-    assert getreportopt(config) == "sxXwEfpP"
+    assert getreportopt(config) == "PpsxXwEf"
 
 
 def test_terminalreporter_reportopt_addopts(testdir):


### PR DESCRIPTION
No changelog, followup to #5068.

Have not really checked if this is sane yet, but "P" means to provide the output of the passed tests, and "p" to include it in the summary - where it should come first also then.