### PR TITLE
addini: allow for default=None, use notset sentinel

### DIFF
--- a/changelog/6117.improvement.rst
+++ b/changelog/6117.improvement.rst
@@ -1,0 +1,3 @@
+Ini options (typically added via ``parser.addini`` in ``pytest_addoption``)
+allow for using ``default=None``, where previously the default would be ``[]``
+then.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -990,7 +990,7 @@ class Config:
             try:
                 value = self.inicfg[name]
             except KeyError:
-                if default is not None:
+                if default is not notset:
                     return default
                 if type is None:
                     return ""

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -10,6 +10,7 @@ from typing import Tuple
 
 import py
 
+from _pytest.config import notset
 from _pytest.config.exceptions import UsageError
 
 FILE_OR_DIR = "file_or_dir"
@@ -127,7 +128,7 @@ class Parser:
         args = [str(x) if isinstance(x, py.path.local) else x for x in args]
         return optparser.parse_known_args(args, namespace=namespace)
 
-    def addini(self, name, help, type=None, default=None):
+    def addini(self, name, help, type=None, default=notset):
         """ register an ini-file option.
 
         :name: name of the ini-variable

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -268,6 +268,7 @@ class TestConfigAPI:
             """
             def pytest_addoption(parser):
                 parser.addini("myname", "my new ini value")
+                parser.addini("defaultunset", "allow None", default=None)
         """
         )
         testdir.makeini(
@@ -279,6 +280,7 @@ class TestConfigAPI:
         config = testdir.parseconfig()
         val = config.getini("myname")
         assert val == "hello"
+        assert config.getini("defaultunset") is None
         pytest.raises(ValueError, config.getini, "other")
 
     def test_addini_pathlist(self, testdir):


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/issues/6117.