### PR TITLE
terminal/reports: use get_verbose_word method

### DIFF
--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -148,6 +148,12 @@ class BaseReport(object):
             fspath, lineno, domain = self.location
             return domain
 
+    def _get_verbose_word(self, config):
+        _category, _short, verbose = config.hook.pytest_report_teststatus(
+            report=self, config=config
+        )
+        return verbose
+
     def _to_json(self):
         """
         This was originally the serialize_report() function from xdist (ca03269).

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -888,14 +888,14 @@ class TerminalReporter(object):
         def show_simple(stat, lines):
             failed = self.stats.get(stat, [])
             for rep in failed:
-                verbose_word = _get_report_str(self.config, rep)
+                verbose_word = rep._get_verbose_word(self.config)
                 pos = _get_pos(self.config, rep)
                 lines.append("%s %s" % (verbose_word, pos))
 
         def show_xfailed(lines):
             xfailed = self.stats.get("xfailed", [])
             for rep in xfailed:
-                verbose_word = _get_report_str(self.config, rep)
+                verbose_word = rep._get_verbose_word(self.config)
                 pos = _get_pos(self.config, rep)
                 lines.append("%s %s" % (verbose_word, pos))
                 reason = rep.wasxfail
@@ -905,7 +905,7 @@ class TerminalReporter(object):
         def show_xpassed(lines):
             xpassed = self.stats.get("xpassed", [])
             for rep in xpassed:
-                verbose_word = _get_report_str(self.config, rep)
+                verbose_word = rep._get_verbose_word(self.config)
                 pos = _get_pos(self.config, rep)
                 reason = rep.wasxfail
                 lines.append("%s %s %s" % (verbose_word, pos, reason))
@@ -915,7 +915,7 @@ class TerminalReporter(object):
             fskips = _folded_skips(skipped) if skipped else []
             if not fskips:
                 return
-            verbose_word = _get_report_str(self.config, report=skipped[0])
+            verbose_word = skipped[0]._get_verbose_word(self.config)
             for num, fspath, lineno, reason in fskips:
                 if reason.startswith("Skipped: "):
                     reason = reason[9:]
@@ -926,12 +926,6 @@ class TerminalReporter(object):
                     )
                 else:
                     lines.append("%s [%d] %s: %s" % (verbose_word, num, fspath, reason))
-
-        def _get_report_str(config, report):
-            _category, _short, verbose = config.hook.pytest_report_teststatus(
-                report=report, config=config
-            )
-            return verbose
 
         def _get_pos(config, rep):
             nodeid = config.cwd_relative_nodeid(rep.nodeid)


### PR DESCRIPTION
Ref: https://github.com/pytest-dev/pytest/issues/5047#issuecomment-483109956

Should become more flexible with regard to other properties also, this is just a request for comments.