### PR TITLE
main: `args` must be a list, not tuple

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -233,13 +233,15 @@ def get_plugin_manager():
     return get_config().pluginmanager
 
 
-def _prepareconfig(args=None, plugins=None):
+def _prepareconfig(
+    args: Optional[Union[py.path.local, List[str]]] = None, plugins=None
+):
     if args is None:
         args = sys.argv[1:]
     elif isinstance(args, py.path.local):
         args = [str(args)]
-    elif not isinstance(args, (tuple, list)):
-        msg = "`args` parameter expected to be a list or tuple of strings, got: {!r} (type: {})"
+    elif not isinstance(args, list):
+        msg = "`args` parameter expected to be a list of strings, got: {!r} (type: {})"
         raise TypeError(msg.format(args, type(args)))
 
     config = get_config(args, plugins)

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -606,7 +606,7 @@ class TestInvocationVariants:
 
     def test_invoke_with_invalid_type(self):
         with pytest.raises(
-            TypeError, match="expected to be a list or tuple of strings, got: '-h'"
+            TypeError, match="expected to be a list of strings, got: '-h'"
         ):
             pytest.main("-h")
 


### PR DESCRIPTION
Passing in a tuple crashes in `_prepareconfig`:

        def test_invoke_with_tuple(self):
    >       pytest.main(("-h",))

    src/_pytest/config/__init__.py:82: in main
        config = _prepareconfig(args, plugins)
    src/_pytest/config/__init__.py:229: in _prepareconfig
        return pluginmanager.hook.pytest_cmdline_parse(
    …
    src/_pytest/helpconfig.py:98: in pytest_cmdline_parse
        config = outcome.get_result()  # type: Config
    src/_pytest/config/__init__.py:808: in pytest_cmdline_parse
        self.parse(args)
    src/_pytest/config/__init__.py:1017: in parse
        self._preparse(args, addopts=addopts)
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

        def _preparse(self, args: List[str], addopts: bool = True) -> None:
            …
            if addopts:
                ini_addopts = self.getini("addopts")
                if ini_addopts:
    >               args[:] = self._validate_args(ini_addopts, "via addopts config") + args
    E               TypeError: can only concatenate list (not "tuple") to list

    addopts    = True
    args       = ('-h',)
    env_addopts = ''
    ini_addopts = ['-rfEX', …]

    src/_pytest/config/__init__.py:956: TypeError: can only concatenate list (not "tuple") to list

Might be worth handling (converting it to a list for example), but it
was documented to be a list to begin with when removing support for
strings (a7e401656).


<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->