### PR TITLE
Mark flaky test as xfail on Python 3.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
     - env: TOXENV=pypy3-xdist
       python: 'pypy3'
 
-    - env: TOXENV=py35-xdist
+    - env: TOXENV=py35
       dist: trusty
       python: '3.5.0'
 


### PR DESCRIPTION
I've tried to reproduce the issue, but it seems to only happen sporadically on Linux.

Mark it is flaky now to avoid people wasting time on PRs when they encounter this problem.

Related to #5795
