### PR TITLE
Terminal plugin is not semi-essential anymore

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -123,7 +123,7 @@ essential_plugins = (
 )
 
 default_plugins = essential_plugins + (
-    "terminal",  # Has essential options, but xdist uses -pno:terminal.
+    "terminal",
     "debugging",
     "unittest",
     "capture",

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1232,8 +1232,10 @@ def test_config_blocked_default_plugins(testdir, plugin):
     if plugin != "terminal":
         result.stdout.fnmatch_lines(["* 1 passed in *"])
 
-    if plugin != "terminal":  # fails to report due to its options being used elsewhere.
-        p = testdir.makepyfile("def test(): assert 0")
-        result = testdir.runpytest(str(p), "-pno:%s" % plugin)
-        assert result.ret == EXIT_TESTSFAILED
+    p = testdir.makepyfile("def test(): assert 0")
+    result = testdir.runpytest(str(p), "-pno:%s" % plugin)
+    assert result.ret == EXIT_TESTSFAILED
+    if plugin != "terminal":
         result.stdout.fnmatch_lines(["* 1 failed in *"])
+    else:
+        assert result.stdout.lines == [""]


### PR DESCRIPTION
Thanks to https://github.com/pytest-dev/pytest/pull/5138.

No changelog.