### PR TITLE
Deprecate funcargnames alias for fixturenames

### DIFF
--- a/changelog/466.deprecation.rst
+++ b/changelog/466.deprecation.rst
@@ -1,0 +1,2 @@
+The ``funcargnames`` attribute has been an alias for ``fixturenames`` since
+pytest 2.3, and is now deprecated in code too.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -19,6 +19,21 @@ Below is a complete list of all pytest features which are considered deprecated.
 :class:`_pytest.warning_types.PytestWarning` or subclasses, which can be filtered using
 :ref:`standard warning filters <warnings>`.
 
+
+Removal of ``funcargnames`` alias for ``fixturenames``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 5.0
+
+The ``FixtureRequest``, ``Metafunc``, and ``Function`` classes track the names of
+their associated fixtures, with the aptly-named ``fixturenames`` attribute.
+
+Prior to pytest 2.3, this attribute was named ``funcargnames``, and we have kept
+that as an alias since.  It is finally due for removal, as it is often confusing
+in places where we or plugin authors must distinguish between fixture names and
+names supplied by non-fixture things such as ``pytest.mark.parametrize``.
+
+
 .. _`raises message deprecated`:
 
 ``"message"`` parameter of ``pytest.raises``

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -325,4 +325,8 @@ class FuncargnamesCompatAttr:
     @property
     def funcargnames(self):
         """ alias attribute for ``fixturenames`` for pre-2.3 compatibility"""
+        import warnings
+        from _pytest.deprecated import FUNCARGNAMES
+
+        warnings.warn(FUNCARGNAMES, stacklevel=2)
         return self.fixturenames

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -40,6 +40,11 @@ GETFUNCARGVALUE = RemovedInPytest4Warning(
     "getfuncargvalue is deprecated, use getfixturevalue"
 )
 
+FUNCARGNAMES = PytestDeprecationWarning(
+    "The `funcargnames` attribute was an alias for `fixturenames`, "
+    "since pytest 2.3 - use the newer attribute instead."
+)
+
 RAISES_MESSAGE_PARAMETER = PytestDeprecationWarning(
     "The 'message' parameter is deprecated.\n"
     "(did you mean to use `match='some regex'` to check the exception message?)\n"

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -654,7 +654,7 @@ class SubRequest(FixtureRequest):
         # if the executing fixturedef was not explicitly requested in the argument list (via
         # getfixturevalue inside the fixture call) then ensure this fixture def will be finished
         # first
-        if fixturedef.argname not in self.funcargnames:
+        if fixturedef.argname not in self.fixturenames:
             fixturedef.addfinalizer(
                 functools.partial(self._fixturedef.finish, request=self)
             )

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -793,12 +793,15 @@ class TestRequestBasic:
             """
             import pytest
             def pytest_generate_tests(metafunc):
-                assert metafunc.funcargnames == metafunc.fixturenames
+                with pytest.warns(pytest.PytestDeprecationWarning):
+                    assert metafunc.funcargnames == metafunc.fixturenames
             @pytest.fixture
             def fn(request):
-                assert request._pyfuncitem.funcargnames == \
-                       request._pyfuncitem.fixturenames
-                return request.funcargnames, request.fixturenames
+                with pytest.warns(pytest.PytestDeprecationWarning):
+                    assert request._pyfuncitem.funcargnames == \
+                           request._pyfuncitem.fixturenames
+                with pytest.warns(pytest.PytestDeprecationWarning):
+                    return request.funcargnames, request.fixturenames
 
             def test_hello(fn):
                 assert fn[0] == fn[1]

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1205,7 +1205,7 @@ class TestMetafuncFunctional:
             import pytest
             values = []
             def pytest_generate_tests(metafunc):
-                if "arg" in metafunc.funcargnames:
+                if "arg" in metafunc.fixturenames:
                     metafunc.parametrize("arg", [1,2], indirect=True,
                                          scope=%r)
             @pytest.fixture


### PR DESCRIPTION
But leave the helper until 5.1, so that the error message can be helpful and suggest using the modern form.  Closes #4676.

This is a direct replacement for #5476, targeting master instead of features.