### PR TITLE
Enable py38 testing on azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,19 +26,22 @@ jobs:
       py36-xdist:
         python.version: '3.6'
         tox.env: 'py36-xdist'
-      py37:
+      py37-xdist:
         python.version: '3.7'
-        tox.env: 'py37-twisted-numpy'
+        tox.env: 'py37-xdist'
+      py38:
+        python.version: '3.8'
+        tox.env: 'py38-twisted-numpy'
         # Coverage for:
         # - _py36_windowsconsoleio_workaround (with py36+)
         # - test_request_garbage (no xdist)
         PYTEST_COVERAGE: '1'
-      py37-linting/docs/doctesting:
-        python.version: '3.7'
+      py38-linting/docs/doctesting:
+        python.version: '3.8'
         tox.env: 'linting,docs,doctesting'
-      py37-pluggymaster-xdist:
-        python.version: '3.7'
-        tox.env: 'py37-pluggymaster-xdist'
+      py38-pluggymaster-xdist:
+        python.version: '3.8'
+        tox.env: 'py38-pluggymaster-xdist'
     maxParallel: 10
 
   steps:

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist =
     py38
     pypy
     pypy3
-    py37-{pexpect,xdist,twisted,numpy,pluggymaster}
+    py38-{pexpect,xdist,twisted,numpy,pluggymaster}
     doctesting
     py37-freeze
     docs


### PR DESCRIPTION
This changes the main interpreter to run several tox envs to py38
