### PR TITLE
Publish GitHub release notes after deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,17 @@ jobs:
 
     - stage: deploy
       python: '3.6'
-      install: pip install -U setuptools setuptools_scm
+      install: pip install -U setuptools setuptools_scm tox
       script: skip
+      # token to upload github release notes: GH_RELEASE_NOTES_TOKEN
+      env:
+        - secure: "OjOeL7/0JUDkV00SsTs732e8vQjHynpbG9FKTNtZZJ+1Zn4Cib+hAlwmlBnvVukML0X60YpcfjnC4quDOIGLPsh5zeXnvJmYtAIIUNQXjWz8NhcGYrhyzuP1rqV22U68RTCdmOq3lMYU/W2acwHP7T49PwJtOiUM5kF120UAQ0Zi5EmkqkIvH8oM5mO9Dlver+/U7Htpz9rhKrHBXQNCMZI6yj2aUyukqB2PN2fjAlDbCF//+FmvYw9NjT4GeFOSkTCf4ER9yfqs7yglRfwiLtOCZ2qKQhWZNsSJDB89rxIRXWavJUjJKeY2EW2/NkomYJDpqJLIF4JeFRw/HhA47CYPeo6BJqyyNV+0CovL1frpWfi9UQw2cMbgFUkUIUk3F6DD59PHNIOX2R/HX56dQsw7WKl3QuHlCOkICXYg8F7Ta684IoKjeTX03/6QNOkURfDBwfGszY0FpbxrjCSWKom6RyZdyidnESaxv9RzjcIRZVh1rp8KMrwS1OrwRSdG0zjlsPr49hWMenN/8fKgcHTV4/r1Tj6mip0dorSRCrgUNIeRBKgmui6FS8642ab5JNKOxMteVPVR2sFuhjOQ0Jy+PmvceYY9ZMWc3+/B/KVh0dZ3hwvLGZep/vxDS2PwCA5/xw31714vT5LxidKo8yECjBynMU/wUTTS695D3NY="
+      addons:
+        apt:
+          packages:
+            # required by publish_gh_release_notes
+            - pandoc
+      after_deploy: tox -e publish_gh_release_notes
       deploy:
         provider: pypi
         user: nicoddemus

--- a/scripts/publish_gh_release_notes.py
+++ b/scripts/publish_gh_release_notes.py
@@ -1,0 +1,86 @@
+"""
+Script used to publish GitHub release notes extracted from CHANGELOG.rst.
+
+This script is meant to be executed after a successful deployment in Travis.
+
+Uses the following environment variables:
+
+* GIT_TAG: the name of the tag of the current commit.
+* GH_RELEASE_NOTES_TOKEN: a personal access token with 'repo' permissions. It should be encrypted using:
+
+    $travis encrypt GH_RELEASE_NOTES_TOKEN=<token> -r pytest-dev/pytest
+
+  And the contents pasted in the ``deploy.env.secure`` section in the ``travis.yml`` file.
+
+The script also requires ``pandoc`` to be previously installed in the system.
+
+Requires Python3.6+.
+"""
+import os
+import re
+import sys
+from pathlib import Path
+
+import github3
+import pypandoc
+
+
+def publish_github_release(token, tag_name, body):
+    github = github3.login(token=token)
+    repo = github.repository("pytest-dev", "pytest")
+    return repo.create_release(tag_name=tag_name, body=body)
+
+
+def parse_changelog(tag_name):
+    p = Path(__file__).parent.parent / "CHANGELOG.rst"
+    changelog_lines = p.read_text(encoding="UTF-8").splitlines()
+
+    title_regex = re.compile(r"pytest (\d\.\d+\.\d+) \(\d{4}-\d{2}-\d{2}\)")
+    consuming_version = False
+    version_lines = []
+    for line in changelog_lines:
+        m = title_regex.match(line)
+        if m:
+            # found the version we want: start to consume lines until we find the next version title
+            if m.group(1) == tag_name:
+                consuming_version = True
+            # found a new version title while parsing the version we want: break out
+            elif consuming_version:
+                break
+        if consuming_version:
+            version_lines.append(line)
+
+    return "\n".join(version_lines)
+
+
+def convert_rst_to_md(text):
+    return pypandoc.convert_text(text, "md", format="rst")
+
+
+def main(argv):
+    if len(argv) > 1:
+        tag_name = argv[1]
+    else:
+        tag_name = os.environ.get("TRAVIS_TAG")
+        if not tag_name:
+            print("tag_name not given and $TRAVIS_TAG not set", file=sys.stderr)
+            return 1
+
+    token = os.environ.get("GH_RELEASE_NOTES_TOKEN")
+    if not token:
+        print("GH_RELEASE_NOTES_TOKEN not set", file=sys.stderr)
+        return 1
+
+    rst_body = parse_changelog(tag_name)
+    md_body = convert_rst_to_md(rst_body)
+    if not publish_github_release(token, tag_name, md_body):
+        print("Could not publish release notes:", file=sys.stderr)
+        print(md_body, file=sys.stderr)
+        return 5
+
+    print(f"Release notes for {tag_name} published successfully")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tox.ini
+++ b/tox.ini
@@ -114,6 +114,17 @@ deps =
     wheel
 commands = python scripts/release.py {posargs}
 
+[testenv:publish_gh_release_notes]
+description = create GitHub release after deployment
+basepython = python3.6
+usedevelop = True
+passenv = GH_RELEASE_NOTES_TOKEN TRAVIS_TAG
+deps =
+    github3.py
+    pypandoc
+commands = python scripts/publish_gh_release_notes.py
+
+
 [pytest]
 minversion = 2.0
 addopts = -ra -p pytester --strict-markers


### PR DESCRIPTION
I tested this in my fork and it published https://github.com/nicoddemus/pytest/releases/tag/4.99.5 successfully. 👍 

Using an after_deploy script so the release doesn't fail in case there's a problem with the script.

Fix #2933
