### PR TITLE
Add Read The Docs badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,10 @@
 .. image:: https://www.codetriage.com/pytest-dev/pytest/badges/users.svg
     :target: https://www.codetriage.com/pytest-dev/pytest
 
+.. image:: https://readthedocs.org/projects/pytest/badge/?version=latest
+    :target: https://pytest.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation Status
+
 The ``pytest`` framework makes it easy to write small tests, yet
 scales to support complex functional testing for applications and libraries.
 


### PR DESCRIPTION
Currently reported as failing, but that appears to be a temporary problem on their end (i.e. a rebuild should fix it).

https://readthedocs.org/projects/pytest/builds/10523470/