### PR TITLE
Remove unused `pytester.getdecoded`

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -25,7 +25,6 @@ import py
 
 import pytest
 from _pytest._code import Source
-from _pytest._io.saferepr import saferepr
 from _pytest.capture import MultiCapture
 from _pytest.capture import SysCapture
 from _pytest.compat import TYPE_CHECKING
@@ -1281,15 +1280,6 @@ class Testdir:
         self.request.addfinalizer(logfile.close)
         child.timeout = expect_timeout
         return child
-
-
-def getdecoded(out):
-    try:
-        return out.decode("utf-8")
-    except UnicodeDecodeError:
-        return "INTERNAL not-utf8-decodeable, truncated string:\n{}".format(
-            saferepr(out)
-        )
 
 
 class LineComp:


### PR DESCRIPTION
Last usage was removed in 22dc47d9f.