### PR TITLE
Update Tidelift docs with latest campaign

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,14 +111,28 @@ Consult the `Changelog <https://docs.pytest.org/en/latest/changelog.html>`__ pag
 Support pytest
 --------------
 
-You can support pytest by obtaining a `Tidelift subscription`_.
+`Open Collective`_ is an online funding platform for open and transparent communities.
+It provide tools to raise money and share your finances in full transparency.
 
-Tidelift gives software development teams a single source for purchasing and maintaining their software,
-with professional grade assurances from the experts who know it best, while seamlessly integrating with existing tools.
+It is the platform of choice for individuals and companies that want to make one-time or
+monthly donations directly to the project.
+
+See more datails in the `pytest collective`_.
+
+.. _Open Collective: https://opencollective.com
+.. _pytest collective: https://opencollective.com/pytest
 
 
-.. _`Tidelift subscription`: https://tidelift.com/subscription/pkg/pypi-pytest?utm_source=pypi-pytest&utm_medium=referral&utm_campaign=readme
+pytest for enterprise
+---------------------
 
+Available as part of the Tidelift Subscription.
+
+The maintainers of pytest and thousands of other packages are working with Tidelift to deliver commercial support and
+maintenance for the open source dependencies you use to build your applications.
+Save time, reduce risk, and improve code health, while paying the maintainers of the exact dependencies you use.
+
+`Learn more. <https://tidelift.com/subscription/pkg/pypi-pytest?utm_source=pypi-pytest&utm_medium=referral&utm_campaign=enterprise&utm_term=repo>`_
 
 Security
 ^^^^^^^^

--- a/doc/en/_templates/globaltoc.html
+++ b/doc/en/_templates/globaltoc.html
@@ -12,6 +12,7 @@
   <li><a href="{{ pathto('backwards-compatibility') }}">Backwards Compatibility</a></li>
   <li><a href="{{ pathto('py27-py34-deprecation') }}">Python 2.7 and 3.4 Support</a></li>
   <li><a href="{{ pathto('sponsor') }}">Sponsor</a></li>
+  <li><a href="{{ pathto('tidelift') }}">pytest for Enterprise</a></li>
   <li><a href="{{ pathto('license') }}">License</a></li>
   <li><a href="{{ pathto('contact') }}">Contact Channels</a></li>
 </ul>

--- a/doc/en/contents.rst
+++ b/doc/en/contents.rst
@@ -38,19 +38,24 @@ Full pytest documentation
    customize
    example/index
    bash-completion
+   faq
 
    backwards-compatibility
    deprecations
    py27-py34-deprecation
-   historical-notes
-   license
+
    contributing
    development_guide
+
+   sponsor
+   tidelift
+   license
+   contact
+
+   historical-notes
    talks
    projects
-   faq
-   contact
-   sponsor
+
 
 .. only:: html
 

--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -83,6 +83,39 @@ Changelog
 
 Consult the :ref:`Changelog <changelog>` page for fixes and enhancements of each version.
 
+Support pytest
+--------------
+
+`Open Collective`_ is an online funding platform for open and transparent communities.
+It provide tools to raise money and share your finances in full transparency.
+
+It is the platform of choice for individuals and companies that want to make one-time or
+monthly donations directly to the project.
+
+See more datails in the `pytest collective`_.
+
+.. _Open Collective: https://opencollective.com
+.. _pytest collective: https://opencollective.com/pytest
+
+
+pytest for enterprise
+---------------------
+
+Available as part of the Tidelift Subscription.
+
+The maintainers of pytest and thousands of other packages are working with Tidelift to deliver commercial support and
+maintenance for the open source dependencies you use to build your applications.
+Save time, reduce risk, and improve code health, while paying the maintainers of the exact dependencies you use.
+
+`Learn more. <https://tidelift.com/subscription/pkg/pypi-pytest?utm_source=pypi-pytest&utm_medium=referral&utm_campaign=enterprise&utm_term=repo>`_
+
+Security
+^^^^^^^^
+
+pytest has never been associated with a security vunerability, but in any case, to report a
+security vulnerability please use the `Tidelift security contact <https://tidelift.com/security>`_.
+Tidelift will coordinate the fix and disclosure.
+
 
 License
 -------

