### PR TITLE
Delineate syntactically that the 'match' argument to 'raises' is keyword-only

### DIFF
--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -59,7 +59,7 @@ pytest.raises
 
 **Tutorial**: :ref:`assertraises`.
 
-.. autofunction:: pytest.raises(expected_exception: Exception, [match])
+.. autofunction:: pytest.raises(expected_exception: Exception [, *, match])
     :with: excinfo
 
 pytest.deprecated_call


### PR DESCRIPTION
Closes #6158 
