### PR TITLE
Remove astor and reproduce the original assertion expression

### DIFF
--- a/changelog/3457.trivial.rst
+++ b/changelog/3457.trivial.rst
@@ -1,1 +1,0 @@
-pytest now also depends on the `astor <https://pypi.org/project/astor/>`__ package.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ INSTALL_REQUIRES = [
     "pluggy>=0.12,<1.0",
     "importlib-metadata>=0.12",
     "wcwidth",
-    "astor",
 ]
 
 


### PR DESCRIPTION
Resolves #5510

This is a little different approach than using `astor` in that it reproduces the original assertion source expression directly

I could make this even simpler by including the whole line of the original assertion (then the indentation would be preserved as well???) what do you think of that?