### PR TITLE
pytester: use no colors with inline runs by default

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -544,11 +544,12 @@ class Testdir:
         mp.delenv("TOX_ENV_DIR", raising=False)
         # Discard outer pytest options.
         mp.delenv("PYTEST_ADDOPTS", raising=False)
-
-        # Environment (updates) for inner runs.
+        # Ensure no user config is used.
         tmphome = str(self.tmpdir)
         mp.setenv("HOME", tmphome)
         mp.setenv("USERPROFILE", tmphome)
+        # Do not use colors for inner runs by default.
+        mp.setenv("PY_COLORS", "0")
 
     def __repr__(self):
         return "<Testdir {!r}>".format(self.tmpdir)

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -193,7 +193,7 @@ class TestPDB:
         )
         child = testdir.spawn_pytest("-rs --pdb %s" % p1)
         child.expect("Skipping also with pdb active")
-        child.expect_exact("= \x1b[33m\x1b[1m1 skipped\x1b[0m\x1b[33m in")
+        child.expect_exact("= 1 skipped in")
         child.sendeof()
         self.flush(child)
 
@@ -221,7 +221,7 @@ class TestPDB:
         child.sendeof()
         rest = child.read().decode("utf8")
         assert "Exit: Quitting debugger" in rest
-        assert "= \x1b[31m\x1b[1m1 failed\x1b[0m\x1b[31m in" in rest
+        assert "= 1 failed in" in rest
         assert "def test_1" not in rest
         assert "get rekt" not in rest
         self.flush(child)
@@ -506,7 +506,7 @@ class TestPDB:
         rest = child.read().decode("utf8")
 
         assert "! _pytest.outcomes.Exit: Quitting debugger !" in rest
-        assert "= \x1b[33mno tests ran\x1b[0m\x1b[33m in" in rest
+        assert "= no tests ran in" in rest
         assert "BdbQuit" not in rest
         assert "UNEXPECTED EXCEPTION" not in rest
 
@@ -725,7 +725,7 @@ class TestPDB:
             assert "> PDB continue (IO-capturing resumed) >" in rest
         else:
             assert "> PDB continue >" in rest
-        assert "= \x1b[32m\x1b[1m1 passed\x1b[0m\x1b[32m in" in rest
+        assert "= 1 passed in" in rest
 
     def test_pdb_used_outside_test(self, testdir):
         p1 = testdir.makepyfile(
@@ -1041,7 +1041,7 @@ class TestTraceOption:
         child.sendline("q")
         child.expect_exact("Exit: Quitting debugger")
         rest = child.read().decode("utf8")
-        assert "= \x1b[32m\x1b[1m2 passed\x1b[0m\x1b[32m in" in rest
+        assert "= 2 passed in" in rest
         assert "reading from stdin while output" not in rest
         # Only printed once - not on stderr.
         assert "Exit: Quitting debugger" not in child.before.decode("utf8")
@@ -1086,7 +1086,7 @@ class TestTraceOption:
             child.sendline("c")
             child.expect_exact("> PDB continue (IO-capturing resumed) >")
         rest = child.read().decode("utf8")
-        assert "= \x1b[32m\x1b[1m6 passed\x1b[0m\x1b[32m in" in rest
+        assert "= 6 passed in" in rest
         assert "reading from stdin while output" not in rest
         # Only printed once - not on stderr.
         assert "Exit: Quitting debugger" not in child.before.decode("utf8")
@@ -1197,7 +1197,7 @@ def test_pdb_suspends_fixture_capturing(testdir, fixture):
 
     TestPDB.flush(child)
     assert child.exitstatus == 0
-    assert "= \x1b[32m\x1b[1m1 passed\x1b[0m\x1b[32m in" in rest
+    assert "= 1 passed in" in rest
     assert "> PDB continue (IO-capturing resumed for fixture %s) >" % (fixture) in rest
 
 

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -154,6 +154,8 @@ class TestTerminal:
                 "test2.py": "def test_2(): pass",
             }
         )
+        # Explicitly test colored output.
+        testdir.monkeypatch.setenv("PY_COLORS", "1")
 
         child = testdir.spawn_pytest("-v test1.py test2.py")
         child.expect(r"collecting \.\.\.")


### PR DESCRIPTION
Sets `PY_COLORS=0` in the environment by default, which is used by pylib.

Via https://github.com/blueyed/pytest/pull/58