### PR TITLE
[Docs] Fix typo in skipping.rst

### DIFF
--- a/doc/en/skipping.rst
+++ b/doc/en/skipping.rst
@@ -208,7 +208,7 @@ Here's a quick guide on how to skip tests in a module in different situations:
 
   .. code-block:: python
 
-        pytestmark = pytest.mark.skipif(sys.platform == "win32", "tests for linux only")
+        pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="tests for linux only")
 
 3. Skip all tests in a module if some import is missing:
 


### PR DESCRIPTION
One of the `pytest.mark.skipif` blocks in `docs/skipping.rst` does not use the `reason` kwarg:

```python
pytestmark = pytest.mark.skipif(sys.platform == "win32", "tests for linux only")
```

This causes an error during setup of test:

```
Failed: you need to specify reason=STRING when using booleans as conditions.
```

This PR fixes the typo by adding `reason=`.

```diff
-pytestmark = pytest.mark.skipif(sys.platform == "win32", "tests for linux only")
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="tests for linux only")
```

Note: I did not make an associated Issue or Changelog entry for this PR because of how trivial it is. If that's needed, please let me know.