### PR TITLE
Improve CSS layout

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -238,6 +238,7 @@ Tareq Alayan
 Ted Xiao
 Thomas Grainger
 Thomas Hisch
+Tim Hoffmann
 Tim Strazny
 Tom Dalton
 Tom Viner

--- a/doc/en/_themes/flask/static/flasky.css_t
+++ b/doc/en/_themes/flask/static/flasky.css_t
@@ -8,11 +8,12 @@
 
 {% set page_width = '1020px' %}
 {% set sidebar_width = '220px' %}
-/* orange of logo is #d67c29 but we use black for links for now */
-{% set link_color = '#000' %}
-{% set link_hover_color = '#000' %}
+/* muted version of green logo color #C9D22A */
+{% set link_color = '#606413' %}
+/* blue logo color */
+{% set link_hover_color = '#009de0' %}
 {% set base_font = 'sans-serif' %}
-{% set header_font = 'serif' %}
+{% set header_font = 'sans-serif' %}
 
 @import url("basic.css");
 
@@ -20,7 +21,7 @@
 
 body {
     font-family: {{ base_font }};
-    font-size: 17px;
+    font-size: 16px;
     background-color: white;
     color: #000;
     margin: 0;
@@ -78,13 +79,13 @@ div.related {
 }
 
 div.sphinxsidebar a {
-    color: #444;
     text-decoration: none;
-    border-bottom: 1px dotted #999;
+    border-bottom: none;
 }
 
 div.sphinxsidebar a:hover {
-    border-bottom: 1px solid #999;
+    color: {{ link_hover_color }};
+    border-bottom: 1px solid {{ link_hover_color }};
 }
 
 div.sphinxsidebar {
@@ -205,21 +206,19 @@ div.body p, div.body dd, div.body li {
     line-height: 1.4em;
 }
 
+ul.simple li {
+    margin-bottom: 0.5em;
+}
+
 div.admonition {
     background: #fafafa;
-    margin: 20px -30px;
-    padding: 10px 30px;
+    padding: 10px 20px;
     border-top: 1px solid #ccc;
     border-bottom: 1px solid #ccc;
 }
 
 div.admonition tt.xref, div.admonition a tt {
     border-bottom: 1px solid #fafafa;
-}
-
-dd div.admonition {
-    margin-left: -60px;
-    padding-left: 60px;
 }
 
 div.admonition p.admonition-title {
@@ -231,7 +230,7 @@ div.admonition p.admonition-title {
     line-height: 1;
 }
 
-div.admonition p.last {
+div.admonition :last-child {
     margin-bottom: 0;
 }
 
@@ -243,7 +242,7 @@ dt:target, .highlight {
     background: #FAF3E8;
 }
 
-div.note {
+div.note, div.warning {
     background-color: #eee;
     border: 1px solid #ccc;
 }
@@ -255,6 +254,11 @@ div.seealso {
 
 div.topic {
     background-color: #eee;
+}
+
+div.topic a {
+    text-decoration: none;
+    border-bottom: none;
 }
 
 p.admonition-title {
@@ -358,19 +362,8 @@ ul, ol {
 
 pre {
     background: #eee;
-    padding: 7px 30px;
-    margin: 15px -30px;
+    padding: 7px 12px;
     line-height: 1.3em;
-}
-
-dl pre, blockquote pre, li pre {
-    margin-left: -60px;
-    padding-left: 60px;
-}
-
-dl dl pre {
-    margin-left: -90px;
-    padding-left: 90px;
 }
 
 tt {
@@ -393,6 +386,20 @@ a.reference:hover {
     border-bottom: 1px solid {{ link_hover_color }};
 }
 
+li.toctree-l1 a.reference,
+li.toctree-l2 a.reference,
+li.toctree-l3 a.reference,
+li.toctree-l4 a.reference {
+    border-bottom: none;
+}
+
+li.toctree-l1 a.reference:hover,
+li.toctree-l2 a.reference:hover,
+li.toctree-l3 a.reference:hover,
+li.toctree-l4 a.reference:hover {
+    border-bottom: 1px solid {{ link_hover_color }};
+}
+
 a.footnote-reference {
     text-decoration: none;
     font-size: 0.7em;
@@ -406,6 +413,12 @@ a.footnote-reference:hover {
 
 a:hover tt {
     background: #EEE;
+}
+
+#reference div.section h3 {
+    /* separate code elements in the reference section */
+    border-top: 1px solid #ccc;
+    padding-top: 0.5em;
 }
 
 


### PR DESCRIPTION
This PR improves some aspects of the documentation layout.


## Links
- Links are now colored #606413, a muted version of the green logo color #C9D22A.
- Hovered links are now colored with the blue logo color #009de0.
  before:
  ![image](https://user-images.githubusercontent.com/2836374/61185909-ffc8d800-a65e-11e9-898f-a9a4c208ad5d.png)
  after:
  ![image](https://user-images.githubusercontent.com/2836374/61185928-330b6700-a65f-11e9-92be-988f3e5100da.png)

- Links in the sidebar do not have dotted underlines. This gives a more clean look. The color itself should be indication enough that this is not normal text. Highlighting and underline on hover is kept.
  before: ![image](https://user-images.githubusercontent.com/2836374/61185939-56361680-a65f-11e9-99ca-e63d660b6fa7.png) after: ![image](https://user-images.githubusercontent.com/2836374/61186505-951b9a80-a666-11e9-9544-55de2e49b713.png)


- The same hold for the links in the Reference TOC:
  before: ![image](https://user-images.githubusercontent.com/2836374/61185959-9bf2df00-a65f-11e9-83af-0321f76b1a06.png)  after: ![image](https://user-images.githubusercontent.com/2836374/61185963-b036dc00-a65f-11e9-8351-996a84b87232.png)

  

## Font
- The body font size is reduced from 17px to 16px. 17px felt a bit too large and 16px is actually the most recommended body font size.
- The headings are switched from `serif` to `sans-serif`. IMHO sans-serif reflects the clean and simple approach of pytest better.

## Margins
- Code blocks and andmonitions were layouted so that the contained text lines up with the body text. As a result the box itself spread out beyond the margin. This gave a false impression of scope, because the box does not follow layout and indentation lines, e.g.

![image](https://user-images.githubusercontent.com/2836374/61185768-4cabaf00-a65d-11e9-88db-20a636e8ed2f.png)

This has been changed so that the edge of the box aligns with the text

![image](https://user-images.githubusercontent.com/2836374/61186533-f0e62380-a666-11e9-8cbf-07e8764cea34.png)

- Code elements in the reference section are now separated by a horizontal line (see also the picture above). This gives a clearer structure and helps to distinguish the different code elements.

- Lists elements get 0.5em vertical margin (before/after):
  ![image](https://user-images.githubusercontent.com/2836374/61186789-9bf7dc80-a669-11e9-84ef-f4a579a06880.png) ![image](https://user-images.githubusercontent.com/2836374/61186793-ab772580-a669-11e9-8360-99641727b6c7.png)

