### PR TITLE
fix deprecation warning of attrs on NodeMarkers

### DIFF
--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -367,7 +367,7 @@ class NodeKeywords(MutableMapping):
         return "<NodeKeywords for node {}>".format(self.node)
 
 
-@attr.s(cmp=False, hash=False)
+@attr.s(eq=False, order=False, hash=False)
 class NodeMarkers:
     """
     internal structure for storing marks belonging to a node


### PR DESCRIPTION
```
/home/batuhan/setuptools/.venv/lib/python3.8/site-packages/_pytest/mark/structures.py:370: DeprecationWarning: The usage of `cmp` is deprecated and will be removed on or after 2021-06-01.  Please use `eq` and `order` instead.
```