### PR TITLE
doc/en/fixture.rst: chdir back to previous directory

### DIFF
--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -1042,11 +1042,13 @@ file:
     import pytest
 
 
-    @pytest.fixture()
+    @pytest.fixture
     def cleandir():
+        old_cwd = os.getcwd()
         newpath = tempfile.mkdtemp()
         os.chdir(newpath)
         yield
+        os.chdir(old_cwd)
         shutil.rmtree(newpath)
 
 and declare its use in a test module via a ``usefixtures`` marker:


### PR DESCRIPTION
This is considered to be best practice, and should be used in docs
therefore.