### PR TITLE
Update mypy 0.750 -> 0.761

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     -   id: pyupgrade
         args: [--py3-plus]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.750
+    rev: v0.761
     hooks:
     -   id: mypy
         files: ^(src/|testing/)

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -339,9 +339,7 @@ def getstatementrange_ast(
         block_finder.started = source.lines[start][0].isspace()
         it = ((x + "\n") for x in source.lines[start:end])
         try:
-            # Type ignored until next mypy release.
-            # https://github.com/python/typeshed/commit/c0d46a20353b733befb85d8b9cc24e5b0bcd8f9a
-            for tok in tokenize.generate_tokens(lambda: next(it)):  # type: ignore
+            for tok in tokenize.generate_tokens(lambda: next(it)):
                 block_finder.tokeneater(*tok)
         except (inspect.EndOfBlock, IndentationError):
             end = block_finder.last + start

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -33,7 +33,7 @@ def pytest_addoption(parser):
     )
 
 
-def register_assert_rewrite(*names):
+def register_assert_rewrite(*names) -> None:
     """Register one or more module names to be rewritten on import.
 
     This function will make sure that this module or all modules inside

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -451,7 +451,9 @@ class DoctestModule(pytest.Module):
                     obj = getattr(obj, "fget", obj)
                 return doctest.DocTestFinder._find_lineno(self, obj, source_lines)
 
-            def _find(self, tests, obj, name, module, source_lines, globs, seen):
+            def _find(
+                self, tests, obj, name, module, source_lines, globs, seen
+            ) -> None:
                 if _is_mocked(obj):
                     return
                 with _patch_unwrap_mock_aware():

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -829,7 +829,7 @@ class Testdir:
         items = [x.item for x in rec.getcalls("pytest_itemcollected")]
         return items, rec
 
-    def inline_run(self, *args, plugins=(), no_reraise_ctrlc=False):
+    def inline_run(self, *args, plugins=(), no_reraise_ctrlc: bool = False):
         """Run ``pytest.main()`` in-process, returning a HookRecorder.
 
         Runs the :py:func:`pytest.main` function to run all of pytest inside

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -129,9 +129,7 @@ def warns(  # noqa: F811
             return func(*args[1:], **kwargs)
 
 
-# Type ignored until next mypy release. Regression fixed by:
-# https://github.com/python/typeshed/commit/41bf6a19822d6694973449d795f8bfe1d50d5a03
-class WarningsRecorder(warnings.catch_warnings):  # type: ignore
+class WarningsRecorder(warnings.catch_warnings):
     """A context manager to record raised warnings.
 
     Adapted from `warnings.catch_warnings`.

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -259,7 +259,7 @@ class TestReport(BaseReport):
         )
 
     @classmethod
-    def from_item_and_call(cls, item, call):
+    def from_item_and_call(cls, item, call) -> "TestReport":
         """
         Factory method to create and fill a TestReport with standard item and call info.
         """

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -250,7 +250,7 @@ def pytest_runtest_makereport(item, call):
     return TestReport.from_item_and_call(item, call)
 
 
-def pytest_make_collect_report(collector):
+def pytest_make_collect_report(collector) -> CollectReport:
     call = CallInfo.from_call(lambda: list(collector.collect()), "collect")
     longrepr = None
     if not call.excinfo:

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -318,16 +318,12 @@ class TestSourceParsingAndCompiling:
 
     @pytest.mark.parametrize("name", ["", None, "my"])
     def test_compilefuncs_and_path_sanity(self, name: Optional[str]) -> None:
-        def check(comp, name):
+        def check(comp, name) -> None:
             co = comp(self.source, name)
             if not name:
                 expected = "codegen %s:%d>" % (mypath, mylineno + 2 + 2)  # type: ignore
             else:
-                expected = "codegen %r %s:%d>" % (
-                    name,
-                    mypath,  # type: ignore
-                    mylineno + 2 + 2,  # type: ignore
-                )  # type: ignore
+                expected = "codegen %r %s:%d>" % (name, mypath, mylineno + 2 + 2)  # type: ignore
             fn = co.co_filename
             assert fn.endswith(expected)
 


### PR DESCRIPTION
This fixes some type: ignores due to typeshed update.

Newer mypy seem to ignore unannotated functions better, so add a few
minor annotations so that existing correct type:ignores make sense.