### PR TITLE
Disable shallow cloning because of setuptools-scm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ env:
   global:
     - PYTEST_ADDOPTS=-vv
 
+# setuptools-scm needs all tags in order to obtain a proper version
+git:
+  depth: false
+
 install:
   - python -m pip install --upgrade --pre tox
 


### PR DESCRIPTION
setuptools-scm needs all tags to guess the version correctly

(cherry-pick from https://github.com/pytest-dev/pytest/pull/5652)