### PR TITLE
tests: move test_getfslineno

### DIFF
--- a/testing/code/test_code.py
+++ b/testing/code/test_code.py
@@ -187,7 +187,7 @@ class TestReprFuncArgs:
 
 def test_getfslineno() -> None:
     def f(x) -> None:
-        pass
+        raise NotImplementedError()
 
     fspath, lineno = getfslineno(f)
 

--- a/testing/code/test_code.py
+++ b/testing/code/test_code.py
@@ -1,9 +1,13 @@
+import inspect
 import sys
 from types import FrameType
 from unittest import mock
 
+import py.path
+
 import _pytest._code
 import pytest
+from _pytest._code import getfslineno
 
 
 def test_ne() -> None:
@@ -179,3 +183,32 @@ class TestReprFuncArgs:
             tw_mock.lines[0]
             == r"unicode_string = São Paulo, utf8_string = b'S\xc3\xa3o Paulo'"
         )
+
+
+def test_getfslineno() -> None:
+    def f(x) -> None:
+        pass
+
+    fspath, lineno = getfslineno(f)
+
+    assert isinstance(fspath, py.path.local)
+    assert fspath.basename == "test_code.py"
+    assert lineno == f.__code__.co_firstlineno - 1  # see findsource
+
+    class A:
+        pass
+
+    fspath, lineno = getfslineno(A)
+
+    _, A_lineno = inspect.findsource(A)
+    assert isinstance(fspath, py.path.local)
+    assert fspath.basename == "test_code.py"
+    assert lineno == A_lineno
+
+    assert getfslineno(3) == ("", -1)
+
+    class B:
+        pass
+
+    B.__name__ = "B2"
+    assert getfslineno(B)[1] == -1

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -495,36 +495,6 @@ def test_findsource() -> None:
     assert src[lineno] == "    def x():"
 
 
-def test_getfslineno() -> None:
-    from _pytest._code import getfslineno
-
-    def f(x) -> None:
-        pass
-
-    fspath, lineno = getfslineno(f)
-
-    assert isinstance(fspath, py.path.local)
-    assert fspath.basename == "test_source.py"
-    assert lineno == f.__code__.co_firstlineno - 1  # see findsource
-
-    class A:
-        pass
-
-    fspath, lineno = getfslineno(A)
-
-    _, A_lineno = inspect.findsource(A)
-    assert fspath.basename == "test_source.py"
-    assert lineno == A_lineno
-
-    assert getfslineno(3) == ("", -1)
-
-    class B:
-        pass
-
-    B.__name__ = "B2"
-    assert getfslineno(B)[1] == -1
-
-
 def test_code_of_object_instance_with_call() -> None:
     class A:
         pass


### PR DESCRIPTION
It should be in `test_code` when testing `_pytest._code.getfslineno`,
not to be confused with `_pytest._code.source.getfslineno`.

Adds an extra assert (via https://github.com/pytest-dev/pytest/pull/6590).