### PR TITLE
Fix --setup-plan fixture lifetimes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -128,6 +128,7 @@ Jeff Widman
 Jenni Rinker
 John Eddie Ayson
 John Towler
+Josh Karpel
 Jon Sonesen
 Jonas Obrist
 Jordan Guymon

--- a/AUTHORS
+++ b/AUTHORS
@@ -128,13 +128,13 @@ Jeff Widman
 Jenni Rinker
 John Eddie Ayson
 John Towler
-Josh Karpel
 Jon Sonesen
 Jonas Obrist
 Jordan Guymon
 Jordan Moldow
 Jordan Speicher
 Joseph Hunkeler
+Josh Karpel
 Joshua Bronson
 Jurko Gospodnetić
 Justyna Janczyszyn

--- a/changelog/2049.bugfix.rst
+++ b/changelog/2049.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``-setup-plan`` showing inaccurate information about fixture lifetimes.

--- a/src/_pytest/setupplan.py
+++ b/src/_pytest/setupplan.py
@@ -16,7 +16,8 @@ def pytest_addoption(parser):
 def pytest_fixture_setup(fixturedef, request):
     # Will return a dummy fixture if the setuponly option is provided.
     if request.config.option.setupplan:
-        fixturedef.cached_result = (None, None, None)
+        my_cache_key = fixturedef.cache_key(request)
+        fixturedef.cached_result = (None, my_cache_key, None)
         return fixturedef.cached_result
 
 

--- a/testing/python/setup_plan.py
+++ b/testing/python/setup_plan.py
@@ -35,15 +35,12 @@ def test_show_multi_test_fixture_setup_and_teardown_correctly_simple(testdir):
     testdir.makepyfile(
         """
         import pytest
-        
         @pytest.fixture(scope = 'class')
         def fix():
             return object()
-            
         class TestClass:
             def test_one(self, fix):
                 assert False
-            
             def test_two(self, fix):
                 assert False
     """
@@ -77,32 +74,23 @@ def test_show_multi_test_fixture_setup_and_teardown_same_as_setup_show(testdir):
     testdir.makepyfile(
         """
         import pytest
-        
         @pytest.fixture(scope = 'session')
         def sess():
             return True
-        
         @pytest.fixture(scope = 'module')
         def mod():
             return True
-        
         @pytest.fixture(scope = 'class')
         def cls():
             return True
-        
         @pytest.fixture(scope = 'function')
         def func():
             return True
-        
-        
         def test_outside(sess, mod, cls, func):
             assert True
-        
-        
         class TestCls:
             def test_one(self, sess, mod, cls, func):
                 assert True
-        
             def test_two(self, sess, mod, cls, func):
                 assert True
     """

--- a/testing/python/setup_plan.py
+++ b/testing/python/setup_plan.py
@@ -17,3 +17,106 @@ def test_show_fixtures_and_test(testdir, dummy_yaml_custom_test):
     result.stdout.fnmatch_lines(
         ["*SETUP    F arg*", "*test_arg (fixtures used: arg)", "*TEARDOWN F arg*"]
     )
+
+
+def test_show_multi_test_fixture_setup_and_teardown_correctly_simple(testdir):
+    """
+    Verify that when a fixture lives for longer than a single test, --setup-plan
+    correctly displays the SETUP/TEARDOWN indicators the right number of times.
+
+    As reported in https://github.com/pytest-dev/pytest/issues/2049
+    --setup-plan was showing SETUP/TEARDOWN on every test, even when the fixture
+    should persist through multiple tests.
+
+    (Note that this bug never affected actual test execution, which used the
+    correct fixture lifetimes. It was purely a display bug for --setup-plan, and
+    did not affect the related --setup-show or --setup-only.)
+    """
+    testdir.makepyfile(
+        """
+        import pytest
+        
+        @pytest.fixture(scope = 'class')
+        def fix():
+            return object()
+            
+        class TestClass:
+            def test_one(self, fix):
+                assert False
+            
+            def test_two(self, fix):
+                assert False
+    """
+    )
+
+    result = testdir.runpytest("--setup-plan")
+    assert result.ret == 0
+
+    setup_fragment = "SETUP    C fix"
+    setup_count = 0
+
+    teardown_fragment = "TEARDOWN C fix"
+    teardown_count = 0
+
+    for line in result.stdout.lines:
+        if setup_fragment in line:
+            setup_count += 1
+        if teardown_fragment in line:
+            teardown_count += 1
+
+    # before the fix this tests, there would have been a setup/teardown
+    # message for each test, so the counts would each have been 2
+    assert setup_count == 1
+    assert teardown_count == 1
+
+
+def test_show_multi_test_fixture_setup_and_teardown_same_as_setup_show(testdir):
+    """
+    Verify that SETUP/TEARDOWN messages match what comes out of --setup-show.
+    """
+    testdir.makepyfile(
+        """
+        import pytest
+        
+        @pytest.fixture(scope = 'session')
+        def sess():
+            return True
+        
+        @pytest.fixture(scope = 'module')
+        def mod():
+            return True
+        
+        @pytest.fixture(scope = 'class')
+        def cls():
+            return True
+        
+        @pytest.fixture(scope = 'function')
+        def func():
+            return True
+        
+        
+        def test_outside(sess, mod, cls, func):
+            assert True
+        
+        
+        class TestCls:
+            def test_one(self, sess, mod, cls, func):
+                assert True
+        
+            def test_two(self, sess, mod, cls, func):
+                assert True
+    """
+    )
+
+    plan_result = testdir.runpytest("--setup-plan")
+    show_result = testdir.runpytest("--setup-show")
+
+    # the number and text of these lines should be identical
+    plan_lines = [
+        l for l in plan_result.stdout.lines if "SETUP" in l or "TEARDOWN" in l
+    ]
+    show_lines = [
+        l for l in show_result.stdout.lines if "SETUP" in l or "TEARDOWN" in l
+    ]
+
+    assert plan_lines == show_lines


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features, improvements, and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

This PR fixes #2049 by setting the `fixturedef` cache key in the dummy fixture result used when `--setup-plan` runs (the current implementation does not). This makes the printing of the `SETUP`/`TEARDOWN` messages obey the fixture lifetimes as expected (and as already correctly happens with `--setup-show`).

I added two tests, but they're both rather crude. One just sets up a simple class-scoped fixture and checks that the correct number of messages appear. The other checks that the printed output of `--setup-show` and `--setup-plan` agree on the ordering and number of messages. I don't know if there any good idioms for this kind of thing in the test suite already. Happy to make changes if they're not up to snuff!