### PR TITLE
Require pluggy>=0.11

### DIFF
--- a/changelog/5229.bugfix.rst
+++ b/changelog/5229.bugfix.rst
@@ -1,0 +1,2 @@
+Require ``pluggy>=0.11.0`` which reverts a dependency to ``importlib-metadata`` added in ``0.10.0``.
+The ``importlib-metadata`` package cannot be imported when installed as an egg and causes issues when relying on ``setup.py`` to install test dependencies.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ INSTALL_REQUIRES = [
     'funcsigs>=1.0;python_version<"3.0"',
     'pathlib2>=2.2.0;python_version<"3.6"',
     'colorama;sys_platform=="win32"',
-    "pluggy>=0.9",
+    "pluggy>=0.11",
 ]
 
 


### PR DESCRIPTION
Pluggy 0.10.0 introduced a new dependency `importlib-metadata` but that package cannot be imported when installed as an egg and that is causing problems for users relying on `setup.py` to install packages present in `test_require`. This change was quickly reverted in pluggy 0.11.0.

See https://github.com/pytest-dev/pluggy/issues/205

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs.
(please delete this text from the final description, this is just a guideline)
-->

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [x] Target the `features` branch for new features and removals/deprecations.
- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS` in alphabetical order;
