### PR TITLE
on_rm_rf_error: ignore os.open (no warning)

### DIFF
--- a/changelog/6074.bugfix.rst
+++ b/changelog/6074.bugfix.rst
@@ -1,0 +1,1 @@
+pytester: fix order of arguments in ``rm_rf`` warning when cleaning up temporary directories, and do not emit warnings for errors with ``os.open``.

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -72,7 +72,7 @@ def on_rm_rf_error(func, path: str, exc, *, start_path: Path) -> bool:
             warnings.warn(
                 PytestWarning(
                     "(rm_rf) unknown function {} when removing {}:\n{}: {}".format(
-                        path, func, exctype, excvalue
+                        func, path, exctype, excvalue
                     )
                 )
             )

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -68,13 +68,14 @@ def on_rm_rf_error(func, path: str, exc, *, start_path: Path) -> bool:
         return False
 
     if func not in (os.rmdir, os.remove, os.unlink):
-        warnings.warn(
-            PytestWarning(
-                "(rm_rf) unknown function {} when removing {}:\n{}: {}".format(
-                    path, func, exctype, excvalue
+        if func not in (os.open,):
+            warnings.warn(
+                PytestWarning(
+                    "(rm_rf) unknown function {} when removing {}:\n{}: {}".format(
+                        path, func, exctype, excvalue
+                    )
                 )
             )
-        )
         return False
 
     # Chmod + retry.

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -393,6 +393,13 @@ class TestRmRf:
             on_rm_rf_error(None, str(fn), exc_info, start_path=tmp_path)
             assert fn.is_file()
 
+        # ignored function
+        with pytest.warns(None) as warninfo:
+            exc_info = (None, PermissionError(), None)
+            on_rm_rf_error(os.open, str(fn), exc_info, start_path=tmp_path)
+            assert fn.is_file()
+        assert not [x.message for x in warninfo]
+
         exc_info = (None, PermissionError(), None)
         on_rm_rf_error(os.unlink, str(fn), exc_info, start_path=tmp_path)
         assert not fn.is_file()

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -388,7 +388,10 @@ class TestRmRf:
         assert not on_rm_rf_error(None, str(fn), exc_info, start_path=tmp_path)
 
         # unknown function
-        with pytest.warns(pytest.PytestWarning):
+        with pytest.warns(
+            pytest.PytestWarning,
+            match=r"^\(rm_rf\) unknown function None when removing .*foo.txt:\nNone: ",
+        ):
             exc_info = (None, PermissionError(), None)
             on_rm_rf_error(None, str(fn), exc_info, start_path=tmp_path)
             assert fn.is_file()


### PR DESCRIPTION
Ref: https://github.com/pytest-dev/pytest/pull/6044/files#r339321752