### PR TITLE
Fix usage of pytester with doctests

### DIFF
--- a/changelog/6802.bugfix.rst
+++ b/changelog/6802.bugfix.rst
@@ -1,0 +1,1 @@
+The :fixture:`testdir fixture <testdir>` works within doctests now.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -545,7 +545,7 @@ class Testdir:
             WeakKeyDictionary()
         )  # type: WeakKeyDictionary[Module, List[Union[Item, Collector]]]
         if request.function:
-            name = request.function.__name__
+            name = request.function.__name__  # type: str
         else:
             name = request.node.name
         self._name = name

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -544,7 +544,11 @@ class Testdir:
         self._mod_collections = (
             WeakKeyDictionary()
         )  # type: WeakKeyDictionary[Module, List[Union[Item, Collector]]]
-        name = request.node.name
+        if request.function:
+            name = request.function.__name__
+        else:
+            name = request.node.name
+        self._name = name
         self.tmpdir = tmpdir_factory.mktemp(name, numbered=True)
         self.test_tmproot = tmpdir_factory.mktemp("tmp-" + name, numbered=True)
         self.plugins = []  # type: List[Union[str, _PluggyPlugin]]
@@ -618,7 +622,7 @@ class Testdir:
 
         if lines:
             source = "\n".join(to_text(x) for x in lines)
-            basename = self.request.node.name
+            basename = self._name
             items.insert(0, (basename, source))
 
         ret = None
@@ -721,7 +725,7 @@ class Testdir:
             example_dir = example_dir.join(*extra_element.args)
 
         if name is None:
-            func_name = self.request.node.name
+            func_name = self._name
             maybe_dir = example_dir / func_name
             maybe_file = example_dir / (func_name + ".py")
 
@@ -1060,7 +1064,7 @@ class Testdir:
             path = self.tmpdir.join(str(source))
             assert not withinit, "not supported for paths"
         else:
-            kw = {self.request.node.name: Source(source).strip()}
+            kw = {self._name: Source(source).strip()}
             path = self.makepyfile(**kw)
         if withinit:
             self.makepyfile(__init__="#")

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -544,7 +544,7 @@ class Testdir:
         self._mod_collections = (
             WeakKeyDictionary()
         )  # type: WeakKeyDictionary[Module, List[Union[Item, Collector]]]
-        name = request.function.__name__
+        name = request.node.name
         self.tmpdir = tmpdir_factory.mktemp(name, numbered=True)
         self.test_tmproot = tmpdir_factory.mktemp("tmp-" + name, numbered=True)
         self.plugins = []  # type: List[Union[str, _PluggyPlugin]]
@@ -618,7 +618,7 @@ class Testdir:
 
         if lines:
             source = "\n".join(to_text(x) for x in lines)
-            basename = self.request.function.__name__
+            basename = self.request.node.name
             items.insert(0, (basename, source))
 
         ret = None
@@ -721,7 +721,7 @@ class Testdir:
             example_dir = example_dir.join(*extra_element.args)
 
         if name is None:
-            func_name = self.request.function.__name__
+            func_name = self.request.node.name
             maybe_dir = example_dir / func_name
             maybe_file = example_dir / (func_name + ".py")
 
@@ -1060,7 +1060,7 @@ class Testdir:
             path = self.tmpdir.join(str(source))
             assert not withinit, "not supported for paths"
         else:
-            kw = {self.request.function.__name__: Source(source).strip()}
+            kw = {self.request.node.name: Source(source).strip()}
             path = self.makepyfile(**kw)
         if withinit:
             self.makepyfile(__init__="#")

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -89,6 +89,23 @@ def test_testdir_runs_with_plugin(testdir) -> None:
     result.assert_outcomes(passed=1)
 
 
+def test_testdir_with_doctest(testdir):
+    """Check that testdir can be used within doctests.
+
+    It used to use `request.function`, which is `None` with doctests."""
+    p1 = testdir.makepyfile(
+        """
+        '''
+        >>> testdir = getfixture("testdir")
+        >>> testdir.makepyfile("content")
+        local('.../test_testdir_with_doctest.py')
+        '''
+    """
+    )
+    result = testdir.runpytest("-p", "pytester", "--doctest-modules", str(p1))
+    assert result.ret == 0
+
+
 def test_runresult_assertion_on_xfail(testdir) -> None:
     testdir.makepyfile(
         """

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -93,19 +93,22 @@ def test_testdir_with_doctest(testdir):
     """Check that testdir can be used within doctests.
 
     It used to use `request.function`, which is `None` with doctests."""
-    p1 = testdir.makepyfile(
+    testdir.makepyfile(
         **{
             "sub/t-doctest.py": """
         '''
+        >>> import os
         >>> testdir = getfixture("testdir")
-        >>> testdir.makepyfile("content")
-        local('.../basetemp/sub.t-doctest0/sub.py')
+        >>> str(testdir.makepyfile("content")).replace(os.sep, '/')
+        '.../basetemp/sub.t-doctest0/sub.py'
         '''
     """,
             "sub/__init__.py": "",
         }
     )
-    result = testdir.runpytest("-p", "pytester", "--doctest-modules", str(p1))
+    result = testdir.runpytest(
+        "-p", "pytester", "--doctest-modules", "sub/t-doctest.py"
+    )
     assert result.ret == 0
 
 

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -94,13 +94,16 @@ def test_testdir_with_doctest(testdir):
 
     It used to use `request.function`, which is `None` with doctests."""
     p1 = testdir.makepyfile(
-        """
+        **{
+            "sub/t-doctest.py": """
         '''
         >>> testdir = getfixture("testdir")
         >>> testdir.makepyfile("content")
-        local('.../test_testdir_with_doctest.py')
+        local('.../basetemp/sub.t-doctest0/sub.py')
         '''
-    """
+    """,
+            "sub/__init__.py": "",
+        }
     )
     result = testdir.runpytest("-p", "pytester", "--doctest-modules", str(p1))
     assert result.ret == 0


### PR DESCRIPTION
Use `request.node.name` instead of `request.function.__name__`:
`request.function` is `None` with `DoctestItem`s.

TODO:

- [x] changelog (after approval/review)