### PR TITLE
_diff_text: use repr with escape characters

### DIFF
--- a/doc/en/example/assertion/failure_demo.py
+++ b/doc/en/example/assertion/failure_demo.py
@@ -45,7 +45,8 @@ class TestSpecialisedExplanations:
         assert "spam" == "eggs"
 
     def test_eq_similar_text(self):
-        assert "foo 1 bar" == "foo 2 bar"
+        x = "foo\n1 bar\n"
+        assert x == "foo\n1 bar"
 
     def test_eq_multiline_text(self):
         assert "foo\nspam\nbar" == "foo\neggs\nbar"

--- a/doc/en/example/assertion/failure_demo.py
+++ b/doc/en/example/assertion/failure_demo.py
@@ -45,8 +45,7 @@ class TestSpecialisedExplanations:
         assert "spam" == "eggs"
 
     def test_eq_similar_text(self):
-        x = "foo\n1 bar\n"
-        assert x == "foo\n1 bar"
+        assert "foo 1 bar" == "foo 2 bar"
 
     def test_eq_multiline_text(self):
         assert "foo\nspam\nbar" == "foo\neggs\nbar"

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -235,7 +235,7 @@ def _diff_text(left: str, right: str, verbose: int = 0) -> List[str]:
 
     if any(
         wcwidth(ch) <= 0
-        for ch in itertools.chain.from_iterable(x for x in left_lines + right_lines)
+        for ch in [ch for lines in left_lines + right_lines for ch in lines]
     ):
         left_lines = [repr(x) for x in left_lines]
         right_lines = [repr(x) for x in right_lines]

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -243,32 +243,23 @@ def _diff_text(left: str, right: str, verbose: int = 0) -> List[str]:
             "NOTE: Strings contain non-printable characters. Escaping them using repr()."
         ]
     else:
-        max_lines = max(len(left_lines), len(right_lines))
-        left_ends = left_split[1:max_lines:2]
-        right_ends = right_split[1:max_lines:2]
+        max_split = max(len(left_split), len(right_split))
+        left_ends = left_split[1:max_split:2]
+        right_ends = right_split[1:max_split:2]
         if left_ends != right_ends:
             explanation += [
                 "NOTE: Strings contain different line-endings. Escaping them using repr()."
             ]
-            left_lines = [line for line in left_lines]
-            right_lines = [line for line in right_lines]
-
-            for idx, (left_line, right_line) in enumerate(
-                itertools.zip_longest(left_lines, right_lines, fillvalue="")
+            for idx, (left_line, right_line, left_end, right_end) in enumerate(
+                itertools.zip_longest(
+                    left_lines, right_lines, left_ends, right_ends, fillvalue=None
+                )
             ):
-                try:
-                    left_end = left_ends[idx]
-                except IndexError:
-                    left_end = ""
-                try:
-                    right_end = right_ends[idx]
-                except IndexError:
-                    right_end = ""
                 if left_end != right_end:
-                    left_lines[idx] += repr(left_end)[1:-1]
-                    right_lines[idx] += repr(right_end)[1:-1]
-                if not left_end or not right_end:
-                    break
+                    if left_end is not None:
+                        left_lines[idx] += repr(left_end)[1:-1]
+                    if right_end is not None:
+                        right_lines[idx] += repr(right_end)[1:-1]
 
     explanation += [line.strip("\n") for line in ndiff(left_lines, right_lines)]
     return explanation

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -232,8 +232,8 @@ def _diff_text(left: str, right: str, verbose: int = 0) -> List[str]:
     right_lines = right.splitlines(keepends)
 
     if any(
-        wcwidth(ch) <= -1
-        for ch in itertools.chain.from_iterable([x for x in left_lines + right_lines])
+        wcwidth(ch) <= 0
+        for ch in itertools.chain.from_iterable(x for x in left_lines + right_lines)
     ):
         left_lines = [repr(x) for x in left_lines]
         right_lines = [repr(x) for x in right_lines]

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -255,11 +255,12 @@ def _diff_text(left: str, right: str, verbose: int = 0) -> List[str]:
                     left_lines, right_lines, left_ends, right_ends, fillvalue=None
                 )
             ):
