### PR TITLE
Fix/improve assertion with "skipped" CollectReports

### DIFF
--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1053,7 +1053,7 @@ def _folded_skips(skipped):
     d = {}
     for event in skipped:
         key = event.longrepr
-        assert len(key) == 3, (event, key)
+        assert key and len(key) == 3, (event, key)
         keywords = getattr(event, "keywords", {})
         # folding reports with global pytestmark variable
         # this is workaround, because for now we cannot identify the scope of a skip marker

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -1327,3 +1327,26 @@ def test_does_not_put_src_on_path(testdir):
     )
     result = testdir.runpytest()
     assert result.ret == ExitCode.OK
+
+
+def test_collectreport_skipped(testdir):
+    testdir.makeconftest(
+        """
+        from _pytest.reports import CollectReport
+
+
+        def pytest_make_collect_report(collector):
+            return CollectReport(
+                collector.nodeid, "skipped", longrepr=None, result=[]
+            )
+        """
+    )
+    result = testdir.runpytest("-ra")
+    assert result.ret == ExitCode.INTERNAL_ERROR
+    result.stdout.fnmatch_lines(["collected 0 items / 1 skipped"])
+    result.stderr.fnmatch_lines(
+        [
+            "    assert key and len(key) == 3, (event, key)",
+            "AssertionError: (<CollectReport '' lenresult=0 outcome='skipped'>, None)",
+        ]
+    )


### PR DESCRIPTION
This does not help that much, but tests and improves the current
behavior when using `CollectReport(outcome="skipped")` (not really
supported likely).