### PR TITLE
Don't delete FixtureDef.cached_result, set it to None instead

### DIFF
--- a/changelog/6737.breaking.rst
+++ b/changelog/6737.breaking.rst
@@ -1,0 +1,7 @@
+The ``cached_result`` attribute of ``FixtureDef`` is now set to ``None`` when
+the result is unavailable, instead of being deleted.
+
+If your plugin perform checks like ``hasattr(fixturedef, 'cached_result')``,
+for example in a ``pytest_fixture_post_finalizer`` hook implementation, replace
+it with ``fixturedef.cached_result is not None``. If you ``del`` the attribute,
+set it to ``None`` instead.

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -423,9 +423,9 @@ def pytest_fixture_setup(fixturedef, request):
 
 
 def pytest_fixture_post_finalizer(fixturedef, request):
-    """ called after fixture teardown, but before the cache is cleared so
-    the fixture result cache ``fixturedef.cached_result`` can
-    still be accessed."""
+    """Called after fixture teardown, but before the cache is cleared, so
+    the fixture result ``fixturedef.cached_result`` is still available (not
+    ``None``)."""
 
 
 # -------------------------------------------------------------------------

--- a/src/_pytest/setuponly.py
+++ b/src/_pytest/setuponly.py
@@ -34,8 +34,8 @@ def pytest_fixture_setup(fixturedef, request):
         _show_fixture_action(fixturedef, "SETUP")
 
 
-def pytest_fixture_post_finalizer(fixturedef):
-    if hasattr(fixturedef, "cached_result"):
+def pytest_fixture_post_finalizer(fixturedef) -> None:
+    if fixturedef.cached_result is not None:
         config = fixturedef._fixturemanager.config
         if config.option.setupshow:
             _show_fixture_action(fixturedef, "TEARDOWN")


### PR DESCRIPTION
Previously `cached_result` was either set or deleted. Type annotations cannot handle this, so use `None` for the non-set state instead.