### PR TITLE
[4.6] Remove usage of parser module, deprecated in Python 3.9

### DIFF
--- a/changelog/6404.trivial.rst
+++ b/changelog/6404.trivial.rst
@@ -1,0 +1,1 @@
+Remove usage of ``parser`` module, deprecated in Python 3.9.

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -123,18 +123,13 @@ class Source(object):
         """ return True if source is parseable, heuristically
             deindenting it by default.
         """
-        from parser import suite as syntax_checker
-
         if deindent:
             source = str(self.deindent())
         else:
             source = str(self)
         try:
-            # compile(source+'\n', "x", "exec")
-            syntax_checker(source + "\n")
-        except KeyboardInterrupt:
-            raise
-        except Exception:
+            ast.parse(source)
+        except (SyntaxError, ValueError, TypeError):
             return False
         else:
             return True


### PR DESCRIPTION
Backport: https://github.com/pytest-dev/pytest/pull/6407