### PR TITLE
testing/conftest.py: testdir: set PYTEST_DISABLE_PLUGIN_AUTOLOAD=1

### DIFF
--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -104,6 +104,8 @@ class TestGeneralUsage:
 
     @pytest.mark.parametrize("load_cov_early", [True, False])
     def test_early_load_setuptools_name(self, testdir, monkeypatch, load_cov_early):
+        monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
+
         testdir.makepyfile(mytestplugin1_module="")
         testdir.makepyfile(mytestplugin2_module="")
         testdir.makepyfile(mycov_module="")

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+from _pytest.pytester import Testdir
 
 if sys.gettrace():
 
@@ -118,3 +119,9 @@ def dummy_yaml_custom_test(testdir):
     """
     )
     testdir.makefile(".yaml", test1="")
+
+
+@pytest.fixture
+def testdir(testdir: Testdir) -> Testdir:
+    testdir.monkeypatch.setenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
+    return testdir

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -3,6 +3,7 @@ from _pytest.main import ExitCode
 
 
 def test_version(testdir, pytestconfig):
+    testdir.monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
     result = testdir.runpytest("--version")
     assert result.ret == 0
     # p = py.path.local(py.__file__).dirpath()

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1227,6 +1227,7 @@ def test_runs_twice(testdir, run_and_parse):
 
 def test_runs_twice_xdist(testdir, run_and_parse):
     pytest.importorskip("xdist")
+    testdir.monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
     f = testdir.makepyfile(
         """
         def test_pass():

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -604,6 +604,7 @@ class TestTerminalFunctional:
         assert result.ret == 0
 
     def test_header_trailer_info(self, testdir, request):
+        testdir.monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
         testdir.makepyfile(
             """
             def test_passes():
@@ -714,6 +715,7 @@ class TestTerminalFunctional:
         if not pytestconfig.pluginmanager.get_plugin("xdist"):
             pytest.skip("xdist plugin not installed")
 
+        testdir.monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
         result = testdir.runpytest(
             verbose_testfile, "-v", "-n 1", "-Walways::pytest.PytestWarning"
         )


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/pull/4518.