### PR TITLE
LFPlugin: use sub-plugins to deselect during collection

### DIFF
--- a/changelog/5301.bugfix.rst
+++ b/changelog/5301.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``--last-failed`` to collect new tests from files with known failures.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -795,6 +795,11 @@ class Config:
             kwargs=dict(parser=self._parser, pluginmanager=self.pluginmanager)
         )
 
+        if False:  # TYPE_CHECKING
+            from _pytest.cacheprovider import Cache
+
+            self.cache = None  # type: Optional[Cache]
+
     @property
     def invocation_dir(self):
         """Backward compatibility"""


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/issues/5301

Two subplugins are necessary due to limitations in pluggy (https://github.com/pytest-dev/pluggy/pull/246).

TODO:

- [x] changelog; NOTE: might only fix later issue reported in #5301 (https://github.com/pytest-dev/pytest/issues/5301#issuecomment-572524754)
