### PR TITLE
Remove deprecated license_file from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ project_urls =
 author = Holger Krekel, Bruno Oliveira, Ronny Pfannschmidt, Floris Bruynooghe, Brianna Laugher, Florian Bruhin and others
 
 license = MIT license
-license_file = LICENSE
 keywords = test, unittest
 classifiers =
     Development Status :: 6 - Mature


### PR DESCRIPTION

- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [trivial] Target the `features` branch for new features, improvements, and removals/deprecations.
- [n/a] Include documentation when adding new features.
- [n/a] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [trivial] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

- [x] Add yourself to `AUTHORS` in alphabetical order.

---

Replaces and closes https://github.com/pytest-dev/pytest/pull/6348.

Starting with wheel 0.32.0 (2018-09-29), the `license_file` option is deprecated.

* https://wheel.readthedocs.io/en/stable/news.html

The wheel will continue to include `LICENSE`, it is now included automatically:

* https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file

And `LICENSE` is still included in sdists thanks to setuptools-scm:

* https://github.com/pytest-dev/pytest/pull/6348#issuecomment-567836331
