### PR TITLE
Simplify SafeRepr a bit

### DIFF
--- a/changelog/5603.trivial.rst
+++ b/changelog/5603.trivial.rst
@@ -1,0 +1,1 @@
+Simplified internal ``SafeRepr`` class and removed some dead code.

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -22,6 +22,12 @@ class SafeRepr(reprlib.Repr):
     and includes information on exceptions raised during the call.
     """
 
+    def __init__(self, maxsize):
+        super().__init__()
+        self.maxstring = maxsize
+        self.maxsize = maxsize
+        self.maxother = 160
+
     def repr(self, x):
         return self._callhelper(reprlib.Repr.repr, self, x)
 
@@ -52,9 +58,4 @@ def saferepr(obj, maxsize=240):
     care to never raise exceptions itself.  This function is a wrapper
     around the Repr/reprlib functionality of the standard 2.6 lib.
     """
-    # review exception handling
-    srepr = SafeRepr()
-    srepr.maxstring = maxsize
-    srepr.maxsize = maxsize
-    srepr.maxother = 160
-    return srepr.repr(obj)
+    return SafeRepr(maxsize).repr(obj)

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -25,24 +25,6 @@ class SafeRepr(reprlib.Repr):
     def repr(self, x):
         return self._callhelper(reprlib.Repr.repr, self, x)
 
-    def repr_unicode(self, x, level):
-        # Strictly speaking wrong on narrow builds
-        def repr(u):
-            if "'" not in u:
-                return "'%s'" % u
-            elif '"' not in u:
-                return '"%s"' % u
-            else:
-                return "'%s'" % u.replace("'", r"\'")
-
-        s = repr(x[: self.maxstring])
-        if len(s) > self.maxstring:
-            i = max(0, (self.maxstring - 3) // 2)
-            j = max(0, self.maxstring - 3 - i)
-            s = repr(x[:i] + x[len(x) - j :])
-            s = s[:i] + "..." + s[len(s) - j :]
-        return s
-
     def repr_instance(self, x, level):
         return self._callhelper(repr, x)
 

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -26,7 +26,6 @@ class SafeRepr(reprlib.Repr):
         super().__init__()
         self.maxstring = maxsize
         self.maxsize = maxsize
-        self.maxother = 160
 
     def repr(self, x):
         return self._callhelper(reprlib.Repr.repr, self, x)

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -45,6 +45,17 @@ def test_exceptions():
     assert "unknown" in s2
 
 
+def test_buggy_builtin_repr():
+    # Simulate a case where a repr for a builtin raises.
+    # reprlib dispatches by type name, so use "int".
+
+    class int:
+        def __repr__(self):
+            raise ValueError("Buggy repr!")
+
+    assert "Buggy" in saferepr(int())
+
+
 def test_big_repr():
     from _pytest._io.saferepr import SafeRepr
 

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -48,7 +48,7 @@ def test_exceptions():
 def test_big_repr():
     from _pytest._io.saferepr import SafeRepr
 
-    assert len(saferepr(range(1000))) <= len("[" + SafeRepr().maxlist * "1000" + "]")
+    assert len(saferepr(range(1000))) <= len("[" + SafeRepr(0).maxlist * "1000" + "]")
 
 
 def test_repr_on_newstyle():


### PR DESCRIPTION
Remove some dead code and make it easier to type-check.

The PR is split to commits.