### PR TITLE
item.obj is again a bound method on TestCase function items

### DIFF
--- a/changelog/5390.bugfix.rst
+++ b/changelog/5390.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression where the ``obj`` attribute of ``TestCase`` items was no longer bound to methods.

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -108,11 +108,13 @@ class TestCaseFunction(Function):
 
     def setup(self):
         self._testcase = self.parent.obj(self.name)
+        self._obj = getattr(self._testcase, self.name)
         if hasattr(self, "_request"):
             self._request._fillfixtures()
 
     def teardown(self):
         self._testcase = None
+        self._obj = None
 
     def startTest(self, testcase):
         pass

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -139,6 +139,29 @@ def test_new_instances(testdir):
     reprec.assertoutcome(passed=2)
 
 
+def test_function_item_obj_is_instance(testdir):
+    """item.obj should be a bound method on unittest.TestCase function items (#5390)."""
+    testdir.makeconftest(
+        """
+        def pytest_runtest_makereport(item, call):
+            if call.when == 'call':
+                class_ = item.parent.obj
+                assert isinstance(item.obj.__self__, class_)
+    """
+    )
+    testdir.makepyfile(
+        """
+        import unittest
+
+        class Test(unittest.TestCase):
+            def test_foo(self):
+                pass
+    """
+    )
+    result = testdir.runpytest_inprocess()
+    result.stdout.fnmatch_lines(["* 1 passed in*"])
+
+
 def test_teardown(testdir):
     testpath = testdir.makepyfile(
         """


### PR DESCRIPTION
Fix #5390
