### PR TITLE
ci: optimize twisted/numpy related jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ jobs:
   include:
     # OSX tests - first (in test stage), since they are the slower ones.
     - os: osx
-      # NOTE: (tests with) pexpect appear to be buggy on Travis,
-      #       at least with coverage.
-      #       Log: https://travis-ci.org/pytest-dev/pytest/jobs/500358864
       osx_image: xcode10.1
       language: generic
       env: TOXENV=py37-xdist PYTEST_COVERAGE=1
@@ -45,12 +42,12 @@ jobs:
     # - TestArgComplete (linux only)
     # - numpy
     # Empty PYTEST_ADDOPTS to run this non-verbose.
-    - env: TOXENV=py37-lsof-numpy-xdist PYTEST_COVERAGE=1 PYTEST_ADDOPTS=
+    - env: TOXENV=py37-lsof-numpy-twisted-xdist PYTEST_COVERAGE=1 PYTEST_ADDOPTS=
 
     # Specialized factors for py37.
     # Coverage for:
     # - test_sys_breakpoint_interception (via pexpect).
-    - env: TOXENV=py37-pexpect,py37-twisted PYTEST_COVERAGE=1
+    - env: TOXENV=py37-pexpect PYTEST_COVERAGE=1
     - env: TOXENV=py37-pluggymaster-xdist
     - env: TOXENV=py37-freeze
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
         tox.env: 'py36-xdist'
       py37:
         python.version: '3.7'
-        tox.env: 'py37'
+        tox.env: 'py37-twisted-numpy'
         # Coverage for:
         # - _py36_windowsconsoleio_workaround (with py36+)
         # - test_request_garbage (no xdist)
@@ -36,9 +36,6 @@ jobs:
       py37-linting/docs/doctesting:
         python.version: '3.7'
         tox.env: 'linting,docs,doctesting'
-      py37-twisted/numpy:
-        python.version: '3.7'
-        tox.env: 'py37-twisted,py37-numpy'
       py37-pluggymaster-xdist:
         python.version: '3.7'
         tox.env: 'py37-pluggymaster-xdist'

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands =
     coverage: coverage report
 passenv = USER USERNAME COVERAGE_* TRAVIS PYTEST_ADDOPTS
 setenv =
-    _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_POSARGS_LSOF:} {env:_PYTEST_TOX_POSARGS_PEXPECT:} {env:_PYTEST_TOX_POSARGS_TWISTED:} {env:_PYTEST_TOX_POSARGS_XDIST:}
+    _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_POSARGS_LSOF:} {env:_PYTEST_TOX_POSARGS_XDIST:}
 
     # Configuration to run with coverage similar to Travis/Appveyor, e.g.
     # "tox -e py37-coverage".
@@ -37,9 +37,6 @@ setenv =
     lsof: _PYTEST_TOX_POSARGS_LSOF=--lsof
 
     pexpect: _PYTEST_TOX_PLATFORM=linux|darwin
-    pexpect: _PYTEST_TOX_POSARGS_PEXPECT=-m uses_pexpect
-
-    twisted: _PYTEST_TOX_POSARGS_TWISTED=testing/test_unittest.py
 
     xdist: _PYTEST_TOX_POSARGS_XDIST=-n auto
 extras = testing


### PR DESCRIPTION
- tox: use twisted as dep only
- Azure: move twisted/numpy to main py37 job
- Travis: move twisted to main py37 build
