### PR TITLE
test_argcomplete: remove usage of `distutils.spawn`

### DIFF
--- a/testing/test_parseopt.py
+++ b/testing/test_parseopt.py
@@ -1,7 +1,7 @@
 import argparse
-import distutils.spawn
 import os
 import shlex
+import shutil
 import sys
 
 import py
@@ -291,7 +291,7 @@ class TestParser:
 
 
 def test_argcomplete(testdir, monkeypatch):
-    if not distutils.spawn.find_executable("bash"):
+    if not shutil.which("bash"):
         pytest.skip("bash not available")
     script = str(testdir.tmpdir.join("test_argcomplete"))
 


### PR DESCRIPTION
Fixes collection error with Python 3.5.3 (Travis):

    testing/test_parseopt.py:2: in <module>
        import distutils.spawn
    .tox/py35-coverage/lib/python3.5/distutils/__init__.py:4: in <module>
        import imp
    .tox/py35-coverage/lib/python3.5/imp.py:33: in <module>
        PendingDeprecationWarning, stacklevel=2)
    E   PendingDeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses

Build log: https://travis-ci.org/blueyed/pytest/builds/648305304


<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features, improvements, and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->