### PR TITLE
Apply workaround for multiple short options for Python <= 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,10 +55,8 @@ jobs:
     - env: TOXENV=py37-pluggymaster-xdist
     - env: TOXENV=py37-freeze
 
-    # Jobs only run via Travis cron jobs (currently daily).
     - env: TOXENV=py38-xdist
       python: '3.8-dev'
-      if: type = cron
 
     - stage: baseline
       env: TOXENV=py36-xdist

--- a/changelog/5523.bugfix.rst
+++ b/changelog/5523.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed using multiple short options together in the command-line (for example ``-vs``) in Python 3.8+.

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -358,7 +358,7 @@ class MyOptionParser(argparse.ArgumentParser):
             getattr(args, FILE_OR_DIR).extend(argv)
         return args
 
-    if sys.version_info[:2] < (3, 8):  # pragma: no cover
+    if sys.version_info[:2] < (3, 9):  # pragma: no cover
         # Backport of https://github.com/python/cpython/pull/14316 so we can
         # disable long --argument abbreviations without breaking short flags.
         def _parse_optional(self, arg_string):


### PR DESCRIPTION
Hopefully by Python 3.9 this will be fixed upstream, if not we will
need to bump the version again.

Fix #5523