### PR TITLE
Fix wrong 'changelog' and 'reference' links in docs

### DIFF
--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -1,3 +1,5 @@
+.. _`changelog`:
+
 =========
 Changelog
 =========

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -1,3 +1,5 @@
+.. _`reference`:
+
 API Reference
 =============
 


### PR DESCRIPTION
Both references were referencing links from Python because of our intersphinx
mapping in `conf.py`:

    intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}

Because Python's docs explicitly define both references, Sphinx fallbacks to
them instead of generating implicit references as was expected.

Found the two references in this PR by commenting the line above in `conf.py`.

Fix #6397