### PR TITLE
ci: add codecov.yml to turn comments off

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project: true
+    patch: true
+    changes: true
+
+comment: off


### PR DESCRIPTION
The only benefit for me is to get notified about finished builds, but
that might happen to early anyway.  Apart from that they are rather big
and distract from actual comments.