### PR TITLE
Added link checking to tox and release.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3462,7 +3462,7 @@ Deprecations and Removals
 
 - ``pytest.approx`` no longer supports ``>``, ``>=``, ``<`` and ``<=``
   operators to avoid surprising/inconsistent behavior. See `the approx docs
-  <https://docs.pytest.org/en/latest/builtin.html#pytest.approx>`_ for more
+  <https://docs.pytest.org/en/latest/reference.html#pytest-approx>`_ for more
   information. (`#2003 <https://github.com/pytest-dev/pytest/issues/2003>`_)
 
 - All old-style specific behavior in current classes in the pytest's API is
@@ -4819,7 +4819,7 @@ time or change existing behaviors in order to make them less surprising/more use
 * Fix (`#1422`_): junit record_xml_property doesn't allow multiple records
   with same name.
 
-.. _`traceback style docs`: https://pytest.org/latest/usage.html#modifying-python-traceback-printing
+.. _`traceback style docs`: https://pytest.org/en/latest/usage.html#modifying-python-traceback-printing
 
 .. _#1609: https://github.com/pytest-dev/pytest/issues/1609
 .. _#1422: https://github.com/pytest-dev/pytest/issues/1422
@@ -5337,7 +5337,7 @@ time or change existing behaviors in order to make them less surprising/more use
 - add ability to set command line options by environment variable PYTEST_ADDOPTS.
 
 - added documentation on the new pytest-dev teams on bitbucket and
-  github.  See https://pytest.org/latest/contributing.html .
+  github.  See https://pytest.org/en/latest/contributing.html .
   Thanks to Anatoly for pushing and initial work on this.
 
 - fix issue650: new option ``--docttest-ignore-import-errors`` which
@@ -6078,7 +6078,7 @@ Bug fixes:
 - yielded test functions will now have autouse-fixtures active but
   cannot accept fixtures as funcargs - it's anyway recommended to
   rather use the post-2.0 parametrize features instead of yield, see:
-  http://pytest.org/latest/example/parametrize.html
+  http://pytest.org/en/latest/example/parametrize.html
 - fix autouse-issue where autouse-fixtures would not be discovered
   if defined in an a/conftest.py file and tests in a/tests/test_some.py
 - fix issue226 - LIFO ordering for fixture teardowns
@@ -6211,7 +6211,7 @@ Bug fixes:
 - pluginmanager.register(...) now raises ValueError if the
   plugin has been already registered or the name is taken
 
-- fix issue159: improve http://pytest.org/latest/faq.html
+- fix issue159: improve http://pytest.org/en/latest/faq.html
   especially with respect to the "magic" history, also mention
   pytest-django, trial and unittest integration.
 
@@ -6324,7 +6324,7 @@ Bug fixes:
   or through plugin hooks.  Also introduce a "--strict" option which
   will treat unregistered markers as errors
   allowing to avoid typos and maintain a well described set of markers
