### PR TITLE
DOC: it's called pytestmark, not pytest_mark

### DIFF
--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -901,8 +901,8 @@ Can be either a ``str`` or ``Sequence[str]``.
     pytest_plugins = ("myapp.testsupport.tools", "myapp.testsupport.regression")
 
 
-pytest_mark
-~~~~~~~~~~~
+pytestmark
+~~~~~~~~~~
 
 **Tutorial**: :ref:`scoped-marking`
 


### PR DESCRIPTION
(Sorry, I seem to have mistaken the commit message box for the pull request message box, so you might want to reword the commit message.)

At least in Debian's pytest (4.6.9), only the pytestmark form works.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [x ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features, improvements, and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
