### PR TITLE
ci: tox: fix py37-freeze

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -118,7 +118,6 @@ commands =
 changedir = testing/freeze
 # Disable PEP 517 with pip, which does not work with PyInstaller currently.
 deps =
-    --no-use-pep517
     pyinstaller
 commands =
     {envpython} create_executable.py


### PR DESCRIPTION
Remove ``--no-use-pep517``, which appears to not be supported anymore,
and PyInstaller works without it by now.

Example build failure: https://travis-ci.org/pytest-dev/pytest/jobs/532103481#L220