### PR TITLE
Add missing version added/changed markers to docs

### DIFF
--- a/doc/en/doctest.rst
+++ b/doc/en/doctest.rst
@@ -156,6 +156,8 @@ pytest also introduces new options:
   a string! This means that it may not be appropriate to enable globally in
   ``doctest_optionflags`` in your configuration file.
 
+  .. versionadded:: 5.1
+
 
 Continue on failure
 -------------------

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -301,8 +301,12 @@ are finalized when the last test of a *package* finishes.
     Use this new feature sparingly and please make sure to report any issues you find.
 
 
+.. _dynamic scope:
+
 Dynamic scope
 ^^^^^^^^^^^^^
+
+.. versionadded:: 5.2
 
 In some cases, you might want to change the scope of the fixture without changing the code.
 To do that, pass a callable to ``scope``. The callable must return a string with a valid scope

--- a/doc/en/usage.rst
+++ b/doc/en/usage.rst
@@ -718,6 +718,11 @@ for example ``-x`` if you only want to send one particular failure.
 
 Currently only pasting to the http://bpaste.net service is implemented.
 
+.. versionchanged:: 5.2
+
+If creating the URL fails for any reason, a warning is generated instead of failing the
+entire test suite.
+
 Early loading plugins
 ---------------------
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -663,6 +663,8 @@ class Config:
     class InvocationParams:
         """Holds parameters passed during ``pytest.main()``
 
+        .. versionadded:: 5.1
+
         .. note::
 
             Currently the environment variable PYTEST_ADDOPTS is also handled by

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1088,9 +1088,13 @@ def fixture(
 
     :arg scope: the scope for which this fixture is shared, one of
                 ``"function"`` (default), ``"class"``, ``"module"``,
-                ``"package"`` or ``"session"``.
+                ``"package"`` or ``"session"`` (``"package"`` is considered **experimental**
+                at this time).
 
-                ``"package"`` is considered **experimental** at this time.
+                This parameter may also be a callable which receives ``(fixture_name, config)``
+                as parameters, and must return a ``str`` with one of the values mentioned above.
+
+                See :ref:`dynamic scope` in the docs for more information.
 
     :arg params: an optional list of parameters which will cause multiple
                 invocations of the fixture function and all of the tests

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -488,6 +488,8 @@ def pytest_assertion_pass(item, lineno, orig, expl):
     """
     **(Experimental)**
 
+    .. versionadded:: 5.0
+
     Hook called whenever an assertion *passes*.
 
     Use this hook to do some processing after a passing assertion.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -20,6 +20,8 @@ from _pytest.runner import collect_one_node
 
 class ExitCode(enum.IntEnum):
     """
+    .. versionadded:: 5.0
+
     Encodes the valid exit codes by pytest.
 
     Currently users and plugins may supply other exit codes as well.


### PR DESCRIPTION
Notice some features since 5.0 were not being properly
marked in which version they have been added/changed.
