### PR TITLE
Ensure colorama version is no newer than 0.4.1

### DIFF
--- a/changelog/6340.trivial.rst
+++ b/changelog/6340.trivial.rst
@@ -1,0 +1,1 @@
+Pin ``colorama`` to ``0.4.1`` as later versions no longer support Python 3.4.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ INSTALL_REQUIRES = [
     "atomicwrites>=1.0",
     'funcsigs>=1.0;python_version<"3.0"',
     'pathlib2>=2.2.0;python_version<"3.6"',
-    'colorama;sys_platform=="win32"',
+    'colorama<=0.4.1;sys_platform=="win32"',
     "pluggy>=0.12,<1.0",
     'importlib-metadata>=0.12;python_version<"3.8"',
     "wcwidth",


### PR DESCRIPTION
On Dec 6, 2019 colorama released version 0.4.2 which dropped Python 3.4 support. This trivial change ensures the colorama version used is <=0.4.1, the last version that supports Python 3.4.

This targets the `4.6-maintenance` branch instead of `master`, because the newer versions of pytest don't need to worry about dependencies dropping Python 3.4 support.

- [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features, improvements, and removals/deprecations.
- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.


I think the change is trivial?
Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:
- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.
- [ ] Add yourself to `AUTHORS` in alphabetical order.
