### PR TITLE
Fix line detection for properties in doctest tests

### DIFF
--- a/changelog/6082.bugfix.rst
+++ b/changelog/6082.bugfix.rst
@@ -1,0 +1,1 @@
+Fix line detection for doctest samples inside ``property`` docstrings, as a workaround to `bpo-17446 <https://bugs.python.org/issue17446>`__.

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -435,6 +435,16 @@ class DoctestModule(pytest.Module):
             https://bugs.python.org/issue25532
             """
 
+            def _find_lineno(self, obj, source_lines):
+                """
+                Doctest code does not take into account `@property`, this is a hackish way to fix it.
+
+                https://bugs.python.org/issue17446
+                """
+                if isinstance(obj, property):
+                    obj = getattr(obj, "fget", obj)
+                return doctest.DocTestFinder._find_lineno(self, obj, source_lines)
+
             def _find(self, tests, obj, name, module, source_lines, globs, seen):
                 if _is_mocked(obj):
                     return


### PR DESCRIPTION
For #6082. Doctest itself does not take into account `@property`. Overriding the line detection method with an additional condition on `isdatadescriptor` helped.