### PR TITLE
[RDY] tox: remove platform restriction, only used for pexpect

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,8 +36,6 @@ setenv =
 
     lsof: _PYTEST_TOX_POSARGS_LSOF=--lsof
 
-    pexpect: _PYTEST_TOX_PLATFORM=linux|darwin
-
     xdist: _PYTEST_TOX_POSARGS_XDIST=-n auto
 extras = testing
 deps =
@@ -49,7 +47,6 @@ deps =
     twisted: twisted
     xdist: pytest-xdist>=1.13
     {env:_PYTEST_TOX_EXTRA_DEP:}
-platform = {env:_PYTEST_TOX_PLATFORM:.*}
 
 [testenv:linting]
 skip_install = True


### PR DESCRIPTION
This would prevent TOXENV=py37-pexpect-… from running on e.g. FreeBSD.
And even on Windows it is pytest's job of skipping the tests then.  This
was probably still from when the pexpect env was only running
pexpect-based tests.