### PR TITLE
tests: test_excinfo: remove unused pytest_version_info

### DIFF
--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -21,8 +21,6 @@ except ImportError:
 else:
     invalidate_import_caches = getattr(importlib, "invalidate_caches", None)
 
-pytest_version_info = tuple(map(int, pytest.__version__.split(".")[:3]))
-
 
 @pytest.fixture
 def limited_recursion_depth():


### PR DESCRIPTION
This might fail unnecessarily with a (wrong) determined version of e.g.
"4.7.dev307+ge98176cf5" (no patch version).
Ref: https://github.com/pytest-dev/pytest/pull/6506