### PR TITLE
Remove unused field FixtureManager._arg2finish

### DIFF
--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1249,7 +1249,6 @@ class FixtureManager:
         self.config = session.config
         self._arg2fixturedefs = {}
         self._holderobjseen = set()
-        self._arg2finish = {}
         self._nodeid_and_autousenames = [("", self.config.getini("usefixtures"))]
         session.config.pluginmanager.register(self, "funcmanage")
 


### PR DESCRIPTION
Not used since 4f0879ff9b3e7ad0da1839131c35b4e6412b972f.