### PR TITLE
Add acceptance tests for "config warnings" stacklevel (#4445)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -207,6 +207,7 @@ Oscar Benjamin
 Patrick Hayes
 Paweł Adamczak
 Pedro Algarvio
+Philipp Loose
 Pieter Mulder
 Piotr Banaszkiewicz
 Pulkit Goyal

--- a/changelog/4445.bugfix.rst
+++ b/changelog/4445.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed some warning reports produced by pytest to point to the correct location of the warning in the user's code.

--- a/changelog/5928.bugfix.rst
+++ b/changelog/5928.bugfix.rst
@@ -1,0 +1,1 @@
+Report ``PytestUnknownMarkWarning`` at the level of the user's code, not ``pytest``'s.

--- a/changelog/5984.improvement.rst
+++ b/changelog/5984.improvement.rst
@@ -1,0 +1,1 @@
+The ``pytest_warning_captured`` hook now receives a ``location`` parameter with the code location that generated the warning.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -133,13 +133,7 @@ def directory_arg(path, optname):
 
 
 # Plugins that cannot be disabled via "-p no:X" currently.
-essential_plugins = (
-    "mark",
-    "main",
-    "runner",
-    "fixtures",
-    "helpconfig",  # Provides -p.
-)
+essential_plugins = ("mark", "main", "runner", "fixtures", "helpconfig")  # Provides -p.
 
 default_plugins = essential_plugins + (
     "python",
@@ -589,7 +583,7 @@ class PytestPluginManager(PluginManager):
             _issue_warning_captured(
                 PytestConfigWarning("skipped plugin {!r}: {}".format(modname, e.msg)),
                 self.hook,
-                stacklevel=1,
+                stacklevel=2,
             )
         else:
             mod = sys.modules[importspec]

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -562,7 +562,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
 
 @hookspec(historic=True)
-def pytest_warning_captured(warning_message, when, item):
+def pytest_warning_captured(warning_message, when, item, location):
     """
     Process a warning captured by the internal pytest warnings plugin.
 
@@ -582,6 +582,10 @@ def pytest_warning_captured(warning_message, when, item):
         in a future release.
 
         The item being executed if ``when`` is ``"runtest"``, otherwise ``None``.
+
+    :param tuple location:
+        Holds information about the execution context of the captured warning (filename, linenumber, function).
+        ``function`` evaluates to <module> when the execution context is at the module level.
     """
 
 

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -347,6 +347,7 @@ class MarkGenerator:
                     "custom marks to avoid this warning - for details, see "
                     "https://docs.pytest.org/en/latest/mark.html" % name,
                     PytestUnknownMarkWarning,
+                    2,
                 )
 
         return MarkDecorator(Mark(name, (), {}))

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -149,6 +149,10 @@ def _issue_warning_captured(warning, hook, stacklevel):
         warnings.warn(warning, stacklevel=stacklevel)
     # Mypy can't infer that record=True means records is not None; help it.
     assert records is not None
+    frame = sys._getframe(stacklevel - 1)
+    location = frame.f_code.co_filename, frame.f_lineno, frame.f_code.co_name
     hook.pytest_warning_captured.call_historic(
-        kwargs=dict(warning_message=records[0], when="config", item=None)
+        kwargs=dict(
+            warning_message=records[0], when="config", item=None, location=location
+        )
     )


### PR DESCRIPTION
This pull requests aims to add the acceptance tests mentioned in #4445. The main intention is to check whether a specific warning emitted by `_issue_warning_captured` points to a reasonable location and, depending on the context, not a location deep inside pytest's internals that may confuse users. 