### PR TITLE
tox: docs: --keep-going and posargs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -60,9 +60,8 @@ basepython = python3
 usedevelop = True
 changedir = doc/en
 deps = -r{toxinidir}/doc/en/requirements.txt
-
 commands =
-    sphinx-build -W -b html . _build
+    sphinx-build -W --keep-going -b html . _build {posargs:}
 
 [testenv:docs-checklinks]
 basepython = python3


### PR DESCRIPTION
`--keep-going` makes sense with `-W` to see all warnings/errors.

`{posargs:}` is useful for passing in custom args.