### PR TITLE
docs: configure default_role=literal

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,10 +37,6 @@ repos:
     hooks:
     -   id: pyupgrade
         args: [--py3-plus]
--   repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.4.0
-    hooks:
-    -   id: rst-backticks
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.740
     hooks:

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -92,7 +92,7 @@ exclude_patterns = [
 
 
 # The reST default role (used for this markup: `text`) to use for all documents.
-# default_role = None
+default_role = "literal"
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 # add_function_parentheses = True


### PR DESCRIPTION
This configures the default role for interpreted text (single
backticks), avoiding the need to check for / enforce double backticks.

Fixes also one instance in the existing changelog:

    - Detect `pytest_` prefixed hooks using the internal plugin manager since
      ``pluggy`` is deprecating the ``implprefix`` argument to ``PluginManager``.
      (`#3487 <https://github.com/pytest-dev/pytest/issues/3487>`_)