### PR TITLE
docs: use doc/en/_build/html for html output

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -86,7 +86,7 @@ without using a local copy.  This can be convenient for small fixes.
 
         $ tox -e docs
 
-    The built documentation should be available in the ``doc/en/_build/``.
+    The built documentation should be available in ``doc/en/_build/html``.
 
     Where 'en' refers to the documentation language.
 

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -34,4 +34,4 @@ If you are not sure what issue type to use, don't hesitate to ask in your PR.
 other than ``features`` it is usually better to stick to a single paragraph to keep it concise.
 
 You can also run ``tox -e docs`` to build the documentation
-with the draft changelog (``doc/en/_build/changelog.html``) if you want to get a preview of how your change will look in the final release notes.
+with the draft changelog (``doc/en/_build/html/changelog.html``) if you want to get a preview of how your change will look in the final release notes.

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ commands =
     # the '-t changelog_towncrier_draft' tags makes sphinx include the draft
     # changelog in the docs; this does not happen on ReadTheDocs because it uses
     # the standard sphinx command so the 'changelog_towncrier_draft' is never set there
-    sphinx-build -W --keep-going -b html doc/en doc/en/_build -t changelog_towncrier_draft {posargs:}
+    sphinx-build -W --keep-going -b html doc/en doc/en/_build/html -t changelog_towncrier_draft {posargs:}
 
 [testenv:docs-checklinks]
 basepython = python3


### PR DESCRIPTION
This will use the same directory as `make -C doc/en` then, and reflects
the default location that Sphinx uses.