### PR TITLE
doc: fix hooks 'path' parameter doc type

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ Christopher Gilling
 Christopher Dignam
 CrazyMerlyn
 Cyrus Maden
+Damian Skrzypczak
 Dhiren Serai
 Daniel Grana
 Daniel Hahler

--- a/changelog/5171.doc.rst
+++ b/changelog/5171.doc.rst
@@ -1,0 +1,1 @@
+Doc: ``pytest_ignore_collect``, ``pytest_collect_directory``, ``pytest_collect_file`` and ``pytest_pycollect_makemodule`` hooks's 'path' parameter documented type is now ``py.path.local``

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -188,7 +188,7 @@ def pytest_ignore_collect(path, config):
 
     Stops at first non-None result, see :ref:`firstresult`
 
-    :param str path: the path to analyze
+    :param path: a :py:class:`py.path.local` - the path to analyze
     :param _pytest.config.Config config: pytest config object
     """
 
@@ -199,7 +199,7 @@ def pytest_collect_directory(path, parent):
 
     Stops at first non-None result, see :ref:`firstresult`
 
-    :param str path: the path to analyze
+    :param path: a :py:class:`py.path.local` - the path to analyze
     """
 
 
@@ -207,7 +207,7 @@ def pytest_collect_file(path, parent):
     """ return collection Node or None for the given path. Any new node
     needs to have the specified ``parent`` as a parent.
 
-    :param str path: the path to collect
+    :param path: a :py:class:`py.path.local` - the path to collect
     """
 
 
@@ -249,7 +249,10 @@ def pytest_pycollect_makemodule(path, parent):
     The pytest_collect_file hook needs to be used if you want to
     create test modules for files that do not match as a test module.
 
-    Stops at first non-None result, see :ref:`firstresult` """
+    Stops at first non-None result, see :ref:`firstresult`
+
+    :param path: a :py:class:`py.path.local` - the path of module to collect
+    """
 
 
 @hookspec(firstresult=True)


### PR DESCRIPTION
by changing it from str to py.path.local
(#5171)

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs.
(please delete this text from the final description, this is just a guideline)
-->

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Add yourself to `AUTHORS` in alphabetical order;
