### PR TITLE
terminal: use "yellow" with any "xpassed" tests

### DIFF
--- a/changelog/449.improvement.rst
+++ b/changelog/449.improvement.rst
@@ -1,0 +1,1 @@
+Use "yellow" main color with any XPASSED tests.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1107,7 +1107,7 @@ def _get_main_color(stats) -> Tuple[str, List[str]]:
     # main color
     if "failed" in stats or "error" in stats:
         main_color = "red"
-    elif "warnings" in stats or unknown_type_seen:
+    elif "warnings" in stats or "xpassed" in stats or unknown_type_seen:
         main_color = "yellow"
     elif "passed" in stats:
         main_color = "green"

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1385,10 +1385,10 @@ def test_terminal_summary_warnings_header_once(testdir):
         ),
         ("yellow", [("1 xpassed", {"bold": True, "yellow": True})], {"xpassed": (1,)}),
         (
-            "green",
+            "yellow",
             [
-                ("1 passed", {"bold": True, "green": True}),
-                ("1 xpassed", {"bold": False, "yellow": True}),
+                ("1 passed", {"bold": False, "green": True}),
+                ("1 xpassed", {"bold": True, "yellow": True}),
             ],
             {"xpassed": (1,), "passed": (1,)},
         ),


### PR DESCRIPTION
Closes https://github.com/pytest-dev/pytest/issues/449.