### PR TITLE
Skip most jobs when making a release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    # when pushing a tag to publish a release, skip most jobs except those with "release_checker: true"
+    if: "!startsWith(github.event.ref, 'refs/tags') || matrix.release_checker"
 
     strategy:
       fail-fast: false
@@ -93,6 +95,7 @@ jobs:
             python: "3.8"
             os: ubuntu-latest
             tox_env: "py38-xdist"
+            release_checker: true
           - name: "ubuntu-pypy3"
             python: "pypy3"
             os: ubuntu-latest
@@ -113,6 +116,7 @@ jobs:
             python: "3.7"
             os: ubuntu-latest
             tox_env: "linting,docs,doctesting"
+            release_checker: true
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
This adds a new optional matrix variable 'release_checker': when true,
the job also executes when we are pushing a tag, otherwise it is skipped.

This is similar to what we did when deploys where done by Travis.