### PR TITLE
Fix "lexer" being used when uploading to bpaste.net

### DIFF
--- a/changelog/5806.bugfix.rst
+++ b/changelog/5806.bugfix.rst
@@ -1,0 +1,1 @@
+Fix "lexer" being used when uploading to bpaste.net from ``--pastebin`` to "text".

--- a/src/_pytest/pastebin.py
+++ b/src/_pytest/pastebin.py
@@ -65,7 +65,7 @@ def create_new_paste(contents):
     from urllib.request import urlopen
     from urllib.parse import urlencode
 
-    params = {"code": contents, "lexer": "python3", "expiry": "1week"}
+    params = {"code": contents, "lexer": "text", "expiry": "1week"}
     url = "https://bpaste.net"
     try:
         response = (

--- a/testing/test_pastebin.py
+++ b/testing/test_pastebin.py
@@ -165,7 +165,7 @@ class TestPaste:
         assert len(mocked_urlopen) == 1
         url, data = mocked_urlopen[0]
         assert type(data) is bytes
-        lexer = "python3"
+        lexer = "text"
         assert url == "https://bpaste.net"
         assert "lexer=%s" % lexer in data.decode()
         assert "code=full-paste-contents" in data.decode()


### PR DESCRIPTION
Closes #5806 

Since this is a followup to #5764, I'm basing this on the `features` branch instead of `master`.