### PR TITLE
Include <testsuites> root tag in generated XML

### DIFF
--- a/changelog/5477.bugfix.rst
+++ b/changelog/5477.bugfix.rst
@@ -1,0 +1,1 @@
+The XML file produced by ``--junitxml`` now correctly contain a ``<testsuites>`` root element.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -657,18 +657,17 @@ class LogXML:
         )
         logfile.write('<?xml version="1.0" encoding="utf-8"?>')
 
-        logfile.write(
-            Junit.testsuite(
-                self._get_global_properties_node(),
-                [x.to_xml() for x in self.node_reporters_ordered],
-                name=self.suite_name,
-                errors=self.stats["error"],
-                failures=self.stats["failure"],
-                skipped=self.stats["skipped"],
-                tests=numtests,
-                time="%.3f" % suite_time_delta,
-            ).unicode(indent=0)
+        suite_node = Junit.testsuite(
+            self._get_global_properties_node(),
+            [x.to_xml() for x in self.node_reporters_ordered],
+            name=self.suite_name,
+            errors=self.stats["error"],
+            failures=self.stats["failure"],
+            skipped=self.stats["skipped"],
+            tests=numtests,
+            time="%.3f" % suite_time_delta,
         )
+        logfile.write(Junit.testsuites([suite_node]).unicode(indent=0))
         logfile.close()
 
     def pytest_terminal_summary(self, terminalreporter):

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -41,6 +41,16 @@ class DomNode:
     def _by_tag(self, tag):
         return self.__node.getElementsByTagName(tag)
 
+    @property
+    def children(self):
+        return [type(self)(x) for x in self.__node.childNodes]
+
+    @property
+    def get_unique_child(self):
+        children = self.children
+        assert len(children) == 1
+        return children[0]
+
     def find_nth_by_tag(self, tag, n):
         items = self._by_tag(tag)
         try:
@@ -75,7 +85,7 @@ class DomNode:
         return self.__node.tagName
 
     @property
-    def next_siebling(self):
+    def next_sibling(self):
         return type(self)(self.__node.nextSibling)
 
 
@@ -384,11 +394,11 @@ class TestPython:
         fnode = tnode.find_first_by_tag("failure")
         fnode.assert_attr(message="ValueError: 42")
         assert "ValueError" in fnode.toxml()
-        systemout = fnode.next_siebling
+        systemout = fnode.next_sibling
         assert systemout.tag == "system-out"
         assert "hello-stdout" in systemout.toxml()
         assert "info msg" not in systemout.toxml()
-        systemerr = systemout.next_siebling
+        systemerr = systemout.next_sibling
         assert systemerr.tag == "system-err"
         assert "hello-stderr" in systemerr.toxml()
         assert "info msg" not in systemerr.toxml()
@@ -1092,6 +1102,20 @@ def test_random_report_log_xdist(testdir, monkeypatch):
             failed.append(case_node["name"])
 
     assert failed == ["test_x[22]"]
+
+
+def test_root_testsuites_tag(testdir):
+    testdir.makepyfile(
+        """
+        def test_x():
+            pass
+    """
+    )
+    _, dom = runandparse(testdir)
+    root = dom.get_unique_child
+    assert root.tag == "testsuites"
+    suite_node = root.get_unique_child
+    assert suite_node.tag == "testsuite"
 
 
 def test_runs_twice(testdir):


### PR DESCRIPTION
One thing that is not clear to me yet is if the attributes defined in the schema (`name`, `title`, etc) are optional:

```xsd
    <xs:element name="testsuites">
        <xs:complexType>
            <xs:sequence>
                <xs:element ref="testsuite" minOccurs="0" maxOccurs="unbounded" />
            </xs:sequence>
            <xs:attribute name="name" type="xs:string" />
            <xs:attribute name="time" type="SUREFIRE_TIME"/>
            <xs:attribute name="tests" type="xs:string" />
            <xs:attribute name="failures" type="xs:string" />
            <xs:attribute name="errors" type="xs:string" />
        </xs:complexType>
```

Judging from the other attributes elsewhere which are defined in the schema but are not written (for example, `testsuite`'s `timestamp` attribute), it seems those are optional.

Fix #5477

@nazariyv @jhunkeler @nazariydolfin 

Would appreciate if you folks could help test the XML file produced by this patch and ensuring it still works with your tools (say Jenkins).