### PR TITLE
pytester: spawn: skip without pexpect.spawn

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1188,6 +1188,8 @@ class Testdir:
             pytest.skip("pypy-64 bit not supported")
         if sys.platform.startswith("freebsd"):
             pytest.xfail("pexpect does not work reliably on freebsd")
+        if not hasattr(pexpect, "spawn"):
+            pytest.skip("pexpect.spawn not available")
         logfile = self.tmpdir.join("spawn.out").open("wb")
 
         # Do not load user config.


### PR DESCRIPTION
"pexpect" can be imported on Windows, but does not have "pexpect.spawn"
then.

Ref: https://github.com/pexpect/pexpect/blob/a803933ed53/pexpect/__init__.py#L73-L76