### PR TITLE
assertrepr_compare: prefer same maxsize

### DIFF
--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -119,9 +119,9 @@ def isiterable(obj):
 
 def assertrepr_compare(config, op, left, right):
     """Return specialised explanations for some operators/operands"""
-    width = 80 - 15 - len(op) - 2  # 15 chars indentation, 1 space around op
-    left_repr = saferepr(left, maxsize=int(width // 2))
-    right_repr = saferepr(right, maxsize=width - len(left_repr))
+    maxsize = (80 - 15 - len(op) - 2) // 2  # 15 chars indentation, 1 space around op
+    left_repr = saferepr(left, maxsize=maxsize)
+    right_repr = saferepr(right, maxsize=maxsize)
 
     summary = "{} {} {}".format(left_repr, op, right_repr)
 

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -200,6 +200,16 @@ class TestAssertionRewrite:
         else:
             assert msg == ["assert cls == 42"]
 
+    def test_assertrepr_compare_same_width(self, request):
+        """Should use same width/truncation with same initial width."""
+
+        def f():
+            assert "1234567890" * 5 + "A" == "1234567890" * 5 + "B"
+
+        assert getmsg(f).splitlines()[0] == (
+            "assert '123456789012...901234567890A' == '123456789012...901234567890B'"
+        )
+
     def test_dont_rewrite_if_hasattr_fails(self, request):
         class Y:
             """ A class whos getattr fails, but not with `AttributeError` """


### PR DESCRIPTION
Previously it would say:

    > assert '123456789012...901234567890A' == '1234567890123...901234567890B'"

This makes it look like the "3" might be different already.

This is clearer, and it is OK to have potentially one less char in the
right one:

    > assert '123456789012...901234567890A' == '123456789012...901234567890B'"
