### PR TITLE
Revert "Enable coverage for 'py37' environment"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
         - test $(python -c 'import sys; print("%d%d" % sys.version_info[0:2])') = 37
 
     # Full run of latest supported version, without xdist.
-    - env: TOXENV=py37  PYTEST_COVERAGE=1
+    - env: TOXENV=py37
       python: '3.7'
 
     # Coverage tracking is slow with pypy, skip it.


### PR DESCRIPTION
This reverts commit 6d393c5dc8bfc9e437f85dae83914004409b1bc2.

It should not be necessary, because we have it via other jobs already.