### PR TITLE
[4.6] Add hostname and timestamp to JUnit XML testsuite tag (#5692)

### DIFF
--- a/changelog/5471.feature.rst
+++ b/changelog/5471.feature.rst
@@ -1,0 +1,1 @@
+JUnit XML now includes a timestamp and hostname in the testsuite tag.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -15,9 +15,11 @@ from __future__ import print_function
 
 import functools
 import os
+import platform
 import re
 import sys
 import time
+from datetime import datetime
 
 import py
 import six
@@ -676,6 +678,8 @@ class LogXML(object):
             skipped=self.stats["skipped"],
             tests=numtests,
             time="%.3f" % suite_time_delta,
+            timestamp=datetime.fromtimestamp(self.suite_start_time).isoformat(),
+            hostname=platform.node(),
         )
         logfile.write(Junit.testsuites([suite_node]).unicode(indent=0))
         logfile.close()

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -4,7 +4,9 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import platform
 import sys
+from datetime import datetime
 from xml.dom import minidom
 
 import py
@@ -144,6 +146,30 @@ class TestPython(object):
         assert result.ret
         node = dom.find_first_by_tag("testsuite")
         node.assert_attr(name="pytest", errors=1, failures=2, skipped=1, tests=5)
+
+    def test_hostname_in_xml(self, testdir):
+        testdir.makepyfile(
+            """
+            def test_pass():
+                pass
+        """
+        )
+        result, dom = runandparse(testdir)
+        node = dom.find_first_by_tag("testsuite")
+        node.assert_attr(hostname=platform.node())
+
+    def test_timestamp_in_xml(self, testdir):
+        testdir.makepyfile(
+            """
+            def test_pass():
+                pass
+        """
+        )
+        start_time = datetime.now()
+        result, dom = runandparse(testdir)
+        node = dom.find_first_by_tag("testsuite")
+        timestamp = datetime.strptime(node["timestamp"], "%Y-%m-%dT%H:%M:%S.%f")
+        assert start_time <= timestamp < datetime.now()
 
     def test_timing_function(self, testdir):
         testdir.makepyfile(


### PR DESCRIPTION
Add hostname and timestamp to JUnit XML testsuite tag

Conflicts:
  	testing/test_junitxml.py

Requested from https://github.com/pytest-dev/pytest/issues/5471#issuecomment-563500493