### PR TITLE
internal: clean up getfslineno

### DIFF
--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -72,6 +72,8 @@ class Code:
         """ return a path object pointing to source code (or a str in case
         of OSError / non-existing file).
         """
+        if not self.raw.co_filename:
+            return ""
         try:
             p = py.path.local(self.raw.co_filename)
             # maybe don't try this checking

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -17,6 +17,7 @@ from typing import Union
 
 import py
 
+from _pytest.compat import get_real_func
 from _pytest.compat import overload
 from _pytest.compat import TYPE_CHECKING
 
@@ -289,6 +290,13 @@ def getfslineno(obj) -> Tuple[Optional[Union["Literal['']", py.path.local]], int
     The line number is 0-based.
     """
     from .code import Code
+
+    # xxx let decorators etc specify a sane ordering
+    # NOTE: this used to be done in _pytest.compat.getfslineno, initially added
+    #       in 6ec13a2b9.  It ("place_as") appears to be something very custom.
+    obj = get_real_func(obj)
+    if hasattr(obj, "place_as"):
+        obj = obj.place_as
 
     try:
         code = Code(obj)

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -8,6 +8,7 @@ import warnings
 from bisect import bisect_right
 from types import CodeType
 from types import FrameType
+from typing import Any
 from typing import Iterator
 from typing import List
 from typing import Optional
@@ -283,7 +284,7 @@ def compile_(  # noqa: F811
     return s.compile(filename, mode, flags, _genframe=_genframe)
 
 
-def getfslineno(obj) -> Tuple[Optional[Union["Literal['']", py.path.local]], int]:
+def getfslineno(obj: Any) -> Tuple[Union[str, py.path.local], int]:
     """ Return source location (path, lineno) for the given object.
     If the source cannot be determined return ("", -1).
 
@@ -306,18 +307,16 @@ def getfslineno(obj) -> Tuple[Optional[Union["Literal['']", py.path.local]], int
         except TypeError:
             return "", -1
 
-        fspath = fn and py.path.local(fn) or None
+        fspath = fn and py.path.local(fn) or ""
         lineno = -1
         if fspath:
             try:
                 _, lineno = findsource(obj)
             except IOError:
                 pass
+        return fspath, lineno
     else:
-        fspath = code.path
-        lineno = code.firstlineno
-    assert isinstance(lineno, int)
-    return fspath, lineno
+        return code.path, code.firstlineno
 
 
 #

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -22,7 +22,6 @@ from typing import Union
 import attr
 import py
 
-import _pytest
 from _pytest._io.saferepr import saferepr
 from _pytest.outcomes import fail
 from _pytest.outcomes import TEST_OUTCOME
@@ -308,13 +307,10 @@ def get_real_method(obj, holder):
 
 
 def getfslineno(obj) -> Tuple[Union[str, py.path.local], int]:
-    # xxx let decorators etc specify a sane ordering
-    obj = get_real_func(obj)
-    if hasattr(obj, "place_as"):
-        obj = obj.place_as
-    fslineno = _pytest._code.getfslineno(obj)
-    assert isinstance(fslineno[1], int), obj
-    return fslineno
+    """(**Deprecated**, use _pytest._code.source.getfslineno directly)"""
+    from _pytest._code.source import getfslineno
+
+    return getfslineno(obj)
 
 
 def getimfunc(func):

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -306,13 +306,6 @@ def get_real_method(obj, holder):
     return obj
 
 
-def getfslineno(obj) -> Tuple[Union[str, py.path.local], int]:
-    """(**Deprecated**, use _pytest._code.source.getfslineno directly)"""
-    import _pytest._code.source
-
-    return _pytest._code.source.getfslineno(obj)
-
-
 def getimfunc(func):
     try:
         return func.__func__

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -308,9 +308,9 @@ def get_real_method(obj, holder):
 
 def getfslineno(obj) -> Tuple[Union[str, py.path.local], int]:
     """(**Deprecated**, use _pytest._code.source.getfslineno directly)"""
-    from _pytest._code.source import getfslineno
+    import _pytest._code.source
 
-    return getfslineno(obj)
+    return _pytest._code.source.getfslineno(obj)
 
 
 def getimfunc(func):

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -16,12 +16,12 @@ import py
 import _pytest
 from _pytest._code.code import FormattedExcinfo
 from _pytest._code.code import TerminalRepr
+from _pytest._code.source import getfslineno
 from _pytest._io import TerminalWriter
 from _pytest.compat import _format_args
 from _pytest.compat import _PytestWrapper
 from _pytest.compat import get_real_func
 from _pytest.compat import get_real_method
-from _pytest.compat import getfslineno
 from _pytest.compat import getfuncargnames
 from _pytest.compat import getimfunc
 from _pytest.compat import getlocation

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -6,9 +6,9 @@ from typing import Set
 
 import attr
 
+from .._code.source import getfslineno
 from ..compat import ascii_escaped
 from ..compat import ATTRS_EQ_FIELD
-from ..compat import getfslineno
 from ..compat import NOTSET
 from _pytest.outcomes import fail
 from _pytest.warning_types import PytestUnknownMarkWarning

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -15,8 +15,8 @@ import _pytest._code
 from _pytest._code.code import ExceptionChainRepr
 from _pytest._code.code import ExceptionInfo
 from _pytest._code.code import ReprExceptionInfo
+from _pytest._code.source import getfslineno
 from _pytest.compat import cached_property
-from _pytest.compat import getfslineno
 from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.config import PytestPluginManager

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -20,10 +20,10 @@ import _pytest
 from _pytest import fixtures
 from _pytest import nodes
 from _pytest._code import filter_traceback
+from _pytest._code.source import getfslineno
 from _pytest.compat import ascii_escaped
 from _pytest.compat import get_default_arg_names
 from _pytest.compat import get_real_func
-from _pytest.compat import getfslineno
 from _pytest.compat import getimfunc
 from _pytest.compat import getlocation
 from _pytest.compat import is_generator

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -524,6 +524,14 @@ def test_getfslineno() -> None:
     B.__name__ = "B2"
     assert getfslineno(B)[1] == -1
 
+    co = compile("...", "", "eval")
+    assert co.co_filename == ""
+
+    if hasattr(sys, "pypy_version_info"):
+        assert getfslineno(co) == ("", -1)
+    else:
+        assert getfslineno(co) == ("", 0)
+
 
 def test_code_of_object_instance_with_call() -> None:
     class A:


### PR DESCRIPTION
Everything was using `_pytest.compat.getfslineno` basically, which
wrapped `_pytest._code.source.getfslineno`.

This moves the extra code from there into it directly, and uses the
latter everywhere.

This helps to eventually remove the one in compat eventually, and also
causes less cyclic imports.