### PR TITLE
tests: use `-rfEX`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -147,7 +147,7 @@ commands = python scripts/publish-gh-release-notes.py {posargs}
 
 [pytest]
 minversion = 2.0
-addopts = -ra -p pytester --strict-markers
+addopts = -rfEX -p pytester --strict-markers
 rsyncdirs = tox.ini doc src testing
 python_files = test_*.py *_test.py testing/*/*.py
 python_classes = Test Acceptance


### PR DESCRIPTION
`-fE` is the default in `features` now [1], but the idea is to add `X`
also to it in the long run, so let's dogfood it ourselves.

1: https://github.com/pytest-dev/pytest/pull/6524
2: https://github.com/pytest-dev/pytest/pull/6524#issuecomment-577650703