### PR TITLE
Skip GitHub actions for py38 on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,10 @@ jobs:
           "windows-py36",
           "windows-py37",
           "windows-py37-pluggy",
-          "windows-py38",
+
+          # skipping windows py38 for now due to:
+          # https://github.com/pytest-dev/pytest/pull/6159
+          # "windows-py38",
 
           "ubuntu-py35",
           "ubuntu-py36",


### PR DESCRIPTION
As discussed in https://github.com/pytest-dev/pytest/pull/6159,
we are waiting for a new py release (https://github.com/pytest-dev/py/pull/229)
