### PR TITLE
tests: fix test_trace_after_runpytest

### DIFF
--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1027,24 +1027,28 @@ def test_trace_after_runpytest(testdir):
         from _pytest.debugging import pytestPDB
 
         def test_outer(testdir):
-            from _pytest.debugging import pytestPDB
-
             assert len(pytestPDB._saved) == 1
 
-            testdir.runpytest("-k test_inner")
+            testdir.makepyfile(
+                \"""
+                from _pytest.debugging import pytestPDB
 
-            __import__('pdb').set_trace()
+                def test_inner():
+                    assert len(pytestPDB._saved) == 2
+                    print()
+                    print("test_inner_" + "end")
+                \"""
+            )
 
-        def test_inner(testdir):
-            assert len(pytestPDB._saved) == 2
+            result = testdir.runpytest("-s", "-k", "test_inner")
+            assert result.ret == 0
+
+            assert len(pytestPDB._saved) == 1
     """
     )
-    child = testdir.spawn_pytest("-p pytester %s -k test_outer" % p1)
-    child.expect(r"\(Pdb")
-    child.sendline("c")
-    rest = child.read().decode("utf8")
-    TestPDB.flush(child)
-    assert child.exitstatus == 0, rest
+    result = testdir.runpytest_subprocess("-s", "-p", "pytester", str(p1))
+    result.stdout.fnmatch_lines(["test_inner_end"])
+    assert result.ret == 0
 
 
 def test_quit_with_swallowed_SystemExit(testdir):


### PR DESCRIPTION
It was not really testing what it was supposed to test (e.g. the inner
test was not run in the first place).