### PR TITLE
Make EncodedFile.write() return the return value from inner write()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -256,6 +256,7 @@ Tim Hoffmann
 Tim Strazny
 Tom Dalton
 Tom Viner
+Tomáš Gavenčiak
 Tomer Keren
 Trevor Bekolay
 Tyler Goodlet

--- a/changelog/6557.bugfix.rst
+++ b/changelog/6557.bugfix.rst
@@ -1,0 +1,1 @@
+Make capture output streams ``.write()`` method return the same return value from original streams.

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -424,7 +424,7 @@ class EncodedFile:
             raise TypeError(
                 "write() argument must be str, not {}".format(type(obj).__name__)
             )
-        self.buffer.write(obj)
+        return self.buffer.write(obj)
 
     def writelines(self, linelist):
         data = "".join(linelist)

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1492,3 +1492,8 @@ def test_typeerror_encodedfile_write(testdir):
     result_with_capture.stdout.fnmatch_lines(
         ["E * TypeError: write() argument must be str, not bytes"]
     )
+
+
+def test_stderr_write_returns_len(capsys):
+    """Write on Encoded files, namely captured stderr, should return number of characters written."""
+    assert sys.stderr.write("Foo") == 3


### PR DESCRIPTION
Stream write() methods should/may return the number of characters or bytes written. Encoded file needlessly discarded the value returned from the wrapped stream write.
Fixes #6557 