### PR TITLE
Avoid getattr when dispatching pytest_runtest_* hooks

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -24,5 +24,6 @@ exclude_lines =
     \#\s*pragma: no cover
     ^\s*raise NotImplementedError\b
     ^\s*return NotImplemented\b
+    ^\s*assert False(,|$)
 
     ^\s*if TYPE_CHECKING:


### PR DESCRIPTION
Using getattr doesn't work with typing, and also breaks grep. It took me a while to find where these hooks are called.