### PR TITLE
Fix rmtree to remove directories with read-only files

### DIFF
--- a/changelog/5524.bugfix.rst
+++ b/changelog/5524.bugfix.rst
@@ -1,0 +1,2 @@
+Fix issue where ``tmp_path`` and ``tmpdir`` would not remove directories containing files marked as read-only,
+which could lead to pytest crashing when executed a second time with the ``--basetemp`` option.

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -14,7 +14,7 @@ import py
 import pytest
 from .pathlib import Path
 from .pathlib import resolve_from_str
-from .pathlib import rmtree
+from .pathlib import rm_rf
 
 README_CONTENT = """\
 # pytest cache directory #
@@ -44,7 +44,7 @@ class Cache:
     def for_config(cls, config):
         cachedir = cls.cache_dir_from_config(config)
         if config.getoption("cacheclear") and cachedir.exists():
-            rmtree(cachedir, force=True)
+            rm_rf(cachedir)
             cachedir.mkdir()
         return cls(cachedir, config)
 


### PR DESCRIPTION
Fix #5524
