### PR TITLE
tests: move test_getfslineno back

### DIFF
--- a/testing/code/test_code.py
+++ b/testing/code/test_code.py
@@ -1,15 +1,11 @@
-import inspect
 import sys
 from types import FrameType
 from unittest import mock
-
-import py.path
 
 import pytest
 from _pytest._code import Code
 from _pytest._code import ExceptionInfo
 from _pytest._code import Frame
-from _pytest._code import getfslineno
 from _pytest._code.code import ReprFuncArgs
 
 
@@ -184,32 +180,3 @@ class TestReprFuncArgs:
             tw_mock.lines[0]
             == r"unicode_string = São Paulo, utf8_string = b'S\xc3\xa3o Paulo'"
         )
-
-
-def test_getfslineno() -> None:
-    def f(x) -> None:
-        raise NotImplementedError()
-
-    fspath, lineno = getfslineno(f)
-
-    assert isinstance(fspath, py.path.local)
-    assert fspath.basename == "test_code.py"
-    assert lineno == f.__code__.co_firstlineno - 1  # see findsource
-
-    class A:
-        pass
-
-    fspath, lineno = getfslineno(A)
-
-    _, A_lineno = inspect.findsource(A)
-    assert isinstance(fspath, py.path.local)
-    assert fspath.basename == "test_code.py"
-    assert lineno == A_lineno
-
-    assert getfslineno(3) == ("", -1)
-
-    class B:
-        pass
-
-    B.__name__ = "B2"
-    assert getfslineno(B)[1] == -1


### PR DESCRIPTION
Reverts https://github.com/pytest-dev/pytest/pull/6610.

The tested `getfslineno` is `src/_pytest/_code/source.py` actually,
exported via `src/_pytest/_code/__init__.py`.
I've confused it with the one in `src/_pytest/compat.py` apparently.