### PR TITLE
Add docs about Tidelift and OpenCollective

### DIFF
--- a/OPENCOLLECTIVE.rst
+++ b/OPENCOLLECTIVE.rst
@@ -1,0 +1,44 @@
+==============
+OpenCollective
+==============
+
+pytest has a collective setup at `OpenCollective`_. This document describes how the core team manages
+OpenCollective-related activities.
+
+What is it
+==========
+
+Open Collective is an online funding platform for open and transparent communities.
+It provide tools to raise money and share your finances in full transparency.
+
+It is the platform of choice for individuals and companies that want to make one-time or
+monthly donations directly to the project.
+
+Funds
+=====
+
+The OpenCollective funds donated to pytest will be used to fund overall maintenance,
+local sprints, merchandising (stickers to distribute in conferences for example), and future
+gatherings of pytest developers (Sprints).
+
+`Core contributors`_ which are contributing on a continuous basis are free to submit invoices
+to bill maintenance hours using the platform. How much each contributor should request is still an
+open question, but we should use common sense and trust in the contributors, most of which know
+themselves in-person. A good rule of thumb is to bill the same amount as monthly payments
+contributors which participate in the `Tidelift`_ subscription. If in doubt, just ask.
+
+Admins
+======
+
+A few people have admin access to the OpenCollective dashboard to make changes. Those people
+are part of the `@pytest-dev/opencollective-admins`_ team.
+
+`Core contributors`_ interested in helping out with OpenCollective maintenance are welcome! We don't
+expect much work here other than the occasional approval of expenses from other core contributors.
+Just drop a line to one of the `@pytest-dev/opencollective-admins`_ or use the mailing list.
+
+
+.. _`OpenCollective`: https://opencollective.com/pytest
+.. _`Tidelift`: https://tidelift.com
+.. _`core contributors`: https://github.com/orgs/pytest-dev/teams/core/members
+.. _`@pytest-dev/opencollective-admins`: https://github.com/orgs/pytest-dev/teams/opencollective-admins/members

--- a/TIDELIFT.rst
+++ b/TIDELIFT.rst
@@ -12,6 +12,9 @@ Tidelift aims to make Open Source sustainable by offering subscriptions to compa
 on Open Source packages. This subscription allows it to pay maintainers of those Open Source
 packages to aid sustainability of the work.
 
+It is the perfect platform for companies that want to support Open Source packages and at the same
+time obtain assurances regarding maintenance, quality and security.
+
 Funds
 =====
 

--- a/doc/en/_templates/globaltoc.html
+++ b/doc/en/_templates/globaltoc.html
@@ -11,6 +11,7 @@
   <li><a href="{{ pathto('contributing') }}">Contributing</a></li>
   <li><a href="{{ pathto('backwards-compatibility') }}">Backwards Compatibility</a></li>
   <li><a href="{{ pathto('py27-py34-deprecation') }}">Python 2.7 and 3.4 Support</a></li>
+  <li><a href="{{ pathto('sponsor') }}">Sponsor</a></li>
   <li><a href="{{ pathto('license') }}">License</a></li>
   <li><a href="{{ pathto('contact') }}">Contact Channels</a></li>
 </ul>

--- a/doc/en/contents.rst
+++ b/doc/en/contents.rst
@@ -50,7 +50,7 @@ Full pytest documentation
    projects
    faq
    contact
-   tidelift
+   sponsor
 
 .. only:: html
 

--- a/doc/en/sponsor.rst
+++ b/doc/en/sponsor.rst
@@ -1,0 +1,39 @@
+Sponsor
+=======
+
+pytest is maintained by a team of volunteers from all around the world in their free time. While
+we work on pytest because we love the project and use it daily at our daily jobs, monetary
+compensation when possible is welcome to justify time away from friends, family and personal time.
+
+Money is also used to fund local sprints, merchandising (stickers to distribute in conferences for example)
+and every few years a large sprint involving all members.
+
+If you or your company benefit from pytest and would like to contribute to the project financially,
+we are members of two online donation platforms to better suit your needs.
+
+Tidelift
+--------
+
+`Tidelift`_ aims to make Open Source sustainable by offering subscriptions to companies which rely
+on Open Source packages. This subscription allows it to pay maintainers of those Open Source
+packages to aid sustainability of the work.
+
+You can help pytest and the ecosystem by obtaining a `Tidelift subscription`_.
+
+OpenCollective
+--------------
+
+`Open Collective`_ is an online funding platform for open and transparent communities.
+It provide tools to raise money and share your finances in full transparency.
+
+It is the platform of choice for individuals and companies that want to make one-time or
+monthly donations directly to the project.
+
+See more datails in the `pytest collective`_.
+
+
+
+.. _Tidelift: https://tidelift.com
+.. _Tidelift subscription: https://tidelift.com/subscription/pkg/pypi-pytest
+.. _Open Collective: https://opencollective.com
+.. _pytest collective: https://opencollective.com/pytest

--- a/doc/en/tidelift.rst
+++ b/doc/en/tidelift.rst
@@ -1,4 +1,0 @@
-
-
-
-.. include:: ../../TIDELIFT.rst


### PR DESCRIPTION
Give an overview of how we as an organization will use the donated money,
as well as show this information more prominently in the docs.
