### PR TITLE
Use exec directly

### DIFF
--- a/bench/empty.py
+++ b/bench/empty.py
@@ -1,4 +1,2 @@
-import six
-
 for i in range(1000):
-    six.exec_("def test_func_%d(): pass" % i)
+    exec("def test_func_%d(): pass" % i)

--- a/doc/en/example/assertion/failure_demo.py
+++ b/doc/en/example/assertion/failure_demo.py
@@ -1,5 +1,3 @@
-import six
-
 import _pytest._code
 import pytest
 from pytest import raises
@@ -199,7 +197,7 @@ def test_dynamic_compile_shows_nicely():
     name = "abc-123"
     module = imp.new_module(name)
     code = _pytest._code.compile(src, name, "exec")
-    six.exec_(code, module.__dict__)
+    exec(code, module.__dict__)
     sys.modules[name] = module
     module.foo()
 

--- a/doc/en/example/reportingdemo.rst
+++ b/doc/en/example/reportingdemo.rst
@@ -460,7 +460,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
             name = "abc-123"
             module = imp.new_module(name)
             code = _pytest._code.compile(src, name, "exec")
-            six.exec_(code, module.__dict__)
+            exec(code, module.__dict__)
             sys.modules[name] = module
     >       module.foo()
 

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -13,7 +13,6 @@ from weakref import ref
 import attr
 import pluggy
 import py
-import six
 from six import text_type
 
 import _pytest
@@ -138,7 +137,7 @@ class Frame(object):
         """
         f_locals = self.f_locals.copy()
         f_locals.update(vars)
-        six.exec_(code, self.f_globals, f_locals)
+        exec(code, self.f_globals, f_locals)
 
     def repr(self, object):
         """ return a 'safe' (non-recursive, one-line) string repr for 'object'

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -296,7 +296,7 @@ class AssertionRewritingHook(object):
             mod.__loader__ = self
             # Normally, this attribute is 3.4+
             mod.__spec__ = spec_from_file_location(name, co.co_filename, loader=self)
-            six.exec_(co, mod.__dict__)
+            exec(co, mod.__dict__)
         except:  # noqa
             if name in sys.modules:
                 del sys.modules[name]

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -7,7 +7,6 @@ import warnings
 from decimal import Decimal
 from numbers import Number
 
-import six
 from more_itertools.more import always_iterable
 from six.moves import filterfalse
 from six.moves import zip
@@ -702,7 +701,7 @@ def raises(expected_exception, *args, **kwargs):
         # print "raises frame scope: %r" % frame.f_locals
         try:
             code = _pytest._code.Source(code).compile(_genframe=frame)
-            six.exec_(code, frame.f_globals, loc)
+            exec(code, frame.f_globals, loc)
             # XXX didn't mean f_globals == f_locals something special?
             #     this is destroyed here ...
         except expected_exception:

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -102,7 +102,7 @@ def warns(expected_warning, *args, **kwargs):
 
         with WarningsChecker(expected_warning):
             code = _pytest._code.Source(code).compile()
-            six.exec_(code, frame.f_globals, loc)
+            exec(code, frame.f_globals, loc)
     else:
         func = args[0]
         with WarningsChecker(expected_warning):

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -312,7 +312,7 @@ class TestSourceParsingAndCompiling(object):
 
     def test_compile_and_getsource(self):
         co = self.source.compile()
-        six.exec_(co, globals())
+        exec(co, globals())
         f(7)
         excinfo = pytest.raises(AssertionError, f, 6)
         frame = excinfo.traceback[-1].frame
@@ -376,7 +376,7 @@ def test_getfuncsource_dynamic():
         def g(): pass
     """
     co = _pytest._code.compile(source)
-    six.exec_(co, globals())
+    exec(co, globals())
     assert str(_pytest._code.Source(f)).strip() == "def f():\n    raise ValueError"
     assert str(_pytest._code.Source(g)).strip() == "def g(): pass"
 

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -52,7 +52,7 @@ def getmsg(f, extra_ns=None, must_pass=False):
     ns = {}
     if extra_ns is not None:
         ns.update(extra_ns)
-    six.exec_(code, ns)
+    exec(code, ns)
     func = ns[f.__name__]
     try:
         func()


### PR DESCRIPTION
Apparently this has always worked, and I just assumed that six was providing the shim for a good reason 🤷‍♂ 

```console
$ ./bin/python1.0.1 
Python 1.0.1 (May  6 2019)
Copyright 1991-1994 Stichting Mathematisch Centrum, Amsterdam
>>> x = {}
>>> exec('y = 5', x)
>>> x['y']
5
```