### PR TITLE
Show fixture scopes with ``--fixtures``, except for "function" scope

### DIFF
--- a/changelog/5220.feature.rst
+++ b/changelog/5220.feature.rst
@@ -1,0 +1,1 @@
+``--fixtures`` now also shows fixture scope for scopes other than ``"function"``.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1342,17 +1342,19 @@ def _showfixtures_main(config, session):
                 currentmodule = module
         if verbose <= 0 and argname[0] == "_":
             continue
+        tw.write(argname, green=True)
+        if fixturedef.scope != "function":
+            tw.write(" [%s scope]" % fixturedef.scope, cyan=True)
         if verbose > 0:
-            funcargspec = "%s -- %s" % (argname, bestrel)
-        else:
-            funcargspec = argname
-        tw.line(funcargspec, green=True)
+            tw.write(" -- %s" % bestrel, yellow=True)
+        tw.write("\n")
         loc = getlocation(fixturedef.func, curdir)
         doc = fixturedef.func.__doc__ or ""
         if doc:
             write_docstring(tw, doc)
         else:
             tw.line("    %s: no docstring available" % (loc,), red=True)
+        tw.line()
 
 
 def write_docstring(tw, doc, indent="    "):

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -3037,11 +3037,25 @@ class TestShowFixtures(object):
 
     def test_show_fixtures(self, testdir):
         result = testdir.runpytest("--fixtures")
-        result.stdout.fnmatch_lines(["*tmpdir*", "*temporary directory*"])
+        result.stdout.fnmatch_lines(
+            [
+                "tmpdir_factory [[]session scope[]]",
+                "*for the test session*",
+                "tmpdir",
+                "*temporary directory*",
+            ]
+        )
 
     def test_show_fixtures_verbose(self, testdir):
         result = testdir.runpytest("--fixtures", "-v")
-        result.stdout.fnmatch_lines(["*tmpdir*--*tmpdir.py*", "*temporary directory*"])
+        result.stdout.fnmatch_lines(
+            [
+                "tmpdir_factory [[]session scope[]] -- *tmpdir.py*",
+                "*for the test session*",
+                "tmpdir -- *tmpdir.py*",
+                "*temporary directory*",
+            ]
+        )
 
     def test_show_fixtures_testmodule(self, testdir):
         p = testdir.makepyfile(


### PR DESCRIPTION
Fix #5220

Screenshots:

```
$ pytest --fixtures 
```

![image](https://user-images.githubusercontent.com/1085180/57259468-256dab80-7036-11e9-8c67-31b821eeec0c.png)

```
$ pytest --fixtures -v
```

![image](https://user-images.githubusercontent.com/1085180/57259487-3ae2d580-7036-11e9-94e1-c1bdf1d06a30.png)

