### PR TITLE
tests: filterwarnings: do not crash with "(rm_rf)" warning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -142,6 +142,8 @@ filterwarnings =
     error
     default:Using or importing the ABCs:DeprecationWarning:unittest2.*
     ignore:Module already imported so cannot be rewritten:pytest.PytestWarning
+    # https://github.com/pytest-dev/pytest/issues/5974
+    default:\(rm_rf\) error removing.*:pytest.PytestWarning
     # produced by python3.6/site.py itself (3.6.7 on Travis, could not trigger it with 3.6.8).
     ignore:.*U.*mode is deprecated:DeprecationWarning:(?!(pytest|_pytest))
     # produced by pytest-xdist


### PR DESCRIPTION
Ref: https://github.com/pytest-dev/pytest/issues/5974