### PR TITLE
Remove a couple of redundant commas

### DIFF
--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -75,7 +75,7 @@ def pytest_addoption(parser):
         dest="maxfail",
         const=1,
         help="exit instantly on first error or failed test.",
-    ),
+    )
     group._addoption(
         "--maxfail",
         metavar="num",
@@ -122,7 +122,7 @@ def pytest_addoption(parser):
         "--co",
         action="store_true",
         help="only collect tests, don't execute them.",
-    ),
+    )
     group.addoption(
         "--pyargs",
         action="store_true",


### PR DESCRIPTION
Mypy complains about this once the function is typed:

```
src/_pytest/main.py:85: error: "_addoption" of "OptionGroup" does not return a value
src/_pytest/main.py:133: error: "addoption" of "OptionGroup" does not return a value
```