### PR TITLE
doctest: handle any OutcomeException

### DIFF
--- a/changelog/310.bugfix.rst
+++ b/changelog/310.bugfix.rst
@@ -1,0 +1,1 @@
+Add support for calling `pytest.xfail()` and `pytest.importorskip()` with doctests.

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -24,7 +24,7 @@ from _pytest._io import TerminalWriter
 from _pytest.compat import safe_getattr
 from _pytest.compat import TYPE_CHECKING
 from _pytest.fixtures import FixtureRequest
-from _pytest.outcomes import Skipped
+from _pytest.outcomes import OutcomeException
 from _pytest.python_api import approx
 from _pytest.warning_types import PytestWarning
 
@@ -178,7 +178,7 @@ def _init_runner_class() -> "Type[doctest.DocTestRunner]":
                 raise failure
 
         def report_unexpected_exception(self, out, test, example, exc_info):
-            if isinstance(exc_info[1], Skipped):
+            if isinstance(exc_info[1], OutcomeException):
                 raise exc_info[1]
             if isinstance(exc_info[1], bdb.BdbQuit):
                 outcomes.exit("Quitting debugger")

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -186,17 +186,41 @@ class TestDoctests:
             ]
         )
 
-    def test_doctest_skip(self, testdir):
+    def test_doctest_outcomes(self, testdir):
         testdir.maketxtfile(
-            """
+            test_skip="""
             >>> 1
             1
             >>> import pytest
             >>> pytest.skip("")
-        """
+            >>> 2
+            3
+            """,
+            test_xfail="""
+            >>> import pytest
+            >>> pytest.xfail("xfail_reason")
+            >>> foo
+            bar
+            """,
+            test_importorskip="""
+            >>> import pytest
+            >>> pytest.importorskip("doesnotexist")
+            >>> foo
+            bar
+            """,
         )
         result = testdir.runpytest("--doctest-modules")
-        result.stdout.fnmatch_lines(["*1 skipped*"])
+        result.stdout.fnmatch_lines(
+            [
+                "collected 3 items",
+                "",
+                "test_importorskip.txt s *",
+                "test_skip.txt s *",
+                "test_xfail.txt x *",
+                "",
+                "*= 2 skipped, 1 xfailed in *",
+            ]
+        )
 
     def test_docstring_partial_context_around_error(self, testdir):
         """Test that we show some context before the actual line of a failing


### PR DESCRIPTION
Fixes using `pytest.xfail()` and `pytest.importorskip()` in doctests.