### PR TITLE
Remove sys.last_traceback attribute using del instead of setting to None

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -165,6 +165,7 @@ Marcelo Duarte Trevisani
 Marcin Bachry
 Marco Gorelli
 Mark Abramowitz
+Mark Dickinson
 Markus Unterwaditzer
 Martijn Faassen
 Martin Altmayer

--- a/changelog/6255.bugfix.rst
+++ b/changelog/6255.bugfix.rst
@@ -1,0 +1,3 @@
+Clear the ``sys.last_traceback``, ``sys.last_type`` and ``sys.last_value``
+attributes by deleting them instead of setting them to ``None``. This better
+matches the behaviour of the Python standard library.

--- a/changelog/6255.bugfix.rst
+++ b/changelog/6255.bugfix.rst
@@ -1,3 +1,4 @@
-Clear the ``sys.last_traceback``, ``sys.last_type`` and ``sys.last_value``
-attributes by deleting them instead of setting them to ``None``. This better
-matches the behaviour of the Python standard library.
+Clear the :py:attr:`sys.last_traceback`, :py:attr:`sys.last_type`
+and :py:attr:`sys.last_value` attributes by deleting them instead
+of setting them to ``None``. This better matches the behaviour of
+the Python standard library.

--- a/changelog/6255.bugfix.rst
+++ b/changelog/6255.bugfix.rst
@@ -1,4 +1,3 @@
-Clear the :py:attr:`sys.last_traceback`, :py:attr:`sys.last_type`
-and :py:attr:`sys.last_value` attributes by deleting them instead
-of setting them to ``None``. This better matches the behaviour of
-the Python standard library.
+Clear the ``sys.last_traceback``, ``sys.last_type`` and ``sys.last_value``
+attributes by deleting them instead of setting them to ``None``. This better
+matches the behaviour of the Python standard library.

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -121,7 +121,12 @@ def pytest_runtest_setup(item):
 
 def pytest_runtest_call(item):
     _update_current_test_var(item, "call")
-    sys.last_type, sys.last_value, sys.last_traceback = (None, None, None)
+    try:
+        del sys.last_type
+        del sys.last_value
+        del sys.last_traceback
+    except AttributeError:
+        pass
     try:
         item.runtest()
     except Exception:

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -900,9 +900,9 @@ def test_store_except_info_on_error():
     # The next run should clear the exception info stored by the previous run
     ItemMightRaise.raise_error = False
     runner.pytest_runtest_call(ItemMightRaise())
-    assert sys.last_type is None
-    assert sys.last_value is None
-    assert sys.last_traceback is None
+    assert not hasattr(sys, "last_type")
+    assert not hasattr(sys, "last_value")
+    assert not hasattr(sys, "last_traceback")
 
 
 def test_current_test_env_var(testdir, monkeypatch):


### PR DESCRIPTION
Existing code in the test runner clears the `sys.last_traceback`, `sys.last_type` and `sys.last_exc` attributes by setting them to `None`. This PR changes that code to delete these attributes using `del` instead.

Rationale:

- In the (presumably common and desirable) case that there were no exceptions, this ensures that the state of this particular part of `sys` module is unchanged by the test run. (Going from the attribute not existing to it existing but being `None` is a change, albeit a fairly benign one.)
- This better matches the behaviour of the Python standard library: in the (very) few places where CPython clears these attributes, it uses `del`.
- In general, we want to restrict the possible states of `sys.last_traceback` (for example) to just two: either the attribute doesn't exist, or it does exist and it's a genuine traceback. Allowing `None` introduces a new third possible state that any user of `sys.last_traceback` needs to be aware of.

Fixes #6255.
