### PR TITLE
terminal: fix line offset with skip reports

### DIFF
--- a/changelog/2548.bugfix.rst
+++ b/changelog/2548.bugfix.rst
@@ -1,0 +1,1 @@
+Fix line offset mismatch with skipped tests in terminal summary.

--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -161,9 +161,9 @@ def pytest_runtest_makereport(item, call):
         # skipped by mark.skipif; change the location of the failure
         # to point to the item definition, otherwise it will display
         # the location of where the skip exception was raised within pytest
-        filename, line, reason = rep.longrepr
+        _, _, reason = rep.longrepr
         filename, line = item.location[:2]
-        rep.longrepr = filename, line, reason
+        rep.longrepr = filename, line + 1, reason
 
 
 # called by terminalreporter progress reporting

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -954,7 +954,7 @@ class TerminalReporter:
                 if lineno is not None:
                     lines.append(
                         "%s [%d] %s:%d: %s"
-                        % (verbose_word, num, fspath, lineno + 1, reason)
+                        % (verbose_word, num, fspath, lineno, reason)
                     )
                 else:
                     lines.append("%s [%d] %s: %s" % (verbose_word, num, fspath, reason))


### PR DESCRIPTION
The original fix in https://github.com/pytest-dev/pytest/pull/2548 was
wrong, and was likely meant to fix the use with decorators instead,
which this does now (while reverting 869eed9898).