### PR TITLE
Prepare for adding a py.typed file by moving pytest.py to a package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ platforms = unix, linux, osx, cygwin, win32
 [options]
 zip_safe = no
 packages =
+    pytest
     _pytest
     _pytest._code
     _pytest._io
@@ -39,7 +40,6 @@ packages =
     _pytest.config
     _pytest.mark
 
-py_modules = pytest
 python_requires = >=3.5
 
 [options.entry_points]

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -4,6 +4,7 @@ pytest: unit and functional testing with Python.
 """
 from _pytest import __version__
 from _pytest.assertion import register_assert_rewrite
+from _pytest.compat import _setup_collect_fakemodule
 from _pytest.config import cmdline
 from _pytest.config import hookimpl
 from _pytest.config import hookspec
@@ -93,14 +94,4 @@ __all__ = [
     "yield_fixture",
 ]
 
-if __name__ == "__main__":
-    # if run as a script or by 'python -m pytest'
-    # we trigger the below "else" condition by the following import
-    import pytest
-
-    raise SystemExit(pytest.main())
-else:
-
-    from _pytest.compat import _setup_collect_fakemodule
-
-    _setup_collect_fakemodule()
+_setup_collect_fakemodule()

--- a/src/pytest/__main__.py
+++ b/src/pytest/__main__.py
@@ -1,0 +1,5 @@
+# PYTHON_ARGCOMPLETE_OK
+import pytest
+
+
+raise SystemExit(pytest.main())


### PR DESCRIPTION
While this commit does not do it yet, we want to eventually publish
pytest's type annotations. According to PEP561, this is done by adding a
`py.typed` file to each top-level package, `pytest` and `_pytest` in
pytest's case. However, the `pytest` package is currently just a single
module/file, so it's not possible to added to file to it.

Change `pytest` to a package (i.e. a directory with `__init__.py`), then
adding a `py.typed` file to it is possible.

The reason for doing it already is that it makes it easy to ask people
to test the types just by touching a couple of files.