### PR TITLE
tests: enable test_expression_multiline

### DIFF
--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -740,7 +740,7 @@ def something():
     assert str(source) == "def func(): raise ValueError(42)"
 
 
-def XXX_test_expression_multiline() -> None:
+def test_expression_multiline() -> None:
     source = """\
 something
 '''


### PR DESCRIPTION
Added in pylib like that already (https://github.com/pytest-dev/py/commit/a8729403).