### PR TITLE
Adding test cases for unrolling an iterable #5062

### DIFF
--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 import argparse
 import collections
 import platform
+import subprocess
 import sys
 import time
 
@@ -574,6 +575,11 @@ class TerminalReporter(object):
         ):
             msg += " -- " + str(sys.executable)
         self.write_line(msg)
+        pipe = subprocess.Popen("pip list", shell=True, stdout=subprocess.PIPE).stdout
+        package_msg = pipe.read()
+        package_msg = package_msg[:-2]
+        if package_msg:
+            self.write_line(package_msg)
         lines = self.config.hook.pytest_report_header(
             config=self.config, startdir=self.startdir
         )

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -671,6 +671,53 @@ class TestAssertionRewrite(object):
         assert "UnicodeDecodeError" not in msg
         assert "UnicodeEncodeError" not in msg
 
+    def test_generator(self, testdir):
+        testdir.makepyfile(
+            """
+            def check_even(num):
+                if num % 2 == 0:
+                    return True
+                return False
+
+            def test_generator():
+                odd_list = list(range(1,9,2))
+                assert all(check_even(num) for num in odd_list)"""
+        )
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines(["*assert False*", "*where False = check_even(1)*"])
+
+    def test_list_comprehension(self, testdir):
+        testdir.makepyfile(
+            """
+            def check_even(num):
+                if num % 2 == 0:
+                    return True
+                return False
+
+            def test_list_comprehension():
+                odd_list = list(range(1,9,2))
+                assert all([check_even(num) for num in odd_list])"""
+        )
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines(["*assert False*", "*where False = check_even(1)*"])
+
+    def test_for_loop(self, testdir):
+        testdir.makepyfile(
+            """
+            def check_even(num):
+                if num % 2 == 0:
+                    return True
+                return False
+
+            def test_for_loop():
+                odd_list = list(range(1,9,2))
+                for num in odd_list:
+                    assert check_even(num)
+        """
+        )
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines(["*assert False*", "*where False = check_even(1)*"])
+
 
 class TestRewriteOnImport(object):
     def test_pycache_is_a_file(self, testdir):

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -285,7 +285,7 @@ class TestTerminal(object):
                 assert 1 == 1"""
         )
         result = testdir.runpytest()
-        result.stdout.fnmatch_lines(["*Package*", "*Version*"])
+        result.stdout.fnmatch_lines(["*Package        Version              *"])
 
 
 class TestCollectonly(object):

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -278,6 +278,15 @@ class TestTerminal(object):
         tr.rewrite("hey", erase=True)
         assert f.getvalue() == "hello" + "\r" + "hey" + (6 * " ")
 
+    def test_packages_display(self, testdir):
+        testdir.makepyfile(
+            """
+            def test_pass(num):
+                assert 1 == 1"""
+        )
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines(["*Package*", "*Version*"])
+
 
 class TestCollectonly(object):
     def test_collectonly_basic(self, testdir):


### PR DESCRIPTION
Adds tests that will check if the pytest terminal output from using assertion statements with "all" or "any" will unroll and produce the same output as assertion statements inside of a for-loop. These tests are related to issue #5062 and two of them currently fail. Once the implementation in #5103 is finished, all three of these tests should pass.