### PR TITLE
Allow user to select if he wants log, std-out/err in junit capture xml file, and respect his decision

### DIFF
--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -167,51 +167,22 @@ class _NodeReporter:
         content_out = report.capstdout
         content_log = report.caplog
         content_err = report.capstderr
+        if self.xml.logging == "no":
+            return
+        if content_log and self.xml.logging in ["log", "all"]:
+            self._write_content(report, content_log, " Captured Log ", "log")
+        if content_out and self.xml.logging in ["system-out", "out-err", "all"]:
+            self._write_content(report, content_out, " Captured Stdout ", "system-out")
+        if content_err and self.xml.logging in ["system-err", "out-err", "all"]:
+            self._write_content(report, content_err, " Captured Stderr ", "system-err")
 
-        if content_log or content_out:
-            if content_log and self.xml.logging == "system-out":
-                if content_out:
-                    # syncing stdout and the log-output is not done yet. It's
-                    # probably not worth the effort. Therefore, first the captured
-                    # stdout is shown and then the captured logs.
-                    content = "\n".join(
-                        [
-                            " Captured Stdout ".center(80, "-"),
-                            content_out,
-                            "",
-                            " Captured Log ".center(80, "-"),
-                            content_log,
-                        ]
-                    )
-                else:
-                    content = content_log
-            else:
-                content = content_out
-
-            if content:
-                tag = getattr(Junit, "system-out")
-                self.append(tag(bin_xml_escape(content)))
-
-        if content_log or content_err:
-            if content_log and self.xml.logging == "system-err":
-                if content_err:
-                    content = "\n".join(
-                        [
-                            " Captured Stderr ".center(80, "-"),
-                            content_err,
-                            "",
-                            " Captured Log ".center(80, "-"),
-                            content_log,
-                        ]
-                    )
-                else:
-                    content = content_log
-            else:
-                content = content_err
-
-            if content:
-                tag = getattr(Junit, "system-err")
-                self.append(tag(bin_xml_escape(content)))
+    def _write_content(self, report, content, header, jheader):
+        result = "\n".join(
+            [header.center(80, "-"),
+             content,
+             ""])
+        tag = getattr(Junit, jheader)
+        self.append(tag(bin_xml_escape(result)))
 
     def append_pass(self, report):
         self.add_stats("passed")
