### PR TITLE
Fix pythonpath anchor

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -98,6 +98,7 @@ Feng Ma
 Florian Bruhin
 Floris Bruynooghe
 Gabriel Reis
+Gene Wood
 George Kussumoto
 Georgy Dyuldin
 Graham Horler

--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -88,7 +88,7 @@ This has the following benefits:
 
 .. note::
 
-    See :ref:`pythonpath` for more information about the difference between calling ``pytest`` and
+    See :ref:`pytest vs python -m pytest` for more information about the difference between calling ``pytest`` and
     ``python -m pytest``.
 
 Note that using this scheme your test files must have **unique names**, because

--- a/doc/en/pythonpath.rst
+++ b/doc/en/pythonpath.rst
@@ -72,6 +72,8 @@ imported in the global import namespace.
 
 This is also discussed in details in :ref:`test discovery`.
 
+.. _`pytest vs python -m pytest`:
+
 Invoking ``pytest`` versus ``python -m pytest``
 -----------------------------------------------
 


### PR DESCRIPTION
The anchor tag from the note in the ["Tests outside application code"](http://doc.pytest.org/en/latest/goodpractices.html#tests-outside-application-code) section of the Good Practices doc points to the Pythonpath doc but doesn't focus on the section about "Invoking pytest versus python -m pytest". This PR changes the link to point directly to the right section.