### PR TITLE
Revert black formatting of essential_plugins

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -133,7 +133,13 @@ def directory_arg(path, optname):
 
 
 # Plugins that cannot be disabled via "-p no:X" currently.
-essential_plugins = ("mark", "main", "runner", "fixtures", "helpconfig")  # Provides -p.
+essential_plugins = (
+    "mark",
+    "main",
+    "runner",
+    "fixtures",
+    "helpconfig",  # Provides -p.
+)
 
 default_plugins = essential_plugins + (
     "python",


### PR DESCRIPTION
Done in a02310a140 (likely automatic), but loses information of the
comment obviously.