### PR TITLE
assertion: save/restore hooks on item

### DIFF
--- a/changelog/6646.bugfix.rst
+++ b/changelog/6646.bugfix.rst
@@ -1,0 +1,1 @@
+Assertion rewriting hooks are (re)stored for the current item, which fixes them being still used after e.g. pytester's :func:`testdir.runpytest <_pytest.pytester.Testdir.runpytest>` etc.

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -8,6 +8,7 @@ from _pytest.assertion import rewrite
 from _pytest.assertion import truncate
 from _pytest.assertion import util
 from _pytest.compat import TYPE_CHECKING
+from _pytest.config import hookimpl
 
 if TYPE_CHECKING:
     from _pytest.main import Session
@@ -105,7 +106,8 @@ def pytest_collection(session: "Session") -> None:
             assertstate.hook.set_session(session)
 
 
-def pytest_runtest_setup(item):
+@hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_protocol(item):
     """Setup the pytest_assertrepr_compare and pytest_assertion_pass hooks
 
     The newinterpret and rewrite modules will use util._reprcompare if
@@ -143,7 +145,7 @@ def pytest_runtest_setup(item):
                 return res
         return None
 
-    item._saved_assert_hooks = util._reprcompare, util._assertion_pass
+    saved_assert_hooks = util._reprcompare, util._assertion_pass
     util._reprcompare = callbinrepr
 
     if item.ihook.pytest_assertion_pass.get_hookimpls():
@@ -155,13 +157,9 @@ def pytest_runtest_setup(item):
 
         util._assertion_pass = call_assertion_pass_hook
 
+    yield
 
-def pytest_runtest_teardown(item):
-    if hasattr(item, "_saved_assert_hooks"):
-        util._reprcompare, util._assertion_pass = item._saved_assert_hooks
-        del item._saved_assert_hooks
-    else:
-        util._reprcompare, util._assertion_pass = None, None
+    util._reprcompare, util._assertion_pass = saved_assert_hooks
 
 
 def pytest_sessionfinish(session):

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -8,7 +8,7 @@ from _pytest.assertion import rewrite
 from _pytest.assertion import truncate
 from _pytest.assertion import util
 from _pytest.compat import TYPE_CHECKING
-from _pytest.config import hookimpl
+from _pytest.config.plugin import hookimpl
 
 if TYPE_CHECKING:
     from _pytest.main import Session

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -13,6 +13,9 @@ if TYPE_CHECKING:
     from _pytest.main import Session
 
 
+saved_hooks = []
+
+
 def pytest_addoption(parser):
     group = parser.getgroup("debugconfig")
     group.addoption(
@@ -35,6 +38,14 @@ def pytest_addoption(parser):
         help="Enables the pytest_assertion_pass hook."
         "Make sure to delete any previously generated pyc cache files.",
     )
+
+
+def pytest_configure():
+    saved_hooks.append((util._reprcompare, util._assertion_pass))
+
+
+def pytest_unconfigure():
+    util._reprcompare, util._assertion_pass = saved_hooks.pop()
 
 
 def register_assert_rewrite(*names) -> None:
@@ -156,8 +167,7 @@ def pytest_runtest_setup(item):
 
 
 def pytest_runtest_teardown(item):
-    util._reprcompare = None
-    util._assertion_pass = None
+    util._reprcompare, util._assertion_pass = saved_hooks[-1]
 
 
 def pytest_sessionfinish(session):

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -157,8 +157,11 @@ def pytest_runtest_setup(item):
 
 
 def pytest_runtest_teardown(item):
-    util._reprcompare, util._assertion_pass = item._saved_assert_hooks
-    del item._saved_assert_hooks
+    if hasattr(item, "_saved_assert_hooks"):
+        util._reprcompare, util._assertion_pass = item._saved_assert_hooks
+        del item._saved_assert_hooks
+    else:
+        util._reprcompare, util._assertion_pass = None, None
 
 
 def pytest_sessionfinish(session):

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -8,7 +8,7 @@ from _pytest.assertion import rewrite
 from _pytest.assertion import truncate
 from _pytest.assertion import util
 from _pytest.compat import TYPE_CHECKING
-from _pytest.config.plugin import hookimpl
+from _pytest.config import hookimpl
 
 if TYPE_CHECKING:
     from _pytest.main import Session

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -27,7 +27,6 @@ from pluggy import HookspecMarker
 from pluggy import PluginManager
 
 import _pytest._code
-import _pytest.assertion
 import _pytest.deprecated
 import _pytest.hookspec  # the extension point definitions
 from .exceptions import PrintHelp
@@ -260,6 +259,8 @@ class PytestPluginManager(PluginManager):
     """
 
     def __init__(self):
