### PR TITLE
ci: Travis: removing linting,docs,doctesting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,6 @@ jobs:
       python: '3.5.1'
       dist: trusty
 
-    - env: TOXENV=linting,docs,doctesting PYTEST_COVERAGE=1
-      cache:
-        directories:
-          - $HOME/.cache/pre-commit
-
 before_script:
   - |
     # Do not (re-)upload coverage with cron runs.


### PR DESCRIPTION
This is handled by GHA already, and not affected/required for coverage.