### PR TITLE
Fix for Python 4: replace unsafe PY3 with PY2

### DIFF
--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -853,7 +853,7 @@ class TestDebuggingBreakpoints:
         Test that supports breakpoint global marks on Python 3.7+ and not on
         CPython 3.5, 2.7
         """
-        if sys.version_info.major == 3 and sys.version_info.minor >= 7:
+        if sys.version_info >= (3, 7):
             assert SUPPORTS_BREAKPOINT_BUILTIN is True
         if sys.version_info.major == 3 and sys.version_info.minor == 5:
             assert SUPPORTS_BREAKPOINT_BUILTIN is False


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule) and work begins on Python 3.9+1.

This will be false for Python 4:

```python
        """
        Test that supports breakpoint global marks on Python 3.7+ and not on
        CPython 3.5, 2.7
        """
        if sys.version_info.major == 3 and sys.version_info.minor >= 7:
            assert SUPPORTS_BREAKPOINT_BUILTIN is True
```

---

Found using https://github.com/asottile/flake8-2020:
```console
$ pip install -U flake8-2020
...
$ flake8 --select YTT
./testing/test_pdb.py:856:44: YTT204 `sys.version_info.minor` compared to integer (python4), compare `sys.version_info` to tuple
```

---

- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [n/a] Target the `features` branch for new features, improvements, and removals/deprecations.
- [n/a] Include documentation when adding new features.
- [n/a] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [n/a] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Add yourself to `AUTHORS` in alphabetical order;
