### PR TITLE
Optimized renaming of test parameter ids 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -235,6 +235,7 @@ Samuele Pedroni
 Sankt Petersbug
 Segev Finer
 Serhii Mozghovyi
+Seth Junot
 Simon Gomizelj
 Skylar Downes
 Srinivas Reddy Thatiparthy

--- a/changelog/6350.trivial.rst
+++ b/changelog/6350.trivial.rst
@@ -1,0 +1,1 @@
+Optimized automatic renaming of test parameter IDs.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -6,6 +6,7 @@ import os
 import sys
 import warnings
 from collections import Counter
+from collections import defaultdict
 from collections.abc import Sequence
 from functools import partial
 from textwrap import dedent
@@ -1190,14 +1191,23 @@ def idmaker(argnames, parametersets, idfn=None, ids=None, config=None, item=None
         _idvalset(valindex, parameterset, argnames, idfn, ids, config=config, item=item)
         for valindex, parameterset in enumerate(parametersets)
     ]
-    if len(set(ids)) != len(ids):
-        # The ids are not unique
-        duplicates = [testid for testid in ids if ids.count(testid) > 1]
-        counters = Counter()
-        for index, testid in enumerate(ids):
-            if testid in duplicates:
-                ids[index] = testid + str(counters[testid])
-                counters[testid] += 1
+
+    # All IDs must be unique!
+    unique_ids = set(ids)
+    if len(unique_ids) != len(ids):
+
+        # Record the number of occurrences of each test ID
+        test_id_counts = Counter(ids)
+
+        # Map the test ID to its next suffix
+        test_id_suffixes = defaultdict(int)
+
+        # Suffix non-unique IDs to make them unique
+        for index, test_id in enumerate(ids):
+            if test_id_counts[test_id] > 1:
+                ids[index] = "{}{}".format(test_id, test_id_suffixes[test_id])
+                test_id_suffixes[test_id] += 1
+
     return ids
 
 


### PR DESCRIPTION
While using pytest-repeat, I noticed the previous implementation is slow
for a large number of duplicate test ids. To optimize, this commit
reduces the amount of data copied and avoids using `in` with List
(unhashable type, and therefore is very slow for many elements).

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features, improvements, and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