-                if left_end != right_end:
-                    if left_end is not None:
-                        left_lines[idx] += repr(left_end)[1:-1]
-                    if right_end is not None:
-                        right_lines[idx] += repr(right_end)[1:-1]
+                if left_end == right_end:
+                    continue
+                if left_end is not None:
+                    left_lines[idx] += repr(left_end)[1:-1]
+                if right_end is not None:
+                    right_lines[idx] += repr(right_end)[1:-1]
 
     explanation += [line.strip("\n") for line in ndiff(left_lines, right_lines)]
     return explanation

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -193,6 +193,7 @@ def _diff_text(left: str, right: str, verbose: int = 0) -> List[str]:
     characters which are identical to keep the diff minimal.
     """
     from difflib import ndiff
+    from wcwidth import wcswidth
 
     explanation = []  # type: List[str]
 
@@ -225,10 +226,18 @@ def _diff_text(left: str, right: str, verbose: int = 0) -> List[str]:
         left = repr(str(left))
         right = repr(str(right))
         explanation += ["Strings contain only whitespace, escaping them using repr()"]
-    explanation += [
-        line.strip("\n")
-        for line in ndiff(left.splitlines(keepends), right.splitlines(keepends))
-    ]
+
+    left_lines = left.splitlines(keepends)
+    right_lines = right.splitlines(keepends)
+
+    if any(wcswidth(x) == -1 for x in left_lines + right_lines):
+        left_lines = [repr(x) for x in left_lines]
+        right_lines = [repr(x) for x in right_lines]
+        explanation += [
+            "Strings contain non-printable/escape characters, escaping them using repr()"
+        ]
+
+    explanation += [line.strip("\n") for line in ndiff(left_lines, right_lines)]
     return explanation
 
 

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -238,7 +238,7 @@ def _diff_text(left: str, right: str, verbose: int = 0) -> List[str]:
         left_lines = [repr(x) for x in left_lines]
         right_lines = [repr(x) for x in right_lines]
         explanation += [
-            "NOTE: Strings contain non-printable/zero-width characters. Escaping them using repr()."
+            "NOTE: Strings contain non-printable characters. Escaping them using repr()."
         ]
 
     explanation += [line.strip("\n") for line in ndiff(left_lines, right_lines)]

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -1,5 +1,6 @@
 """Utilities for assertion debugging"""
 import collections.abc
+import itertools
 import pprint
 from typing import AbstractSet
 from typing import Any
@@ -193,7 +194,7 @@ def _diff_text(left: str, right: str, verbose: int = 0) -> List[str]:
     characters which are identical to keep the diff minimal.
     """
     from difflib import ndiff
-    from wcwidth import wcswidth
+    from wcwidth import wcwidth
 
     explanation = []  # type: List[str]
 
@@ -230,11 +231,14 @@ def _diff_text(left: str, right: str, verbose: int = 0) -> List[str]:
     left_lines = left.splitlines(keepends)
     right_lines = right.splitlines(keepends)
 
-    if any(wcswidth(x) == -1 for x in left_lines + right_lines):
+    if any(
+        wcwidth(ch) <= -1
+        for ch in itertools.chain.from_iterable([x for x in left_lines + right_lines])
+    ):
         left_lines = [repr(x) for x in left_lines]
         right_lines = [repr(x) for x in right_lines]
         explanation += [
-            "Strings contain non-printable/escape characters, escaping them using repr()"
+            "NOTE: Strings contain non-printable/zero-width characters. Escaping them using repr()."
         ]
 
     explanation += [line.strip("\n") for line in ndiff(left_lines, right_lines)]

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -243,7 +243,7 @@ def _diff_text(left: str, right: str, verbose: int = 0) -> List[str]:
             "NOTE: Strings contain non-printable characters. Escaping them using repr()."
         ]
     else:
-        max_split = max(len(left_split), len(right_split))
+        max_split = min(len(left_split), len(right_split)) + 1
         left_ends = left_split[1:max_split:2]
         right_ends = right_split[1:max_split:2]
         if left_ends != right_ends:

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -243,7 +243,7 @@ def _diff_text(left: str, right: str, verbose: int = 0) -> List[str]:
             "NOTE: Strings contain non-printable characters. Escaping them using repr()."
         ]
     else:
