### PR TITLE
Drop unittest2 support

### DIFF
--- a/changelog/5565.removal.rst
+++ b/changelog/5565.removal.rst
@@ -1,0 +1,13 @@
+Removed unused support code for `unittest2 <https://pypi.org/project/unittest2/>`__.
+
+The ``unittest2`` backport module is no longer
+necessary since Python 3.3+, and the small amount of code in pytest to support it also doesn't seem
+to be used: after removed, all tests still pass unchanged.
+
+Although our policy is to introduce a deprecation period before removing any features or support
+for third party libraries, because this code is apparently not used
+at all (even if ``unittest2`` is used by a test suite executed by pytest), it was decided to
+remove it in this release.
+
+If you experience a regression because of this, please
+`file an issue <https://github.com/pytest-dev/pytest/issues/new>`__.

--- a/src/_pytest/nose.py
+++ b/src/_pytest/nose.py
@@ -1,29 +1,7 @@
 """ run test suites written for nose. """
-import sys
-
-import pytest
 from _pytest import python
-from _pytest import runner
 from _pytest import unittest
 from _pytest.config import hookimpl
-
-
-def get_skip_exceptions():
-    skip_classes = set()
-    for module_name in ("unittest", "unittest2", "nose"):
-        mod = sys.modules.get(module_name)
-        if hasattr(mod, "SkipTest"):
-            skip_classes.add(mod.SkipTest)
-    return tuple(skip_classes)
-
-
-def pytest_runtest_makereport(item, call):
-    if call.excinfo and call.excinfo.errisinstance(get_skip_exceptions()):
-        # let's substitute the excinfo with a pytest.skip one
-        call2 = runner.CallInfo.from_call(
-            lambda: pytest.skip(str(call.excinfo.value)), call.when
-        )
-        call.excinfo = call2.excinfo
 
 
 @hookimpl(trylast=True)
@@ -40,9 +18,6 @@ def teardown_nose(item):
     if is_potential_nosetest(item):
         if not call_optional(item.obj, "teardown"):
             call_optional(item.parent.obj, "teardown")
-        # if hasattr(item.parent, '_nosegensetup'):
-        #    #call_optional(item._nosegensetup, 'teardown')
-        #    del item.parent._nosegensetup
 
 
 def is_potential_nosetest(item):

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -249,10 +249,11 @@ def pytest_make_collect_report(collector):
     if not call.excinfo:
         outcome = "passed"
     else:
-        from _pytest import nose
-
-        skip_exceptions = (Skipped,) + nose.get_skip_exceptions()
-        if call.excinfo.errisinstance(skip_exceptions):
+        skip_exceptions = [Skipped]
+        unittest = sys.modules.get("unittest")
+        if unittest is not None:
+            skip_exceptions.append(unittest.SkipTest)
+        if call.excinfo.errisinstance(tuple(skip_exceptions)):
             outcome = "skipped"
             r = collector._repr_failure_py(call.excinfo, "line").reprcrash
             longrepr = (str(r.path), r.lineno, r.message)

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -11,6 +11,7 @@ from _pytest.outcomes import skip
 from _pytest.outcomes import xfail
 from _pytest.python import Class
 from _pytest.python import Function
+from _pytest.runner import CallInfo
 
 
 def pytest_pycollect_makeitem(collector, name, obj):
@@ -222,6 +223,14 @@ def pytest_runtest_makereport(item, call):
                 del call.result
             except AttributeError:
                 pass
+
+    unittest = sys.modules.get("unittest")
+    if unittest and call.excinfo and call.excinfo.errisinstance(unittest.SkipTest):
+        # let's substitute the excinfo with a pytest.skip one
+        call2 = CallInfo.from_call(
+            lambda: pytest.skip(str(call.excinfo.value)), call.when
+        )
+        call.excinfo = call2.excinfo
 
 
 # twisted trial support

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -939,9 +939,7 @@ def test_class_method_containing_test_issue1558(testdir):
     reprec.assertoutcome(passed=1)
 
 
-@pytest.mark.parametrize(
-    "base", ["builtins.object", "unittest.TestCase", "unittest2.TestCase"]
-)
+@pytest.mark.parametrize("base", ["builtins.object", "unittest.TestCase"])
 def test_usefixtures_marker_on_unittest(base, testdir):
     """#3498"""
     module = base.rsplit(".", 1)[0]

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,6 @@ deps =
     pexpect: pexpect
     pluggymaster: git+https://github.com/pytest-dev/pluggy.git@master
     twisted: twisted
-    twisted: unittest2
     xdist: pytest-xdist>=1.13
     {env:_PYTEST_TOX_EXTRA_DEP:}
 platform = {env:_PYTEST_TOX_PLATFORM:.*}


### PR DESCRIPTION
[unittest2](https://pypi.org/project/unittest2) is a backport for Python <=3.2, so we no longer need
to support it (last release was in 2015). 

I suspect it has not been used at all by users after 5.0 has been released.
