### PR TITLE
Fix typo replace `circuting` with `circuiting`.

### DIFF
--- a/changelog/5497.trivial.rst
+++ b/changelog/5497.trivial.rst
@@ -1,1 +1,0 @@
-Fix typo replace ``circuting`` with circuiting.

--- a/changelog/5497.trivial.rst
+++ b/changelog/5497.trivial.rst
@@ -1,1 +1,1 @@
-Fix typo replace `circuting` with `circuiting`.
+Fix typo replace ``circuting`` with circuiting.

--- a/changelog/5497.trivial.rst
+++ b/changelog/5497.trivial.rst
@@ -1,0 +1,1 @@
+Fix typo replace `circuting` with `circuiting`.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -771,7 +771,7 @@ warn_explicit(
         fail_save = self.on_failure
         levels = len(boolop.values) - 1
         self.push_format_context()
-        # Process each operand, short-circuting if needed.
+        # Process each operand, short-circuiting if needed.
         for i, v in enumerate(boolop.values):
             if i:
                 fail_inner = []


### PR DESCRIPTION
- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
