### PR TITLE
Add Item.runtest stub implementation

### DIFF
--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -239,7 +239,7 @@ class DoctestItem(pytest.Item):
                 globs[name] = value
             self.dtest.globs.update(globs)
 
-    def runtest(self):
+    def runtest(self) -> None:
         _check_all_skipped(self.dtest)
         self._disable_output_capturing_for_darwin()
         failures = []  # type: List[doctest.DocTestFailure]

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -521,6 +521,9 @@ class Item(Node):
         #: defined properties for this test.
         self.user_properties = []  # type: List[Tuple[str, Any]]
 
+    def runtest(self) -> None:
+        raise NotImplementedError("runtest must be implemented by Item subclass")
+
     def add_report_section(self, when: str, key: str, content: str) -> None:
         """
         Adds a new report section, similar to what's done internally to add stdout and

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1474,7 +1474,7 @@ class Function(PyobjMixin, nodes.Item):
         warnings.warn(FUNCARGNAMES, stacklevel=2)
         return self.fixturenames
 
-    def runtest(self):
+    def runtest(self) -> None:
         """ execute the underlying test function. """
         self.ihook.pytest_pyfunc_call(pyfuncitem=self)
 
@@ -1519,7 +1519,7 @@ class FunctionDefinition(Function):
     crappy metafunc hack
     """
 
-    def runtest(self):
+    def runtest(self) -> None:
         raise RuntimeError("function definitions are not supposed to be used")
 
     setup = runtest


### PR DESCRIPTION
Every Item must implement this method (called on all items collected in a session). Add a stub for typing and clarity.