### PR TITLE
assertrepr_compare: use safeformat with -vv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,13 @@ install:
 jobs:
   include:
     # OSX tests - first (in test stage), since they are the slower ones.
+    # Coverage for:
+    # - osx
+    # - verbose=1
     - os: osx
       osx_image: xcode10.1
       language: generic
-      env: TOXENV=py37-xdist PYTEST_COVERAGE=1
+      env: TOXENV=py37-xdist PYTEST_COVERAGE=1 PYTEST_ADDOPTS=-v
       before_install:
         - which python3
         - python3 -V
@@ -52,7 +55,7 @@ jobs:
     # - TestArgComplete (linux only)
     # - numpy
     # - old attrs
-    # Empty PYTEST_ADDOPTS to run this non-verbose.
+    # - verbose=0
     - env: TOXENV=py37-lsof-oldattrs-numpy-twisted-xdist PYTEST_COVERAGE=1 PYTEST_ADDOPTS=
 
     # Specialized factors for py37.

--- a/changelog/5936.feature.rst
+++ b/changelog/5936.feature.rst
@@ -1,0 +1,1 @@
+Display untruncated assertion message with ``-vv``.

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import _pytest._code
 from _pytest import outcomes
+from _pytest._io.saferepr import safeformat
 from _pytest._io.saferepr import saferepr
 from _pytest.compat import ATTRS_EQ_FIELD
 
@@ -123,13 +124,21 @@ def isiterable(obj):
 
 def assertrepr_compare(config, op, left, right):
     """Return specialised explanations for some operators/operands"""
-    maxsize = (80 - 15 - len(op) - 2) // 2  # 15 chars indentation, 1 space around op
-    left_repr = saferepr(left, maxsize=maxsize)
-    right_repr = saferepr(right, maxsize=maxsize)
+    verbose = config.getoption("verbose")
+    if verbose > 1:
+        left_repr = safeformat(left)
+        right_repr = safeformat(right)
+    else:
+        # XXX: "15 chars indentation" is wrong
+        #      ("E       AssertionError: assert "); should use term width.
+        maxsize = (
+            80 - 15 - len(op) - 2
+        ) // 2  # 15 chars indentation, 1 space around op
+        left_repr = saferepr(left, maxsize=maxsize)
+        right_repr = saferepr(right, maxsize=maxsize)
 
     summary = "{} {} {}".format(left_repr, op, right_repr)
 
-    verbose = config.getoption("verbose")
     explanation = None
     try:
         if op == "==":

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -190,11 +190,12 @@ class TestAssertionRewrite:
             pass
 
         msg = getmsg(f, {"cls": X}).splitlines()
-        if verbose > 0:
-
+        if verbose > 1:
+            assert msg == ["assert {!r} == 42".format(X), "  -{!r}".format(X), "  +42"]
+        elif verbose > 0:
             assert msg == [
                 "assert <class 'test_...e.<locals>.X'> == 42",
-                "  -<class 'test_assertrewrite.TestAssertionRewrite.test_name.<locals>.X'>",
+                "  -{!r}".format(X),
                 "  +42",
             ]
         else:
@@ -206,9 +207,17 @@ class TestAssertionRewrite:
         def f():
             assert "1234567890" * 5 + "A" == "1234567890" * 5 + "B"
 
-        assert getmsg(f).splitlines()[0] == (
-            "assert '123456789012...901234567890A' == '123456789012...901234567890B'"
-        )
+        msg = getmsg(f).splitlines()[0]
+        if request.config.getoption("verbose") > 1:
+            assert msg == (
+                "assert '12345678901234567890123456789012345678901234567890A' "
+                "== '12345678901234567890123456789012345678901234567890B'"
+            )
+        else:
+            assert msg == (
+                "assert '123456789012...901234567890A' "
+                "== '123456789012...901234567890B'"
+            )
 
     def test_dont_rewrite_if_hasattr_fails(self, request):
         class Y:


### PR DESCRIPTION
Ref: https://github.com/pytest-dev/pytest/issues/3962

TODO:

- [x] changelog