-        max_split = min(len(left_split), len(right_split)) + 1
+        max_split = min(len(left_lines), len(right_lines)) + 1
         left_ends = left_split[1:max_split:2]
         right_ends = right_split[1:max_split:2]
         if left_ends != right_ends:

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1358,6 +1358,26 @@ def test_diff_newline_at_end(testdir):
     )
 
 
+def test_diff_different_line_endings():
+    assert callequal("asdf\n", "asdf", verbose=2) == [
+        r"'asdf\n' == 'asdf'",
+        r"NOTE: Strings contain different line-endings. Escaping them using repr().",
+        r"- asdf\n",
+        r"?     --",
+        r"+ asdf",
+        r"- ",
+    ]
+
+    assert callequal("line1\r\nline2", "line1\nline2", verbose=2) == [
+        r"'line1\r\nline2' == 'line1\nline2'",
+        r"NOTE: Strings contain different line-endings. Escaping them using repr().",
+        r"- line1\r\n",
+        r"?       --",
+        r"+ line1\n",
+        r"  line2",
+    ]
+
+
 @pytest.mark.filterwarnings("default")
 def test_assert_tuple_warning(testdir):
     msg = "assertion is always true"

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1394,11 +1394,8 @@ def test_diff_different_line_endings():
         r"- line1\r\n",
         r"?       --",
         r"+ line1\n",
-        r"- line2\r\n",
+        r"  line2",
         r"- line3",
-        r"?     ^",
-        r"+ line2",
-        r"?     ^",
         r"- ",
     ]
 

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1081,40 +1081,14 @@ def test_reprcompare_whitespaces():
     ]
 
 
-def test_reprcompare_escape_sequences():
-    config = mock_config()
-    detail = plugin.pytest_assertrepr_compare(
-        config, "==", "\x1b[31mred", "\x1b[31mgreen"
-    )
-    assert detail == [
+def test_reprcompare_escape_sequences_strings():
+    assert callequal("\x1b[31mred", "\x1b[31mgreen") == [
         "'\\x1b[31mred' == '\\x1b[31mgreen'",
         "Strings contain non-printable/escape characters, escaping them using repr()",
         "- '\\x1b[31mred'",
         "?            ^",
         "+ '\\x1b[31mgreen'",
         "?          +  ^^",
-    ]
-
-    detail = plugin.pytest_assertrepr_compare(
-        config, "==", ["\x1b[31mred"], ["\x1b[31mgreen"]
-    )
-    assert detail == [
-        "['\\x1b[31mred'] == ['\\x1b[31mgreen']",
-        "At index 0 diff: '\\x1b[31mred' != '\\x1b[31mgreen'",
-        "Use -v to get the full diff",
-    ]
-    config = mock_config(verbose=2)
-    detail = plugin.pytest_assertrepr_compare(
-        config, "==", ["\x1b[31mred"], ["\x1b[31mgreen"]
-    )
-    assert detail == [
-        "['\\x1b[31mred'] == ['\\x1b[31mgreen']",
-        "At index 0 diff: '\\x1b[31mred' != '\\x1b[31mgreen'",
-        "Full diff:",
-        "- ['\\x1b[31mred']",
-        "?             ^",
-        "+ ['\\x1b[31mgreen']",
-        "?           +  ^^",
     ]
 
 

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1387,16 +1387,18 @@ def test_diff_different_line_endings():
         r"?       ++",
     ]
 
-    # More on left: escapes them also.
+    # More on left.
     assert callequal("line1\r\nline2\r\nline3\r\n", "line1\nline2", verbose=2) == [
         r"'line1\r\nline2\r\nline3\r\n' == 'line1\nline2'",
         r"NOTE: Strings contain different line-endings. Escaping them using repr().",
         r"- line1\r\n",
         r"?       --",
         r"+ line1\n",
-        r"+ line2",
         r"- line2\r\n",
-        r"- line3\r\n",
+        r"- line3",
+        r"?     ^",
+        r"+ line2",
+        r"?     ^",
         r"- ",
     ]
 

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1377,6 +1377,29 @@ def test_diff_different_line_endings():
         r"  line2",
     ]
 
