### PR TITLE
Fix removal of very long paths on Windows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -277,6 +277,7 @@ Tom Dalton
 Tom Viner
 Tomáš Gavenčiak
 Tomer Keren
+Tor Colvin
 Trevor Bekolay
 Tyler Goodlet
 Tzu-ping Chung

--- a/changelog/6755.bugfix.rst
+++ b/changelog/6755.bugfix.rst
@@ -1,1 +1,1 @@
-Support deleting paths longer than 260 characters on windows created inside tmpdir. 
+Support deleting paths longer than 260 characters on windows created inside tmpdir.

--- a/changelog/6755.bugfix.rst
+++ b/changelog/6755.bugfix.rst
@@ -1,0 +1,1 @@
+Support deleting paths longer than 260 characters on windows created inside tmpdir. 

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -99,11 +99,23 @@ def on_rm_rf_error(func, path: str, exc, *, start_path: Path) -> bool:
     func(path)
     return True
 
+def create_long_path(path: Path) -> Path:
+    """Construct a path which will work on Windows if greater
+    than 260 characters. Resolves into a absolute path which
+    bypasses the typical MAX_PATH limitation:
+    https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation"""
+    if sys.platform.startswith("win32"):
+        path = path.resolve()
+        # for the API
+        if not str(path).startswith(r"\\?\"):
+            path = Path(r"\\?\" + str(path))
+    return path
 
 def rm_rf(path: Path) -> None:
     """Remove the path contents recursively, even if some elements
     are read-only.
     """
+    path = create_long_path(path)
     onerror = partial(on_rm_rf_error, start_path=path)
     shutil.rmtree(str(path), onerror=onerror)
 

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -99,6 +99,7 @@ def on_rm_rf_error(func, path: str, exc, *, start_path: Path) -> bool:
     func(path)
     return True
 
+
 def create_long_path(path: Path) -> Path:
     """Construct a path which will work on Windows if greater
     than 260 characters. Resolves into a absolute path which
@@ -110,6 +111,7 @@ def create_long_path(path: Path) -> Path:
         if not str(path).startswith("\\\\?\\"):
             path = Path("\\\\?\\" + str(path))
     return path
+
 
 def rm_rf(path: Path) -> None:
     """Remove the path contents recursively, even if some elements

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -107,8 +107,8 @@ def create_long_path(path: Path) -> Path:
     if sys.platform.startswith("win32"):
         path = path.resolve()
         # for the API
-        if not str(path).startswith(r"\\?\"):
-            path = Path(r"\\?\" + str(path))
+        if not str(path).startswith("\\\\?\\"):
+            path = Path("\\\\?\\" + str(path))
     return path
 
 def rm_rf(path: Path) -> None:

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -251,6 +251,7 @@ def register_cleanup_lock_removal(lock_path: Path, register=atexit.register):
 
 def maybe_delete_a_numbered_dir(path: Path) -> None:
     """removes a numbered directory if its lock can be obtained and it does not seem to be in use"""
+    path = ensure_extended_length_path(path)
     lock_path = None
     try:
         lock_path = create_cleanup_lock(path)

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -114,7 +114,7 @@ def ensure_extended_length_path(path: Path) -> Path:
     """
     if sys.platform.startswith("win32"):
         path = path.resolve()
-        path = Path(get_extended_length_path_str(path))
+        path = Path(get_extended_length_path_str(str(path)))
     return path
 
 

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -95,7 +95,7 @@ def test_long_path_during_cleanup(tmp_path):
     path = tmp_path / ("a" * 200)
     if sys.platform == "win32":
         dirname = path.resolve()
-        dirname = r"\\?\" + str(path)
+        dirname = "\\\\?\\" + str(path)
         os.mkdir(dirname)
 
     lock_path = get_lock_path(path)

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -5,6 +5,7 @@ import py
 
 import pytest
 from _pytest.pathlib import fnmatch_ex
+from _pytest.pathlib import get_extended_length_path_str
 from _pytest.pathlib import get_lock_path
 from _pytest.pathlib import maybe_delete_a_numbered_dir
 from _pytest.pathlib import Path
@@ -104,3 +105,10 @@ def test_long_path_during_cleanup(tmp_path):
     lock_path = get_lock_path(path)
     maybe_delete_a_numbered_dir(path)
     assert not lock_path.is_file()
+
+
+def test_get_extended_length_path_str():
+    assert get_extended_length_path_str(r"c:\foo") == r"\\?\c:\foo"
+    assert get_extended_length_path_str(r"\\share\foo") == r"\\?\UNC\share\foo"
+    assert get_extended_length_path_str(r"\\?\UNC\share\foo") == r"\\?\UNC\share\foo"
+    assert get_extended_length_path_str(r"\\?\c:\foo") == r"\\?\c:\foo"

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -93,12 +93,14 @@ def test_access_denied_during_cleanup(tmp_path, monkeypatch):
 
 def test_long_path_during_cleanup(tmp_path):
     """Ensure that deleting long path works (particularly on Windows (#6775))."""
-    path = tmp_path / ("a" * 200)
+    path = tmp_path / ("a" * 250)
     if sys.platform == "win32":
         dirname = path.resolve()
+        # make sure that the full path is > 260 characters without any
+        # component being over 260 characters
+        assert len(path) > 260
         dirname = "\\\\?\\" + str(path)
         os.mkdir(dirname)
-
     lock_path = get_lock_path(path)
     maybe_delete_a_numbered_dir(path)
     assert not lock_path.is_file()

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -93,7 +93,7 @@ def test_access_denied_during_cleanup(tmp_path, monkeypatch):
 
 def test_long_path_during_cleanup(tmp_path):
     """Ensure that deleting long path works (particularly on Windows (#6775))."""
-    path = tmp_path / ("a" * 300)
+    path = tmp_path / ("a" * 200)
     if sys.platform == "win32":
         dirname = path.resolve()
         dirname = "\\\\?\\" + str(path)

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -4,7 +4,6 @@ import sys
 import py
 
 import pytest
-from _pytest.pathlib import create_long_path
 from _pytest.pathlib import fnmatch_ex
 from _pytest.pathlib import get_lock_path
 from _pytest.pathlib import maybe_delete_a_numbered_dir
@@ -102,5 +101,4 @@ def test_long_path_during_cleanup(tmp_path):
 
     lock_path = get_lock_path(path)
     maybe_delete_a_numbered_dir(path)
-    # is_file also fails on the long path
-    assert not os.path.exists(create_long_path(lock_path))
+    assert not lock_path.is_file()

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -89,3 +89,15 @@ def test_access_denied_during_cleanup(tmp_path, monkeypatch):
     lock_path = get_lock_path(path)
     maybe_delete_a_numbered_dir(path)
     assert not lock_path.is_file()
+
+def test_long_path_during_cleanup(tmp_path):
+    """Ensure that deleting long path works (particularly on Windows (#6775))."""
+    path = tmp_path / ("a" * 200)
+    if sys.platform == "win32":
+        dirname = path.resolve()
+        dirname = r"\\?\" + str(path)
+        os.mkdir(dirname)
+
+    lock_path = get_lock_path(path)
+    maybe_delete_a_numbered_dir(path)
+    assert not lock_path.is_file()

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -94,17 +94,18 @@ def test_access_denied_during_cleanup(tmp_path, monkeypatch):
 
 def test_long_path_during_cleanup(tmp_path):
     """Ensure that deleting long path works (particularly on Windows (#6775))."""
-    path = tmp_path / ("a" * 250)
+    path = (tmp_path / ("a" * 250)).resolve()
     if sys.platform == "win32":
-        dirname = path.resolve()
         # make sure that the full path is > 260 characters without any
         # component being over 260 characters
         assert len(str(path)) > 260
-        dirname = "\\\\?\\" + str(path)
-        os.mkdir(dirname)
-    lock_path = get_lock_path(path)
+        extended_path = "\\\\?\\" + str(path)
+    else:
+        extended_path = str(path)
+    os.mkdir(extended_path)
+    assert os.path.isdir(extended_path)
     maybe_delete_a_numbered_dir(path)
-    assert not lock_path.is_file()
+    assert not os.path.isdir(extended_path)
 
 
 def test_get_extended_length_path_str():

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -90,6 +90,7 @@ def test_access_denied_during_cleanup(tmp_path, monkeypatch):
     maybe_delete_a_numbered_dir(path)
     assert not lock_path.is_file()
 
+
 def test_long_path_during_cleanup(tmp_path):
     """Ensure that deleting long path works (particularly on Windows (#6775))."""
     path = tmp_path / ("a" * 200)

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -4,6 +4,7 @@ import sys
 import py
 
 import pytest
+from _pytest.pathlib import create_long_path
 from _pytest.pathlib import fnmatch_ex
 from _pytest.pathlib import get_lock_path
 from _pytest.pathlib import maybe_delete_a_numbered_dir
@@ -101,4 +102,5 @@ def test_long_path_during_cleanup(tmp_path):
 
     lock_path = get_lock_path(path)
     maybe_delete_a_numbered_dir(path)
-    assert not lock_path.is_file()
+    # is_file also fails on the long path
+    assert not os.path.exists(create_long_path(lock_path))

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -98,7 +98,7 @@ def test_long_path_during_cleanup(tmp_path):
         dirname = path.resolve()
         # make sure that the full path is > 260 characters without any
         # component being over 260 characters
-        assert len(path) > 260
+        assert len(str(path)) > 260
         dirname = "\\\\?\\" + str(path)
         os.mkdir(dirname)
     lock_path = get_lock_path(path)

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -93,7 +93,7 @@ def test_access_denied_during_cleanup(tmp_path, monkeypatch):
 
 def test_long_path_during_cleanup(tmp_path):
     """Ensure that deleting long path works (particularly on Windows (#6775))."""
-    path = tmp_path / ("a" * 200)
+    path = tmp_path / ("a" * 300)
     if sys.platform == "win32":
         dirname = path.resolve()
         dirname = "\\\\?\\" + str(path)


### PR DESCRIPTION
Allow tmpdir to be removed in cases where the creation of files does not exceed the length of MAX_PATH, but adding garbage + UUID does exceed the length of path. Fixes https://github.com/pytest-dev/pytest/issues/291

