### PR TITLE
 Clarify docs for pytest.raises `match`.

### DIFF
--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -558,12 +558,12 @@ def raises(expected_exception, *args, **kwargs):
     Assert that a code block/function call raises ``expected_exception``
     or raise a failure exception otherwise.
 
-    :kwparam match: if specified, a string containing a regular expression, 
-        or a regular expression object, that is tested against the string 
-        representation of the exception using ``re.match``. To match a literal 
-        string that may contain `special characters`__, the pattern can 
+    :kwparam match: if specified, a string containing a regular expression,
+        or a regular expression object, that is tested against the string
+        representation of the exception using ``re.match``. To match a literal
+        string that may contain `special characters`__, the pattern can
         first be escaped with ``re.escape``.
-        
+
     __ https://docs.python.org/3/library/re.html#regular-expression-syntax
 
     :kwparam message: **(deprecated since 4.1)** if specified, provides a custom failure message

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -558,7 +558,13 @@ def raises(expected_exception, *args, **kwargs):
     Assert that a code block/function call raises ``expected_exception``
     or raise a failure exception otherwise.
 
-    :kwparam match: if specified, asserts that the exception matches a text or regex
+    :kwparam match: if specified, a string containing a regular expression, 
+        or a regular expression object, that is tested against the string 
+        representation of the exception using ``re.match``. To match a literal 
+        string that may contain ``special characters``__, the pattern can 
+        first be escaped with ``re.escape``.
+        
+    __ https://docs.python.org/3/library/re.html#regular-expression-syntax
 
     :kwparam message: **(deprecated since 4.1)** if specified, provides a custom failure message
         if the exception is not raised. See :ref:`the deprecation docs <raises message deprecated>` for a workaround.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -561,7 +561,7 @@ def raises(expected_exception, *args, **kwargs):
     :kwparam match: if specified, a string containing a regular expression, 
         or a regular expression object, that is tested against the string 
         representation of the exception using ``re.match``. To match a literal 
-        string that may contain ``special characters``__, the pattern can 
+        string that may contain `special characters`__, the pattern can 
         first be escaped with ``re.escape``.
         
     __ https://docs.python.org/3/library/re.html#regular-expression-syntax


### PR DESCRIPTION
Fix #5208.

Document explicit behavior of `match` and brief note on how to handle matching a string that may contain special re chars.