### PR TITLE
Fix self reference in function scoped fixtures

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -209,6 +209,7 @@ Raphael Castaneda
 Raphael Pierzina
 Raquel Alegre
 Ravi Chandra
+Robert Holt
 Roberto Polli
 Roland Puntaier
 Romain Dorgueil

--- a/changelog/2270.bugfix.rst
+++ b/changelog/2270.bugfix.rst
@@ -1,1 +1,2 @@
-Fix ``self`` reference in function scoped fixtures that are in a plugin class
+Fixed ``self`` reference in function-scoped fixtures defined plugin classes: previously ``self``
+would be a reference to a *test* class, not the *plugin* class.

--- a/changelog/2270.bugfix.rst
+++ b/changelog/2270.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``self`` reference in function scoped fixtures that are in a plugin class

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -897,6 +897,10 @@ def resolve_fixture_function(fixturedef, request):
         # request.instance so that code working with "fixturedef" behaves
         # as expected.
         if request.instance is not None:
+            if hasattr(fixturefunc, "__self__") and not isinstance(
+                request.instance, fixturefunc.__self__.__class__
+            ):
+                return fixturefunc
             fixturefunc = getimfunc(fixturedef.func)
             if fixturefunc != fixturedef.func:
                 fixturefunc = fixturefunc.__get__(request.instance)

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -897,6 +897,8 @@ def resolve_fixture_function(fixturedef, request):
         # request.instance so that code working with "fixturedef" behaves
         # as expected.
         if request.instance is not None:
+            # handle the case where fixture is defined not in a test class, but some other class
+            # (for example a plugin class with a fixture), see #2270
             if hasattr(fixturefunc, "__self__") and not isinstance(
                 request.instance, fixturefunc.__self__.__class__
             ):

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -3946,6 +3946,9 @@ class TestScopeOrdering:
         reprec.assertoutcome(passed=2)
 
     def test_class_fixture_self_instance(self, testdir):
+        """Check that plugin classes which implement fixtures receive the plugin instance
+        as self (see #2270).
+        """
         testdir.makeconftest(
             """
             import pytest

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -3945,6 +3945,35 @@ class TestScopeOrdering:
         reprec = testdir.inline_run()
         reprec.assertoutcome(passed=2)
 
+    def test_class_fixture_self_instance(self, testdir):
+        testdir.makeconftest(
+            """
+            import pytest
+
+            def pytest_configure(config):
+                config.pluginmanager.register(MyPlugin())
+
+            class MyPlugin():
+                def __init__(self):
+                    self.arg = 1
+
+                @pytest.fixture(scope='function')
+                def myfix(self):
+                    assert isinstance(self, MyPlugin)
+                    return self.arg
+        """
+        )
+
+        testdir.makepyfile(
+            """
+            class TestClass(object):
+                def test_1(self, myfix):
+                    assert myfix == 1
+        """
+        )
+        reprec = testdir.inline_run()
+        reprec.assertoutcome(passed=1)
+
 
 def test_call_fixture_function_error():
     """Check if an error is raised if a fixture function is called directly (#4545)"""


### PR DESCRIPTION
This fixes an old issue #2270 that was closed at the time without a fix. That issue has more info, but basically function scope fixtures in a class (not a test class) are given a reference to the test class, not their own class, as `self`. This causes problems when that fixture tries to access attributes on its class.