### PR TITLE
Make dataclasses/attrs comparison recursive, fixes #4675

### DIFF
--- a/changelog/4675.bugfix.rst
+++ b/changelog/4675.bugfix.rst
@@ -1,1 +1,0 @@
-Make dataclasses/attrs comparison recursive.

--- a/changelog/4675.bugfix.rst
+++ b/changelog/4675.bugfix.rst
@@ -1,0 +1,1 @@
+Make dataclasses/attrs comparison recursive.

--- a/changelog/4675.improvement.rst
+++ b/changelog/4675.improvement.rst
@@ -1,1 +1,1 @@
-Rich comparision for dataclasses and `attrs`-classes is now recursive.
+Rich comparison for dataclasses and `attrs`-classes is now recursive.

--- a/changelog/4675.improvement.rst
+++ b/changelog/4675.improvement.rst
@@ -1,0 +1,1 @@
+Rich comparision for dataclasses and `attrs`-classes is now recursive.

--- a/testing/example_scripts/dataclasses/test_compare_recursive_dataclasses.py
+++ b/testing/example_scripts/dataclasses/test_compare_recursive_dataclasses.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+
+@dataclass
+class SimpleDataObject:
+    field_a: int = field()
+    field_b: int = field()
+
+
+@dataclass
+class ComplexDataObject2:
+    field_a: SimpleDataObject = field()
+    field_b: SimpleDataObject = field()
+
+
+@dataclass
+class ComplexDataObject:
+    field_a: SimpleDataObject = field()
+    field_b: ComplexDataObject2 = field()
+
+
+def test_recursive_dataclasses():
+
+    left = ComplexDataObject(
+        SimpleDataObject(1, "b"),
+        ComplexDataObject2(SimpleDataObject(1, "b"), SimpleDataObject(2, "c"),),
+    )
+    right = ComplexDataObject(
+        SimpleDataObject(1, "b"),
+        ComplexDataObject2(SimpleDataObject(1, "b"), SimpleDataObject(3, "c"),),
+    )
+
+    assert left == right

--- a/testing/example_scripts/dataclasses/test_compare_recursive_dataclasses.py
+++ b/testing/example_scripts/dataclasses/test_compare_recursive_dataclasses.py
@@ -5,7 +5,7 @@ from dataclasses import field
 @dataclass
 class SimpleDataObject:
     field_a: int = field()
-    field_b: int = field()
+    field_b: str = field()
 
 
 @dataclass

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -888,6 +888,7 @@ class TestAssert_reprcompare_attrsclass:
         right = SimpleDataObject(OtherDataObject(1, "b"), "b")
 
         lines = callequal(left, right)
+        assert lines is not None
         assert "Matching attributes" not in lines
         for line in lines[1:]:
             assert "field_b:" not in line
@@ -908,8 +909,8 @@ class TestAssert_reprcompare_attrsclass:
         right = SimpleDataObject(OtherDataObject(1, "b"), "b")
 
         lines = callequal(left, right)
+        assert lines is not None
         assert "field_d: 'a' != 'b'" in lines
-        print("\n".join(lines))
 
     def test_attrs_verbose(self) -> None:
         @attr.s

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -817,8 +817,7 @@ class TestAssert_reprcompare_dataclass:
                 "*Matching attributes:*",
                 "*['field_a']*",
                 "*Differing attributes:*",
-                "*field_b: SimpleDataObject(field_a=2, field_b='c') "
-                "!= SimpleDataObject(field_a=3, field_b='c')*",
+                "*field_b: SimpleDataObject(field_a=2, field_b='c') != SimpleDataObject(field_a=3, field_b='c')*",  # noqa
                 "*Matching attributes:*",
                 "*['field_b']*",
                 "*Differing attributes:*",

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -781,6 +781,48 @@ class TestAssert_reprcompare_dataclass:
                 "*Omitting 1 identical items, use -vv to show*",
                 "*Differing attributes:*",
                 "*field_b: 'b' != 'c'*",
