### PR TITLE
Fix `RunResult.parseoutcomes` (follow-up to #6353)

### DIFF
--- a/changelog/6532.bugfix.rst
+++ b/changelog/6532.bugfix.rst
@@ -1,1 +1,1 @@
-Fix problem with ``testdir`` not recognizing errors correctly in runs with a single test.
+Fix parsing of outcomes containing multiple errors with ``testdir`` results (regression in 5.3.0).

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -433,9 +433,14 @@ class RunResult:
         for line in reversed(self.outlines):
             if rex_session_duration.search(line):
                 outcomes = rex_outcome.findall(line)
-                return {noun: int(count) for (count, noun) in outcomes}
-
-        raise ValueError("Pytest terminal summary report not found")
+                ret = {noun: int(count) for (count, noun) in outcomes}
+                break
+        else:
+            raise ValueError("Pytest terminal summary report not found")
+        if "errors" in ret:
+            assert "error" not in ret
+            ret["error"] = ret.pop("errors")
+        return ret
 
     def assert_outcomes(
         self,
@@ -456,7 +461,7 @@ class RunResult:
             "passed": d.get("passed", 0),
             "skipped": d.get("skipped", 0),
             "failed": d.get("failed", 0),
-            "error": d.get("error", 0) + d.get("errors", 0),
+            "error": d.get("error", 0),
             "xpassed": d.get("xpassed", 0),
             "xfailed": d.get("xfailed", 0),
         }

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -684,8 +684,9 @@ def test_run_result_repr():
     )
 
 
-def test_run_pytester_with_single_test(testdir):
-    testcode = """
+def test_testdir_outcomes_with_multiple_errors(testdir):
+    p1 = testdir.makepyfile(
+        """
         import pytest
 
         @pytest.fixture
@@ -698,7 +699,8 @@ def test_run_pytester_with_single_test(testdir):
         def test_error2(bad_fixture):
             pass
     """
-
-    testdir.makepyfile(testcode)
-    result = testdir.runpytest()
+    )
+    result = testdir.runpytest(str(p1))
     result.assert_outcomes(error=2)
+
+    assert result.parseoutcomes() == {"error": 2}


### PR DESCRIPTION
/cc @mulatinho

follow-up to #6353 (for #6352)