### PR TITLE
Improve docs sidebar layout

### DIFF
--- a/doc/en/_themes/flask/slim_searchbox.html
+++ b/doc/en/_themes/flask/slim_searchbox.html
@@ -1,0 +1,15 @@
+{#
+    basic/searchbox.html with heading removed.
+#}
+{%- if pagename != "search" and builder != "singlehtml" %}
+<div id="searchbox" style="display: none" role="search">
+  <div class="searchformwrapper">
+    <form class="search" action="{{ pathto('search') }}" method="get">
+      <input type="text" name="q" aria-labelledby="searchlabel"
+        placeholder="Search"/>
+      <input type="submit" value="{{ _('Go') }}" />
+    </form>
+  </div>
+</div>
+<script type="text/javascript">$('#searchbox').show(0);</script>
+{%- endif %}

--- a/doc/en/_themes/flask/static/flasky.css_t
+++ b/doc/en/_themes/flask/static/flasky.css_t
@@ -106,14 +106,14 @@ div.sphinxsidebar h3,
 div.sphinxsidebar h4 {
     font-family: {{ header_font }};
     color: #444;
-    font-size: 24px;
+    font-size: 21px;
     font-weight: normal;
-    margin: 0 0 5px 0;
+    margin: 16px 0 0 0;
     padding: 0;
 }
 
 div.sphinxsidebar h4 {
-    font-size: 20px;
+    font-size: 18px;
 }
 
 div.sphinxsidebar h3 a {

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -167,18 +167,18 @@ html_favicon = "img/pytest1favi.ico"
 
 html_sidebars = {
     "index": [
+        "slim_searchbox.html",
         "sidebarintro.html",
         "globaltoc.html",
         "links.html",
         "sourcelink.html",
-        "searchbox.html",
     ],
     "**": [
+        "slim_searchbox.html",
         "globaltoc.html",
         "relations.html",
         "links.html",
         "sourcelink.html",
-        "searchbox.html",
     ],
 }
 


### PR DESCRIPTION
This PR improves the layout of the sidebar:

- Move the search field to the top (should be easily accessible without the need to scroll).
- Reduce the heading font size so that "Table Of Contents" is not wrapped.

Here's a screenshot of the change (left: before, right: after):

![grafik](https://user-images.githubusercontent.com/2836374/60771646-73149c00-a0eb-11e9-92ff-8d32313086ad.png) ![grafik](https://user-images.githubusercontent.com/2836374/60771686-c5ee5380-a0eb-11e9-859d-49128a853a9b.png)
