### PR TITLE
_format_assertmsg: use safeformat instead of saferepr

### DIFF
--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -19,6 +19,7 @@ from typing import Optional
 from typing import Set
 from typing import Tuple
 
+from _pytest._io.saferepr import safeformat
 from _pytest._io.saferepr import saferepr
 from _pytest._version import version
 from _pytest.assertion import util
@@ -381,8 +382,7 @@ def _format_assertmsg(obj):
 
     For strings this simply replaces newlines with '\n~' so that
     util.format_explanation() will preserve them instead of escaping
-    newlines.  For other objects saferepr() is used first.
-
+    newlines.  For other objects ``safeformat()`` is used first.
     """
     # reprlib appears to have a bug which means that if a string
     # contains a newline it gets escaped, however if an object has a
@@ -390,8 +390,7 @@ def _format_assertmsg(obj):
     # However in either case we want to preserve the newline.
     replaces = [("\n", "\n~"), ("%", "%%")]
     if not isinstance(obj, str):
-        obj = saferepr(obj)
-        replaces.append(("\\n", "\n~"))
+        obj = safeformat(obj).replace("\\n", "\n~")
 
     for r1, r2 in replaces:
         obj = obj.replace(r1, r2)

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -72,10 +72,11 @@ class TestImportHookInstallation:
         result = testdir.runpytest_subprocess()
         result.stdout.fnmatch_lines(
             [
-                "E * AssertionError: ([[][]], [[][]], [[]<TestReport *>[]])*",
-                "E * assert"
-                " {'failed': 1, 'passed': 0, 'skipped': 0} =="
-                " {'failed': 0, 'passed': 1, 'skipped': 0}",
+                ">       r.assertoutcome(passed=1)",
+                "E       AssertionError: ([],",
+                "E          [],",
+                "E          [<TestReport 'test_dummy_failure.py::test' when='call' outcome='failed'>])",
+                "E       assert {'failed': 1, 'passed': 0, 'skipped': 0} == {'failed': 0, 'passed': 1, 'skipped': 0}",
             ]
         )
 
@@ -1287,15 +1288,30 @@ def test_AssertionError_message(testdir):
         def test_hello():
             x,y = 1,2
             assert 0, (x,y)
+
+        def test_bytes():
+            assert 0, b'b' * 80
     """
     )
     result = testdir.runpytest()
     result.stdout.fnmatch_lines(
-        """
-        *def test_hello*
-        *assert 0, (x,y)*
-        *AssertionError: (1, 2)*
-    """
+        [
+            "    def test_hello():",
+            "        x,y = 1,2",
+            ">       assert 0, (x,y)",
+            "E       AssertionError: (1, 2)",
+            "E       assert 0",
+            "",
+            "test_AssertionError_message.py:3: AssertionError",
+            "    def test_bytes():",
+            ">       assert 0, b'b' * 80",
+            "E       AssertionError: (b'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'",
+            "E          b'bbbb')",
+            "E       assert 0",
+            "",
+            "test_AssertionError_message.py:6: AssertionError",
+            "*= 2 failed in *",
+        ]
     )
 
 


### PR DESCRIPTION
Custom assertion messages should not get shortened via `saferepr`.

Via https://github.com/blueyed/pytest/pull/125.
Fixes https://github.com/pytest-dev/pytest/issues/5199.