### PR TITLE
Use OSError subclasses instead of handling errno

### DIFF
--- a/changelog/5684.trivial.rst
+++ b/changelog/5684.trivial.rst
@@ -1,0 +1,1 @@
+Replace manual handling of ``OSError.errno`` in the codebase by new ``OSError`` subclasses (``PermissionError``, ``FileNotFoundError``, etc.).

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -1,5 +1,4 @@
 import atexit
-import errno
 import fnmatch
 import itertools
 import operator
@@ -151,14 +150,8 @@ def create_cleanup_lock(p):
     lock_path = get_lock_path(p)
     try:
         fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
-    except OSError as e:
-        if e.errno == errno.EEXIST:
-            raise EnvironmentError(
-                "cannot create lockfile in {path}".format(path=p)
-            ) from e
-
-        else:
-            raise
+    except FileExistsError as e:
+        raise EnvironmentError("cannot create lockfile in {path}".format(path=p)) from e
     else:
         pid = os.getpid()
         spid = str(pid).encode()


### PR DESCRIPTION
![img](https://i.imgflip.com/2/brbbk.jpg)