### PR TITLE
doc: fix test with link to `python_files`

### DIFF
--- a/doc/en/writing_plugins.rst
+++ b/doc/en/writing_plugins.rst
@@ -179,12 +179,12 @@ assertion failures.  This is provided by "assertion rewriting" which
 modifies the parsed AST before it gets compiled to bytecode.  This is
 done via a :pep:`302` import hook which gets installed early on when
 ``pytest`` starts up and will perform this rewriting when modules get
-imported.  However since we do not want to test different bytecode
-then you will run in production this hook only rewrites test modules
-themselves (as defined by the :confval:`python_files` configuration option)
-themselves as well as any modules which are part of plugins.  Any
-other imported module will not be rewritten and normal assertion
-behaviour will happen.
+imported.  However, since we do not want to test different bytecode
+from what you will run in production, this hook only rewrites test modules
+themselves (as defined by the :confval:`python_files` configuration option),
+and any modules which are part of plugins.
+Any other imported module will not be rewritten and normal assertion behaviour
+will happen.
 
 If you have assertion helpers in other modules where you would need
 assertion rewriting to be enabled you need to ask ``pytest``


### PR DESCRIPTION
Follow-up to b09762d (#6705).

Ref: https://github.com/pytest-dev/pytest/pull/6705#discussion_r379819573