### PR TITLE
Fix `EncodedFile.writelines`

### DIFF
--- a/changelog/6566.bugfix.rst
+++ b/changelog/6566.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``EncodedFile.writelines`` to call the underlying buffer's ``writelines`` method.

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -9,6 +9,7 @@ import os
 import sys
 from io import UnsupportedOperation
 from tempfile import TemporaryFile
+from typing import List
 
 import pytest
 from _pytest.compat import CaptureIO
@@ -426,9 +427,8 @@ class EncodedFile:
             )
         return self.buffer.write(obj)
 
-    def writelines(self, linelist):
-        data = "".join(linelist)
-        self.write(data)
+    def writelines(self, linelist: List[str]) -> None:
+        self.buffer.writelines([x.encode(self.encoding, "replace") for x in linelist])
 
     @property
     def name(self):

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -9,6 +9,7 @@ import os
 import sys
 from io import UnsupportedOperation
 from tempfile import TemporaryFile
+from typing import BinaryIO
 from typing import List
 
 import pytest
@@ -414,29 +415,27 @@ def safe_text_dupfile(f, mode, default_encoding="UTF8"):
 class EncodedFile:
     errors = "strict"  # possibly needed by py3 code (issue555)
 
-    def __init__(self, buffer, encoding):
+    def __init__(self, buffer: BinaryIO, encoding: str) -> None:
         self.buffer = buffer
         self.encoding = encoding
 
-    def write(self, obj):
-        if isinstance(obj, str):
-            obj = obj.encode(self.encoding, "replace")
-        else:
+    def write(self, obj: str) -> int:
+        if not isinstance(obj, str):
             raise TypeError(
                 "write() argument must be str, not {}".format(type(obj).__name__)
             )
-        return self.buffer.write(obj)
+        return self.buffer.write(obj.encode(self.encoding, "replace"))
 
     def writelines(self, linelist: List[str]) -> None:
         self.buffer.writelines([x.encode(self.encoding, "replace") for x in linelist])
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Ensure that file.name is a string."""
         return repr(self.buffer)
 
     @property
-    def mode(self):
+    def mode(self) -> str:
         return self.buffer.mode.replace("b", "")
 
     def __getattr__(self, name):

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -10,7 +10,7 @@ import sys
 from io import UnsupportedOperation
 from tempfile import TemporaryFile
 from typing import BinaryIO
-from typing import List
+from typing import Iterable
 
 import pytest
 from _pytest.compat import CaptureIO
@@ -419,15 +419,15 @@ class EncodedFile:
         self.buffer = buffer
         self.encoding = encoding
 
-    def write(self, obj: str) -> int:
-        if not isinstance(obj, str):
+    def write(self, s: str) -> int:
+        if not isinstance(s, str):
             raise TypeError(
-                "write() argument must be str, not {}".format(type(obj).__name__)
+                "write() argument must be str, not {}".format(type(s).__name__)
             )
-        return self.buffer.write(obj.encode(self.encoding, "replace"))
+        return self.buffer.write(s.encode(self.encoding, "replace"))
 
-    def writelines(self, linelist: List[str]) -> None:
-        self.buffer.writelines([x.encode(self.encoding, "replace") for x in linelist])
+    def writelines(self, lines: Iterable[str]) -> None:
+        self.buffer.writelines(x.encode(self.encoding, "replace") for x in lines)
 
     @property
     def name(self) -> str:

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -8,6 +8,7 @@ import textwrap
 from io import StringIO
 from io import UnsupportedOperation
 from typing import BinaryIO
+from typing import Generator
 from typing import List
 from typing import TextIO
 
@@ -832,7 +833,7 @@ def test_dontreadfrominput():
 
 
 @pytest.fixture
-def tmpfile(testdir):
+def tmpfile(testdir) -> Generator[BinaryIO, None, None]:
     f = testdir.makepyfile("").open("wb+")
     yield f
     if not f.closed:

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1497,3 +1497,15 @@ def test_typeerror_encodedfile_write(testdir):
 def test_stderr_write_returns_len(capsys):
     """Write on Encoded files, namely captured stderr, should return number of characters written."""
     assert sys.stderr.write("Foo") == 3
+
+
+def test_encodedfile_writelines(tmpfile) -> None:
+    ef = capture.EncodedFile(tmpfile, "utf-8")
+    with pytest.raises(AttributeError):
+        ef.writelines([b"line1", b"line2"])  # type: ignore[list-item]  # noqa: F821
+    assert ef.writelines(["line1", "line2"]) is None  # type: ignore[func-returns-value]  # noqa: F821
+    tmpfile.seek(0)
+    assert tmpfile.read() == b"line1line2"
+    tmpfile.close()
+    with pytest.raises(ValueError):
+        ef.read()

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -7,6 +7,7 @@ import sys
 import textwrap
 from io import StringIO
 from io import UnsupportedOperation
+from typing import BinaryIO
 from typing import List
 from typing import TextIO
 
@@ -1499,7 +1500,7 @@ def test_stderr_write_returns_len(capsys):
     assert sys.stderr.write("Foo") == 3
 
 
-def test_encodedfile_writelines(tmpfile) -> None:
+def test_encodedfile_writelines(tmpfile: BinaryIO) -> None:
     ef = capture.EncodedFile(tmpfile, "utf-8")
     with pytest.raises(AttributeError):
         ef.writelines([b"line1", b"line2"])  # type: ignore[list-item]  # noqa: F821


### PR DESCRIPTION
This is implemented by IOBase already, which additionally checks if the
stream is not closed, and calls `write` per line.

Ref/via: https://github.com/pytest-dev/pytest/pull/6558#issuecomment-578210807

TODO:

- [x] test: could check if it calls through to `self._checkClosed()` (https://github.com/cpython/cpython/blob/58f525a216e651f1e17a18d31f190db727ed3de5/Lib/_pyio.py#L589) now
- [x] changelog