### PR TITLE
Fix node ids which contain a parametrized empty-string variable

### DIFF
--- a/changelog/6597.bugfix.rst
+++ b/changelog/6597.bugfix.rst
@@ -1,0 +1,1 @@
+Fix node ids which contain a parametrized empty-string variable.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -873,7 +873,7 @@ class CallSpec2:
 
     @property
     def id(self):
-        return "-".join(map(str, filter(None, self._idlist)))
+        return "-".join(map(str, self._idlist))
 
     def setmulti2(self, valtypes, argnames, valset, id, marks, scopenum, param_index):
         for arg, val in zip(argnames, valset):

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -492,6 +492,19 @@ class TestFunction:
         )
         assert "foo" in keywords[1] and "bar" in keywords[1] and "baz" in keywords[1]
 
+    def test_parametrize_with_empty_string_arguments(self, testdir):
+        items = testdir.getitems(
+            """\
+            import pytest
+
+            @pytest.mark.parametrize('v', ('', ' '))
+            @pytest.mark.parametrize('w', ('', ' '))
+            def test(v, w): ...
+            """
+        )
+        names = {item.name for item in items}
+        assert names == {"test[-]", "test[ -]", "test[- ]", "test[ - ]"}
+
     def test_function_equality_with_callspec(self, testdir):
         items = testdir.getitems(
             """


### PR DESCRIPTION
I went with `features` as this changes the node ids -- I could target master instead if this is desirable as a bugfix.

partially fixes #6597