### PR TITLE
warnings: use _setoption without escaping for cmdline options

### DIFF
--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -78,7 +78,7 @@ def catch_warnings_for_item(config, ihook, when, item):
             _setoption(warnings, arg)
 
         for arg in cmdline_filters:
-            warnings._setoption(arg)
+            _setoption(warnings, arg)
 
         if item is not None:
             for mark in item.iter_markers(name="filterwarnings"):


### PR DESCRIPTION
It is nice that pytest supports regular expressions (as documented by
Python itself already), but should do so also for cmdline options.

It is likely to be fixed in Python eventually.
Ref: https://github.com/python/cpython/pull/9358

Targetting features since it is a change in behavior.

TODO:
- [ ] test
- [ ] changelog