### PR TITLE
Link deprecation docs pytest.raises 'message' warning

### DIFF
--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -35,8 +35,8 @@ GETFUNCARGVALUE = RemovedInPytest4Warning(
 RAISES_MESSAGE_PARAMETER = PytestDeprecationWarning(
     "The 'message' parameter is deprecated.\n"
     "(did you mean to use `match='some regex'` to check the exception message?)\n"
-    "Please comment on https://github.com/pytest-dev/pytest/issues/3974 "
-    "if you have concerns about removal of this parameter."
+    "Please see:\n"
+    "  https://docs.pytest.org/en/4.6-maintenance/deprecations.html#message-parameter-of-pytest-raises"
 )
 
 RESULT_LOG = PytestDeprecationWarning(


### PR DESCRIPTION
As commented in https://github.com/pytest-dev/pytest/issues/3974#issuecomment-499870914
