### PR TITLE
Fix pytest_ignore_collect hooks: do not return False

### DIFF
--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -198,7 +198,8 @@ def pytest_ignore_collect(path, config):
     This hook is consulted for all files and directories prior to calling
     more specific hooks.
 
-    Stops at first non-None result, see :ref:`firstresult`
+    Stops at first non-None result, see :ref:`firstresult`, i.e. you should
+    only return `False` if the file should never get ignored (by other hooks).
 
     :param path: a :py:class:`py.path.local` - the path to analyze
     :param _pytest.config.Config config: pytest config object

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -198,8 +198,7 @@ def pytest_ignore_collect(path, config):
     This hook is consulted for all files and directories prior to calling
     more specific hooks.
 
-    Stops at first non-None result, see :ref:`firstresult`, i.e. you should
-    only return `False` if the file should never get ignored (by other hooks).
+    Stops at first non-None result, see :ref:`firstresult`
 
     :param path: a :py:class:`py.path.local` - the path to analyze
     :param _pytest.config.Config config: pytest config object

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -33,6 +33,7 @@ from _pytest.runner import SetupState
 
 if TYPE_CHECKING:
     from typing import Type
+    from typing_extensions import Literal
 
     from _pytest.python import Package
 
@@ -295,7 +296,9 @@ def _in_venv(path):
     return any([fname.basename in activates for fname in bindir.listdir()])
 
 
-def pytest_ignore_collect(path, config):
+def pytest_ignore_collect(
+    path: py.path.local, config: Config
+) -> "Optional[Literal[True]]":
     ignore_paths = config._getconftest_pathlist("collect_ignore", path=path.dirpath())
     ignore_paths = ignore_paths or []
     excludeopt = config.getoption("ignore")

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -320,8 +320,6 @@ def pytest_ignore_collect(path, config):
     if not allow_in_venv and _in_venv(path):
         return True
 
-    return False
-
 
 def pytest_collection_modifyitems(items, config):
     deselect_prefixes = tuple(config.getoption("deselect") or [])

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -319,6 +319,7 @@ def pytest_ignore_collect(path, config):
     allow_in_venv = config.getoption("collect_in_virtualenv")
     if not allow_in_venv and _in_venv(path):
         return True
+    return None
 
 
 def pytest_collection_modifyitems(items, config):


### PR DESCRIPTION
It should only return `True` when something is to be ignored, not
`False` otherwise typically.

This caused e.g. bad interaction with the cacheprovider (before
https://github.com/pytest-dev/pytest/pull/6448).