### PR TITLE
Use same code for setting up cli/non-cli formatter

### DIFF
--- a/changelog/5311.feature.rst
+++ b/changelog/5311.feature.rst
@@ -1,0 +1,2 @@
+Captured logs that are output for each failing test are formatted using the
+ColoredLevelFromatter.

--- a/changelog/5311.feature.rst
+++ b/changelog/5311.feature.rst
@@ -1,2 +1,2 @@
 Captured logs that are output for each failing test are formatted using the
-ColoredLevelFromatter.
+ColoredLevelFormatter.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -17,6 +17,11 @@ from _pytest.pathlib import Path
 
 DEFAULT_LOG_FORMAT = "%(levelname)-8s %(name)s:%(filename)s:%(lineno)d %(message)s"
 DEFAULT_LOG_DATE_FORMAT = "%H:%M:%S"
+_ANSI_ESCAPE_SEQ = re.compile(r"\x1b\[[\d;]+m")
+
+
+def _remove_ansi_escape_sequences(text):
+    return _ANSI_ESCAPE_SEQ.sub("", text)
 
 
 class ColoredLevelFormatter(logging.Formatter):
@@ -256,8 +261,8 @@ class LogCaptureFixture(object):
 
     @property
     def text(self):
-        """Returns the log text."""
-        return self.handler.stream.getvalue()
+        """Returns the formatted log text."""
+        return _remove_ansi_escape_sequences(self.handler.stream.getvalue())
 
     @property
     def records(self):
@@ -393,7 +398,7 @@ class LoggingPlugin(object):
             config.option.verbose = 1
 
         self.print_logs = get_option_ini(config, "log_print")
-        self.formatter = logging.Formatter(
+        self.formatter = self._create_formatter(
             get_option_ini(config, "log_format"),
             get_option_ini(config, "log_date_format"),
         )
@@ -427,6 +432,19 @@ class LoggingPlugin(object):
         if self._log_cli_enabled():
             self._setup_cli_logging()
 
+    def _create_formatter(self, log_format, log_date_format):
+        # color option doesn't exist if terminal plugin is disabled
+        color = getattr(self._config.option, "color", "no")
+        if color != "no" and ColoredLevelFormatter.LEVELNAME_FMT_REGEX.search(
+            log_format
+        ):
+            formatter = ColoredLevelFormatter(
+                create_terminal_writer(self._config), log_format, log_date_format
+            )
+        else:
+            formatter = logging.Formatter(log_format, log_date_format)
+        return formatter
+
     def _setup_cli_logging(self):
         config = self._config
         terminal_reporter = config.pluginmanager.get_plugin("terminalreporter")
@@ -437,23 +455,12 @@ class LoggingPlugin(object):
         capture_manager = config.pluginmanager.get_plugin("capturemanager")
         # if capturemanager plugin is disabled, live logging still works.
         log_cli_handler = _LiveLoggingStreamHandler(terminal_reporter, capture_manager)
-        log_cli_format = get_option_ini(config, "log_cli_format", "log_format")
-        log_cli_date_format = get_option_ini(
-            config, "log_cli_date_format", "log_date_format"
+
+        log_cli_formatter = self._create_formatter(
+            get_option_ini(config, "log_cli_format", "log_format"),
+            get_option_ini(config, "log_cli_date_format", "log_date_format"),
         )
-        if (
-            config.option.color != "no"
-            and ColoredLevelFormatter.LEVELNAME_FMT_REGEX.search(log_cli_format)
-        ):
-            log_cli_formatter = ColoredLevelFormatter(
-                create_terminal_writer(config),
-                log_cli_format,
-                datefmt=log_cli_date_format,
-            )
-        else:
-            log_cli_formatter = logging.Formatter(
-                log_cli_format, datefmt=log_cli_date_format
-            )
+
         log_cli_level = get_actual_log_level(config, "log_cli_level", "log_level")
         self.log_cli_handler = log_cli_handler
         self.live_logs_context = lambda: catching_logs(


### PR DESCRIPTION
A method _create_formatter was introduced that is used for both the
log_cli_formatter and the log_formatter.

Consequences of this commit are:
* Captured logs that are output for each failing test are formatted
  using the ColoredLevelFromatter.
* caplog.text now contains ansi escape sequences.
* The formatter used for writing to a file still uses the non-colored
  logging.Formatter class.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.
(please delete this text from the final description, this is just a guideline)
-->

- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [x] Target the `features` branch for new features and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Add yourself to `AUTHORS` in alphabetical order;
