### PR TITLE
CSS changes to the API reference

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
-=================
-Changelog history
-=================
+=========
+Changelog
+=========
 
 Versions follow `Semantic Versioning <https://semver.org/>`_ (``<major>.<minor>.<patch>``).
 

--- a/doc/en/_templates/globaltoc.html
+++ b/doc/en/_templates/globaltoc.html
@@ -4,7 +4,7 @@
   <li><a href="{{ pathto('index') }}">Home</a></li>
   <li><a href="{{ pathto('getting-started') }}">Install</a></li>
   <li><a href="{{ pathto('contents') }}">Contents</a></li>
-  <li><a href="{{ pathto('reference') }}">Reference</a></li>
+  <li><a href="{{ pathto('reference') }}">API Reference</a></li>
   <li><a href="{{ pathto('example/index') }}">Examples</a></li>
   <li><a href="{{ pathto('customize') }}">Customize</a></li>
   <li><a href="{{ pathto('changelog') }}">Changelog</a></li>

--- a/doc/en/_themes/flask/static/flasky.css_t
+++ b/doc/en/_themes/flask/static/flasky.css_t
@@ -424,12 +424,56 @@ a:hover tt {
     background: #EEE;
 }
 
+#reference div.section h2 {
+    /* separate code elements in the reference section */
+    border-top: 2px solid #ccc;
+    padding-top: 0.5em;
+}
+
 #reference div.section h3 {
     /* separate code elements in the reference section */
     border-top: 1px solid #ccc;
     padding-top: 0.5em;
 }
 
+dl.class, dl.function {
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+
+dl.class > dd {
+    border-left: 3px solid #ccc;
+    margin-left: 0px;
+    padding-left: 30px;
+}
+
+dl.field-list {
+    flex-direction: column;
+}
+
+dl.field-list dd {
+    padding-left: 4em;
+    border-left: 3px solid #ccc;
+    margin-bottom: 0.5em;
+}
+
+dl.field-list dd > ul {
+    list-style: none;
+    padding-left: 0px;
+}
+
+dl.field-list dd > ul > li li :first-child {
+    text-indent: 0;
+}
+
+dl.field-list dd > ul > li :first-child {
+    text-indent: -2em;
+    padding-left: 0px;
+}
+
+dl.field-list dd > p:first-child {
+    text-indent: -2em;
+}
 
 @media screen and (max-width: 870px) {
 

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -1,5 +1,5 @@
-Reference
-=========
+API Reference
+=============
 
 This page contains the full reference to pytest's API.
 

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -193,17 +193,18 @@ class MarkDecorator:
             pass
 
     When a MarkDecorator instance is called it does the following:
-      1. If called with a single class as its only positional argument and no
-         additional keyword arguments, it attaches itself to the class so it
-         gets applied automatically to all test cases found in that class.
-      2. If called with a single function as its only positional argument and
-         no additional keyword arguments, it attaches a MarkInfo object to the
-         function, containing all the arguments already stored internally in
-         the MarkDecorator.
-      3. When called in any other case, it performs a 'fake construction' call,
-         i.e. it returns a new MarkDecorator instance with the original
-         MarkDecorator's content updated with the arguments passed to this
-         call.
+
+    1. If called with a single class as its only positional argument and no
+       additional keyword arguments, it attaches itself to the class so it
+       gets applied automatically to all test cases found in that class.
+    2. If called with a single function as its only positional argument and
+       no additional keyword arguments, it attaches a MarkInfo object to the
+       function, containing all the arguments already stored internally in
+       the MarkDecorator.
+    3. When called in any other case, it performs a 'fake construction' call,
+       i.e. it returns a new MarkDecorator instance with the original
+       MarkDecorator's content updated with the arguments passed to this
+       call.
 
     Note: The rules above prevent MarkDecorator objects from storing only a
     single function or class reference as their positional argument with no

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -542,7 +542,7 @@ def raises(expected_exception, *args, **kwargs):
         string that may contain `special characters`__, the pattern can
         first be escaped with ``re.escape``.
 
-    __ https://docs.python.org/3/library/re.html#regular-expression-syntax
+        __ https://docs.python.org/3/library/re.html#regular-expression-syntax
 
     :kwparam message: **(deprecated since 4.1)** if specified, provides a custom failure message
         if the exception is not raised. See :ref:`the deprecation docs <raises message deprecated>` for a workaround.


### PR DESCRIPTION
### CSS changes to the API reference

- Changed layout of parameters sections
  - Don't indent by the width of "Parameters". Parameter documentation is less cramped.
  - Haning indent for parameter docs: Better overview where the next parameter starts.
  - Draw a vertical line along all parameters: The parameters section is easy to distinguish from other parts of the docstring

  before/after:

  ![grafik](https://user-images.githubusercontent.com/2836374/61224312-a88a3c80-a71e-11e9-9d57-90c8cbb4f03b.png) ![grafik](https://user-images.githubusercontent.com/2836374/61224277-99a38a00-a71e-11e9-8904-78874bbf8bdf.png)

- Draw a vertical line along class docstrings. Class docstrings can be quite long. The line makes it obvious that the attribute/method definitions therein are not toplevel but belong to a class.

  before/after:

  ![grafik](https://user-images.githubusercontent.com/2836374/61224915-d15f0180-a71f-11e9-9923-0d000c642738.png) ![grafik](https://user-images.githubusercontent.com/2836374/61224944-e0de4a80-a71f-11e9-8af4-c192e3592d66.png)

- Some spacing adjustments to give the text more space to breathe.

### ReST fixes
Fixed two indentation issues in docstrings, which resulted in incorrect formatting of the rendered API reference.

### Change of section titles
- "Changelog history" -> "Changelog":
  A changelog is by definition a history of changes. No need to double the meaning; and the trem "changelog history" is rather uncommon.
- "Reference" -> "API Reference":
  Reference feels a bit to unspecific. - However this may be caused by my non-native english. Please report back if "Reference" itself is enough.