### PR TITLE
Improve warning about incoming change to 'junitxml_family' default

### DIFF
--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -37,5 +37,6 @@ FIXTURE_POSITIONAL_ARGUMENTS = PytestDeprecationWarning(
 
 JUNIT_XML_DEFAULT_FAMILY = PytestDeprecationWarning(
     "The 'junit_family' default value will change to 'xunit2' in pytest 6.0.\n"
-    "Add 'junit_family=legacy' to your pytest.ini file to silence this warning and make your suite compatible."
+    "Add 'junit_family=xunit1' to your pytest.ini file to keep the current format "
+    "in future versions of pytest and silence this warning."
 )


### PR DESCRIPTION
Fix #6265
