### PR TITLE
WIP/RFC pdb: fix usage in child thread after main thread exited

### DIFF
--- a/changelog/5228.bugfix.rst
+++ b/changelog/5228.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``pdb.set_trace`` wrapper when used in child threads after main thread exited.

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -77,9 +77,7 @@ def pytest_configure(config):
     if config.getvalue("usepdb"):
         config.pluginmanager.register(PdbInvoke(), "pdbinvoke")
 
-    pytestPDB._saved.append(
-        (pdb.set_trace, pytestPDB._pluginmanager, pytestPDB._config, pytestPDB._pdb_cls)
-    )
+    pytestPDB._saved.append(pdb.set_trace)
     pdb.set_trace = pytestPDB.set_trace
     pytestPDB._pluginmanager = config.pluginmanager
     pytestPDB._config = config
@@ -88,12 +86,7 @@ def pytest_configure(config):
     # NOTE: not using pytest_unconfigure, since it might get called although
     #       pytest_configure was not (if another plugin raises UsageError).
     def fin():
-        (
-            pdb.set_trace,
-            pytestPDB._pluginmanager,
-            pytestPDB._config,
-            pytestPDB._pdb_cls,
-        ) = pytestPDB._saved.pop()
+        pdb.set_trace = pytestPDB._saved.pop()
 
     config._cleanup.append(fin)
 


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/issues/5228.

(not done against master to avoid conflicts)