### PR TITLE
tests: revisit test_cacheprovider

### DIFF
--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -59,7 +59,8 @@ class TestNewAPI:
     @pytest.mark.filterwarnings(
         "ignore:could not create cache path:pytest.PytestWarning"
     )
-    def test_cache_failure_warns(self, testdir):
+    def test_cache_failure_warns(self, testdir, monkeypatch):
+        monkeypatch.setenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
         cache_dir = str(testdir.tmpdir.ensure_dir(".pytest_cache"))
         mode = os.stat(cache_dir)[stat.ST_MODE]
         testdir.tmpdir.ensure_dir(".pytest_cache").chmod(0)

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -253,7 +253,7 @@ def test_cache_show(testdir):
 
 class TestLastFailed:
     def test_lastfailed_usecase(self, testdir, monkeypatch):
-        monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", "1")
+        monkeypatch.setattr("sys.dont_write_bytecode", True)
         p = testdir.makepyfile(
             """
             def test_1():
@@ -345,7 +345,7 @@ class TestLastFailed:
         result.stdout.no_fnmatch_line("*test_a.py*")
 
     def test_lastfailed_difference_invocations(self, testdir, monkeypatch):
-        monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", "1")
+        monkeypatch.setattr("sys.dont_write_bytecode", True)
         testdir.makepyfile(
             test_a="""\
             def test_a1():
@@ -379,7 +379,7 @@ class TestLastFailed:
         result.stdout.fnmatch_lines(["*1 failed*1 desel*"])
 
     def test_lastfailed_usecase_splice(self, testdir, monkeypatch):
-        monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", "1")
+        monkeypatch.setattr("sys.dont_write_bytecode", True)
         testdir.makepyfile(
             """\
             def test_1():


### PR DESCRIPTION
- Setting PYTHONDONTWRITEBYTECODE in the environment does not change it
for the current process.
- Revisit tests in general, mainly formatting.