### PR TITLE
Improve full diff output for lists

### DIFF
--- a/changelog/5924.feature.rst
+++ b/changelog/5924.feature.rst
@@ -1,0 +1,34 @@
+Improve verbose diff output with sequences.
+
+Before:
+
+.. code-block::
+
+    E   AssertionError: assert ['version', '...version_info'] == ['version', '...version', ...]
+    E     Right contains 3 more items, first extra item: ' '
+    E     Full diff:
+    E     - ['version', 'version_info', 'sys.version', 'sys.version_info']
+    E     + ['version',
+    E     +  'version_info',
+    E     +  'sys.version',
+    E     +  'sys.version_info',
+    E     +  ' ',
+    E     +  'sys.version',
+    E     +  'sys.version_info']
+
+After:
+
+.. code-block::
+
+    E   AssertionError: assert ['version', '...version_info'] == ['version', '...version', ...]
+    E     Right contains 3 more items, first extra item: ' '
+    E     Full diff:
+    E       [
+    E        'version',
+    E        'version_info',
+    E        'sys.version',
+    E        'sys.version_info',
+    E     +  ' ',
+    E     +  'sys.version',
+    E     +  'sys.version_info',
+    E       ]

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -413,6 +413,55 @@ class TestAssert_reprcompare:
         expl = callequal([0, 1, 2], [0, 1])
         assert len(expl) > 1
 
+    def test_list_wrap_for_multiple_lines(self):
+        long_d = "d" * 80
+        l1 = ["a", "b", "c"]
+        l2 = ["a", "b", "c", long_d]
+        diff = callequal(l1, l2, verbose=True)
+        assert diff == [
+            "['a', 'b', 'c'] == ['a', 'b', 'c...dddddddddddd']",
+            "Right contains one more item: '" + long_d + "'",
+            "Full diff:",
+            "  [",
+            "   'a',",
+            "   'b',",
+            "   'c',",
+            "+  '" + long_d + "',",
+            "  ]",
+        ]
+
+        diff = callequal(l2, l1, verbose=True)
+        assert diff == [
+            "['a', 'b', 'c...dddddddddddd'] == ['a', 'b', 'c']",
+            "Left contains one more item: '" + long_d + "'",
+            "Full diff:",
+            "  [",
+            "   'a',",
+            "   'b',",
+            "   'c',",
+            "-  '" + long_d + "',",
+            "  ]",
+        ]
+
+    def test_list_wrap_for_width_rewrap_same_length(self):
+        long_a = "a" * 30
+        long_b = "b" * 30
+        long_c = "c" * 30
+        l1 = [long_a, long_b, long_c]
+        l2 = [long_b, long_c, long_a]
+        diff = callequal(l1, l2, verbose=True)
+        assert diff == [
+            "['aaaaaaaaaaa...cccccccccccc'] == ['bbbbbbbbbbb...aaaaaaaaaaaa']",
+            "At index 0 diff: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' != 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'",
+            "Full diff:",
+            "  [",
+            "-  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',",
+            "   'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',",
+            "   'cccccccccccccccccccccccccccccc',",
+            "+  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',",
+            "  ]",
+        ]
+
     def test_dict(self):
         expl = callequal({"a": 0}, {"a": 1})
         assert len(expl) > 1


### PR DESCRIPTION
Massage text input for difflib when comparing pformat output of
different line lengths.

Also do not strip ndiff output on the left, which currently already
removes indenting for lines with no differences.

Before:

    E   AssertionError: assert ['version', '...version_info'] == ['version', '...version', ...]
    E     Right contains 3 more items, first extra item: ' '
    E     Full diff:
    E     - ['version', 'version_info', 'sys.version', 'sys.version_info']
    E     + ['version',
    E     +  'version_info',
    E     +  'sys.version',
    E     +  'sys.version_info',
    E     +  ' ',
    E     +  'sys.version',
    E     +  'sys.version_info']

After:

    E   AssertionError: assert ['version', '...version_info'] == ['version', '...version', ...]
    E     Right contains 3 more items, first extra item: ' '
    E     Full diff:
    E       ['version',
    E        'version_info',
    E        'sys.version',
    E     +  'sys.version_info',
    E     +  ' ',
    E     +  'sys.version',
    E        'sys.version_info'
    E       ]

TODO:

- [x] changelog
- [x] "improve" / remove `asserts`
- [x] more tests (?)