### PR TITLE
ci: codecov: only use "comment: off"

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,1 @@
-coverage:
-  status:
-    project: true
-    patch: true
-    changes: true
-
 comment: off


### PR DESCRIPTION
The changes status is quite buggy, remove it for now.
This just uses "comment: off" then.