### PR TITLE
In test_xfail_handling, only remove __pycache__ if it exists

### DIFF
--- a/changelog/5664.trivial.rst
+++ b/changelog/5664.trivial.rst
@@ -1,0 +1,2 @@
+When invoking pytest's own testsuite with ``PYTHONDONTWRITEBYTECODE=1``,
+the ``test_xfail_handling`` test no longer fails.

--- a/testing/test_stepwise.py
+++ b/testing/test_stepwise.py
@@ -207,7 +207,8 @@ def test_xfail_handling(testdir):
 
     # because we are writing to the same file, mtime might not be affected enough to
     # invalidate the cache, making this next run flaky
-    testdir.tmpdir.join("__pycache__").remove()
+    if testdir.tmpdir.join("__pycache__").exists():
+        testdir.tmpdir.join("__pycache__").remove()
     testdir.makepyfile(contents.format(assert_value="0", strict="True"))
     result = testdir.runpytest("--sw", "-v")
     result.stdout.fnmatch_lines(


### PR DESCRIPTION
Previously, the test failed when the directory was not present,
which could have been caused for example by invoking the tests
with PYTHONDONTWRITEBYTECODE=1.

Fixes https://github.com/pytest-dev/pytest/issues/5664

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.
(please delete this text from the final description, this is just a guideline)
-->

- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [x] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Add yourself to `AUTHORS` in alphabetical order;

