### PR TITLE
Display `session.shouldfail` with summary stats

### DIFF
--- a/changelog/6181.improvement.rst
+++ b/changelog/6181.improvement.rst
@@ -1,0 +1,1 @@
+The reason for a stopped session, e.g. with ``--maxfail`` / ``-x``, now gets reported in the test summary stats line.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -427,7 +427,9 @@ class Session(nodes.FSCollector):
             self.testsfailed += 1
             maxfail = self.config.getvalue("maxfail")
             if maxfail and self.testsfailed >= maxfail:
-                self.shouldfail = "stopping after %d failures" % (self.testsfailed)
+                self.shouldfail = "stopping after {} failure{}".format(
+                    self.testsfailed, "s" if self.testsfailed > 1 else ""
+                )
 
     pytest_collectreport = pytest_runtest_logreport
 

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -864,8 +864,7 @@ def test_exit_on_collection_with_maxfail_smaller_than_n_errors(testdir):
             "collected 1 item / 1 error",
             "*ERROR collecting test_02_import_error.py*",
             "*No module named *asdfa*",
-            "*! stopping after 1 failures !*",
-            "*= 1 error in *",
+            "*= 1 error in *s (stopping after 1 failure) =*",
         ]
     )
     res.stdout.no_fnmatch_line("*test_03*")

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -964,12 +964,36 @@ class TestGenericReporting:
         """
         )
         result = testdir.runpytest("--maxfail=2", *option.args)
+        if option.verbosity <= -1:
+            result.stdout.fnmatch_lines(
+                [
+                    "*def test_1():*",
+                    "*def test_2():*",
+                    "2 failed in *s (stopping after 2 failures)",
+                ]
+            )
+        else:
+            result.stdout.fnmatch_lines(
+                [
+                    "*def test_1():*",
+                    "*def test_2():*",
+                    "*= 2 failed in *s (stopping after 2 failures) =*",
+                ]
+            )
+
+    def test_maxfailures_veryquiet(self, testdir):
+        testdir.makepyfile(
+            """
+            def test_1(): assert 0
+            def test_2(): assert 0
+        """
+        )
+        result = testdir.runpytest("-x", "-qq")
         result.stdout.fnmatch_lines(
             [
                 "*def test_1():*",
-                "*def test_2():*",
-                "*! stopping after 2 failures !*",
-                "*2 failed*",
+                "test_maxfailures_veryquiet.py:1: AssertionError",
+                "!! stopping after 1 failure !!",
             ]
         )
 
@@ -986,9 +1010,8 @@ class TestGenericReporting:
             [
                 "*= short test summary info =*",
                 "FAILED *",
-                "*! stopping after 1 failures !*",
                 "*! session_interrupted !*",
-                "*= 1 failed in*",
+                "*= 1 failed in *s (stopping after 1 failure) =*",
             ]
         )
 


### PR DESCRIPTION
This makes it more pleasant with the typical use case of using `-x`.

Follow-up to https://github.com/pytest-dev/pytest/issues/6181 / b06f33f47.