### PR TITLE
main: report ignored paths

### DIFF
--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -445,22 +445,21 @@ class Session(nodes.FSCollector):
             return True
         return None
 
-    def pytest_report_collectionfinish(self) -> Optional[List[str]]:
-        if self._collect_ignored:
-            total = 0
-            desc = []
-            for via, count in self._collect_ignored.items():
-                total += count
-                if len(self._collect_ignored) > 1:
-                    desc.append("{} ({})".format(via, count))
-                else:
-                    desc.append("via {}".format(via))
-            return [
-                "ignored {} {} ({})".format(
-                    total, "path" if total == 1 else "paths", ", ".join(desc)
-                )
-            ]
-        return None
+    def pytest_report_collectionfinish(self) -> Optional[str]:
+        if not self._collect_ignored:
+            return None
+
+        total = 0
+        desc = []
+        for via, count in self._collect_ignored.items():
+            total += count
+            if len(self._collect_ignored) > 1:
+                desc.append("{} ({})".format(via, count))
+            else:
+                desc.append("via {}".format(via))
+        return "ignored {} {} ({})".format(
+            total, "path" if total == 1 else "paths", ", ".join(desc)
+        )
 
     @hookimpl(tryfirst=True)
     def pytest_runtest_logreport(self, report):

--- a/testing/test_session.py
+++ b/testing/test_session.py
@@ -288,7 +288,7 @@ def test_exclude_glob(testdir):
     assert result.ret == 0
     result.stdout.fnmatch_lines(["*1 passed*"])
     result.stdout.fnmatch_lines(
-        ["collected 1 item", "ignored 4 paths (via ignore_glob)", "*1 passed*"]
+        ["collected 1 item", "ignored 4 paths (via --ignore_glob)", "*1 passed*"]
     )
 
 

--- a/testing/test_session.py
+++ b/testing/test_session.py
@@ -269,7 +269,9 @@ def test_exclude(testdir):
     testdir.makepyfile(test_ok="def test_pass(): pass")
     result = testdir.runpytest("--ignore=hello", "--ignore=hello2")
     assert result.ret == 0
-    result.stdout.fnmatch_lines(["*1 passed*"])
+    result.stdout.fnmatch_lines(
+        ["collected 1 item", "ignored 2 paths (via --ignore)", "*1 passed*"]
+    )
 
 
 def test_exclude_glob(testdir):
@@ -285,6 +287,9 @@ def test_exclude_glob(testdir):
     result = testdir.runpytest("--ignore-glob=*h[ea]llo*")
     assert result.ret == 0
     result.stdout.fnmatch_lines(["*1 passed*"])
+    result.stdout.fnmatch_lines(
+        ["collected 1 item", "ignored 4 paths (via ignore_glob)", "*1 passed*"]
+    )
 
 
 def test_deselect(testdir):


### PR DESCRIPTION
This is useful to know if you're using `collect_ignore_glob`
accidentally still.

This could additionally introduce and use a `pytest_ignored_path` hook, similar
to `pytest_deselected` that could also be called automatically then.
But it would still make sense to call it manually for additional info (`via`).

TODO:

- [ ] changelog


<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->