### PR TITLE
[parametrize] enforce explicit argnames declaration

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -274,6 +274,7 @@ Vidar T. Fauske
 Virgil Dupras
 Vitaly Lashmanov
 Vlad Dragos
+Vladyslav Rachek
 Volodymyr Piskun
 Wei Lin
 Wil Cooley

--- a/changelog/5712.feature.rst
+++ b/changelog/5712.feature.rst
@@ -1,0 +1,2 @@
+Now all arguments to ``@pytest.mark.parametrize`` need to be explicitly declared in the function signature or via ``indirect``.
+Previously it was possible to omit an argument if a fixture with the same name existed, which was just an accident of implementation and was not meant to be a part of the API.

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -398,6 +398,9 @@ The result of this test will be successful:
 
 .. regendoc:wipe
 
+Note, that each argument in `parametrize` list should be explicitly declared in corresponding
+python test function or via `indirect`.
+
 Parametrizing test methods through per-class configuration
 --------------------------------------------------------------
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1,6 +1,5 @@
 import functools
 import inspect
-import itertools
 import sys
 import warnings
 from collections import defaultdict
@@ -1280,10 +1279,8 @@ class FixtureManager:
         else:
             argnames = ()
 
-        usefixtures = itertools.chain.from_iterable(
-            mark.args for mark in node.iter_markers(name="usefixtures")
-        )
-        initialnames = tuple(usefixtures) + argnames
+        usefixtures = get_use_fixtures_for_node(node)
+        initialnames = usefixtures + argnames
         fm = node.session._fixturemanager
         initialnames, names_closure, arg2fixturedefs = fm.getfixtureclosure(
             initialnames, node, ignore_args=self._get_direct_parametrize_args(node)
@@ -1480,3 +1477,12 @@ class FixtureManager:
         for fixturedef in fixturedefs:
             if nodes.ischildnode(fixturedef.baseid, nodeid):
                 yield fixturedef
+
+
+def get_use_fixtures_for_node(node) -> Tuple[str, ...]:
+    """Returns the names of all the usefixtures() marks on the given node"""
+    return tuple(
+        str(name)
+        for mark in node.iter_markers(name="usefixtures")
+        for name in mark.args
+    )

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1012,6 +1012,8 @@ class Metafunc:
 
         arg_values_types = self._resolve_arg_value_types(argnames, indirect)
 
+        self._validate_explicit_parameters(argnames, indirect)
+
         # Use any already (possibly) generated ids with parametrize Marks.
         if _param_mark and _param_mark._param_ids_from:
             generated_ids = _param_mark._param_ids_from._param_ids_generated
@@ -1161,6 +1163,37 @@ class Metafunc:
                         "In {}: function uses no {} '{}'".format(func_name, name, arg),
                         pytrace=False,
                     )
+
+    def _validate_explicit_parameters(self, argnames, indirect):
+        """
+        The argnames in *parametrize* should either be declared explicitly via
+        indirect list or in the function signature
+
+        :param List[str] argnames: list of argument names passed to ``parametrize()``.
+        :param indirect: same ``indirect`` parameter of ``parametrize()``.
+        :raise ValueError: if validation fails
+        """
+        if isinstance(indirect, bool) and indirect is True:
+            return
+        parametrized_argnames = list()
+        funcargnames = _pytest.compat.getfuncargnames(self.function)
+        if isinstance(indirect, Sequence):
+            for arg in argnames:
+                if arg not in indirect:
+                    parametrized_argnames.append(arg)
+        elif indirect is False:
+            parametrized_argnames = argnames
+
+        usefixtures = fixtures.get_use_fixtures_for_node(self.definition)
+
+        for arg in parametrized_argnames:
+            if arg not in funcargnames and arg not in usefixtures:
+                func_name = self.function.__name__
+                msg = (
+                    'In function "{func_name}":\n'
+                    'Parameter "{arg}" should be declared explicitly via indirect or in function itself'
+                ).format(func_name=func_name, arg=arg)
+                fail(msg, pytrace=False)
 
 
 def _find_parametrized_scope(argnames, arg2fixturedefs, indirect):

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -463,7 +463,7 @@ class TestFunction:
                return '3'
 
             @pytest.mark.parametrize('fix2', ['2'])
-            def test_it(fix1):
+            def test_it(fix1, fix2):
                assert fix1 == '21'
                assert not fix3_instantiated
         """

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -28,6 +28,9 @@ class TestMetafunc:
         class DefinitionMock(python.FunctionDefinition):
             obj = attr.ib()
 
+            def listchain(self):
+                return []
+
         names = fixtures.getfuncargnames(func)
         fixtureinfo = FixtureInfo(names)
         definition = DefinitionMock._create(func)
@@ -1875,5 +1878,53 @@ class TestMarkersWithParametrization:
                 "test_parametrize_iterator.py::test_converted_to_str[0] PASSED",
                 "test_parametrize_iterator.py::test_converted_to_str[1] PASSED",
                 "*= 6 passed in *",
+            ]
+        )
+
+    def test_parametrize_explicit_parameters_func(self, testdir):
+        testdir.makepyfile(
+            """
+            import pytest
+
+
+            @pytest.fixture
+            def fixture(arg):
+                return arg
+
+            @pytest.mark.parametrize("arg", ["baz"])
+            def test_without_arg(fixture):
+                assert "baz" == fixture
+        """
+        )
+        result = testdir.runpytest()
+        result.assert_outcomes(error=1)
+        result.stdout.fnmatch_lines(
+            [
+                '*In function "test_without_arg"*',
+                '*Parameter "arg" should be declared explicitly via indirect or in function itself*',
+            ]
+        )
+
+    def test_parametrize_explicit_parameters_method(self, testdir):
+        testdir.makepyfile(
+            """
+            import pytest
+
+            class Test:
+                @pytest.fixture
+                def test_fixture(self, argument):
+                    return argument
+
+                @pytest.mark.parametrize("argument", ["foobar"])
+                def test_without_argument(self, test_fixture):
+                    assert "foobar" == test_fixture
+        """
+        )
+        result = testdir.runpytest()
+        result.assert_outcomes(error=1)
+        result.stdout.fnmatch_lines(
+            [
+                '*In function "test_without_argument"*',
+                '*Parameter "argument" should be declared explicitly via indirect or in function itself*',
             ]
         )


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features, improvements, and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
Hi, 

that's my first PR, ref. issue #5712 
The purpose of this is to enforce that every argument used in `parametrize` is explicitly declared either by corresponding test function or via `indirect` list. The example of how this is intended to work is given in documentation (added few lines to *doc/en/example/parametrize.rst*)
I target master branch because I consider it a small change/bugfix. 
