### PR TITLE
[4.6] Merge pull request #5373 from asottile/revert_all_handling

### DIFF
--- a/changelog/5370.bugfix.rst
+++ b/changelog/5370.bugfix.rst
@@ -1,0 +1,1 @@
+Revert unrolling of ``all()`` to fix ``NameError`` on nested comprehensions.

--- a/changelog/5371.bugfix.rst
+++ b/changelog/5371.bugfix.rst
@@ -1,0 +1,1 @@
+Revert unrolling of ``all()`` to fix incorrect handling of generators with ``if``.

--- a/changelog/5372.bugfix.rst
+++ b/changelog/5372.bugfix.rst
@@ -1,0 +1,1 @@
+Revert unrolling of ``all()`` to fix incorrect assertion when using ``all()`` in an expression.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -949,22 +949,10 @@ warn_explicit(
         res = self.assign(ast.BinOp(left_expr, binop.op, right_expr))
         return res, explanation
 
-    @staticmethod
-    def _is_any_call_with_generator_or_list_comprehension(call):
-        """Return True if the Call node is an 'any' call with a generator or list comprehension"""
-        return (
-            isinstance(call.func, ast.Name)
-            and call.func.id == "all"
-            and len(call.args) == 1
-            and isinstance(call.args[0], (ast.GeneratorExp, ast.ListComp))
-        )
-
     def visit_Call_35(self, call):
         """
         visit `ast.Call` nodes on Python3.5 and after
         """
-        if self._is_any_call_with_generator_or_list_comprehension(call):
-            return self._visit_all(call)
         new_func, func_expl = self.visit(call.func)
         arg_expls = []
         new_args = []
@@ -988,25 +976,6 @@ warn_explicit(
         outer_expl = "%s\n{%s = %s\n}" % (res_expl, res_expl, expl)
         return res, outer_expl
 
-    def _visit_all(self, call):
-        """Special rewrite for the builtin all function, see #5062"""
-        gen_exp = call.args[0]
-        assertion_module = ast.Module(
-            body=[ast.Assert(test=gen_exp.elt, lineno=1, msg="", col_offset=1)]
-        )
-        AssertionRewriter(module_path=None, config=None).run(assertion_module)
-        for_loop = ast.For(
-            iter=gen_exp.generators[0].iter,
-            target=gen_exp.generators[0].target,
-            body=assertion_module.body,
-            orelse=[],
-        )
-        self.statements.append(for_loop)
-        return (
-            ast.Num(n=1),
-            "",
-        )  # Return an empty expression, all the asserts are in the for_loop
-
     def visit_Starred(self, starred):
         # From Python 3.5, a Starred node can appear in a function call
         res, expl = self.visit(starred.value)
@@ -1017,8 +986,6 @@ warn_explicit(
         """
         visit `ast.Call nodes on 3.4 and below`
         """
-        if self._is_any_call_with_generator_or_list_comprehension(call):
-            return self._visit_all(call)
         new_func, func_expl = self.visit(call.func)
         arg_expls = []
         new_args = []


### PR DESCRIPTION
Revert unrolling of `all()`

I had to manually resolve conflicts and apply the patch to `visit_Call_legacy` as well