### PR TITLE
[4.6] Remove unused _pytest.code.Source.isparseable function (#6405)

### DIFF
--- a/changelog/6404.trivial.rst
+++ b/changelog/6404.trivial.rst
@@ -1,0 +1,1 @@
+Removed unused ``_pytest.code.Source.isparseable`` function.

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -119,26 +119,6 @@ class Source(object):
         newsource.lines[:] = deindent(self.lines)
         return newsource
 
-    def isparseable(self, deindent=True):
-        """ return True if source is parseable, heuristically
-            deindenting it by default.
-        """
-        from parser import suite as syntax_checker
-
-        if deindent:
-            source = str(self.deindent())
-        else:
-            source = str(self)
-        try:
-            # compile(source+'\n', "x", "exec")
-            syntax_checker(source + "\n")
-        except KeyboardInterrupt:
-            raise
-        except Exception:
-            return False
-        else:
-            return True
-
     def __str__(self):
         return "\n".join(self.lines)
 

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -126,15 +126,6 @@ def test_syntaxerror_rerepresentation():
     assert ex.value.text.strip(), "x x"
 
 
-def test_isparseable():
-    assert Source("hello").isparseable()
-    assert Source("if 1:\n  pass").isparseable()
-    assert Source(" \nif 1:\n  pass").isparseable()
-    assert not Source("if 1:\n").isparseable()
-    assert not Source(" \nif 1:\npass").isparseable()
-    assert not Source(chr(0)).isparseable()
-
-
 class TestAccesses(object):
     source = Source(
         """\
@@ -147,7 +138,6 @@ class TestAccesses(object):
 
     def test_getrange(self):
         x = self.source[0:2]
-        assert x.isparseable()
         assert len(x.lines) == 2
         assert str(x) == "def f(x):\n    pass"
 


### PR DESCRIPTION
Remove unused _pytest.code.Source.isparseable function

