### PR TITLE
tests: fix testing/test_capture.py::test_typeerror_encodedfile_write

### DIFF
--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1503,11 +1503,9 @@ def test_typeerror_encodedfile_write(testdir):
     """
     )
     result_without_capture = testdir.runpytest("-s", str(p))
-
     result_with_capture = testdir.runpytest(str(p))
 
     assert result_with_capture.ret == result_without_capture.ret
-
     result_with_capture.stdout.fnmatch_lines(
-        ["E           TypeError: write() argument must be str, not bytes"]
+        ["E * TypeError: write() argument must be str, not bytes"]
     )


### PR DESCRIPTION
Failed for me due to different indent (?) - not reproducible:

    >   ???
    E   Failed: nomatch: 'E           TypeError: write() argument must be str, not bytes'
    …
    E       and: '>   def mode(self):'
    E       and: 'E   TypeError: write() argument must be str, not bytes'
    …
    E   remains unmatched: 'E           TypeError: write() argument must be str, not bytes'
