### PR TITLE
#6289: Add new example to XFAIL documentation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -191,6 +191,7 @@ Mihai Capotă
 Mike Hoyle (hoylemd)
 Mike Lundy
 Miro Hrončok
+Nathaniel Compton
 Nathaniel Waisbrot
 Ned Batchelder
 Neven Mundar

--- a/doc/en/skipping.rst
+++ b/doc/en/skipping.rst
@@ -234,7 +234,7 @@ expect a test to fail:
     def test_function():
         ...
 
-This test will run but no traceback will be reported when it fails. Instead terminal
+This test will run but no traceback will be reported when it fails. Instead, terminal
 reporting will list it in the "expected to fail" (``XFAIL``) or "unexpectedly
 passing" (``XPASS``) sections.
 

--- a/doc/en/skipping.rst
+++ b/doc/en/skipping.rst
@@ -234,11 +234,11 @@ expect a test to fail:
     def test_function():
         ...
 
-This test will be run but no traceback will be reported
-when it fails. Instead terminal reporting will list it in the
-"expected to fail" (``XFAIL``) or "unexpectedly passing" (``XPASS``) sections.
+This test will run but no traceback will be reported when it fails. Instead terminal
+reporting will list it in the "expected to fail" (``XFAIL``) or "unexpectedly
+passing" (``XPASS``) sections.
 
-Alternatively, you can also mark a test as ``XFAIL`` from within a test or setup function
+Alternatively, you can mark tests as ``XFAIL`` from within a test or setup function
 imperatively:
 
 .. code-block:: python
@@ -247,9 +247,20 @@ imperatively:
         if not valid_config():
             pytest.xfail("failing configuration (but should work)")
 
-This will unconditionally make ``test_function`` ``XFAIL``. Note that no other code is executed
-after ``pytest.xfail`` call, differently from the marker. That's because it is implemented
-internally by raising a known exception.
+.. code-block:: python
+
+    def test_function2():
+        import slow_module
+
+        if slow_module.slow_function():
+            pytest.xfail("slow_module taking too long")
+
+These two examples illustrate situations where you don't want to check for a condition
+at the module level, which is when a condition would otherwise be evaluated for marks.
+
+They will unconditionally make the two examples ``XFAIL``. Note that no other code is executed
+after a ``pytest.xfail`` call, which is different from a marker. This is because current
+implementation raises an internally known exception.
 
 **Reference**: :ref:`pytest.mark.xfail ref`
 
@@ -261,7 +272,7 @@ internally by raising a known exception.
 
 
 
-Both ``XFAIL`` and ``XPASS`` don't fail the test suite, unless the ``strict`` keyword-only
+Both ``XFAIL`` and ``XPASS`` don't fail the test suite unless the ``strict`` keyword-only
 parameter is passed as ``True``:
 
 .. code-block:: python

--- a/doc/en/skipping.rst
+++ b/doc/en/skipping.rst
@@ -238,7 +238,7 @@ This test will run but no traceback will be reported when it fails. Instead term
 reporting will list it in the "expected to fail" (``XFAIL``) or "unexpectedly
 passing" (``XPASS``) sections.
 
-Alternatively, you can mark tests as ``XFAIL`` from within a test or setup function
+Alternatively, you can also mark a test as ``XFAIL`` from within the test or its setup function
 imperatively:
 
 .. code-block:: python
@@ -258,9 +258,9 @@ imperatively:
 These two examples illustrate situations where you don't want to check for a condition
 at the module level, which is when a condition would otherwise be evaluated for marks.
 
-They will unconditionally make the two examples ``XFAIL``. Note that no other code is executed
-after a ``pytest.xfail`` call, which is different from a marker. This is because current
-implementation raises an internally known exception.
+This will make ``test_function`` ``XFAIL``. Note that no other code is executed after
+``pytest.xfail`` call, differently from the marker. That's because it is implemented
+internally by raising a known exception.
 
 **Reference**: :ref:`pytest.mark.xfail ref`
 
@@ -272,8 +272,8 @@ implementation raises an internally known exception.
 
 
 
-Both ``XFAIL`` and ``XPASS`` don't fail the test suite unless the ``strict`` keyword-only
-parameter is passed as ``True``:
+Both ``XFAIL`` and ``XPASS`` don't fail the test suite by default.
+You can change this by setting the ``strict`` keyword-only parameter to ``True``:
 
 .. code-block:: python
 

--- a/doc/en/skipping.rst
+++ b/doc/en/skipping.rst
@@ -259,7 +259,7 @@ These two examples illustrate situations where you don't want to check for a con
 at the module level, which is when a condition would otherwise be evaluated for marks.
 
 This will make ``test_function`` ``XFAIL``. Note that no other code is executed after
-``pytest.xfail`` call, differently from the marker. That's because it is implemented
+the ``pytest.xfail`` call, differently from the marker. That's because it is implemented
 internally by raising a known exception.
 
 **Reference**: :ref:`pytest.mark.xfail ref`


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [N/A] Target the `features` branch for new features, improvements, and removals/deprecations.
- [N/A] Include documentation when adding new features.
- [N/A] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->

Based on the discussions linked in [open issue #6289 ](https://github.com/pytest-dev/pytest/issues/6289#issuecomment-559775183), I added an additional example to the `xfail` documentation.