### PR TITLE
[RFC] assert: keep "where … and …" output in verbose mode

### DIFF
--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -110,8 +110,8 @@ def pytest_runtest_setup(item):
     comparison for the test.
     """
 
-    def callbinrepr(op, left, right):
-        # type: (str, object, object) -> Optional[str]
+    def callbinrepr(op, left, right, expl):
+        # type: (str, object, object, str) -> Optional[str]
         """Call the pytest_assertrepr_compare hook and prepare the result
 
         This uses the first result from the hook and then ensures the
@@ -127,10 +127,13 @@ def pytest_runtest_setup(item):
         pretty printing.
         """
         hook_result = item.ihook.pytest_assertrepr_compare(
-            config=item.config, op=op, left=left, right=right
+            config=item.config, op=op, left=left, right=right, expl=expl
         )
         for new_expl in hook_result:
             if new_expl:
+                if isinstance(new_expl, str):
+                    return new_expl
+
                 new_expl = truncate.truncate_if_required(new_expl, item)
                 new_expl = [line.replace("\n", "\\n") for line in new_expl]
                 res = "\n~".join(new_expl)

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -392,7 +392,7 @@ def _call_reprcompare(ops, results, expls, each_obj):
         if done:
             break
     if util._reprcompare is not None:
-        custom = util._reprcompare(ops[i], each_obj[i], each_obj[i + 1])
+        custom = util._reprcompare(ops[i], each_obj[i], each_obj[i + 1], expl)
         if custom is not None:
             return custom
     return expl

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -14,7 +14,9 @@ from _pytest.compat import ATTRS_EQ_FIELD
 # interpretation code and assertion rewriter to detect this plugin was
 # loaded and in turn call the hooks defined here as part of the
 # DebugInterpreter.
-_reprcompare = None  # type: Optional[Callable[[str, object, object], Optional[str]]]
+_reprcompare = (
+    None
+)  # type: Optional[Callable[[str, object, object, str], Optional[str]]]
 
 # Works similarly as _reprcompare attribute. Is populated with the hook call
 # when pytest_runtest_setup is called.
@@ -121,7 +123,7 @@ def isiterable(obj):
         return False
 
 
-def assertrepr_compare(config, op, left, right):
+def assertrepr_compare(config, op, left, right, expl):
     """Return specialised explanations for some operators/operands"""
     maxsize = (80 - 15 - len(op) - 2) // 2  # 15 chars indentation, 1 space around op
     left_repr = saferepr(left, maxsize=maxsize)
@@ -146,7 +148,7 @@ def assertrepr_compare(config, op, left, right):
                     type_fn = (isdatacls, isattrs)
                     explanation = _compare_eq_cls(left, right, verbose, type_fn)
                 elif verbose > 0:
-                    explanation = _compare_eq_verbose(left, right)
+                    return expl + "\n~" + "\n~".join(_compare_eq_verbose(left, right))
                 if isiterable(left) and isiterable(right):
                     expl = _compare_eq_iterable(left, right, verbose)
                     if explanation is not None:

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -472,7 +472,7 @@ def pytest_unconfigure(config):
 # -------------------------------------------------------------------------
 
 
-def pytest_assertrepr_compare(config, op, left, right):
+def pytest_assertrepr_compare(config, op, left, right, expl):
     """return explanation for comparisons in failing assert expressions.
 
     Return None for no custom explanation, otherwise return a list

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -299,7 +299,7 @@ class TestBinReprIntegration:
 def callequal(left, right, verbose=False):
     config = mock_config()
     config.verbose = verbose
-    return plugin.pytest_assertrepr_compare(config, "==", left, right)
+    return plugin.pytest_assertrepr_compare(config, "==", left, right, "XXX")
 
 
 class TestAssert_reprcompare:
@@ -938,13 +938,15 @@ def test_rewritten(testdir):
 
 def test_reprcompare_notin():
     config = mock_config()
-    detail = plugin.pytest_assertrepr_compare(config, "not in", "foo", "aaafoobbb")[1:]
+    detail = plugin.pytest_assertrepr_compare(
+        config, "not in", "foo", "aaafoobbb", "XXX"
+    )[1:]
     assert detail == ["'foo' is contained here:", "  aaafoobbb", "?    +++"]
 
 
 def test_reprcompare_whitespaces():
     config = mock_config()
-    detail = plugin.pytest_assertrepr_compare(config, "==", "\r\n", "\n")
+    detail = plugin.pytest_assertrepr_compare(config, "==", "\r\n", "\n", "XXX")
     assert detail == [
         r"'\r\n' == '\n'",
         r"Strings contain only whitespace, escaping them using repr()",

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -626,7 +626,7 @@ class TestAssertionRewrite:
             assert msg == "assert 10 == 11\n +  where 10 = len([0, 1, 2, 3, 4, 5, ...])"
 
     def test_custom_reprcompare(self, monkeypatch):
-        def my_reprcompare(op, left, right):
+        def my_reprcompare(op, left, right, expl):
             return "42"
 
         monkeypatch.setattr(util, "_reprcompare", my_reprcompare)
@@ -636,7 +636,7 @@ class TestAssertionRewrite:
 
         assert getmsg(f) == "assert 42"
 
-        def my_reprcompare(op, left, right):
+        def my_reprcompare(op, left, right, expl):
             return "{} {} {}".format(left, op, right)
 
         monkeypatch.setattr(util, "_reprcompare", my_reprcompare)

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -226,10 +226,15 @@ class TestAssertionRewrite:
         def f():
             assert cls().foo == 2  # noqa
 
-        # XXX: looks like the "where" should also be there in verbose mode?!
         message = getmsg(f, {"cls": Y}).splitlines()
         if request.config.getoption("verbose") > 0:
-            assert message == ["assert 3 == 2", "  -3", "  +2"]
+            assert message == [
+                "assert 3 == 2",
+                " +  where 3 = Y.foo",
+                " +    where Y = cls()",
+                "  -3",
+                "  +2",
+            ]
         else:
             assert message == [
                 "assert 3 == 2",

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -618,7 +618,10 @@ class TestAssertionRewrite:
 
         msg = getmsg(f)
         if request.config.getoption("verbose") > 0:
-            assert msg == "assert 10 == 11\n  -10\n  +11"
+            assert (
+                msg
+                == "assert 10 == 11\n +  where 10 = len([0, 1, 2, 3, 4, 5, ...])\n  -10\n  +11"
+            )
         else:
             assert msg == "assert 10 == 11\n +  where 10 = len([0, 1, 2, 3, 4, 5, ...])"
 


### PR DESCRIPTION
Ref: https://github.com/pytest-dev/pytest/issues/5932
Fixes: https://github.com/pytest-dev/pytest/issues/5192