### PR TITLE
Fixes #6326: Typo in the Security section docs home page.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,7 @@ Save time, reduce risk, and improve code health, while paying the maintainers of
 Security
 ^^^^^^^^
 
-pytest has never been associated with a security vunerability, but in any case, to report a
+pytest has never been associated with a security vulnerability, but in any case, to report a
 security vulnerability please use the `Tidelift security contact <https://tidelift.com/security>`_.
 Tidelift will coordinate the fix and disclosure.
 

--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -112,7 +112,7 @@ Save time, reduce risk, and improve code health, while paying the maintainers of
 Security
 ^^^^^^^^
 
-pytest has never been associated with a security vunerability, but in any case, to report a
+pytest has never been associated with a security vulnerability, but in any case, to report a
 security vulnerability please use the `Tidelift security contact <https://tidelift.com/security>`_.
 Tidelift will coordinate the fix and disclosure.
 


### PR DESCRIPTION
Fixes a typo in the docs.