### PR TITLE
4.6: Run pyupgrade without --py3-plus

### DIFF
--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -969,7 +969,9 @@ class ReprEntry(TerminalRepr):
             self.reprfileloc.toterminal(tw)
 
     def __str__(self):
-        return "{}\n{}\n{}".format("\n".join(self.lines), self.reprlocals, self.reprfileloc)
+        return "{}\n{}\n{}".format(
+            "\n".join(self.lines), self.reprlocals, self.reprfileloc
+        )
 
 
 class ReprFileLocation(TerminalRepr):

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -41,7 +41,7 @@ class Code(object):
             self.firstlineno = rawcode.co_firstlineno - 1
             self.name = rawcode.co_name
         except AttributeError:
-            raise TypeError("not a code object: %r" % (rawcode,))
+            raise TypeError("not a code object: {!r}".format(rawcode))
         self.raw = rawcode
 
     def __eq__(self, other):
@@ -677,7 +677,7 @@ class FormattedExcinfo(object):
                         str_repr = safeformat(value)
                     # if len(str_repr) < 70 or not isinstance(value,
                     #                            (list, tuple, dict)):
-                    lines.append("%-10s = %s" % (name, str_repr))
+                    lines.append("{:<10} = {}".format(name, str_repr))
                     # else:
                     #    self._line("%-10s =\\" % (name,))
                     #    # XXX
@@ -850,7 +850,7 @@ class TerminalRepr(object):
         return io.getvalue().strip()
 
     def __repr__(self):
-        return "<%s instance at %0x>" % (self.__class__, id(self))
+        return "<{} instance at {:0x}>".format(self.__class__, id(self))
 
 
 class ExceptionRepr(TerminalRepr):
@@ -969,7 +969,7 @@ class ReprEntry(TerminalRepr):
             self.reprfileloc.toterminal(tw)
 
     def __str__(self):
-        return "%s\n%s\n%s" % ("\n".join(self.lines), self.reprlocals, self.reprfileloc)
+        return "{}\n{}\n{}".format("\n".join(self.lines), self.reprlocals, self.reprfileloc)
 
 
 class ReprFileLocation(TerminalRepr):
@@ -986,7 +986,7 @@ class ReprFileLocation(TerminalRepr):
         if i != -1:
             msg = msg[:i]
         tw.write(self.path, bold=True, red=True)
-        tw.line(":%s: %s" % (self.lineno, msg))
+        tw.line(":{}: {}".format(self.lineno, msg))
 
 
 class ReprLocals(TerminalRepr):
@@ -1006,7 +1006,7 @@ class ReprFuncArgs(TerminalRepr):
         if self.args:
             linesofar = ""
             for name, value in self.args:
-                ns = "%s = %s" % (safe_str(name), safe_str(value))
+                ns = "{} = {}".format(safe_str(name), safe_str(value))
                 if len(ns) + len(linesofar) + 2 > tw.fullwidth:
                     if linesofar:
                         tw.line(linesofar)

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -14,7 +14,7 @@ def _call_and_format_exception(call, x, *args):
             exc_info = str(exc)
         except Exception:
             exc_info = "unknown"
