### PR TITLE
Node._repr_failure_py: remove dead code

### DIFF
--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -265,10 +265,7 @@ class Node:
         if self.config.getoption("fulltrace", False):
             style = "long"
         else:
-            tb = _pytest._code.Traceback([excinfo.traceback[-1]])
             self._prunetraceback(excinfo)
-            if len(excinfo.traceback) == 0:
-                excinfo.traceback = tb
             if style == "auto":
                 style = "long"
         # XXX should excinfo.getrepr record all data and toterminal() process it?

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -351,7 +351,9 @@ class Collector(Node):
             ntraceback = traceback.cut(path=self.fspath)
             if ntraceback == traceback:
                 ntraceback = ntraceback.cut(excludepath=tracebackcutdir)
-            excinfo.traceback = ntraceback.filter()
+            ntraceback = ntraceback.filter()
+            if ntraceback:
+                excinfo.traceback = ntraceback
 
 
 def _check_initialpaths_for_relpath(session, fspath):

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -802,7 +802,9 @@ class FunctionMixin(PyobjMixin):
                     if not ntraceback:
                         ntraceback = traceback
 
-            excinfo.traceback = ntraceback.filter()
+            ntraceback = ntraceback.filter()
+            if ntraceback:
+                excinfo.traceback = ntraceback
             # issue364: mark all but first and last frames to
             # only show a single-line message for each frame
             if self.config.getoption("tbstyle", "auto") == "auto":


### PR DESCRIPTION
It is not covered in tests, and likely meant to be a fallback in case
all of the traceback gets pruned.  This gets handled in some
_prunetraceback implementations already, and should be done there in
general.