### PR TITLE
[4.6] Distribution.files is None in some packages

### DIFF
--- a/changelog/5389.bugfix.rst
+++ b/changelog/5389.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regressions of `#5063 <https://github.com/pytest-dev/pytest/pull/5063>`__ for ``importlib_metadata.PathDistribution`` which have their ``files`` attribute being ``None``.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -800,7 +800,7 @@ class Config(object):
             str(file)
             for dist in importlib_metadata.distributions()
             if any(ep.group == "pytest11" for ep in dist.entry_points)
-            for file in dist.files
+            for file in dist.files or []
         )
 
         for name in _iter_rewritable_modules(package_files):

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -586,6 +586,29 @@ def test_setuptools_importerror_issue1479(testdir, monkeypatch):
         testdir.parseconfig()
 
 
+def test_importlib_metadata_broken_distribution(testdir, monkeypatch):
+    """Integration test for broken distributions with 'files' metadata being None (#5389)"""
+    monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
+
+    class DummyEntryPoint:
+        name = "mytestplugin"
+        group = "pytest11"
+
+        def load(self):
+            return object()
+
+    class Distribution:
+        version = "1.0"
+        files = None
+        entry_points = (DummyEntryPoint(),)
+
+    def distributions():
+        return (Distribution(),)
+
+    monkeypatch.setattr(importlib_metadata, "distributions", distributions)
+    testdir.parseconfig()
+
+
 @pytest.mark.parametrize("block_it", [True, False])
 def test_plugin_preparse_prevents_setuptools_loading(testdir, monkeypatch, block_it):
     monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)


### PR DESCRIPTION
Backport of #5389

**Question**: when backporting, should we squash commits? I vote yes.