### PR TITLE
tests: check result with `test_510` - test likely needs fixing

### DIFF
--- a/testing/examples/test_issue519.py
+++ b/testing/examples/test_issue519.py
@@ -1,3 +1,20 @@
+"""Test for https://github.com/pytest-dev/pytest/issues/519."""
+
+
 def test_510(testdir):
     testdir.copy_example("issue_519.py")
-    testdir.runpytest("issue_519.py")
+    result = testdir.runpytest("issue_519.py")
+    result.stdout.fnmatch_lines(
+        [
+            "collected 0 items / 1 error",
+            "",
+            "*= ERRORS =*",
+            "*_ ERROR collecting issue_519.py _*",
+            'In function "test_one":',
+            'Parameter "arg1" should be declared explicitly via indirect or in function itself',
+            "*= short test summary info =*",
+            "ERROR issue_519.py",
+            "*! Interrupted: 1 error during collection !*",
+            "*= 1 error in *=",
+        ]
+    )


### PR DESCRIPTION
Note that the output changed with 9e262038c8 (https://github.com/pytest-dev/pytest/pull/3623), so the test should likely
be fixed.

Ref: https://github.com/pytest-dev/pytest/issues/519 (- haven't looked into what the issue is about).
Might also be https://github.com/pytest-dev/pytest/issues/510 ? (mixed names)

Example script was added in c081c5ee2, changed in ea906056f, currently outputs:

Previous output:
```
['============================= test session starts ==============================',
 'platform linux -- Python 3.8.1, pytest-5.3.5.dev567+gfba7d992a.d20200224, py-1.8.2.dev3+g2b6bd292, pluggy-0.13.1',
 'rootdir: ~',
 'collected 8 items',
 '',
 'issue_519.py ........E                                                   [100%]',
 '',
 '==================================== ERRORS ====================================',
 '_________________ ERROR at teardown of test_two[arg1v2-arg2v2] _________________',
 '',
 '    @pytest.fixture(scope="session")',
 '    def checked_order():',
 '        order = []',
 '    ',
 '        yield order',
 '        pprint.pprint(order)',
 '>       assert order == [',
 '            ("testing/example_scripts/issue_519.py", "fix1", "arg1v1"),',
 '            ("test_one[arg1v1-arg2v1]", "fix2", "arg2v1"),',
 '            ("test_two[arg1v1-arg2v1]", "fix2", "arg2v1"),',
 '            ("test_one[arg1v1-arg2v2]", "fix2", "arg2v2"),',
 '            ("test_two[arg1v1-arg2v2]", "fix2", "arg2v2"),',
 '            ("testing/example_scripts/issue_519.py", "fix1", "arg1v2"),',
 '            ("test_one[arg1v2-arg2v1]", "fix2", "arg2v1"),',
 '            ("test_two[arg1v2-arg2v1]", "fix2", "arg2v1"),',
 '            ("test_one[arg1v2-arg2v2]", "fix2", "arg2v2"),',
 '            ("test_two[arg1v2-arg2v2]", "fix2", "arg2v2"),',
 '        ]',
 "E       AssertionError: assert [('issue_519....arg1v2'), ...] == [('testing/ex...arg1v2'), ...]",
 'E         At index 0 diff:',
 "E         ('issue_519.py', 'fix1', 'arg1v1') !=",
 "E         ('testing/example_scripts/issue_519.py', 'fix1', 'arg1v1')",
 'E         Use -v to get the full diff',
 '',
 "issue_519.py:20: AssertionError: assert [('issue_519....arg1v2'), ...] == [('testing/ex...arg1v2'), ...]...",
 '--------------------------- Captured stdout teardown ---------------------------',
 "[('issue_519.py', 'fix1', 'arg1v1'),",
 " ('test_one[arg1v1-arg2v1]', 'fix2', 'arg2v1'),",
 " ('test_two[arg1v1-arg2v1]', 'fix2', 'arg2v1'),",
 " ('test_one[arg1v1-arg2v2]', 'fix2', 'arg2v2'),",
 " ('test_two[arg1v1-arg2v2]', 'fix2', 'arg2v2'),",
 " ('issue_519.py', 'fix1', 'arg1v2'),",
 " ('test_one[arg1v2-arg2v1]', 'fix2', 'arg2v1'),",
 " ('test_two[arg1v2-arg2v1]', 'fix2', 'arg2v1'),",
 " ('test_one[arg1v2-arg2v2]', 'fix2', 'arg2v2'),",
 " ('test_two[arg1v2-arg2v2]', 'fix2', 'arg2v2')]",
```


<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->