### PR TITLE
Revert "ci: Travis: add pypy3 to allowed failures temporarily"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,9 +112,6 @@ matrix:
   allow_failures:
     - python: '3.8-dev'
       env: TOXENV=py38-xdist
-    # Temporary (https://github.com/pytest-dev/pytest/pull/5334).
-    - env: TOXENV=pypy3-xdist
-      python: 'pypy3'
 
 before_script:
   - |


### PR DESCRIPTION
This reverts commit 5ac498ea9634729d3281d67a8cd27d20a34cf684.

The idea is that maybe https://github.com/pytest-dev/pytest/pull/5360
fixes the failures here also.