### PR TITLE
[WIP] cacheprovider: pytest_collectreport: do not add to lastfailed with passes

### DIFF
--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -210,8 +210,7 @@ class LFPlugin:
     def pytest_collectreport(self, report):
         passed = report.outcome in ("passed", "skipped")
         if passed:
-            if report.nodeid in self.lastfailed:
-                self.lastfailed.pop(report.nodeid)
+            self.lastfailed.pop(report.nodeid, None)
         else:
             self.lastfailed[report.nodeid] = True
 

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -212,7 +212,6 @@ class LFPlugin:
         if passed:
             if report.nodeid in self.lastfailed:
                 self.lastfailed.pop(report.nodeid)
-                self.lastfailed.update((item.nodeid, True) for item in report.result)
         else:
             self.lastfailed[report.nodeid] = True
 


### PR DESCRIPTION
Not clear what this is meant to do - it will usually get cleared with
test reports afterwards already.

Replacing it with `assert 0` causes a test failure, but not when doing
so with the commit that merged the cache plugin (e20216a1a).