### PR TITLE
doctest: Add +NUMBER option to ignore irrelevant floating-point differences

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -70,6 +70,7 @@ Danielle Jenkins
 Dave Hunt
 David Díaz-Barquero
 David Mohr
+David Paul Röthlisberger
 David Szotten
 David Vierra
 Daw-Ran Liou

--- a/changelog/5576.feature.rst
+++ b/changelog/5576.feature.rst
@@ -1,0 +1,4 @@
+New `NUMBER <https://docs.pytest.org/en/latest/doctest.html#using-doctest-options>`__
+option for doctests to ignore irrelevant differences in floating-point numbers.
+Inspired by Sébastien Boisgérault's `numtest <https://github.com/boisgera/numtest>`__
+extension for doctest.

--- a/doc/en/doctest.rst
+++ b/doc/en/doctest.rst
@@ -103,7 +103,7 @@ that will be used for those doctest files using the
 Using 'doctest' options
 -----------------------
 
-The standard ``doctest`` module provides some `options <https://docs.python.org/3/library/doctest.html#option-flags>`__
+Python's standard ``doctest`` module provides some `options <https://docs.python.org/3/library/doctest.html#option-flags>`__
 to configure the strictness of doctest tests. In pytest, you can enable those flags using the
 configuration file.
 
@@ -114,6 +114,15 @@ lengthy exception stack traces you can just write:
 
     [pytest]
     doctest_optionflags= NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
+
+Alternatively, options can be enabled by an inline comment in the doc test
+itself:
+
+.. code-block:: rst
+
+    >>> something_that_raises()  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ValueError: ...
 
 pytest also introduces new options:
 
@@ -145,14 +154,9 @@ pytest also introduces new options:
   ``NUMBER`` also supports lists of floating-point numbers -- in fact, it
   supports floating-point numbers appearing anywhere in the output.
 
-Alternatively, options can be enabled by an inline comment in the doc test
-itself:
 
-.. code-block:: rst
-
-    # content of example.rst
-    >>> get_unicode_greeting()  # doctest: +ALLOW_UNICODE
-    'Hello'
+Continue on failure
+-------------------
 
 By default, pytest would report only the first failure for a given doctest. If
 you want to continue the test even when you have failures, do:

--- a/doc/en/doctest.rst
+++ b/doc/en/doctest.rst
@@ -115,14 +115,35 @@ lengthy exception stack traces you can just write:
     [pytest]
     doctest_optionflags= NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
 
-pytest also introduces new options to allow doctests to run in Python 2 and
-Python 3 unchanged:
+pytest also introduces new options:
 
 * ``ALLOW_UNICODE``: when enabled, the ``u`` prefix is stripped from unicode
-  strings in expected doctest output.
+  strings in expected doctest output. This allows doctests to run in Python 2
+  and Python 3 unchanged.
 
-* ``ALLOW_BYTES``: when enabled, the ``b`` prefix is stripped from byte strings
+* ``ALLOW_BYTES``: similarly, the ``b`` prefix is stripped from byte strings
   in expected doctest output.
+
+* ``NUMBER``: when enabled, floating-point numbers only need to match as far as
+  the precision you have written in the expected doctest output. For example,
+  the following output would only need to match to 2 decimal places::
+
+      >>> math.pi
+      3.14
+
+  If you wrote ``3.1416`` then the actual output would need to match to 4
+  decimal places; and so on.
+
+  This avoids false positives caused by limited floating-point precision, like
+  this::
+
+      Expected:
+          0.233
+      Got:
+          0.23300000000000001
+
+  ``NUMBER`` also supports lists of floating-point numbers -- in fact, it
+  supports floating-point numbers appearing anywhere in the output.
 
 Alternatively, options can be enabled by an inline comment in the doc test
 itself:

--- a/doc/en/doctest.rst
+++ b/doc/en/doctest.rst
@@ -152,7 +152,9 @@ pytest also introduces new options:
           0.23300000000000001
 
   ``NUMBER`` also supports lists of floating-point numbers -- in fact, it
-  supports floating-point numbers appearing anywhere in the output.
+  matches floating-point numbers appearing anywhere in the output, even inside
+  a string! This means that it may not be appropriate to enable globally in
+  ``doctest_optionflags`` in your configuration file.
 
 
 Continue on failure

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -3,6 +3,7 @@ import textwrap
 
 import pytest
 from _pytest.compat import MODULE_NOT_FOUND_ERROR
+from _pytest.doctest import _get_checker
 from _pytest.doctest import _is_mocked
 from _pytest.doctest import _patch_unwrap_mock_aware
 from _pytest.doctest import DoctestItem
@@ -837,6 +838,149 @@ class TestLiterals:
         )
         reprec = testdir.inline_run()
         reprec.assertoutcome(failed=1)
