### PR TITLE
Replace internal config._origargs with invocation_params.args

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -632,10 +632,10 @@ class Config:
         Object containing the parameters regarding the ``pytest.main``
         invocation.
 
-        Contains the followinig read-only attributes:
+        Contains the following read-only attributes:
 
         * ``args``: list of command-line arguments as passed to ``pytest.main()``.
-        * ``plugins``: list of extra plugins, might be None
+        * ``plugins``: list of extra plugins, might be None.
         * ``dir``: directory where ``pytest.main()`` was invoked from.
     """
 
@@ -915,7 +915,7 @@ class Config:
         assert not hasattr(
             self, "args"
         ), "can only parse cmdline args at most once per Config object"
-        self._origargs = args
+        assert self.invocation_params.args == args
         self.hook.pytest_addhooks.call_historic(
             kwargs=dict(pluginmanager=self.pluginmanager)
         )

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -98,7 +98,7 @@ def pytest_cmdline_parse():
                 py.__version__,
                 ".".join(map(str, sys.version_info)),
                 os.getcwd(),
-                config._origargs,
+                config.invocation_params.args,
             )
         )
         config.trace.root.setwriter(debugfile.write)

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -441,7 +441,7 @@ class TestConfigFromdictargs:
         assert config.option.capture == "no"
         assert config.args == args
 
-    def test_origargs(self, _sys_snapshot):
+    def test_invocation_params_args(self, _sys_snapshot):
         """Show that fromdictargs can handle args in their "orig" format"""
         from _pytest.config import Config
 
@@ -450,7 +450,7 @@ class TestConfigFromdictargs:
 
         config = Config.fromdictargs(option_dict, args)
         assert config.args == ["a", "b"]
-        assert config._origargs == args
+        assert config.invocation_params.args == args
         assert config.option.verbose == 4
         assert config.option.capture == "no"
 


### PR DESCRIPTION
Added in https://github.com/pytest-dev/pytest/pull/5564.