### PR TITLE
Postpone removal of --result-log to pytest 6.0

### DIFF
--- a/changelog/4488.deprecation.rst
+++ b/changelog/4488.deprecation.rst
@@ -1,0 +1,2 @@
+The removal of the ``--result-log`` option and module has been postponed to (tentatively) pytest 6.0 as
+the team has not yet got around to implement a good alternative for it.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -101,20 +101,21 @@ Becomes:
 
 
 
-
-
-
 Result log (``--result-log``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. deprecated:: 4.0
 
+The ``--result-log`` option produces a stream of test reports which can be
+analysed at runtime. It uses a custom format which requires users to implement their own
+parser, but the team believes using a line-based format that can be parsed using standard
+tools would provide a suitable and better alternative.
 
-The ``--resultlog`` command line option has been deprecated: it is little used
-and there are more modern and better alternatives, for example `pytest-tap <https://tappy.readthedocs.io/en/latest/>`_.
+The current plan is to provide an alternative in the pytest 5.0 series and remove the ``--result-log``
+option in pytest 6.0 after the new implementation proves satisfactory to all users and is deemed
+stable.
 
-This feature will be effectively removed in pytest 4.0 as the team intends to include a better alternative in the core.
-
-If you have any concerns, please don't hesitate to `open an issue <https://github.com/pytest-dev/pytest/issues>`__.
+The actual alternative is still being discussed in issue `#4488 <https://github.com/pytest-dev/pytest/issues/4488>`__.
 
 Removed Features
 ----------------

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -40,7 +40,7 @@ RAISES_MESSAGE_PARAMETER = PytestDeprecationWarning(
 )
 
 RESULT_LOG = PytestDeprecationWarning(
-    "--result-log is deprecated and scheduled for removal in pytest 5.0.\n"
+    "--result-log is deprecated and scheduled for removal in pytest 6.0.\n"
     "See https://docs.pytest.org/en/latest/deprecations.html#result-log-result-log for more information."
 )
 

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -49,7 +49,7 @@ def test_resultlog_is_deprecated(testdir):
     result = testdir.runpytest("--result-log=%s" % testdir.tmpdir.join("result.log"))
     result.stdout.fnmatch_lines(
         [
-            "*--result-log is deprecated and scheduled for removal in pytest 5.0*",
+            "*--result-log is deprecated and scheduled for removal in pytest 6.0*",
             "*See https://docs.pytest.org/en/latest/deprecations.html#result-log-result-log for more information*",
         ]
     )


### PR DESCRIPTION
As we did not provide an alternative yet, it is better to postpone
the actual removal until we have provided a suitable and stable
alternative.

Related to #4488