### PR TITLE
[RFC/WIP]: assert: use safeformat for display with -vv

### DIFF
--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -46,13 +46,13 @@ class SafeRepr(reprlib.Repr):
         return _ellipsize(s, self.maxsize)
 
 
-def safeformat(obj):
+def safeformat(obj, **kwargs):
     """return a pretty printed string for the given object.
     Failing __repr__ functions of user instances will be represented
     with a short exception info.
     """
     try:
-        return pprint.pformat(obj)
+        return pprint.pformat(obj, **kwargs)
     except Exception as exc:
         return _format_repr_exception(exc, obj)
 

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -141,6 +141,17 @@ def pytest_runtest_setup(item):
 
     util._reprcompare = callbinrepr
 
+    from _pytest._io.saferepr import safeformat
+    from _pytest._io.saferepr import saferepr
+
+    def call_assertion_display_hook(obj):
+        verbose = item.config.getoption("verbose")
+        if verbose > 1:
+            return safeformat(obj)
+        return saferepr(obj).replace("\n", "\\n")
+
+    util._reprdisplay = call_assertion_display_hook
+
     if item.ihook.pytest_assertion_pass.get_hookimpls():
 
         def call_assertion_pass_hook(lineno, orig, expl):
@@ -153,6 +164,7 @@ def pytest_runtest_setup(item):
 
 def pytest_runtest_teardown(item):
     util._reprcompare = None
+    util._reprdisplay = None
     util._assertion_pass = None
 
 

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -147,7 +147,7 @@ def pytest_runtest_setup(item):
     def call_assertion_display_hook(obj):
         verbose = item.config.getoption("verbose")
         if verbose > 1:
-            return safeformat(obj).replace("\n", "\n~")
+            return safeformat(obj, compact=True).replace("\n", "\n~")
         return saferepr(obj).replace("\n", "\\n")
 
     util._reprdisplay = call_assertion_display_hook

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -147,7 +147,7 @@ def pytest_runtest_setup(item):
     def call_assertion_display_hook(obj):
         verbose = item.config.getoption("verbose")
         if verbose > 1:
-            return safeformat(obj)
+            return safeformat(obj).replace("\n", "\n~")
         return saferepr(obj).replace("\n", "\\n")
 
     util._reprdisplay = call_assertion_display_hook

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -398,6 +398,10 @@ def _call_reprcompare(ops, results, expls, each_obj):
     return expl
 
 
+def _call_reprdisplay(obj):
+    return util._reprdisplay(obj)
+
+
 def _call_assertion_pass(lineno, orig, expl):
     # type: (int, str, str) -> None
     if util._assertion_pass is not None:
@@ -662,8 +666,7 @@ class AssertionRewriter(ast.NodeVisitor):
         return ast.Name(name, ast.Load())
 
     def display(self, expr):
-        """Call saferepr on the expression."""
-        return self.helper("_saferepr", expr)
+        return self.helper("_call_reprdisplay", expr)
 
     def helper(self, name, *args):
         """Call a helper in this module."""

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -399,7 +399,10 @@ def _call_reprcompare(ops, results, expls, each_obj):
 
 
 def _call_reprdisplay(obj):
-    return util._reprdisplay(obj)
+    if util._reprdisplay is not None:
+        return util._reprdisplay(obj)
+    # XXX: happens/used with testing/test_assertion.py::TestImportHookInstallation::test_rewrite_assertions_pytester_plugin  # noqa: E501
+    return _saferepr(obj)
 
 
 def _call_assertion_pass(lineno, orig, expl):


### PR DESCRIPTION
TODO:

- [ ] ~~real plugin hook?~~
- [ ] should handle other places where safeformat is used also, via
      args/options to the hook then likely.
- [ ] test

Ref: https://github.com/pytest-dev/pytest/issues/3962
Ref: https://github.com/pytest-dev/pytest/pull/5933