### PR TITLE
Fix regression due to different cases on Windows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,6 +56,7 @@ Charnjit SiNGH (CCSJ)
 Chris Lamb
 Christian Boelsen
 Christian Fetzer
+Christian Neumüller
 Christian Theunert
 Christian Tismer
 Christopher Gilling

--- a/AUTHORS
+++ b/AUTHORS
@@ -56,7 +56,6 @@ Charnjit SiNGH (CCSJ)
 Chris Lamb
 Christian Boelsen
 Christian Fetzer
-Christian Neumüller
 Christian Theunert
 Christian Tismer
 Christopher Gilling

--- a/changelog/5819.bugfix.rst
+++ b/changelog/5819.bugfix.rst
@@ -1,0 +1,2 @@
+Windows: Fix regression with conftest whose qualified name contains uppercase
+characters (introduced by #5792).

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -414,10 +414,7 @@ class PytestPluginManager(PluginManager):
                 continue
             conftestpath = parent.join("conftest.py")
             if conftestpath.isfile():
-                # Use realpath to avoid loading the same conftest twice
-                # with build systems that create build directories containing
-                # symlinks to actual files.
-                mod = self._importconftest(conftestpath.realpath())
+                mod = self._importconftest(conftestpath)
                 clist.append(mod)
         self._dirpath2confmods[directory] = clist
         return clist
@@ -432,8 +429,14 @@ class PytestPluginManager(PluginManager):
         raise KeyError(name)
 
     def _importconftest(self, conftestpath):
+        # Use a resolved Path object as key to avoid loading the same conftest twice
+        # with build systems that create build directories containing
+        # symlinks to actual files.
+        # Using Path().resolve() is better than py.path.realpath because
+        # it resolves to the correct path/drive in case-insensitive file systems (#5792)
+        key = Path(str(conftestpath)).resolve()
         try:
-            return self._conftestpath2mod[conftestpath]
+            return self._conftestpath2mod[key]
         except KeyError:
             pkgpath = conftestpath.pypkgpath()
             if pkgpath is None:
@@ -450,7 +453,7 @@ class PytestPluginManager(PluginManager):
                 raise ConftestImportFailure(conftestpath, sys.exc_info())
 
             self._conftest_plugins.add(mod)
-            self._conftestpath2mod[conftestpath] = mod
+            self._conftestpath2mod[key] = mod
             dirpath = conftestpath.dirpath()
             if dirpath in self._dirpath2confmods:
                 for path, mods in self._dirpath2confmods.items():

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -11,7 +11,6 @@ from functools import partial
 from os.path import expanduser
 from os.path import expandvars
 from os.path import isabs
-from os.path import normcase
 from os.path import sep
 from posixpath import sep as posix_sep
 
@@ -335,12 +334,3 @@ def fnmatch_ex(pattern, path):
 def parts(s):
     parts = s.split(sep)
     return {sep.join(parts[: i + 1]) or sep for i in range(len(parts))}
-
-
-def unique_path(path):
-    """Returns a unique path in case-insensitive (but case-preserving) file
-    systems such as Windows.
-
-    This is needed only for ``py.path.local``; ``pathlib.Path`` handles this
-    natively with ``resolve()``."""
-    return type(path)(normcase(str(path.realpath())))

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -1,4 +1,3 @@
-import os.path
 import textwrap
 
 import py
@@ -6,7 +5,6 @@ import py
 import pytest
 from _pytest.config import PytestPluginManager
 from _pytest.main import ExitCode
-from _pytest.pathlib import unique_path
 
 
 def ConftestWithSetinitial(path):
@@ -143,11 +141,11 @@ def test_conftestcutdir(testdir):
     # but we can still import a conftest directly
     conftest._importconftest(conf)
     values = conftest._getconftestmodules(conf.dirpath())
-    assert values[0].__file__.startswith(str(unique_path(conf)))
+    assert values[0].__file__.startswith(str(conf))
     # and all sub paths get updated properly
     values = conftest._getconftestmodules(p)
     assert len(values) == 1
-    assert values[0].__file__.startswith(str(unique_path(conf)))
+    assert values[0].__file__.startswith(str(conf))
 
 
 def test_conftestcutdir_inplace_considered(testdir):
@@ -156,7 +154,7 @@ def test_conftestcutdir_inplace_considered(testdir):
     conftest_setinitial(conftest, [conf.dirpath()], confcutdir=conf.dirpath())
     values = conftest._getconftestmodules(conf.dirpath())
     assert len(values) == 1
-    assert values[0].__file__.startswith(str(unique_path(conf)))
+    assert values[0].__file__.startswith(str(conf))
 
 
 @pytest.mark.parametrize("name", "test tests whatever .dotdir".split())
@@ -166,7 +164,7 @@ def test_setinitial_conftest_subdirs(testdir, name):
     conftest = PytestPluginManager()
     conftest_setinitial(conftest, [sub.dirpath()], confcutdir=testdir.tmpdir)
     if name not in ("whatever", ".dotdir"):
-        assert unique_path(subconftest) in conftest._conftestpath2mod
+        assert subconftest in conftest._conftestpath2mod
         assert len(conftest._conftestpath2mod) == 1
     else:
         assert subconftest not in conftest._conftestpath2mod
@@ -275,21 +273,6 @@ def test_conftest_symlink_files(testdir):
     result = testdir.runpytest("-vs", "app/test_foo.py")
     result.stdout.fnmatch_lines(["*conftest_loaded*", "PASSED"])
     assert result.ret == ExitCode.OK
-
-
-@pytest.mark.skipif(
-    os.path.normcase("x") != os.path.normcase("X"),
-    reason="only relevant for case insensitive file systems",
-)
-def test_conftest_badcase(testdir):
-    """Check conftest.py loading when directory casing is wrong."""
-    testdir.tmpdir.mkdir("JenkinsRoot").mkdir("test")
-    source = {"setup.py": "", "test/__init__.py": "", "test/conftest.py": ""}
-    testdir.makepyfile(**{"JenkinsRoot/%s" % k: v for k, v in source.items()})
-
-    testdir.tmpdir.join("jenkinsroot/test").chdir()
-    result = testdir.runpytest()
-    assert result.ret == ExitCode.NO_TESTS_COLLECTED
 
 
 def test_no_conftest(testdir):


### PR DESCRIPTION
This PR reverts #5792 to introduce a simpler fix: instead of changing all conftest paths to a unique representation, which unfortunately introduced #5819, it only uses a resolved `Path` object as key to the avoid importing `conftest` files more than once.

I would have taken the commits from #5823 (Sorry @Oberon00!), but unfortunately the fork seems to be gone, so I introduced the changes manually: a new test and the CHANGELOG. 

Supersedes #5823.