### PR TITLE
[WIP/RFC] pdb: set sys.last_{type,value,traceback} in _enter_pdb

### DIFF
--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -289,6 +289,7 @@ def _enter_pdb(node, excinfo, rep):
     tw.sep(">", "entering PDB")
     tb = _postmortem_traceback(excinfo)
     rep._pdbshown = True
+    sys.last_type, sys.last_value, sys.last_traceback = excinfo._excinfo
     post_mortem(tb)
     return rep
 

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -89,6 +89,7 @@ class TestPDB(object):
         return pdblist
 
     def test_pdb_on_fail(self, testdir, pdblist):
+        sys.last_type, sys.last_value, sys.last_traceback = (None, None, None)
         rep = runpdb_and_get_report(
             testdir,
             """
@@ -100,6 +101,9 @@ class TestPDB(object):
         assert len(pdblist) == 1
         tb = _pytest._code.Traceback(pdblist[0][0])
         assert tb[-1].name == "test_func"
+        assert sys.last_type == AssertionError
+        assert type(sys.last_value) == AssertionError
+        assert sys.last_traceback == pdblist[0][0]
 
     def test_pdb_on_xfail(self, testdir, pdblist):
         rep = runpdb_and_get_report(


### PR DESCRIPTION
This affects pytest_exception_interact (`--pdb`) currently only, but
makes sense for all calls to `post_mortem` probably, or even more in
general.

Ref: https://github.com/python/cpython/blame/9f316bd9684d27b7e21fbf43ca86dc5e65dac4af/Doc/library/sys.rst#L891-L904