### PR TITLE
Revert "Revert "ci: Travis: add pypy3 to allowed failures temporarily""

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,9 @@ matrix:
   allow_failures:
     - python: '3.8-dev'
       env: TOXENV=py38-xdist
+    # Temporary (https://github.com/pytest-dev/pytest/pull/5334).
+    - env: TOXENV=pypy3-xdist
+      python: 'pypy3'
 
 before_script:
   - |


### PR DESCRIPTION
This reverts commit a6dc283133c6ee3a3fdedacf5d363d72b58ffa88.

Did not notice that master started to fail with it again - which is likely the reason for codecov getting confused also even more.

I'd remove it completely until proven to be fixed, but allow-failure is better already.