### PR TITLE
Revert "ci: use tox -vv"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ before_script:
       export _PYTEST_TOX_EXTRA_DEP=coverage-enable-subprocess
     fi
 
-script: tox -vv
+script: tox
 
 after_success:
   - |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
         export COVERAGE_FILE="$PWD/.coverage"
         export COVERAGE_PROCESS_START="$PWD/.coveragerc"
       fi
-      python -m tox -e $(tox.env) -vv
+      python -m tox -e $(tox.env)
     displayName: 'Run tests'
 
   - task: PublishTestResults@2


### PR DESCRIPTION
`tox -vv` is too verbose, and was only used as a hack to get the output
of durations.

As for information in logs `-v` could be used maybe still, but I've
decided to revert it for now.

This reverts commit 56cec5fa79106c0e8c02eb34bd8e5768ec52044d.