--- a/doc/en/sponsor.rst
+++ b/doc/en/sponsor.rst
@@ -8,18 +8,6 @@ compensation when possible is welcome to justify time away from friends, family 
 Money is also used to fund local sprints, merchandising (stickers to distribute in conferences for example)
 and every few years a large sprint involving all members.
 
-If you or your company benefit from pytest and would like to contribute to the project financially,
-we are members of two online donation platforms to better suit your needs.
-
-Tidelift
---------
-
-`Tidelift`_ aims to make Open Source sustainable by offering subscriptions to companies which rely
-on Open Source packages. This subscription allows it to pay maintainers of those Open Source
-packages to aid sustainability of the work.
-
-You can help pytest and the ecosystem by obtaining a `Tidelift subscription`_.
-
 OpenCollective
 --------------
 
@@ -30,7 +18,6 @@ It is the platform of choice for individuals and companies that want to make one
 monthly donations directly to the project.
 
 See more datails in the `pytest collective`_.
-
 
 
 .. _Tidelift: https://tidelift.com

--- a/doc/en/tidelift.rst
+++ b/doc/en/tidelift.rst
@@ -1,0 +1,45 @@
+pytest for enterprise
+=====================
+
+`Tidelift`_ is working with the maintainers of pytest and thousands of other
+open source projects to deliver commercial support and maintenance for the open source dependencies you use
+to build your applications. Save time, reduce risk, and improve code health, while paying the maintainers of the
+exact dependencies you use.
+
+`Get more details <https://tidelift.com/subscription/pkg/pypi-pytest?utm_source=pypi-pytest&utm_medium=referral&utm_campaign=enterprise>`_
+
+The Tidelift Subscription is a managed open source subscription for application dependencies covering millions of open source projects across JavaScript, Python, Java, PHP, Ruby, .NET, and more.
+
+Your subscription includes:
+
+* **Security updates**
+
+  - Tidelift's security response team coordinates patches for new breaking security vulnerabilities and alerts immediately through a private channel, so your software supply chain is always secure.
+
+* **Licensing verification and indemnification**
+
+  - Tidelift verifies license information to enable easy policy enforcement and adds intellectual property indemnification to cover creators and users in case something goes wrong. You always have a 100% up-to-date bill of materials for your dependencies to share with your legal team, customers, or partners.
+
+* **Maintenance and code improvement**
+
+  - Tidelift ensures the software you rely on keeps working as long as you need it to work. Your managed dependencies are actively maintained and we recruit additional maintainers where required.
+
+* **Package selection and version guidance**
+
+  - Tidelift helps you choose the best open source packages from the start—and then guide you through updates to stay on the best releases as new issues arise.
+
+* **Roadmap input**
+
+  - Take a seat at the table with the creators behind the software you use. Tidelift's participating maintainers earn more income as their software is used by more subscribers, so they're interested in knowing what you need.
+
+* **Tooling and cloud integration**
+
+  - Tidelift works with GitHub, GitLab, BitBucket, and every cloud platform (and other deployment targets, too).
+
+The end result? All of the capabilities you expect from commercial-grade software, for the full breadth of open
+source you use. That means less time grappling with esoteric open source trivia, and more time building your own
+applications—and your business.
+
+`Request a demo <https://tidelift.com/subscription/request-a-demo?utm_source=pypi-pytest&utm_medium=referral&utm_campaign=enterprise>`_
+
+.. _Tidelift: https://tidelift.com


### PR DESCRIPTION
Tidelift has launched a new marketing campaign as outlined here:

* https://forum.tidelift.com/t/task-enhancement-marketing-the-tidelift-subscription-to-your-users/321

This PR splits the previous "sponsor" information into two, Open Collective
and Tidelift (as they have very different target audiences).

Also took the opportunity to reorder some items at the end of
the contents page in a manner that I believe make more sense.