+
+    def test_number_re(self):
+        for s in [
+            "1.",
+            "+1.",
+            "-1.",
+            ".1",
+            "+.1",
+            "-.1",
+            "0.1",
+            "+0.1",
+            "-0.1",
+            "1e5",
+            "+1e5",
+            "1e+5",
+            "+1e+5",
+            "1e-5",
+            "+1e-5",
+            "-1e-5",
+            "1.2e3",
+            "-1.2e-3",
+        ]:
+            print(s)
+            m = _get_checker()._number_re.match(s)
+            assert m is not None
+            assert float(m.group()) == pytest.approx(float(s))
+        for s in ["1", "abc"]:
+            print(s)
+            assert _get_checker()._number_re.match(s) is None
+
+    @pytest.mark.parametrize("config_mode", ["ini", "comment"])
+    def test_number_precision(self, testdir, config_mode):
+        """Test the NUMBER option."""
+        if config_mode == "ini":
+            testdir.makeini(
+                """
+                [pytest]
+                doctest_optionflags = NUMBER
+                """
+            )
+            comment = ""
+        else:
+            comment = "#doctest: +NUMBER"
+
+        testdir.maketxtfile(
+            test_doc="""
+
+            Scalars:
+
+            >>> import math
+            >>> math.pi {comment}
+            3.141592653589793
+            >>> math.pi {comment}
+            3.1416
+            >>> math.pi {comment}
+            3.14
+            >>> -math.pi {comment}
+            -3.14
+            >>> math.pi {comment}
+            3.
+            >>> 3. {comment}
+            3.0
+            >>> 3. {comment}
+            3.
+            >>> 3. {comment}
+            3.01
+            >>> 3. {comment}
+            2.99
+            >>> .299 {comment}
+            .3
+            >>> .301 {comment}
+            .3
+            >>> 951. {comment}
+            1e3
+            >>> 1049. {comment}
+            1e3
+            >>> -1049. {comment}
+            -1e3
+            >>> 1e3 {comment}
+            1e3
+            >>> 1e3 {comment}
+            1000.
+
+            Lists:
+
+            >>> [3.1415, 0.097, 13.1, 7, 8.22222e5, 0.598e-2] {comment}
+            [3.14, 0.1, 13., 7, 8.22e5, 6.0e-3]
+            >>> [[0.333, 0.667], [0.999, 1.333]] {comment}
+            [[0.33, 0.667], [0.999, 1.333]]
+            >>> [[[0.101]]] {comment}
+            [[[0.1]]]
+
+            Doesn't barf on non-numbers:
+
+            >>> 'abc' {comment}
+            'abc'
+            >>> None {comment}
+            """.format(
+                comment=comment
+            )
+        )
+        reprec = testdir.inline_run()
+        reprec.assertoutcome(passed=1)
+
+    @pytest.mark.parametrize(
+        "expression,output",
+        [
+            # ints shouldn't match floats:
+            ("3.0", "3"),
+            ("3e0", "3"),
+            ("1e3", "1000"),
+            ("3", "3.0"),
+            # Rounding:
+            ("3.1", "3.0"),
+            ("3.1", "3.2"),
+            ("3.1", "4.0"),
+            ("8.22e5", "810000.0"),
+            # Only the actual output is rounded up, not the expected output:
+            ("3.0", "2.99"),
+            ("1e3", "999"),
+        ],
+    )
+    def test_number_non_matches(self, testdir, expression, output):
+        testdir.maketxtfile(
+            test_doc="""
+            >>> {expression} #doctest: +NUMBER
+            {output}
+            """
+        )
+        reprec = testdir.inline_run()
+        reprec.assertoutcome(passed=0, failed=1)
+
+    def test_number_and_allow_unicode(self, testdir):
+        testdir.maketxtfile(
+            test_doc="""
+            >>> from collections import namedtuple
+            >>> T = namedtuple('T', 'a b c')
+            >>> T(a=0.2330000001, b=u'str', c=b'bytes') # doctest: +ALLOW_UNICODE, +ALLOW_BYTES, +NUMBER
+            T(a=0.233, b=u'str', c='bytes')
+            """
+        )
+        reprec = testdir.inline_run()
+        reprec.assertoutcome(passed=1)
 
 
 class TestDoctestSkips:

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -958,6 +958,9 @@ class TestLiterals:
             # Only the actual output is rounded up, not the expected output:
             ("3.0", "2.98"),
             ("1e3", "999"),
+            # The current implementation doesn't understand that numbers inside
+            # strings shouldn't be treated as numbers:
+            pytest.param("'3.1416'", "'3.14'", marks=pytest.mark.xfail),
         ],
     )
     def test_number_non_matches(self, testdir, expression, output):

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -956,7 +956,7 @@ class TestLiterals:
             ("3.1", "4.0"),
             ("8.22e5", "810000.0"),
             # Only the actual output is rounded up, not the expected output:
-            ("3.0", "2.99"),
+            ("3.0", "2.98"),
             ("1e3", "999"),
         ],
     )
@@ -965,7 +965,9 @@ class TestLiterals:
             test_doc="""
             >>> {expression} #doctest: +NUMBER
             {output}
-            """
+            """.format(
+                expression=expression, output=output
+            )
         )
         reprec = testdir.inline_run()
         reprec.assertoutcome(passed=0, failed=1)


### PR DESCRIPTION
When enabled, floating-point numbers only need to match as far as the
precision you have written in the expected doctest output. This avoids
false positives caused by limited floating-point precision, like this:

    Expected:
        0.233
    Got:
        0.23300000000000001

This is inspired by Sébastien Boisgérault's [numtest] but the
implementation is a bit different:

* This implementation edits the literals that are in the "got"
  string (the actual output from the expression being tested), and then
  proceeds to compare the strings literally. This is similar to pytest's
  existing ALLOW_UNICODE and ALLOW_BYTES implementation.

* This implementation only compares floats against floats, not ints
  against floats. That is, the following doctest will fail with pytest
  whereas it would pass with numtest:

      >>> math.py  # doctest: +NUMBER
      3

  This behaviour should be less surprising (less false negatives) when
  you enable NUMBER globally in pytest.ini.

Advantages of this implementation compared to numtest:

* Doesn't require `import numtest` at the top level of the file.
* Works with pytest (if you try to use pytest & numtest together, pytest
  raises "TypeError: unbound method check_output() must be called with
  NumTestOutputChecker instance as first argument (got
  LiteralsOutputChecker instance instead)").
* Works with Python 3.

[numtest]: https://github.com/boisgera/numtest
