### PR TITLE
Type annotate some hookspecs & impls

### DIFF
--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -9,12 +9,13 @@ from _pytest.assertion import truncate
 from _pytest.assertion import util
 from _pytest.compat import TYPE_CHECKING
 from _pytest.config import hookimpl
+from _pytest.config.argparsing import Parser
 
 if TYPE_CHECKING:
     from _pytest.main import Session
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("debugconfig")
     group.addoption(
         "--assert",
@@ -162,7 +163,7 @@ def pytest_runtest_protocol(item):
     util._reprcompare, util._assertion_pass = saved_assert_hooks
 
 
-def pytest_sessionfinish(session):
+def pytest_sessionfinish(session: "Session") -> None:
     assertstate = getattr(session.config, "_assertstate", None)
     if assertstate:
         if assertstate.hook is not None:

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -12,6 +12,7 @@ from typing import Generator
 from typing import List
 from typing import Optional
 from typing import Set
+from typing import Union
 
 import attr
 import py
@@ -24,6 +25,8 @@ from .reports import CollectReport
 from _pytest import nodes
 from _pytest._io import TerminalWriter
 from _pytest.config import Config
+from _pytest.config import ExitCode
+from _pytest.config.argparsing import Parser
 from _pytest.main import Session
 from _pytest.python import Module
 
@@ -316,11 +319,12 @@ class LFPlugin:
             else:
                 self._report_status += "not deselecting items."
 
-    def pytest_sessionfinish(self, session):
+    def pytest_sessionfinish(self, session: Session) -> None:
         config = self.config
         if config.getoption("cacheshow") or hasattr(config, "slaveinput"):
             return
 
+        assert config.cache is not None
         saved_lastfailed = config.cache.get("cache/lastfailed", {})
         if saved_lastfailed != self.lastfailed:
             config.cache.set("cache/lastfailed", self.lastfailed)
@@ -358,7 +362,7 @@ class NFPlugin:
     def _get_increasing_order(self, items):
         return sorted(items, key=lambda item: item.fspath.mtime(), reverse=True)
 
-    def pytest_sessionfinish(self, session):
+    def pytest_sessionfinish(self, session: Session) -> None:
         config = self.config
         if config.getoption("cacheshow") or hasattr(config, "slaveinput"):
             return
@@ -366,7 +370,7 @@ class NFPlugin:
         config.cache.set("cache/nodeids", self.cached_nodeids)
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("general")
     group.addoption(
         "--lf",
@@ -424,16 +428,18 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_cmdline_main(config):
+def pytest_cmdline_main(config: Config) -> Optional[Union[int, ExitCode]]:
     if config.option.cacheshow:
         from _pytest.main import wrap_session
 
         return wrap_session(config, cacheshow)
+    return None
 
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_configure(config: Config) -> None:
-    config.cache = Cache.for_config(config)
+    # Type ignored: pending mechanism to store typed objects scoped to config.
+    config.cache = Cache.for_config(config)  # type: ignore # noqa: F821
     config.pluginmanager.register(LFPlugin(config), "lfplugin")
     config.pluginmanager.register(NFPlugin(config), "nfplugin")
 

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -19,6 +19,7 @@ from _pytest.compat import CaptureAndPassthroughIO
 from _pytest.compat import CaptureIO
 from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
+from _pytest.config.argparsing import Parser
 from _pytest.fixtures import FixtureRequest
 
 if TYPE_CHECKING:
@@ -29,7 +30,7 @@ if TYPE_CHECKING:
 patchsysdict = {0: "stdin", 1: "stdout", 2: "stderr"}
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("general")
     group._addoption(
         "--capture",

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -393,7 +393,7 @@ class PytestPluginManager(PluginManager):
         """Return True if the plugin with the given name is registered."""
         return bool(self.get_plugin(name))
 
-    def pytest_configure(self, config):
+    def pytest_configure(self, config: "Config") -> None:
         # XXX now that the pluginmanager exposes hookimpl(tryfirst...)
         # we should remove tryfirst/trylast as markers
         config.addinivalue_line(
@@ -831,7 +831,9 @@ class Config:
     def get_terminal_writer(self):
         return self.pluginmanager.get_plugin("terminalreporter")._tw
 
-    def pytest_cmdline_parse(self, pluginmanager, args):
+    def pytest_cmdline_parse(
+        self, pluginmanager: PytestPluginManager, args: List[str]
+    ) -> object:
         try:
             self.parse(args)
         except UsageError:

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -4,7 +4,10 @@ import functools
 import sys
 
 from _pytest import outcomes
+from _pytest.config import Config
 from _pytest.config import hookimpl
+from _pytest.config import PytestPluginManager
+from _pytest.config.argparsing import Parser
 from _pytest.config.exceptions import UsageError
 
 
@@ -19,7 +22,7 @@ def _validate_usepdb_cls(value):
     return (modname, classname)
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("general")
     group._addoption(
         "--pdb",
@@ -43,7 +46,7 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_configure(config):
+def pytest_configure(config: Config) -> None:
     import pdb
 
     if config.getvalue("trace"):
@@ -73,8 +76,8 @@ def pytest_configure(config):
 class pytestPDB:
     """ Pseudo PDB that defers to the real pdb. """
 
-    _pluginmanager = None
-    _config = None
+    _pluginmanager = None  # type: PytestPluginManager
+    _config = None  # type: Config
     _saved = []  # type: list
     _recursive_debug = 0
     _wrapped_pdb_cls = None

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -23,6 +23,7 @@ from _pytest._code.code import TerminalRepr
 from _pytest._io import TerminalWriter
 from _pytest.compat import safe_getattr
 from _pytest.compat import TYPE_CHECKING
+from _pytest.config.argparsing import Parser
 from _pytest.fixtures import FixtureRequest
 from _pytest.outcomes import OutcomeException
 from _pytest.python_api import approx
@@ -52,7 +53,7 @@ RUNNER_CLASS = None
 CHECKER_CLASS = None  # type: Optional[Type[doctest.OutputChecker]]
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     parser.addini(
         "doctest_optionflags",
         "option flags for doctests",
@@ -102,7 +103,7 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_unconfigure():
+def pytest_unconfigure() -> None:
     global RUNNER_CLASS
 
     RUNNER_CLASS = None

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -28,6 +28,7 @@ from _pytest.compat import is_generator
 from _pytest.compat import NOTSET
 from _pytest.compat import safe_getattr
 from _pytest.compat import TYPE_CHECKING
+from _pytest.config.argparsing import Parser
 from _pytest.deprecated import FIXTURE_POSITIONAL_ARGUMENTS
 from _pytest.deprecated import FUNCARGNAMES
 from _pytest.mark import ParameterSet
@@ -47,7 +48,7 @@ class PseudoFixtureDef:
     scope = attr.ib()
 
 
-def pytest_sessionstart(session: "Session"):
+def pytest_sessionstart(session: "Session") -> None:
     import _pytest.python
     import _pytest.nodes
 
@@ -1200,7 +1201,7 @@ def pytestconfig(request):
     return request.config
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     parser.addini(
         "usefixtures",
         type="args",

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -2,11 +2,16 @@
 import os
 import sys
 from argparse import Action
+from typing import Optional
+from typing import Union
 
 import py
 
 import pytest
+from _pytest.config import Config
+from _pytest.config import ExitCode
 from _pytest.config import PrintHelp
+from _pytest.config.argparsing import Parser
 
 
 class HelpAction(Action):
@@ -36,7 +41,7 @@ class HelpAction(Action):
             raise PrintHelp
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("debugconfig")
     group.addoption(
         "--version",
@@ -106,7 +111,7 @@ def pytest_cmdline_parse():
         undo_tracing = config.pluginmanager.enable_tracing()
         sys.stderr.write("writing pytestdebug information to %s\n" % path)
 
-        def unset_tracing():
+        def unset_tracing() -> None:
             debugfile.close()
             sys.stderr.write("wrote pytestdebug information to %s\n" % debugfile.name)
             config.trace.root.setwriter(None)
@@ -127,7 +132,7 @@ def showversion(config):
             sys.stderr.write(line + "\n")
 
 
-def pytest_cmdline_main(config):
+def pytest_cmdline_main(config: Config) -> Optional[Union[int, ExitCode]]:
     if config.option.version:
         showversion(config)
         return 0
@@ -136,9 +141,10 @@ def pytest_cmdline_main(config):
         showhelp(config)
         config._ensure_unconfigure()
         return 0
+    return None
 
 
-def showhelp(config):
+def showhelp(config: Config) -> None:
     import textwrap
 
     reporter = config.pluginmanager.get_plugin("terminalreporter")

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -1,14 +1,21 @@
 """ hook specifications for pytest plugins, invoked from main.py and builtin plugins.  """
 from typing import Any
+from typing import List
 from typing import Optional
+from typing import Union
 
 from pluggy import HookspecMarker
 
 from _pytest.compat import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from _pytest.config import Config
+    from _pytest.config import PytestPluginManager
+    from _pytest.config import _PluggyPlugin
+    from _pytest.config.argparsing import Parser
+    from _pytest.config import ExitCode
     from _pytest.main import Session
-
+    from _pytest.python import Metafunc
 
 hookspec = HookspecMarker("pytest")
 
@@ -18,7 +25,7 @@ hookspec = HookspecMarker("pytest")
 
 
 @hookspec(historic=True)
-def pytest_addhooks(pluginmanager):
+def pytest_addhooks(pluginmanager: "PytestPluginManager") -> None:
     """called at plugin registration time to allow adding new hooks via a call to
     ``pluginmanager.add_hookspecs(module_or_class, prefix)``.
 
@@ -31,7 +38,9 @@ def pytest_addhooks(pluginmanager):
 
 
 @hookspec(historic=True)
-def pytest_plugin_registered(plugin, manager):
+def pytest_plugin_registered(
+    plugin: "_PluggyPlugin", manager: "PytestPluginManager"
+) -> None:
     """ a new pytest plugin got registered.
 
     :param plugin: the plugin module or instance
@@ -43,7 +52,7 @@ def pytest_plugin_registered(plugin, manager):
 
 
 @hookspec(historic=True)
-def pytest_addoption(parser, pluginmanager):
+def pytest_addoption(parser: "Parser", pluginmanager: "PytestPluginManager") -> None:
     """register argparse-style options and ini-style config values,
     called once at the beginning of a test run.
 
@@ -81,7 +90,7 @@ def pytest_addoption(parser, pluginmanager):
 
 
 @hookspec(historic=True)
-def pytest_configure(config):
+def pytest_configure(config: "Config") -> None:
     """
     Allows plugins and conftest files to perform initial configuration.
 
@@ -105,7 +114,9 @@ def pytest_configure(config):
 
 
 @hookspec(firstresult=True)
-def pytest_cmdline_parse(pluginmanager, args):
+def pytest_cmdline_parse(
+    pluginmanager: "PytestPluginManager", args: List[str]
+) -> Optional[object]:
     """return initialized config object, parsing the specified args.
 
     Stops at first non-None result, see :ref:`firstresult`
@@ -119,7 +130,7 @@ def pytest_cmdline_parse(pluginmanager, args):
     """
 
 
-def pytest_cmdline_preparse(config, args):
+def pytest_cmdline_preparse(config: "Config", args: List[str]) -> None:
     """(**Deprecated**) modify command line arguments before option parsing.
 
     This hook is considered deprecated and will be removed in a future pytest version. Consider
@@ -134,7 +145,7 @@ def pytest_cmdline_preparse(config, args):
 
 
 @hookspec(firstresult=True)
-def pytest_cmdline_main(config):
+def pytest_cmdline_main(config: "Config") -> "Optional[Union[ExitCode, int]]":
     """ called for performing the main command line action. The default
     implementation will invoke the configure hooks and runtest_mainloop.
 
@@ -147,7 +158,9 @@ def pytest_cmdline_main(config):
     """
 
 
-def pytest_load_initial_conftests(early_config, parser, args):
+def pytest_load_initial_conftests(
+    early_config: "Config", parser: "Parser", args: List[str]
+) -> None:
     """ implements the loading of initial conftest files ahead
     of command line option parsing.
 
@@ -175,7 +188,7 @@ def pytest_collection(session: "Session") -> Optional[Any]:
     """
 
 
-def pytest_collection_modifyitems(session, config, items):
+def pytest_collection_modifyitems(session: "Session", config: "Config", items):
     """ called after collection has been performed, may filter or re-order
     the items in-place.
 
@@ -185,7 +198,7 @@ def pytest_collection_modifyitems(session, config, items):
     """
 
 
-def pytest_collection_finish(session):
+def pytest_collection_finish(session: "Session"):
     """ called after collection has been performed and modified.
 
     :param _pytest.main.Session session: the pytest session object
@@ -193,7 +206,7 @@ def pytest_collection_finish(session):
 
 
 @hookspec(firstresult=True)
-def pytest_ignore_collect(path, config):
+def pytest_ignore_collect(path, config: "Config"):
     """ return True to prevent considering this path for collection.
     This hook is consulted for all files and directories prior to calling
     more specific hooks.
@@ -281,12 +294,12 @@ def pytest_pyfunc_call(pyfuncitem):
     Stops at first non-None result, see :ref:`firstresult` """
 
 
-def pytest_generate_tests(metafunc):
+def pytest_generate_tests(metafunc: "Metafunc") -> None:
     """ generate (multiple) parametrized calls to a test function."""
 
 
 @hookspec(firstresult=True)
-def pytest_make_parametrize_id(config, val, argname):
+def pytest_make_parametrize_id(config: "Config", val, argname) -> Optional[str]:
     """Return a user-friendly string representation of the given ``val`` that will be used
     by @pytest.mark.parametrize calls. Return None if the hook doesn't know about ``val``.
     The parameter name is available as ``argname``, if required.
@@ -305,7 +318,7 @@ def pytest_make_parametrize_id(config, val, argname):
 
 
 @hookspec(firstresult=True)
-def pytest_runtestloop(session):
+def pytest_runtestloop(session: "Session"):
     """ called for performing the main runtest loop
     (after collection finished).
 
@@ -388,7 +401,7 @@ def pytest_runtest_logreport(report):
 
 
 @hookspec(firstresult=True)
-def pytest_report_to_serializable(config, report):
+def pytest_report_to_serializable(config: "Config", report):
     """
     Serializes the given report object into a data structure suitable for sending
     over the wire, e.g. converted to JSON.
@@ -396,7 +409,7 @@ def pytest_report_to_serializable(config, report):
 
 
 @hookspec(firstresult=True)
-def pytest_report_from_serializable(config, data):
+def pytest_report_from_serializable(config: "Config", data):
     """
     Restores a report object previously serialized with pytest_report_to_serializable().
     """
@@ -433,7 +446,7 @@ def pytest_fixture_post_finalizer(fixturedef, request):
 # -------------------------------------------------------------------------
 
 
-def pytest_sessionstart(session):
+def pytest_sessionstart(session: "Session") -> None:
     """ called after the ``Session`` object has been created and before performing collection
     and entering the run test loop.
 
@@ -441,7 +454,9 @@ def pytest_sessionstart(session):
     """
 
 
-def pytest_sessionfinish(session, exitstatus):
+def pytest_sessionfinish(
+    session: "Session", exitstatus: "Union[int, ExitCode]"
+) -> None:
     """ called after whole test run finished, right before returning the exit status to the system.
 
     :param _pytest.main.Session session: the pytest session object
@@ -449,7 +464,7 @@ def pytest_sessionfinish(session, exitstatus):
     """
 
 
-def pytest_unconfigure(config):
+def pytest_unconfigure(config: "Config") -> None:
     """ called before test process is exited.
 
     :param _pytest.config.Config config: pytest config object
@@ -461,7 +476,7 @@ def pytest_unconfigure(config):
 # -------------------------------------------------------------------------
 
 
-def pytest_assertrepr_compare(config, op, left, right):
+def pytest_assertrepr_compare(config: "Config", op, left, right):
     """return explanation for comparisons in failing assert expressions.
 
     Return None for no custom explanation, otherwise return a list
@@ -516,7 +531,7 @@ def pytest_assertion_pass(item, lineno, orig, expl):
 # -------------------------------------------------------------------------
 
 
-def pytest_report_header(config, startdir):
+def pytest_report_header(config: "Config", startdir):
     """ return a string or list of strings to be displayed as header info for terminal reporting.
 
     :param _pytest.config.Config config: pytest config object
@@ -530,7 +545,7 @@ def pytest_report_header(config, startdir):
     """
 
 
-def pytest_report_collectionfinish(config, startdir, items):
+def pytest_report_collectionfinish(config: "Config", startdir, items):
     """
     .. versionadded:: 3.2
 
@@ -545,7 +560,7 @@ def pytest_report_collectionfinish(config, startdir, items):
 
 
 @hookspec(firstresult=True)
-def pytest_report_teststatus(report, config):
+def pytest_report_teststatus(report, config: "Config"):
     """ return result-category, shortletter and verbose word for reporting.
 
     :param _pytest.config.Config config: pytest config object
@@ -553,7 +568,7 @@ def pytest_report_teststatus(report, config):
     Stops at first non-None result, see :ref:`firstresult` """
 
 
-def pytest_terminal_summary(terminalreporter, exitstatus, config):
+def pytest_terminal_summary(terminalreporter, exitstatus, config: "Config"):
     """Add a section to terminal summary reporting.
 
     :param _pytest.terminal.TerminalReporter terminalreporter: the internal terminal reporter object
@@ -627,7 +642,7 @@ def pytest_exception_interact(node, call, report):
     """
 
 
-def pytest_enter_pdb(config, pdb):
+def pytest_enter_pdb(config: "Config", pdb):
     """ called upon pdb.set_trace(), can be used by plugins to take special
     action just before the python debugger enters in interactive mode.
 
@@ -636,7 +651,7 @@ def pytest_enter_pdb(config, pdb):
     """
 
 
-def pytest_leave_pdb(config, pdb):
+def pytest_leave_pdb(config: "Config", pdb):
     """ called when leaving pdb (e.g. with continue after pdb.set_trace()).
 
     Can be used by plugins to take special action just after the python

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -1,4 +1,7 @@
 """ generic mechanism for marking and selecting python functions. """
+from typing import Optional
+from typing import Union
+
 from .legacy import matchkeyword
 from .legacy import matchmark
 from .structures import EMPTY_PARAMETERSET_OPTION
@@ -8,8 +11,12 @@ from .structures import MARK_GEN
 from .structures import MarkDecorator
 from .structures import MarkGenerator
 from .structures import ParameterSet
+from _pytest.config import Config
+from _pytest.config import ExitCode
 from _pytest.config import hookimpl
 from _pytest.config import UsageError
+from _pytest.config.argparsing import Parser
+
 
 __all__ = ["Mark", "MarkDecorator", "MarkGenerator", "get_empty_parameterset_mark"]
 
@@ -34,7 +41,7 @@ def param(*values, **kw):
     return ParameterSet.param(*values, **kw)
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("general")
     group._addoption(
         "-k",
@@ -77,7 +84,7 @@ def pytest_addoption(parser):
 
 
 @hookimpl(tryfirst=True)
-def pytest_cmdline_main(config):
+def pytest_cmdline_main(config: Config) -> Optional[Union[int, ExitCode]]:
     import _pytest.config
 
     if config.option.markers:
@@ -92,6 +99,8 @@ def pytest_cmdline_main(config):
             tw.line()
         config._ensure_unconfigure()
         return 0
+
+    return None
 
 
 def deselect_by_keyword(items, config):
@@ -144,8 +153,9 @@ def pytest_collection_modifyitems(items, config):
     deselect_by_mark(items, config)
 
 
-def pytest_configure(config):
-    config._old_mark_config = MARK_GEN._config
+def pytest_configure(config: Config) -> None:
+    # Type ignored: pending mechanism to store typed objects scoped to config.
+    config._old_mark_config = MARK_GEN._config  # type: ignore[attr-defined] # noqa: F821
     MARK_GEN._config = config
 
     empty_parameterset = config.getini(EMPTY_PARAMETERSET_OPTION)
@@ -157,5 +167,5 @@ def pytest_configure(config):
         )
 
 
-def pytest_unconfigure(config):
+def pytest_unconfigure(config: Config) -> None:
     MARK_GEN._config = getattr(config, "_old_mark_config", None)

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -13,6 +13,7 @@ import attr
 from .._code.source import getfslineno
 from ..compat import ascii_escaped
 from ..compat import NOTSET
+from _pytest.config import Config
 from _pytest.outcomes import fail
 from _pytest.warning_types import PytestUnknownMarkWarning
 
@@ -310,7 +311,7 @@ class MarkGenerator:
     will set a 'slowtest' :class:`MarkInfo` object
     on the ``test_function`` object. """
 
-    _config = None
+    _config = None  # type: Optional[Config]
     _markers = set()  # type: Set[str]
 
     def __getattr__(self, name: str) -> MarkDecorator:

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -107,7 +107,7 @@ class Node(metaclass=NodeMeta):
 
         #: the pytest config object
         if config:
-            self.config = config
+            self.config = config  # type: Config
         else:
             if not parent:
                 raise TypeError("config or parent must be provided")

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -29,7 +29,9 @@ from _pytest.capture import MultiCapture
 from _pytest.capture import SysCapture
 from _pytest.compat import TYPE_CHECKING
 from _pytest.config import _PluggyPlugin
+from _pytest.config import Config
 from _pytest.config import ExitCode
+from _pytest.config.argparsing import Parser
 from _pytest.fixtures import FixtureRequest
 from _pytest.main import Session
 from _pytest.monkeypatch import MonkeyPatch
@@ -51,7 +53,7 @@ IGNORE_PAM = [  # filenames added when obtaining details about the current user
 ]
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     parser.addoption(
         "--lsof",
         action="store_true",
@@ -76,7 +78,7 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_configure(config):
+def pytest_configure(config: Config) -> None:
     if config.getvalue("lsof"):
         checker = LsofFdLeakChecker()
         if checker.matching_platform():
@@ -887,7 +889,7 @@ class Testdir:
             rec = []
 
             class Collect:
-                def pytest_configure(x, config):
+                def pytest_configure(x, config: Config) -> None:
                     rec.append(self.make_hook_recorder(config.pluginmanager))
 
             plugins.append(Collect())

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -17,6 +17,7 @@ from .reports import TestReport
 from _pytest._code.code import ExceptionInfo
 from _pytest._code.code import ExceptionRepr
 from _pytest.compat import TYPE_CHECKING
+from _pytest.config.argparsing import Parser
 from _pytest.nodes import Collector
 from _pytest.nodes import Node
 from _pytest.outcomes import Exit
@@ -27,11 +28,13 @@ if TYPE_CHECKING:
     from typing import Type
     from typing_extensions import Literal
 
+    from _pytest.main import Session
+
 #
 # pytest plugin hooks
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("terminal reporting", "reporting", after="general")
     group.addoption(
         "--durations",
@@ -72,11 +75,11 @@ def pytest_terminal_summary(terminalreporter):
         tr.write_line("{:02.2f}s {:<8} {}".format(rep.duration, rep.when, rep.nodeid))
 
 
-def pytest_sessionstart(session):
+def pytest_sessionstart(session: "Session") -> None:
     session._setupstate = SetupState()
 
 
-def pytest_sessionfinish(session):
+def pytest_sessionfinish(session: "Session") -> None:
     session._setupstate.teardown_all()
 
 

--- a/src/_pytest/setuponly.py
+++ b/src/_pytest/setuponly.py
@@ -1,7 +1,13 @@
+from typing import Optional
+from typing import Union
+
 import pytest
+from _pytest.config import Config
+from _pytest.config import ExitCode
+from _pytest.config.argparsing import Parser
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("debugconfig")
     group.addoption(
         "--setuponly",
@@ -73,6 +79,7 @@ def _show_fixture_action(fixturedef, msg):
 
 
 @pytest.hookimpl(tryfirst=True)
-def pytest_cmdline_main(config):
+def pytest_cmdline_main(config: Config) -> Optional[Union[int, ExitCode]]:
     if config.option.setuponly:
         config.option.setupshow = True
+    return None

--- a/src/_pytest/setupplan.py
+++ b/src/_pytest/setupplan.py
@@ -1,7 +1,13 @@
+from typing import Optional
+from typing import Union
+
 import pytest
+from _pytest.config import Config
+from _pytest.config import ExitCode
+from _pytest.config.argparsing import Parser
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("debugconfig")
     group.addoption(
         "--setupplan",
@@ -19,10 +25,12 @@ def pytest_fixture_setup(fixturedef, request):
         my_cache_key = fixturedef.cache_key(request)
         fixturedef.cached_result = (None, my_cache_key, None)
         return fixturedef.cached_result
+    return None
 
 
 @pytest.hookimpl(tryfirst=True)
-def pytest_cmdline_main(config):
+def pytest_cmdline_main(config: Config) -> Optional[Union[int, ExitCode]]:
     if config.option.setupplan:
         config.option.setuponly = True
         config.option.setupshow = True
+    return None

--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -1,12 +1,14 @@
 """ support for skip/xfail functions and markers. """
+from _pytest.config import Config
 from _pytest.config import hookimpl
+from _pytest.config.argparsing import Parser
 from _pytest.mark.evaluate import MarkEvaluator
 from _pytest.outcomes import fail
 from _pytest.outcomes import skip
 from _pytest.outcomes import xfail
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("general")
     group.addoption(
         "--runxfail",
@@ -25,7 +27,7 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_configure(config):
+def pytest_configure(config: Config) -> None:
     if config.option.runxfail:
         # yay a hack
         import pytest
@@ -36,7 +38,7 @@ def pytest_configure(config):
         def nop(*args, **kwargs):
             pass
 
-        nop.Exception = xfail.Exception
+        nop.Exception = xfail.Exception  # type: ignore[attr-defined] # noqa: F821
         setattr(pytest, "xfail", nop)
 
     config.addinivalue_line(

--- a/src/_pytest/stepwise.py
+++ b/src/_pytest/stepwise.py
@@ -1,7 +1,10 @@
 import pytest
+from _pytest.config import Config
+from _pytest.config.argparsing import Parser
+from _pytest.main import Session
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("general")
     group.addoption(
         "--sw",
@@ -19,7 +22,7 @@ def pytest_addoption(parser):
 
 
 @pytest.hookimpl
-def pytest_configure(config):
+def pytest_configure(config: Config) -> None:
     config.pluginmanager.register(StepwisePlugin(config), "stepwiseplugin")
 
 
@@ -34,7 +37,7 @@ class StepwisePlugin:
             self.lastfailed = config.cache.get("cache/stepwise", None)
             self.skip = config.getvalue("stepwise_skip")
 
-    def pytest_sessionstart(self, session):
+    def pytest_sessionstart(self, session: Session) -> None:
         self.session = session
 
     def pytest_collection_modifyitems(self, session, config, items):
@@ -100,7 +103,7 @@ class StepwisePlugin:
         if self.active and self.config.getoption("verbose") >= 0 and self.report_status:
             return "stepwise: %s" % self.report_status
 
-    def pytest_sessionfinish(self, session):
+    def pytest_sessionfinish(self, session: Session) -> None:
         if self.active:
             self.config.cache.set("cache/stepwise", self.lastfailed)
         else:

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -17,6 +17,7 @@ from typing import Mapping
 from typing import Optional
 from typing import Set
 from typing import Tuple
+from typing import Union
 
 import attr
 import pluggy
@@ -25,8 +26,10 @@ from more_itertools import collapse
 
 import pytest
 from _pytest import nodes
+from _pytest.config import _PluggyPlugin
 from _pytest.config import Config
 from _pytest.config import ExitCode
+from _pytest.config.argparsing import Parser
 from _pytest.main import Session
 from _pytest.reports import CollectReport
 from _pytest.reports import TestReport
@@ -72,7 +75,7 @@ class MoreQuietAction(argparse.Action):
         namespace.quiet = getattr(namespace, "quiet", 0) + 1
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("terminal reporting", "reporting", after="general")
     group._addoption(
         "-v",
@@ -407,7 +410,7 @@ class TerminalReporter:
         )
         self._add_stats("warnings", [warning_report])
 
-    def pytest_plugin_registered(self, plugin):
+    def pytest_plugin_registered(self, plugin: _PluggyPlugin) -> None:
         if self.config.option.traceconfig:
             msg = "PLUGIN registered: {}".format(plugin)
             # XXX this event may happen during setup/teardown time
@@ -699,7 +702,7 @@ class TerminalReporter:
                             self._tw.line("{}{}".format(indent + "  ", line.strip()))
 
     @pytest.hookimpl(hookwrapper=True)
-    def pytest_sessionfinish(self, session: Session, exitstatus: ExitCode):
+    def pytest_sessionfinish(self, session: Session, exitstatus: Union[int, ExitCode]):
         outcome = yield
         outcome.get_result()
         self._tw.line("")
@@ -734,10 +737,10 @@ class TerminalReporter:
         # Display any extra warnings from teardown here (if any).
         self.summary_warnings()
 
-    def pytest_keyboard_interrupt(self, excinfo):
+    def pytest_keyboard_interrupt(self, excinfo) -> None:
         self._keyboardinterrupt_memo = excinfo.getrepr(funcargs=True)
 
-    def pytest_unconfigure(self):
+    def pytest_unconfigure(self) -> None:
         if hasattr(self, "_keyboardinterrupt_memo"):
             self._report_keyboardinterrupt()
 

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -4,6 +4,8 @@ from contextlib import contextmanager
 from typing import Generator
 
 import pytest
+from _pytest.config import Config
+from _pytest.config.argparsing import Parser
 from _pytest.main import Session
 
 
@@ -31,7 +33,7 @@ def _setoption(wmod, arg):
     wmod.filterwarnings(action, message, category, module, lineno)
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("pytest-warnings")
     group.addoption(
         "-W",
@@ -48,7 +50,7 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_configure(config):
+def pytest_configure(config: Config) -> None:
     config.addinivalue_line(
         "markers",
         "filterwarnings(warning): add a warning filter to the given test. "


### PR DESCRIPTION
Extracted from #6717.

Annotate some "easy" arguments of hooks that repeat in a lot of internal plugins.

Not all of the arguments are annotated fully for now.