### PR TITLE
[RFC/WIP] do not collect dunder attributes

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -369,6 +369,8 @@ class PyCollector(PyobjMixin, nodes.Collector):
             for name, obj in list(dic.items()):
                 if name in seen:
                     continue
+                if name.startswith("__"):
+                    continue
                 seen[name] = True
                 res = self._makeitem(name, obj)
                 if res is None:


### PR DESCRIPTION
At least `__builtins__` should be skipped / not be contained as a whole
in `ParsedCall`s `__repr__` then.

(cherry picked from commit d08c96e099c31f5d049a188a0666c34995f73a73)