### PR TITLE
tox: move doctesting into main testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,11 +20,12 @@ envlist =
 [testenv]
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest {posargs:{env:_PYTEST_TOX_DEFAULT_POSARGS:}}
+    doctesting: {env:_PYTEST_TOX_COVERAGE_RUN:} pytest --doctest-modules --pyargs _pytest
     coverage: coverage combine
     coverage: coverage report -m
 passenv = USER USERNAME COVERAGE_* TRAVIS PYTEST_ADDOPTS TERM
 setenv =
-    _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_POSARGS_LSOF:} {env:_PYTEST_TOX_POSARGS_XDIST:}
+    _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_POSARGS_DOCTESTING:} {env:_PYTEST_TOX_POSARGS_LSOF:} {env:_PYTEST_TOX_POSARGS_XDIST:}
 
     # Configuration to run with coverage similar to CI, e.g.
     # "tox -e py37-coverage".
@@ -33,6 +34,8 @@ setenv =
     coverage: COVERAGE_FILE={toxinidir}/.coverage
     coverage: COVERAGE_PROCESS_START={toxinidir}/.coveragerc
 
+    doctesting: _PYTEST_TOX_POSARGS_DOCTESTING=doc/en
+
     nobyte: PYTHONDONTWRITEBYTECODE=1
 
     lsof: _PYTEST_TOX_POSARGS_LSOF=--lsof
@@ -40,6 +43,7 @@ setenv =
     xdist: _PYTEST_TOX_POSARGS_XDIST=-n auto
 extras = testing
 deps =
+    doctesting: PyYAML
     oldattrs: attrs==17.4.0
     oldattrs: hypothesis<=4.38.1
     numpy: numpy
@@ -89,16 +93,6 @@ changedir = doc/en
 deps = -r{toxinidir}/doc/en/requirements.txt
 commands =
     sphinx-build -W -q --keep-going -b linkcheck . _build
-
-[testenv:doctesting]
-basepython = python3
-skipsdist = True
-deps =
-    {[testenv]deps}
-    PyYAML
-commands =
-    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest doc/en
-    {env:_PYTEST_TOX_COVERAGE_RUN:} pytest --doctest-modules --pyargs _pytest
 
 [testenv:regen]
 changedir = doc/en


### PR DESCRIPTION
This allows for `tox -e doctesting-coverage`, which would otherwise not
use the "doctesting" testenv.