### PR TITLE
[4.6] Review rm_rf handling of FileNotFoundErrors 

### DIFF
--- a/changelog/6044.bugfix.rst
+++ b/changelog/6044.bugfix.rst
@@ -1,0 +1,3 @@
+Properly ignore ``FileNotFoundError`` (``OSError.errno == NOENT`` in Python 2) exceptions when trying to remove old temporary directories,
+for instance when multiple processes try to remove the same directory (common with ``pytest-xdist``
+for example).

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -398,9 +398,14 @@ class TestRmRf:
             on_rm_rf_error(os.unlink, str(fn), exc_info, start_path=tmp_path)
             assert fn.is_file()
 
+        # we ignore FileNotFoundError
+        file_not_found = OSError()
+        file_not_found.errno = errno.ENOENT
+        exc_info = (None, file_not_found, None)
+        assert not on_rm_rf_error(None, str(fn), exc_info, start_path=tmp_path)
+
         permission_error = OSError()
         permission_error.errno = errno.EACCES
-
         # unknown function
         with pytest.warns(pytest.PytestWarning):
             exc_info = (None, permission_error, None)


### PR DESCRIPTION
Backport of #6044

Conflicts:
 	 src/_pytest/pathlib.py
  	testing/test_tmpdir.py