### PR TITLE
More CSS fine-tuning

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,8 +5,9 @@ Contribution getting started
 Contributions are highly welcomed and appreciated.  Every little help counts,
 so do not hesitate!
 
-.. contents:: Contribution links
+.. contents::
    :depth: 2
+   :backlinks: none
 
 
 .. _submitfeedback:

--- a/doc/en/_themes/flask/static/flasky.css_t
+++ b/doc/en/_themes/flask/static/flasky.css_t
@@ -210,6 +210,15 @@ ul.simple li {
     margin-bottom: 0.5em;
 }
 
+div.topic ul.simple li {
+    margin-bottom: 0;
+}
+
+div.topic li > p:first-child {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
 div.admonition {
     background: #fafafa;
     padding: 10px 20px;


### PR DESCRIPTION
Followup to #5602.

1. Fixes a regresssion from #5602. The contents list items unintendedly got a margin in between. This        is removed again (before/after):
  ![grafik](https://user-images.githubusercontent.com/2836374/61213805-66ed9780-a706-11e9-95ad-0fe49caa6bee.png) ![grafik](https://user-images.githubusercontent.com/2836374/61213834-7d93ee80-a706-11e9-952c-d606291581cc.png)

2. Removed the header backlinks in the section "Contributing". The main motivation is to not style the headings like links. While this could also be overridden with additional CSS, I decided to just remove the backlinks. Since most of the other pages do not have TOCs, headings in the pytest docs usually do not have backlinks. Additionally, IMHO the semantics of a heading backlink is not quite intuitive (clicking on a heading brings you to the TOC which is only structurally but not sematically related to the section); and I don't think the actual action "Go to TOC" is really needed here.
  before:
  ![grafik](https://user-images.githubusercontent.com/2836374/61214023-0f9bf700-a707-11e9-90e1-7792c02d7f82.png)
  after:
  ![grafik](https://user-images.githubusercontent.com/2836374/61214080-38bc8780-a707-11e9-848e-315258423e31.png)