### PR TITLE
pytester: LineMatcher: __tracebackhide__ with _fail

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1481,6 +1481,7 @@ class LineMatcher:
         self._log_output = []
 
     def _fail(self, msg):
+        __tracebackhide__ = True
         log_text = self._log_text
         self._log_output = []
         pytest.fail(log_text)


### PR DESCRIPTION
Follow-up to 2228ccb (gone lost in resolving the conflict).