### PR TITLE
typing: ignore false positive with more-itertools

### DIFF
--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -685,7 +685,7 @@ def raises(  # noqa: F811
     """
     __tracebackhide__ = True
     for exc in filterfalse(
-        inspect.isclass, always_iterable(expected_exception, BASE_TYPE)
+        inspect.isclass, always_iterable(expected_exception, BASE_TYPE)  # type: ignore[arg-type]  # noqa: F821
     ):
         msg = "exceptions must be derived from BaseException, not %s"
         raise TypeError(msg % type(exc))


### PR DESCRIPTION
Fixed in https://github.com/erikrose/more-itertools/pull/374.

Verified that `mypy --warn-unused-ignores src/_pytest/python_api.py` with
more-itertools master catches it (i.e. states that it is not required anymore).