### PR TITLE
Improve output when parsing an ini configuration fails

### DIFF
--- a/changelog/5650.bugfix.rst
+++ b/changelog/5650.bugfix.rst
@@ -1,0 +1,1 @@
+Improved output when parsing an ini configuration file fails.

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -32,7 +32,11 @@ def getcfg(args, config=None):
             for inibasename in inibasenames:
                 p = base.join(inibasename)
                 if exists(p):
-                    iniconfig = py.iniconfig.IniConfig(p)
+                    try:
+                        iniconfig = py.iniconfig.IniConfig(p)
+                    except py.iniconfig.ParseError as exc:
+                        raise UsageError(str(exc))
+
                     if (
                         inibasename == "setup.cfg"
                         and "tool:pytest" in iniconfig.sections

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -122,6 +122,14 @@ class TestParseIni:
         config = testdir.parseconfigure(sub)
         assert config.getini("minversion") == "2.0"
 
+    def test_ini_parse_error(self, testdir):
+        testdir.tmpdir.join("pytest.ini").write('addopts = -x')
+        result = testdir.runpytest()
+        assert result.ret != 0
+        result.stderr.fnmatch_lines([
+            "ERROR: *pytest.ini:1: no section header defined"
+        ])
+
     @pytest.mark.xfail(reason="probably not needed")
     def test_confcutdir(self, testdir):
         sub = testdir.mkdir("sub")

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -123,12 +123,10 @@ class TestParseIni:
         assert config.getini("minversion") == "2.0"
 
     def test_ini_parse_error(self, testdir):
-        testdir.tmpdir.join("pytest.ini").write('addopts = -x')
+        testdir.tmpdir.join("pytest.ini").write("addopts = -x")
         result = testdir.runpytest()
         assert result.ret != 0
-        result.stderr.fnmatch_lines([
-            "ERROR: *pytest.ini:1: no section header defined"
-        ])
+        result.stderr.fnmatch_lines(["ERROR: *pytest.ini:1: no section header defined"])
 
     @pytest.mark.xfail(reason="probably not needed")
     def test_confcutdir(self, testdir):


### PR DESCRIPTION
Before this change, a config file with a syntax error (like a missing section header) produces a rather intimidating stacktrace:

```
Traceback (most recent call last):
  File ".venv/bin/pytest", line 11, in <module>
    load_entry_point('pytest', 'console_scripts', 'pytest')()
  File "/home/florian/proj/pytest/src/_pytest/config/__init__.py", line 55, in main
    config = _prepareconfig(args, plugins)
  File "/home/florian/proj/pytest/src/_pytest/config/__init__.py", line 200, in _prepareconfig
    pluginmanager=pluginmanager, args=args
  File "/home/florian/tmp/ini/.venv/lib/python3.7/site-packages/pluggy/hooks.py", line 289, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/home/florian/tmp/ini/.venv/lib/python3.7/site-packages/pluggy/manager.py", line 87, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/home/florian/tmp/ini/.venv/lib/python3.7/site-packages/pluggy/manager.py", line 81, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/home/florian/tmp/ini/.venv/lib/python3.7/site-packages/pluggy/callers.py", line 203, in _multicall
    gen.send(outcome)
  File "/home/florian/proj/pytest/src/_pytest/helpconfig.py", line 89, in pytest_cmdline_parse
    config = outcome.get_result()
  File "/home/florian/tmp/ini/.venv/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/home/florian/tmp/ini/.venv/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/home/florian/proj/pytest/src/_pytest/config/__init__.py", line 661, in pytest_cmdline_parse
    self.parse(args)
  File "/home/florian/proj/pytest/src/_pytest/config/__init__.py", line 869, in parse
    self._preparse(args, addopts=addopts)
  File "/home/florian/proj/pytest/src/_pytest/config/__init__.py", line 803, in _preparse
    self._initini(args)
  File "/home/florian/proj/pytest/src/_pytest/config/__init__.py", line 734, in _initini
    config=self,
  File "/home/florian/proj/pytest/src/_pytest/config/findpaths.py", line 122, in determine_setup
    rootdir, inifile, inicfg = getcfg([ancestor], config=config)
  File "/home/florian/proj/pytest/src/_pytest/config/findpaths.py", line 35, in getcfg
    iniconfig = py.iniconfig.IniConfig(p)
  File "/home/florian/tmp/ini/.venv/lib/python3.7/site-packages/py/_vendored_packages/iniconfig.py", line 65, in __init__
    self._raise(lineno, 'no section header defined')
  File "/home/florian/tmp/ini/.venv/lib/python3.7/site-packages/py/_vendored_packages/iniconfig.py", line 77, in _raise
    raise ParseError(self.path, lineno, msg)
py._vendored_packages.iniconfig.ParseError: /home/florian/tmp/ini/pytest.ini:1: no section header defined
```

after the change:

```
ERROR: /home/florian/tmp/ini/pytest.ini:1: no section header defined
```