### PR TITLE
Fix pytest with mixed up filename casing.

### DIFF
--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -3,8 +3,9 @@ import textwrap
 import py
 
 import pytest
-from _pytest.config import PytestPluginManager
+from _pytest.config import PytestPluginManager, _uniquepath
 from _pytest.main import ExitCode
+import os.path
 
 
 def ConftestWithSetinitial(path):
@@ -141,11 +142,11 @@ def test_conftestcutdir(testdir):
     # but we can still import a conftest directly
     conftest._importconftest(conf)
     values = conftest._getconftestmodules(conf.dirpath())
-    assert values[0].__file__.startswith(str(conf))
+    assert values[0].__file__.startswith(str(_uniquepath(conf)))
     # and all sub paths get updated properly
     values = conftest._getconftestmodules(p)
     assert len(values) == 1
-    assert values[0].__file__.startswith(str(conf))
+    assert values[0].__file__.startswith(str(_uniquepath(conf)))
 
 
 def test_conftestcutdir_inplace_considered(testdir):
@@ -154,7 +155,7 @@ def test_conftestcutdir_inplace_considered(testdir):
     conftest_setinitial(conftest, [conf.dirpath()], confcutdir=conf.dirpath())
     values = conftest._getconftestmodules(conf.dirpath())
     assert len(values) == 1
-    assert values[0].__file__.startswith(str(conf))
+    assert values[0].__file__.startswith(str(_uniquepath(conf)))
 
 
 @pytest.mark.parametrize("name", "test tests whatever .dotdir".split())
@@ -164,7 +165,7 @@ def test_setinitial_conftest_subdirs(testdir, name):
     conftest = PytestPluginManager()
     conftest_setinitial(conftest, [sub.dirpath()], confcutdir=testdir.tmpdir)
     if name not in ("whatever", ".dotdir"):
-        assert subconftest in conftest._conftestpath2mod
+        assert _uniquepath(subconftest) in conftest._conftestpath2mod
         assert len(conftest._conftestpath2mod) == 1
     else:
         assert subconftest not in conftest._conftestpath2mod
@@ -273,6 +274,24 @@ def test_conftest_symlink_files(testdir):
     result = testdir.runpytest("-vs", "app/test_foo.py")
     result.stdout.fnmatch_lines(["*conftest_loaded*", "PASSED"])
     assert result.ret == ExitCode.OK
+
+@pytest.mark.skipif(
+    os.path.normcase('x') != os.path.normcase('X'),
+    reason="only relevant for case insensitive file systems",
+)
+def test_conftest_badcase(testdir):
+    """Check conftest.py loading when directory casing is wrong."""
+    testdir.tmpdir.mkdir("JenkinsRoot").mkdir("test")
+    source = {
+        "setup.py": "",
+        "test/__init__.py": "",
+        "test/conftest.py": ""
+    }
+    testdir.makepyfile(**{"JenkinsRoot/%s" % k: v for k, v in source.items()})
+
+    testdir.tmpdir.join("jenkinsroot/test").chdir()
+    result = testdir.runpytest()
+    assert result.ret == ExitCode.NO_TESTS_COLLECTED
 
 
 def test_no_conftest(testdir):


### PR DESCRIPTION
- [X] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features, improvements, and removals/deprecations.
- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
> If your PR fixes an issue, use that number here. If there is no issue, then after you submit the PR and get the PR number you can add a changelog using that instead.

- [ ] Add yourself to `AUTHORS` in alphabetical order;