### PR TITLE
invocation in last section 'pythonpath.rst' title swapped

### DIFF
--- a/doc/en/pythonpath.rst
+++ b/doc/en/pythonpath.rst
@@ -74,7 +74,7 @@ This is also discussed in details in :ref:`test discovery`.
 
 .. _`pytest vs python -m pytest`:
 
-Invoking ``pytest`` versus ``python -m pytest``
+Invoking ``python -m pytest`` versus ``pytest`` 
 -----------------------------------------------
 
 Running pytest with ``python -m pytest [...]`` instead of ``pytest [...]`` yields nearly

--- a/doc/en/pythonpath.rst
+++ b/doc/en/pythonpath.rst
@@ -74,9 +74,11 @@ This is also discussed in details in :ref:`test discovery`.
 
 .. _`pytest vs python -m pytest`:
 
-Invoking ``python -m pytest`` versus ``pytest`` 
+Invoking ``pytest`` versus ``python -m pytest``
 -----------------------------------------------
 
-Running pytest with ``python -m pytest [...]`` instead of ``pytest [...]`` yields nearly
-equivalent behaviour, except that the former call will add the current directory to ``sys.path``.
+Running pytest with ``pytest [...]`` instead of ``python -m pytest [...]`` yields nearly
+equivalent behaviour, except that the latter will add the current directory to ``sys.path``, which
+is standard ``python`` behavior.
+
 See also :ref:`cmdline`.


### PR DESCRIPTION
The order of invocations 'python -m pytest' and 'pytest' are different in the header and the explanation. Me being lazy reading about the behaviour of 'former' looked up quickly the title and rushed to implementation to discover it actually works the other way - as stated in the documentation. So I propose to switch the order in the title to achieve consistent ordering and not confusing somebody like me again! :)