### PR TITLE
Import Path from _pytest.pathlib for py35

### DIFF
--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -13,7 +13,6 @@ import struct
 import sys
 import tokenize
 import types
-from pathlib import Path
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -28,6 +27,7 @@ from _pytest.assertion.util import (  # noqa: F401
 )
 from _pytest.compat import fspath
 from _pytest.pathlib import fnmatch_ex
+from _pytest.pathlib import Path
 from _pytest.pathlib import PurePath
 
 # pytest caches rewritten pycs in pycache dirs

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -8,7 +8,6 @@ import sys
 import types
 import warnings
 from functools import lru_cache
-from pathlib import Path
 from types import TracebackType
 from typing import Any
 from typing import Callable
@@ -40,6 +39,7 @@ from _pytest._code import filter_traceback
 from _pytest.compat import importlib_metadata
 from _pytest.outcomes import fail
 from _pytest.outcomes import Skipped
+from _pytest.pathlib import Path
 from _pytest.warning_types import PytestConfigWarning
 
 if False:  # TYPE_CHECKING

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -9,7 +9,6 @@ import sys
 import textwrap
 import zipfile
 from functools import partial
-from pathlib import Path
 
 import py
 
@@ -23,6 +22,7 @@ from _pytest.assertion.rewrite import PYC_TAIL
 from _pytest.assertion.rewrite import PYTEST_TAG
 from _pytest.assertion.rewrite import rewrite_asserts
 from _pytest.main import ExitCode
+from _pytest.pathlib import Path
 
 
 def setup_module(mod):

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import textwrap
-from pathlib import Path
 
 import _pytest._code
 import pytest
@@ -13,6 +12,7 @@ from _pytest.config.findpaths import determine_setup
 from _pytest.config.findpaths import get_common_ancestor
 from _pytest.config.findpaths import getcfg
 from _pytest.main import ExitCode
+from _pytest.pathlib import Path
 
 
 class TestParseIni:

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -1,12 +1,12 @@
 import os
 import textwrap
-from pathlib import Path
 
 import py
 
 import pytest
 from _pytest.config import PytestPluginManager
 from _pytest.main import ExitCode
+from _pytest.pathlib import Path
 
 
 def ConftestWithSetinitial(path):

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1,7 +1,6 @@
 import os
 import platform
 from datetime import datetime
-from pathlib import Path
 from xml.dom import minidom
 
 import py
@@ -9,6 +8,7 @@ import xmlschema
 
 import pytest
 from _pytest.junitxml import LogXML
+from _pytest.pathlib import Path
 from _pytest.reports import BaseReport
 
 


### PR DESCRIPTION
This is important for `isinstance` checks etc.

TODO:

~~- [ ] after #6192 (conflicts there, https://github.com/pytest-dev/pytest/pull/6192/files#diff-af40f12336a069d7f9538cf71a4010ecL2)~~