### PR TITLE
[4.6] capsys: ensure fd is unbuffered

### DIFF
--- a/changelog/5134.bugfix.rst
+++ b/changelog/5134.bugfix.rst
@@ -1,0 +1,1 @@
+Fix buffering with capsys fixture on Python 2.


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/issues/5134.