### PR TITLE
assert: fix _compare_eq_iterable: re-format both sides

### DIFF
--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -273,12 +273,13 @@ def _compare_eq_iterable(
     if lines_left != lines_right:
         if lines_left > lines_right:
             max_width = min(len(x) for x in left_formatting)
-            right_formatting = pprint.pformat(right, width=max_width).splitlines()
-            lines_right = len(right_formatting)
         else:
             max_width = min(len(x) for x in right_formatting)
-            left_formatting = pprint.pformat(left, width=max_width).splitlines()
-            lines_left = len(left_formatting)
+
+        right_formatting = pprint.pformat(right, width=max_width).splitlines()
+        lines_right = len(right_formatting)
+        left_formatting = pprint.pformat(left, width=max_width).splitlines()
+        lines_left = len(left_formatting)
 
     if lines_left > 1 or lines_right > 1:
         _surrounding_parens_on_own_lines(left_formatting)

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -459,6 +459,43 @@ class TestAssert_reprcompare:
             "  ]",
         ]
 
+    def test_dict_wrap(self):
+        d1 = {"common": 1, "env": {"env1": 1}}
+        d2 = {"common": 1, "env": {"env1": 1, "env2": 2}}
+
+        diff = callequal(d1, d2, verbose=True)
+        assert diff == [
+            "{'common': 1,...: {'env1': 1}} == {'common': 1,...1, 'env2': 2}}",
+            "Omitting 1 identical items, use -vv to show",
+            "Differing items:",
+            "{'env': {'env1': 1}} != {'env': {'env1': 1, 'env2': 2}}",
+            "Full diff:",
+            "- {'common': 1, 'env': {'env1': 1}}",
+            "+ {'common': 1, 'env': {'env1': 1, 'env2': 2}}",
+            "?                                +++++++++++",
+        ]
+
+        long_a = "a" * 80
+        sub = {"long_a": long_a, "sub1": {"long_a": "substring that gets wrapped"}}
+        d1 = {"env": {"sub": sub}}
+        d2 = {"env": {"sub": sub}, "new": 1}
+        diff = callequal(d1, d2, verbose=True)
+        assert diff == [
+            "{'env': {'sub...s wrapped'}}}} == {'env': {'sub...}}}, 'new': 1}",
+            "Omitting 1 identical items, use -vv to show",
+            "Right contains 1 more item:",
+            "{'new': 1}",
+            "Full diff:",
+            "  {",
+            "   'env': {'sub': {'long_a': '" + long_a + "',",
+            "                   'sub1': {'long_a': 'substring '",
+            "                                      'that '",
+            "                                      'gets '",
+            "                                      'wrapped'}}},",
+            "+  'new': 1,",
+            "  }",
+        ]
+
     def test_dict(self):
         expl = callequal({"a": 0}, {"a": 1})
         assert len(expl) > 1


### PR DESCRIPTION
Follow-up to 946434c61 (#5924).

Before this patch the test would look like this:

    {'env': {'sub...s wrapped'}}}} == {'env': {'sub...}}}, 'new': 1}
    Omitting 1 identical items, use -vv to show
    Right contains 1 more item:
    {'new': 1}
    Full diff:
      {
       'env': {'sub': {'long_a': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
    -                  'sub1': {'long_a': 'substring '
    +                  'sub1': {'long_a': 'substring that gets wrapped'}}},
    ?                                                +++++++++++++++++ ++++
    +  'new': 1,
    -                                     'that '
    -                                     'gets '
    -                                     'wrapped'}}},
      }