### PR TITLE
Fix internal assert failure regression in 5.3.4

### DIFF
--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -82,8 +82,8 @@ class Parser:
 
         self.optparser = self._getparser()
         try_argcomplete(self.optparser)
-        strargs = [str(x) if isinstance(x, py.path.local) else x for x in args]
-        return self.optparser.parse_args(strargs, namespace=namespace)
+        args = [str(x) if isinstance(x, py.path.local) else x for x in args]
+        return self.optparser.parse_args(args, namespace=namespace)
 
     def _getparser(self) -> "MyOptionParser":
         from _pytest._argcomplete import filescompleter
@@ -124,8 +124,8 @@ class Parser:
         the remaining arguments unknown at this point.
         """
         optparser = self._getparser()
-        strargs = [str(x) if isinstance(x, py.path.local) else x for x in args]
-        return optparser.parse_known_args(strargs, namespace=namespace)
+        args = [str(x) if isinstance(x, py.path.local) else x for x in args]
+        return optparser.parse_known_args(args, namespace=namespace)
 
     def addini(self, name, help, type=None, default=None):
         """ register an ini-file option.

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -1,9 +1,6 @@
 import os
-from typing import Any
-from typing import Iterable
 from typing import List
 from typing import Optional
-from typing import Tuple
 
 import py
 
@@ -63,7 +60,7 @@ def getcfg(args, config=None):
     return None, None, None
 
 
-def get_common_ancestor(paths: Iterable[py.path.local]) -> py.path.local:
+def get_common_ancestor(paths):
     common_ancestor = None
     for path in paths:
         if not path.exists():
@@ -116,7 +113,7 @@ def determine_setup(
     args: List[str],
     rootdir_cmd_arg: Optional[str] = None,
     config: Optional["Config"] = None,
-) -> Tuple[py.path.local, Optional[str], Any]:
+):
     dirs = get_dirs_from_args(args)
     if inifile:
         iniconfig = py.iniconfig.IniConfig(inifile)

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -308,7 +308,7 @@ class DoctestItem(pytest.Item):
         else:
             return super().repr_failure(excinfo)
 
-    def reportinfo(self) -> Tuple[py.path.local, int, str]:
+    def reportinfo(self) -> Tuple[str, int, str]:
         return self.fspath, self.dtest.lineno, "[doctest] %s" % self.name
 
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -351,7 +351,7 @@ class FixtureRequest:
         self.fixturename = None
         #: Scope string, one of "function", "class", "module", "session"
         self.scope = "function"
-        self._fixture_defs = {}  # type: Dict[str, FixtureDef]
+        self._fixture_defs = {}  # argname -> FixtureDef
         fixtureinfo = pyfuncitem._fixtureinfo
         self._arg2fixturedefs = fixtureinfo.name2fixturedefs.copy()
         self._arg2index = {}
@@ -426,8 +426,7 @@ class FixtureRequest:
     @scopeproperty()
     def fspath(self) -> py.path.local:
         """ the file system path of the test module which collected this test. """
-        # TODO: Remove ignore once _pyfuncitem is properly typed.
-        return self._pyfuncitem.fspath  # type: ignore
+        return self._pyfuncitem.fspath
 
     @property
     def keywords(self):
@@ -550,9 +549,7 @@ class FixtureRequest:
                 source_lineno = frameinfo.lineno
                 source_path = py.path.local(source_path)
                 if source_path.relto(funcitem.config.rootdir):
-                    source_path_str = source_path.relto(funcitem.config.rootdir)
-                else:
-                    source_path_str = str(source_path)
+                    source_path = source_path.relto(funcitem.config.rootdir)
                 msg = (
                     "The requested fixture has no parameter defined for test:\n"
                     "    {}\n\n"
@@ -561,7 +558,7 @@ class FixtureRequest:
                         funcitem.nodeid,
                         fixturedef.argname,
                         getlocation(fixturedef.func, funcitem.config.rootdir),
-                        source_path_str,
+                        source_path,
                         source_lineno,
                     )
                 )

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -367,9 +367,9 @@ class Failed(Exception):
 
 @attr.s
 class _bestrelpath_cache(dict):
