### PR TITLE
Replace py.io.TextIO with io.StringIO

### DIFF
--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -4,6 +4,7 @@ import sys
 import traceback
 from inspect import CO_VARARGS
 from inspect import CO_VARKEYWORDS
+from io import StringIO
 from traceback import format_exception_only
 from types import CodeType
 from types import TracebackType
@@ -865,7 +866,7 @@ class TerminalRepr:
     def __str__(self):
         # FYI this is called from pytest-xdist's serialization of exception
         # information.
-        io = py.io.TextIO()
+        io = StringIO()
         tw = py.io.TerminalWriter(file=io)
         self.toterminal(tw)
         return io.getvalue().strip()

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -2,8 +2,7 @@
 import logging
 import re
 from contextlib import contextmanager
-
-import py
+from io import StringIO
 
 import pytest
 from _pytest.compat import nullcontext
@@ -218,7 +217,7 @@ class LogCaptureHandler(logging.StreamHandler):
 
     def __init__(self):
         """Creates a new log handler."""
-        logging.StreamHandler.__init__(self, py.io.TextIO())
+        logging.StreamHandler.__init__(self, StringIO())
         self.records = []
 
     def emit(self, record):
@@ -228,7 +227,7 @@ class LogCaptureHandler(logging.StreamHandler):
 
     def reset(self):
         self.records = []
-        self.stream = py.io.TextIO()
+        self.stream = StringIO()
 
 
 class LogCaptureFixture:

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -10,6 +10,7 @@ import time
 import traceback
 from collections.abc import Sequence
 from fnmatch import fnmatch
+from io import StringIO
 from weakref import WeakKeyDictionary
 
 import py
@@ -1218,7 +1219,7 @@ def getdecoded(out):
 
 class LineComp:
     def __init__(self):
-        self.stringio = py.io.TextIO()
+        self.stringio = StringIO()
 
     def assert_contains_lines(self, lines2):
         """Assert that lines2 are contained (linearly) in lines1.

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -1,3 +1,4 @@
+from io import StringIO
 from pprint import pprint
 from typing import Optional
 from typing import Union
@@ -180,7 +181,7 @@ class BaseReport:
 
 def _report_unserialization_failure(type_name, report_class, reportdict):
     url = "https://github.com/pytest-dev/pytest/issues"
-    stream = py.io.TextIO()
+    stream = StringIO()
     pprint("-" * 100, stream=stream)
     pprint("INTERNALERROR: Unknown entry type returned: %s" % type_name, stream=stream)
     pprint("report_name: %s" % report_class, stream=stream)

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -5,9 +5,8 @@ import pickle
 import subprocess
 import sys
 import textwrap
+from io import StringIO
 from io import UnsupportedOperation
-
-import py
 
 import pytest
 from _pytest import capture
@@ -892,10 +891,10 @@ def test_dupfile_on_bytesio():
 
 
 def test_dupfile_on_textio():
-    tio = py.io.TextIO()
-    f = capture.safe_text_dupfile(tio, "wb")
+    sio = StringIO()
+    f = capture.safe_text_dupfile(sio, "wb")
     f.write("hello")
-    assert tio.getvalue() == "hello"
+    assert sio.getvalue() == "hello"
     assert not hasattr(f, "name")
 
 

--- a/testing/test_resultlog.py
+++ b/testing/test_resultlog.py
@@ -1,6 +1,5 @@
 import os
-
-import py
+from io import StringIO
 
 import _pytest._code
 import pytest
@@ -13,7 +12,7 @@ pytestmark = pytest.mark.filterwarnings("ignore:--result-log is deprecated")
 
 def test_write_log_entry():
     reslog = ResultLog(None, None)
-    reslog.logfile = py.io.TextIO()
+    reslog.logfile = StringIO()
     reslog.write_log_entry("name", ".", "")
     entry = reslog.logfile.getvalue()
     assert entry[-1] == "\n"
@@ -21,7 +20,7 @@ def test_write_log_entry():
     assert len(entry_lines) == 1
     assert entry_lines[0] == ". name"
 
-    reslog.logfile = py.io.TextIO()
+    reslog.logfile = StringIO()
     reslog.write_log_entry("name", "s", "Skipped")
     entry = reslog.logfile.getvalue()
     assert entry[-1] == "\n"
@@ -30,7 +29,7 @@ def test_write_log_entry():
     assert entry_lines[0] == "s name"
     assert entry_lines[1] == " Skipped"
 
-    reslog.logfile = py.io.TextIO()
+    reslog.logfile = StringIO()
     reslog.write_log_entry("name", "s", "Skipped\n")
     entry = reslog.logfile.getvalue()
     assert entry[-1] == "\n"
@@ -39,7 +38,7 @@ def test_write_log_entry():
     assert entry_lines[0] == "s name"
     assert entry_lines[1] == " Skipped"
 
-    reslog.logfile = py.io.TextIO()
+    reslog.logfile = StringIO()
     longrepr = " tb1\n tb 2\nE tb3\nSome Error"
     reslog.write_log_entry("name", "F", longrepr)
     entry = reslog.logfile.getvalue()
@@ -118,7 +117,7 @@ class TestWithFunctionIntegration:
             raise ValueError
         except ValueError:
             excinfo = _pytest._code.ExceptionInfo.from_current()
-        reslog = ResultLog(None, py.io.TextIO())
+        reslog = ResultLog(None, StringIO())
         reslog.pytest_internalerror(excinfo.getrepr(style=style))
         entry = reslog.logfile.getvalue()
         entry_lines = entry.splitlines()

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -5,6 +5,7 @@ import collections
 import os
 import sys
 import textwrap
+from io import StringIO
 
 import pluggy
 import py
@@ -268,7 +269,7 @@ class TestTerminal:
 
     def test_rewrite(self, testdir, monkeypatch):
         config = testdir.parseconfig()
-        f = py.io.TextIO()
+        f = StringIO()
         monkeypatch.setattr(f, "isatty", lambda *args: True)
         tr = TerminalReporter(config, f)
         tr._tw.fullwidth = 10


### PR DESCRIPTION
In Python3, `py.io.TextIO` is just an alias to `io.StringIO`. Remove the indirection.