### PR TITLE
cacheprovider: --lf/--ff: use hookwrapper, respect --collect-only

### DIFF
--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -234,8 +234,8 @@ class LFPlugin:
         self.lastfailed = config.cache.get(
             "cache/lastfailed", {}
         )  # type: Dict[str, bool]
-        self._previously_failed_count = None
-        self._report_status = None
+        self._previously_failed_count = None  # type: Optional[int]
+        self._report_status = None  # type: Optional[str]
         self._skipped_files = 0  # count skipped files during collection due to --lf
 
         if config.getoption("lf"):
@@ -269,7 +269,12 @@ class LFPlugin:
         else:
             self.lastfailed[report.nodeid] = True
 
-    def pytest_collection_modifyitems(self, session, config, items):
+    @pytest.hookimpl(hookwrapper=True, tryfirst=True)
+    def pytest_collection_modifyitems(
+        self, config: Config, items: List[nodes.Item]
+    ) -> Generator[None, None, None]:
+        yield
+
         if not self.active:
             return
 
@@ -334,9 +339,12 @@ class NFPlugin:
         self.active = config.option.newfirst
         self.cached_nodeids = config.cache.get("cache/nodeids", [])
 
+    @pytest.hookimpl(hookwrapper=True, tryfirst=True)
     def pytest_collection_modifyitems(
-        self, session: Session, config: Config, items: List[nodes.Item]
-    ) -> None:
+        self, items: List[nodes.Item]
+    ) -> Generator[None, None, None]:
+        yield
+
         new_items = OrderedDict()  # type: OrderedDict[str, nodes.Item]
         if self.active:
             other_items = OrderedDict()  # type: OrderedDict[str, nodes.Item]
@@ -358,11 +366,12 @@ class NFPlugin:
     def _get_increasing_order(self, items):
         return sorted(items, key=lambda item: item.fspath.mtime(), reverse=True)
 
-    def pytest_sessionfinish(self, session):
+    def pytest_sessionfinish(self) -> None:
         config = self.config
         if config.getoption("cacheshow") or hasattr(config, "slaveinput"):
             return
-
+        if config.getoption("collectonly"):
+            return
         config.cache.set("cache/nodeids", self.cached_nodeids)
 
 

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -859,63 +859,35 @@ class TestNewFirst:
             **{
                 "test_1/test_1.py": """
                 def test_1(): assert 1
-                def test_2(): assert 1
-                def test_3(): assert 1
             """,
                 "test_2/test_2.py": """
                 def test_1(): assert 1
-                def test_2(): assert 1
-                def test_3(): assert 1
             """,
             }
         )
-
         testdir.tmpdir.join("test_1/test_1.py").setmtime(1)
 
         result = testdir.runpytest("-v")
         result.stdout.fnmatch_lines(
-            [
-                "*test_1/test_1.py::test_1 PASSED*",
-                "*test_1/test_1.py::test_2 PASSED*",
-                "*test_1/test_1.py::test_3 PASSED*",
-                "*test_2/test_2.py::test_1 PASSED*",
-                "*test_2/test_2.py::test_2 PASSED*",
-                "*test_2/test_2.py::test_3 PASSED*",
-            ]
+            ["*test_1/test_1.py::test_1 PASSED*", "*test_2/test_2.py::test_1 PASSED*"]
         )
 
         result = testdir.runpytest("-v", "--nf")
-
         result.stdout.fnmatch_lines(
-            [
-                "*test_2/test_2.py::test_1 PASSED*",
-                "*test_2/test_2.py::test_2 PASSED*",
-                "*test_2/test_2.py::test_3 PASSED*",
-                "*test_1/test_1.py::test_1 PASSED*",
-                "*test_1/test_1.py::test_2 PASSED*",
-                "*test_1/test_1.py::test_3 PASSED*",
-            ]
+            ["*test_2/test_2.py::test_1 PASSED*", "*test_1/test_1.py::test_1 PASSED*"]
         )
 
         testdir.tmpdir.join("test_1/test_1.py").write(
-            "def test_1(): assert 1\n"
-            "def test_2(): assert 1\n"
-            "def test_3(): assert 1\n"
-            "def test_4(): assert 1\n"
+            "def test_1(): assert 1\n" "def test_2(): assert 1\n"
         )
         testdir.tmpdir.join("test_1/test_1.py").setmtime(1)
 
         result = testdir.runpytest("-v", "--nf")
-
         result.stdout.fnmatch_lines(
             [
-                "*test_1/test_1.py::test_4 PASSED*",
-                "*test_2/test_2.py::test_1 PASSED*",
-                "*test_2/test_2.py::test_2 PASSED*",
-                "*test_2/test_2.py::test_3 PASSED*",
-                "*test_1/test_1.py::test_1 PASSED*",
                 "*test_1/test_1.py::test_2 PASSED*",
-                "*test_1/test_1.py::test_3 PASSED*",
+                "*test_2/test_2.py::test_1 PASSED*",
+                "*test_1/test_1.py::test_1 PASSED*",
             ]
         )
 


### PR DESCRIPTION
Ref: https://github.com/pytest-dev/pytest-django/issues/819

Includes: 3abc13d27 (tests: simplify test_newfirst_usecase)

Also fixes `--lf` with regard to `-k`, where with `--lf -k "not foo"` with "foo" as known failure would not run anything.

TODO:

- [ ] fix tests for different repr
- [ ] changelog
- [ ] stepwise?

Ref: https://github.com/pytest-dev/pytest/commit/f75f7c192586fd856dad10673cd6d1f8cce03f75 (https://github.com/pytest-dev/pytest/pull/5145)