### PR TITLE
Add links to pytest.raises `message` workaround

### DIFF
--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -19,6 +19,8 @@ Below is a complete list of all pytest features which are considered deprecated.
 :class:`_pytest.warning_types.PytestWarning` or subclasses, which can be filtered using
 :ref:`standard warning filters <warnings>`.
 
+.. _`raises message deprecated`:
+
 ``"message"`` parameter of ``pytest.raises``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -83,7 +83,7 @@ Run multiple tests
 Assert that a certain exception is raised
 --------------------------------------------------------------
 
-Use the ``raises`` helper to assert that some code raises an exception::
+Use the :ref:`raises <assertraises>` helper to assert that some code raises an exception::
 
     # content of test_sysexit.py
     import pytest

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -561,7 +561,7 @@ def raises(expected_exception, *args, **kwargs):
     :kwparam match: if specified, asserts that the exception matches a text or regex
 
     :kwparam message: **(deprecated since 4.1)** if specified, provides a custom failure message
-        if the exception is not raised
+        if the exception is not raised. See :ref:`the deprecation docs <raises message deprecated>` for a workaround.
 
     .. currentmodule:: _pytest._code
 
@@ -597,6 +597,7 @@ def raises(expected_exception, *args, **kwargs):
         ``message`` to specify a custom failure message that will be displayed
         in case the ``pytest.raises`` check fails. This has been deprecated as it
         is considered error prone as users often mean to use ``match`` instead.
+        See :ref:`the deprecation docs <raises message deprecated>` for a workaround.
 
     .. note::
 


### PR DESCRIPTION
Related to #3974
