### PR TITLE
ci: GHA: codecov: fail_ci_if_error=true

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,7 @@ jobs:
         token: ${{ secrets.codecov }}
         file: ./coverage.xml
         flags: GHA
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         name: ${{ matrix.name }}
 
   deploy:


### PR DESCRIPTION
This should make it obvious if missing coverage is due to the upload
having failed.

Using https://github.com/pytest-dev/pytest/pull/6553 would be an
alternative, but this can be used already if that takes longer.

Ref: https://github.com/pytest-dev/pytest/pull/6463#issuecomment-578092851