### PR TITLE
Pin pluggy to <1.0

### DIFF
--- a/changelog/5239.trivial.rst
+++ b/changelog/5239.trivial.rst
@@ -1,0 +1,3 @@
+Pin ``pluggy`` to ``< 1.0`` so we don't update to ``1.0`` automatically when
+it gets released: there are planned breaking changes, and we want to ensure
+pytest properly supports ``pluggy 1.0``.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ INSTALL_REQUIRES = [
     'funcsigs>=1.0;python_version<"3.0"',
     'pathlib2>=2.2.0;python_version<"3.6"',
     'colorama;sys_platform=="win32"',
-    "pluggy>=0.11",
+    "pluggy>=0.9,!=0.10,<1.0",
 ]
 
 


### PR DESCRIPTION
Make sure we don't update to pluggy 1.0 automatically, as there are planned breaking
changes in the 1.0 release.

Follow up to https://github.com/pytest-dev/pytest/pull/5229#issuecomment-490648714.