### PR TITLE
PyCollector._genfunctions: use already created fixtureinfo

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -387,7 +387,7 @@ class PyCollector(PyobjMixin, nodes.Collector):
         fm = self.session._fixturemanager
 
         definition = FunctionDefinition(name=name, parent=self, callobj=funcobj)
-        fixtureinfo = fm.getfixtureinfo(definition, funcobj, cls)
+        fixtureinfo = definition._fixtureinfo
 
         metafunc = Metafunc(
             definition, fixtureinfo, self.config, cls=cls, module=module


### PR DESCRIPTION
`Function` creates a `_fixtureinfo` already:
https://github.com/pytest-dev/pytest/blob/fed535694/src/_pytest/python.py#L1392-L1395