### PR TITLE
Do not attempt to rewrite non-source files

### DIFF
--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -69,6 +69,8 @@ class AssertionRewritingHook:
             # python3.5 - python3.6: `namespace`
             # python3.7+: `None`
             or spec.origin in {None, "namespace"}
+            # we can only rewrite source files
+            or not isinstance(spec.loader, importlib.machinery.SourceFileLoader)
             # if the file doesn't exist, we can't rewrite it
             or not os.path.exists(spec.origin)
         ):


### PR DESCRIPTION
Resolves #5488

I couldn't find a good way to reproduce this in a test, so here's my "minimal reproduction":

```console
$ tree
.
├── setup.py
└── x
    ├── basic_c_module.c
    ├── __init__.py
    └── y.py

1 directory, 4 files
$ find -type f | xargs tail -n 99
==> ./setup.py <==
from setuptools import setup, Extension

setup(
    name='foo',
    packages=['x'],
    ext_modules=[Extension('x.basic_c_module', ['x/basic_c_module.c'])],
    entry_points={'pytest11': ['x=x.y']},
)

==> ./x/basic_c_module.c <==
#include <Python.h>

static PyObject* _hello_world(PyObject* self) {
    return PyUnicode_FromString("hello world");
}

static struct PyMethodDef methods[] = {
    {"hello_world", (PyCFunction)_hello_world, METH_NOARGS},
    {NULL, NULL}
};

#if PY_MAJOR_VERSION >= 3
static struct PyModuleDef module = {
    PyModuleDef_HEAD_INIT,
    "basic_c_module",
    NULL,
    -1,
    methods
};

PyMODINIT_FUNC PyInit_basic_c_module(void) {
    return PyModule_Create(&module);
}
#else
PyMODINIT_FUNC initbasic_c_module(void) {
    Py_InitModule3("basic_c_module", methods, NULL);
}
#endif

==> ./x/y.py <==
import x.basic_c_module

==> ./x/__init__.py <==
```

I then did

```
pip install .
pytest x
```

Which resulted in:

```console
$ pytest x
Traceback (most recent call last):
  File "/tmp/pytest/venv/bin/pytest", line 11, in <module>
    load_entry_point('pytest', 'console_scripts', 'pytest')()
  File "/tmp/pytest/src/_pytest/config/__init__.py", line 55, in main
    config = _prepareconfig(args, plugins)
  File "/tmp/pytest/src/_pytest/config/__init__.py", line 200, in _prepareconfig
    pluginmanager=pluginmanager, args=args
  File "/tmp/pytest/venv/lib/python3.6/site-packages/pluggy/hooks.py", line 289, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/tmp/pytest/venv/lib/python3.6/site-packages/pluggy/manager.py", line 87, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/tmp/pytest/venv/lib/python3.6/site-packages/pluggy/manager.py", line 81, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/tmp/pytest/venv/lib/python3.6/site-packages/pluggy/callers.py", line 203, in _multicall
    gen.send(outcome)
  File "/tmp/pytest/src/_pytest/helpconfig.py", line 89, in pytest_cmdline_parse
    config = outcome.get_result()
  File "/tmp/pytest/venv/lib/python3.6/site-packages/pluggy/callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/tmp/pytest/venv/lib/python3.6/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/tmp/pytest/src/_pytest/config/__init__.py", line 661, in pytest_cmdline_parse
    self.parse(args)
  File "/tmp/pytest/src/_pytest/config/__init__.py", line 869, in parse
    self._preparse(args, addopts=addopts)
  File "/tmp/pytest/src/_pytest/config/__init__.py", line 815, in _preparse
    self.pluginmanager.load_setuptools_entrypoints("pytest11")
  File "/tmp/pytest/venv/lib/python3.6/site-packages/pluggy/manager.py", line 292, in load_setuptools_entrypoints
    plugin = ep.load()
  File "/tmp/pytest/venv/lib/python3.6/site-packages/importlib_metadata/__init__.py", line 90, in load
    module = import_module(match.group('module'))
  File "/tmp/pytest/venv/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "/tmp/pytest/src/_pytest/assertion/rewrite.py", line 143, in exec_module
    exec(co, module.__dict__)
  File "/tmp/pytest/venv/lib/python3.6/site-packages/x/y.py", line 1, in <module>
    import x.basic_c_module
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "/tmp/pytest/src/_pytest/assertion/rewrite.py", line 134, in exec_module
    source_stat, co = _rewrite_test(fn)
  File "/tmp/pytest/src/_pytest/assertion/rewrite.py", line 283, in _rewrite_test
    tree = ast.parse(source, filename=fn)
  File "/usr/lib/python3.6/ast.py", line 35, in parse
    return compile(source, filename, mode, PyCF_ONLY_AST)
ValueError: source code string cannot contain null bytes
```

After fixing:

```
$ pytest x
============================= test session starts ==============================
platform linux -- Python 3.6.7, pytest-4.6.1.dev136+ga54e2e19f.d20190625, py-1.8.0, pluggy-0.12.0
rootdir: /tmp/pytest, inifile: tox.ini
plugins: foo-0.0.0
collected 0 items                                                              

========================= no tests ran in 0.01 seconds =========================
```