### PR TITLE
pytester: _makefile: use `abs=True` when joining paths

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -614,7 +614,7 @@ class Testdir:
 
         ret = None
         for basename, value in items:
-            p = self.tmpdir.join(basename).new(ext=ext)
+            p = self.tmpdir.join(basename, abs=True).new(ext=ext)
             p.dirpath().ensure_dir()
             source = Source(value)
             source = "\n".join(to_text(line) for line in source.lines)

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -710,3 +710,9 @@ def test_testdir_outcomes_with_multiple_errors(testdir):
     result.assert_outcomes(error=2)
 
     assert result.parseoutcomes() == {"error": 2}
+
+
+def test_makefile_abs(testdir):
+    path = str(testdir.tmpdir / "absfile")
+    p1 = testdir.makepyfile(**{path: "..."})
+    assert str(p1) == path + ".py"


### PR DESCRIPTION
Passing in an absolute path should use that, but not join it with the
tmpdir.

TODO:

- [ ] changelog