### PR TITLE
Add `enabled()` context manager to output capture fixtures, to force capture even if it is disabled globally

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Ben Webb
 Benjamin Peterson
 Bernard Pratz
 Bob Ippolito
+Bogdan Opanchuk
 Brian Dorsey
 Brian Maissy
 Brian Okken

--- a/changelog/5713.feature.rst
+++ b/changelog/5713.feature.rst
@@ -1,0 +1,3 @@
+Add ``capsys/capfd.enabled()`` context manager to force output capture
+even if it is disabled globally.
+(`#5713 <https://github.com/pytest-dev/pytest/pull/5713>`_)

--- a/doc/en/capture.rst
+++ b/doc/en/capture.rst
@@ -155,4 +155,18 @@ as a context manager, disabling capture inside the ``with`` block:
             print("output not captured, going directly to sys.stdout")
         print("this output is also captured")
 
+
+
+
+Alternatively, one can ensure that the fixture is enabled in a target block,
+even if it is disabled globally with ``-s``.
+
+.. code-block:: python
+
+    def test_enabling_capturing(capsys):
+        with capsys.enabled():
+            print("this output is always captured")
+        captured = capsys.readouterr()
+        assert captured.out == "this output is always captured\n"
+
 .. include:: links.inc

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -178,6 +178,15 @@ class CaptureManager:
             self.resume()
 
     @contextlib.contextmanager
+    def global_and_fixture_enabled(self):
+        """Context manager to temporarily disable global and current fixture capturing."""
+        self.resume()
+        try:
+            yield
+        finally:
+            self.suspend()
+
+    @contextlib.contextmanager
     def item_capture(self, when, item):
         self.resume_global_capture()
         self.activate_fixture(item)
@@ -388,6 +397,13 @@ class CaptureFixture:
         """Temporarily disables capture while inside the 'with' block."""
         capmanager = self.request.config.pluginmanager.getplugin("capturemanager")
         with capmanager.global_and_fixture_disabled():
+            yield
+
+    @contextlib.contextmanager
+    def enabled(self):
+        """Temporarily disables capture while inside the 'with' block."""
+        capmanager = self.request.config.pluginmanager.getplugin("capturemanager")
+        with capmanager.global_and_fixture_enabled():
             yield
 
 

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -617,6 +617,43 @@ class TestCaptureFixture:
             assert "test_normal executed" not in result.stdout.str()
 
     @pytest.mark.parametrize("fixture", ["capsys", "capfd"])
+    @pytest.mark.parametrize("no_capture", [True, False])
+    def test_enabled_capture_fixture(self, testdir, fixture, no_capture):
+
+        if no_capture:
+            expected_capture = "captured before\ncaptured after\n"
+        else:
+            expected_capture = "captured before\nwhile capture is enabled\ncaptured after\n"
+
+        testdir.makepyfile(
+            """\
+            def test_enabled({fixture}):
+                print('captured before')
+                with {fixture}.enabled():
+                    print('while capture is enabled')
+                print('captured after')
+                assert {fixture}.readouterr() == ({expected_capture}, '')
+
+            def test_normal():
+                print('test_normal executed')
+        """.format(
+                fixture=fixture,
+                expected_capture=repr(expected_capture)
+            )
+        )
+        args = ("-s",) if no_capture else ()
+        result = testdir.runpytest_subprocess(*args)
+        assert "while capture is enabled" not in result.stdout.str()
+        if no_capture:
+            assert "captured before" in result.stdout.str()
+            assert "captured after" in result.stdout.str()
+            assert "test_normal executed" in result.stdout.str()
+        else:
+            assert "captured before" not in result.stdout.str()
+            assert "captured after" not in result.stdout.str()
+            assert "test_normal executed" not in result.stdout.str()
+
+    @pytest.mark.parametrize("fixture", ["capsys", "capfd"])
     def test_fixture_use_by_other_fixtures(self, testdir, fixture):
         """
         Ensure that capsys and capfd can be used by other fixtures during setup and teardown.


### PR DESCRIPTION
Use case: testing a block of code whose output must be captured (and checked). Since the test suite might be executed with or without `-s` flag, there should be a way to force output capture in a block if the output is used in some assertions. For example:

    def test_enabling_capturing(capsys):
        print("this output may be captured")
        with capsys.enabled():
            print("this output is always captured")
        captured = capsys.readouterr()
        assert "this output is always captured\n" in captured.out

The current PR is made by analogy with `CaptureFixture.disabled()`, and has a drawback: if `-s` is not given, there is no way to separate the output in the `enabled()` block from the output of the rest of the testcase (that is, in the example above `captured.out == "this output may be captured\nthis output is always captured\n"`). Ideally, it would be more convenient to capture only the output of the block, but I am not sure how to approach this without breaking the existing capturing mechanic.
