### PR TITLE
conftest: allow skipping of test re-ordering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
     # Full run of latest supported version, without xdist.
     # Coverage for:
     # - test_sys_breakpoint_interception (via pexpect).
-    - env: TOXENV=py37-pexpect PYTEST_COVERAGE=1
+    - env: TOXENV=py37-pexpect PYTEST_COVERAGE=1 PYTEST_REORDER_TESTS=0
       python: '3.7'
 
     # Coverage tracking is slow with pypy, skip it.

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 import pytest
@@ -27,6 +28,10 @@ def pytest_collection_modifyitems(config, items):
     slow_items = []
     slowest_items = []
     neutral_items = []
+
+    if not int(os.environ.get("PYTEST_REORDER_TESTS", 1)):
+        yield
+        return
 
     spawn_names = {"spawn_pytest", "spawn"}
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest {posargs:{env:_PYTEST_TOX_DEFAULT_POSARGS:}}
     coverage: coverage combine
     coverage: coverage report -m
-passenv = USER USERNAME COVERAGE_* TRAVIS PYTEST_ADDOPTS TERM
+passenv = USER USERNAME COVERAGE_* TRAVIS PYTEST_ADDOPTS PYTEST_REORDER_TESTS TERM
 setenv =
     _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_POSARGS_LSOF:} {env:_PYTEST_TOX_POSARGS_XDIST:}
 


### PR DESCRIPTION
I've wanted this when checking why a certain test is failing when only
being run directly, and thought it would be due to the re-ordering.
Therefore it is useful to being able to skip it via an env.

Adds it to a Travis job, so that we are running tests in two different
orders at least.