### PR TITLE
ci: codecov: use `--retry-connrefused` with curl

### DIFF
--- a/scripts/report-coverage.sh
+++ b/scripts/report-coverage.sh
@@ -14,5 +14,5 @@ python -m coverage combine
 python -m coverage xml
 python -m coverage report -m
 # Set --connect-timeout to work around https://github.com/curl/curl/issues/4461
-curl -S -L --connect-timeout 5 --retry 6 -s https://codecov.io/bash -o codecov-upload.sh
+curl -S -L --connect-timeout 5 --retry 6 --retry-connrefused -s https://codecov.io/bash -o codecov-upload.sh
 bash codecov-upload.sh -Z -X fix -f coverage.xml "$@"


### PR DESCRIPTION
While it might not help with the following, it certainly might happen as
well.

```
+ curl -S -L --connect-timeout 5 --retry 6 -s https://codecov.io/bash -o codecov-upload.sh
curl: (16) Error in the HTTP2 framing layer
```