### PR TITLE
tox.ini: clean up filterwarnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -133,10 +133,6 @@ filterwarnings =
     ignore::pytest.RemovedInPytest4Warning
     default:Using or importing the ABCs:DeprecationWarning:unittest2.*
     ignore:Module already imported so cannot be rewritten:pytest.PytestWarning
-    # produced by path.local
-    ignore:bad escape.*:DeprecationWarning:re
-    # produced by path.readlines
-    ignore:.*U.*mode is deprecated:DeprecationWarning
     # produced by pytest-xdist
     ignore:.*type argument to addoption.*:DeprecationWarning
     # produced by python >=3.5 on execnet (pytest-xdist)
@@ -144,6 +140,8 @@ filterwarnings =
     # pytest's own futurewarnings
     ignore::pytest.PytestExperimentalApiWarning
     # Do not cause SyntaxError for invalid escape sequences in py37.
+    # Those are caught/handled by pyupgrade, and not easy to filter with the
+    # module being the filename (with .py removed).
     default:invalid escape sequence:DeprecationWarning
     # ignore use of unregistered marks, because we use many to test the implementation
     ignore::_pytest.warning_types.PytestUnknownMarkWarning

--- a/tox.ini
+++ b/tox.ini
@@ -133,6 +133,8 @@ filterwarnings =
     ignore::pytest.RemovedInPytest4Warning
     default:Using or importing the ABCs:DeprecationWarning:unittest2.*
     ignore:Module already imported so cannot be rewritten:pytest.PytestWarning
+    # produced by python3.6/site.py itself (3.6.7 on Travis, could not trigger it with 3.6.8).
+    ignore:.*U.*mode is deprecated:DeprecationWarning:(?!(pytest|_pytest))
     # produced by pytest-xdist
     ignore:.*type argument to addoption.*:DeprecationWarning
     # produced by python >=3.5 on execnet (pytest-xdist)


### PR DESCRIPTION
- path.local/path.readlines is not used anymore
- enhance doc for "invalid escape sequence" filter