### PR TITLE
Explicitly state on the PR template that we can squash commits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@ Here is a quick checklist that should be present in PRs.
 - [ ] Target the `features` branch for new features, improvements, and removals/deprecations.
 - [ ] Include documentation when adding new features.
 - [ ] Include new tests or update existing tests when applicable.
+- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
 
 Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:
 
@@ -20,5 +21,4 @@ Unless your change is trivial or a small documentation fix (e.g., a typo or rewo
   Also make sure to end the sentence with a `.`.
 
 - [ ] Add yourself to `AUTHORS` in alphabetical order.
-- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,4 +20,7 @@ Unless your change is trivial or a small documentation fix (e.g., a typo or rewo
   Also make sure to end the sentence with a `.`.
 
 - [ ] Add yourself to `AUTHORS` in alphabetical order.
+
+If you leave the *Allow edits from maintainers* checked, the mainteiners might squash your commits before merging. If unchecked, maintainers
+will probably ask you to squash yourself then.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,5 @@ Unless your change is trivial or a small documentation fix (e.g., a typo or rewo
   Also make sure to end the sentence with a `.`.
 
 - [ ] Add yourself to `AUTHORS` in alphabetical order.
-
-If you leave the *Allow edits from maintainers* checked, the mainteiners might squash your commits before merging. If unchecked, maintainers
-will probably ask you to squash yourself then.
+- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
 -->


### PR DESCRIPTION
This way we don't need to ask everytime, and users who for some reason
would not like us to squash their commits can uncheck the box then.

