### PR TITLE
Emit a warning for record_property when used with xunit2

### DIFF
--- a/changelog/5202.trivial.rst
+++ b/changelog/5202.trivial.rst
@@ -1,0 +1,4 @@
+``record_property`` now emits a ``PytestWarning`` when used with ``junit_family=xunit2``: the fixture generates
+``property`` tags as children of ``testcase``, which is not permitted according to the most
+`recent schema <https://github.com/jenkinsci/xunit-plugin/blob/master/
+src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd>`__.


### PR DESCRIPTION
`property` elements cannot be children of `testsuite` according to the schema, so it is incompatible with xunit2

Related to #5202

cc @danilomendesdias