### PR TITLE
logging: Extend LEVELNAME_FMT_REGEX

### DIFF
--- a/changelog/5335.bugfix.rst
+++ b/changelog/5335.bugfix.rst
@@ -1,0 +1,2 @@
+Colorize level names when the level in the logging format is formatted using
+'%(levelname).Xs' (truncated fixed width alignment), where X is an integer.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -39,7 +39,7 @@ class ColoredLevelFormatter(logging.Formatter):
         logging.DEBUG: {"purple"},
         logging.NOTSET: set(),
     }
-    LEVELNAME_FMT_REGEX = re.compile(r"%\(levelname\)([+-]?\d*s)")
+    LEVELNAME_FMT_REGEX = re.compile(r"%\(levelname\)([+-.]?\d*s)")
 
     def __init__(self, terminalwriter, *args, **kwargs):
         super(ColoredLevelFormatter, self).__init__(*args, **kwargs)

--- a/testing/logging/test_formatter.py
+++ b/testing/logging/test_formatter.py
@@ -65,3 +65,28 @@ def test_multiline_message():
         "dummypath                   10 INFO     Test Message line1\n"
         "                                        line2"
     )
+
+
+def test_colored_short_level():
+    logfmt = "%(levelname).1s %(message)s"
+
+    record = logging.LogRecord(
+        name="dummy",
+        level=logging.INFO,
+        pathname="dummypath",
+        lineno=10,
+        msg="Test Message",
+        args=(),
+        exc_info=False,
+    )
+
+    class ColorConfig(object):
+        class option(object):
+            pass
+
+    tw = py.io.TerminalWriter()
+    tw.hasmarkup = True
+    formatter = ColoredLevelFormatter(tw, logfmt)
+    output = formatter.format(record)
+    # the I (of INFO) is colored
+    assert output == ("\x1b[32mI\x1b[0m Test Message")


### PR DESCRIPTION
The reason why I've added support for truncated fixed with alignment of the levelname is saving horizontal space by using, e.g., '%(levelname).1s'.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.
(please delete this text from the final description, this is just a guideline)
-->

- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features and removals/deprecations.
- [ ] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [ ] Add yourself to `AUTHORS` in alphabetical order;
