### PR TITLE
tests: restore tracing function

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,4 +1,19 @@
+import sys
+
 import pytest
+
+if sys.gettrace():
+
+    @pytest.fixture(autouse=True)
+    def restore_tracing():
+        """Restore tracing function (when run with Coverage.py).
+
+        https://bugs.python.org/issue37011
+        """
+        orig_trace = sys.gettrace()
+        yield
+        if sys.gettrace() != orig_trace:
+            sys.settrace(orig_trace)
 
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)


### PR DESCRIPTION
Without this, `testing/test_pdb.py` (already without pexpect) will cause
missing test coverage afterwards (for the same process).

https://bugs.python.org/issue37011