### PR TITLE
Fixed rare race condition error when creating the basetemp directory

### DIFF
--- a/changelog/5524.bugfix.rst
+++ b/changelog/5524.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed rare race condition error when creating the ``basetemp`` directory.

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -33,7 +33,7 @@ def ensure_reset_dir(path):
     """
     if path.exists():
         rmtree(path, force=True)
-    path.mkdir()
+    path.mkdir(exist_ok=True)
 
 
 def rmtree(path, force=False):


### PR DESCRIPTION
Fix #5524

Probably hard/impossible to reproduce in a test, I'm afraid.