### PR TITLE
Fix pytest.raises handling of unicode exceptions in Python 2

### DIFF
--- a/changelog/5478.bugfix.rst
+++ b/changelog/5478.bugfix.rst
@@ -1,0 +1,1 @@
+Use safe_str to serialize Exceptions in pytest.raises

--- a/changelog/5478.bugfix.rst
+++ b/changelog/5478.bugfix.rst
@@ -1,1 +1,1 @@
-Use safe_str to serialize Exceptions in pytest.raises
+Fix encode error when using unicode strings in exceptions with ``pytest.raises``.

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -572,8 +572,9 @@ class ExceptionInfo(object):
         raised.
         """
         __tracebackhide__ = True
-        if not re.search(regexp, str(self.value)):
-            assert 0, "Pattern '{!s}' not found in '{!s}'".format(regexp, self.value)
+        value = safe_str(self.value)
+        if not re.search(regexp, value):
+            assert 0, "Pattern '{!s}' not found in '{!s}'".format(regexp, value)
         return True
 
 

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -572,9 +572,13 @@ class ExceptionInfo(object):
         raised.
         """
         __tracebackhide__ = True
-        value = safe_str(self.value)
+        value = (
+            text_type(self.value) if isinstance(regexp, text_type) else str(self.value)
+        )
         if not re.search(regexp, value):
-            assert 0, "Pattern '{!s}' not found in '{!s}'".format(regexp, value)
+            raise AssertionError(
+                "Pattern '{!s}' not found in '{!s}'".format(regexp, value)
+            )
         return True
 
 

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -577,7 +577,7 @@ class ExceptionInfo(object):
         )
         if not re.search(regexp, value):
             raise AssertionError(
-                u"Pattern '{}' not found in '{}'".format(regexp, value)
+                u"Pattern {!r} not found in {!r}".format(regexp, value)
             )
         return True
 

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -577,7 +577,7 @@ class ExceptionInfo(object):
         )
         if not re.search(regexp, value):
             raise AssertionError(
-                "Pattern '{!s}' not found in '{!s}'".format(regexp, value)
+                u"Pattern '{}' not found in '{}'".format(regexp, value)
             )
         return True
 

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -221,7 +221,7 @@ class TestRaises(object):
             int("asdf")
 
         msg = "with base 16"
-        expr = r"Pattern '{}' not found in 'invalid literal for int\(\) with base 10: 'asdf''".format(
+        expr = r"Pattern '{}' not found in \"invalid literal for int\(\) with base 10: 'asdf'\"".format(
             msg
         )
         with pytest.raises(AssertionError, match=expr):
@@ -304,6 +304,18 @@ class TestUnicodeHandling:
             pytest.param(u"hello", b"hello", success(), marks=py2_only),
             pytest.param(
                 u"hello", b"world", pytest.raises(AssertionError), marks=py2_only
+            ),
+            pytest.param(
+                u"😊".encode("UTF-8"),
+                b"world",
+                pytest.raises(AssertionError),
+                marks=py2_only,
+            ),
+            pytest.param(
+                u"world",
+                u"😊".encode("UTF-8"),
+                pytest.raises(AssertionError),
+                marks=py2_only,
             ),
         ],
     )

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -279,6 +279,8 @@ class TestRaises(object):
                     pass
             assert "via __class__" in excinfo.value.args[0]
 
-    def test_u(self):
+    def test_unicode_message(self):
+        """pytest.raises should be able to match unicode messages when using a unicode regex (#5478)
+        """
         with pytest.raises(AssertionError, match=u"\u2603"):
             assert False, u"\u2603"

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -278,3 +278,7 @@ class TestRaises(object):
                 with pytest.raises(CrappyClass()):
                     pass
             assert "via __class__" in excinfo.value.args[0]
+
+    def test_u(self):
+        with pytest.raises(AssertionError, match=u"\u2603"):
+            assert False, u"\u2603"


### PR DESCRIPTION
Fixes #5478