### PR TITLE
Add note about pytest_load_initial_conftests working only from plugins

### DIFF
--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -107,7 +107,7 @@ the command line arguments before they get processed:
 
 .. code-block:: python
 
-    # content of conftest.py
+    # setuptools plugin
     import sys
 
 


### PR DESCRIPTION
Fix #5175

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs.
(please delete this text from the final description, this is just a guideline)
-->
