### PR TITLE
unittest: do not use `TestCase.debug` with `--pdb`

### DIFF
--- a/changelog/5991.bugfix.rst
+++ b/changelog/5991.bugfix.rst
@@ -1,0 +1,1 @@
+Do not use ``TestCase.debug()`` for unittests with ``--pdb``.

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -187,29 +187,8 @@ class TestCaseFunction(Function):
     def stopTest(self, testcase):
         pass
 
-    def _handle_skip(self):
-        # implements the skipping machinery (see #2137)
-        # analog to pythons Lib/unittest/case.py:run
-        testMethod = getattr(self._testcase, self._testcase._testMethodName)
-        if getattr(self._testcase.__class__, "__unittest_skip__", False) or getattr(
-            testMethod, "__unittest_skip__", False
-        ):
-            # If the class or method was skipped.
-            skip_why = getattr(
-                self._testcase.__class__, "__unittest_skip_why__", ""
-            ) or getattr(testMethod, "__unittest_skip_why__", "")
-            self._testcase._addSkip(self, self._testcase, skip_why)
-            return True
-        return False
-
     def runtest(self):
-        if self.config.pluginmanager.get_plugin("pdbinvoke") is None:
-            self._testcase(result=self)
-        else:
-            # disables tearDown and cleanups for post mortem debugging (see #1890)
-            if self._handle_skip():
-                return
-            self._testcase.debug()
+        self._testcase(result=self)
 
     def _prunetraceback(self, excinfo):
         Function._prunetraceback(self, excinfo)


### PR DESCRIPTION
Reverts https://github.com/pytest-dev/pytest/pull/1890, which needs to
be fixed/addressed in another way
(https://github.com/pytest-dev/pytest/pull/5996).

Fixes https://github.com/pytest-dev/pytest/issues/5991.