-  for your test suite.  See exaples at http://pytest.org/latest/mark.html
+  for your test suite.  See exaples at http://pytest.org/en/latest/mark.html
   and its links.
 - issue50: introduce "-m marker" option to select tests based on markers
   (this is a stricter and more predictable version of '-k' in that "-m"
@@ -6507,7 +6507,7 @@ Bug fixes:
 - refinements to "collecting" output on non-ttys
 - refine internal plugin registration and --traceconfig output
 - introduce a mechanism to prevent/unregister plugins from the
-  command line, see http://pytest.org/plugins.html#cmdunregister
+  command line, see http://pytest.org/en/latest/plugins.html#cmdunregister
 - activate resultlog plugin by default
 - fix regression wrt yielded tests which due to the
   collection-before-running semantics were not

--- a/doc/en/announce/release-2.0.0.rst
+++ b/doc/en/announce/release-2.0.0.rst
@@ -7,7 +7,7 @@ see below for summary and detailed lists.  A lot of long-deprecated code
 has been removed, resulting in a much smaller and cleaner
 implementation.  See the new docs with examples here:
 
-    http://pytest.org/2.0.0/index.html
+    http://pytest.org/en/latest/index.html
 
 A note on packaging: pytest used to part of the "py" distribution up
 until version py-1.3.4 but this has changed now:  pytest-2.0.0 only
@@ -36,12 +36,12 @@ New Features
 
     import pytest ; pytest.main(arglist, pluginlist)
 
-  see http://pytest.org/2.0.0/usage.html for details.
+  see http://pytest.org/en/latest/usage.html for details.
 
 - new and better reporting information in assert expressions
   if comparing lists, sequences or strings.
 
-  see http://pytest.org/2.0.0/assert.html#newreport
+  see http://pytest.org/en/latest/assert.html#newreport
 
 - new configuration through ini-files (setup.cfg or tox.ini recognized),
   for example::
@@ -50,7 +50,7 @@ New Features
     norecursedirs = .hg data*  # don't ever recurse in such dirs
     addopts = -x --pyargs      # add these command line options by default
 
-  see http://pytest.org/2.0.0/customize.html
+  see http://pytest.org/en/latest/customize.html
 
 - improved standard unittest support.  In general py.test should now
   better be able to run custom unittest.TestCases like twisted trial

--- a/doc/en/announce/release-2.0.1.rst
+++ b/doc/en/announce/release-2.0.1.rst
@@ -57,7 +57,7 @@ Changes between 2.0.0 and 2.0.1
 - refinements to "collecting" output on non-ttys
 - refine internal plugin registration and --traceconfig output
 - introduce a mechanism to prevent/unregister plugins from the
-  command line, see http://pytest.org/latest/plugins.html#cmdunregister
+  command line, see http://pytest.org/en/latest/plugins.html#cmdunregister
 - activate resultlog plugin by default
 - fix regression wrt yielded tests which due to the
   collection-before-running semantics were not

--- a/doc/en/announce/release-2.2.0.rst
+++ b/doc/en/announce/release-2.2.0.rst
@@ -9,7 +9,7 @@ with these improvements:
 
   - new @pytest.mark.parametrize decorator to run tests with different arguments
   - new metafunc.parametrize() API for parametrizing arguments independently
-  - see examples at http://pytest.org/latest/example/parametrize.html
+  - see examples at http://pytest.org/en/latest/example/parametrize.html
   - NOTE that parametrize() related APIs are still a bit experimental
     and might change in future releases.
 
@@ -18,7 +18,7 @@ with these improvements:
   - "-m markexpr" option for selecting tests according to their mark
   - a new "markers" ini-variable for registering test markers for your project
   - the new "--strict" bails out with an error if using unregistered markers.
-  - see examples at http://pytest.org/latest/example/markers.html
+  - see examples at http://pytest.org/en/latest/example/markers.html
 
 * duration profiling: new "--duration=N" option showing the N slowest test
   execution or setup/teardown calls. This is most useful if you want to
@@ -78,7 +78,7 @@ Changes between 2.1.3 and 2.2.0
   or through plugin hooks.  Also introduce a "--strict" option which
   will treat unregistered markers as errors
   allowing to avoid typos and maintain a well described set of markers
-  for your test suite.  See examples at http://pytest.org/latest/mark.html
+  for your test suite.  See examples at http://pytest.org/en/latest/mark.html
   and its links.
 - issue50: introduce "-m marker" option to select tests based on markers
   (this is a stricter and more predictable version of "-k" in that "-m"

--- a/doc/en/announce/release-2.3.0.rst
+++ b/doc/en/announce/release-2.3.0.rst
@@ -13,12 +13,12 @@ re-useable fixture design.
 
 For detailed info and tutorial-style examples, see:
 
-    http://pytest.org/latest/fixture.html
+    http://pytest.org/en/latest/fixture.html
 
 Moreover, there is now support for using pytest fixtures/funcargs with
 unittest-style suites, see here for examples:
 
-    http://pytest.org/latest/unittest.html
+    http://pytest.org/en/latest/unittest.html
 
 Besides, more unittest-test suites are now expected to "simply work"
 with pytest.
@@ -29,11 +29,11 @@ pytest-2.2.4.
 
 If you are interested in the precise reasoning (including examples) of the
 pytest-2.3 fixture evolution, please consult
-http://pytest.org/latest/funcarg_compare.html
+http://pytest.org/en/latest/funcarg_compare.html
 
 For general info on installation and getting started:
 
-    http://pytest.org/latest/getting-started.html
+    http://pytest.org/en/latest/getting-started.html
 
 Docs and PDF access as usual at:
 
@@ -94,7 +94,7 @@ Changes between 2.2.4 and 2.3.0
 - pluginmanager.register(...) now raises ValueError if the
   plugin has been already registered or the name is taken
 
-- fix issue159: improve http://pytest.org/latest/faq.html
+- fix issue159: improve http://pytest.org/en/latest/faq.html
   especially with respect to the "magic" history, also mention
   pytest-django, trial and unittest integration.
 

--- a/doc/en/announce/release-2.3.4.rst
+++ b/doc/en/announce/release-2.3.4.rst
@@ -16,7 +16,7 @@ comes with the following fixes and features:
 - yielded test functions will now have autouse-fixtures active but
   cannot accept fixtures as funcargs - it's anyway recommended to
   rather use the post-2.0 parametrize features instead of yield, see:
-  http://pytest.org/latest/example/parametrize.html
+  http://pytest.org/en/latest/example/parametrize.html
 - fix autouse-issue where autouse-fixtures would not be discovered
   if defined in an a/conftest.py file and tests in a/tests/test_some.py
 - fix issue226 - LIFO ordering for fixture teardowns

--- a/doc/en/announce/release-2.4.0.rst
+++ b/doc/en/announce/release-2.4.0.rst
@@ -7,7 +7,7 @@ from a few supposedly very minor incompatibilities.  See below for
 a full list of details.  A few feature highlights:
 
 - new yield-style fixtures `pytest.yield_fixture
-  <http://pytest.org/latest/yieldfixture.html>`_, allowing to use
+  <http://pytest.org/en/latest/yieldfixture.html>`_, allowing to use
   existing with-style context managers in fixture functions.
 
 - improved pdb support: ``import pdb ; pdb.set_trace()`` now works

--- a/doc/en/announce/release-2.7.0.rst
+++ b/doc/en/announce/release-2.7.0.rst
@@ -52,7 +52,7 @@ holger krekel
 - add ability to set command line options by environment variable PYTEST_ADDOPTS.
 
 - added documentation on the new pytest-dev teams on bitbucket and
-  github.  See https://pytest.org/latest/contributing.html .
+  github.  See https://pytest.org/en/latest/contributing.html .
   Thanks to Anatoly for pushing and initial work on this.
 
 - fix issue650: new option ``--docttest-ignore-import-errors`` which

--- a/doc/en/announce/release-2.9.0.rst
+++ b/doc/en/announce/release-2.9.0.rst
@@ -131,7 +131,7 @@ The py.test Development Team
   with same name.
 
 
-.. _`traceback style docs`: https://pytest.org/latest/usage.html#modifying-python-traceback-printing
+.. _`traceback style docs`: https://pytest.org/en/latest/usage.html#modifying-python-traceback-printing
 
 .. _#1422: https://github.com/pytest-dev/pytest/issues/1422
 .. _#1379: https://github.com/pytest-dev/pytest/issues/1379

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -112,6 +112,19 @@ pygments_style = "sphinx"
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
 
+# A list of regular expressions that match URIs that should not be checked when
+# doing a linkcheck.
+linkcheck_ignore = [
+    "https://github.com/numpy/numpy/blob/master/doc/release/1.16.0-notes.rst#new-deprecations",
+    "https://blogs.msdn.microsoft.com/bharry/2017/06/28/testing-in-a-cloud-delivery-cadence/",
+    "http://pythontesting.net/framework/pytest-introduction/",
+    r"https://github.com/pytest-dev/pytest/issues/\d+",
+    r"https://github.com/pytest-dev/pytest/pull/\d+",
+]
+
+# The number of worker threads to use when checking links (default=5).
+linkcheck_workers = 5
+
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -9,9 +9,9 @@ pytest fixtures: explicit, modular, scalable
 
 
 
-.. _`xUnit`: http://en.wikipedia.org/wiki/XUnit
-.. _`purpose of test fixtures`: http://en.wikipedia.org/wiki/Test_fixture#Software
-.. _`Dependency injection`: http://en.wikipedia.org/wiki/Dependency_injection
+.. _`xUnit`: https://en.wikipedia.org/wiki/XUnit
+.. _`purpose of test fixtures`: https://en.wikipedia.org/wiki/Test_fixture#Software
+.. _`Dependency injection`: https://en.wikipedia.org/wiki/Dependency_injection
 
 The `purpose of test fixtures`_ is to provide a fixed baseline
 upon which tests can reliably and repeatedly execute.   pytest fixtures

--- a/doc/en/projects.rst
+++ b/doc/en/projects.rst
@@ -73,7 +73,6 @@ Some organisations using pytest
 
 * `Square Kilometre Array, Cape Town <http://ska.ac.za/>`_
 * `Some Mozilla QA people <http://www.theautomatedtester.co.uk/blog/2011/pytest_and_xdist_plugin.html>`_ use pytest to distribute their Selenium tests
-* `Tandberg <http://www.tandberg.com/>`_
 * `Shootq <http://web.shootq.com/>`_
 * `Stups department of Heinrich Heine University Duesseldorf <http://www.stups.uni-duesseldorf.de/projects.php>`_
 * cellzome

--- a/doc/en/talks.rst
+++ b/doc/en/talks.rst
@@ -64,7 +64,7 @@ Talks and blog postings
 - `pytest introduction from Brian Okken (January 2013)
   <http://pythontesting.net/framework/pytest-introduction/>`_
 
-- pycon australia 2012 pytest talk from Brianna Laugher (`video <http://www.youtube.com/watch?v=DTNejE9EraI>`_, `slides <http://www.slideshare.net/pfctdayelise/funcargs-other-fun-with-pytest>`_, `code <https://gist.github.com/3386951>`_)
+- pycon australia 2012 pytest talk from Brianna Laugher (`video <http://www.youtube.com/watch?v=DTNejE9EraI>`_, `slides <https://www.slideshare.net/pfctdayelise/funcargs-other-fun-with-pytest>`_, `code <https://gist.github.com/3386951>`_)
 - `pycon 2012 US talk video from Holger Krekel <http://www.youtube.com/watch?v=9LVqBQcFmyw>`_
 
 - `monkey patching done right`_ (blog post, consult `monkeypatch plugin`_ for up-to-date API)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -79,12 +79,19 @@ def fix_formatting():
     call(["pre-commit", "run", "--all-files"])
 
 
+def check_links():
+    """Runs sphinx-build to check links"""
+    print(f"{Fore.CYAN}[generate.check_links] {Fore.RESET}Checking links")
+    check_call(["tox", "-e", "docs-checklinks"])
+
+
 def pre_release(version):
     """Generates new docs, release announcements and creates a local tag."""
     announce(version)
     regen()
     changelog(version, write_out=True)
     fix_formatting()
+    check_links()
 
     msg = "Preparing release version {}".format(version)
     check_call(["git", "commit", "-a", "-m", msg])

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ usedevelop = True
 changedir = doc/en
 deps = -r{toxinidir}/doc/en/requirements.txt
 commands =
-    sphinx-build -W --keep-going -b linkcheck . _build
+    sphinx-build -W -q --keep-going -b linkcheck . _build
 
 [testenv:doctesting]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ envlist =
     doctesting
     py37-freeze
     docs
+    docs-checklinks
 
 [testenv]
 commands =
@@ -65,6 +66,14 @@ deps = -r{toxinidir}/doc/en/requirements.txt
 
 commands =
     sphinx-build -W -b html . _build
+
+[testenv:docs-checklinks]
+basepython = python3
+usedevelop = True
+changedir = doc/en
+deps = -r{toxinidir}/doc/en/requirements.txt
+commands =
+    sphinx-build -W --keep-going -b linkcheck . _build
 
 [testenv:doctesting]
 basepython = python3


### PR DESCRIPTION
Fixes #1722 by checking all links in documentation during the release process.
Should only be merged after all broken links are fixed (https://github.com/pytest-dev/pytest/pull/5613)

It's running during release in release.py or can be triggered manually by executing `tox -e docs-checklinks`.

False positives can be added to list `linkcheck_ignore` in `doc/en/conf.py`.