-    path = attr.ib(type=py.path.local)
+    path = attr.ib()
 
-    def __missing__(self, path: py.path.local) -> str:
+    def __missing__(self, path: str) -> str:
         r = self.path.bestrelpath(path)  # type: str
         self[path] = r
         return r
@@ -399,7 +399,7 @@ class Session(nodes.FSCollector):
         self._node_cache = {}
         self._bestrelpathcache = _bestrelpath_cache(
             config.rootdir
-        )  # type: Dict[py.path.local, str]
+        )  # type: Dict[str, str]
         # Dirnames of pkgs with dunder-init files.
         self._pkg_roots = {}
 
@@ -414,7 +414,7 @@ class Session(nodes.FSCollector):
             self.testscollected,
         )
 
-    def _node_location_to_relpath(self, node_path: py.path.local) -> str:
+    def _node_location_to_relpath(self, node_path: str) -> str:
         # bestrelpath is a quite slow function
         return self._bestrelpathcache[node_path]
 

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -462,7 +462,6 @@ class Item(Node):
     @cached_property
     def location(self) -> Tuple[str, Optional[int], str]:
         location = self.reportinfo()
-        assert isinstance(location[0], py.path.local), location[0]
         fspath = self.session._node_location_to_relpath(location[0])
         assert type(location[2]) is str
         return (fspath, location[1], location[2])

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -1018,10 +1018,10 @@ class TestReportInfo:
     def test_itemreport_reportinfo(self, testdir):
         testdir.makeconftest(
             """
-            import pytest, py
+            import pytest
             class MyFunction(pytest.Function):
                 def reportinfo(self):
-                    return py.path.local("foo"), 42, "custom"
+                    return "ABCDE", 42, "custom"
             def pytest_pycollect_makeitem(collector, name, obj):
                 if name == "test_func":
                     return MyFunction(name, parent=collector)
@@ -1029,7 +1029,7 @@ class TestReportInfo:
         )
         item = testdir.getitem("def test_func(): pass")
         item.config.pluginmanager.getplugin("runner")
-        assert item.location == ("foo", 42, "custom")
+        assert item.location == ("ABCDE", 42, "custom")
 
     def test_func_reportinfo(self, testdir):
         item = testdir.getitem("def test_func(): pass")

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -375,3 +375,17 @@ def test_skip_test_with_unicode(testdir):
     )
     result = testdir.runpytest()
     result.stdout.fnmatch_lines(["* 1 skipped *"])
+
+
+def test_issue_6517(testdir):
+    testdir.makepyfile(
+        """
+        from nose.tools import raises
+
+        @raises(RuntimeError)
+        def test_fail_without_tcp():
+            raise RuntimeError
+        """
+    )
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(["* 1 passed *"])


### PR DESCRIPTION
This reverts commit 930a158a6a4d58ceb37aff97fa476215a68c915e (pr #6510).

Fixes #6517.

The assert is failing on a real test suite. Basically, I was sure the assert was safe because the  `_node_location_to_relpath` cache that the value is passed into is only designed to work with `py.path.local`s, not `str`s, and code-wise if given an `str`, it would fail. *Or so I thought*. Turns out several less-than-nice things combined to mislead me:

1. The `py.path.local` function `bestrelpath` is wrapped in a giant `try...except AttributeError` which masks any wrong types.
2. `py.path.local` has an `__eq__` implementation that can compare true with an `str`: `py.path.local('/foo') == '/foo'` is true.
3. The cache seems to always be warmed up with a `py.path.local`, so the `bestrelpath` code actually does run with `py.path.local`s. When an `str` comes in which compares true with a previous `py.path.local`, it seems like everything's fine.

Anyway, can look into these things later :fearful: , but for now, better to just revert the offending commit to fix people's tests.