### PR TITLE
RFC: Streamlining pytest's git workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,6 @@ Thanks for submitting a PR, your contribution is really appreciated!
 
 Here is a quick checklist that should be present in PRs.
 
-- [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
-- [ ] Target the `features` branch for new features, improvements, and removals/deprecations.
 - [ ] Include documentation when adding new features.
 - [ ] Include new tests or update existing tests when applicable.
 - [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,14 @@ on:
   push:
     branches:
       - master
+      - "[0-9]+.[0-9]+.x"
     tags:
       - "*"
 
   pull_request:
     branches:
       - master
+      - "[0-9]+.[0-9]+.x"
 
 jobs:
   build:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     -   id: rst
         name: rst
         entry: rst-lint --encoding utf-8
-        files: ^(HOWTORELEASE.rst|README.rst|TIDELIFT.rst)$
+        files: ^(RELEASING.rst|README.rst|TIDELIFT.rst)$
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]
     -   id: changelogs-rst

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,4 @@ notifications:
 branches:
   only:
     - master
-    - features
-    - 4.6-maintenance
-    - /^\d+(\.\d+)+$/
+    - /^\d+\.\d+\.x$/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -166,8 +166,6 @@ Short version
 
 #. Fork the repository.
 #. Enable and install `pre-commit <https://pre-commit.com>`_ to ensure style-guides and code checks are followed.
-#. Target ``master`` for bug fixes and doc changes.
-#. Target ``features`` for new features or functionality changes.
 #. Follow **PEP-8** for naming and `black <https://github.com/psf/black>`_ for formatting.
 #. Tests are run using ``tox``::
 
@@ -204,13 +202,9 @@ Here is a simple overview, with pytest-specific bits:
 
     $ git clone git@github.com:YOUR_GITHUB_USERNAME/pytest.git
     $ cd pytest
-    # now, to fix a bug create your own branch off "master":
+    # now, create your own branch off "master":
 
         $ git checkout -b your-bugfix-branch-name master
-
-    # or to instead add a feature create your own branch off "features":
-
-        $ git checkout -b your-feature-branch-name features
 
    Given we have "major.minor.micro" version numbers, bug fixes will usually
    be released in micro releases whereas features will be released in
@@ -294,8 +288,7 @@ Here is a simple overview, with pytest-specific bits:
     compare: your-branch-name
 
     base-fork: pytest-dev/pytest
-    base: master          # if it's a bug fix
-    base: features        # if it's a feature
+    base: master
 
 
 Writing Tests

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -10,40 +10,38 @@ taking a lot of time to make a new one.
     pytest releases must be prepared on **Linux** because the docs and examples expect
     to be executed on that platform.
 
-#. Create a branch ``release-X.Y.Z`` with the version for the release.
+To release a version ``MAJOR.MINOR.PATCH``, follow these steps:
 
-   * **maintenance releases**: from ``4.6-maintenance``;
+#. For major and minor releases, create a new branch ``MAJOR.MINOR.x`` from the
+   latest ``master`` and push it to the ``pytest-dev/pytest`` repo.
 
-   * **patch releases**: from the latest ``master``;
+#. Create a branch ``release-MAJOR.MINOR.PATCH`` from the ``MAJOR.MINOR.x`` branch.
 
-   * **minor releases**: from the latest ``features``; then merge with the latest ``master``;
-
-   Ensure your are in a clean work tree.
+   Ensure your are updated and in a clean working tree.
 
 #. Using ``tox``, generate docs, changelog, announcements::
 
-    $ tox -e release -- <VERSION>
+    $ tox -e release -- MAJOR.MINOR.PATCH
 
    This will generate a commit with all the changes ready for pushing.
 
-#. Open a PR for this branch targeting ``master`` (or ``4.6-maintenance`` for
-   maintenance releases).
+#. Open a PR for the ``release-MAJOR.MINOR.PATCH`` branch targeting ``MAJOR.MINOR.x``.
 
-#. After all tests pass and the PR has been approved, publish to PyPI by pushing the tag::
+#. After all tests pass and the PR has been approved, tag the release commit
+   in the ``MAJOR.MINOR.x`` branch and push it. This will publish to PyPI::
 
-     git tag <VERSION>
-     git push git@github.com:pytest-dev/pytest.git <VERSION>
+     git tag MAJOR.MINOR.PATCH
+     git push git@github.com:pytest-dev/pytest.git MAJOR.MINOR.PATCH
 
    Wait for the deploy to complete, then make sure it is `available on PyPI <https://pypi.org/project/pytest>`_.
 
 #. Merge the PR.
 
-#. If this is a maintenance release, cherry-pick the CHANGELOG / announce
-   files to the ``master`` branch::
+#. Cherry-pick the CHANGELOG / announce files to the ``master`` branch::
 
        git fetch --all --prune
-       git checkout origin/master -b cherry-pick-maintenance-release
-       git cherry-pick --no-commit -m1 origin/4.6-maintenance
+       git checkout origin/master -b cherry-pick-release
+       git cherry-pick --no-commit -m1 origin/MAJOR.MINOR.x
        git checkout origin/master -- changelog
        git commit  # no arguments
 

--- a/doc/en/development_guide.rst
+++ b/doc/en/development_guide.rst
@@ -57,4 +57,4 @@ Issues created at those events should have other relevant labels added as well.
 Those labels should be removed after they are no longer relevant.
 
 
-.. include:: ../../HOWTORELEASE.rst
+.. include:: ../../RELEASING.rst

--- a/doc/en/py27-py34-deprecation.rst
+++ b/doc/en/py27-py34-deprecation.rst
@@ -29,9 +29,9 @@ Maintenance of 4.6.X versions
 -----------------------------
 
 Until January 2020, the pytest core team ported many bug-fixes from the main release into the
