### PR TITLE
ci: codecov: disable comments really

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,4 +4,4 @@ coverage:
     patch: true
     changes: true
 
-comment: off
+comment: false


### PR DESCRIPTION
Apparently it has to be "false" instead of "off".

Follow-up to d50198a3f.