### PR TITLE
Allow user to select if he wants log, std-out/err in junit capture xml file, and respect his decision

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -122,6 +122,7 @@ Ilya Konstantinov
 Ionuț Turturică
 Iwan Briquemont
 Jaap Broekhuizen
+Jakub Mitoraj
 Jan Balster
 Janne Vanhala
 Jason R. Coombs

--- a/changelog/6469.feature.rst
+++ b/changelog/6469.feature.rst
@@ -1,0 +1,1 @@
+User can set ``junit_logging`` to one of ``no|log|system-out|system-err|out-err|all`` in order to put selected output in xml file.

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -1166,7 +1166,7 @@ passed multiple times. The expected format is ``name=value``. For example::
     .. versionadded:: 3.5
 
     Configures if stdout/stderr should be written to the JUnit XML file. Valid values are
-    ``system-out``, ``system-err``, and ``no`` (the default).
+    ``log``, ``out-err``, ``all``, ``system-out``, ``system-err``, and ``no`` (the default).
 
     .. code-block:: ini
 

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1297,7 +1297,11 @@ def test_tee_stdio_captures_and_live_prints(testdir):
     """
     )
     result = testdir.runpytest_subprocess(
-        testpath, "--capture=tee-sys", "--junitxml=output.xml"
+        testpath,
+        "--capture=tee-sys",
+        "--junitxml=output.xml",
+        "-o",
+        "junit_logging=all",
     )
 
     # ensure stdout/stderr were 'live printed'
@@ -1307,6 +1311,5 @@ def test_tee_stdio_captures_and_live_prints(testdir):
     # now ensure the output is in the junitxml
     with open(os.path.join(testdir.tmpdir.strpath, "output.xml"), "r") as f:
         fullXml = f.read()
-
-    assert "<system-out>@this is stdout@\n</system-out>" in fullXml
-    assert "<system-err>@this is stderr@\n</system-err>" in fullXml
+    assert "@this is stdout@\n" in fullXml
+    assert "@this is stderr@\n" in fullXml


### PR DESCRIPTION
The purpose for this PR is enabling user to set what should be contained in generated xml file since for some (me included) this file is used only for report generation, hence log/out/err are not always welcome, and can take lots of space.

User can pick between no|log|system-out|system-err|out-err|all in order to put selected output in xml file.