### PR TITLE
Fix doc typo

### DIFF
--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -1003,7 +1003,7 @@ passed multiple times. The expected format is ``name=value``. For example::
         [pytest]
         addopts = --maxfail=2 -rf  # exit after 2 failures, report fail info
 
-   issuing ``pytest test_hello.py`` actually means::
+   issuing ``pytest test_hello.py`` actually means:
 
    .. code-block:: bash
 


### PR DESCRIPTION
I built the docs locally and confirmed that section now renders as expected