### PR TITLE
Show the mnemonic of pytest.ExitCode in RunResult's repr

### DIFF
--- a/changelog/4901.trivial.rst
+++ b/changelog/4901.trivial.rst
@@ -1,0 +1,2 @@
+``RunResult`` from ``pytester`` now displays the mnemonic of the ``ret`` attribute when it is a
+valid ``pytest.ExitCode`` value.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -362,7 +362,10 @@ class RunResult:
     """
 
     def __init__(self, ret, outlines, errlines, duration):
-        self.ret = ret
+        try:
+            self.ret = pytest.ExitCode(ret)
+        except ValueError:
+            self.ret = ret
         self.outlines = outlines
         self.errlines = errlines
         self.stdout = LineMatcher(outlines)
@@ -371,7 +374,7 @@ class RunResult:
 
     def __repr__(self):
         return (
-            "<RunResult ret=%r len(stdout.lines)=%d len(stderr.lines)=%d duration=%.2fs>"
+            "<RunResult ret=%s len(stdout.lines)=%d len(stderr.lines)=%d duration=%.2fs>"
             % (self.ret, len(self.stdout.lines), len(self.stderr.lines), self.duration)
         )
 

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -121,17 +121,6 @@ def test_runresult_assertion_on_xpassed(testdir):
     assert result.ret == 0
 
 
-def test_runresult_repr():
-    from _pytest.pytester import RunResult
-
-    assert (
-        repr(
-            RunResult(ret="ret", outlines=[""], errlines=["some", "errors"], duration=1)
-        )
-        == "<RunResult ret='ret' len(stdout.lines)=1 len(stderr.lines)=2 duration=1.00s>"
-    )
-
-
 def test_xpassed_with_strict_is_considered_a_failure(testdir):
     testdir.makepyfile(
         """
@@ -616,3 +605,22 @@ def test_spawn_uses_tmphome(testdir):
     child = testdir.spawn_pytest(str(p1))
     out = child.read()
     assert child.wait() == 0, out.decode("utf8")
+
+
+def test_run_result_repr():
+    outlines = ["some", "normal", "output"]
+    errlines = ["some", "nasty", "errors", "happened"]
+
+    # known exit code
+    r = pytester.RunResult(1, outlines, errlines, duration=0.5)
+    assert (
+        repr(r) == "<RunResult ret=ExitCode.TESTS_FAILED len(stdout.lines)=3"
+        " len(stderr.lines)=4 duration=0.50s>"
+    )
+
+    # unknown exit code: just the number
+    r = pytester.RunResult(99, outlines, errlines, duration=0.5)
+    assert (
+        repr(r) == "<RunResult ret=99 len(stdout.lines)=3"
+        " len(stderr.lines)=4 duration=0.50s>"
+    )


### PR DESCRIPTION
Fix #4901
