### PR TITLE
Use license_files instead of deprecated license_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ project_urls =
 author = Holger Krekel, Bruno Oliveira, Ronny Pfannschmidt, Floris Bruynooghe, Brianna Laugher, Florian Bruhin and others
 
 license = MIT license
-license_file = LICENSE
+license_files = LICENSE
 keywords = test, unittest
 classifiers =
     Development Status :: 6 - Mature


### PR DESCRIPTION
Here is a quick checklist that should be present in PRs.

- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [trivial] Target the `features` branch for new features, improvements, and removals/deprecations.
- [n/a] Include documentation when adding new features.
- [n/a] Include new tests or update existing tests when applicable.
- [trivial] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Add yourself to `AUTHORS` in alphabetical order.

---

`license_file` has been deprecated in favour of `license_files`.

> **0.32.0 (2018-09-29)**
> ...
> * Allowed multiple license files to be specified using the `license_files` option
> * Deprecated the `license_file` option

https://wheel.readthedocs.io/en/stable/news.html


And setuptools 42 was released Nov 23, 2019:

> The following files are included in a source distribution by default:
...
> * the file specified by the `license_file` option in `setup.cfg` (setuptools 40.8.0+)
> * all files specified by the `license_files` option in `setup.cfg` (setuptools 42.0.0+)


https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist
