### PR TITLE
pytester: testdir: add makefiles helper

### DIFF
--- a/changelog/6603.feature.rst
+++ b/changelog/6603.feature.rst
@@ -1,0 +1,1 @@
+Add :py:func:`~_pytest.pytester.Testdir.makefiles` helper to :ref:`testdir`, which allows to more easily create files with absolute paths.


### PR DESCRIPTION
This is a sane method to create a set of files, allowing for absolute
paths.

TODO:

- [x] changelog
- [x] doc: mention that absolute paths work?

Ref: https://github.com/pytest-dev/pytest/pull/6578
Ref: https://github.com/pytest-dev/pytest/pull/6579