### PR TITLE
Add `slow` marker in run/skip option example.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -200,6 +200,7 @@ Pulkit Goyal
 Punyashloka Biswal
 Quentin Pradet
 Ralf Schmitt
+Ralph Giles
 Ran Benita
 Raphael Castaneda
 Raphael Pierzina

--- a/changelog/5416.doc.rst
+++ b/changelog/5416.doc.rst
@@ -1,0 +1,1 @@
+Fix PytestUnknownMarkWarning in run/skip example.

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -157,6 +157,10 @@ line option to control skipping of ``pytest.mark.slow`` marked tests:
         )
 
 
+    def pytest_configure(config):
+        config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
     def pytest_collection_modifyitems(config, items):
         if config.getoption("--runslow"):
             # --runslow given in cli: do not skip slow tests


### PR DESCRIPTION
The example implementation of a `--runslow` option results in
a `PytestUnknownMarkWarning`. Include registering the custom
mark in the example, based on the documentation in markers.rst.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.
(please delete this text from the final description, this is just a guideline)
-->

- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Add yourself to `AUTHORS` in alphabetical order;
