### PR TITLE
[RFC] pytester. support stdin with runpytest_inprocess

### DIFF
--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -633,16 +633,20 @@ class FDCapture(FDCaptureBinary):
 
 class SysCapture:
 
+    CLOSE_STDIN = object
     EMPTY_BUFFER = str()
     _state = None
 
-    def __init__(self, fd, tmpfile=None):
+    def __init__(self, fd, tmpfile=None, stdin=CLOSE_STDIN):
         name = patchsysdict[fd]
         self._old = getattr(sys, name)
         self.name = name
         if tmpfile is None:
             if name == "stdin":
-                tmpfile = DontReadFromInput()
+                if stdin is self.CLOSE_STDIN:
+                    tmpfile = DontReadFromInput()
+                else:
+                    tmpfile = stdin
             else:
                 tmpfile = CaptureIO()
         self.tmpfile = tmpfile

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -847,7 +847,7 @@ class Testdir:
             for finalizer in finalizers:
                 finalizer()
 
-    def runpytest_inprocess(self, *args, **kwargs):
+    def runpytest_inprocess(self, *args, stdin=CLOSE_STDIN, **kwargs):
         """Return result of running pytest in-process, providing a similar
         interface to what self.runpytest() provides.
         """
@@ -856,7 +856,18 @@ class Testdir:
         if syspathinsert:
             self.syspathinsert()
         now = time.time()
-        capture = MultiCapture(Capture=SysCapture)
+        if stdin is self.CLOSE_STDIN:
+            Capture = SysCapture
+        else:
+            if isinstance(stdin, str):
+                import io
+                import functools
+
+                Capture = functools.partial(SysCapture, stdin=io.StringIO(stdin))
+            else:
+                Capture = stdin
+
+        capture = MultiCapture(Capture=Capture)
         capture.start_capturing()
         try:
             try:

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -724,17 +724,21 @@ class TestPDB:
             """
             import pytest
             def pytest_generate_tests(metafunc):
-                pytest.set_trace()
                 x = 5
+                pytest.set_trace()
+
             def test_foo(a):
                 pass
         """
         )
-        child = testdir.spawn_pytest(str(p1))
-        child.expect("x = 5")
-        child.expect("Pdb")
-        child.sendeof()
-        self.flush(child)
+        result = testdir.runpytest(str(p1), stdin="p 'x=' + str(x)\nq\n")
+        result.stdout.fnmatch_lines(
+            [
+                "*> PDB set_trace (IO-capturing turned off) >*",
+                "'x=5'",
+                "E   _pytest.outcomes.Exit: Quitting debugger",
+            ]
+        )
 
     def test_pdb_collection_failure_is_shown(self, testdir):
         p1 = testdir.makepyfile("xxx")


### PR DESCRIPTION
This allows for speeding up / replacing pexpect with some pdb tests.

Ref: https://github.com/pytest-dev/pytest/pull/4996 (less controversial).