### PR TITLE
Avoiding looking upwards for parameter argnames when generating fixtu…

### DIFF
--- a/changelog/5036.bugfix.rst
+++ b/changelog/5036.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue where fixtures dependent on other parametrized fixtures would be erroneously parametrized.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -103,8 +103,11 @@ class ParameterSet(namedtuple("ParameterSet", "values, marks, id")):
         else:
             return cls(parameterset, marks=[], id=None)
 
-    @classmethod
-    def _for_parametrize(cls, argnames, argvalues, func, config, function_definition):
+    @staticmethod
+    def _parse_parametrize_args(argnames, argvalues, **_):
+        """It receives an ignored _ (kwargs) argument so this function can
+        take also calls from parametrize ignoring scope, indirect, and other
+        arguments..."""
         if not isinstance(argnames, (tuple, list)):
             argnames = [x.strip() for x in argnames.split(",") if x.strip()]
             force_tuple = len(argnames) == 1
@@ -113,6 +116,11 @@ class ParameterSet(namedtuple("ParameterSet", "values, marks, id")):
         parameters = [
             ParameterSet.extract_from(x, force_tuple=force_tuple) for x in argvalues
         ]
+        return argnames, parameters
+
+    @classmethod
+    def _for_parametrize(cls, argnames, argvalues, func, config, function_definition):
+        argnames, parameters = cls._parse_parametrize_args(argnames, argvalues)
         del argvalues
 
         if parameters:


### PR DESCRIPTION
…reinfo.

Closes #5036 

Basically even though there is code to check if a fixture is a parameter name:

https://github.com/pytest-dev/pytest/blob/6a43c8cd9405c68e223f4c6270bd1e1ac4bc8c5f/src/_pytest/fixtures.py#L1218-L1231

The problem is that any other higher level dependant fixtures would also be included in the 
 `metafunc.fixturenames` for the function, and because of course the name of this higher fixture does not match the parametrization parameter, the function would be erroneously additionally parametrized.

///

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [x] Target the `features` branch for new features and removals/deprecations.
- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Add yourself to `AUTHORS` in alphabetical order;
