### PR TITLE
Ignore PytestUnknownMark warning when generating docs

### DIFF
--- a/doc/en/Makefile
+++ b/doc/en/Makefile
@@ -43,7 +43,7 @@ clean:
 
 regen: REGENDOC_FILES:=*.rst */*.rst
 regen:
-	PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS=-pno:hypothesis COLUMNS=76 regendoc --update ${REGENDOC_FILES} ${REGENDOC_ARGS}
+	PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS="-pno:hypothesis -Wignore::pytest.PytestUnknownMarkWarning" COLUMNS=76 regendoc --update ${REGENDOC_FILES} ${REGENDOC_ARGS}
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/doc/en/builtin.rst
+++ b/doc/en/builtin.rst
@@ -27,33 +27,39 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
         name of your plugin or application to avoid clashes with other cache users.
 
         Values can be any object handled by the json stdlib module.
+
     capsys
         Enable text capturing of writes to ``sys.stdout`` and ``sys.stderr``.
 
         The captured output is made available via ``capsys.readouterr()`` method
         calls, which return a ``(out, err)`` namedtuple.
         ``out`` and ``err`` will be ``text`` objects.
+
     capsysbinary
         Enable bytes capturing of writes to ``sys.stdout`` and ``sys.stderr``.
 
         The captured output is made available via ``capsysbinary.readouterr()``
         method calls, which return a ``(out, err)`` namedtuple.
         ``out`` and ``err`` will be ``bytes`` objects.
+
     capfd
         Enable text capturing of writes to file descriptors ``1`` and ``2``.
 
         The captured output is made available via ``capfd.readouterr()`` method
         calls, which return a ``(out, err)`` namedtuple.
         ``out`` and ``err`` will be ``text`` objects.
+
     capfdbinary
         Enable bytes capturing of writes to file descriptors ``1`` and ``2``.
 
         The captured output is made available via ``capfd.readouterr()`` method
         calls, which return a ``(out, err)`` namedtuple.
         ``out`` and ``err`` will be ``byte`` objects.
-    doctest_namespace
+
+    doctest_namespace [session scope]
         Fixture that returns a :py:class:`dict` that will be injected into the namespace of doctests.
-    pytestconfig
+
+    pytestconfig [session scope]
         Session-scoped fixture that returns the :class:`_pytest.config.Config` object.
 
         Example::
@@ -61,6 +67,7 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
             def test_foo(pytestconfig):
                 if pytestconfig.getoption("verbose") > 0:
                     ...
+
     record_property
         Add an extra properties the calling test.
         User properties become part of the test report and are available to the
@@ -72,10 +79,12 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
 
             def test_function(record_property):
                 record_property("example_key", 1)
+
     record_xml_attribute
         Add extra xml attributes to the tag for the calling test.
         The fixture is callable with ``(name, value)``, with value being
         automatically xml-encoded
+
     caplog
         Access and control log capturing.
 
@@ -85,6 +94,7 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
         * caplog.records         -> list of logging.LogRecord instances
         * caplog.record_tuples   -> list of (logger_name, level, message) tuples
         * caplog.clear()         -> clear captured records and formatted log output string
+
     monkeypatch
         The returned ``monkeypatch`` fixture provides these
         helper methods to modify objects, dictionaries or os.environ::
@@ -102,15 +112,19 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
         test function or fixture has finished. The ``raising``
         parameter determines if a KeyError or AttributeError
         will be raised if the set/deletion operation has no target.
+
     recwarn
         Return a :class:`WarningsRecorder` instance that records all warnings emitted by test functions.
 
         See http://docs.python.org/library/warnings.html for information
         on warning categories.
-    tmpdir_factory
+
+    tmpdir_factory [session scope]
         Return a :class:`_pytest.tmpdir.TempdirFactory` instance for the test session.
-    tmp_path_factory
+
+    tmp_path_factory [session scope]
         Return a :class:`_pytest.tmpdir.TempPathFactory` instance for the test session.
+
     tmpdir
         Return a temporary directory path object
         which is unique to each test function invocation,
@@ -119,6 +133,7 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
         path object.
 
         .. _`py.path.local`: https://py.readthedocs.io/en/latest/path.html
+
     tmp_path
         Return a temporary directory path object
         which is unique to each test function invocation,
@@ -129,6 +144,7 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
         .. note::
 
             in python < 3.6 this is a pathlib2.Path
+
 
     no tests ran in 0.12 seconds
 

--- a/doc/en/cache.rst
+++ b/doc/en/cache.rst
@@ -286,7 +286,7 @@ filtering:
     =========================== test session starts ============================
     platform linux -- Python 3.x.y, pytest-4.x.y, py-1.x.y, pluggy-0.x.y
     cachedir: $PYTHON_PREFIX/.pytest_cache
-    rootdir: $REGENDOC_TMPDIR, inifile:
+    rootdir: $REGENDOC_TMPDIR
     cachedir: $PYTHON_PREFIX/.pytest_cache
     ----------------------- cache values for 'example/*' -----------------------
     example/value contains:

--- a/doc/en/example/markers.rst
+++ b/doc/en/example/markers.rst
@@ -619,9 +619,9 @@ then you will see two tests skipped and two executed tests as expected:
     collected 4 items
 
     test_plat.py s.s.                                                    [100%]
+
     ========================= short test summary info ==========================
     SKIPPED [2] $REGENDOC_TMPDIR/conftest.py:13: cannot run on platform linux
-
     =================== 2 passed, 2 skipped in 0.12 seconds ====================
 
 Note that if you specify a platform via the marker-command line option like this:

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -492,9 +492,9 @@ If you run this with reporting for skips enabled:
     collected 2 items
 
     test_module.py .s                                                    [100%]
+
     ========================= short test summary info ==========================
     SKIPPED [1] $REGENDOC_TMPDIR/conftest.py:11: could not import 'opt2'
-
     =================== 1 passed, 1 skipped in 0.12 seconds ====================
 
 You'll see that we don't have an ``opt2`` module and thus the second test run

--- a/doc/en/example/reportingdemo.rst
+++ b/doc/en/example/reportingdemo.rst
@@ -182,9 +182,9 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     E         Omitting 1 identical items, use -vv to show
     E         Differing items:
     E         {'b': 1} != {'b': 2}
-    E         Left contains more items:
+    E         Left contains 1 more item:
     E         {'c': 0}
-    E         Right contains more items:
+    E         Right contains 1 more item:
     E         {'d': 0}...
     E
     E         ...Full output truncated (2 lines hidden), use '-vv' to show
@@ -215,7 +215,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
         def test_eq_longer_list(self):
     >       assert [1, 2] == [1, 2, 3]
     E       assert [1, 2] == [1, 2, 3]
-    E         Right contains more items, first extra item: 3
+    E         Right contains one more item: 3
     E         Use -v to get the full diff
 
     failure_demo.py:80: AssertionError

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -194,9 +194,9 @@ and when running it will see a skipped "slow" test:
     collected 2 items
 
     test_module.py .s                                                    [100%]
+
     ========================= short test summary info ==========================
     SKIPPED [1] test_module.py:8: need --runslow option to run
-
     =================== 1 passed, 1 skipped in 0.12 seconds ====================
 
 Or run it including the ``slow`` marked test:

--- a/doc/en/skipping.rst
+++ b/doc/en/skipping.rst
@@ -352,6 +352,7 @@ Running it with the report-on-xfail option gives this output:
     collected 7 items
 
     xfail_demo.py xxxxxxx                                                [100%]
+
     ========================= short test summary info ==========================
     XFAIL xfail_demo.py::test_hello
     XFAIL xfail_demo.py::test_hello2
@@ -365,7 +366,6 @@ Running it with the report-on-xfail option gives this output:
     XFAIL xfail_demo.py::test_hello6
       reason: reason
     XFAIL xfail_demo.py::test_hello7
-
     ======================== 7 xfailed in 0.12 seconds =========================
 
 .. _`skip/xfail with parametrize`:

--- a/doc/en/usage.rst
+++ b/doc/en/usage.rst
@@ -231,9 +231,9 @@ Example:
     XFAIL test_example.py::test_xfail
       reason: xfailing this test
     XPASS test_example.py::test_xpass always xfail
-    ERROR test_example.py::test_error
-    FAILED test_example.py::test_fail
-     1 failed, 1 passed, 1 skipped, 1 xfailed, 1 xpassed, 1 error in 0.12 seconds
+    ERROR test_example.py::test_error - assert 0
+    FAILED test_example.py::test_fail - assert 0
+    = 1 failed, 1 passed, 1 skipped, 1 xfailed, 1 xpassed, 1 error in 0.12 seconds =
 
 The ``-r`` options accepts a number of characters after it, with ``a`` used
 above meaning "all except passes".
@@ -281,9 +281,9 @@ More than one character can be used, so for example to only see failed and skipp
 
     test_example.py:14: AssertionError
     ========================= short test summary info ==========================
-    FAILED test_example.py::test_fail
+    FAILED test_example.py::test_fail - assert 0
     SKIPPED [1] $REGENDOC_TMPDIR/test_example.py:23: skipping this test
-     1 failed, 1 passed, 1 skipped, 1 xfailed, 1 xpassed, 1 error in 0.12 seconds
+    = 1 failed, 1 passed, 1 skipped, 1 xfailed, 1 xpassed, 1 error in 0.12 seconds =
 
 Using ``p`` lists the passing tests, whilst ``P`` adds an extra section "PASSES" with those tests that passed but had
 captured output:
@@ -316,13 +316,13 @@ captured output:
     E       assert 0
 
     test_example.py:14: AssertionError
-    ========================= short test summary info ==========================
-    PASSED test_example.py::test_ok
     ================================== PASSES ==================================
     _________________________________ test_ok __________________________________
     --------------------------- Captured stdout call ---------------------------
     ok
-     1 failed, 1 passed, 1 skipped, 1 xfailed, 1 xpassed, 1 error in 0.12 seconds
+    ========================= short test summary info ==========================
+    PASSED test_example.py::test_ok
+    = 1 failed, 1 passed, 1 skipped, 1 xfailed, 1 xpassed, 1 error in 0.12 seconds =
 
 .. _pdb-option:
 

--- a/doc/en/warnings.rst
+++ b/doc/en/warnings.rst
@@ -400,7 +400,7 @@ defines an ``__init__`` constructor, as this prevents the class from being insta
 
     ============================= warnings summary =============================
     test_pytest_warnings.py:1
-      $REGENDOC_TMPDIR/test_pytest_warnings.py:1: PytestWarning: cannot collect test class 'Test' because it has a __init__ constructor
+      $REGENDOC_TMPDIR/test_pytest_warnings.py:1: PytestCollectionWarning: cannot collect test class 'Test' because it has a __init__ constructor
         class Test:
 
     -- Docs: https://docs.pytest.org/en/latest/warnings.html


### PR DESCRIPTION
Given that our examples use a lot of custom marks, they end up generating a lot of warnings which are only noise in the documentation.