### PR TITLE
Update mypy 0.720 -> 0.740

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     hooks:
     -   id: rst-backticks
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.720
+    rev: v0.740
     hooks:
     -   id: mypy
         files: ^(src/|testing/)

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -187,7 +187,7 @@ class WarningsRecorder(warnings.catch_warnings):
         exc_type: Optional["Type[BaseException]"],
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
-    ) -> bool:
+    ) -> None:
         if not self._entered:
             __tracebackhide__ = True
             raise RuntimeError("Cannot exit %r without entering first" % self)
@@ -197,8 +197,6 @@ class WarningsRecorder(warnings.catch_warnings):
         # Built-in catch_warnings does not reset entered state so we do it
         # manually here for this context manager to become reusable.
         self._entered = False
-
-        return False
 
 
 class WarningsChecker(WarningsRecorder):
@@ -232,7 +230,7 @@ class WarningsChecker(WarningsRecorder):
         exc_type: Optional["Type[BaseException]"],
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
-    ) -> bool:
+    ) -> None:
         super().__exit__(exc_type, exc_val, exc_tb)
 
         __tracebackhide__ = True
@@ -263,4 +261,3 @@ class WarningsChecker(WarningsRecorder):
                                 [each.message for each in self],
                             )
                         )
-        return False


### PR DESCRIPTION
Changelogs:
- http://mypy-lang.blogspot.com/2019/09/mypy-730-released.html
- http://mypy-lang.blogspot.com/2019/10/mypy-0740-released.html

New errors:

```
src/_pytest/recwarn.py:77: error: Missing return statement
src/_pytest/recwarn.py:185: error: "bool" is invalid as return type for "__exit__" that always returns False
src/_pytest/recwarn.py:185: note: Use "typing_extensions.Literal[False]" as the return type or change it to "None"
src/_pytest/recwarn.py:185: note: If return type of "__exit__" implies that it may return True, the context manager may swallow exceptions
src/_pytest/recwarn.py:185: error: Return type "bool" of "__exit__" incompatible with return type "None" in supertype "catch_warnings"
src/_pytest/recwarn.py:230: error: "bool" is invalid as return type for "__exit__" that always returns False
src/_pytest/recwarn.py:230: note: Use "typing_extensions.Literal[False]" as the return type or change it to "None"
src/_pytest/recwarn.py:230: note: If return type of "__exit__" implies that it may return True, the context manager may swallow exceptions
src/_pytest/recwarn.py:230: error: Return type "bool" of "__exit__" incompatible with return type "None" in supertype "catch_warnings"
```

The errors are due to this new error:
https://mypy.readthedocs.io/en/latest/error_code_list.html#check-the-return-type-of-exit-exit-return