### PR TITLE
tests: remove unnecessary `-rw` option

### DIFF
--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -68,7 +68,7 @@ class TestModule:
     def test_invalid_test_module_name(self, testdir):
         a = testdir.mkdir("a")
         a.ensure("test_one.part1.py")
-        result = testdir.runpytest("-rw")
+        result = testdir.runpytest()
         result.stdout.fnmatch_lines(
             [
                 "ImportError while importing test module*test_one.part1*",
@@ -137,7 +137,7 @@ class TestClass:
                     pass
         """
         )
-        result = testdir.runpytest("-rw")
+        result = testdir.runpytest()
         result.stdout.fnmatch_lines(
             [
                 "*cannot collect test class 'TestClass1' because it has "
@@ -153,7 +153,7 @@ class TestClass:
                     pass
         """
         )
-        result = testdir.runpytest("-rw")
+        result = testdir.runpytest()
         result.stdout.fnmatch_lines(
             [
                 "*cannot collect test class 'TestClass1' because it has "
@@ -230,7 +230,7 @@ class TestClass:
             TestCase = collections.namedtuple('TestCase', ['a'])
         """
         )
-        result = testdir.runpytest("-rw")
+        result = testdir.runpytest()
         result.stdout.fnmatch_lines(
             "*cannot collect test class 'TestCase' "
             "because it has a __new__ constructor*"
@@ -1162,7 +1162,7 @@ def test_dont_collect_non_function_callable(testdir):
             pass
     """
     )
-    result = testdir.runpytest("-rw")
+    result = testdir.runpytest()
     result.stdout.fnmatch_lines(
         [
             "*collected 1 item*",

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1349,7 +1349,7 @@ def test_assert_indirect_tuple_no_warning(testdir):
             assert tpl
     """
     )
-    result = testdir.runpytest("-rw")
+    result = testdir.runpytest()
     output = "\n".join(result.stdout.lines)
     assert "WR1" not in output
 

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -66,7 +66,7 @@ class TestNewAPI:
         testdir.tmpdir.ensure_dir(".pytest_cache").chmod(0)
         try:
             testdir.makepyfile("def test_error(): raise Exception")
-            result = testdir.runpytest("-rw")
+            result = testdir.runpytest()
             assert result.ret == 1
             # warnings from nodeids, lastfailed, and stepwise
             result.stdout.fnmatch_lines(

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1061,7 +1061,7 @@ def test_record_property(testdir, run_and_parse):
             record_property("foo", "<1");
     """
     )
-    result, dom = run_and_parse("-rw")
+    result, dom = run_and_parse()
     node = dom.find_first_by_tag("testsuite")
     tnode = node.find_first_by_tag("testcase")
     psnode = tnode.find_first_by_tag("properties")
@@ -1079,7 +1079,7 @@ def test_record_property_same_name(testdir, run_and_parse):
             record_property("foo", "baz")
     """
     )
-    result, dom = run_and_parse("-rw")
+    result, dom = run_and_parse()
     node = dom.find_first_by_tag("testsuite")
     tnode = node.find_first_by_tag("testcase")
     psnode = tnode.find_first_by_tag("properties")
@@ -1121,7 +1121,7 @@ def test_record_attribute(testdir, run_and_parse):
             record_xml_attribute("foo", "<1");
     """
     )
-    result, dom = run_and_parse("-rw")
+    result, dom = run_and_parse()
     node = dom.find_first_by_tag("testsuite")
     tnode = node.find_first_by_tag("testcase")
     tnode.assert_attr(bar="1")
@@ -1156,7 +1156,7 @@ def test_record_fixtures_xunit2(testdir, fixture_name, run_and_parse):
         )
     )
 
-    result, dom = run_and_parse("-rw", family=None)
+    result, dom = run_and_parse(family=None)
     expected_lines = []
     if fixture_name == "record_xml_attribute":
         expected_lines.append(

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -256,7 +256,7 @@ class TestPytestPluginManager:
         )
         p.copy(p.dirpath("skipping2.py"))
         monkeypatch.setenv("PYTEST_PLUGINS", "skipping2")
-        result = testdir.runpytest("-rw", "-p", "skipping1", syspathinsert=True)
+        result = testdir.runpytest("-p", "skipping1", syspathinsert=True)
         assert result.ret == ExitCode.NO_TESTS_COLLECTED
         result.stdout.fnmatch_lines(
             ["*skipped plugin*skipping1*hello*", "*skipped plugin*skipping2*hello*"]


### PR DESCRIPTION
Warnings are enabled by default, which is tested by `test_getreportopt`.

Ref: https://github.com/pytest-dev/pytest/pull/6524