### PR TITLE
Add a @cached_property implementation

### DIFF
--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -15,6 +15,7 @@ import _pytest._code
 from _pytest._code.code import ExceptionChainRepr
 from _pytest._code.code import ExceptionInfo
 from _pytest._code.code import ReprExceptionInfo
+from _pytest.compat import cached_property
 from _pytest.compat import getfslineno
 from _pytest.fixtures import FixtureDef
 from _pytest.fixtures import FixtureLookupError
@@ -448,17 +449,9 @@ class Item(Node):
     def reportinfo(self) -> Tuple[str, Optional[int], str]:
         return self.fspath, None, ""
 
-    @property
+    @cached_property
     def location(self) -> Tuple[str, Optional[int], str]:
-        try:
-            return self._location
-        except AttributeError:
-            location = self.reportinfo()
-            fspath = self.session._node_location_to_relpath(location[0])
-            assert type(location[2]) is str
-            self._location = (
-                fspath,
-                location[1],
-                location[2],
-            )  # type: Tuple[str, Optional[int], str]
-            return self._location
+        location = self.reportinfo()
+        fspath = self.session._node_location_to_relpath(location[0])
+        assert type(location[2]) is str
+        return (fspath, location[1], location[2])

--- a/testing/test_compat.py
+++ b/testing/test_compat.py
@@ -4,6 +4,7 @@ from functools import wraps
 
 import pytest
 from _pytest.compat import _PytestWrapper
+from _pytest.compat import cached_property
 from _pytest.compat import get_real_func
 from _pytest.compat import is_generator
 from _pytest.compat import safe_getattr
@@ -178,3 +179,23 @@ def test_safe_isclass():
             assert False, "Should be ignored"
 
     assert safe_isclass(CrappyClass()) is False
+
+
+def test_cached_property() -> None:
+    ncalls = 0
+
+    class Class:
+        @cached_property
+        def prop(self) -> int:
+            nonlocal ncalls
+            ncalls += 1
+            return ncalls
+
+    c1 = Class()
+    assert ncalls == 0
+    assert c1.prop == 1
+    assert c1.prop == 1
+    c2 = Class()
+    assert ncalls == 1
+    assert c2.prop == 2
+    assert c1.prop == 1


### PR DESCRIPTION
This is a useful utility to abstract the caching property idiom.

It is in compat.py since eventually it will be replaced by
functools.cached_property.

Fixes #6131.