### PR TITLE
summary/OutcomeException: add support for short_msg

### DIFF
--- a/changelog/6003.improvement.rst
+++ b/changelog/6003.improvement.rst
@@ -1,0 +1,1 @@
+Improve short excinfo with LineMatcher failures in short test summaries, via new ``OutcomeException.short_msg``.

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -27,6 +27,7 @@ import py
 import _pytest
 from _pytest._io.saferepr import safeformat
 from _pytest._io.saferepr import saferepr
+from _pytest.outcomes import OutcomeException
 
 if False:  # TYPE_CHECKING
     from typing import Type
@@ -520,6 +521,13 @@ class ExceptionInfo(Generic[_E]):
             the exception representation is returned (so 'AssertionError: ' is
             removed from the beginning)
         """
+        if (
+            tryshort
+            and isinstance(self.value, OutcomeException)
+            and self.value.short_msg
+        ):
+            return self.value.short_msg
+
         lines = format_exception_only(self.type, self.value)
         text = "".join(lines)
         text = text.rstrip()

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -17,7 +17,13 @@ class OutcomeException(BaseException):
         contain info about test and collection outcomes.
     """
 
-    def __init__(self, msg: Optional[str] = None, pytrace: bool = True) -> None:
+    def __init__(
+        self,
+        msg: Optional[str] = None,
+        pytrace: bool = True,
+        *,
+        short_msg: Optional[str] = None
+    ) -> None:
         if msg is not None and not isinstance(msg, str):
             error_msg = (
                 "{} expected string as 'msg' parameter, got '{}' instead.\n"
@@ -27,13 +33,24 @@ class OutcomeException(BaseException):
         BaseException.__init__(self, msg)
         self.msg = msg
         self.pytrace = pytrace
+        self.short_msg = short_msg
 
     def __repr__(self) -> str:
+        if self.short_msg:
+            return "<{} short_msg={!r}>".format(self.__class__.__name__, self.short_msg)
+        msg = self.msg
+        if msg:
+            lines = msg.split("\n", maxsplit=1)
+            if len(lines) > 1:
+                msg = lines[0] + "..."
+            else:
+                msg = lines[0]
+        return "<{} msg={!r}>".format(self.__class__.__name__, msg)
+
+    def __str__(self) -> str:
         if self.msg:
             return self.msg
-        return "<{} instance>".format(self.__class__.__name__)
-
-    __str__ = __repr__
+        return repr(self)
 
 
 TEST_OUTCOME = (OutcomeException, Exception)
@@ -116,7 +133,9 @@ def skip(msg: str = "", *, allow_module_level: bool = False) -> "NoReturn":
 skip.Exception = Skipped  # type: ignore
 
 
-def fail(msg: str = "", pytrace: bool = True) -> "NoReturn":
+def fail(
+    msg: str = "", pytrace: bool = True, *, short_msg: Optional[str] = None
+) -> "NoReturn":
     """
     Explicitly fail an executing test with the given message.
 
@@ -125,7 +144,7 @@ def fail(msg: str = "", pytrace: bool = True) -> "NoReturn":
         python traceback will be reported.
     """
     __tracebackhide__ = True
-    raise Failed(msg=msg, pytrace=pytrace)
+    raise Failed(msg=msg, pytrace=pytrace, short_msg=short_msg)
 
 
 # Ignore type because of https://github.com/python/mypy/issues/2087.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1387,7 +1387,9 @@ class LineMatcher:
                 extralines.append(nextline)
             else:
                 self._log("remains unmatched: {!r}".format(line))
-                pytest.fail(self._log_text.lstrip())
+                pytest.fail(
+                    self._log_text, short_msg="remains unmatched: {!r}".format(line)
+                )
 
     def no_fnmatch_line(self, pat):
         """Ensure captured lines do not match the given pattern, using ``fnmatch.fnmatch``.

--- a/testing/test_outcomes.py
+++ b/testing/test_outcomes.py
@@ -1,0 +1,11 @@
+from _pytest.outcomes import OutcomeException
+
+
+def test_OutcomeException():
+    assert repr(OutcomeException()) == "<OutcomeException msg=None>"
+    assert repr(OutcomeException(msg="msg")) == "<OutcomeException msg='msg'>"
+    assert repr(OutcomeException(msg="msg\nline2")) == "<OutcomeException msg='msg...'>"
+    assert (
+        repr(OutcomeException(short_msg="short"))
+        == "<OutcomeException short_msg='short'>"
+    )

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -493,6 +493,21 @@ def test_linematcher_match_failure():
     ]
 
 
+def test_linematcher_fnmatch_lines():
+    lm = LineMatcher(["1", "2", "3"])
+    with pytest.raises(pytest.fail.Exception) as excinfo:
+        lm.fnmatch_lines(["2", "last_unmatched"])
+    assert excinfo.value.short_msg == "remains unmatched: 'last_unmatched'"
+    assert str(excinfo.value).splitlines() == [
+        "nomatch: '2'",
+        "    and: '1'",
+        "exact match: '2'",
+        "nomatch: 'last_unmatched'",
+        "    and: '3'",
+        "remains unmatched: 'last_unmatched'",
+    ]
+
+
 @pytest.mark.parametrize("function", ["no_fnmatch_line", "no_re_match_line"])
 def test_no_matching(function):
     if function == "no_fnmatch_line":

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -559,8 +559,13 @@ def test_pytest_exit():
 def test_pytest_fail():
     with pytest.raises(pytest.fail.Exception) as excinfo:
         pytest.fail("hello")
-    s = excinfo.exconly(tryshort=True)
-    assert s.startswith("Failed")
+    assert excinfo.exconly(tryshort=True) == "Failed: hello"
+    assert excinfo.exconly(tryshort=False) == "Failed: hello"
+
+    with pytest.raises(pytest.fail.Exception) as excinfo:
+        pytest.fail("hello", short_msg="short message")
+    assert excinfo.exconly(tryshort=True) == "short message"
+    assert excinfo.exconly(tryshort=False) == "Failed: hello"
 
 
 def test_pytest_exit_msg(testdir):

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -758,7 +758,17 @@ class TestTerminalFunctional:
 
 def test_fail_extra_reporting(testdir, monkeypatch):
     monkeypatch.setenv("COLUMNS", "80")
-    testdir.makepyfile("def test_this(): assert 0, 'this_failed' * 100")
+    testdir.makepyfile(
+        """
+        def test_this():
+            assert 0, 'this_failed' * 100
+
+        def test_linematcher():
+            from _pytest.pytester import LineMatcher
+
+            LineMatcher(["1", "2", "3"]).fnmatch_lines(["2", "last_unmatched"])
+    """
+    )
     result = testdir.runpytest()
     result.stdout.no_fnmatch_line("*short test summary*")
     result = testdir.runpytest("-rf")
@@ -766,6 +776,8 @@ def test_fail_extra_reporting(testdir, monkeypatch):
         [
             "*test summary*",
             "FAILED test_fail_extra_reporting.py::test_this - AssertionError: this_failedt...",
+            "FAILED test_fail_extra_reporting.py::test_linematcher - remains unmatched: 'l...",
+            "*= 2 failed in *",
         ]
     )
 


### PR DESCRIPTION
This is meant to improve the short msg with `-r`, where you want to see
the non-matched line, and not the first line (that might have matched),
from pytester's `_match_lines`.

This also improves `__str__` / `__repr__`.

TODO:

- [ ] use it for doctests (ReprFailDoctest, https://github.com/pytest-dev/pytest/blob/5e7b2ae704da84db5e9d4a786ebe1efe1997f9ff/src/_pytest/doctest.py#L229-L280) - not really sure what though - but might be just as simple as "doctest failed" - currently it is empty, see `test_doctest_id`.