### PR TITLE
fix logic if importlib_metadata.PathDistribution.files is None [breaks pytest 4.6.0|1|2]

### DIFF
--- a/changelog/5389.bugfix.rst
+++ b/changelog/5389.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regressions of `#5063 <https://github.com/pytest-dev/pytest/pull/5063>`__ for ``importlib_metadata.PathDistribution`` which have their ``files`` attribute being ``None``.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -784,7 +784,7 @@ class Config:
             str(file)
             for dist in importlib_metadata.distributions()
             if any(ep.group == "pytest11" for ep in dist.entry_points)
-            for file in dist.files
+            for file in dist.files or []
         )
 
         for name in _iter_rewritable_modules(package_files):

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -578,6 +578,29 @@ def test_setuptools_importerror_issue1479(testdir, monkeypatch):
         testdir.parseconfig()
 
 
+def test_importlib_metadata_broken_distribution(testdir, monkeypatch):
+    """Integration test for broken distributions with 'files' metadata being None (#5389)"""
+    monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
+
+    class DummyEntryPoint:
+        name = "mytestplugin"
+        group = "pytest11"
+
+        def load(self):
+            return object()
+
+    class Distribution:
+        version = "1.0"
+        files = None
+        entry_points = (DummyEntryPoint(),)
+
+    def distributions():
+        return (Distribution(),)
+
+    monkeypatch.setattr(importlib_metadata, "distributions", distributions)
+    testdir.parseconfig()
+
+
 @pytest.mark.parametrize("block_it", [True, False])
 def test_plugin_preparse_prevents_setuptools_loading(testdir, monkeypatch, block_it):
     monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)


### PR DESCRIPTION
For some Python packages the `files` attribute of a `importlib_metadata.PathDistribution` is `None` (see e.g ros2/ros2_documentation#271). In that case the code modified in #5358 and released in 4.6 fails with the stacktrace mentioned in the referenced ticket.

This patch certainly fixes the exception (trying to iterate `None`). I am not certain if it is the right way to address the issue though.