-        return '<[%s("%s") raised in repr()] %s object at 0x%x>' % (
+        return '<[{}("{}") raised in repr()] {} object at 0x{:x}>'.format(
             exc_name,
             exc_info,
             x.__class__.__name__,

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -15,10 +15,7 @@ def _call_and_format_exception(call, x, *args):
         except Exception:
             exc_info = "unknown"
         return '<[{}("{}") raised in repr()] {} object at 0x{:x}>'.format(
-            exc_name,
-            exc_info,
-            x.__class__.__name__,
-            id(x),
+            exc_name, exc_info, x.__class__.__name__, id(x)
         )
 
 

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -228,7 +228,9 @@ class AssertionRewritingHook(object):
 
         if self.session is not None:
             if self.session.isinitpath(fn):
-                state.trace("matched test file (was specified on cmdline): {!r}".format(fn))
+                state.trace(
+                    "matched test file (was specified on cmdline): {!r}".format(fn)
+                )
                 return True
 
         # modules not passed explicitly on the command line are only
@@ -246,7 +248,9 @@ class AssertionRewritingHook(object):
         except KeyError:
             for marked in self._must_rewrite:
                 if name == marked or name.startswith(marked + "."):
-                    state.trace("matched marked file {!r} (from {!r})".format(name, marked))
+                    state.trace(
+                        "matched marked file {!r} (from {!r})".format(name, marked)
+                    )
                     self._marked_for_rewrite_cache[name] = True
                     return True
 

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -142,7 +142,7 @@ def assertrepr_compare(config, op, left, right):
     left_repr = saferepr(left, maxsize=int(width // 2))
     right_repr = saferepr(right, maxsize=width - len(left_repr))
 
-    summary = u"%s %s %s" % (ecu(left_repr), op, ecu(right_repr))
+    summary = u"{} {} {}".format(ecu(left_repr), op, ecu(right_repr))
 
     verbose = config.getoption("verbose")
     explanation = None
@@ -290,7 +290,7 @@ def _compare_eq_sequence(left, right, verbose=0):
     len_right = len(right)
     for i in range(min(len_left, len_right)):
         if left[i] != right[i]:
-            explanation += [u"At index %s diff: %r != %r" % (i, left[i], right[i])]
+            explanation += [u"At index {} diff: {!r} != {!r}".format(i, left[i], right[i])]
             break
     len_diff = len_left - len_right
 
@@ -304,7 +304,7 @@ def _compare_eq_sequence(left, right, verbose=0):
             extra = saferepr(right[len_left])
 
         if len_diff == 1:
-            explanation += [u"%s contains one more item: %s" % (dir_with_more, extra)]
+            explanation += [u"{} contains one more item: {}".format(dir_with_more, extra)]
         else:
             explanation += [
                 u"%s contains %d more items, first extra item: %s"

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -290,7 +290,9 @@ def _compare_eq_sequence(left, right, verbose=0):
     len_right = len(right)
     for i in range(min(len_left, len_right)):
         if left[i] != right[i]:
-            explanation += [u"At index {} diff: {!r} != {!r}".format(i, left[i], right[i])]
+            explanation += [
+                u"At index {} diff: {!r} != {!r}".format(i, left[i], right[i])
+            ]
             break
     len_diff = len_left - len_right
 
@@ -304,7 +306,9 @@ def _compare_eq_sequence(left, right, verbose=0):
             extra = saferepr(right[len_left])
 
         if len_diff == 1:
-            explanation += [u"{} contains one more item: {}".format(dir_with_more, extra)]
+            explanation += [
+                u"{} contains one more item: {}".format(dir_with_more, extra)
+            ]
         else:
             explanation += [
                 u"%s contains %d more items, first extra item: %s"

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -86,7 +86,7 @@ class CaptureManager(object):
         self._current_item = None
 
     def __repr__(self):
-        return "<CaptureManager _method=%r _global_capturing=%r _current_item=%r>" % (
+        return "<CaptureManager _method={!r} _global_capturing={!r} _current_item={!r}>".format(
             self._method,
             self._global_capturing,
             self._current_item,
@@ -473,7 +473,7 @@ class MultiCapture(object):
             self.err = Capture(2)
 
     def __repr__(self):
-        return "<MultiCapture out=%r err=%r in_=%r _state=%r _in_suspended=%r>" % (
+        return "<MultiCapture out={!r} err={!r} in_={!r} _state={!r} _in_suspended={!r}>".format(
             self.out,
             self.err,
             self.in_,
@@ -578,7 +578,7 @@ class FDCaptureBinary(object):
             self.tmpfile_fd = tmpfile.fileno()
 
     def __repr__(self):
-        return "<FDCapture %s oldfd=%s _state=%r>" % (
+        return "<FDCapture {} oldfd={} _state={!r}>".format(
             self.targetfd,
             getattr(self, "targetfd_save", None),
             self._state,
@@ -661,7 +661,7 @@ class SysCapture(object):
         self.tmpfile = tmpfile
 
     def __repr__(self):
-        return "<SysCapture %s _old=%r, tmpfile=%r _state=%r>" % (
+        return "<SysCapture {} _old={!r}, tmpfile={!r} _state={!r}>".format(
             self.name,
             self._old,
             self.tmpfile,

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -87,9 +87,7 @@ class CaptureManager(object):
 
     def __repr__(self):
         return "<CaptureManager _method={!r} _global_capturing={!r} _current_item={!r}>".format(
-            self._method,
-            self._global_capturing,
-            self._current_item,
+            self._method, self._global_capturing, self._current_item
         )
 
     def _getcapture(self, method):
@@ -579,9 +577,7 @@ class FDCaptureBinary(object):
 
     def __repr__(self):
         return "<FDCapture {} oldfd={} _state={!r}>".format(
-            self.targetfd,
-            getattr(self, "targetfd_save", None),
-            self._state,
+            self.targetfd, getattr(self, "targetfd_save", None), self._state
         )
 
     def start(self):
@@ -662,10 +658,7 @@ class SysCapture(object):
 
     def __repr__(self):
         return "<SysCapture {} _old={!r}, tmpfile={!r} _state={!r}>".format(
-            self.name,
-            self._old,
-            self.tmpfile,
-            self._state,
+            self.name, self._old, self.tmpfile, self._state
         )
 
     def start(self):

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -565,8 +565,7 @@ class PytestPluginManager(PluginManager):
             __import__(importspec)
         except ImportError as e:
             new_exc_message = 'Error importing plugin "{}": {}'.format(
-                modname,
-                safe_str(e.args[0]),
+                modname, safe_str(e.args[0])
             )
             new_exc = ImportError(new_exc_message)
             tb = sys.exc_info()[2]

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -564,7 +564,7 @@ class PytestPluginManager(PluginManager):
         try:
             __import__(importspec)
         except ImportError as e:
-            new_exc_message = 'Error importing plugin "%s": %s' % (
+            new_exc_message = 'Error importing plugin "{}": {}'.format(
                 modname,
                 safe_str(e.args[0]),
             )
@@ -577,7 +577,7 @@ class PytestPluginManager(PluginManager):
             from _pytest.warnings import _issue_warning_captured
 
             _issue_warning_captured(
-                PytestConfigWarning("skipped plugin %r: %s" % (modname, e.msg)),
+                PytestConfigWarning("skipped plugin {!r}: {}".format(modname, e.msg)),
                 self.hook,
                 stacklevel=1,
             )
@@ -644,7 +644,7 @@ class Config(object):
 
         _a = FILE_OR_DIR
         self._parser = Parser(
-            usage="%%(prog)s [options] [%s] [%s] [...]" % (_a, _a),
+            usage="%(prog)s [options] [{}] [{}] [...]".format(_a, _a),
             processopt=self._processopt,
         )
         #: a pluginmanager instance
@@ -932,7 +932,7 @@ class Config(object):
         try:
             description, type, default = self._parser._inidict[name]
         except KeyError:
-            raise ValueError("unknown configuration value: %r" % (name,))
+            raise ValueError("unknown configuration value: {!r}".format(name))
         value = self._get_override_ini_value(name)
         if value is None:
             try:
@@ -1009,8 +1009,8 @@ class Config(object):
             if skip:
                 import pytest
 
-                pytest.skip("no %r option found" % (name,))
-            raise ValueError("no option named %r" % (name,))
+                pytest.skip("no {!r} option found".format(name))
+            raise ValueError("no option named {!r}".format(name))
 
     def getvalue(self, name, path=None):
         """ (deprecated, use getoption()) """
@@ -1098,4 +1098,4 @@ def _strtobool(val):
     elif val in ("n", "no", "f", "false", "off", "0"):
         return 0
     else:
-        raise ValueError("invalid truth value %r" % (val,))
+        raise ValueError("invalid truth value {!r}".format(val))

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -145,7 +145,7 @@ class ArgumentError(Exception):
 
     def __str__(self):
         if self.option_id:
-            return "option %s: %s" % (self.option_id, self.msg)
+            return "option {}: {}".format(self.option_id, self.msg)
         else:
             return self.msg
 
@@ -337,10 +337,10 @@ class MyOptionParser(argparse.ArgumentParser):
 
     def error(self, message):
         """Transform argparse error message into UsageError."""
-        msg = "%s: error: %s" % (self.prog, message)
+        msg = "{}: error: {}".format(self.prog, message)
 
         if hasattr(self._parser, "_config_source_hint"):
-            msg = "%s (%s)" % (msg, self._parser._config_source_hint)
+            msg = "{} ({})".format(msg, self._parser._config_source_hint)
 
         raise UsageError(self.format_usage() + msg)
 
@@ -352,7 +352,7 @@ class MyOptionParser(argparse.ArgumentParser):
                 if arg and arg[0] == "-":
                     lines = ["unrecognized arguments: %s" % (" ".join(argv))]
                     for k, v in sorted(self.extra_info.items()):
-                        lines.append("  %s: %s" % (k, v))
+                        lines.append("  {}: {}".format(k, v))
                     self.error("\n".join(lines))
             getattr(args, FILE_OR_DIR).extend(argv)
         return args

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -230,7 +230,7 @@ class pytestPDB(object):
                 else:
                     capturing = cls._is_capturing(capman)
                     if capturing == "global":
-                        tw.sep(">", "PDB %s (IO-capturing turned off)" % (method,))
+                        tw.sep(">", "PDB {} (IO-capturing turned off)".format(method))
                     elif capturing:
                         tw.sep(
                             ">",
@@ -238,7 +238,7 @@ class pytestPDB(object):
                             % (method, capturing),
                         )
                     else:
-                        tw.sep(">", "PDB %s" % (method,))
+                        tw.sep(">", "PDB {}".format(method))
 
         _pdb = cls._import_pdb_cls(capman)(**kwargs)
 

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -258,7 +258,7 @@ class DoctestItem(pytest.Item):
                     ]
                     indent = ">>>"
                     for line in example.source.splitlines():
-                        lines.append("??? %s %s" % (indent, line))
+                        lines.append("??? {} {}".format(indent, line))
                         indent = "..."
                 if isinstance(failure, doctest.DocTestFailure):
                     lines += checker.output_difference(

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -895,9 +895,7 @@ class FixtureDef(object):
 
     def __repr__(self):
         return "<FixtureDef argname={!r} scope={!r} baseid={!r}>".format(
-            self.argname,
-            self.scope,
-            self.baseid,
+            self.argname, self.scope, self.baseid
         )
 
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -81,7 +81,7 @@ def scopeproperty(name=None, doc=None):
             if func.__name__ in scope2props[self.scope]:
                 return func(self)
             raise AttributeError(
-                "%s not available in %s-scoped context" % (scopename, self.scope)
+                "{} not available in {}-scoped context".format(scopename, self.scope)
             )
 
         return property(provide, None, None, func.__doc__)
@@ -94,7 +94,7 @@ def get_scope_package(node, fixturedef):
 
     cls = pytest.Package
     current = node
-    fixture_package_name = "%s/%s" % (fixturedef.baseid, "__init__.py")
+    fixture_package_name = "{}/{}".format(fixturedef.baseid, "__init__.py")
     while current and (
         type(current) is not cls or fixture_package_name != current.nodeid
     ):
@@ -657,7 +657,7 @@ class SubRequest(FixtureRequest):
         self._fixturemanager = request._fixturemanager
 
     def __repr__(self):
-        return "<SubRequest %r for %r>" % (self.fixturename, self._pyfuncitem)
+        return "<SubRequest {!r} for {!r}>".format(self.fixturename, self._pyfuncitem)
 
     def addfinalizer(self, finalizer):
         self._fixturedef.addfinalizer(finalizer)
@@ -723,7 +723,7 @@ class FixtureLookupError(LookupError):
                 error_msg = "file %s, line %s: source code not available"
                 addline(error_msg % (fspath, lineno + 1))
             else:
-                addline("file %s, line %s" % (fspath, lineno + 1))
+                addline("file {}, line {}".format(fspath, lineno + 1))
                 for i, line in enumerate(lines):
                     line = line.rstrip()
                     addline("  " + line)
@@ -779,7 +779,7 @@ class FixtureLookupErrorRepr(TerminalRepr):
 
 def fail_fixturefunc(fixturefunc, msg):
     fs, lineno = getfslineno(fixturefunc)
-    location = "%s:%s" % (fs, lineno + 1)
+    location = "{}:{}".format(fs, lineno + 1)
     source = _pytest._code.Source(fixturefunc)
     fail(msg + ":\n\n" + str(source.indent()) + "\n" + location, pytrace=False)
 
@@ -894,7 +894,7 @@ class FixtureDef(object):
         return hook.pytest_fixture_setup(fixturedef=self, request=request)
 
     def __repr__(self):
-        return "<FixtureDef argname=%r scope=%r baseid=%r>" % (
+        return "<FixtureDef argname={!r} scope={!r} baseid={!r}>".format(
             self.argname,
             self.scope,
             self.baseid,

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -229,7 +229,9 @@ def getpluginversioninfo(config):
 def pytest_report_header(config):
     lines = []
     if config.option.debug or config.option.traceconfig:
-        lines.append("using: pytest-{} pylib-{}".format(pytest.__version__, py.__version__))
+        lines.append(
+            "using: pytest-{} pylib-{}".format(pytest.__version__, py.__version__)
+        )
 
         verinfo = getpluginversioninfo(config)
         if verinfo:

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -122,7 +122,7 @@ def pytest_cmdline_parse():
 def showversion(config):
     p = py.path.local(pytest.__file__)
     sys.stderr.write(
-        "This is pytest version %s, imported from %s\n" % (pytest.__version__, p)
+        "This is pytest version {}, imported from {}\n".format(pytest.__version__, p)
     )
     plugininfo = getpluginversioninfo(config)
     if plugininfo:
@@ -160,7 +160,7 @@ def showhelp(config):
         help, type, default = config._parser._inidict[name]
         if type is None:
             type = "string"
-        spec = "%s (%s):" % (name, type)
+        spec = "{} ({}):".format(name, type)
         tw.write("  %s" % spec)
         spec_len = len(spec)
         if spec_len > (indent_len - 3):
@@ -194,7 +194,7 @@ def showhelp(config):
         ("PYTEST_DEBUG", "set to enable debug tracing of pytest's internals"),
     ]
     for name, help in vars:
-        tw.line("  %-24s %s" % (name, help))
+        tw.line("  {:<24} {}".format(name, help))
     tw.line()
     tw.line()
 
@@ -221,7 +221,7 @@ def getpluginversioninfo(config):
         lines.append("setuptools registered plugins:")
         for plugin, dist in plugininfo:
             loc = getattr(plugin, "__file__", repr(plugin))
-            content = "%s-%s at %s" % (dist.project_name, dist.version, loc)
+            content = "{}-{} at {}".format(dist.project_name, dist.version, loc)
             lines.append("  " + content)
     return lines
 
@@ -229,7 +229,7 @@ def getpluginversioninfo(config):
 def pytest_report_header(config):
     lines = []
     if config.option.debug or config.option.traceconfig:
-        lines.append("using: pytest-%s pylib-%s" % (pytest.__version__, py.__version__))
+        lines.append("using: pytest-{} pylib-{}".format(pytest.__version__, py.__version__))
 
         verinfo = getpluginversioninfo(config)
         if verinfo:
@@ -243,5 +243,5 @@ def pytest_report_header(config):
                 r = plugin.__file__
             else:
                 r = repr(plugin)
-            lines.append("    %-20s: %s" % (name, r))
+            lines.append("    {:<20}: {}".format(name, r))
     return lines

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -43,7 +43,7 @@ class Junit(py.xml.Namespace):
 _legal_chars = (0x09, 0x0A, 0x0D)
 _legal_ranges = ((0x20, 0x7E), (0x80, 0xD7FF), (0xE000, 0xFFFD), (0x10000, 0x10FFFF))
 _legal_xml_re = [
-    u"%s-%s" % (six.unichr(low), six.unichr(high))
+    u"{}-{}".format(six.unichr(low), six.unichr(high))
     for (low, high) in _legal_ranges
     if low < sys.maxunicode
 ]
@@ -268,7 +268,7 @@ class _NodeReporter(object):
             filename, lineno, skipreason = report.longrepr
             if skipreason.startswith("Skipped: "):
                 skipreason = skipreason[9:]
-            details = "%s:%s: %s" % (filename, lineno, skipreason)
+            details = "{}:{}: {}".format(filename, lineno, skipreason)
 
             self.append(
                 Junit.skipped(

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -627,11 +627,10 @@ class Session(nodes.FSCollector):
                 yield y
 
     def _collectfile(self, path, handle_dupes=True):
-        assert path.isfile(), "{!r} is not a file (isdir={!r}, exists={!r}, islink={!r})".format(
-            path,
-            path.isdir(),
-            path.exists(),
-            path.islink(),
+        assert (
+            path.isfile()
+        ), "{!r} is not a file (isdir={!r}, exists={!r}, islink={!r})".format(
+            path, path.isdir(), path.exists(), path.islink()
         )
         ihook = self.gethookproxy(path)
         if not self.isinitpath(path):

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -522,8 +522,8 @@ class Session(nodes.FSCollector):
         if self._notfound:
             errors = []
             for arg, exc in self._notfound:
-                line = "(no name %r in any of %r)" % (arg, exc.args[0])
-                errors.append("not found: %s\n%s" % (arg, line))
+                line = "(no name {!r} in any of {!r})".format(arg, exc.args[0])
+                errors.append("not found: {}\n{}".format(arg, line))
                 # XXX: test this
             raise UsageError(*errors)
         if not genitems:
@@ -578,7 +578,7 @@ class Session(nodes.FSCollector):
         # If it's a directory argument, recurse and look for any Subpackages.
         # Let the Package collector deal with subnodes, don't collect here.
         if argpath.check(dir=1):
-            assert not names, "invalid arg %r" % (arg,)
+            assert not names, "invalid arg {!r}".format(arg)
 
             seen_dirs = set()
             for path in argpath.visit(
@@ -627,7 +627,7 @@ class Session(nodes.FSCollector):
                 yield y
 
     def _collectfile(self, path, handle_dupes=True):
-        assert path.isfile(), "%r is not a file (isdir=%r, exists=%r, islink=%r)" % (
+        assert path.isfile(), "{!r} is not a file (isdir={!r}, exists={!r}, islink={!r})".format(
             path,
             path.isdir(),
             path.exists(),

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -229,7 +229,7 @@ class MarkDecorator(object):
         return self.mark == other.mark if isinstance(other, MarkDecorator) else False
 
     def __repr__(self):
-        return "<MarkDecorator %r>" % (self.mark,)
+        return "<MarkDecorator {!r}>".format(self.mark)
 
     def with_args(self, *args, **kwargs):
         """ return a MarkDecorator with extra arguments added
@@ -377,7 +377,7 @@ class NodeKeywords(MappingMixin):
         return len(self._seen())
 
     def __repr__(self):
-        return "<NodeKeywords for node %s>" % (self.node,)
+        return "<NodeKeywords for node {}>".format(self.node)
 
 
 @attr.s(cmp=False, hash=False)

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -77,14 +77,18 @@ def annotated_getattr(obj, name, ann):
         obj = getattr(obj, name)
     except AttributeError:
         raise AttributeError(
-            "{!r} object at {} has no attribute {!r}".format(type(obj).__name__, ann, name)
+            "{!r} object at {} has no attribute {!r}".format(
+                type(obj).__name__, ann, name
+            )
         )
     return obj
 
 
 def derive_importpath(import_path, raising):
     if not isinstance(import_path, six.string_types) or "." not in import_path:
-        raise TypeError("must be absolute import path string, not {!r}".format(import_path))
+        raise TypeError(
+            "must be absolute import path string, not {!r}".format(import_path)
+        )
     module, attr = import_path.rsplit(".", 1)
     target = resolve(module)
     if raising:

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -67,7 +67,7 @@ def resolve(name):
             if expected == used:
                 raise
             else:
-                raise ImportError("import error in %s: %s" % (used, ex))
+                raise ImportError("import error in {}: {}".format(used, ex))
         found = annotated_getattr(found, part, used)
     return found
 
@@ -77,14 +77,14 @@ def annotated_getattr(obj, name, ann):
         obj = getattr(obj, name)
     except AttributeError:
         raise AttributeError(
-            "%r object at %s has no attribute %r" % (type(obj).__name__, ann, name)
+            "{!r} object at {} has no attribute {!r}".format(type(obj).__name__, ann, name)
         )
     return obj
 
 
 def derive_importpath(import_path, raising):
     if not isinstance(import_path, six.string_types) or "." not in import_path:
-        raise TypeError("must be absolute import path string, not %r" % (import_path,))
+        raise TypeError("must be absolute import path string, not {!r}".format(import_path))
     module, attr = import_path.rsplit(".", 1)
     target = resolve(module)
     if raising:
@@ -162,7 +162,7 @@ class MonkeyPatch(object):
 
         oldval = getattr(target, name, notset)
         if raising and oldval is notset:
-            raise AttributeError("%r has no attribute %r" % (target, name))
+            raise AttributeError("{!r} has no attribute {!r}".format(target, name))
 
         # avoid class descriptors like staticmethod/classmethod
         if inspect.isclass(target):

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -103,7 +103,7 @@ class Node(object):
         return self.session.gethookproxy(self.fspath)
 
     def __repr__(self):
-        return "<%s %s>" % (self.__class__.__name__, getattr(self, "name", None))
+        return "<{} {}>".format(self.__class__.__name__, getattr(self, "name", None))
 
     def warn(self, warning):
         """Issue a warning for this item.

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -28,7 +28,7 @@ class OutcomeException(BaseException):
             if isinstance(val, bytes):
                 val = val.decode("UTF-8", errors="replace")
             return val
-        return "<%s instance>" % (self.__class__.__name__,)
+        return "<{} instance>".format(self.__class__.__name__)
 
     __str__ = __repr__
 
@@ -171,7 +171,7 @@ def importorskip(modname, minversion=None, reason=None):
             import_exc = exc
     if import_exc:
         if reason is None:
-            reason = "could not import %r: %s" % (modname, import_exc)
+            reason = "could not import {!r}: {}".format(modname, import_exc)
         raise Skipped(reason, allow_module_level=True)
     mod = sys.modules[modname]
     if minversion is None:

--- a/src/_pytest/pastebin.py
+++ b/src/_pytest/pastebin.py
@@ -86,7 +86,7 @@ def create_new_paste(contents):
     response = urlopen(url, data=urlencode(params).encode("ascii")).read()
     m = re.search(r'href="/raw/(\w+)"', response.decode("utf-8"))
     if m:
-        return "%s/show/%s" % (url, m.group(1))
+        return "{}/show/{}".format(url, m.group(1))
     else:
         return "bad response: " + response
 
@@ -111,4 +111,4 @@ def pytest_terminal_summary(terminalreporter):
             s = tw.stringio.getvalue()
             assert len(s)
             pastebinurl = create_new_paste(s)
-            tr.write_line("%s --> %s" % (msg, pastebinurl))
+            tr.write_line("{} --> {}".format(msg, pastebinurl))

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -284,7 +284,9 @@ class HookRecorder(object):
             )
         if len(values) > 1:
             raise ValueError(
-                "found 2 or more testreports matching {!r}: {}".format(inamepart, values)
+                "found 2 or more testreports matching {!r}: {}".format(
+                    inamepart, values
+                )
             )
         return values[0]
 
@@ -970,9 +972,7 @@ class Testdir(object):
             if item.name == funcname:
                 return item
         assert 0, "{!r} item not found in module:\n{}\nitems: {}".format(
-            funcname,
-            source,
-            items,
+            funcname, source, items
         )
 
     def getitems(self, source):
@@ -1250,7 +1250,9 @@ def getdecoded(out):
     try:
         return out.decode("utf-8")
     except UnicodeDecodeError:
-        return "INTERNAL not-utf8-decodeable, truncated string:\n{}".format(saferepr(out))
+        return "INTERNAL not-utf8-decodeable, truncated string:\n{}".format(
+            saferepr(out)
+        )
 
 
 class LineComp(object):

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -189,7 +189,7 @@ class ParsedCall(object):
     def __repr__(self):
         d = self.__dict__.copy()
         del d["_name"]
-        return "<ParsedCall %r(**%r)>" % (self._name, d)
+        return "<ParsedCall {!r}(**{!r})>".format(self._name, d)
 
 
 class HookRecorder(object):
@@ -239,7 +239,7 @@ class HookRecorder(object):
                     break
                 print("NONAMEMATCH", name, "with", call)
             else:
-                pytest.fail("could not find %r check %r" % (name, check))
+                pytest.fail("could not find {!r} check {!r}".format(name, check))
 
     def popcall(self, name):
         __tracebackhide__ = True
@@ -247,7 +247,7 @@ class HookRecorder(object):
             if call._name == name:
                 del self.calls[i]
                 return call
-        lines = ["could not find call %r, in:" % (name,)]
+        lines = ["could not find call {!r}, in:".format(name)]
         lines.extend(["  %s" % x for x in self.calls])
         pytest.fail("\n".join(lines))
 
@@ -284,7 +284,7 @@ class HookRecorder(object):
             )
         if len(values) > 1:
             raise ValueError(
-                "found 2 or more testreports matching %r: %s" % (inamepart, values)
+                "found 2 or more testreports matching {!r}: {}".format(inamepart, values)
             )
         return values[0]
 
@@ -513,7 +513,7 @@ class Testdir(object):
         self._env_run_update = {"HOME": tmphome, "USERPROFILE": tmphome}
 
     def __repr__(self):
-        return "<Testdir %r>" % (self.tmpdir,)
+        return "<Testdir {!r}>".format(self.tmpdir)
 
     def __str__(self):
         return str(self.tmpdir)
@@ -969,7 +969,7 @@ class Testdir(object):
         for item in items:
             if item.name == funcname:
                 return item
-        assert 0, "%r item not found in module:\n%s\nitems: %s" % (
+        assert 0, "{!r} item not found in module:\n{}\nitems: {}".format(
             funcname,
             source,
             items,
@@ -1163,7 +1163,7 @@ class Testdir(object):
             for line in lines:
                 print(line, file=fp)
         except UnicodeEncodeError:
-            print("couldn't print to %s because of encoding" % (fp,))
+            print("couldn't print to {} because of encoding".format(fp))
 
     def _getpytestargs(self):
         return sys.executable, "-mpytest"
@@ -1220,7 +1220,7 @@ class Testdir(object):
         """
         basetemp = self.tmpdir.mkdir("temp-pexpect")
         invoke = " ".join(map(str, self._getpytestargs()))
-        cmd = "%s --basetemp=%s %s" % (invoke, basetemp, string)
+        cmd = "{} --basetemp={} {}".format(invoke, basetemp, string)
         return self.spawn(cmd, expect_timeout=expect_timeout)
 
     def spawn(self, cmd, expect_timeout=10.0):
@@ -1250,7 +1250,7 @@ def getdecoded(out):
     try:
         return out.decode("utf-8")
     except UnicodeDecodeError:
-        return "INTERNAL not-utf8-decodeable, truncated string:\n%s" % (saferepr(out),)
+        return "INTERNAL not-utf8-decodeable, truncated string:\n{}".format(saferepr(out))
 
 
 class LineComp(object):
@@ -1409,5 +1409,5 @@ class LineMatcher(object):
                     self._log("    and:", repr(nextline))
                 extralines.append(nextline)
             else:
-                self._log("remains unmatched: %r" % (line,))
+                self._log("remains unmatched: {!r}".format(line))
                 pytest.fail(self._log_text)

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -56,7 +56,7 @@ def pyobj_property(name):
             return node.obj
 
     doc = "python {} object this node was collected from (can be None).".format(
-        name.lower(),
+        name.lower()
     )
     return property(get, None, None, doc)
 
@@ -606,11 +606,10 @@ class Package(Module):
         return proxy
 
     def _collectfile(self, path, handle_dupes=True):
-        assert path.isfile(), "{!r} is not a file (isdir={!r}, exists={!r}, islink={!r})".format(
-            path,
-            path.isdir(),
-            path.exists(),
-            path.islink(),
+        assert (
+            path.isfile()
+        ), "{!r} is not a file (isdir={!r}, exists={!r}, islink={!r})".format(
+            path, path.isdir(), path.exists(), path.islink()
         )
         ihook = self.gethookproxy(path)
         if not self.isinitpath(path):

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -55,7 +55,7 @@ def pyobj_property(name):
         if node is not None:
             return node.obj
 
-    doc = "python %s object this node was collected from (can be None)." % (
+    doc = "python {} object this node was collected from (can be None).".format(
         name.lower(),
     )
     return property(get, None, None, doc)
@@ -421,7 +421,7 @@ class PyCollector(PyobjMixin, nodes.Collector):
             fixtureinfo.prune_dependency_tree()
 
             for callspec in metafunc._calls:
-                subname = "%s[%s]" % (name, callspec.id)
+                subname = "{}[{}]".format(name, callspec.id)
                 yield Function(
                     name=subname,
                     parent=self,
@@ -606,7 +606,7 @@ class Package(Module):
         return proxy
 
     def _collectfile(self, path, handle_dupes=True):
-        assert path.isfile(), "%r is not a file (isdir=%r, exists=%r, islink=%r)" % (
+        assert path.isfile(), "{!r} is not a file (isdir={!r}, exists={!r}, islink={!r})".format(
             path,
             path.isdir(),
             path.exists(),
@@ -884,7 +884,7 @@ class CallSpec2(object):
 
     def _checkargnotcontained(self, arg):
         if arg in self.params or arg in self.funcargs:
-            raise ValueError("duplicate %r" % (arg,))
+            raise ValueError("duplicate {!r}".format(arg))
 
     def getparam(self, name):
         try:
@@ -1335,7 +1335,7 @@ def _showfixtures_main(config, session):
         if currentmodule != module:
             if not module.startswith("_pytest."):
                 tw.line()
-                tw.sep("-", "fixtures defined from %s" % (module,))
+                tw.sep("-", "fixtures defined from {}".format(module))
                 currentmodule = module
         if verbose <= 0 and argname[0] == "_":
             continue
@@ -1350,7 +1350,7 @@ def _showfixtures_main(config, session):
         if doc:
             write_docstring(tw, doc)
         else:
-            tw.line("    %s: no docstring available" % (loc,), red=True)
+            tw.line("    {}: no docstring available".format(loc), red=True)
         tw.line()
 
 

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -23,7 +23,7 @@ def getslaveinfoline(node):
     except AttributeError:
         d = node.slaveinfo
         ver = "%s.%s.%s" % d["version_info"][:3]
-        node._slaveinfocache = s = "[%s] %s -- Python %s %s" % (
+        node._slaveinfocache = s = "[{}] {} -- Python {} {}".format(
             d["id"],
             d["sysplatform"],
             ver,
@@ -335,7 +335,7 @@ class TestReport(BaseReport):
         self.__dict__.update(extra)
 
     def __repr__(self):
-        return "<%s %r when=%r outcome=%r>" % (
+        return "<{} {!r} when={!r} outcome={!r}>".format(
             self.__class__.__name__,
             self.nodeid,
             self.when,
@@ -372,7 +372,7 @@ class TestReport(BaseReport):
                         excinfo, style=item.config.getoption("tbstyle", "auto")
                     )
         for rwhen, key, content in item._report_sections:
-            sections.append(("Captured %s %s" % (key, rwhen), content))
+            sections.append(("Captured {} {}".format(key, rwhen), content))
         return cls(
             item.nodeid,
             item.location,
@@ -402,7 +402,7 @@ class CollectReport(BaseReport):
         return (self.fspath, None, self.fspath)
 
     def __repr__(self):
-        return "<CollectReport %r lenresult=%s outcome=%r>" % (
+        return "<CollectReport {!r} lenresult={} outcome={!r}>".format(
             self.nodeid,
             len(self.result),
             self.outcome,

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -24,10 +24,7 @@ def getslaveinfoline(node):
         d = node.slaveinfo
         ver = "%s.%s.%s" % d["version_info"][:3]
         node._slaveinfocache = s = "[{}] {} -- Python {} {}".format(
-            d["id"],
-            d["sysplatform"],
-            ver,
-            d["executable"],
+            d["id"], d["sysplatform"], ver, d["executable"]
         )
         return s
 
@@ -336,10 +333,7 @@ class TestReport(BaseReport):
 
     def __repr__(self):
         return "<{} {!r} when={!r} outcome={!r}>".format(
-            self.__class__.__name__,
-            self.nodeid,
-            self.when,
-            self.outcome,
+            self.__class__.__name__, self.nodeid, self.when, self.outcome
         )
 
     @classmethod
@@ -403,9 +397,7 @@ class CollectReport(BaseReport):
 
     def __repr__(self):
         return "<CollectReport {!r} lenresult={} outcome={!r}>".format(
-            self.nodeid,
-            len(self.result),
-            self.outcome,
+            self.nodeid, len(self.result), self.outcome
         )
 
 

--- a/src/_pytest/resultlog.py
+++ b/src/_pytest/resultlog.py
@@ -54,7 +54,7 @@ class ResultLog(object):
         self.logfile = logfile  # preferably line buffered
 
     def write_log_entry(self, testpath, lettercode, longrepr):
-        print("%s %s" % (lettercode, testpath), file=self.logfile)
+        print("{} {}".format(lettercode, testpath), file=self.logfile)
         for line in longrepr.splitlines():
             print(" %s" % line, file=self.logfile)
 

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -62,7 +62,7 @@ def pytest_terminal_summary(terminalreporter):
             tr.write_line("")
             tr.write_line("(0.00 durations hidden.  Use -vv to show these durations.)")
             break
-        tr.write_line("%02.2fs %-8s %s" % (rep.duration, rep.when, rep.nodeid))
+        tr.write_line("{:02.2f}s {:<8} {}".format(rep.duration, rep.when, rep.nodeid))
 
 
 def pytest_sessionstart(session):

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -219,7 +219,7 @@ class WarningReport(object):
                 relpath = py.path.local(filename).relto(config.invocation_dir)
                 if not relpath:
                     relpath = str(filename)
-                return "%s:%s" % (relpath, linenum)
+                return "{}:{}".format(relpath, linenum)
             else:
                 return str(self.fslocation)
         return None
@@ -374,7 +374,7 @@ class TerminalReporter(object):
 
     def pytest_plugin_registered(self, plugin):
         if self.config.option.traceconfig:
-            msg = "PLUGIN registered: %s" % (plugin,)
+            msg = "PLUGIN registered: {}".format(plugin)
             # XXX this event may happen during setup/teardown time
             #     which unfortunately captures our output here
             #     which garbles our output if we use self.write_line
@@ -561,11 +561,11 @@ class TerminalReporter(object):
             return
         self.write_sep("=", "test session starts", bold=True)
         verinfo = platform.python_version()
-        msg = "platform %s -- Python %s" % (sys.platform, verinfo)
+        msg = "platform {} -- Python {}".format(sys.platform, verinfo)
         if hasattr(sys, "pypy_version_info"):
             verinfo = ".".join(map(str, sys.pypy_version_info[:3]))
-            msg += "[pypy-%s-%s]" % (verinfo, sys.pypy_version_info[3])
-        msg += ", pytest-%s, py-%s, pluggy-%s" % (
+            msg += "[pypy-{}-{}]".format(verinfo, sys.pypy_version_info[3])
+        msg += ", pytest-{}, py-{}, pluggy-{}".format(
             pytest.__version__,
             py.__version__,
             pluggy.__version__,
@@ -650,11 +650,11 @@ class TerminalReporter(object):
                 if col.name == "()":  # Skip Instances.
                     continue
                 indent = (len(stack) - 1) * "  "
-                self._tw.line("%s%s" % (indent, col))
+                self._tw.line("{}{}".format(indent, col))
                 if self.config.option.verbose >= 1:
                     if hasattr(col, "_obj") and col._obj.__doc__:
                         for line in col._obj.__doc__.strip().splitlines():
-                            self._tw.line("%s%s" % (indent + "  ", line.strip()))
+                            self._tw.line("{}{}".format(indent + "  ", line.strip()))
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_sessionfinish(self, exitstatus):
@@ -854,7 +854,7 @@ class TerminalReporter(object):
                 if rep.when == "collect":
                     msg = "ERROR collecting " + msg
                 else:
-                    msg = "ERROR at %s of %s" % (rep.when, msg)
+                    msg = "ERROR at {} of {}".format(rep.when, msg)
                 self.write_sep("_", msg, red=True, bold=True)
                 self._outrep_summary(rep)
 
@@ -874,7 +874,7 @@ class TerminalReporter(object):
     def summary_stats(self):
         session_duration = time.time() - self._sessionstarttime
         (line, color) = build_summary_stats_line(self.stats)
-        msg = "%s in %.2f seconds" % (line, session_duration)
+        msg = "{} in {:.2f} seconds".format(line, session_duration)
         markup = {color: True, "bold": True}
 
         if self.verbosity >= 0:
@@ -901,7 +901,7 @@ class TerminalReporter(object):
             for rep in xfailed:
                 verbose_word = rep._get_verbose_word(self.config)
                 pos = _get_pos(self.config, rep)
-                lines.append("%s %s" % (verbose_word, pos))
+                lines.append("{} {}".format(verbose_word, pos))
                 reason = rep.wasxfail
                 if reason:
                     lines.append("  " + str(reason))
@@ -912,7 +912,7 @@ class TerminalReporter(object):
                 verbose_word = rep._get_verbose_word(self.config)
                 pos = _get_pos(self.config, rep)
                 reason = rep.wasxfail
-                lines.append("%s %s %s" % (verbose_word, pos, reason))
+                lines.append("{} {} {}".format(verbose_word, pos, reason))
 
         def show_skipped(lines):
             skipped = self.stats.get("skipped", [])
@@ -966,7 +966,7 @@ def _get_line_with_reprcrash_message(config, rep, termwidth):
     verbose_word = rep._get_verbose_word(config)
     pos = _get_pos(config, rep)
 
-    line = "%s %s" % (verbose_word, pos)
+    line = "{} {}".format(verbose_word, pos)
     len_line = wcswidth(line)
     ellipsis, len_ellipsis = "...", 3
     if len_line > termwidth - len_ellipsis:

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -566,9 +566,7 @@ class TerminalReporter(object):
             verinfo = ".".join(map(str, sys.pypy_version_info[:3]))
             msg += "[pypy-{}-{}]".format(verinfo, sys.pypy_version_info[3])
         msg += ", pytest-{}, py-{}, pluggy-{}".format(
-            pytest.__version__,
-            py.__version__,
-            pluggy.__version__,
+            pytest.__version__, py.__version__, pluggy.__version__
         )
         if (
             self.verbosity > 0

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -19,7 +19,7 @@ def _setoption(wmod, arg):
     """
     parts = arg.split(":")
     if len(parts) > 5:
-        raise wmod._OptionError("too many fields (max 5): %r" % (arg,))
+        raise wmod._OptionError("too many fields (max 5): {!r}".format(arg))
     while len(parts) < 5:
         parts.append("")
     action, message, category, module, lineno = [s.strip() for s in parts]
@@ -31,7 +31,7 @@ def _setoption(wmod, arg):
             if lineno < 0:
                 raise ValueError
         except (ValueError, OverflowError):
-            raise wmod._OptionError("invalid lineno %r" % (lineno,))
+            raise wmod._OptionError("invalid lineno {!r}".format(lineno))
     else:
         lineno = 0
     wmod.filterwarnings(action, message, category, module, lineno)

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -676,7 +676,7 @@ class TestPDB(object):
                 set_trace()
         """
         )
-        child = testdir.spawn_pytest("--tb=short %s %s" % (p1, capture_arg))
+        child = testdir.spawn_pytest("--tb=short {} {}".format(p1, capture_arg))
         child.expect("=== SET_TRACE ===")
         before = child.before.decode("utf8")
         if not capture_arg:

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1648,7 +1648,7 @@ def test_line_with_reprcrash(monkeypatch):
         actual = _get_line_with_reprcrash_message(config, rep(), width)
 
         assert actual == expected
-        if actual != "%s %s" % (mocked_verbose_word, mocked_pos):
+        if actual != "{} {}".format(mocked_verbose_word, mocked_pos):
             assert len(actual) <= width
             assert wcswidth(actual) <= width
 


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.
(please delete this text from the final description, this is just a guideline)
-->

- [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [ ] Add yourself to `AUTHORS` in alphabetical order;


To help with backports, and related to #5275, this runs `pyupgrade` _without_ `--py3-plus` on the `4.6-maintenance` branch, to minimise the difference between it and the master branch, where `pyupgrade` has been run (with `--py3-plus`).

(And run Black.)