### PR TITLE
Disallow abbreviated command-line options

### DIFF
--- a/changelog/1149.feature.rst
+++ b/changelog/1149.feature.rst
@@ -1,0 +1,4 @@
+Pytest no longer accepts prefixes of command-line arguments.
+This was previously allowed where the ``ArgumentParser`` thought it was unambigious,
+because this could be incorrect due to delayed parsing of options for plugins.
+See for example issues #1149, #3413, and #4009.

--- a/extra/get_issues.py
+++ b/extra/get_issues.py
@@ -74,7 +74,7 @@ def report(issues):
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser("process bitbucket issues")
+    parser = argparse.ArgumentParser("process bitbucket issues", allow_abbrev=False)
     parser.add_argument(
         "--refresh", action="store_true", help="invalidate cache, refresh issues"
     )

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -105,7 +105,7 @@ def changelog(version, write_out=False):
 
 def main():
     init(autoreset=True)
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("version", help="Release version")
     options = parser.parse_args()
     pre_release(options.version)

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -328,6 +328,7 @@ class MyOptionParser(argparse.ArgumentParser):
             usage=parser._usage,
             add_help=False,
             formatter_class=DropShorterLongHelpFormatter,
+            allow_abbrev=False,
         )
         # extra_info is a dict of (param -> value) to display if there's
         # an usage error to provide more contextual information to the user

--- a/testing/example_scripts/perf_examples/collect_stats/generate_folders.py
+++ b/testing/example_scripts/perf_examples/collect_stats/generate_folders.py
@@ -4,7 +4,7 @@ import pathlib
 HERE = pathlib.Path(__file__).parent
 TEST_CONTENT = (HERE / "template_test.py").read_bytes()
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(allow_abbrev=False)
 parser.add_argument("numbers", nargs="*", type=int)
 
 

--- a/testing/test_parseopt.py
+++ b/testing/test_parseopt.py
@@ -200,7 +200,7 @@ class TestParser:
 
     def test_drop_short_helper(self):
         parser = argparse.ArgumentParser(
-            formatter_class=parseopt.DropShorterLongHelpFormatter
+            formatter_class=parseopt.DropShorterLongHelpFormatter, allow_abbrev=False
         )
         parser.add_argument(
             "-t", "--twoword", "--duo", "--two-word", "--two", help="foo"


### PR DESCRIPTION
This was previously allowed where the ``ArgumentParser`` thought it was unambigious, because this could be incorrect due to delayed parsing of options for plugins.

Fixes #1149, fixes #3413, and fixes #4009 - it's been a known problem for quite a while, but this fix is only available on Python 3.5+... which means we can finally do it!