### PR TITLE
pytester: use temporary HOME with spawn

### DIFF
--- a/changelog/4956.feature.rst
+++ b/changelog/4956.feature.rst
@@ -1,0 +1,1 @@
+pytester's ``testdir.spawn`` uses ``tmpdir`` as HOME/USERPROFILE directory.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1233,7 +1233,13 @@ class Testdir(object):
         if sys.platform.startswith("freebsd"):
             pytest.xfail("pexpect does not work reliably on freebsd")
         logfile = self.tmpdir.join("spawn.out").open("wb")
-        child = pexpect.spawn(cmd, logfile=logfile)
+
+        # Do not load user config.
+        env = os.environ.copy()
+        env["HOME"] = str(self.tmpdir)
+        env["USERPROFILE"] = env["HOME"]
+
+        child = pexpect.spawn(cmd, logfile=logfile, env=env)
         self.request.addfinalizer(logfile.close)
         child.timeout = expect_timeout
         return child

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -508,6 +508,10 @@ class Testdir(object):
         # Discard outer pytest options.
         mp.delenv("PYTEST_ADDOPTS", raising=False)
 
+        # Environment (updates) for inner runs.
+        tmphome = str(self.tmpdir)
+        self._env_run_update = {"HOME": tmphome, "USERPROFILE": tmphome}
+
     def __repr__(self):
         return "<Testdir %r>" % (self.tmpdir,)
 
@@ -804,8 +808,8 @@ class Testdir(object):
         try:
             # Do not load user config (during runs only).
             mp_run = MonkeyPatch()
-            mp_run.setenv("HOME", str(self.tmpdir))
-            mp_run.setenv("USERPROFILE", str(self.tmpdir))
+            for k, v in self._env_run_update.items():
+                mp_run.setenv(k, v)
             finalizers.append(mp_run.undo)
 
             # When running pytest inline any plugins active in the main test
@@ -1045,9 +1049,7 @@ class Testdir(object):
         env["PYTHONPATH"] = os.pathsep.join(
             filter(None, [os.getcwd(), env.get("PYTHONPATH", "")])
         )
-        # Do not load user config.
-        env["HOME"] = str(self.tmpdir)
-        env["USERPROFILE"] = env["HOME"]
+        env.update(self._env_run_update)
         kw["env"] = env
 
         if stdin is Testdir.CLOSE_STDIN:
@@ -1236,8 +1238,7 @@ class Testdir(object):
 
         # Do not load user config.
         env = os.environ.copy()
-        env["HOME"] = str(self.tmpdir)
-        env["USERPROFILE"] = env["HOME"]
+        env.update(self._env_run_update)
 
         child = pexpect.spawn(cmd, logfile=logfile, env=env)
         self.request.addfinalizer(logfile.close)

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -559,3 +559,26 @@ def test_popen_default_stdin_stderr_and_stdin_None(testdir):
     assert stdout.splitlines() == [b"", b"stdout"]
     assert stderr.splitlines() == [b"stderr"]
     assert proc.returncode == 0
+
+
+def test_spawn_uses_tmphome(testdir):
+    import os
+
+    tmphome = str(testdir.tmpdir)
+
+    # Does use HOME only during run.
+    assert os.environ.get("HOME") != tmphome
+
+    p1 = testdir.makepyfile(
+        """
+        import os
+
+        def test():
+            assert os.environ["HOME"] == {tmphome!r}
+        """.format(
+            tmphome=tmphome
+        )
+    )
+    child = testdir.spawn_pytest(str(p1))
+    out = child.read()
+    assert child.wait() == 0, out.decode("utf8")

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -569,12 +569,15 @@ def test_spawn_uses_tmphome(testdir):
     # Does use HOME only during run.
     assert os.environ.get("HOME") != tmphome
 
+    testdir._env_run_update["CUSTOMENV"] = "42"
+
     p1 = testdir.makepyfile(
         """
         import os
 
         def test():
             assert os.environ["HOME"] == {tmphome!r}
+            assert os.environ["CUSTOMENV"] == "42"
         """.format(
             tmphome=tmphome
         )


### PR DESCRIPTION
Followup to https://github.com/pytest-dev/pytest/issues/4956.