### PR TITLE
help: display default verbosity

### DIFF
--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -66,7 +66,11 @@ def pytest_addoption(parser):
         help="decrease verbosity.",
     ),
     group._addoption(
-        "--verbosity", dest="verbose", type=int, default=0, help="set verbosity"
+        "--verbosity",
+        dest="verbose",
+        type=int,
+        default=0,
+        help="set verbosity. Default is 0.",
     )
     group._addoption(
         "-r",


### PR DESCRIPTION
Note that the style with help texts is not consistent, but this appears to be the one used in most cases.