### PR TITLE
Substituted 'yml' to '.yaml' in relevant files

### DIFF
--- a/doc/en/example/nonpython.rst
+++ b/doc/en/example/nonpython.rst
@@ -12,14 +12,14 @@ A basic example for specifying tests in Yaml files
 .. _`pytest-yamlwsgi`: http://bitbucket.org/aafshar/pytest-yamlwsgi/src/tip/pytest_yamlwsgi.py
 .. _`PyYAML`: https://pypi.org/project/PyYAML/
 
-Here is an example ``conftest.py`` (extracted from Ali Afshnars special purpose `pytest-yamlwsgi`_ plugin).   This ``conftest.py`` will  collect ``test*.yml`` files and will execute the yaml-formatted content as custom tests:
+Here is an example ``conftest.py`` (extracted from Ali Afshnars special purpose `pytest-yamlwsgi`_ plugin).   This ``conftest.py`` will  collect ``test*.yaml`` files and will execute the yaml-formatted content as custom tests:
 
 .. include:: nonpython/conftest.py
     :literal:
 
 You can create a simple example file:
 
-.. include:: nonpython/test_simple.yml
+.. include:: nonpython/test_simple.yaml
     :literal:
 
 and if you installed `PyYAML`_ or a compatible YAML-parser you can
@@ -27,14 +27,14 @@ now execute the test specification:
 
 .. code-block:: pytest
 
-    nonpython $ pytest test_simple.yml
+    nonpython $ pytest test_simple.yaml
     =========================== test session starts ============================
     platform linux -- Python 3.x.y, pytest-4.x.y, py-1.x.y, pluggy-0.x.y
     cachedir: $PYTHON_PREFIX/.pytest_cache
     rootdir: $REGENDOC_TMPDIR/nonpython
     collected 2 items
 
-    test_simple.yml F.                                                   [100%]
+    test_simple.yaml F.                                                   [100%]
 
     ================================= FAILURES =================================
     ______________________________ usecase: hello ______________________________
@@ -69,8 +69,8 @@ consulted when reporting in ``verbose`` mode:
     rootdir: $REGENDOC_TMPDIR/nonpython
     collecting ... collected 2 items
 
-    test_simple.yml::hello FAILED                                        [ 50%]
-    test_simple.yml::ok PASSED                                           [100%]
+    test_simple.yaml::hello FAILED                                        [ 50%]
+    test_simple.yaml::ok PASSED                                           [100%]
 
     ================================= FAILURES =================================
     ______________________________ usecase: hello ______________________________
@@ -93,7 +93,7 @@ interesting to just look at the collection tree:
     rootdir: $REGENDOC_TMPDIR/nonpython
     collected 2 items
     <Package $REGENDOC_TMPDIR/nonpython>
-      <YamlFile test_simple.yml>
+      <YamlFile test_simple.yaml>
         <YamlItem hello>
         <YamlItem ok>
 

--- a/doc/en/example/nonpython/conftest.py
+++ b/doc/en/example/nonpython/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 
 def pytest_collect_file(parent, path):
-    if path.ext == ".yml" and path.basename.startswith("test"):
+    if path.ext == ".yaml" and path.basename.startswith("test"):
         return YamlFile(path, parent)
 
 

--- a/doc/en/example/nonpython/test_simple.yaml
+++ b/doc/en/example/nonpython/test_simple.yaml
@@ -1,4 +1,4 @@
-# test_simple.yml
+# test_simple.yaml
 ok:
     sub1: sub1
 


### PR DESCRIPTION
This is a small doc fix for 
https://github.com/pytest-dev/pytest/issues/5533

Resolves #5533