### PR TITLE
MarkGenerator: Report unknown mark warning at caller level

### DIFF
--- a/changelog/5928.bugfix.rst
+++ b/changelog/5928.bugfix.rst
@@ -1,0 +1,1 @@
+Report ``PytestUnknownMarkWarning`` at the level of the user's code, not ``pytest``'s.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -323,6 +323,7 @@ class MarkGenerator:
                         "custom marks to avoid this warning - for details, see "
                         "https://docs.pytest.org/en/latest/mark.html" % name,
                         PytestUnknownMarkWarning,
+                        2,
                     )
 
         return MarkDecorator(Mark(name, (), {}))


### PR DESCRIPTION
Currently, `PytestUnknownMarkWarning` is reported at the level of `MarkGenerator`, which is unhelpful to callers as the warning is shown as being "caused" by pytest. This commit therefore increases the stack level passed to the warning call to 2, which will make the warning log as being "caused" by the caller, which is much more helpful.

- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features, improvements, and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [ ] Add yourself to `AUTHORS` in alphabetical order;

Closes #5928.