### PR TITLE
tests: test_unicode_plus_minus: use unicode sign directly

### DIFF
--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -452,7 +452,7 @@ class TestApprox:
         expected = "4.0e-06"
         result = testdir.runpytest()
         result.stdout.fnmatch_lines(
-            ["*At index 0 diff: 3 != 4 * {}".format(expected), "=* 1 failed in *="]
+            ["*At index 0 diff: 3 != 4 ± {}".format(expected), "=* 1 failed in *="]
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Was globbed for Python 2 before (57c448991).