### PR TITLE
ci: codecov: add flag for GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,7 +154,7 @@ jobs:
       with:
         token: ${{ secrets.codecov }}
         file: ./coverage.xml
-        flags: ${{ runner.os }}
+        flags: GHA
         fail_ci_if_error: false
         name: ${{ matrix.name }}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ script: tox
 after_success:
   - |
     if [[ "$PYTEST_COVERAGE" = 1 ]]; then
-      env CODECOV_NAME="$TOXENV-$TRAVIS_OS_NAME" scripts/report-coverage.sh
+      env CODECOV_NAME="$TOXENV-$TRAVIS_OS_NAME" scripts/report-coverage.sh -F Travis
     fi
 
 notifications:

--- a/scripts/report-coverage.sh
+++ b/scripts/report-coverage.sh
@@ -15,4 +15,4 @@ python -m coverage xml
 python -m coverage report -m
 # Set --connect-timeout to work around https://github.com/curl/curl/issues/4461
 curl -S -L --connect-timeout 5 --retry 6 -s https://codecov.io/bash -o codecov-upload.sh
-bash codecov-upload.sh -Z -X fix -f coverage.xml
+bash codecov-upload.sh -Z -X fix -f coverage.xml "$@"


### PR DESCRIPTION
This would help with debugging missing coverage when removing Travis
jobs.