### PR TITLE
Update doc regarding pytest.raises

### DIFF
--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -59,7 +59,7 @@ pytest.raises
 
 **Tutorial**: :ref:`assertraises`.
 
-.. autofunction:: pytest.raises(expected_exception: Exception, [match], [message])
+.. autofunction:: pytest.raises(expected_exception: Exception, [match])
     :with: excinfo
 
 pytest.deprecated_call


### PR DESCRIPTION
Remove reference to the `message` argument in the docs as it was deprecated in #4539