### PR TITLE
Remove broken/unused PytestPluginManager.addhooks

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -23,7 +23,6 @@ from .exceptions import PrintHelp
 from .exceptions import UsageError
 from .findpaths import determine_setup
 from .findpaths import exists
-from _pytest import deprecated
 from _pytest._code import ExceptionInfo
 from _pytest._code import filter_traceback
 from _pytest.outcomes import fail
@@ -241,16 +240,6 @@ class PytestPluginManager(PluginManager):
         self.rewrite_hook = _pytest.assertion.DummyRewriteHook()
         # Used to know when we are importing conftests after the pytest_configure stage
         self._configured = False
-
-    def addhooks(self, module_or_class):
-        """
-        .. deprecated:: 2.8
-
-        Use :py:meth:`pluggy.PluginManager.add_hookspecs <PluginManager.add_hookspecs>`
-        instead.
-        """
-        warnings.warn(deprecated.PLUGIN_MANAGER_ADDHOOKS, stacklevel=2)
-        return self.add_hookspecs(module_or_class)
 
     def parse_hookimpl_opts(self, plugin, name):
         # pytest hooks are always prefixed with pytest_


### PR DESCRIPTION
The function has been deprecated for ages and the `PLUGIN_MANAGER_ADDHOOKS` constant doesn't even exist since 3.0.

Because the function is clearly broken, this change doesn't even require a `CHANGELOG`.
