### PR TITLE
Do not treat warnings as errors during ``pytest_configure``.

### DIFF
--- a/changelog/5115.bugfix.rst
+++ b/changelog/5115.bugfix.rst
@@ -1,0 +1,1 @@
+Warnings issued during ``pytest_configure`` are explicitly not treated as errors, even if configured as such, because it otherwise completely breaks pytest.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -642,7 +642,9 @@ class Config:
     def _do_configure(self):
         assert not self._configured
         self._configured = True
-        self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
+        with warnings.catch_warnings():
+            warnings.simplefilter("default")
+            self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
 
     def _ensure_unconfigure(self):
         if self._configured:

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -645,3 +645,21 @@ def test_group_warnings_by_message(testdir):
     warning_code = 'warnings.warn(UserWarning("foo"))'
     assert warning_code in result.stdout.str()
     assert result.stdout.str().count(warning_code) == 1
+
+
+def test_pytest_configure_warning(testdir, recwarn):
+    """Issue 5115."""
+    testdir.makeconftest(
+        """
+        def pytest_configure():
+            import warnings
+
+            warnings.warn("from pytest_configure")
+        """
+    )
+
+    result = testdir.runpytest()
+    assert result.ret == 5
+    assert "INTERNALERROR" not in result.stderr.str()
+    warning = recwarn.pop()
+    assert str(warning.message) == "from pytest_configure"


### PR DESCRIPTION
Before it led to an internal error

Ref: #5115 

Not sure how to validate that the warning is emitted, tho :(