### PR TITLE
Update Black URLs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 exclude: doc/en/example/py2py3/test_py2.py
 repos:
--   repo: https://github.com/ambv/black
+-   repo: https://github.com/python/black
     rev: 19.3b0
     hooks:
     -   id: black

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -166,7 +166,7 @@ Short version
 #. Enable and install `pre-commit <https://pre-commit.com>`_ to ensure style-guides and code checks are followed.
 #. Target ``master`` for bugfixes and doc changes.
 #. Target ``features`` for new features or functionality changes.
-#. Follow **PEP-8** for naming and `black <https://github.com/ambv/black>`_ for formatting.
+#. Follow **PEP-8** for naming and `black <https://github.com/python/black>`_ for formatting.
 #. Tests are run using ``tox``::
 
     tox -e linting,py27,py37

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@
     :target: https://dev.azure.com/pytest-dev/pytest
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-    :target: https://github.com/ambv/black
+    :target: https://github.com/python/black
 
 .. image:: https://www.codetriage.com/pytest-dev/pytest/badges/users.svg
     :target: https://www.codetriage.com/pytest-dev/pytest


### PR DESCRIPTION
> Black, your uncompromising #Python code formatter, was a project
> created with the community in mind from Day 1. Today we moved it under
> the PSF umbrella. It's now available on GitHub under
> https://github.com/python/black/ . You install and use it just like
> before.

https://twitter.com/llanga/status/1123980466292445190