### PR TITLE
pytest_sessionfinish: preset exitstatus with UsageErrors

### DIFF
--- a/changelog/5144.bugfix.rst
+++ b/changelog/5144.bugfix.rst
@@ -1,0 +1,1 @@
+With usage errors ``exitstatus`` is set to ``EXIT_USAGEERROR`` in the ``pytest_sessionfinish`` hook now as expected.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -208,6 +208,7 @@ def wrap_session(config, doit):
             initstate = 2
             session.exitstatus = doit(config, session) or 0
         except UsageError:
+            session.exitstatus = EXIT_USAGEERROR
             raise
         except Failed:
             session.exitstatus = EXIT_TESTSFAILED

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -428,9 +428,20 @@ class TestGeneralUsage(object):
             assert result.ret == 4  # usage error only if item not found
 
     def test_report_all_failed_collections_initargs(self, testdir):
+        testdir.makeconftest(
+            """
+            from _pytest.main import EXIT_USAGEERROR
+
+            def pytest_sessionfinish(exitstatus):
+                assert exitstatus == EXIT_USAGEERROR
+                print("pytest_sessionfinish_called")
+            """
+        )
         testdir.makepyfile(test_a="def", test_b="def")
         result = testdir.runpytest("test_a.py::a", "test_b.py::b")
         result.stderr.fnmatch_lines(["*ERROR*test_a.py::a*", "*ERROR*test_b.py::b*"])
+        result.stdout.fnmatch_lines(["pytest_sessionfinish_called"])
+        assert result.ret == EXIT_USAGEERROR
 
     @pytest.mark.usefixtures("recwarn")
     def test_namespace_import_doesnt_confuse_import_hook(self, testdir):


### PR DESCRIPTION
Previously it would be 0.  Setting it to the expected outcome
(EXIT_USAGEERROR) here already helps `pytest_sessionfinish` hooks.

TODO:

- [x] changelog