+    # Only '\r' is considered non-printable
+    assert callequal("line1\r\nline2", "line1\nline2\r", verbose=2) == [
+        r"'line1\r\nline2' == 'line1\nline2\r'",
+        r"NOTE: Strings contain non-printable characters. Escaping them using repr().",
+        r"  'line1'",
+        r"- 'line2'",
+        r"+ 'line2\r'",
+        r"?       ++",
+    ]
+
+    # More on left: escapes them also.
+    assert callequal("line1\r\nline2\r\nline3\r\n", "line1\nline2", verbose=2) == [
+        r"'line1\r\nline2\r\nline3\r\n' == 'line1\nline2'",
+        r"NOTE: Strings contain different line-endings. Escaping them using repr().",
+        r"- line1\r\n",
+        r"?       --",
+        r"+ line1\n",
+        r"+ line2",
+        r"- line2\r\n",
+        r"- line3\r\n",
+        r"- ",
+    ]
+
 
 @pytest.mark.filterwarnings("default")
 def test_assert_tuple_warning(testdir):

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -335,12 +335,12 @@ class TestAssert_reprcompare:
         right = "foo\neggs\nbar"
         diff = callequal(left, right)
         assert diff == [
-            "'foo\\nspam\\nbar' == 'foo\\neggs\\nbar'",
-            "Strings contain non-printable/escape characters, escaping them using repr()",
-            "  'foo\\n'",
-            "- 'spam\\n'",
-            "+ 'eggs\\n'",
-            "  'bar'",
+            r"'foo\nspam\nbar' == 'foo\neggs\nbar'",
+            r"NOTE: Strings contain non-printable/zero-width characters. Escaping them using repr().",
+            r"  'foo\n'",
+            r"- 'spam\n'",
+            r"+ 'eggs\n'",
+            r"  'bar'",
         ]
 
     def test_bytes_diff_normal(self):
@@ -1013,17 +1013,17 @@ class TestTruncateExplanation:
         # without -vv, truncate the message showing a few diff lines only
         result.stdout.fnmatch_lines(
             [
-                ">       assert a == b",
-                "E       AssertionError: assert '000000000000...6666666666666' == '000000000000...6666666666666'",
-                "E         Skipping 91 identical leading characters in diff, use -v to show",
-                "E         Strings contain non-printable/escape characters, escaping them using repr()",
-                "E           '000000000\\n'",
-                "E         - '1*\\n'",
-                "E           '2*\\n'",
-                "E         - '3*\\n'",
-                "E           '4*\\...",
-                "E         ",
-                "*truncated (%d lines hidden)*use*-vv*" % expected_truncated_lines,
+                r">       assert a == b",
+                r"E       AssertionError: assert '000000000000...6666666666666' == '000000000000...6666666666666'",
+                r"E         Skipping 91 identical leading characters in diff, use -v to show",
+                r"E         NOTE: Strings contain non-printable/zero-width characters. Escaping them using repr().",
+                r"E           '000000000\n'",
+                r"E         - '1*\n'",
+                r"E           '2*\n'",
+                r"E         - '3*\n'",
+                r"E           '4*",
+                r"E         ",
+                r"*truncated (%d lines hidden)*use*-vv*" % expected_truncated_lines,
             ]
         )
 
@@ -1081,12 +1081,12 @@ def test_reprcompare_whitespaces():
     ]
 
 
