### PR TITLE
Remove some redundant commas

### DIFF
--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -66,7 +66,7 @@ def pytest_addoption(parser):
         action="store_true",
         default=False,
         help="trace considerations of conftest.py files.",
-    ),
+    )
     group.addoption(
         "--debug",
         action="store_true",

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -39,7 +39,7 @@ def pytest_addoption(parser):
         default=None,
         metavar="N",
         help="show N slowest setup/test durations (N=0 for all).",
-    ),
+    )
 
 
 def pytest_terminal_summary(terminalreporter):

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -70,7 +70,7 @@ def pytest_addoption(parser):
         default=0,
         dest="verbose",
         help="increase verbosity.",
-    ),
+    )
     group._addoption(
         "-q",
         "--quiet",
@@ -78,7 +78,7 @@ def pytest_addoption(parser):
         default=0,
         dest="verbose",
         help="decrease verbosity.",
-    ),
+    )
     group._addoption(
         "--verbosity",
         dest="verbose",


### PR DESCRIPTION
Fix mypy errors:

```
src/_pytest/runner.py:36: error: "addoption" of "OptionGroup" does not return a value  [func-returns-value]
src/_pytest/helpconfig.py:64: error: "addoption" of "OptionGroup" does not return a value  [func-returns-value]
src/_pytest/terminal.py:67: error: "_addoption" of "OptionGroup" does not return a value  [func-returns-value]
src/_pytest/terminal.py:75: error: "_addoption" of "OptionGroup" does not return a value  [func-returns-value]
```