### PR TITLE
Fix the confusing different names of `fulltrace`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -132,7 +132,6 @@ Joseph Hunkeler
 Joshua Bronson
 Jurko Gospodnetić
 Justyna Janczyszyn
-Kaiqi Dong
 Kale Kundert
 Katarzyna Jachim
 Katerina Koukiou

--- a/AUTHORS
+++ b/AUTHORS
@@ -132,6 +132,7 @@ Joseph Hunkeler
 Joshua Bronson
 Jurko Gospodnetić
 Justyna Janczyszyn
+Kaiqi Dong
 Kale Kundert
 Katarzyna Jachim
 Katerina Koukiou

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -114,7 +114,7 @@ def pytest_addoption(parser):
     )
     group._addoption(
         "--fulltrace",
-        "--fulltrace",
+        "--full-trace",
         action="store_true",
         default=False,
         help="don't cut any tracebacks (default is to cut).",
@@ -692,7 +692,7 @@ class TerminalReporter:
             else:
                 excrepr.reprcrash.toterminal(self._tw)
                 self._tw.line(
-                    "(to show a full traceback on KeyboardInterrupt use --fulltrace)",
+                    "(to show a full traceback on KeyboardInterrupt use --full-trace)",
                     yellow=True,
                 )
 

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -114,7 +114,7 @@ def pytest_addoption(parser):
     )
     group._addoption(
         "--fulltrace",
-        "--full-trace",
+        "--fulltrace",
         action="store_true",
         default=False,
         help="don't cut any tracebacks (default is to cut).",

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -233,7 +233,7 @@ class TestTerminal:
             )
         else:
             result.stdout.fnmatch_lines(
-                ["(to show a full traceback on KeyboardInterrupt use --fulltrace)"]
+                ["(to show a full traceback on KeyboardInterrupt use --full-trace)"]
             )
         result.stdout.fnmatch_lines(["*KeyboardInterrupt*"])
 


### PR DESCRIPTION
Fix the confusing different names of `fulltrace` showed in `pytest --help` (#5647)

Since this is a small fix, and I don't think this needs to create a changelog, please let me know if needed.