-def test_reprcompare_escape_sequences_strings():
-    assert callequal("\x1b[31mred", "\x1b[31mgreen") == [
-        "'\\x1b[31mred' == '\\x1b[31mgreen'",
-        "Strings contain non-printable/escape characters, escaping them using repr()",
-        "- '\\x1b[31mred'",
-        "?            ^",
+def test_reprcompare_zerowidth_and_non_printable():
+    assert callequal("\x00\x1b[31mred", "\x1b[31mgreen") == [
+        "'\\x00\\x1b[31mred' == '\\x1b[31mgreen'",
+        "NOTE: Strings contain non-printable/zero-width characters. Escaping them using repr().",
+        "- '\\x00\\x1b[31mred'",
+        "?  ----          ^",
         "+ '\\x1b[31mgreen'",
         "?          +  ^^",
     ]
@@ -1335,7 +1335,8 @@ def test_diff_newline_at_end(testdir):
     result.stdout.fnmatch_lines(
         r"""
         *assert 'asdf' == 'asdf\n'
-        E         Strings contain non-printable/escape characters, escaping them using repr()
+        E       AssertionError: assert 'asdf' == 'asdf\n'
+        E         NOTE: Strings contain non-printable/zero-width characters. Escaping them using repr().
         *  - 'asdf'
         *  + 'asdf\n'
         *  ?      ++

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1083,12 +1083,12 @@ def test_reprcompare_whitespaces():
 
 def test_reprcompare_zerowidth_and_non_printable():
     assert callequal("\x00\x1b[31mred", "\x1b[31mgreen") == [
-        "'\\x00\\x1b[31mred' == '\\x1b[31mgreen'",
-        "NOTE: Strings contain non-printable/zero-width characters. Escaping them using repr().",
-        "- '\\x00\\x1b[31mred'",
-        "?  ----          ^",
-        "+ '\\x1b[31mgreen'",
-        "?          +  ^^",
+        r"'\x00\x1b[31mred' == '\x1b[31mgreen'",
+        r"NOTE: Strings contain non-printable/zero-width characters. Escaping them using repr().",
+        r"- '\x00\x1b[31mred'",
+        r"?  ----          ^",
+        r"+ '\x1b[31mgreen'",
+        r"?          +  ^^",
     ]
 
 

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -336,7 +336,7 @@ class TestAssert_reprcompare:
         diff = callequal(left, right)
         assert diff == [
             r"'foo\nspam\nbar' == 'foo\neggs\nbar'",
-            r"NOTE: Strings contain non-printable/zero-width characters. Escaping them using repr().",
+            r"NOTE: Strings contain non-printable characters. Escaping them using repr().",
             r"  'foo\n'",
             r"- 'spam\n'",
             r"+ 'eggs\n'",
@@ -1016,7 +1016,7 @@ class TestTruncateExplanation:
                 r">       assert a == b",
                 r"E       AssertionError: assert '000000000000...6666666666666' == '000000000000...6666666666666'",
                 r"E         Skipping 91 identical leading characters in diff, use -v to show",
-                r"E         NOTE: Strings contain non-printable/zero-width characters. Escaping them using repr().",
+                r"E         NOTE: Strings contain non-printable characters. Escaping them using repr().",
                 r"E           '000000000\n'",
                 r"E         - '1*\n'",
                 r"E           '2*\n'",
@@ -1084,7 +1084,7 @@ def test_reprcompare_whitespaces():
 def test_reprcompare_zerowidth_and_non_printable():
     assert callequal("\x00\x1b[31mred", "\x1b[31mgreen") == [
         r"'\x00\x1b[31mred' == '\x1b[31mgreen'",
-        r"NOTE: Strings contain non-printable/zero-width characters. Escaping them using repr().",
+        r"NOTE: Strings contain non-printable characters. Escaping them using repr().",
         r"- '\x00\x1b[31mred'",
         r"?  ----          ^",
         r"+ '\x1b[31mgreen'",
@@ -1336,7 +1336,7 @@ def test_diff_newline_at_end(testdir):
         r"""
         *assert 'asdf' == 'asdf\n'
         E       AssertionError: assert 'asdf' == 'asdf\n'
-        E         NOTE: Strings contain non-printable/zero-width characters. Escaping them using repr().
+        E         NOTE: Strings contain non-printable characters. Escaping them using repr().
         *  - 'asdf'
         *  + 'asdf\n'
         *  ?      ++


### PR DESCRIPTION
This helps especially with comparing strings containing terminal escape
sequences, but also newlines already.

Ref: #3443

TODO:

- [ ] 8de826cb1