### PR TITLE
Expand first sentence on fixtures into a paragraph

### DIFF
--- a/changelog/6742.doc.rst
+++ b/changelog/6742.doc.rst
@@ -1,0 +1,1 @@
+Expand first sentence on fixtures into a paragraph.

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -10,15 +10,16 @@ pytest fixtures: explicit, modular, scalable
 
 
 .. _`xUnit`: https://en.wikipedia.org/wiki/XUnit
-.. _`Fixtures initialize`: https://en.wikipedia.org/wiki/Test_fixture#Software
+.. _`Software test fixtures`: https://en.wikipedia.org/wiki/Test_fixture#Software
 .. _`Dependency injection`: https://en.wikipedia.org/wiki/Dependency_injection
 
-`Fixtures initialize`_ software tests.  They provide a fixed baseline
-so that tests execute reliably and produce consistent, repeatable,
-results.  Initialization may setup services, state, or other operating
-environments.  These are accessed by test functions though arguments;
-for each fixture used by a test function there is typically a
-parameter (named after the fixture) in the test function's definition.
+`Software test fixtures`_ initialize test functions.  They provide a
+fixed baseline so that tests execute reliably and produce consistent,
+repeatable, results.  Initialization may setup services, state, or
+other operating environments.  These are accessed by test functions
+though arguments; for each fixture used by a test function there is
+typically a parameter (named after the fixture) in the test function's
+definition.
 
 pytest fixtures offer dramatic improvements over the classic xUnit
 style of setup/teardown functions:

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -17,7 +17,7 @@ pytest fixtures: explicit, modular, scalable
 fixed baseline so that tests execute reliably and produce consistent,
 repeatable, results.  Initialization may setup services, state, or
 other operating environments.  These are accessed by test functions
-though arguments; for each fixture used by a test function there is
+through arguments; for each fixture used by a test function there is
 typically a parameter (named after the fixture) in the test function's
 definition.
 

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -10,13 +10,18 @@ pytest fixtures: explicit, modular, scalable
 
 
 .. _`xUnit`: https://en.wikipedia.org/wiki/XUnit
-.. _`purpose of test fixtures`: https://en.wikipedia.org/wiki/Test_fixture#Software
+.. _`Fixtures initialize`: https://en.wikipedia.org/wiki/Test_fixture#Software
 .. _`Dependency injection`: https://en.wikipedia.org/wiki/Dependency_injection
 
-The `purpose of test fixtures`_ is to provide a fixed baseline
-upon which tests can reliably and repeatedly execute.   pytest fixtures
-offer dramatic improvements over the classic xUnit style of setup/teardown
-functions:
+`Fixtures initialize`_ software tests.  They provide a fixed baseline
+so that tests execute reliably and produce consistent, repeatable,
+results.  Initialization may setup services, state, or other operating
+environments.  These are accessed by test functions though arguments;
+for each fixture used by a test function there is typically a
+parameter (named after the fixture) in the test function's definition.
+
+pytest fixtures offer dramatic improvements over the classic xUnit
+style of setup/teardown functions:
 
 * fixtures have explicit names and are activated by declaring their use
   from test functions, modules, classes or whole projects.


### PR DESCRIPTION
I would like to hyperlink just the first word, "Fixtures", but I don't think this is possible with RST  given that there is a pre-existing link target called "fixtures".