### PR TITLE
Deprecate no print logs

### DIFF
--- a/changelog/3238.deprecation.rst
+++ b/changelog/3238.deprecation.rst
@@ -1,0 +1,5 @@
+Option ``--no-print-logs`` is deprecated and meant to be removed in a future release. If you use ``--no-print-logs``, please try out ``--show-capture`` and
+provide feedback.
+
+``--show-capture`` command-line option was added in ``pytest 3.5.0`` and allows to specify how to
+display captured output when tests fail: ``no``, ``stdout``, ``stderr``, ``log`` or ``all`` (the default).

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -20,6 +20,20 @@ Below is a complete list of all pytest features which are considered deprecated.
 :ref:`standard warning filters <warnings>`.
 
 
+``--no-print-logs`` command-line option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 5.4
+
+
+Option ``--no-print-logs`` is deprecated and meant to be removed in a future release. If you use ``--no-print-logs``, please try out ``--show-capture`` and
+provide feedback.
+
+``--show-capture`` command-line option was added in ``pytest 3.5.0` and allows to specify how to
+display captured output when tests fail: ``no``, ``stdout``, ``stderr``, ``log`` or ``all`` (the default).
+
+
+
 Node Construction changed to ``Node.from_parent``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -19,12 +19,10 @@ DEPRECATED_EXTERNAL_PLUGINS = {
     "pytest_faulthandler",
 }
 
-
 FUNCARGNAMES = PytestDeprecationWarning(
     "The `funcargnames` attribute was an alias for `fixturenames`, "
     "since pytest 2.3 - use the newer attribute instead."
 )
-
 
 RESULT_LOG = PytestDeprecationWarning(
     "--result-log is deprecated, please try the new pytest-reportlog plugin.\n"
@@ -44,4 +42,9 @@ NODE_USE_FROM_PARENT = UnformattedWarning(
 JUNIT_XML_DEFAULT_FAMILY = PytestDeprecationWarning(
     "The 'junit_family' default value will change to 'xunit2' in pytest 6.0.\n"
     "Add 'junit_family=legacy' to your pytest.ini file to silence this warning and make your suite compatible."
+)
+
+NO_PRINT_LOGS = PytestDeprecationWarning(
+    "--no-print-logs is deprecated and scheduled for removal in pytest 6.0.\n"
+    "Please use --show-capture instead."
 )

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -485,6 +485,12 @@ class LoggingPlugin:
         self._config = config
 
         self.print_logs = get_option_ini(config, "log_print")
+        if not self.print_logs:
+            from _pytest.warnings import _issue_warning_captured
+            from _pytest.deprecated import NO_PRINT_LOGS
+
+            _issue_warning_captured(NO_PRINT_LOGS, self._config.hook, stacklevel=2)
+
         self.formatter = self._create_formatter(
             get_option_ini(config, "log_format"),
             get_option_ini(config, "log_date_format"),

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -90,3 +90,44 @@ def test_node_direct_ctor_warning():
         nodes.Node(name="test", config=ms, session=ms, nodeid="None")
     assert w[0].lineno == inspect.currentframe().f_lineno - 1
     assert w[0].filename == __file__
+
+
+def assert_no_print_logs(testdir, args):
+    result = testdir.runpytest(*args)
+    result.stdout.fnmatch_lines(
+        [
+            "*--no-print-logs is deprecated and scheduled for removal in pytest 6.0*",
+            "*Please use --show-capture instead.*",
+        ]
+    )
+
+
+@pytest.mark.filterwarnings("default")
+def test_noprintlogs_is_deprecated_cmdline(testdir):
+    testdir.makepyfile(
+        """
+        def test_foo():
+            pass
+        """
+    )
+
+    assert_no_print_logs(testdir, ("--no-print-logs",))
+
+
+@pytest.mark.filterwarnings("default")
+def test_noprintlogs_is_deprecated_ini(testdir):
+    testdir.makeini(
+        """
+        [pytest]
+        log_print=False
+        """
+    )
+
+    testdir.makepyfile(
+        """
+        def test_foo():
+            pass
+        """
+    )
+
+    assert_no_print_logs(testdir, ())


### PR DESCRIPTION
Deprecated the --no-print-logs option.
Added 2 unit tests, for ini and command line.
Added 3238.deprecation.rst file.
Updated the deprecations.rst doc.

--Recreated PR as i messed up the old one