### PR TITLE
cache: NFPlugin: keep known nodeids

### DIFF
--- a/changelog/5206.bugfix.rst
+++ b/changelog/5206.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``--nf`` to not forget about known nodeids with partial test selection.

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -264,8 +264,8 @@ class NFPlugin:
         self.cached_nodeids = config.cache.get("cache/nodeids", [])
 
     def pytest_collection_modifyitems(self, session, config, items):
+        new_items = OrderedDict()
         if self.active:
-            new_items = OrderedDict()
             other_items = OrderedDict()
             for item in items:
                 if item.nodeid not in self.cached_nodeids:
@@ -276,7 +276,11 @@ class NFPlugin:
             items[:] = self._get_increasing_order(
                 new_items.values()
             ) + self._get_increasing_order(other_items.values())
-        self.cached_nodeids = [x.nodeid for x in items if isinstance(x, pytest.Item)]
+        else:
+            for item in items:
+                if item.nodeid not in self.cached_nodeids:
+                    new_items[item.nodeid] = item
+        self.cached_nodeids.extend(new_items)
 
     def _get_increasing_order(self, items):
         return sorted(items, key=lambda item: item.fspath.mtime(), reverse=True)

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -982,8 +982,13 @@ class TestNewFirst:
         )
         testdir.tmpdir.join("test_1/test_1.py").setmtime(1)
 
-        result = testdir.runpytest("-v", "--nf")
+        # Running only a subset does not forget about existing ones.
+        result = testdir.runpytest("-v", "--nf", "test_2/test_2.py")
+        result.stdout.fnmatch_lines(
+            ["*test_2/test_2.py::test_1[1*", "*test_2/test_2.py::test_1[2*"]
+        )
 
+        result = testdir.runpytest("-v", "--nf")
         result.stdout.fnmatch_lines(
             [
                 "*test_1/test_1.py::test_1[3*",


### PR DESCRIPTION
Caveat: does not forget about old nodeids

Fixes https://github.com/pytest-dev/pytest/issues/5206