### PR TITLE
[4.6] Fix crash when discovery fails while using `-p no:terminal`

### DIFF
--- a/changelog/5505.bugfix.rst
+++ b/changelog/5505.bugfix.rst
@@ -1,0 +1,1 @@
+Fix crash when discovery fails while using ``-p no:terminal``.

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -329,7 +329,7 @@ class Collector(Node):
 
         # Respect explicit tbstyle option, but default to "short"
         # (None._repr_failure_py defaults to "long" without "fulltrace" option).
-        tbstyle = self.config.getoption("tbstyle")
+        tbstyle = self.config.getoption("tbstyle", "auto")
         if tbstyle == "auto":
             tbstyle = "short"
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -15,6 +15,7 @@ from _pytest.config.exceptions import UsageError
 from _pytest.config.findpaths import determine_setup
 from _pytest.config.findpaths import get_common_ancestor
 from _pytest.config.findpaths import getcfg
+from _pytest.main import EXIT_INTERRUPTED
 from _pytest.main import EXIT_NOTESTSCOLLECTED
 from _pytest.main import EXIT_OK
 from _pytest.main import EXIT_TESTSFAILED
@@ -752,10 +753,10 @@ def test_config_in_subdirectory_colon_command_line_issue2148(testdir):
         **{
             "conftest": conftest_source,
             "subdir/conftest": conftest_source,
-            "subdir/test_foo": """
+            "subdir/test_foo": """\
             def test_foo(pytestconfig):
                 assert pytestconfig.getini('foo') == 'subdir'
-        """,
+            """,
         }
     )
 
@@ -786,6 +787,12 @@ def test_notify_exception(testdir, capfd):
     config.notify_exception(excinfo, config.option)
     out, err = capfd.readouterr()
     assert "ValueError" in err
+
+
+def test_no_terminal_discovery_error(testdir):
+    testdir.makepyfile("raise TypeError('oops!')")
+    result = testdir.runpytest("-p", "no:terminal", "--collect-only")
+    assert result.ret == EXIT_INTERRUPTED
 
 
 def test_load_initial_conftest_last_ordering(testdir, _config_for_test):


### PR DESCRIPTION
via #5506