### PR TITLE
minor: clarify help with reportchars

### DIFF
--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -76,8 +76,7 @@ def pytest_addoption(parser):
         help="show extra test summary info as specified by chars: (f)ailed, "
         "(E)rror, (s)kipped, (x)failed, (X)passed, "
         "(p)assed, (P)assed with output, (a)ll except passed (p/P), or (A)ll. "
-        "Warnings are displayed at all times except when "
-        "--disable-warnings is set.",
+        "(w)arnings are enabled by default (see --disable-warnings).",
     )
     group._addoption(
         "--disable-warnings",


### PR DESCRIPTION
`-ra` / `-rA` will include "w" also.  This does not explicitly mention
it (allowing for change the behavior), but makes it a) clearer that "w"
is a recognized reportchar, and b) less confusing that `-ra
--disable-warnings` still displays them.

Code ref: https://github.com/blueyed/pytest/blob/01a094cc4316a2840254a66f829367f3d67fd442/src/_pytest/terminal.py#L151-L166