### PR TITLE
Remove deprecated 'pytest_itemstart' hook

### DIFF
--- a/changelog/6637.breaking.rst
+++ b/changelog/6637.breaking.rst
@@ -1,0 +1,3 @@
+Removed the long-deprecated ``pytest_itemstart`` hook.
+
+This hook has been marked as deprecated and not been even called by pytest for over 10 years now.

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -307,10 +307,6 @@ def pytest_runtestloop(session):
     """
 
 
-def pytest_itemstart(item, node):
-    """(**Deprecated**) use pytest_runtest_logstart. """
-
-
 @hookspec(firstresult=True)
 def pytest_runtest_protocol(item, nextitem):
     """ implements the runtest_setup/call/teardown protocol for


### PR DESCRIPTION
This hook has been deprecated for more than 10 years (https://github.com/pytest-dev/pytest/commit/a2fe6714f860dfffb657d423355d6c644ccb7550) and has not even
being called by pytest in a long time.

