### PR TITLE
Test behavior of Source with regard to decorators

### DIFF
--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -630,7 +630,7 @@ def test_source_with_decorator() -> None:
 
     @pytest.mark.foo
     def deco_mark():
-        pass
+        assert False
 
     src = inspect.getsource(deco_mark)
     assert str(Source(deco_mark, deindent=False)) == src
@@ -638,10 +638,10 @@ def test_source_with_decorator() -> None:
 
     @pytest.fixture
     def deco_fixture():
-        pass
+        assert False
 
     src = inspect.getsource(deco_fixture)
-    assert src == "    @pytest.fixture\n    def deco_fixture():\n        pass\n"
+    assert src == "    @pytest.fixture\n    def deco_fixture():\n        assert False\n"
     assert str(Source(deco_fixture)).startswith("@functools.wraps(function)")
     assert str(Source(get_real_func(deco_fixture), deindent=False)) == src
 

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -642,6 +642,9 @@ def test_source_with_decorator() -> None:
 
     src = inspect.getsource(deco_fixture)
     assert src == "    @pytest.fixture\n    def deco_fixture():\n        assert False\n"
+    # currenly Source does not unwrap decorators, testing the
+    # existing behavior here for explicitness, but perhaps we should revisit/change this
+    # in the future
     assert str(Source(deco_fixture)).startswith("@functools.wraps(function)")
     assert str(Source(get_real_func(deco_fixture), deindent=False)) == src
 

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -624,6 +624,28 @@ def test_comment_in_statement() -> None:
         )
 
 
+def test_source_with_decorator() -> None:
+    """Test behavior with Source / Code().source with regard to decorators."""
+    from _pytest.compat import get_real_func
+
+    @pytest.mark.foo
+    def deco_mark():
+        pass
+
+    src = inspect.getsource(deco_mark)
+    assert str(Source(deco_mark, deindent=False)) == src
+    assert src.startswith("    @pytest.mark.foo")
+
+    @pytest.fixture
+    def deco_fixture():
+        pass
+
+    src = inspect.getsource(deco_fixture)
+    assert src == "    @pytest.fixture\n    def deco_fixture():\n        pass\n"
+    assert str(Source(deco_fixture)).startswith("@functools.wraps(function)")
+    assert str(Source(get_real_func(deco_fixture), deindent=False)) == src
+
+
 def test_single_line_else() -> None:
     source = getstatement(1, "if False: 2\nelse: 3")
     assert str(source) == "else: 3"


### PR DESCRIPTION
Unlike `inspect.getsource` it does not unwrap functions.