### PR TITLE
Remove unreachable code from config._prepareconfig

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -195,7 +195,6 @@ def get_plugin_manager():
 
 
 def _prepareconfig(args=None, plugins=None):
-    warning = None
     if args is None:
         args = sys.argv[1:]
     elif isinstance(args, py.path.local):
@@ -213,10 +212,6 @@ def _prepareconfig(args=None, plugins=None):
                     pluginmanager.consider_pluginarg(plugin)
                 else:
                     pluginmanager.register(plugin)
-        if warning:
-            from _pytest.warnings import _issue_warning_captured
-
-            _issue_warning_captured(warning, hook=config.hook, stacklevel=4)
         return pluginmanager.hook.pytest_cmdline_parse(
             pluginmanager=pluginmanager, args=args
         )


### PR DESCRIPTION
Related to https://github.com/pytest-dev/pytest/issues/4445#issuecomment-543180101 and https://github.com/pytest-dev/pytest/issues/4445#issuecomment-543287636. The code that could trigger the execution of _issue_warning_captured was removed with a7e4016.


- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features, improvements, and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [ ] Add yourself to `AUTHORS` in alphabetical order;
