### PR TITLE
Fix pypy3.6 on windows

### DIFF
--- a/changelog/5807.bugfix.rst
+++ b/changelog/5807.bugfix.rst
@@ -1,0 +1,1 @@
+Fix pypy3.6 (nightly) on windows.

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -789,7 +789,11 @@ def _py36_windowsconsoleio_workaround(stream):
 
     See https://github.com/pytest-dev/py/issues/103
     """
-    if not sys.platform.startswith("win32") or sys.version_info[:2] < (3, 6):
+    if (
+        not sys.platform.startswith("win32")
+        or sys.version_info[:2] < (3, 6)
+        or hasattr(sys, "pypy_version_info")
+    ):
         return
 
     # bail out if ``stream`` doesn't seem like a proper ``io`` stream (#2666)


### PR DESCRIPTION
pypy3.6 on windows doesn't have an `_io.WinConsoleIO`