### PR TITLE
Unifying black version in pre-commit config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: v1.0.0
     hooks:
     -   id: blacken-docs
-        additional_dependencies: [black==19.3b0]
+        additional_dependencies: [black==19.10b0]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:


### PR DESCRIPTION
Should the black version be the same as that is being in use by the black hook?