### PR TITLE
logging: improve default logging format (issue5214)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -194,6 +194,7 @@ Paweł Adamczak
 Pedro Algarvio
 Pieter Mulder
 Piotr Banaszkiewicz
+Pulkit Goyal
 Punyashloka Biswal
 Quentin Pradet
 Ralf Schmitt

--- a/changelog/5214.feature.rst
+++ b/changelog/5214.feature.rst
@@ -1,0 +1,10 @@
+The default logging format has been changed to improve readability. Here is an
+example of a previous logging message::
+
+    test_log_cli_enabled_disabled.py    3 CRITICAL critical message logged by test
+
+This has now become::
+
+    CRITICAL root:test_log_cli_enabled_disabled.py:3 critical message logged by test
+
+The formatting can be changed through the `log_format <https://docs.pytest.org/en/latest/reference.html#confval-log_format>`__ configuration option.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -15,7 +15,7 @@ from _pytest.compat import dummy_context_manager
 from _pytest.config import create_terminal_writer
 from _pytest.pathlib import Path
 
-DEFAULT_LOG_FORMAT = "%(filename)-25s %(lineno)4d %(levelname)-8s %(message)s"
+DEFAULT_LOG_FORMAT = "%(levelname)-8s %(name)s:%(filename)s:%(lineno)d %(message)s"
 DEFAULT_LOG_DATE_FORMAT = "%H:%M:%S"
 
 

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -248,7 +248,7 @@ def test_log_cli_enabled_disabled(testdir, enabled):
             [
                 "test_log_cli_enabled_disabled.py::test_log_cli ",
                 "*-- live log call --*",
-                "test_log_cli_enabled_disabled.py* CRITICAL critical message logged by test",
+                "CRITICAL *test_log_cli_enabled_disabled.py* critical message logged by test",
                 "PASSED*",
             ]
         )
@@ -282,7 +282,7 @@ def test_log_cli_default_level(testdir):
     result.stdout.fnmatch_lines(
         [
             "test_log_cli_default_level.py::test_log_cli ",
-            "test_log_cli_default_level.py*WARNING message will be shown*",
+            "WARNING*test_log_cli_default_level.py* message will be shown*",
         ]
     )
     assert "INFO message won't be shown" not in result.stdout.str()
@@ -523,7 +523,7 @@ def test_sections_single_new_line_after_test_outcome(testdir, request):
     )
     assert (
         re.search(
-            r"(.+)live log teardown(.+)\n(.+)WARNING(.+)\n(.+)WARNING(.+)",
+            r"(.+)live log teardown(.+)\nWARNING(.+)\nWARNING(.+)",
             result.stdout.str(),
             re.MULTILINE,
         )
@@ -531,7 +531,7 @@ def test_sections_single_new_line_after_test_outcome(testdir, request):
     )
     assert (
         re.search(
-            r"(.+)live log finish(.+)\n(.+)WARNING(.+)\n(.+)WARNING(.+)",
+            r"(.+)live log finish(.+)\nWARNING(.+)\nWARNING(.+)",
             result.stdout.str(),
             re.MULTILINE,
         )
@@ -565,7 +565,7 @@ def test_log_cli_level(testdir):
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
         [
-            "test_log_cli_level.py*This log message will be shown",
+            "*test_log_cli_level.py*This log message will be shown",
             "PASSED",  # 'PASSED' on its own line because the log message prints a new line
         ]
     )
@@ -579,7 +579,7 @@ def test_log_cli_level(testdir):
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
         [
-            "test_log_cli_level.py* This log message will be shown",
+            "*test_log_cli_level.py* This log message will be shown",
             "PASSED",  # 'PASSED' on its own line because the log message prints a new line
         ]
     )
@@ -615,7 +615,7 @@ def test_log_cli_ini_level(testdir):
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
         [
-            "test_log_cli_ini_level.py* This log message will be shown",
+            "*test_log_cli_ini_level.py* This log message will be shown",
             "PASSED",  # 'PASSED' on its own line because the log message prints a new line
         ]
     )


### PR DESCRIPTION
We improve the following things in the logging format:

  * Show module name instead of just the filename
  * show level of logging as the first thing
  * show lineno attached to module:file details

Thanks to @blueyed who suggested this on the github issue.

It's my first contribution and I have added myself to AUTHORS.

I also added to a changelog file.

Fix #5214

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features and removals/deprecations.
- [ ] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS` in alphabetical order;
