### PR TITLE
use __name__ attribute in the parametrize id for modules as well

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -103,6 +103,7 @@ George Kussumoto
 Georgy Dyuldin
 Graham Horler
 Greg Price
+Gregory Lee
 Grig Gheorghiu
 Grigorii Eremeev (budulianin)
 Guido Wesdorp

--- a/changelog/6152.improvement.rst
+++ b/changelog/6152.improvement.rst
@@ -1,0 +1,1 @@
+Now parametrization will use the ``__name__`` attribute of any object for the id, if present. Previously it would only use ``__name__`` for functions and classes.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1162,7 +1162,8 @@ def _idval(val, argname, idx, idfn, item, config):
         return ascii_escaped(val.pattern)
     elif isinstance(val, enum.Enum):
         return str(val)
-    elif (inspect.isclass(val) or inspect.isfunction(val)) and hasattr(val, "__name__"):
+    elif hasattr(val, "__name__") and isinstance(val.__name__, str):
+        # name of a class, function, module, etc.
         return val.__name__
     return str(argname) + str(idx)
 

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -314,6 +314,21 @@ def test_keyword_option_parametrize(spec, testdir):
     assert list(passed) == list(passed_result)
 
 
+def test_parametrize_with_module(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        @pytest.mark.parametrize("arg", [pytest,])
+        def test_func(arg):
+            pass
+    """
+    )
+    rec = testdir.inline_run()
+    passed, skipped, fail = rec.listoutcomes()
+    expected_id = "test_func[" + pytest.__name__ + "]"
+    assert passed[0].nodeid.split("::")[-1] == expected_id
+
+
 @pytest.mark.parametrize(
     "spec",
     [


### PR DESCRIPTION
`pytest.mark.parametrize` will currently use the name of a function or class as the parameter "id" by default. This PR extends this behavior to modules (or other objects defining `__name__`) as well.

An alternative implementation would have been to add an (`or inspect.ismodule(var)`) to the existing case, but I thought perhaps there may be other objects with `__name__` as well that could benefit from this behavior.

A concrete use case where I wanted these was for some tests that parametrize using different numerical array modules with matching API (NumPy and CuPy). It is preferable for the name of the module to show up in the id rather than "module0" or similar.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.
(please delete this text from the final description, this is just a guideline)
-->

- [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ x ] Target the `features` branch for new features, improvements, and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ x ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g.,  a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [ x ] Add yourself to `AUTHORS` in alphabetical order;
