### PR TITLE
Make it clear that small typos in docs don't require a CHANGELOG entry

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,6 @@ Here's a quick checklist that should be present in PRs.
 (please delete this text from the final description, this is just a guideline)
 -->
 
-- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
 - [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
 - [ ] Target the `features` branch for new features and removals/deprecations.
 - [ ] Include documentation when adding new features.
@@ -13,4 +12,5 @@ Here's a quick checklist that should be present in PRs.
 
 Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:
 
+- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
 - [ ] Add yourself to `AUTHORS` in alphabetical order;


### PR DESCRIPTION
From: https://github.com/pytest-dev/pytest/pull/5273#issuecomment-493076587
