### PR TITLE
Revisit PR template  [ci skip]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,19 @@
-<!--
 Thanks for submitting a PR, your contribution is really appreciated!
 
 Here is a quick checklist that should be present in PRs.
-(please delete this text from the final description, this is just a guideline)
--->
 
-- [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
-- [ ] Target the `features` branch for new features, improvements, and removals/deprecations.
+!! Please delete this text from the final description, this is just a guideline) !!
+
+- [ ] Target the `master` branch for bug fixes, documentation updates and
+      trivial changes.  But please use `features` for changes touching many
+      files.
+      Target the `features` branch for new features, improvements, and
+      removals/deprecations.
 - [ ] Include documentation when adding new features.
 - [ ] Include new tests or update existing tests when applicable.
 
-Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:
+Unless your change is trivial or a small documentation fix (e.g., a typo or
+reword of a small section) please:
 
 - [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
-- [ ] Add yourself to `AUTHORS` in alphabetical order;
+- [ ] Add yourself to `AUTHORS` in alphabetical order


### PR DESCRIPTION
- make it clear that the text should be deleted, which is often not the
  case - resulting in handling it as incomplete TODOs
- clarify targetting master/features and make it a single actionable
  item.  Ref: https://github.com/pytest-dev/pytest/pull/6064#issuecomment-547568299
- fix punctuation