### PR TITLE
Bugfix 5430 pass logs to junit report

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,6 +61,7 @@ Christian Theunert
 Christian Tismer
 Christopher Gilling
 Christopher Dignam
+Claudio Madotto
 CrazyMerlyn
 Cyrus Maden
 Damian Skrzypczak

--- a/changelog/5430.bugfix.rst
+++ b/changelog/5430.bugfix.rst
@@ -1,0 +1,1 @@
+junitxml: Logs for failed test are now passed to junit report in case the test fails during call phase.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -591,7 +591,8 @@ class LogXML:
             if report.when == "call":
                 reporter.append_failure(report)
                 self.open_reports.append(report)
-                reporter.write_captured_output(report)
+                if not self.log_passing_tests:
+                    reporter.write_captured_output(report)
             else:
                 reporter.append_error(report)
         elif report.skipped:

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -591,6 +591,7 @@ class LogXML:
             if report.when == "call":
                 reporter.append_failure(report)
                 self.open_reports.append(report)
+                reporter.write_captured_output(report)
             else:
                 reporter.append_error(report)
         elif report.skipped:

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1477,3 +1477,45 @@ def test_logging_passing_tests_disabled_does_not_log_test_output(
     node = dom.find_first_by_tag("testcase")
     assert len(node.find_by_tag("system-err")) == 0
     assert len(node.find_by_tag("system-out")) == 0
+
+
+@parametrize_families
+@pytest.mark.parametrize("junit_logging", ["no", "system-out", "system-err"])
+def test_logging_passing_tests_disabled_logs_output_for_failing_test_issue5430(
+    testdir, junit_logging, run_and_parse, xunit_family
+):
+    testdir.makeini(
+        """
+        [pytest]
+        junit_log_passing_tests=False
+        junit_family={family}
+    """.format(
+            family=xunit_family
+        )
+    )
+    testdir.makepyfile(
+        """
+        import pytest
+        import logging
+        import sys
+
+        def test_func():
+            logging.warning('hello')
+            assert 0
+    """
+    )
+    result, dom = run_and_parse(
+        "-o", "junit_logging=%s" % junit_logging, family=xunit_family
+    )
+    assert result.ret == 1
+    node = dom.find_first_by_tag("testcase")
+    if junit_logging == "system-out":
+        assert len(node.find_by_tag("system-err")) == 0
+        assert len(node.find_by_tag("system-out")) == 1
+    elif junit_logging == "system-err":
+        assert len(node.find_by_tag("system-err")) == 1
+        assert len(node.find_by_tag("system-out")) == 0
+    else:
+        assert junit_logging == "no"
+        assert len(node.find_by_tag("system-err")) == 0
+        assert len(node.find_by_tag("system-out")) == 0


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features, improvements, and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
This PR fixes a bug that does not allow logs for failed test to be passed to junit report in case the test fails during the `call` phase.
