### PR TITLE
Improve check for misspelling of parametrize

### DIFF
--- a/changelog/6231.improvement.rst
+++ b/changelog/6231.improvement.rst
@@ -1,0 +1,1 @@
+Improve check for misspelling of ``pytest.mark.parametrize``.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -314,13 +314,18 @@ class MarkGenerator:
                         "{!r} not found in `markers` configuration option".format(name),
                         pytrace=False,
                     )
-                else:
-                    warnings.warn(
-                        "Unknown pytest.mark.%s - is this a typo?  You can register "
-                        "custom marks to avoid this warning - for details, see "
-                        "https://docs.pytest.org/en/latest/mark.html" % name,
-                        PytestUnknownMarkWarning,
-                    )
+
+                # Raise a specific error for common misspellings of "parametrize".
+                if name in ["parameterize", "parametrise", "parameterise"]:
+                    __tracebackhide__ = True
+                    fail("Unknown '{}' mark, did you mean 'parametrize'?".format(name))
+
+                warnings.warn(
+                    "Unknown pytest.mark.%s - is this a typo?  You can register "
+                    "custom marks to avoid this warning - for details, see "
+                    "https://docs.pytest.org/en/latest/mark.html" % name,
+                    PytestUnknownMarkWarning,
+                )
 
         return MarkDecorator(Mark(name, (), {}))
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -120,17 +120,7 @@ def pytest_cmdline_main(config):
         return 0
 
 
-def _validate_parametrize_spelling(metafunc):
-    """Raise a specific error for common misspellings of "parametrize"."""
-    for mark_name in ["parameterize", "parametrise", "parameterise"]:
-        if metafunc.definition.get_closest_marker(mark_name):
-            msg = "{0} has '{1}' mark, spelling should be 'parametrize'"
-            fail(msg.format(metafunc.function.__name__, mark_name), pytrace=False)
-
-
 def pytest_generate_tests(metafunc):
-    _validate_parametrize_spelling(metafunc)
-
     for marker in metafunc.definition.iter_markers(name="parametrize"):
         metafunc.parametrize(*marker.args, **marker.kwargs)
 

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1323,25 +1323,29 @@ class TestMetafuncFunctional:
         reprec = testdir.runpytest()
         reprec.assert_outcomes(passed=4)
 
-    @pytest.mark.parametrize("attr", ["parametrise", "parameterize", "parameterise"])
-    def test_parametrize_misspelling(self, testdir, attr):
+    def test_parametrize_misspelling(self, testdir):
         """#463"""
         testdir.makepyfile(
             """
             import pytest
 
-            @pytest.mark.{}("x", range(2))
+            @pytest.mark.parametrise("x", range(2))
             def test_foo(x):
                 pass
-        """.format(
-                attr
-            )
+        """
         )
         result = testdir.runpytest("--collectonly")
         result.stdout.fnmatch_lines(
             [
-                "test_foo has '{}' mark, spelling should be 'parametrize'".format(attr),
-                "*1 error in*",
+                "collected 0 items / 1 error",
+                "",
+                "*= ERRORS =*",
+                "*_ ERROR collecting test_parametrize_misspelling.py _*",
+                "test_parametrize_misspelling.py:3: in <module>",
+                '    @pytest.mark.parametrise("x", range(2))',
+                "E   Failed: Unknown 'parametrise' mark, did you mean 'parametrize'?",
+                "*! Interrupted: 1 error during collection !*",
+                "*= 1 error in *",
             ]
         )
 


### PR DESCRIPTION
- there is no need to do this with `--strict-markers`
- it can be done when looking up marks, instead of for every generated
  test

TODO:
- [x] changelog