### PR TITLE
Introduce Config.invocation_params

### DIFF
--- a/changelog/5564.feature.rst
+++ b/changelog/5564.feature.rst
@@ -1,0 +1,3 @@
+New ``Config.invocation_args`` and ``Config.invocation_plugins`` attributes.
+
+These attributes can be used by plugins to access the unchanged arguments passed to ``pytest.main()``.

--- a/changelog/5564.feature.rst
+++ b/changelog/5564.feature.rst
@@ -1,3 +1,1 @@
-New ``Config.invocation_args`` and ``Config.invocation_plugins`` attributes.
-
-These attributes can be used by plugins to access the unchanged arguments passed to ``pytest.main()``.
+New ``Config.invocation_args`` attribute containing the unchanged arguments passed to ``pytest.main()``.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -636,7 +636,15 @@ class Config:
 
     @attr.s(frozen=True)
     class InvocationParams:
-        """Holds parameters passed during ``pytest.main()``"""
+        """Holds parameters passed during ``pytest.main()``
+
+        .. note::
+
+            Currently the environment variable PYTEST_ADDOPTS is also handled by
+            pytest implicitly, not being part of the invocation.
+
+            Plugins accessing ``InvocationParams`` must be aware of that.
+        """
 
         args = attr.ib()
         plugins = attr.ib()

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1199,7 +1199,7 @@ def test_config_does_not_load_blocked_plugin_from_args(testdir):
     assert result.ret == ExitCode.USAGE_ERROR
 
 
-def test_invocation_arguments(testdir):
+def test_invocation_args(testdir):
     """Ensure that Config.invocation_* arguments are correctly defined"""
 
     class DummyPlugin:
@@ -1214,7 +1214,7 @@ def test_invocation_arguments(testdir):
     config = call.item.config
 
     assert config.invocation_params.args == [p, "-v"]
-    assert config.invocation_params.dir == Path(testdir.tmpdir)
+    assert config.invocation_params.dir == Path(str(testdir.tmpdir))
 
     plugins = config.invocation_params.plugins
     assert len(plugins) == 2

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1198,6 +1198,28 @@ def test_config_does_not_load_blocked_plugin_from_args(testdir):
     assert result.ret == ExitCode.USAGE_ERROR
 
 
+def test_invocation_arguments(testdir):
+    """Ensure that Config.invocation_* arguments are correctly defined"""
+
+    class DummyPlugin:
+        pass
+
+    p = testdir.makepyfile("def test(): pass")
+    plugin = DummyPlugin()
+    rec = testdir.inline_run(p, "-v", plugins=[plugin])
+    calls = rec.getcalls("pytest_runtest_protocol")
+    assert len(calls) == 1
+    call = calls[0]
+    config = call.item.config
+
+    assert config.invocation_args == [p, "-v"]
+
+    plugins = config.invocation_plugins
+    assert len(plugins) == 2
+    assert plugins[0] is plugin
+    assert type(plugins[1]).__name__ == "Collect"  # installed by testdir.inline_run()
+
+
 @pytest.mark.parametrize(
     "plugin",
     [

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1,5 +1,6 @@
 import sys
 import textwrap
+from pathlib import Path
 
 import _pytest._code
 import pytest
@@ -1212,9 +1213,10 @@ def test_invocation_arguments(testdir):
     call = calls[0]
     config = call.item.config
 
-    assert config.invocation_args == [p, "-v"]
+    assert config.invocation_params.args == [p, "-v"]
+    assert config.invocation_params.dir == Path(testdir.tmpdir)
 
-    plugins = config.invocation_plugins
+    plugins = config.invocation_params.plugins
     assert len(plugins) == 2
     assert plugins[0] is plugin
     assert type(plugins[1]).__name__ == "Collect"  # installed by testdir.inline_run()


### PR DESCRIPTION
These attributes can be used to access the unchanged arguments passed
to `pytest.main()`.

The intention is to use these attributes to initialize workers in
the same manner as the master node is initialized in pytest-xdist (https://github.com/pytest-dev/pytest-xdist/pull/448).
