### PR TITLE
Fix some typos

### DIFF
--- a/doc/en/mark.rst
+++ b/doc/en/mark.rst
@@ -40,7 +40,7 @@ You can register custom marks in your ``pytest.ini`` file like this:
 
 Note that everything after the ``:`` is an optional description.
 
-Alternatively, you can register new markers programatically in a
+Alternatively, you can register new markers programmatically in a
 :ref:`pytest_configure <initialization-hooks>` hook:
 
 .. code-block:: python

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -399,7 +399,7 @@ class DropShorterLongHelpFormatter(argparse.HelpFormatter):
     """shorten help for long options that differ only in extra hyphens
 
     - collapse **long** options that are the same except for extra hyphens
-    - special action attribute map_long_option allows surpressing additional
+    - special action attribute map_long_option allows suppressing additional
       long options
     - shortcut if there are only two options and one of them is a short one
     - cache result on action object as this is called at least 2 times

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -370,7 +370,7 @@ def test_excinfo_no_python_sourcecode(tmpdir):
     excinfo = pytest.raises(ValueError, template.render, h=h)
     for item in excinfo.traceback:
         print(item)  # XXX: for some reason jinja.Template.render is printed in full
-        item.source  # shouldnt fail
+        item.source  # shouldn't fail
         if item.path.basename == "test.txt":
             assert str(item.source) == "{{ h()}}:"
 

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -582,7 +582,7 @@ class TestPython:
         assert "hx" in fnode.toxml()
 
     def test_assertion_binchars(self, testdir):
-        """this test did fail when the escaping wasnt strict"""
+        """this test did fail when the escaping wasn't strict"""
         testdir.makepyfile(
             """
 

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -705,7 +705,7 @@ def test_dont_configure_on_slaves(tmpdir):
             return "pytest"
 
         junitprefix = None
-        # XXX: shouldnt need tmpdir ?
+        # XXX: shouldn't need tmpdir ?
         xmlpath = str(tmpdir.join("junix.xml"))
         register = gotten.append
 

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -435,7 +435,7 @@ class TestFunctional:
                 def test_b(self):
                     assert True
                 class TestC(object):
-                    # this one didnt get marked
+                    # this one didn't get marked
                     def test_d(self):
                         assert True
         """

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -253,7 +253,7 @@ def test_apiwrapper_problem_issue260(testdir):
 
 
 def test_setup_teardown_linking_issue265(testdir):
-    # we accidentally didnt integrate nose setupstate with normal setupstate
+    # we accidentally didn't integrate nose setupstate with normal setupstate
     # this test ensures that won't happen again
     testdir.makepyfile(
         '''


### PR DESCRIPTION
Fixed typos in comments:
shouldnt -> shouldn't
wasnt -> wasn't
didnt -> didn't
programatically -> programmatically
surpressing -> suppressing

Found with: https://github.com/ss18/grep-typos