### PR TITLE
python: remove unused pytest_make_parametrize_id hookimpl

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -241,10 +241,6 @@ def pytest_pycollect_makeitem(collector, name, obj):
             outcome.force_result(res)
 
 
-def pytest_make_parametrize_id(config, val, argname=None):
-    return None
-
-
 class PyobjContext:
     module = pyobj_property("Module")
     cls = pyobj_property("Class")


### PR DESCRIPTION
Added in 79927428d initially, but never used.