### PR TITLE
Use TYPE_CHECKING instead of False

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -24,3 +24,5 @@ exclude_lines =
     \#\s*pragma: no cover
     ^\s*raise NotImplementedError\b
     ^\s*return NotImplemented\b
+
+    ^\s*if TYPE_CHECKING:

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -19,8 +19,9 @@ import os
 import sys
 
 from _pytest import __version__ as version
+from _pytest.compat import TYPE_CHECKING
 
-if False:  # TYPE_CHECKING
+if TYPE_CHECKING:
     import sphinx.application
 
 

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -32,8 +32,9 @@ import _pytest
 from _pytest._io.saferepr import safeformat
 from _pytest._io.saferepr import saferepr
 from _pytest.compat import overload
+from _pytest.compat import TYPE_CHECKING
 
-if False:  # TYPE_CHECKING
+if TYPE_CHECKING:
     from typing import Type
     from typing_extensions import Literal
     from weakref import ReferenceType  # noqa: F401

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -27,7 +27,13 @@ from _pytest._io.saferepr import saferepr
 from _pytest.outcomes import fail
 from _pytest.outcomes import TEST_OUTCOME
 
-if False:  # TYPE_CHECKING
+if sys.version_info < (3, 5, 2):
+    TYPE_CHECKING = False  # type: bool
+else:
+    from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
     from typing import Type  # noqa: F401 (used in type string)
 
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -37,12 +37,13 @@ from .findpaths import exists
 from _pytest._code import ExceptionInfo
 from _pytest._code import filter_traceback
 from _pytest.compat import importlib_metadata
+from _pytest.compat import TYPE_CHECKING
 from _pytest.outcomes import fail
 from _pytest.outcomes import Skipped
 from _pytest.pathlib import Path
 from _pytest.warning_types import PytestConfigWarning
 
-if False:  # TYPE_CHECKING
+if TYPE_CHECKING:
     from typing import Type
 
 

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -5,9 +5,10 @@ from typing import Optional
 import py
 
 from .exceptions import UsageError
+from _pytest.compat import TYPE_CHECKING
 from _pytest.outcomes import fail
 
-if False:
+if TYPE_CHECKING:
     from . import Config  # noqa: F401
 
 

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -19,12 +19,13 @@ from _pytest._code.code import ExceptionInfo
 from _pytest._code.code import ReprFileLocation
 from _pytest._code.code import TerminalRepr
 from _pytest.compat import safe_getattr
+from _pytest.compat import TYPE_CHECKING
 from _pytest.fixtures import FixtureRequest
 from _pytest.outcomes import Skipped
 from _pytest.python_api import approx
 from _pytest.warning_types import PytestWarning
 
-if False:  # TYPE_CHECKING
+if TYPE_CHECKING:
     import doctest
     from typing import Type
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -27,12 +27,13 @@ from _pytest.compat import getlocation
 from _pytest.compat import is_generator
 from _pytest.compat import NOTSET
 from _pytest.compat import safe_getattr
+from _pytest.compat import TYPE_CHECKING
 from _pytest.deprecated import FIXTURE_POSITIONAL_ARGUMENTS
 from _pytest.deprecated import FUNCARGNAMES
 from _pytest.outcomes import fail
 from _pytest.outcomes import TEST_OUTCOME
 
-if False:  # TYPE_CHECKING
+if TYPE_CHECKING:
     from typing import Type
 
     from _pytest import nodes

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -17,6 +17,7 @@ from _pytest._code.code import ExceptionInfo
 from _pytest._code.code import ReprExceptionInfo
 from _pytest.compat import cached_property
 from _pytest.compat import getfslineno
+from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.fixtures import FixtureDef
 from _pytest.fixtures import FixtureLookupError
@@ -26,7 +27,7 @@ from _pytest.mark.structures import MarkDecorator
 from _pytest.mark.structures import NodeKeywords
 from _pytest.outcomes import Failed
 
-if False:  # TYPE_CHECKING
+if TYPE_CHECKING:
     # Imported here due to circular import.
     from _pytest.main import Session  # noqa: F401
 

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -8,7 +8,9 @@ from typing import Optional
 
 from packaging.version import Version
 
-if False:  # TYPE_CHECKING
+TYPE_CHECKING = False  # avoid circular import through compat
+
+if TYPE_CHECKING:
     from typing import NoReturn
 
 

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -28,6 +28,7 @@ from _pytest._code import Source
 from _pytest._io.saferepr import saferepr
 from _pytest.capture import MultiCapture
 from _pytest.capture import SysCapture
+from _pytest.compat import TYPE_CHECKING
 from _pytest.fixtures import FixtureRequest
 from _pytest.main import ExitCode
 from _pytest.main import Session
@@ -35,7 +36,7 @@ from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pathlib import Path
 from _pytest.reports import TestReport
 
-if False:  # TYPE_CHECKING
+if TYPE_CHECKING:
     from typing import Type
 
 
@@ -189,7 +190,7 @@ class ParsedCall:
         del d["_name"]
         return "<ParsedCall {!r}(**{!r})>".format(self._name, d)
 
-    if False:  # TYPE_CHECKING
+    if TYPE_CHECKING:
         # The class has undetermined attributes, this tells mypy about it.
         def __getattr__(self, key):
             raise NotImplementedError()

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -23,9 +23,10 @@ from more_itertools.more import always_iterable
 import _pytest._code
 from _pytest.compat import overload
 from _pytest.compat import STRING_TYPES
+from _pytest.compat import TYPE_CHECKING
 from _pytest.outcomes import fail
 
-if False:  # TYPE_CHECKING
+if TYPE_CHECKING:
     from typing import Type  # noqa: F401 (used in type string)
 
 

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -12,10 +12,11 @@ from typing import Tuple
 from typing import Union
 
 from _pytest.compat import overload
+from _pytest.compat import TYPE_CHECKING
 from _pytest.fixtures import yield_fixture
 from _pytest.outcomes import fail
 
-if False:  # TYPE_CHECKING
+if TYPE_CHECKING:
     from typing import Type
 
 

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -15,12 +15,13 @@ from .reports import CollectErrorRepr
 from .reports import CollectReport
 from .reports import TestReport
 from _pytest._code.code import ExceptionInfo
+from _pytest.compat import TYPE_CHECKING
 from _pytest.nodes import Node
 from _pytest.outcomes import Exit
 from _pytest.outcomes import Skipped
 from _pytest.outcomes import TEST_OUTCOME
 
-if False:  # TYPE_CHECKING
+if TYPE_CHECKING:
     from typing import Type
 
 #

--- a/src/_pytest/warning_types.py
+++ b/src/_pytest/warning_types.py
@@ -4,8 +4,9 @@ from typing import TypeVar
 
 import attr
 
+from _pytest.compat import TYPE_CHECKING
 
-if False:  # TYPE_CHECKING
+if TYPE_CHECKING:
     from typing import Type  # noqa: F401 (used in type string)
 
 


### PR DESCRIPTION
This allows for e.g. Jedi to infer types.

It was only used to support Python 3.5.0/3.5.1, where this is available
in `typing_extensions`.

Ref: https://github.com/davidhalter/jedi/issues/1472

TODO:

- [x] I'll rebase this (with changelog) after merging master after #6440
- [x] rebased on / blocked by https://github.com/pytest-dev/pytest/pull/6458