### PR TITLE
mypy: config: use mypy_path=src

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ ignore =
 formats = sdist.tgz,bdist_wheel
 
 [mypy]
+mypy_path = src
 ignore_missing_imports = True
 no_implicit_optional = True
 strict_equality = True


### PR DESCRIPTION
This allows for checking files inside of "testing" without having
"src/…" as an argument also.

Related: https://github.com/python/mypy/issues/7967, https://github.com/python/mypy/issues/7968.