### PR TITLE
Handle --fulltrace with pytest.raises

### DIFF
--- a/changelog/5811.bugfix.rst
+++ b/changelog/5811.bugfix.rst
@@ -1,0 +1,1 @@
+Handle ``--fulltrace`` correctly with ``pytest.raises``.

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -245,7 +245,6 @@ class Node:
         fm = self.session._fixturemanager
         if excinfo.errisinstance(fm.FixtureLookupError):
             return excinfo.value.formatrepr()
-        tbfilter = True
         if self.config.getoption("fulltrace", False):
             style = "long"
         else:
@@ -253,7 +252,6 @@ class Node:
             self._prunetraceback(excinfo)
             if len(excinfo.traceback) == 0:
                 excinfo.traceback = tb
-            tbfilter = False  # prunetraceback already does it
             if style == "auto":
                 style = "long"
         # XXX should excinfo.getrepr record all data and toterminal() process it?
@@ -279,7 +277,7 @@ class Node:
             abspath=abspath,
             showlocals=self.config.getoption("showlocals", False),
             style=style,
-            tbfilter=tbfilter,
+            tbfilter=False,  # pruned already, or in --fulltrace mode.
             truncate_locals=truncate_locals,
         )
 

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -399,6 +399,13 @@ def test_match_raises_error(testdir):
     result = testdir.runpytest()
     assert result.ret != 0
     result.stdout.fnmatch_lines(["*AssertionError*Pattern*[123]*not found*"])
+    assert "__tracebackhide__ = True" not in result.stdout.str()
+
+    result = testdir.runpytest("--fulltrace")
+    assert result.ret != 0
+    result.stdout.fnmatch_lines(
+        ["*__tracebackhide__ = True*", "*AssertionError*Pattern*[123]*not found*"]
+    )
 
 
 class TestFormattedExcinfo:


### PR DESCRIPTION
This changes `_repr_failure_py` to use `tbfilter=False` always.

TODO:

- [x] changelog