### PR TITLE
Ensure .pytest_cache file has a newline at the end

### DIFF
--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -135,7 +135,7 @@ class Cache:
         readme_path.write_text(README_CONTENT)
 
         gitignore_path = self._cachedir.joinpath(".gitignore")
-        msg = "# Created by pytest automatically.\n*"
+        msg = "# Created by pytest automatically.\n*\n"
         gitignore_path.write_text(msg, encoding="UTF-8")
 
         cachedir_tag_path = self._cachedir.joinpath("CACHEDIR.TAG")

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -1029,7 +1029,7 @@ def test_gitignore(testdir):
     config = testdir.parseconfig()
     cache = Cache.for_config(config)
     cache.set("foo", "bar")
-    msg = "# Created by pytest automatically.\n*"
+    msg = "# Created by pytest automatically.\n*\n"
     gitignore_path = cache._cachedir.joinpath(".gitignore")
     assert gitignore_path.read_text(encoding="UTF-8") == msg
 


### PR DESCRIPTION
noticed this while poking around, makes `cat .pytest_cache/.gitignore` work slightly better