### PR TITLE
tests: fix flaky test_timeout

### DIFF
--- a/testing/test_faulthandler.py
+++ b/testing/test_faulthandler.py
@@ -56,9 +56,9 @@ def test_timeout(testdir, enabled):
     """
     testdir.makepyfile(
         """
-    import time
+    import os, time
     def test_timeout():
-        time.sleep(0.1)
+        time.sleep(1 if "CI" in os.environ else 0.1)
     """
     )
     testdir.makeini(


### PR DESCRIPTION
Use a longer timeout on CI - seen a failure with it with GHA (Windows).