### PR TITLE
Make 'S' and 'F' aliases to 's' and 'f' respectively

### DIFF
--- a/changelog/6334.bugfix.rst
+++ b/changelog/6334.bugfix.rst
@@ -1,0 +1,3 @@
+Fix summary entries appearing twice when ``f/F`` and ``s/S`` report chars were used at the same time in the ``-r`` command-line option (for example ``-rFf``).
+
+The upper case variants were never documented and the preferred form should be the lower case.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -172,10 +172,11 @@ def getreportopt(config: Config) -> str:
         reportchars += "w"
     elif config.option.disable_warnings and "w" in reportchars:
         reportchars = reportchars.replace("w", "")
+    aliases = {"F", "S"}
     for char in reportchars:
-        # f and F are aliases
-        if char == "F":
-            char = "f"
+        # handle old aliases
+        if char in aliases:
+            char = char.lower()
         if char == "a":
             reportopts = "sxXwEf"
         elif char == "A":
@@ -989,7 +990,6 @@ class TerminalReporter:
             "X": show_xpassed,
             "f": partial(show_simple, "failed"),
             "s": show_skipped,
-            "S": show_skipped,
             "p": partial(show_simple, "passed"),
             "E": partial(show_simple, "error"),
         }  # type: Mapping[str, Callable[[List[str]], None]]

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -755,6 +755,7 @@ class TestTerminalFunctional:
         result.stdout.fnmatch_lines(["collected 3 items", "hello from hook: 3 items"])
 
     def test_summary_f_alias(self, testdir):
+        """Test that 'f' and 'F' report chars are aliases and don't show up twice in the summary (#6334)"""
         testdir.makepyfile(
             """
             def test():
@@ -763,6 +764,22 @@ class TestTerminalFunctional:
         )
         result = testdir.runpytest("-rfF")
         expected = "FAILED test_summary_f_alias.py::test - assert False"
+        result.stdout.fnmatch_lines([expected])
+        assert result.stdout.lines.count(expected) == 1
+
+    def test_summary_s_alias(self, testdir):
+        """Test that 's' and 'S' report chars are aliases and don't show up twice in the summary"""
+        testdir.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.skip
+            def test():
+                pass
+            """
+        )
+        result = testdir.runpytest("-rsS")
+        expected = "SKIPPED [1] test_summary_s_alias.py:3: unconditional skip"
         result.stdout.fnmatch_lines([expected])
         assert result.stdout.lines.count(expected) == 1
 

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -754,6 +754,18 @@ class TestTerminalFunctional:
         result = testdir.runpytest(*params)
         result.stdout.fnmatch_lines(["collected 3 items", "hello from hook: 3 items"])
 
+    def test_summary_f_alias(self, testdir):
+        testdir.makepyfile(
+            """
+            def test():
+                assert False
+            """
+        )
+        result = testdir.runpytest("-rfF")
+        expected = "FAILED test_summary_f_alias.py::test - assert False"
+        result.stdout.fnmatch_lines([expected])
+        assert result.stdout.lines.count(expected) == 1
+
 
 def test_fail_extra_reporting(testdir, monkeypatch):
     monkeypatch.setenv("COLUMNS", "80")
@@ -1685,12 +1697,16 @@ class TestProgressWithTeardown:
         testdir.makepyfile(
             """
             def test_foo(fail_teardown):
-                assert False
+                assert 0
         """
         )
-        output = testdir.runpytest()
+        output = testdir.runpytest("-rfE")
         output.stdout.re_match_lines(
-            [r"test_teardown_with_test_also_failing.py FE\s+\[100%\]"]
+            [
+                r"test_teardown_with_test_also_failing.py FE\s+\[100%\]",
+                "FAILED test_teardown_with_test_also_failing.py::test_foo - assert 0",
+                "ERROR test_teardown_with_test_also_failing.py::test_foo - assert False",
+            ]
         )
 
     def test_teardown_many(self, testdir, many_files):


### PR DESCRIPTION
@RonnyPfannschmidt do you remember why `-r` supports both `s/S` and `f/F`? I can't really trace it back in the Git history as the related code has been moved around quite a bit.

Fix #6334 