### PR TITLE
ci: GHA: run less jobs with coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
             python: "3.5"
             os: windows-latest
             tox_env: "py35-xdist"
+            use_coverage: true
           - name: "windows-py36"
             python: "3.6"
             os: windows-latest
@@ -68,6 +69,7 @@ jobs:
             python: "3.8"
             os: windows-latest
             tox_env: "py38"
+            use_coverage: true
 
           - name: "ubuntu-py35"
             python: "3.5"
@@ -81,6 +83,7 @@ jobs:
             python: "3.7"
             os: ubuntu-latest
             tox_env: "py37-lsof-numpy-oldattrs-pexpect-twisted"
+            use_coverage: true
           - name: "ubuntu-py37-pluggy"
             python: "3.7"
             os: ubuntu-latest
@@ -89,8 +92,6 @@ jobs:
             python: "3.7"
             os: ubuntu-latest
             tox_env: "py37-freeze"
-            # coverage does not apply for freeze test, skip it
-            skip_coverage: true
           - name: "ubuntu-py38"
             python: "3.8"
             os: ubuntu-latest
@@ -99,8 +100,6 @@ jobs:
             python: "pypy3"
             os: ubuntu-latest
             tox_env: "pypy3-xdist"
-            # coverage too slow with pypy3, skip it
-            skip_coverage: true
 
           - name: "macos-py37"
             python: "3.7"
@@ -110,21 +109,21 @@ jobs:
             python: "3.8"
             os: macos-latest
             tox_env: "py38-xdist"
+            use_coverage: true
 
           - name: "linting"
             python: "3.7"
             os: ubuntu-latest
             tox_env: "linting"
-            skip_coverage: true
           - name: "docs"
             python: "3.7"
             os: ubuntu-latest
             tox_env: "docs"
-            skip_coverage: true
           - name: "doctesting"
             python: "3.7"
             os: ubuntu-latest
             tox_env: "doctesting"
+            use_coverage: true
 
     steps:
     - uses: actions/checkout@v1
@@ -138,11 +137,11 @@ jobs:
         pip install tox coverage
 
     - name: Test without coverage
-      if: "matrix.skip_coverage"
+      if: "! matrix.use_coverage"
       run: "tox -e ${{ matrix.tox_env }}"
 
     - name: Test with coverage
-      if: "! matrix.skip_coverage"
+      if: "matrix.use_coverage"
       env:
         _PYTEST_TOX_COVERAGE_RUN: "coverage run -m"
         COVERAGE_PROCESS_START: ".coveragerc"
@@ -150,12 +149,12 @@ jobs:
       run: "tox -e ${{ matrix.tox_env }}"
 
     - name: Prepare coverage token
-      if: (!matrix.skip_coverage && ( github.repository == 'pytest-dev/pytest' || github.event_name == 'pull_request' ))
+      if: (matrix.use_coverage && ( github.repository == 'pytest-dev/pytest' || github.event_name == 'pull_request' ))
       run: |
         python scripts/append_codecov_token.py
 
     - name: Report coverage
-      if: (!matrix.skip_coverage)
+      if: (matrix.use_coverage)
       env:
         CODECOV_NAME: ${{ matrix.name }}
       run: bash scripts/report-coverage.sh -F GHA,${{ runner.os }}


### PR DESCRIPTION
This often might be causing for jobs to take longer than 10 minutes,
which is a timeout Codecov uses to wait for successful CI.

Also it is good in general to have CI finish faster, of course.