### PR TITLE
pytester: runpytest_inprocess: use splitlines()

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -878,7 +878,9 @@ class Testdir:
             sys.stdout.write(out)
             sys.stderr.write(err)
 
-        res = RunResult(reprec.ret, out.split("\n"), err.split("\n"), time.time() - now)
+        res = RunResult(
+            reprec.ret, out.splitlines(), err.splitlines(), time.time() - now
+        )
         res.reprec = reprec
         return res
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1291,7 +1291,7 @@ def test_config_blocked_default_plugins(testdir, plugin):
     if plugin != "terminal":
         result.stdout.fnmatch_lines(["* 1 failed in *"])
     else:
-        assert result.stdout.lines == [""]
+        assert result.stdout.lines == []
 
 
 class TestSetupCfg:

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -597,7 +597,7 @@ def test_pytest_exit_returncode(testdir):
     result = testdir.runpytest()
     result.stdout.fnmatch_lines(["*! *Exit: some exit msg !*"])
 
-    assert _strip_resource_warnings(result.stderr.lines) == [""]
+    assert _strip_resource_warnings(result.stderr.lines) == []
     assert result.ret == 99
 
     # It prints to stderr also in case of exit during pytest_sessionstart.
@@ -612,8 +612,7 @@ def test_pytest_exit_returncode(testdir):
     result = testdir.runpytest()
     result.stdout.fnmatch_lines(["*! *Exit: during_sessionstart !*"])
     assert _strip_resource_warnings(result.stderr.lines) == [
-        "Exit: during_sessionstart",
-        "",
+        "Exit: during_sessionstart"
     ]
     assert result.ret == 98
 


### PR DESCRIPTION
This avoids having a trailing empty lines always.