### PR TITLE
Fix fixture example and regendocs

### DIFF
--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -552,13 +552,13 @@ Then run ``pytest`` with verbose mode and with only the ``basic`` marker:
     platform linux -- Python 3.x.y, pytest-5.x.y, py-1.x.y, pluggy-0.x.y -- $PYTHON_PREFIX/bin/python
     cachedir: $PYTHON_PREFIX/.pytest_cache
     rootdir: $REGENDOC_TMPDIR
-    collecting ... collected 17 items / 14 deselected / 3 selected
+    collecting ... collected 18 items / 15 deselected / 3 selected
 
     test_pytest_param_example.py::test_eval[1+7-8] PASSED                [ 33%]
     test_pytest_param_example.py::test_eval[basic_2+4] PASSED            [ 66%]
     test_pytest_param_example.py::test_eval[basic_6*9] XFAIL             [100%]
 
-    ============ 2 passed, 14 deselected, 1 xfailed in 0.12 seconds ============
+    ============ 2 passed, 15 deselected, 1 xfailed in 0.12 seconds ============
 
 As the result:
 

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -391,7 +391,12 @@ close all resources created by a fixture even if one of them fails to be created
 
     import pytest
 
-    from .utils import connect
+
+    @contextlib.contextmanager
+    def connect(port):
+        ...  # create connection
+        yield
+        ...  # close connection
 
 
     @pytest.fixture
@@ -441,7 +446,12 @@ Here's the ``equipments`` fixture changed to use ``addfinalizer`` for cleanup:
 
     import pytest
 
-    from .utils import connect
+
+    @contextlib.contextmanager
+    def connect(port):
+        ...  # create connection
+        yield
+        ...  # close connection
 
 
     @pytest.fixture


### PR DESCRIPTION
The previous example was failing with:

```
   ================================== ERRORS ==================================
   _____________________ ERROR collecting test_yield3.py ______________________
   ImportError while importing test module '$REGENDOC_TMPDIR/test_yield3.py'.
   Hint: make sure your test modules/packages have valid Python names.
   Traceback:
   test_yield3.py:7: in <module>
       from .utils import connect
   E   ImportError: attempted relative import with no known parent package
   !!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!
   ========================= 1 error in 0.12 seconds ==========================
```