### PR TITLE
Reinstate AssertionRewritingHook._register_with_pkg_resources

### DIFF
--- a/changelog/5392.bugfix.rst
+++ b/changelog/5392.bugfix.rst
@@ -1,0 +1,1 @@
+Reinstate ``AssertionRewritingHook._register_with_pkg_resources`` so ``has_resource`` for ``pkg_resources`` providers doesn't fail in tests.

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1305,3 +1305,18 @@ class TestEarlyRewriteBailout:
         )
         result = testdir.runpytest()
         result.stdout.fnmatch_lines(["* 1 passed in *"])
+
+
+def test_issue_5392_registriation_with_pkg_resources(testdir):
+    """See https://github.com/pytest-dev/pytest/issues/5392"""
+    pkg = testdir.mkpydir("loadme")
+    pkg.join("templates").mkdir().join("test.txt").write("hello")
+    pkg.join("test_pkg_resources.py").write(
+        """\
+from pkg_resources import get_provider
+def test_has_resource():
+    assert get_provider(__name__).has_resource("templates/test.txt")
+"""
+    )
+
+    testdir.runpytest().assert_outcomes(passed=1)


### PR DESCRIPTION
As discussed in #5392, restore `_register_with_pkg_resources` removed in 13f02af97d676bdf7143aa1834c8898fbf753d87 so ``has_resource`` for ``pkg_resources`` providers doesn't fail in tests. Haven't changed the code otherwise, comments and docstring are from the original.

Added a unit test that fails without the fix, and passes with it. Added a changelog entry, might not be required for such a trivial revert?