### PR TITLE
Make --showlocals work together with --tb=short

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -208,6 +208,7 @@ Omer Hadari
 Ondřej Súkup
 Oscar Benjamin
 Patrick Hayes
+Pauli Virtanen
 Paweł Adamczak
 Pedro Algarvio
 Philipp Loose

--- a/changelog/6384.improvement.rst
+++ b/changelog/6384.improvement.rst
@@ -1,0 +1,1 @@
+Make `--showlocals` work also with `--tb=short`.

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -785,9 +785,7 @@ class FormattedExcinfo:
                 message = excinfo and excinfo.typename or ""
             path = self._makepath(entry.path)
             filelocrepr = ReprFileLocation(path, entry.lineno + 1, message)
-            localsrepr = None
-            if not short:
-                localsrepr = self.repr_locals(entry.locals)
+            localsrepr = self.repr_locals(entry.locals)
             return ReprEntry(lines, reprargs, localsrepr, filelocrepr, style)
         if excinfo:
             lines.extend(self.get_exconly(excinfo, indent=4))
@@ -1044,6 +1042,8 @@ class ReprEntry(TerminalRepr):
             for line in self.lines:
                 red = line.startswith("E   ")
                 tw.line(line, bold=True, red=red)
+            if self.reprlocals:
+                self.reprlocals.toterminal(tw, indent=" " * 8)
             return
         if self.reprfuncargs:
             self.reprfuncargs.toterminal(tw)
@@ -1085,9 +1085,9 @@ class ReprLocals(TerminalRepr):
     def __init__(self, lines: Sequence[str]) -> None:
         self.lines = lines
 
-    def toterminal(self, tw) -> None:
+    def toterminal(self, tw, indent="") -> None:
         for line in self.lines:
-            tw.line(line)
+            tw.line(indent + line)
 
 
 class ReprFuncArgs(TerminalRepr):

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -670,6 +670,26 @@ class TestTerminalFunctional:
             ]
         )
 
+    def test_showlocals_short(self, testdir):
+        p1 = testdir.makepyfile(
+            """
+            def test_showlocals_short():
+                x = 3
+                y = "xxxx"
+                assert 0
+        """
+        )
+        result = testdir.runpytest(p1, "-l", "--tb=short")
+        result.stdout.fnmatch_lines(
+            [
+                "test_showlocals_short.py:*",
+                "    assert 0",
+                "E   assert 0",
+                "        x          = 3",
+                "        y          = 'xxxx'",
+            ]
+        )
+
     @pytest.fixture
     def verbose_testfile(self, testdir):
         return testdir.makepyfile(


### PR DESCRIPTION
Enable showing local variables when asked to do so in the short
traceback mode.

Fixes #494

Looks like this in practice:
```
$ python3 -mpytest scipy/_lib/tests/test__util.py --tb=short -l
...
================================ FAILURES =================================
___________________________ test__aligned_zeros ___________________________
scipy/_lib/tests/test__util.py:49: in test__aligned_zeros
    check(shape, dtype, order, align)
        align      = 1
        check      = <function test__aligned_zeros.<locals>.check at 0x7f866a141560>
        dtype      = <class 'numpy.uint8'>
        j          = 0
        n          = 0
        niter      = 10
        order      = 'C'
        shape      = 0
scipy/_lib/tests/test__util.py:22: in check
    assert dtype is None
E   AssertionError: assert <class 'numpy.uint8'> is None
        align      = 1
        dtype      = <class 'numpy.uint8'>
        err_msg    = "(0, <class 'numpy.uint8'>, 'C', 1)"
        order      = 'C'
        shape      = 0
        x          = array([], dtype=uint8)
====================== 1 failed, 11 passed in 0.23s =======================
```