### PR TITLE
conftest: add uses_pexpect mark

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -11,9 +11,10 @@ def pytest_collection_modifyitems(config, items):
     """
     fast_items = []
     slow_items = []
+    slowest_items = []
     neutral_items = []
 
-    slow_fixturenames = ("testdir",)
+    spawn_names = {"spawn_pytest", "spawn"}
 
     for item in items:
         try:
@@ -23,12 +24,16 @@ def pytest_collection_modifyitems(config, items):
             # (https://github.com/pytest-dev/pytest/issues/5070)
             neutral_items.append(item)
         else:
-            if any(x for x in fixtures if x in slow_fixturenames):
-                slow_items.append(item)
+            if "testdir" in fixtures:
+                if spawn_names.intersection(item.function.__code__.co_names):
+                    item.add_marker(pytest.mark.uses_pexpect)
+                    slow_items.append(item)
+                else:
+                    slowest_items.append(0)
             else:
                 marker = item.get_closest_marker("slow")
                 if marker:
-                    slow_items.append(item)
+                    slowest_items.append(item)
                 else:
                     fast_items.append(item)
 

--- a/tox.ini
+++ b/tox.ini
@@ -175,6 +175,8 @@ markers =
     baz
     # conftest.py reorders tests moving slow ones to the end of the list
     slow
+    # experimental mark for all tests using pexpect
+    uses_pexpect
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
Pulled out of https://github.com/pytest-dev/pytest/pull/5313 - is this something we want to have?