### PR TITLE
Replace importlib_metadata with importlib.metadata on Python 3.8+

### DIFF
--- a/changelog/5523.bugfix.rst
+++ b/changelog/5523.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed using multiple short options together in the command-line (for example ``-vs``) in Python 3.8+.

--- a/changelog/5537.bugfix.rst
+++ b/changelog/5537.bugfix.rst
@@ -1,0 +1,2 @@
+Replace ``importlib_metadata`` backport with ``importlib.metadata`` from the
+standard library on Python 3.8+.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ INSTALL_REQUIRES = [
     'pathlib2>=2.2.0;python_version<"3.6"',
     'colorama;sys_platform=="win32"',
     "pluggy>=0.12,<1.0",
-    "importlib-metadata>=0.12",
+    'importlib-metadata>=0.12;python_version<"3.8"',
     "wcwidth",
 ]
 

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -26,6 +26,12 @@ MODULE_NOT_FOUND_ERROR = (
 )
 
 
+if sys.version_info >= (3, 8):
+    from importlib import metadata as importlib_metadata  # noqa
+else:
+    import importlib_metadata  # noqa
+
+
 def _format_args(func):
     return str(signature(func))
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -9,7 +9,6 @@ import types
 import warnings
 from functools import lru_cache
 
-import importlib_metadata
 import py
 from packaging.version import Version
 from pluggy import HookimplMarker
@@ -25,6 +24,7 @@ from .findpaths import determine_setup
 from .findpaths import exists
 from _pytest._code import ExceptionInfo
 from _pytest._code import filter_traceback
+from _pytest.compat import importlib_metadata
 from _pytest.outcomes import fail
 from _pytest.outcomes import Skipped
 from _pytest.warning_types import PytestConfigWarning

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -358,7 +358,7 @@ class MyOptionParser(argparse.ArgumentParser):
             getattr(args, FILE_OR_DIR).extend(argv)
         return args
 
-    if sys.version_info[:2] < (3, 8):  # pragma: no cover
+    if sys.version_info[:2] < (3, 9):  # pragma: no cover
         # Backport of https://github.com/python/cpython/pull/14316 so we can
         # disable long --argument abbreviations without breaking short flags.
         def _parse_optional(self, arg_string):

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -4,10 +4,10 @@ import textwrap
 import types
 
 import attr
-import importlib_metadata
 import py
 
 import pytest
+from _pytest.compat import importlib_metadata
 from _pytest.main import ExitCode
 from _pytest.warnings import SHOW_PYTEST_WARNINGS_ARG
 

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -172,7 +172,8 @@ class TestImportHookInstallation:
                 return check
             """,
             "mainwrapper.py": """\
-            import pytest, importlib_metadata
+            import pytest
+            from _pytest.compat import importlib_metadata
 
             class DummyEntryPoint(object):
                 name = 'spam'

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1,10 +1,9 @@
 import sys
 import textwrap
 
-import importlib_metadata
-
 import _pytest._code
 import pytest
+from _pytest.compat import importlib_metadata
 from _pytest.config import _iter_rewritable_modules
 from _pytest.config.exceptions import UsageError
 from _pytest.config.findpaths import determine_setup

--- a/testing/test_entry_points.py
+++ b/testing/test_entry_points.py
@@ -1,4 +1,4 @@
-import importlib_metadata
+from _pytest.compat import importlib_metadata
 
 
 def test_pytest_entry_points_are_identical():


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/issues/5537

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.
(please delete this text from the final description, this is just a guideline)
-->

- [x] Target the `features` branch

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Add yourself to `AUTHORS` in alphabetical order;


I'm still running tox locally, there are some 3.8 failures, not yet sure if related.