### PR TITLE
docs: remove extra characters in the command line prompt

### DIFF
--- a/changelog/5153.trivial.rst
+++ b/changelog/5153.trivial.rst
@@ -1,0 +1,2 @@
+Remove extra characters in the shown command line prompts in the test discovery
+documentation.

--- a/doc/en/example/pythoncollection.rst
+++ b/doc/en/example/pythoncollection.rst
@@ -206,7 +206,7 @@ You can always peek at the collection tree without running tests like this:
 
 .. code-block:: pytest
 
-    . $ pytest --collect-only pythoncollection.py
+    $ pytest --collect-only pythoncollection.py
     =========================== test session starts ============================
     platform linux -- Python 3.x.y, pytest-4.x.y, py-1.x.y, pluggy-0.x.y
     cachedir: $PYTHON_PREFIX/.pytest_cache
@@ -266,7 +266,7 @@ leave out the ``setup.py`` file:
 
 .. code-block:: pytest
 
-    #$ pytest --collect-only
+    $ pytest --collect-only
     ====== test session starts ======
     platform linux2 -- Python 2.7.10, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
     rootdir: $REGENDOC_TMPDIR, inifile: pytest.ini


### PR DESCRIPTION
Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs (you can delete this text from the final description, this is
just a guideline):

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
