### PR TITLE
Remove unused `setns`

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1197,28 +1197,6 @@ def _warn_about_missing_assertion(mode):
             )
 
 
-def setns(obj, dic):
-    import pytest
-
-    for name, value in dic.items():
-        if isinstance(value, dict):
-            mod = getattr(obj, name, None)
-            if mod is None:
-                modname = "pytest.%s" % name
-                mod = types.ModuleType(modname)
-                sys.modules[modname] = mod
-                mod.__all__ = []
-                setattr(obj, name, mod)
-            obj.__all__.append(name)
-            setns(mod, value)
-        else:
-            setattr(obj, name, value)
-            obj.__all__.append(name)
-            # if obj != pytest:
-            #    pytest.__all__.append(name)
-            setattr(pytest, name, value)
-
-
 def create_terminal_writer(config: Config, *args, **kwargs) -> TerminalWriter:
     """Create a TerminalWriter instance configured according to the options
     in the config object. Every code which requires a TerminalWriter object


### PR DESCRIPTION
Last usage of it was removed in ba17363d7.

TODO:

- [ ] after https://github.com/pytest-dev/pytest/pull/6803