### PR TITLE
Improve help for --runxfail flag

### DIFF
--- a/changelog/5188.doc.rst
+++ b/changelog/5188.doc.rst
@@ -1,0 +1,1 @@
+Improve help for ``--runxfail`` flag.

--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -17,7 +17,7 @@ def pytest_addoption(parser):
         action="store_true",
         dest="runxfail",
         default=False,
-        help="run tests even if they are marked xfail",
+        help="report the results of xfail tests as if they were not marked",
     )
 
     parser.addini(


### PR DESCRIPTION
As per 528eea7:

> The help for the '--runxfail' flag is incorrect. The default behaviour is to run tests marked as 'xfail' but to ignore the results. This flag alters that behaviour in two ways:
>
> 1. *Only* tests marked 'xfail' are run.
> 2. The results of these tests are reported as if they weren't marked 'xfail'.
>
> This commit updates the help to describe point 1 above; point 2 is implied.

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] ~~Target the `features` branch for new features and removals/deprecations.~~
- [ ] ~~Include documentation when adding new features.~~
- [ ] ~~Include new tests or update existing tests when applicable.~~