### PR TITLE
[WIP] Refactor _getcapture

### DIFF
--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -380,7 +380,7 @@ class CaptureIO(io.TextIOWrapper):
         return self.buffer.getvalue().decode("UTF-8")
 
 
-class CaptureAndPassthroughIO(CaptureIO):
+class PassthroughCaptureIO(CaptureIO):
     def __init__(self, other: IO) -> None:
         self._other = other
         super().__init__()

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -822,10 +822,10 @@ class TestCaptureIO:
         assert f.getvalue() == "foo\r\n"
 
 
-class TestCaptureAndPassthroughIO(TestCaptureIO):
+class TestPassthroughCaptureIO(TestCaptureIO):
     def test_text(self):
         sio = io.StringIO()
-        f = capture.CaptureAndPassthroughIO(sio)
+        f = capture.PassthroughCaptureIO(sio)
         f.write("hello")
         s1 = f.getvalue()
         assert s1 == "hello"
@@ -836,7 +836,7 @@ class TestCaptureAndPassthroughIO(TestCaptureIO):
 
     def test_unicode_and_str_mixture(self):
         sio = io.StringIO()
-        f = capture.CaptureAndPassthroughIO(sio)
+        f = capture.PassthroughCaptureIO(sio)
         f.write("\u00f6")
         pytest.raises(TypeError, f.write, b"hello")
 


### PR DESCRIPTION
This refactors the Capture classes to be more flexible.

The new `--capture=tee-sys` (https://github.com/pytest-dev/pytest/pull/6315)
is rather a flag that could have been also done via `--capture-tee`, to
later also apply to `fd`.

This was inspired by looking at it from the point of adding a "duplicate stderr
to stdout" mode (i.e. a single stream), which also is a new mode that can be
applied to both the fd and sys method.

Therefore this handles `--capture` now as a set of modes (split on dashes).

This does not change any behavior for now, but can be refactored more, and
I might look into adding support for `tee-fd` then also.

Ref: https://github.com/pytest-dev/pytest/pull/6315#issuecomment-562232980
Ref: https://github.com/pytest-dev/pytest/issues/4597

*Question*: should there also be new fixtures for this, i.e. `capteesys`?
That would result in 4 new fixtures then though:
"capteefd", "capteefdbinary", "capteesys", "capteesysbinary", and twice as much
again with "single" - i.e. it gets messy with `--fixtures` etc.
So for this it might make sense to have a fixture that only works as a flag
then (`captee`), so that you would request `capsys` and `captee`.

/cc @csm10495 