### PR TITLE
terminal: _get_main_color: help pytest-parallel

### DIFF
--- a/changelog/6254.bugfix.rst
+++ b/changelog/6254.bugfix.rst
@@ -1,0 +1,1 @@
+Fix compatibility with pytest-parallel (regression in pytest 5.3.0).

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1099,7 +1099,7 @@ def _get_main_color(stats) -> Tuple[str, List[str]]:
         "failed passed skipped deselected xfailed xpassed warnings error".split()
     )
     unknown_type_seen = False
-    for found_type in stats:
+    for found_type in stats.keys():
         if found_type not in known_types:
             if found_type:  # setup/teardown reports have an empty key, ignore them
                 known_types.append(found_type)


### PR DESCRIPTION
Use `dict.keys()` to work around `__iter__` not working with a
multiprocessing DictProxy.

Ref: https://github.com/python/cpython/pull/17333
Fixes https://github.com/pytest-dev/pytest/issues/6254.
Ref: https://github.com/browsertron/pytest-parallel/issues/36