### PR TITLE
Preparing release version 4.6.9

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,15 @@ with advance notice in the **Deprecations** section of releases.
 
 .. towncrier release notes start
 
+pytest 4.6.9 (2020-01-04)
+=========================
+
+Bug Fixes
+---------
+
+- `#6301 <https://github.com/pytest-dev/pytest/issues/6301>`_: Fix assertion rewriting for egg-based distributions and ``editable`` installs (``pip install --editable``).
+
+
 pytest 4.6.8 (2019-12-19)
 =========================
 

--- a/changelog/6301.bugfix.rst
+++ b/changelog/6301.bugfix.rst
@@ -1,1 +1,0 @@
-Fix assertion rewriting for egg-based distributions and ``editable`` installs (``pip install --editable``).

--- a/doc/en/announce/index.rst
+++ b/doc/en/announce/index.rst
@@ -6,6 +6,7 @@ Release announcements
    :maxdepth: 2
 
 
+   release-4.6.9
    release-4.6.8
    release-4.6.7
    release-4.6.6

--- a/doc/en/announce/release-4.6.9.rst
+++ b/doc/en/announce/release-4.6.9.rst
@@ -1,0 +1,21 @@
+pytest-4.6.9
+=======================================
+
+pytest 4.6.9 has just been released to PyPI.
+
+This is a bug-fix release, being a drop-in replacement. To upgrade::
+
+  pip install --upgrade pytest
+
+The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+
+Thanks to all who contributed to this release, among them:
+
+* Anthony Sottile
+* Bruno Oliveira
+* Felix Yan
+* Hugo
+
+
+Happy testing,
+The pytest Development Team


### PR DESCRIPTION
Shall we do the last core-supported python 2.x release?