### PR TITLE
[WIP] capture: do not close tmpfile buffer, but redirect

### DIFF
--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -80,7 +80,7 @@ class CaptureManager:
         self._method = method
         self._global_capturing = None
         self._current_item = None
-        self._atexit_funcs: List[Callable] = []
+        self._atexit_funcs = []  # type: List[Callable]
         atexit.register(self._atexit_run)
         self._tmpfiles = {}
 

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -573,7 +573,14 @@ class FDCaptureBinary:
             self.done = self._done
             if targetfd == 0:
                 assert not tmpfile, "cannot set tmpfile with stdin"
-                tmpfile = open(os.devnull, "r")
+                if capman:
+                    try:
+                        tmpfile = capman._tmpfiles[0]
+                        assert not tmpfile.closed
+                    except KeyError:
+                        tmpfile = open(os.devnull, "r")
+                else:
+                    tmpfile = open(os.devnull, "r")
                 self.syscapture = SysCapture(targetfd)
             else:
                 if tmpfile is None:

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -579,6 +579,7 @@ class FDCaptureBinary:
                         assert not tmpfile.closed
                     except KeyError:
                         tmpfile = open(os.devnull, "r")
+                        capman._tmpfiles[targetfd] = tmpfile
                 else:
                     tmpfile = open(os.devnull, "r")
                 self.syscapture = SysCapture(targetfd)

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -2,6 +2,7 @@
 per-test stdout/stderr capturing mechanism.
 
 """
+import atexit
 import collections
 import contextlib
 import io
@@ -595,9 +596,8 @@ class FDCaptureBinary:
         os.close(targetfd_save)
         self.syscapture.done()
         # Redirect any remaining output.
-        os.dup2(self.targetfd, self.tmpfile.buffer.fileno())
-        # TODO: atexit?
-        # self.tmpfile.close()
+        os.dup2(self.targetfd, self.tmpfile_fd)
+        atexit.register(self.tmpfile.close)
         self._state = "done"
 
     def suspend(self):
@@ -668,8 +668,7 @@ class SysCapture:
     def done(self):
         setattr(sys, self.name, self._old)
         del self._old
-        # TODO: atexit?
-        # self.tmpfile.close()
+        atexit.register(self.tmpfile.close)
         self._state = "done"
 
     def suspend(self):

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -594,7 +594,10 @@ class FDCaptureBinary:
         os.dup2(targetfd_save, self.targetfd)
         os.close(targetfd_save)
         self.syscapture.done()
-        self.tmpfile.close()
+        # Redirect any remaining output.
+        os.dup2(self.targetfd, self.tmpfile.buffer.fileno())
+        # TODO: atexit?
+        # self.tmpfile.close()
         self._state = "done"
 
     def suspend(self):
@@ -665,7 +668,8 @@ class SysCapture:
     def done(self):
         setattr(sys, self.name, self._old)
         del self._old
-        self.tmpfile.close()
+        # TODO: atexit?
+        # self.tmpfile.close()
         self._state = "done"
 
     def suspend(self):

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -12,6 +12,7 @@ from io import UnsupportedOperation
 from tempfile import TemporaryFile
 from typing import Callable
 from typing import List
+from typing import Optional
 
 import pytest
 from _pytest.compat import CaptureIO
@@ -464,7 +465,12 @@ class MultiCapture:
     _state = None
 
     def __init__(
-        self, out=True, err=True, in_=True, Capture=None, capman: CaptureManager = None
+        self,
+        out=True,
+        err=True,
+        in_=True,
+        Capture=None,
+        capman: Optional[CaptureManager] = None,
     ):
         if in_:
             self.in_ = Capture(0, capman=capman)
@@ -554,7 +560,7 @@ class FDCaptureBinary:
     EMPTY_BUFFER = b""
     _state = None
 
-    def __init__(self, targetfd, tmpfile=None, capman: CaptureManager = None):
+    def __init__(self, targetfd, tmpfile=None, capman: Optional[CaptureManager] = None):
         self.targetfd = targetfd
         self._capman = capman
         try:
@@ -667,7 +673,7 @@ class SysCapture:
     EMPTY_BUFFER = str()
     _state = None
 
-    def __init__(self, fd, tmpfile=None, capman: CaptureManager = None):
+    def __init__(self, fd, tmpfile=None, capman: Optional[CaptureManager] = None):
         name = patchsysdict[fd]
         self._capman = capman
         self._old = getattr(sys, name)


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/issues/5502

TODO:

- [ ] changelog
- [x] currently might fail with pytest's own suite: OSError: [Errno 24] Too many open files - addressed via tmpfile-reuse
 - ~~[ ] after https://github.com/pytest-dev/pytest/pull/6036~~