### PR TITLE
[4.6.x] Fix one issue for compat::getfuncargnames

### DIFF
--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -164,8 +164,8 @@ def getfuncargnames(function, is_method=False, cls=None):
     # parameter name.
     if is_method or (
         cls
-        and not isinstance(cls.__dict__.get(function.__name__, None), staticmethod)
         and (not hasattr(function, "__self__") or not function.__self__)
+        and not isinstance(cls.__dict__.get(function.__name__, None), staticmethod)
     ):
         arg_names = arg_names[1:]
     # Remove any names that will be replaced with mocks.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -163,7 +163,9 @@ def getfuncargnames(function, is_method=False, cls=None):
     # it's passed as an unbound method or function, remove the first
     # parameter name.
     if is_method or (
-        cls and not isinstance(cls.__dict__.get(function.__name__, None), staticmethod) and not function.__self__
+        cls
+        and not isinstance(cls.__dict__.get(function.__name__, None), staticmethod)
+        and not function.__self__
     ):
         arg_names = arg_names[1:]
     # Remove any names that will be replaced with mocks.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -163,7 +163,7 @@ def getfuncargnames(function, is_method=False, cls=None):
     # it's passed as an unbound method or function, remove the first
     # parameter name.
     if is_method or (
-        cls and not isinstance(cls.__dict__.get(function.__name__, None), staticmethod)
+        cls and not isinstance(cls.__dict__.get(function.__name__, None), staticmethod) and not function.__self__
     ):
         arg_names = arg_names[1:]
     # Remove any names that will be replaced with mocks.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -165,7 +165,7 @@ def getfuncargnames(function, is_method=False, cls=None):
     if is_method or (
         cls
         and not isinstance(cls.__dict__.get(function.__name__, None), staticmethod)
-        and not function.__self__
+        and (not hasattr(function, "__self__") or not function.__self__)
     ):
         arg_names = arg_names[1:]
     # Remove any names that will be replaced with mocks.


### PR DESCRIPTION
Fix so the self of an instancemethod will not be removed again in getfuncargnames because it is already removed from signature(function)

I will deal with changelog later.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
