### PR TITLE
Fix documentation of pytest.raises(match=...)

### DIFF
--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -564,10 +564,11 @@ class ExceptionInfo(object):
 
     def match(self, regexp):
         """
-        Match the regular expression 'regexp' on the string representation of
-        the exception. If it matches then True is returned (so that it is
-        possible to write 'assert excinfo.match()'). If it doesn't match an
-        AssertionError is raised.
+        Check whether the regular expression 'regexp' is found in the string
+        representation of the exception using ``re.search``. If it matches
+        then True is returned (so that it is possible to write
+        ``assert excinfo.match()``). If it doesn't match an AssertionError is
+        raised.
         """
         __tracebackhide__ = True
         if not re.search(regexp, str(self.value)):

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -559,7 +559,7 @@ def raises(expected_exception, *args, **kwargs):
 
     :kwparam match: if specified, a string containing a regular expression,
         or a regular expression object, that is tested against the string
-        representation of the exception using ``re.match``. To match a literal
+        representation of the exception using ``re.search``. To match a literal
         string that may contain `special characters`__, the pattern can
         first be escaped with ``re.escape``.
 


### PR DESCRIPTION
Clarify that `pytest.raises(match=...)` uses `re.search` and not `re.match`.
