### PR TITLE
FSCollector: use session._node_location_to_relpath

### DIFF
--- a/changelog/6701.bugfix.rst
+++ b/changelog/6701.bugfix.rst
@@ -1,0 +1,1 @@
+Node ids for paths outside of the rootdir are generated properly, e.g. for ``pytest testing --rootdir=/tmp -vv``.

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -422,12 +422,6 @@ class Collector(Node):
             excinfo.traceback = ntraceback.filter()
 
 
-def _check_initialpaths_for_relpath(session, fspath):
-    for initial_path in session._initialpaths:
-        if fspath.common(initial_path) == initial_path:
-            return fspath.relto(initial_path)
-
-
 class FSHookProxy:
     def __init__(
         self, fspath: py.path.local, pm: PytestPluginManager, remove_mods
@@ -444,7 +438,12 @@ class FSHookProxy:
 
 class FSCollector(Collector):
     def __init__(
-        self, fspath: py.path.local, parent=None, config=None, session=None, nodeid=None
+        self,
+        fspath: py.path.local,
+        parent=None,
+        config=None,
+        session=None,
+        nodeid: Optional[str] = None,
     ) -> None:
         name = fspath.basename
         if parent is not None:
@@ -457,11 +456,8 @@ class FSCollector(Collector):
         session = session or parent.session
 
         if nodeid is None:
-            nodeid = self.fspath.relto(session.config.rootdir)
-
-            if not nodeid:
-                nodeid = _check_initialpaths_for_relpath(session, fspath)
-            if nodeid and os.sep != SEP:
+            nodeid = session._node_location_to_relpath(self.fspath)
+            if os.sep != SEP:
                 nodeid = nodeid.replace(os.sep, SEP)
 
         super().__init__(name, parent, config, session, nodeid=nodeid, fspath=fspath)

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -730,8 +730,8 @@ class TestInvocationVariants:
         assert result.ret == 0
         result.stdout.fnmatch_lines(
             [
-                "test_hello.py::test_hello*PASSED*",
-                "test_hello.py::test_other*PASSED*",
+                "../hello/ns_pkg/hello/test_hello.py::test_hello PASSED *",
+                "../hello/ns_pkg/hello/test_hello.py::test_other PASSED *",
                 "ns_pkg/world/test_world.py::test_world*PASSED*",
                 "ns_pkg/world/test_world.py::test_other*PASSED*",
                 "*4 passed in*",

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -730,6 +730,7 @@ class TestInvocationVariants:
         assert result.ret == 0
         result.stdout.fnmatch_lines(
             [
+                "rootdir: {}/world".format(testdir.tmpdir),
                 "../hello/ns_pkg/hello/test_hello.py::test_hello PASSED *",
                 "../hello/ns_pkg/hello/test_hello.py::test_other PASSED *",
                 "ns_pkg/world/test_world.py::test_world*PASSED*",
@@ -745,7 +746,11 @@ class TestInvocationVariants:
         )
         assert result.ret == 0
         result.stdout.fnmatch_lines(
-            ["*test_world.py::test_other*PASSED*", "*1 passed*"]
+            [
+                "rootdir: {}".format(testdir.tmpdir),
+                "world/ns_pkg/world/test_world.py::test_other PASSED *",
+                "=* 1 passed in *=",
+            ]
         )
 
     def test_invoke_test_and_doctestmodules(self, testdir):

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -3690,6 +3690,7 @@ class TestParameterizedSubRequest:
         result = testdir.runpytest()
         result.stdout.fnmatch_lines(
             [
+                "test_foos.py F *",
                 "The requested fixture has no parameter defined for test:",
                 "    test_foos.py::test_foo",
                 "",
@@ -3707,8 +3708,9 @@ class TestParameterizedSubRequest:
         result = testdir.runpytest("--rootdir", rootdir, tests_dir)
         result.stdout.fnmatch_lines(
             [
+                "../tests/test_foos.py F *",
                 "The requested fixture has no parameter defined for test:",
-                "    test_foos.py::test_foo",
+                "    ../tests/test_foos.py::test_foo",
                 "",
                 "Requested fixture 'fix_with_param' defined in:",
                 "{}:4".format(fixfile),

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -274,7 +274,14 @@ def test_conftest_symlink_files(testdir):
         build.join(f).mksymlinkto(real.join(f))
     build.chdir()
     result = testdir.runpytest("-vs", "app/test_foo.py")
-    result.stdout.fnmatch_lines(["*conftest_loaded*", "PASSED"])
+    result.stdout.fnmatch_lines(
+        [
+            "conftest_loaded",
+            "../real/app/test_foo.py::test1 fixture_used",
+            "PASSED",
+            "*= 1 passed in *",
+        ]
+    )
     assert result.ret == ExitCode.OK
 
 

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -1,5 +1,3 @@
-import py
-
 import pytest
 from _pytest import nodes
 
@@ -38,23 +36,3 @@ def test_std_warn_not_pytestwarning(testdir):
     )
     with pytest.raises(ValueError, match=".*instance of PytestWarning.*"):
         items[0].warn(UserWarning("some warning"))
-
-
-def test__check_initialpaths_for_relpath():
-    """Ensure that it handles dirs, and does not always use dirname."""
-    cwd = py.path.local()
-
-    class FakeSession:
-        _initialpaths = [cwd]
-
-    assert nodes._check_initialpaths_for_relpath(FakeSession, cwd) == ""
-
-    sub = cwd.join("file")
-
-    class FakeSession:
-        _initialpaths = [cwd]
-
-    assert nodes._check_initialpaths_for_relpath(FakeSession, sub) == "file"
-
-    outside = py.path.local("/outside")
-    assert nodes._check_initialpaths_for_relpath(FakeSession, outside) is None


### PR DESCRIPTION
Maybe related/fixes https://github.com/pytest-dev/pytest/issues/3714.

`_check_initialpaths_for_relpath` was added in https://github.com/pytest-dev/pytest/pull/2776 (https://github.com/pytest-dev/pytest/commit/14b6380e5f8c2e26aa518de8a499978eb9601848).

The adjusted test for it still works, and was hardened inbetween (and fixed here).