### PR TITLE
tests: test_collection_collect_only_live_logging: allow for 1+s

### DIFF
--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -946,7 +946,7 @@ def test_collection_collect_only_live_logging(testdir, verbose):
         expected_lines.extend(
             [
                 "*test_collection_collect_only_live_logging.py::test_simple*",
-                "no tests ran in 0.[0-9][0-9]s",
+                "no tests ran in [0-1].[0-9][0-9]s",
             ]
         )
     elif verbose == "-qq":


### PR DESCRIPTION
Might be slow on CI.

Ref: https://github.com/pytest-dev/pytest/pull/6570/checks?check_run_id=408752475#step:6:109