### PR TITLE
Change report-coverage.sh in attempt to fix Azure

### DIFF
--- a/scripts/report-coverage.sh
+++ b/scripts/report-coverage.sh
@@ -13,4 +13,5 @@ fi
 python -m coverage combine
 python -m coverage xml
 python -m coverage report -m
-bash <(curl -s https://codecov.io/bash) -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml
+curl -S -L --retry 3 -s https://codecov.io/bash -o codecov-upload.sh
+bash codecov-upload.sh -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml

--- a/scripts/report-coverage.sh
+++ b/scripts/report-coverage.sh
@@ -14,4 +14,4 @@ python -m coverage combine
 python -m coverage xml
 python -m coverage report -m
 curl -S -L --retry 3 -s https://codecov.io/bash -o codecov-upload.sh
-bash codecov-upload.sh -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml
+bash codecov-upload.sh -Z -X fix -f coverage.xml


### PR DESCRIPTION
Recently sometimes Azure has failed with:

```
++ curl -s https://codecov.io/bash
bash: /dev/fd/63: No such file or directory
```

This attempts to fix this by modifying report-coverage.sh slightly.
