### PR TITLE
_perform_collect: remove comment about untested code

### DIFF
--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -476,7 +476,6 @@ class Session(nodes.FSCollector):
             for arg, exc in self._notfound:
                 line = "(no name {!r} in any of {!r})".format(arg, exc.args[0])
                 errors.append("not found: {}\n{}".format(arg, line))
-                # XXX: test this
             raise UsageError(*errors)
         if not genitems:
             return rep.result

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -178,8 +178,14 @@ class TestGeneralUsage:
         p1 = testdir.makepyfile("")
         p2 = testdir.makefile(".pyc", "123")
         result = testdir.runpytest(p1, p2)
-        assert result.ret
-        result.stderr.fnmatch_lines(["*ERROR: not found:*{}".format(p2.basename)])
+        assert result.ret == ExitCode.USAGE_ERROR
+        result.stderr.fnmatch_lines(
+            [
+                "ERROR: not found: {}".format(p2),
+                "(no name {!r} in any of [[][]])".format(str(p2)),
+                "",
+            ]
+        )
 
     @pytest.mark.filterwarnings("default")
     def test_better_reporting_on_conftest_load_failure(self, testdir, request):


### PR DESCRIPTION
Harden one test where it is tested.

All tests testing this:

    testing/acceptance_test.py:184(TestGeneralUsage::test_not_collectable_arguments)
    testing/acceptance_test.py:373(TestGeneralUsage::test_direct_addressing_notfound)
    testing/acceptance_test.py:403(TestGeneralUsage::test_issue134_report_error_when_collecting_member[test_fun.py::test_a])
    testing/acceptance_test.py:420(TestGeneralUsage::test_report_all_failed_collections_initargs)
    testing/test_config.py:1309(test_config_blocked_default_plugins[python])

(via https://github.com/blueyed/pytest/pull/88)