### PR TITLE
GitHub: revisit issue/PR templates  [ci skip]

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,10 @@
+<!--
 Thanks for submitting an issue!
 
-Here's a quick checklist in what to include:
+Here's a quick checklist for what to provide:
+-->
 
-- [ ] Include a detailed description of the bug or suggestion
-- [ ] `pip list` of the virtual environment you are using
+- [ ] a detailed description of the bug or suggestion
+- [ ] output of `pip list` from the virtual environment you are using
 - [ ] pytest and operating system versions
-- [ ] Minimal example if possible
+- [ ] minimal example if possible

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,9 @@
+<!--
 Thanks for submitting a PR, your contribution is really appreciated!
 
-Here's a quick checklist that should be present in PRs (you can delete this text from the final description, this is
-just a guideline):
+Here's a quick checklist that should be present in PRs.
+(please delete this text from the final description, this is just a guideline)
+-->
 
 - [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
 - [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.


### PR DESCRIPTION
The motivation here is to not have the same boilerplate with PRs.