### PR TITLE
Remove usage of parser module (deprecated in Python 3.9)

### DIFF
--- a/changelog/6404.trivial.rst
+++ b/changelog/6404.trivial.rst
@@ -1,0 +1,1 @@
+Remove usage of ``parser`` module, deprecated in Python 3.9.

--- a/changelog/6404.trivial.rst
+++ b/changelog/6404.trivial.rst
@@ -1,1 +1,0 @@
-Removed unused ``_pytest.code.Source.isparseable`` function.

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -140,18 +140,13 @@ class Source:
         """ return True if source is parseable, heuristically
             deindenting it by default.
         """
-        from parser import suite as syntax_checker
-
         if deindent:
             source = str(self.deindent())
         else:
             source = str(self)
         try:
-            # compile(source+'\n', "x", "exec")
-            syntax_checker(source + "\n")
-        except KeyboardInterrupt:
-            raise
-        except Exception:
+            ast.parse(source)
+        except (SyntaxError, ValueError, TypeError):
             return False
         else:
             return True

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -136,6 +136,26 @@ class Source:
         newsource.lines[:] = deindent(self.lines)
         return newsource
 
+    def isparseable(self, deindent: bool = True) -> bool:
+        """ return True if source is parseable, heuristically
+            deindenting it by default.
+        """
+        from parser import suite as syntax_checker
+
+        if deindent:
+            source = str(self.deindent())
+        else:
+            source = str(self)
+        try:
+            # compile(source+'\n', "x", "exec")
+            syntax_checker(source + "\n")
+        except KeyboardInterrupt:
+            raise
+        except Exception:
+            return False
+        else:
+            return True
+
     def __str__(self) -> str:
         return "\n".join(self.lines)
 

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -121,6 +121,15 @@ def test_syntaxerror_rerepresentation() -> None:
     assert ex.value.text == "xyz xyz\n"
 
 
+def test_isparseable() -> None:
+    assert Source("hello").isparseable()
+    assert Source("if 1:\n  pass").isparseable()
+    assert Source(" \nif 1:\n  pass").isparseable()
+    assert not Source("if 1:\n").isparseable()
+    assert not Source(" \nif 1:\npass").isparseable()
+    assert not Source(chr(0)).isparseable()
+
+
 class TestAccesses:
     def setup_class(self) -> None:
         self.source = Source(
@@ -134,6 +143,7 @@ class TestAccesses:
 
     def test_getrange(self) -> None:
         x = self.source[0:2]
+        assert x.isparseable()
         assert len(x.lines) == 2
         assert str(x) == "def f(x):\n    pass"
 


### PR DESCRIPTION
Fix #6404 