### PR TITLE
Sort parametrize params to test_external_plugins_integrated

### DIFF
--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -70,7 +70,7 @@ def test_terminal_reporter_writer_attr(pytestconfig):
     assert terminal_reporter.writer is terminal_reporter._tw
 
 
-@pytest.mark.parametrize("plugin", deprecated.DEPRECATED_EXTERNAL_PLUGINS)
+@pytest.mark.parametrize("plugin", sorted(deprecated.DEPRECATED_EXTERNAL_PLUGINS))
 @pytest.mark.filterwarnings("default")
 def test_external_plugins_integrated(testdir, plugin):
     testdir.syspathinsert()

--- a/tox.ini
+++ b/tox.ini
@@ -131,6 +131,7 @@ filterwarnings =
     ignore:yield tests are deprecated, and scheduled to be removed in pytest 4.0:pytest.RemovedInPytest4Warning
     ignore:Metafunc.addcall is deprecated and scheduled to be removed in pytest 4.0:pytest.RemovedInPytest4Warning
     ignore::pytest.RemovedInPytest4Warning
+    default:Using or importing the ABCs:DeprecationWarning:unittest2.*
     ignore:Module already imported so cannot be rewritten:pytest.PytestWarning
     # produced by path.local
     ignore:bad escape.*:DeprecationWarning:re


### PR DESCRIPTION
This might cause problems during collection with pytest-xdist; we
didn't see any so far mostly by luck I think.

Shame on me for letting that slip in. 😓 
