### PR TITLE
Remove obsolete "importorskip('unittest.mock')" calls

### DIFF
--- a/testing/python/integration.py
+++ b/testing/python/integration.py
@@ -104,21 +104,15 @@ class TestMockDecoration:
         values = getfuncargnames(f)
         assert values == ("x",)
 
-    @pytest.mark.xfail(
-        strict=False, reason="getfuncargnames breaks if mock is imported"
-    )
-    def test_wrapped_getfuncargnames_patching(self):
+    def test_getfuncargnames_patching(self):
         from _pytest.compat import getfuncargnames
+        from unittest.mock import patch
 
-        def wrap(f):
-            def func():
+        class T:
+            def original(self, x, y, z):
                 pass
 
-            func.__wrapped__ = f
-            func.patchings = ["qwe"]
-            return func
-
-        @wrap
+        @patch.object(T, "original")
         def f(x, y, z):
             pass
 

--- a/testing/python/integration.py
+++ b/testing/python/integration.py
@@ -126,7 +126,6 @@ class TestMockDecoration:
         assert values == ("y", "z")
 
     def test_unittest_mock(self, testdir):
-        pytest.importorskip("unittest.mock")
         testdir.makepyfile(
             """
             import unittest.mock
@@ -142,7 +141,6 @@ class TestMockDecoration:
         reprec.assertoutcome(passed=1)
 
     def test_unittest_mock_and_fixture(self, testdir):
-        pytest.importorskip("unittest.mock")
         testdir.makepyfile(
             """
             import os.path
@@ -164,7 +162,6 @@ class TestMockDecoration:
         reprec.assertoutcome(passed=1)
 
     def test_unittest_mock_and_pypi_mock(self, testdir):
-        pytest.importorskip("unittest.mock")
         pytest.importorskip("mock", "1.0.1")
         testdir.makepyfile(
             """


### PR DESCRIPTION
No longer make sense given that `unittest.mock` is part of the stdlib for all Python versions we support now.