### PR TITLE
Fix logging doc: change x.level to x.levelno

### DIFF
--- a/doc/en/logging.rst
+++ b/doc/en/logging.rst
@@ -161,7 +161,7 @@ the records for the ``setup`` and ``call`` stages during teardown like so:
         yield window
         for when in ("setup", "call"):
             messages = [
-                x.message for x in caplog.get_records(when) if x.level == logging.WARNING
+                x.message for x in caplog.get_records(when) if x.levelno == logging.WARNING
             ]
             if messages:
                 pytest.fail(


### PR DESCRIPTION
A tiny fix in the docs that caught me out... Just validating my debugging here:
    
```
ipdb> record = caplog.records[0]

ipdb> dir(record)
['__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', 'args', 'created', 'exc_info', 'exc_text', 'filename', 'funcName', 'getMessage', 'levelname', 'levelno', 'lineno', 'message', 'module', 'msecs', 'msg', 'name', 'pathname', 'process', 'processName', 'relativeCreated', 'stack_info', 'thread', 'threadName']

ipdb> record.levelno
10
```
