### PR TITLE
[RFC] _get_line_with_reprcrash_message: remove duplicate prefix

### DIFF
--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -1167,6 +1167,9 @@ def test_summary_list_after_errors(testdir):
         import pytest
         def test_fail():
             assert 0
+
+        def test_pytest_fail():
+            pytest.fail("fail exc")
     """
     )
     result = testdir.runpytest("-ra")
@@ -1175,5 +1178,6 @@ def test_summary_list_after_errors(testdir):
             "=* FAILURES *=",
             "*= short test summary info =*",
             "FAILED test_summary_list_after_errors.py::test_fail - assert 0",
+            "FAILED test_summary_list_after_errors.py::test_pytest_fail - fail exc",
         ]
     )


### PR DESCRIPTION
Before:

> FAILED foo/test.py::test_bar - Failed: Database access not allowed, …

After:

> FAILED foo/test.py::test_bar - Database access not allowed, …

No changelog, not yet released.. \o/ ;)