### PR TITLE
Show a better message when 'request' is used in parametrize

### DIFF
--- a/changelog/6183.bugfix.rst
+++ b/changelog/6183.bugfix.rst
@@ -1,0 +1,2 @@
+Using ``request`` as a parameter name in ``@pytest.mark.parametrize`` now produces a more
+user-friendly error.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -977,6 +977,12 @@ class Metafunc(fixtures.FuncargnamesCompatAttr):
         )
         del argvalues
 
+        if "request" in argnames:
+            fail(
+                "'request' is a reserved name and cannot be used in @pytest.mark.parametrize",
+                pytrace=False,
+            )
+
         if scope is None:
             scope = _find_parametrized_scope(argnames, self._arg2fixturedefs, indirect)
 

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -72,6 +72,19 @@ class TestMetafunc:
         ):
             metafunc.parametrize("x", [1], scope="doggy")
 
+    def test_parametrize_request_name(self, testdir):
+        """Show proper error  when 'request' is used as a parameter name in parametrize (#6183)"""
+
+        def func(request):
+            raise NotImplementedError()
+
+        metafunc = self.Metafunc(func)
+        with pytest.raises(
+            pytest.fail.Exception,
+            match=r"'request' is a reserved name and cannot be used in @pytest.mark.parametrize",
+        ):
+            metafunc.parametrize("request", [1])
+
     def test_find_parametrized_scope(self):
         """unittest for _find_parametrized_scope (#3941)"""
         from _pytest.python import _find_parametrized_scope


### PR DESCRIPTION
Fix #6183
