### PR TITLE
Remove reference to old konira plugin from docs

### DIFF
--- a/doc/en/plugins.rst
+++ b/doc/en/plugins.rst
@@ -41,8 +41,7 @@ Here is a little annotated list for some popular plugins:
 * `pytest-instafail <https://pypi.org/project/pytest-instafail/>`_:
   to report failures while the test run is happening.
 
-* `pytest-bdd <https://pypi.org/project/pytest-bdd/>`_ and
-  `pytest-konira <https://pypi.org/project/pytest-konira/>`_
+* `pytest-bdd <https://pypi.org/project/pytest-bdd/>`_:
   to write tests using behaviour-driven testing.
 
 * `pytest-timeout <https://pypi.org/project/pytest-timeout/>`_:


### PR DESCRIPTION
The pytest-konira plugin has not seen an update since 2011, moreover
the "project description" on PyPI points to a dubious website that
does not actually correspond to the project and instead redirects to
advertising content.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
