### PR TITLE
Improve UsageError with invalid `-o` style

### DIFF
--- a/changelog/6795.improvement.rst
+++ b/changelog/6795.improvement.rst
@@ -1,0 +1,1 @@
+Import usage error message with invalid `-o` option.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1131,7 +1131,11 @@ class Config:
             try:
                 key, user_ini_value = ini_config.split("=", 1)
             except ValueError:
-                raise UsageError("-o/--override-ini expects option=value style.")
+                raise UsageError(
+                    "-o/--override-ini expects option=value style (got: {!r}).".format(
+                        ini_config
+                    )
+                )
             else:
                 if key == name:
                     value = user_ini_value

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1058,8 +1058,12 @@ class TestOverrideIniArgs:
             xdist_strict=False
         """
         )
-        result = testdir.runpytest("--override-ini", "xdist_strict True", "-s")
-        result.stderr.fnmatch_lines(["*ERROR* *expects option=value*"])
+        result = testdir.runpytest("--override-ini", "xdist_strict", "True")
+        result.stderr.fnmatch_lines(
+            [
+                "ERROR: -o/--override-ini expects option=value style (got: 'xdist_strict').",
+            ]
+        )
 
     @pytest.mark.parametrize("with_ini", [True, False])
     def test_override_ini_handled_asap(self, testdir, with_ini):


### PR DESCRIPTION
This started from fixing the test, where `"xdist_strict True"` was used
as a single argument, although you typically would see `["xdist_strict",
"True"]`.

Improves the error message to mention the option that caused the error.