### PR TITLE
Inline FunctionMixin with Function

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -504,9 +504,7 @@ class Module(nodes.File, PyCollector):
         try:
             mod = self.fspath.pyimport(ensuresyspath=importmode)
         except SyntaxError:
-            raise self.CollectError(
-                _pytest._code.ExceptionInfo.from_current().getrepr(style="short")
-            )
+            raise self.CollectError(ExceptionInfo.from_current().getrepr(style="short"))
         except self.fspath.ImportMismatchError:
             e = sys.exc_info()[1]
             raise self.CollectError(
@@ -519,8 +517,6 @@ class Module(nodes.File, PyCollector):
                 "unique basename for your test file modules" % e.args
             )
         except ImportError:
-            from _pytest._code.code import ExceptionInfo
-
             exc_info = ExceptionInfo.from_current()
             if self.config.getoption("verbose") < 2:
                 exc_info.traceback = exc_info.traceback.filter(filter_traceback)
@@ -1463,7 +1459,7 @@ class Function(PyobjMixin, nodes.Item):
         """ execute the underlying test function. """
         self.ihook.pytest_pyfunc_call(pyfuncitem=self)
 
-    def setup(self):
+    def setup(self) -> None:
         if isinstance(self.parent, Instance):
             self.parent.newinstance()
             self.obj = self._getobj()

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -21,6 +21,7 @@ import _pytest
 from _pytest import fixtures
 from _pytest import nodes
 from _pytest._code import filter_traceback
+from _pytest._code.code import ExceptionInfo
 from _pytest.compat import ascii_escaped
 from _pytest.compat import get_default_arg_names
 from _pytest.compat import get_real_func
@@ -1468,7 +1469,7 @@ class Function(PyobjMixin, nodes.Item):
             self.obj = self._getobj()
         fixtures.fillfixtures(self)
 
-    def _prunetraceback(self, excinfo):
+    def _prunetraceback(self, excinfo: ExceptionInfo) -> None:
         if hasattr(self, "_obj") and not self.config.getoption("fulltrace", False):
             code = _pytest._code.Code(get_real_func(self.obj))
             path, firstlineno = code.path, code.firstlineno


### PR DESCRIPTION
`Generator` was removed in 7eb28f9eb, and this pleases mypy to correctly
complain that `FunctionMixin` has no `config` (within
`_prunetraceback`).