+        import _pytest.assertion
+
         super().__init__("pytest")
         # The objects are module objects, only used generically.
         self._conftest_plugins = set()  # type: Set[object]
@@ -891,6 +892,8 @@ class Config:
         ns, unknown_args = self._parser.parse_known_and_unknown_args(args)
         mode = getattr(ns, "assertmode", "plain")
         if mode == "rewrite":
+            import _pytest.assertion
+
             try:
                 hook = _pytest.assertion.install_importhook(self)
             except SystemError:

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -22,8 +22,6 @@ from typing import Union
 import attr
 import py
 from packaging.version import Version
-from pluggy import HookimplMarker
-from pluggy import HookspecMarker
 from pluggy import PluginManager
 
 import _pytest._code
@@ -34,6 +32,8 @@ from .exceptions import PrintHelp
 from .exceptions import UsageError
 from .findpaths import determine_setup
 from .findpaths import exists
+from .plugin import hookimpl
+from .plugin import hookspec  # noqa: F401
 from _pytest._code import ExceptionInfo
 from _pytest._code import filter_traceback
 from _pytest._io import TerminalWriter
@@ -53,10 +53,6 @@ _PluggyPlugin = object
 Plugins can be any namespace, so we can't narrow it down much, but we use an
 alias to make the intent clear.
 Ideally this type would be provided by pluggy itself."""
-
-
-hookimpl = HookimplMarker("pytest")
-hookspec = HookspecMarker("pytest")
 
 
 class ConftestImportFailure(Exception):

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -22,6 +22,8 @@ from typing import Union
 import attr
 import py
 from packaging.version import Version
+from pluggy import HookimplMarker
+from pluggy import HookspecMarker
 from pluggy import PluginManager
 
 import _pytest._code
@@ -32,8 +34,6 @@ from .exceptions import PrintHelp
 from .exceptions import UsageError
 from .findpaths import determine_setup
 from .findpaths import exists
-from .plugin import hookimpl
-from .plugin import hookspec  # noqa: F401
 from _pytest._code import ExceptionInfo
 from _pytest._code import filter_traceback
 from _pytest._io import TerminalWriter
@@ -53,6 +53,10 @@ _PluggyPlugin = object
 Plugins can be any namespace, so we can't narrow it down much, but we use an
 alias to make the intent clear.
 Ideally this type would be provided by pluggy itself."""
+
+
+hookimpl = HookimplMarker("pytest")
+hookspec = HookspecMarker("pytest")
 
 
 class ConftestImportFailure(Exception):

--- a/src/_pytest/config/plugin.py
+++ b/src/_pytest/config/plugin.py
@@ -1,0 +1,6 @@
+from pluggy import HookimplMarker
+from pluggy import HookspecMarker
+
+
+hookimpl = HookimplMarker("pytest")
+hookspec = HookspecMarker("pytest")

--- a/src/_pytest/config/plugin.py
+++ b/src/_pytest/config/plugin.py
@@ -1,6 +1,0 @@
-from pluggy import HookimplMarker
-from pluggy import HookspecMarker
-
-
-hookimpl = HookimplMarker("pytest")
-hookspec = HookspecMarker("pytest")

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -72,10 +72,19 @@ class TestImportHookInstallation:
         result = testdir.runpytest_subprocess()
         result.stdout.fnmatch_lines(
             [
-                "E * AssertionError: ([[][]], [[][]], [[]<TestReport *>[]])*",
-                "E * assert"
-                " {'failed': 1, 'passed': 0, 'skipped': 0} =="
-                " {'failed': 0, 'passed': 1, 'skipped': 0}",
+                ">       r.assertoutcome(passed=1)",
+                "E       AssertionError: ([[][]], [[][]], [[]<TestReport *>[]])*",
+                "E       assert {'failed': 1,... 'skipped': 0} == {'failed': 0,... 'skipped': 0}",
+                "E         Omitting 1 identical items, use -vv to show",
+                "E         Differing items:",
+                "E         Use -v to get the full diff",
+            ]
+        )
+        # XXX: unstable output.
+        result.stdout.fnmatch_lines_random(
+            [
+                "E         {'failed': 1} != {'failed': 0}",
+                "E         {'passed': 0} != {'passed': 1}",
             ]
         )
 


### PR DESCRIPTION
This fixes the hook(s) not being used after `testdir.runpytest` etc.

TODO:

- [x] changelog?