### PR TITLE
setup.py: set git_describe_command to not include `--first-parent`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,10 @@ INSTALL_REQUIRES = [
 
 def main():
     setup(
-        use_scm_version={"write_to": "src/_pytest/_version.py"},
+        use_scm_version={
+            "write_to": "src/_pytest/_version.py",
+            "git_describe_command": "git describe --dirty --tags --long --match *.*",
+        },
         setup_requires=["setuptools-scm", "setuptools>=40.0"],
         package_dir={"": "src"},
         extras_require={

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -5,10 +5,10 @@ from _pytest.main import ExitCode
 def test_version(testdir, pytestconfig):
     result = testdir.runpytest("--version")
     assert result.ret == 0
-    # p = py.path.local(py.__file__).dirpath()
     result.stderr.fnmatch_lines(
         ["*pytest*{}*imported from*".format(pytest.__version__)]
     )
+    assert pytest.__version__[0] == "5"
     if pytestconfig.pluginmanager.list_plugin_distinfo():
         result.stderr.fnmatch_lines(["*setuptools registered plugins:", "*at*"])
 


### PR DESCRIPTION
This is the default since setuptools-scm [1], and does not match pytest's
release workflow.

1: https://github.com/pypa/setuptools_scm/pull/346