### PR TITLE
typing: fix getfslineno (assignment)

### DIFF
--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -305,11 +305,9 @@ def getfslineno(obj) -> Tuple[Optional[Union["Literal['']", py.path.local]], int
                 _, lineno = findsource(obj)
             except IOError:
                 pass
+        return fspath, lineno
     else:
-        fspath = code.path
-        lineno = code.firstlineno
-    assert isinstance(lineno, int)
-    return fspath, lineno
+        return code.path, code.firstlineno
 
 
 #

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -282,7 +282,7 @@ def compile_(  # noqa: F811
     return s.compile(filename, mode, flags, _genframe=_genframe)
 
 
-def getfslineno(obj) -> Tuple[Optional[Union["Literal['']", py.path.local]], int]:
+def getfslineno(obj) -> Tuple[Optional[Union[str, py.path.local]], int]:
     """ Return source location (path, lineno) for the given object.
     If the source cannot be determined return ("", -1).
 


### PR DESCRIPTION
Fixes:

> src/_pytest/_code/source.py:309: error: Incompatible types in
> assignment (expression has type "Union[local, str]", variable has type
> "Optional[local]")  [assignment]

Taken out of https://github.com/pytest-dev/pytest/pull/6590.