### PR TITLE
saferepr: handle BaseExceptions

### DIFF
--- a/changelog/6047.bugfix.rst
+++ b/changelog/6047.bugfix.rst
@@ -1,0 +1,1 @@
+BaseExceptions are handled in ``saferepr``, which includes ``pytest.fail.Exception`` etc.

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -3,14 +3,24 @@ import reprlib
 from typing import Any
 
 
-def _format_repr_exception(exc: Exception, obj: Any) -> str:
-    exc_name = type(exc).__name__
+def _try_repr_or_str(obj):
     try:
-        exc_info = str(exc)
-    except Exception:
-        exc_info = "unknown"
-    return '<[{}("{}") raised in repr()] {} object at 0x{:x}>'.format(
-        exc_name, exc_info, obj.__class__.__name__, id(obj)
+        return repr(obj)
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except BaseException:
+        return '{}("{}")'.format(type(obj).__name__, obj)
+
+
+def _format_repr_exception(exc: BaseException, obj: Any) -> str:
+    try:
+        exc_info = _try_repr_or_str(exc)
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except BaseException as exc:
+        exc_info = "unpresentable exception ({})".format(_try_repr_or_str(exc))
+    return "<[{} raised in repr()] {} object at 0x{:x}>".format(
+        exc_info, obj.__class__.__name__, id(obj)
     )
 
 
@@ -35,14 +45,18 @@ class SafeRepr(reprlib.Repr):
     def repr(self, x: Any) -> str:
         try:
             s = super().repr(x)
-        except Exception as exc:
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except BaseException as exc:
             s = _format_repr_exception(exc, x)
         return _ellipsize(s, self.maxsize)
 
     def repr_instance(self, x: Any, level: int) -> str:
         try:
             s = repr(x)
-        except Exception as exc:
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except BaseException as exc:
             s = _format_repr_exception(exc, x)
         return _ellipsize(s, self.maxsize)
 

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -584,7 +584,7 @@ raise ValueError()
         reprlocals = p.repr_locals(loc)
         assert reprlocals.lines
         assert reprlocals.lines[0] == "__builtins__ = <builtins>"
-        assert '[NotImplementedError("") raised in repr()]' in reprlocals.lines[1]
+        assert "[NotImplementedError() raised in repr()]" in reprlocals.lines[1]
 
     def test_repr_local_with_exception_in_class_property(self):
         class ExceptionWithBrokenClass(Exception):
@@ -602,7 +602,7 @@ raise ValueError()
         reprlocals = p.repr_locals(loc)
         assert reprlocals.lines
         assert reprlocals.lines[0] == "__builtins__ = <builtins>"
-        assert '[ExceptionWithBrokenClass("") raised in repr()]' in reprlocals.lines[1]
+        assert "[ExceptionWithBrokenClass() raised in repr()]" in reprlocals.lines[1]
 
     def test_repr_local_truncated(self):
         loc = {"l": [i for i in range(10)]}

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -41,9 +41,10 @@ def test_exceptions():
     assert "TypeError" in s
     assert "TypeError" in saferepr(BrokenRepr("string"))
 
+    none = None
     try:
-        None()
-    except Exception as exc:
+        none()
+    except BaseException as exc:
         exp_exc = repr(exc)
     obj = BrokenRepr(BrokenReprException("omg even worse"))
     s2 = saferepr(obj)


### PR DESCRIPTION
Ref: https://github.com/pytest-dev/pytest-django/pull/776

This causes INTERNALERRORs within pytest-django, which uses `pytest.fail` to prevent DB access, and that is derived from BaseException.