### PR TITLE
Preserve chronological order of stdout and stderr with ``capsys``

### DIFF
--- a/changelog/5449.feature.rst
+++ b/changelog/5449.feature.rst
@@ -1,0 +1,1 @@
+Allow ``capsys`` to retrieve combined stdout + stderr streams with original order of messages.

--- a/doc/en/capture.rst
+++ b/doc/en/capture.rst
@@ -170,3 +170,21 @@ as a context manager, disabling capture inside the ``with`` block:
         with capsys.disabled():
             print("output not captured, going directly to sys.stdout")
         print("this output is also captured")
+
+
+Preserving streams order
+------------------------
+
+The ``capsys`` fixture has an additional ``read_combined()`` method. This method returns single value
+with both ``stdout`` and ``stderr`` streams combined with preserved chronological order.
+
+.. code-block:: python
+
+    def test_combine(capsys):
+        print("I'm in stdout")
+        print("I'm in stderr", file=sys.stderr)
+        print("Hey, stdout again!")
+
+        output = capsys.read_combined()
+
+        assert output == "I'm in stdout\nI'm in stderr\nHey, stdout again!\n"

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1522,3 +1522,32 @@ def test_logging_while_collecting(testdir):
     )
     result.stdout.no_fnmatch_line("*Captured stderr call*")
     result.stdout.no_fnmatch_line("*during collection*")
+
+
+def test_combined_streams(capsys):
+    """Show that capsys is capable of preserving chronological order of streams."""
+    print("stdout1")
+    print("stdout2")
+    print("stderr1", file=sys.stderr)
+    print("stdout3")
+    print("stderr2", file=sys.stderr)
+    print("stderr3", file=sys.stderr)
+    print("stdout4")
+    print("stdout5")
+
+    output = capsys.read_combined()
+    assert (
+        output == "stdout1\n"
+        "stdout2\n"
+        "stderr1\n"
+        "stdout3\n"
+        "stderr2\n"
+        "stderr3\n"
+        "stdout4\n"
+        "stdout5\n"
+    )
+
+
+def test_no_capsys_exceptions(capfd):
+    with pytest.raises(AttributeError, match="Only capsys is able to combine streams."):
+        capfd.read_combined()


### PR DESCRIPTION
This is a solution that will allow preserving chronological order of stdout and stderr while capturing (#5449). 

The solution changes `capsys` to use `deque` for keeping the order of streams. It is possible to retrieve both streams traditionally or as a combined version.  

I've added two arguments to `readouterr()` but only for `capsys`. I wonder if that's a good approach, or should I add a new method for retrieving combined output? An additional argument is to not flush streams while retrieving. This will allow retrieving the streams traditionally *and* combined at the same time. 