### PR TITLE
assertion: rewrite: only catch EnvironmentError

### DIFF
--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -276,7 +276,7 @@ if sys.platform == "win32":
             with atomic_write(fspath(pyc), mode="wb", overwrite=True) as fp:
                 _write_pyc_fp(fp, source_stat, co)
         except EnvironmentError as e:
-            state.trace("error writing pyc file at {}: errno={}".format(pyc, e.errno))
+            state.trace("error writing pyc file at {}: {}".format(pyc, e))
             # we ignore any failure to write the cache file
             # there are many reasons, permission-denied, pycache dir being a
             # file etc.
@@ -299,8 +299,8 @@ else:
         try:
             _write_pyc_fp(fp, source_stat, co)
             os.rename(proc_pyc, fspath(pyc))
-        except BaseException as e:
-            state.trace("error writing pyc file at {}: errno={}".format(pyc, e.errno))
+        except EnvironmentError as e:
+            state.trace("error writing pyc file at {}: {}".format(pyc, e))
             # we ignore any failure to write the cache file
             # there are many reasons, permission-denied, pycache dir being a
             # file etc.


### PR DESCRIPTION
This was changed unintentionally in 45c4a8fb3 (pytest 5.3.0), but only
EnvironmentErrors might have `errno`.
Since that is not really guaranteed and it is good to have more
information this uses the string representation of the exc in the trace
message.

TODO:

- [ ] test