### PR TITLE
tests: fix test_cwd_snapshot

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -527,6 +527,8 @@ class Testdir:
 
     """
 
+    __test__ = False
+
     CLOSE_STDIN = object
 
     class TimeoutExpired(Exception):

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -16,6 +16,7 @@ from _pytest.pytester import HookRecorder
 from _pytest.pytester import LineMatcher
 from _pytest.pytester import SysModulesSnapshot
 from _pytest.pytester import SysPathsSnapshot
+from _pytest.pytester import Testdir
 
 
 def test_make_hook_recorder(testdir) -> None:
@@ -273,7 +274,8 @@ def test_assert_outcomes_after_pytest_error(testdir) -> None:
         result.assert_outcomes(passed=0)
 
 
-def test_cwd_snapshot(tmpdir) -> None:
+def test_cwd_snapshot(testdir: Testdir) -> None:
+    tmpdir = testdir.tmpdir
     foo = tmpdir.ensure("foo", dir=1)
     bar = tmpdir.ensure("bar", dir=1)
     foo.chdir()


### PR DESCRIPTION
Without restoring the cwd, successive tests might fail to parse the
config (via `_pytest.config._prepareconfig()`, for when `--lsof` is
used).

And it is good practice to restore the cwd in any case anyway.