@@ -408,9 +379,9 @@ def pytest_addoption(parser):
     parser.addini(
         "junit_logging",
         "Write captured log messages to JUnit report: "
-        "one of no|system-out|system-err",
+        "one of no|log|system-out|system-err|out-err|all",
         default="no",
-    )  # choices=['no', 'stdout', 'stderr'])
+    )
     parser.addini(
         "junit_log_passing_tests",
         "Capture log information for passing tests to JUnit report: ",

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -17,6 +17,7 @@ import time
 from datetime import datetime
 
 import py
+
 import pytest
 from _pytest import deprecated
 from _pytest import nodes

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -168,17 +168,26 @@ class _NodeReporter:
         content_err = report.capstderr
         if self.xml.logging == "no":
             return
+        content_all = ""
         if self.xml.logging in ["log", "all"]:
-            self._write_content(report, content_log, " Captured Log ", "log")
+            content_all = self._prepare_content(content_log, " Captured Log ")
         if self.xml.logging in ["system-out", "out-err", "all"]:
-            self._write_content(report, content_out, " Captured Out ", "system-out")
+            content_all += self._prepare_content(content_out, " Captured Out ")
+            self._write_content(report, content_all, "system-out")
+            content_all = ""
         if self.xml.logging in ["system-err", "out-err", "all"]:
-            self._write_content(report, content_err, " Captured Err ", "system-err")
+            content_all += self._prepare_content(content_err, " Captured Err ")
+            self._write_content(report, content_all, "system-err")
+            content_all = ""
+        if content_all:
+            self._write_content(report, content_all, "system-out")
 
-    def _write_content(self, report, content, header, jheader):
-        result = "\n".join([header.center(80, "-"), content, ""])
+    def _prepare_content(self, content, header):
+        return "\n".join([header.center(80, "-"), content, ""])
+
+    def _write_content(self, report, content, jheader):
         tag = getattr(Junit, jheader)
-        self.append(tag(bin_xml_escape(result)))
+        self.append(tag(bin_xml_escape(content)))
 
     def append_pass(self, report):
         self.add_stats("passed")

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -17,7 +17,6 @@ import time
 from datetime import datetime
 
 import py
-
 import pytest
 from _pytest import deprecated
 from _pytest import nodes
@@ -169,18 +168,15 @@ class _NodeReporter:
         content_err = report.capstderr
         if self.xml.logging == "no":
             return
-        if content_log and self.xml.logging in ["log", "all"]:
+        if self.xml.logging in ["log", "all"]:
             self._write_content(report, content_log, " Captured Log ", "log")
-        if content_out and self.xml.logging in ["system-out", "out-err", "all"]:
-            self._write_content(report, content_out, " Captured Stdout ", "system-out")
-        if content_err and self.xml.logging in ["system-err", "out-err", "all"]:
-            self._write_content(report, content_err, " Captured Stderr ", "system-err")
+        if self.xml.logging in ["system-out", "out-err", "all"]:
+            self._write_content(report, content_out, " Captured Out ", "system-out")
+        if self.xml.logging in ["system-err", "out-err", "all"]:
+            self._write_content(report, content_err, " Captured Err ", "system-err")
 
     def _write_content(self, report, content, header, jheader):
-        result = "\n".join(
-            [header.center(80, "-"),
-             content,
-             ""])
+        result = "\n".join([header.center(80, "-"), content, ""])
         tag = getattr(Junit, jheader)
         self.append(tag(bin_xml_escape(result)))
 

--- a/testing/example_scripts/junit-10.xsd
+++ b/testing/example_scripts/junit-10.xsd
@@ -77,6 +77,7 @@ THE SOFTWARE.
 
     <xs:element name="system-err" type="xs:string"/>
     <xs:element name="system-out" type="xs:string"/>
+    <xs:element name="log" type="xs:string"/>
     <xs:element name="rerunFailure" type="rerunType"/>
     <xs:element name="rerunError" type="rerunType"/>
     <xs:element name="flakyFailure" type="rerunType"/>
@@ -95,6 +96,7 @@ THE SOFTWARE.
                     <xs:element ref="flakyError" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element ref="system-out"/>
                     <xs:element ref="system-err"/>
+                    <xs:element ref="log"/>
                 </xs:choice>
             </xs:sequence>
             <xs:attribute name="name" type="xs:string" use="required"/>

--- a/testing/example_scripts/junit-10.xsd
+++ b/testing/example_scripts/junit-10.xsd
@@ -77,7 +77,6 @@ THE SOFTWARE.
 
     <xs:element name="system-err" type="xs:string"/>
     <xs:element name="system-out" type="xs:string"/>
-    <xs:element name="log" type="xs:string"/>
     <xs:element name="rerunFailure" type="rerunType"/>
     <xs:element name="rerunError" type="rerunType"/>
     <xs:element name="flakyFailure" type="rerunType"/>
@@ -96,7 +95,6 @@ THE SOFTWARE.
                     <xs:element ref="flakyError" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element ref="system-out"/>
                     <xs:element ref="system-err"/>
-                    <xs:element ref="log"/>
                 </xs:choice>
             </xs:sequence>
             <xs:attribute name="name" type="xs:string" use="required"/>

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -4,8 +4,9 @@ from datetime import datetime
 from xml.dom import minidom
 
 import py
-import pytest
 import xmlschema
+
+import pytest
 from _pytest.junitxml import LogXML
 from _pytest.pathlib import Path
 from _pytest.reports import BaseReport

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -489,9 +489,7 @@ class TestPython:
         elif junit_logging in ["system-out", "out-err", "all"]:
             systemout = tnode.find_first_by_tag("system-out")
             systemout_xml = systemout.toxml()
-            assert (
-                systemout.tag == "system-out"
-            ), f"Expected tag: system-out, actual: {systemout.tag}"
+            assert systemout.tag == "system-out", "Expected tag: system-out"
             assert "info msg" not in systemout_xml, "INFO message found in system-out"
             assert (
                 "hello-stdout" in systemout_xml
@@ -502,9 +500,7 @@ class TestPython:
         elif junit_logging in ["system-err", "out-err", "all"]:
             systemerr = tnode.find_first_by_tag("system-err")
             systemerr_xml = systemerr.toxml()
-            assert (
-                systemerr.tag == "system-err"
-            ), f"Expected tag: system-err, actual: {systemerr.tag}"
+            assert systemerr.tag == "system-err", "Expected tag: system-err"
             assert "info msg" not in systemerr_xml, "INFO message found in system-err"
             assert (
                 "hello-stderr" in systemerr_xml
@@ -513,7 +509,7 @@ class TestPython:
                 "warning msg" not in systemerr_xml
             ), "WARN message found in system-err"
         else:
-            assert junit_logging == "no", f"Expected: no, actual: {junit_logging}"
+            assert junit_logging == "no", "Expected: no"
             assert not tnode.find_by_tag("log"), "Found unexpected content: log"
             assert not tnode.find_by_tag(
                 "system-out"
@@ -938,7 +934,7 @@ def test_nullbyte(testdir, junit_logging):
     """
     )
     xmlf = testdir.tmpdir.join("junit.xml")
-    testdir.runpytest("--junitxml=%s" % xmlf, "-o", f"junit_logging={junit_logging}")
+    testdir.runpytest("--junitxml=%s" % xmlf, "-o", "junit_logging=%s" % junit_logging)
     text = xmlf.read()
     assert "\x00" not in text
     if junit_logging == "system-out":
@@ -960,7 +956,7 @@ def test_nullbyte_replace(testdir, junit_logging):
     """
     )
     xmlf = testdir.tmpdir.join("junit.xml")
-    testdir.runpytest("--junitxml=%s" % xmlf, "-o", f"junit_logging={junit_logging}")
+    testdir.runpytest("--junitxml=%s" % xmlf, "-o", "junit_logging=%s" % junit_logging)
     text = xmlf.read()
     if junit_logging == "system-out":
         assert "#x0" in text

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -4,9 +4,8 @@ from datetime import datetime
 from xml.dom import minidom
 
 import py
-import xmlschema
-
 import pytest
+import xmlschema
 from _pytest.junitxml import LogXML
 from _pytest.pathlib import Path
 from _pytest.reports import BaseReport
@@ -445,7 +444,9 @@ class TestPython:
         fnode.assert_attr(message="internal error")
         assert "Division" in fnode.toxml()
 
-    @pytest.mark.parametrize("junit_logging", ["no", "system-out", "system-err"])
+    @pytest.mark.parametrize(
+        "junit_logging", ["no", "log", "system-out", "system-err", "out-err", "all"]
+    )
     @parametrize_families
     def test_failure_function(
         self, testdir, junit_logging, run_and_parse, xunit_family
@@ -467,35 +468,59 @@ class TestPython:
         result, dom = run_and_parse(
             "-o", "junit_logging=%s" % junit_logging, family=xunit_family
         )
-        assert result.ret
+        assert result.ret, "Expected ret > 0"
         node = dom.find_first_by_tag("testsuite")
         node.assert_attr(failures=1, tests=1)
         tnode = node.find_first_by_tag("testcase")
         tnode.assert_attr(classname="test_failure_function", name="test_fail")
         fnode = tnode.find_first_by_tag("failure")
         fnode.assert_attr(message="ValueError: 42")
-        assert "ValueError" in fnode.toxml()
-        systemout = fnode.next_sibling
-        assert systemout.tag == "system-out"
-        systemout_xml = systemout.toxml()
-        assert "hello-stdout" in systemout_xml
-        assert "info msg" not in systemout_xml
-        systemerr = systemout.next_sibling
-        assert systemerr.tag == "system-err"
-        systemerr_xml = systemerr.toxml()
-        assert "hello-stderr" in systemerr_xml
-        assert "info msg" not in systemerr_xml
+        assert "ValueError" in fnode.toxml(), "ValueError not included"
 
-        if junit_logging == "system-out":
-            assert "warning msg" in systemout_xml
-            assert "warning msg" not in systemerr_xml
-        elif junit_logging == "system-err":
-            assert "warning msg" not in systemout_xml
-            assert "warning msg" in systemerr_xml
+        if junit_logging == "log":
+            logdata = tnode.find_first_by_tag("log")
+            log_xml = logdata.toxml()
+            assert logdata.tag == "log", f"Expected tag: log, actual: {logdata.tag}"
+            assert (
+                "info msg" not in log_xml
+            ), "Missing INFO message"  # TODO where log capture lvl is stored?
+            assert "warning msg" in log_xml, "Missing WARN message"
+            assert "hello-stdout" not in log_xml, "'hello-stdout' found in log"
+        elif junit_logging in ["system-out", "out-err", "all"]:
+            systemout = tnode.find_first_by_tag("system-out")
+            systemout_xml = systemout.toxml()
+            assert (
+                systemout.tag == "system-out"
+            ), f"Expected tag: system-out, actual: {systemout.tag}"
+            assert "info msg" not in systemout_xml, "INFO message found in system-out"
+            assert (
+                "hello-stdout" in systemout_xml
+            ), "Missing 'hello-stdout' in system-out"
+            assert (
+                "warning msg" not in systemout_xml
+            ), "WARN message found in system-out"
+        elif junit_logging in ["system-err", "out-err", "all"]:
+            systemerr = tnode.find_first_by_tag("system-err")
+            systemerr_xml = systemerr.toxml()
+            assert (
+                systemerr.tag == "system-err"
+            ), f"Expected tag: system-err, actual: {systemerr.tag}"
+            assert "info msg" not in systemerr_xml, "INFO message found in system-err"
+            assert (
+                "hello-stderr" in systemerr_xml
+            ), "Missing 'hello-stderr' in system-err"
+            assert (
+                "warning msg" not in systemerr_xml
+            ), "WARN message found in system-err"
         else:
-            assert junit_logging == "no"
-            assert "warning msg" not in systemout_xml
-            assert "warning msg" not in systemerr_xml
+            assert junit_logging == "no", f"Expected: no, actual: {junit_logging}"
+            assert not tnode.find_by_tag("log"), "Found unexpected content: log"
+            assert not tnode.find_by_tag(
+                "system-out"
+            ), "Found unexpected content: system-out"
+            assert not tnode.find_by_tag(
+                "system-err"
+            ), "Found unexpected content: system-err"
 
     @parametrize_families
     def test_failure_verbose_message(self, testdir, run_and_parse, xunit_family):
@@ -523,7 +548,9 @@ class TestPython:
                 assert 0
         """
         )
-        result, dom = run_and_parse(family=xunit_family)
+        result, dom = run_and_parse(
+            "-o", "junit_logging=system-out", family=xunit_family
+        )
         assert result.ret
         node = dom.find_first_by_tag("testsuite")
         node.assert_attr(failures=3, tests=3)
@@ -536,7 +563,7 @@ class TestPython:
             )
             sysout = tnode.find_first_by_tag("system-out")
             text = sysout.text
-            assert text == "%s\n" % char
+            assert "%s\n" % char in text
 
     @parametrize_families
     def test_junit_prefixing(self, testdir, run_and_parse, xunit_family):
@@ -597,7 +624,10 @@ class TestPython:
         fnode = tnode.find_first_by_tag("skipped")
         fnode.assert_attr(type="pytest.xfail", message="42")
 
-    def test_xfail_captures_output_once(self, testdir, run_and_parse):
+    @pytest.mark.parametrize(
+        "junit_logging", ["no", "log", "system-out", "system-err", "out-err", "all"]
+    )
+    def test_xfail_captures_output_once(self, testdir, junit_logging, run_and_parse):
         testdir.makepyfile(
             """
             import sys
@@ -610,11 +640,18 @@ class TestPython:
                 assert 0
         """
         )
-        result, dom = run_and_parse()
+        result, dom = run_and_parse("-o", "junit_logging=%s" % junit_logging)
         node = dom.find_first_by_tag("testsuite")
         tnode = node.find_first_by_tag("testcase")
-        assert len(tnode.find_by_tag("system-err")) == 1
-        assert len(tnode.find_by_tag("system-out")) == 1
+        if junit_logging in ["system-err", "out-err", "all"]:
+            assert len(tnode.find_by_tag("system-err")) == 1
+        else:
+            assert len(tnode.find_by_tag("system-err")) == 0
+
+        if junit_logging in ["system-out", "out-err", "all"]:
+            assert len(tnode.find_by_tag("system-out")) == 1
+        else:
+            assert len(tnode.find_by_tag("system-out")) == 0
 
     @parametrize_families
     def test_xfailure_xpass(self, testdir, run_and_parse, xunit_family):
@@ -696,20 +733,29 @@ class TestPython:
         result, dom = run_and_parse()
         print(dom.toxml())
 
-    def test_pass_captures_stdout(self, testdir, run_and_parse):
+    @pytest.mark.parametrize("junit_logging", ["no", "system-out"])
+    def test_pass_captures_stdout(self, testdir, run_and_parse, junit_logging):
         testdir.makepyfile(
             """
             def test_pass():
                 print('hello-stdout')
         """
         )
-        result, dom = run_and_parse()
+        result, dom = run_and_parse("-o", "junit_logging=%s" % junit_logging)
         node = dom.find_first_by_tag("testsuite")
         pnode = node.find_first_by_tag("testcase")
-        systemout = pnode.find_first_by_tag("system-out")
-        assert "hello-stdout" in systemout.toxml()
+        if junit_logging == "no":
+            assert not node.find_by_tag(
+                "system-out"
+            ), "system-out should not be generated"
+        if junit_logging == "system-out":
+            systemout = pnode.find_first_by_tag("system-out")
+            assert (
+                "hello-stdout" in systemout.toxml()
+            ), "'hello-stdout' should be in system-out"
 
-    def test_pass_captures_stderr(self, testdir, run_and_parse):
+    @pytest.mark.parametrize("junit_logging", ["no", "system-err"])
+    def test_pass_captures_stderr(self, testdir, run_and_parse, junit_logging):
         testdir.makepyfile(
             """
             import sys
@@ -717,13 +763,21 @@ class TestPython:
                 sys.stderr.write('hello-stderr')
         """
         )
-        result, dom = run_and_parse()
+        result, dom = run_and_parse("-o", "junit_logging=%s" % junit_logging)
         node = dom.find_first_by_tag("testsuite")
         pnode = node.find_first_by_tag("testcase")
-        systemout = pnode.find_first_by_tag("system-err")
-        assert "hello-stderr" in systemout.toxml()
+        if junit_logging == "no":
+            assert not node.find_by_tag(
+                "system-err"
+            ), "system-err should not be generated"
+        if junit_logging == "system-err":
+            systemerr = pnode.find_first_by_tag("system-err")
+            assert (
+                "hello-stderr" in systemerr.toxml()
+            ), "'hello-stderr' should be in system-err"
 
-    def test_setup_error_captures_stdout(self, testdir, run_and_parse):
+    @pytest.mark.parametrize("junit_logging", ["no", "system-out"])
+    def test_setup_error_captures_stdout(self, testdir, run_and_parse, junit_logging):
         testdir.makepyfile(
             """
             import pytest
@@ -736,13 +790,21 @@ class TestPython:
                 pass
         """
         )
-        result, dom = run_and_parse()
+        result, dom = run_and_parse("-o", "junit_logging=%s" % junit_logging)
         node = dom.find_first_by_tag("testsuite")
         pnode = node.find_first_by_tag("testcase")
-        systemout = pnode.find_first_by_tag("system-out")
-        assert "hello-stdout" in systemout.toxml()
+        if junit_logging == "no":
+            assert not node.find_by_tag(
+                "system-out"
+            ), "system-out should not be generated"
+        if junit_logging == "system-out":
+            systemout = pnode.find_first_by_tag("system-out")
+            assert (
+                "hello-stdout" in systemout.toxml()
+            ), "'hello-stdout' should be in system-out"
 
-    def test_setup_error_captures_stderr(self, testdir, run_and_parse):
+    @pytest.mark.parametrize("junit_logging", ["no", "system-err"])
+    def test_setup_error_captures_stderr(self, testdir, run_and_parse, junit_logging):
         testdir.makepyfile(
             """
             import sys
@@ -756,13 +818,21 @@ class TestPython:
                 pass
         """
         )
-        result, dom = run_and_parse()
+        result, dom = run_and_parse("-o", "junit_logging=%s" % junit_logging)
         node = dom.find_first_by_tag("testsuite")
         pnode = node.find_first_by_tag("testcase")
-        systemout = pnode.find_first_by_tag("system-err")
-        assert "hello-stderr" in systemout.toxml()
+        if junit_logging == "no":
+            assert not node.find_by_tag(
+                "system-err"
+            ), "system-err should not be generated"
+        if junit_logging == "system-err":
+            systemerr = pnode.find_first_by_tag("system-err")
+            assert (
+                "hello-stderr" in systemerr.toxml()
+            ), "'hello-stderr' should be in system-err"
 
-    def test_avoid_double_stdout(self, testdir, run_and_parse):
+    @pytest.mark.parametrize("junit_logging", ["no", "system-out"])
+    def test_avoid_double_stdout(self, testdir, run_and_parse, junit_logging):
         testdir.makepyfile(
             """
             import sys
@@ -777,12 +847,17 @@ class TestPython:
                 sys.stdout.write('hello-stdout call')
         """
         )
-        result, dom = run_and_parse()
+        result, dom = run_and_parse("-o", "junit_logging=%s" % junit_logging)
         node = dom.find_first_by_tag("testsuite")
         pnode = node.find_first_by_tag("testcase")
-        systemout = pnode.find_first_by_tag("system-out")
-        assert "hello-stdout call" in systemout.toxml()
-        assert "hello-stdout teardown" in systemout.toxml()
+        if junit_logging == "no":
+            assert not node.find_by_tag(
+                "system-out"
+            ), "system-out should not be generated"
+        if junit_logging == "system-out":
+            systemout = pnode.find_first_by_tag("system-out")
+            assert "hello-stdout call" in systemout.toxml()
+            assert "hello-stdout teardown" in systemout.toxml()
 
 
 def test_mangle_test_address():
@@ -850,7 +925,8 @@ class TestNonPython:
         assert "custom item runtest failed" in fnode.toxml()
 
 
-def test_nullbyte(testdir):
+@pytest.mark.parametrize("junit_logging", ["no", "system-out"])
+def test_nullbyte(testdir, junit_logging):
     # A null byte can not occur in XML (see section 2.2 of the spec)
     testdir.makepyfile(
         """
@@ -862,13 +938,17 @@ def test_nullbyte(testdir):
     """
     )
     xmlf = testdir.tmpdir.join("junit.xml")
-    testdir.runpytest("--junitxml=%s" % xmlf)
+    testdir.runpytest("--junitxml=%s" % xmlf, "-o", f"junit_logging={junit_logging}")
     text = xmlf.read()
     assert "\x00" not in text
-    assert "#x00" in text
+    if junit_logging == "system-out":
+        assert "#x00" in text
+    if junit_logging == "no":
+        assert "#x00" not in text
 
 
-def test_nullbyte_replace(testdir):
+@pytest.mark.parametrize("junit_logging", ["no", "system-out"])
+def test_nullbyte_replace(testdir, junit_logging):
     # Check if the null byte gets replaced
     testdir.makepyfile(
         """
@@ -880,9 +960,12 @@ def test_nullbyte_replace(testdir):
     """
     )
     xmlf = testdir.tmpdir.join("junit.xml")
-    testdir.runpytest("--junitxml=%s" % xmlf)
+    testdir.runpytest("--junitxml=%s" % xmlf, "-o", f"junit_logging={junit_logging}")
     text = xmlf.read()
-    assert "#x0" in text
+    if junit_logging == "system-out":
+        assert "#x0" in text
+    if junit_logging == "no":
+        assert "#x0" not in text
 
 
 def test_invalid_xml_escape():

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -477,16 +477,13 @@ class TestPython:
         fnode.assert_attr(message="ValueError: 42")
         assert "ValueError" in fnode.toxml(), "ValueError not included"
 
-        if junit_logging == "log":
-            logdata = tnode.find_first_by_tag("log")
+        if junit_logging in ["log", "all"]:
+            logdata = tnode.find_first_by_tag("system-out")
             log_xml = logdata.toxml()
-            assert logdata.tag == "log", "Expected tag: log"
-            assert (
-                "info msg" not in log_xml
-            ), "Missing INFO message"  # TODO where log capture lvl is stored?
+            assert logdata.tag == "system-out", "Expected tag: system-out"
+            assert "info msg" not in log_xml, "Unexpected INFO message"
             assert "warning msg" in log_xml, "Missing WARN message"
-            assert "hello-stdout" not in log_xml, "'hello-stdout' found in log"
-        elif junit_logging in ["system-out", "out-err", "all"]:
+        if junit_logging in ["system-out", "out-err", "all"]:
             systemout = tnode.find_first_by_tag("system-out")
             systemout_xml = systemout.toxml()
             assert systemout.tag == "system-out", "Expected tag: system-out"
@@ -494,10 +491,7 @@ class TestPython:
             assert (
                 "hello-stdout" in systemout_xml
             ), "Missing 'hello-stdout' in system-out"
-            assert (
-                "warning msg" not in systemout_xml
-            ), "WARN message found in system-out"
-        elif junit_logging in ["system-err", "out-err", "all"]:
+        if junit_logging in ["system-err", "out-err", "all"]:
             systemerr = tnode.find_first_by_tag("system-err")
             systemerr_xml = systemerr.toxml()
             assert systemerr.tag == "system-err", "Expected tag: system-err"
@@ -508,8 +502,7 @@ class TestPython:
             assert (
                 "warning msg" not in systemerr_xml
             ), "WARN message found in system-err"
-        else:
-            assert junit_logging == "no", "Expected: no"
+        if junit_logging == "no":
             assert not tnode.find_by_tag("log"), "Found unexpected content: log"
             assert not tnode.find_by_tag(
                 "system-out"
@@ -644,7 +637,7 @@ class TestPython:
         else:
             assert len(tnode.find_by_tag("system-err")) == 0
 
-        if junit_logging in ["system-out", "out-err", "all"]:
+        if junit_logging in ["log", "system-out", "out-err", "all"]:
             assert len(tnode.find_by_tag("system-out")) == 1
         else:
             assert len(tnode.find_by_tag("system-out")) == 0

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -480,7 +480,7 @@ class TestPython:
         if junit_logging == "log":
             logdata = tnode.find_first_by_tag("log")
             log_xml = logdata.toxml()
-            assert logdata.tag == "log", f"Expected tag: log"
+            assert logdata.tag == "log", "Expected tag: log"
             assert (
                 "info msg" not in log_xml
             ), "Missing INFO message"  # TODO where log capture lvl is stored?

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -480,7 +480,7 @@ class TestPython:
         if junit_logging == "log":
             logdata = tnode.find_first_by_tag("log")
             log_xml = logdata.toxml()
-            assert logdata.tag == "log", f"Expected tag: log, actual: {logdata.tag}"
+            assert logdata.tag == "log", f"Expected tag: log"
             assert (
                 "info msg" not in log_xml
             ), "Missing INFO message"  # TODO where log capture lvl is stored?


### PR DESCRIPTION
The purpose for this PR is enabling user to set what should be contained in generated xml file since for some (me included) this file is used only for report generation, hence log/out/err are not always welcome, and can take lots of space.

User can pick between _no|log|system-out|system-err|out-err|all_ in order to put selected output in xml file.
