### PR TITLE
Issue 1120 (Cleaning up tmpdir's)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,6 +47,7 @@ Brian Maissy
 Brian Okken
 Brianna Laugher
 Bruno Oliveira
+Caitlin Macleod
 Cal Leeming
 Carl Friedrich Bolz
 Carlos Jenkins

--- a/AUTHORS
+++ b/AUTHORS
@@ -177,6 +177,7 @@ Matt Williams
 Matthias Hafner
 Maxim Filipenko
 mbyt
+Michael Abel
 Michael Aquilina
 Michael Birtwell
 Michael Droettboom

--- a/changelog/1120.bugfix.rst
+++ b/changelog/1120.bugfix.rst
@@ -1,0 +1,2 @@
+Fix issue where directories from ``tmpdir`` are not removed properly when
+multiple instances of pytest are running in parallel.

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -301,11 +301,13 @@ def make_numbered_dir_with_cleanup(
             p = make_numbered_dir(root, prefix)
             consider_lock_dead_if_created_before = p.stat().st_mtime - lock_timeout
             lock_path = create_cleanup_lock(p)
+            # Register a cleanup for program exit
             atexit.register(cleanup_numbered_dir, root, prefix, keep, consider_lock_dead_if_created_before)
             register_cleanup_lock_removal(lock_path)
         except Exception as exc:
             e = exc
         else:
+            # Cleanup now at the beginning of the test execution
             cleanup_numbered_dir(
                 root=root,
                 prefix=prefix,

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -296,19 +296,19 @@ def make_numbered_dir_with_cleanup(
 ) -> Path:
     """creates a numbered dir with a cleanup lock and removes old ones"""
     e = None
+    # Register a cleanup for program exit
+    consider_lock_dead_if_created_before = p.stat().st_mtime - lock_timeout
+    atexit.register(
+        cleanup_numbered_dir,
+        root,
+        prefix,
+        keep,
+        consider_lock_dead_if_created_before,
+    )
     for i in range(10):
         try:
             p = make_numbered_dir(root, prefix)
-            consider_lock_dead_if_created_before = p.stat().st_mtime - lock_timeout
             lock_path = create_cleanup_lock(p)
-            # Register a cleanup for program exit
-            atexit.register(
-                cleanup_numbered_dir,
-                root,
-                prefix,
-                keep,
-                consider_lock_dead_if_created_before,
-            )
             register_cleanup_lock_removal(lock_path)
         except Exception as exc:
             e = exc

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -299,12 +299,13 @@ def make_numbered_dir_with_cleanup(
     for i in range(10):
         try:
             p = make_numbered_dir(root, prefix)
+            consider_lock_dead_if_created_before = p.stat().st_mtime - lock_timeout
             lock_path = create_cleanup_lock(p)
+            atexit.register(cleanup_numbered_dir, root, prefix, keep, consider_lock_dead_if_created_before)
             register_cleanup_lock_removal(lock_path)
         except Exception as exc:
             e = exc
         else:
-            consider_lock_dead_if_created_before = p.stat().st_mtime - lock_timeout
             cleanup_numbered_dir(
                 root=root,
                 prefix=prefix,

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -307,13 +307,6 @@ def make_numbered_dir_with_cleanup(
         except Exception as exc:
             e = exc
         else:
-            # Cleanup now at the beginning of the test execution
-            cleanup_numbered_dir(
-                root=root,
-                prefix=prefix,
-                keep=keep,
-                consider_lock_dead_if_created_before=consider_lock_dead_if_created_before,
-            )
             return p
     assert e is not None
     raise e

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -302,7 +302,13 @@ def make_numbered_dir_with_cleanup(
             consider_lock_dead_if_created_before = p.stat().st_mtime - lock_timeout
             lock_path = create_cleanup_lock(p)
             # Register a cleanup for program exit
-            atexit.register(cleanup_numbered_dir, root, prefix, keep, consider_lock_dead_if_created_before)
+            atexit.register(
+                cleanup_numbered_dir,
+                root,
+                prefix,
+                keep,
+                consider_lock_dead_if_created_before,
+            )
             register_cleanup_lock_removal(lock_path)
         except Exception as exc:
             e = exc


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features, improvements, and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
-->

Hi folks,

I have rebased the bugfix @bitmuster which closes #1120, including moving the at_exit registration outside a loop it didn't need to be in. The registration will be called once regardless of how the creation or exceptions in the area go.

Mostly prepared by @bitmuster, chatted in person with @Zac-HD.