### PR TITLE
Add Tidelift management docs and blurb on README, as discussed in the ML

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     -   id: rst
         name: rst
         entry: rst-lint --encoding utf-8
-        files: ^(CHANGELOG.rst|HOWTORELEASE.rst|README.rst|changelog/.*)$
+        files: ^(CHANGELOG.rst|HOWTORELEASE.rst|README.rst|TIDELIFT.rst|changelog/.*)$
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]
     -   id: changelogs-rst

--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,26 @@ Changelog
 Consult the `Changelog <https://docs.pytest.org/en/latest/changelog.html>`__ page for fixes and enhancements of each version.
 
 
+Support pytest
+--------------
+
+You can support pytest by obtaining a `Tideflift subscription`_.
+
+Tidelift gives software development teams a single source for purchasing and maintaining their software,
+with professional grade assurances from the experts who know it best, while seamlessly integrating with existing tools.
+
+
+.. _`Tideflift subscription`: https://tidelift.com/subscription/pkg/pypi-pytest?utm_source=pypi-pytest&utm_medium=referral&utm_campaign=readme
+
+
+Security
+^^^^^^^^
+
+pytest has never been associated with a security vunerability, but in any case, to report a
+security vulnerability please use the `Tidelift security contact <https://tidelift.com/security>`_.
+Tidelift will coordinate the fix and disclosure.
+
+
 License
 -------
 

--- a/TIDELIFT.rst
+++ b/TIDELIFT.rst
@@ -1,0 +1,57 @@
+========
+Tidelift
+========
+
+pytest is a member of `Tidelift`_. This document describes how the core team manages
+Tidelift-related activities.
+
+What is it
+==========
+
+Tidelift aims to make Open Source sustainable by offering subscriptions to companies which rely
+on Open Source packages. This subscription allows it to pay maintainers of those Open Source
+packages to aid sustainability of the work.
+
+Funds
+=====
+
+It was decided in the `mailing list`_ that the Tidelift contribution will be split evenly between
+members of the `contributors team`_ interested in receiving funding.
+
+The current list of contributors receiving funding are:
+
+* `@asottile`_
+* `@blueyed`_
+* `@nicoddemus`_
+
+Contributors interested in receiving a part of the funds just need to submit a PR adding their
+name to the list. Contributors that want to stop receiving the funds should also submit a PR
+in the same way.
+
+The PR should mention `@pytest-dev/tidelift-admins`_ so appropriate changes
+can be made in the Tidelift platform.
+
+After the PR has been accepted and merged, the contributor should register in the `Tidelift`_
+platform and follow the instructions there, including signing an `agreement`_.
+
+Admins
+======
+
+A few people have admin access to the Tidelift dashboard to make changes. Those people
+are part of the `@pytest-dev/tidelift-admins`_ team.
+
+`Core contributors`_ interested in helping out with Tidelift maintenance are welcome! We don't
+expect much work here other than the occasional adding/removal of a contributor from receiving
+funds. Just drop a line to one of the `@pytest-dev/tidelift-admins`_ or use the mailing list.
+
+
+.. _`Tidelift`: https://tidelift.com
+.. _`mailing list`: https://mail.python.org/pipermail/pytest-dev/2019-May/004716.html
+.. _`contributors team`: https://github.com/orgs/pytest-dev/teams/contributors
+.. _`core contributors`: https://github.com/orgs/pytest-dev/teams/core/members
+.. _`@pytest-dev/tidelift-admins`: https://github.com/orgs/pytest-dev/teams/tidelift-admins/members
+.. _`agreement`: https://tidelift.com/docs/lifting/agreement
+
+.. _`@asottile`: https://github.com/asottile
+.. _`@blueyed`: https://github.com/blueyed
+.. _`@nicoddemus`: https://github.com/nicoddemus


### PR DESCRIPTION
As discussed in the ML, adding a document describing how we plan to split the funds, and how maintainers can start/stop receiving funding.

A quick draft, so suggestions on the docs are very welcome!

@asottile and @blueyed can already start their subscription process. Payments occur at the end of each month.

@RonnyPfannschmidt would you also like to join right now?

---

I created @pytest-dev/tidelift-admins to list the people which can make changes to Tidelift. What do you folks think?

cc @kszu