-``4.6-maintenance`` branch, with several 4.6.X releases being made along the year.
+``4.6.x`` branch, with several 4.6.X releases being made along the year.
 
-From now on, the core team will **no longer actively backport patches**, but the ``4.6-maintenance``
+From now on, the core team will **no longer actively backport patches**, but the ``4.6.x``
 branch will continue to exist so the community itself can contribute patches.
 
 The core team will be happy to accept those patches, and make new 4.6.X releases **until mid-2020**
@@ -74,7 +74,7 @@ Please follow these instructions:
 
 #. ``git fetch --all --prune``
 
-#. ``git checkout origin/4.6-maintenance -b backport-XXXX`` # use the PR number here
+#. ``git checkout origin/4.6.x -b backport-XXXX`` # use the PR number here
 
 #. Locate the merge commit on the PR, in the *merged* message, for example:
 
@@ -82,14 +82,14 @@ Please follow these instructions:
 
 #. ``git cherry-pick -m1 REVISION`` # use the revision you found above (``0f8b462``).
 
-#. Open a PR targeting ``4.6-maintenance``:
+#. Open a PR targeting ``4.6.x``:
 
    * Prefix the message with ``[4.6]`` so it is an obvious backport
    * Delete the PR body, it usually contains a duplicate commit message.
 
 **Providing new PRs to 4.6**
 
-Fresh pull requests to ``4.6-maintenance`` will be accepted provided that
+Fresh pull requests to ``4.6.x`` will be accepted provided that
 the equivalent code in the active branches does not contain that bug (for example, a bug is specific
 to Python 2 only).
 


### PR DESCRIPTION
This RFC proposes changes to pytest's git workflow, with the aim of streamlining development.

### Current situation

There are two branches, `master` and `features`.

CONTRIBUTING.md and the pull request template instruct contributors to

- Target `master` for bug fixes/doc changes/trivial changes.
- Target `features` for new features/improvements/functionality changes/removals/deprecations.

Patch releases are made by branching from `master`, making the release and merging back to `master` in the release PR.

Minor releases are made by branching from `features`, merging `master`, making the release and merging back to `master` in the release PR.

Occasionally, changes that pile up in `master` are merged back into `features` with a "Merge master into features" PR.

### Problems with current situation

Contributors need to make a choice to target either `master` or `features`. This adds some friction.

Sometimes, they don't read CONTRIBUTING.md or the pull request template, and they target `master` when they should have targeted `features`. The maintainers need to ask them to rebase.

Sometimes, the maintainers disagree with the contributor's choice, and the contributor is asked to rebase.

Sometimes, maintainers themselves disagree if some change should go to `master` or just `features`.

To need for "Merge master into features" PRs adds work and overhead.

Sometimes, some feature development discovers bugs or minor fixes which should go to master. They then need to be split and submitted in a separate PR. The feature PR is then blocked until a "Merge master into features" happens.

Sometimes, changes that don't really need to go to patch releases are merged to `master`, and cause regressions in patch releases, which end users expect to be safe to upgrade to.

### Proposed solution

The `features` branch is removed. Both feature and bugfix development happens on `master`.

Releases are made as follows:

Create a branch `MAJOR.MINOR.x` (e.g. `5.3.x`), if one doesn't already exist from a previous minor/major release, branched from the latest `MAJOR.MINOR.0` tag (e.g. `5.3.0`), and push it to the main repository.

Branch from the `MAJOR.MINOR.x` branch, cherry pick commits for the release from `master`, make the release and merge back to `MAJOR.MINOR.x` in the release PR.

After the release, cherry-pick the changelog/announce from `MAJOR.MINOR.x` to master.

### Rationale

Developing on just the `master` branch is the most common and "default" git workflow for contributors, so should not cause any confusion, and reduce the "bureaucracy".

Avoiding the two branches removes the synchronization overhead and friction.

The slight overhead of cherry-picking commits helps with ensuring that patch releases are minimal, in that only fixes that really affect some users and need to be in a patch release get picked. This reduces the chances of regressions.

If a release needs time to "bake", it is possible to create the `MAJOR.MINOR.x` branch earlier, when creating the 0 release, without blocking `master`.

pytest already sort-of works this way for *major* releases, with the `4.6-maintenance` branch.

### Prior art

The proposed workflow is quite common, but to stay close to home I'll mention two examples:

- CPython ([ref](https://www.python.org/dev/peps/pep-0101/)): All development is done on `master`. Each release (e.g. 3.7, 3.8) gets a branch names `MAJOR.MINOR`. Changes from `master` can be backported to release branches. There seems to be a bot `miss-islington` which can be ordered to automatically create cherry-pick PRs. We can try something like that if needed.

- Django ([ref](https://docs.djangoproject.com/en/dev/internals/release-process/)): All development is done on `master`. Release branches are called `stable/MAJOR.MINOR.x`. Backports for patch releases happen regularly as needed.

- Pillow ([ref](https://github.com/python-pillow/Pillow/blob/master/RELEASING.md)) - see [comment](https://github.com/pytest-dev/pytest/pull/6571#issuecomment-578429803) by hugovk.

### Transition plan

1. Create `5.3.x` from existing `5.3.4` tag, release `5.3.5` according to new workflow.
2. Freeze `master`.
3. Merge `features` into `master`.
4. Delete `features`.
5. Merge this PR.
6. Rename `4.6-maintenance` branch to `4.6.x`.
6. Ask current open PRs filed against `features` to rebase against `master` (one last time ☺).

### Contingency

If the new workflow turns out to have unfixable issues, than worst case we can just revert back to change.