### PR TITLE
Fix broken venv link

### DIFF
--- a/doc/en/links.inc
+++ b/doc/en/links.inc
@@ -14,7 +14,7 @@
 .. _`distribute docs`:
 .. _`distribute`: https://pypi.org/project/distribute/
 .. _`pip`: https://pypi.org/project/pip/
-.. _`venv`: https://docs.python.org/3/library/venv.html/
+.. _`venv`: https://docs.python.org/3/library/venv.html
 .. _`virtualenv`: https://pypi.org/project/virtualenv/
 .. _hudson: http://hudson-ci.org/
 .. _jenkins: http://jenkins-ci.org/


### PR DESCRIPTION
There's a small typo in the `venv` link that returns a 404. This change removes the trailing `/` to fix the link.