### PR TITLE
ci: Travis: Python 3.5.1 via Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,10 @@ jobs:
     - env: TOXENV=pypy3-xdist
       python: 'pypy3'
 
-    - env: TOXENV=py35-xdist
-      python: '3.5'
+    # Coverage for Python 3.5.{0,1} specific code, mostly typing related.
+    - env: TOXENV=py35 PYTEST_COVERAGE=1 PYTEST_ADDOPTS="-k test_raises_cyclic_reference"
+      python: '3.5.1'
+      dist: trusty
 
     # Specialized factors for py37.
     - env: TOXENV=py37-pluggymaster-xdist

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -371,7 +371,7 @@ class CaptureIO(io.TextIOWrapper):
         return self.buffer.getvalue().decode("UTF-8")
 
 
-if sys.version_info < (3, 5, 2):  # pragma: no cover
+if sys.version_info < (3, 5, 2):
 
     def overload(f):  # noqa: F811
         return f

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -166,7 +166,7 @@ class TestRaises:
                 # Early versions of Python 3.5 have some bug causing the
                 # __call__ frame to still refer to t even after everything
                 # is done. This makes the test pass for them.
-                if sys.version_info < (3, 5, 2):  # pragma: no cover
+                if sys.version_info < (3, 5, 2):
                     del self
                 raise ValueError
 


### PR DESCRIPTION
Python 3.5.0 caused flaky failures before
(https://github.com/pytest-dev/pytest/issues/5795), hopefully this is
more stable.

This is pulled out of https://github.com/pytest-dev/pytest/pull/6435,
which adds code specific for Python < 3.5.2, and therefore it makes
sense to test it.