### PR TITLE
cacheprovider: pytest_collection_modifyitems: copy items

### DIFF
--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -258,7 +258,7 @@ class LFPlugin:
             self._report_status = "no previously failed tests, "
             if self.config.getoption("last_failed_no_failures") == "none":
                 self._report_status += "deselecting all items."
-                config.hook.pytest_deselected(items=items)
+                config.hook.pytest_deselected(items=items[:])
                 items[:] = []
             else:
                 self._report_status += "not deselecting items."

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -681,11 +681,28 @@ class TestLastFailed:
         result.stdout.fnmatch_lines(["*2 passed*"])
         result = testdir.runpytest("--lf", "--lfnf", "all")
         result.stdout.fnmatch_lines(["*2 passed*"])
+
+        # Ensure the list passed to pytest_deselected is a copy,
+        # and not a reference which is cleared right after.
+        testdir.makeconftest(
+            """
+            deselected = []
+
+            def pytest_deselected(items):
+                global deselected
+                deselected = items
+
+            def pytest_sessionfinish():
+                print("\\ndeselected={}".format(len(deselected)))
+        """
+        )
+
         result = testdir.runpytest("--lf", "--lfnf", "none")
         result.stdout.fnmatch_lines(
             [
                 "collected 2 items / 2 deselected",
                 "run-last-failure: no previously failed tests, deselecting all items.",
+                "deselected=2",
                 "* 2 deselected in *",
             ]
         )


### PR DESCRIPTION
Noticed this with https://github.com/pytest-dev/pytest/pull/6409, where `items` is stored/used as-is when there are no "deselected" stats yet.