### PR TITLE
tox: add mypy toxenv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     -   id: pyupgrade
         args: [--py3-plus]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.761
+    rev: v0.761  # NOTE: keep this in sync with setup.py.
     hooks:
     -   id: mypy
         files: ^(src/|testing/)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,10 @@ def main():
                 "nose",
                 "requests",
                 "xmlschema",
-            ]
+            ],
+            "checkqa-mypy": [
+                "mypy==v0.761",  # keep this in sync with .pre-commit-config.yaml.
+            ],
         },
         install_requires=INSTALL_REQUIRES,
     )

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,10 @@ basepython = python3
 deps = pre-commit>=1.11.0
 commands = pre-commit run --all-files --show-diff-on-failure {posargs:}
 
+[testenv:mypy]
+extras = checkqa-mypy, testing
+commands = mypy {posargs:src testing}
+
 [testenv:docs]
 basepython = python3
 usedevelop = True


### PR DESCRIPTION
This is different from what pre-commit (in "linting") runs in that it
uses our config (alone), and stubs from dependencies.

It would make sense to run this on CI additionally (since there is no
"pre-commit --skip mypy", and a separate config is not worth it).
Currently it triggers a false positive though anyway
(https://github.com/erikrose/more-itertools/pull/374).