### PR TITLE
Added info to access exitcodes directly

### DIFF
--- a/doc/en/usage.rst
+++ b/doc/en/usage.rst
@@ -33,7 +33,11 @@ Running ``pytest`` can result in six different exit codes:
 :Exit code 4: pytest command line usage error
 :Exit code 5: No tests were collected
 
-They are represented by the :class:`_pytest.main.ExitCode` enum.
+They are represented by the :class:`_pytest.main.ExitCode` enum. The exit codes being a part of the public API can be imported and accessed directly using:
+
+.. code-block:: python
+
+    from pytest import ExitCode
 
 Getting help on version, option names, environment variables
 --------------------------------------------------------------


### PR DESCRIPTION
Relates to:

1. [pytest#5125](https://github.com/pytest-dev/pytest/issues/5125)
2. [pytest#5420](https://github.com/pytest-dev/pytest/pull/5420)

Better visibility on usage of exitcodes.