### PR TITLE
Workaround curl bug which makes retries of fetching codecov.io/bash not work

### DIFF
--- a/scripts/report-coverage.sh
+++ b/scripts/report-coverage.sh
@@ -13,5 +13,6 @@ fi
 python -m coverage combine
 python -m coverage xml
 python -m coverage report -m
-curl -S -L --retry 6 -s https://codecov.io/bash -o codecov-upload.sh
+# Set --connect-timeout to work around https://github.com/curl/curl/issues/4461
+curl -S -L --connect-timeout 5 --retry 6 -s https://codecov.io/bash -o codecov-upload.sh
 bash codecov-upload.sh -Z -X fix -f coverage.xml


### PR DESCRIPTION
Fetching this URL is very flaky, even after adding retries. I found a possible explanation here: https://github.com/python-trio/trio/issues/1231, let's try it!