### PR TITLE
tests: fix/harden test_record_property

### DIFF
--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1061,13 +1061,14 @@ def test_record_property(testdir, run_and_parse):
             record_property("foo", "<1");
     """
     )
-    result, dom = run_and_parse("-rwv")
+    result, dom = run_and_parse("-rw")
     node = dom.find_first_by_tag("testsuite")
     tnode = node.find_first_by_tag("testcase")
     psnode = tnode.find_first_by_tag("properties")
     pnodes = psnode.find_by_tag("property")
     pnodes[0].assert_attr(name="bar", value="1")
     pnodes[1].assert_attr(name="foo", value="<1")
+    result.stdout.fnmatch_lines(["*= 1 passed in *"])
 
 
 def test_record_property_same_name(testdir, run_and_parse):


### PR DESCRIPTION
`-rv` is not a recognized reportchar.  Probably `-v` was meant, but is
not necessary to check there are no warnings.

Followup to 2018cf12b (https://github.com/pytest-dev/pytest/pull/3360).