### PR TITLE
Remove redundant mention from 5.2.0 release notes.

### DIFF
--- a/doc/en/announce/release-5.2.0.rst
+++ b/doc/en/announce/release-5.2.0.rst
@@ -29,7 +29,6 @@ Thanks to all who contributed to this release, among them:
 * Michael Goerz
 * Ran Benita
 * Tomáš Chvátal
-* aklajnert
 
 
 Happy testing,


### PR DESCRIPTION
I got mentioned twice in the `5.2.0` release notes - once by full name and once by the username. I've removed the username mention.