### PR TITLE
Revert "Merge pull request #4854 from blueyed/pdb-skip"

### DIFF
--- a/changelog/4854.feature.rst
+++ b/changelog/4854.feature.rst
@@ -1,5 +1,0 @@
-The ``--pdb-skip`` option can now be used to ignore calls to
-``pdb.set_trace()`` (and ``pytest.set_trace()``).
-
-This is meant to help while debugging, where you want to use e.g. ``--pdb`` or
-``--trace`` only, or just run the tests again without any interruption.

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -46,13 +46,6 @@ def pytest_addoption(parser):
         action="store_true",
         help="Immediately break when running each test.",
     )
-    group._addoption(
-        "--pdb-skip",
-        "--pdb-ignore-set_trace",
-        dest="pdb_ignore_set_trace",
-        action="store_true",
-        help="Ignore calls to pdb.set_trace().",
-    )
 
 
 def _import_pdbcls(modname, classname):
@@ -222,9 +215,6 @@ class pytestPDB(object):
     @classmethod
     def set_trace(cls, *args, **kwargs):
         """Invoke debugging via ``Pdb.set_trace``, dropping any IO capturing."""
-        if pytestPDB._config:  # Might not be available when called directly.
-            if pytestPDB._config.getoption("pdb_ignore_set_trace"):
-                return
         frame = sys._getframe().f_back
         _pdb = cls._init_pdb(*args, **kwargs)
         _pdb.set_trace(frame)

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -9,7 +9,6 @@ import sys
 import _pytest._code
 import pytest
 from _pytest.debugging import _validate_usepdb_cls
-from _pytest.main import EXIT_NOTESTSCOLLECTED
 
 try:
     breakpoint
@@ -1121,19 +1120,6 @@ def test_pdb_suspends_fixture_capturing(testdir, fixture):
     assert child.exitstatus == 0
     assert "= 1 passed in " in rest
     assert "> PDB continue (IO-capturing resumed for fixture %s) >" % (fixture) in rest
-
-
-def test_pdb_skip_option(testdir):
-    p = testdir.makepyfile(
-        """
-        print("before_set_trace")
-        __import__('pdb').set_trace()
-        print("after_set_trace")
-        """
-    )
-    result = testdir.runpytest_inprocess("--pdb-ignore-set_trace", "-s", p)
-    assert result.ret == EXIT_NOTESTSCOLLECTED
-    result.stdout.fnmatch_lines(["*before_set_trace*", "*after_set_trace*"])
 
 
 def test_pdbcls_via_local_module(testdir):


### PR DESCRIPTION
This reverts commit e88aa957aed7ee9dc3649e88052f548f5ffd0911, reversing
changes made to 1410d3dc9a61001f71b74ea800b203e92a25d689.

I do not think it warrants an option anymore, and there is a way to
achieve this via `--pdbcls` if needed.