### PR TITLE
Do not use fixed line number with test_cache_failure_warns

### DIFF
--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -71,8 +71,8 @@ class TestNewAPI:
                 [
                     # Validate location/stacklevel of warning from cacheprovider.
                     "*= warnings summary =*",
-                    "*/cacheprovider.py:314",
-                    "  */cacheprovider.py:314: PytestCacheWarning: could not create cache path "
+                    "*/cacheprovider.py:*",
+                    "  */cacheprovider.py:*: PytestCacheWarning: could not create cache path "
                     "{}/v/cache/nodeids".format(cache_dir),
                     '    config.cache.set("cache/nodeids", self.cached_nodeids)',
                     "*1 failed, 3 warnings in*",


### PR DESCRIPTION
It was not previously checking for the line number also (02aa8ad), and this is
obviously wrong (affected by changes to the file).

Unblocks https://github.com/pytest-dev/pytest/pull/6448.