### PR TITLE
Revert "ci: Travis: add pypy3 to allowed failures temporarily"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,9 +90,6 @@ matrix:
   allow_failures:
     - python: '3.8-dev'
       env: TOXENV=py38-xdist
-    # Temporary (https://github.com/pytest-dev/pytest/pull/5334).
-    - env: TOXENV=pypy3-xdist
-      python: 'pypy3'
 
 before_script:
   - |


### PR DESCRIPTION
Reverts pytest-dev/pytest#5377

Shouldn't be necessary with the unrolling of all being removed... - and might serve as an indication when trying to get it in again (since this started failing with it).