### PR TITLE
[RFC/TEST/WIP] on_rm_rf_error: raise for unknown func

### DIFF
--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -49,10 +49,7 @@ def on_rm_rf_error(func, path: str, exc, *, start_path):
         return
 
     if func not in (os.rmdir, os.remove, os.unlink):
-        warnings.warn(
-            PytestWarning("(rm_rf) error removing {}: {}".format(path, excvalue))
-        )
-        return
+        raise
 
     # Chmod + retry.
     import stat


### PR DESCRIPTION
`maybe_delete_a_numbered_dir` will silently ignore it then:
https://github.com/pytest-dev/pytest/blob/3045834b0bad8916af5b33f644dc58e98ead0dbe/src/_pytest/pathlib.py#L201-L206