### PR TITLE
unittest: handle outcomes.Exit

### DIFF
--- a/changelog/5634.bugfix.rst
+++ b/changelog/5634.bugfix.rst
@@ -1,0 +1,1 @@
+``pytest.exit`` and ``bdb.BdbQuit`` are now correctly handled in ``unittest`` cases.

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -6,6 +6,7 @@ import _pytest._code
 import pytest
 from _pytest.compat import getimfunc
 from _pytest.config import hookimpl
+from _pytest.outcomes import exit
 from _pytest.outcomes import fail
 from _pytest.outcomes import skip
 from _pytest.outcomes import xfail
@@ -153,6 +154,11 @@ class TestCaseFunction(Function):
         self.__dict__.setdefault("_excinfo", []).append(excinfo)
 
     def addError(self, testcase, rawexcinfo):
+        try:
+            if isinstance(rawexcinfo[1], exit.Exception):
+                exit(rawexcinfo[1].msg)
+        except TypeError:
+            pass
         self._addexcinfo(rawexcinfo)
 
     def addFailure(self, testcase, rawexcinfo):

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1078,11 +1078,11 @@ def test_exit_outcome(testdir):
 
         class MyTestCase(unittest.TestCase):
             def test_exit_outcome(self):
-                pytest.exit("pytest_exit")
+                pytest.exit("pytest_exit called")
 
             def test_should_not_run(self):
                 pass
     """
     )
-    reprec = testdir.inline_run()
-    reprec.assertoutcome()
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines("*Exit: pytest_exit called*")

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1050,3 +1050,39 @@ def test_setup_inheritance_skipping(testdir, test_name, expected_outcome):
     testdir.copy_example("unittest/{}".format(test_name))
     result = testdir.runpytest()
     result.stdout.fnmatch_lines(["* {} in *".format(expected_outcome)])
+
+
+def test_BdbQuit(testdir):
+    testdir.makepyfile(
+        test_foo="""
+        import unittest
+
+        class MyTestCase(unittest.TestCase):
+            def test_bdbquit(self):
+                import bdb
+                raise bdb.BdbQuit()
+
+            def test_should_not_run(self):
+                pass
+    """
+    )
+    reprec = testdir.inline_run()
+    reprec.assertoutcome(failed=1, passed=1)
+
+
+def test_exit_outcome(testdir):
+    testdir.makepyfile(
+        test_foo="""
+        import pytest
+        import unittest
+
+        class MyTestCase(unittest.TestCase):
+            def test_exit_outcome(self):
+                pytest.exit("pytest_exit")
+
+            def test_should_not_run(self):
+                pass
+    """
+    )
+    reprec = testdir.inline_run()
+    reprec.assertoutcome()


### PR DESCRIPTION
This is required for pytest to stop when using "quit" in pdb, and should
get honored/handled in general.