+                "*- c*",
+                "*+ b*",
+            ]
+        )
+
+    @pytest.mark.skipif(sys.version_info < (3, 7), reason="Dataclasses in Python3.7+")
+    def test_recursive_dataclasses(self, testdir):
+        p = testdir.copy_example("dataclasses/test_compare_recursive_dataclasses.py")
+        result = testdir.runpytest(p)
+        result.assert_outcomes(failed=1, passed=0)
+        result.stdout.fnmatch_lines(
+            [
+                "*Omitting 1 identical items, use -vv to show*",
+                "*Differing attributes:*",
+                "*field_b: ComplexDataObject2(*SimpleDataObject(field_a=2, field_b='c')) != ComplexDataObject2(*SimpleDataObject(field_a=3, field_b='c'))*",  # noqa
+                "*Drill down into differing attribute field_b:*",
+                "*Omitting 1 identical items, use -vv to show*",
+                "*Differing attributes:*",
+                "*Full output truncated*",
+            ]
+        )
+
+    @pytest.mark.skipif(sys.version_info < (3, 7), reason="Dataclasses in Python3.7+")
+    def test_recursive_dataclasses_verbose(self, testdir):
+        p = testdir.copy_example("dataclasses/test_compare_recursive_dataclasses.py")
+        result = testdir.runpytest(p, "-vv")
+        result.assert_outcomes(failed=1, passed=0)
+        result.stdout.fnmatch_lines(
+            [
+                "*Matching attributes:*",
+                "*['field_a']*",
+                "*Differing attributes:*",
+                "*field_b: ComplexDataObject2(*SimpleDataObject(field_a=2, field_b='c')) != ComplexDataObject2(*SimpleDataObject(field_a=3, field_b='c'))*",  # noqa
+                "*Matching attributes:*",
+                "*['field_a']*",
+                "*Differing attributes:*",
+                "*field_b: SimpleDataObject(field_a=2, field_b='c') "
+                "!= SimpleDataObject(field_a=3, field_b='c')*",
+                "*Matching attributes:*",
+                "*['field_b']*",
+                "*Differing attributes:*",
+                "*field_a: 2 != 3",
             ]
         )
 
@@ -831,6 +873,44 @@ class TestAssert_reprcompare_attrsclass:
         assert "Matching attributes" not in lines
         for line in lines[1:]:
             assert "field_a" not in line
+
+    def test_attrs_recursive(self) -> None:
+        @attr.s
+        class OtherDataObject:
+            field_c = attr.ib()
+            field_d = attr.ib()
+
+        @attr.s
+        class SimpleDataObject:
+            field_a = attr.ib()
+            field_b = attr.ib()
+
+        left = SimpleDataObject(OtherDataObject(1, "a"), "b")
+        right = SimpleDataObject(OtherDataObject(1, "b"), "b")
+
+        lines = callequal(left, right)
+        assert "Matching attributes" not in lines
+        for line in lines[1:]:
+            assert "field_b:" not in line
+            assert "field_c:" not in line
+
+    def test_attrs_recursive_verbose(self) -> None:
+        @attr.s
+        class OtherDataObject:
+            field_c = attr.ib()
+            field_d = attr.ib()
+
+        @attr.s
+        class SimpleDataObject:
+            field_a = attr.ib()
+            field_b = attr.ib()
+
+        left = SimpleDataObject(OtherDataObject(1, "a"), "b")
+        right = SimpleDataObject(OtherDataObject(1, "b"), "b")
+
+        lines = callequal(left, right)
+        assert "field_d: 'a' != 'b'" in lines
+        print("\n".join(lines))
 
     def test_attrs_verbose(self) -> None:
         @attr.s


### PR DESCRIPTION
I extracted the equality check in its own function and I call it from the dataclass comparison function to get recursive comparisons.

It could also be used for dict comparison, but the issue mentioned there was already some mechanism for dicts (I didn't see it in the code though).

Fixes #4675.