### PR TITLE
When writing rewritten module's pyc, only ignore OSError

### DIFF
--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -299,7 +299,7 @@ else:
         try:
             _write_pyc_fp(fp, source_stat, co)
             os.rename(proc_pyc, fspath(pyc))
-        except BaseException as e:
+        except OSError as e:
             state.trace("error writing pyc file at {}: errno={}".format(pyc, e.errno))
             # we ignore any failure to write the cache file
             # there are many reasons, permission-denied, pycache dir being a


### PR DESCRIPTION
The trace error in particular assumes `e.errno` works. This means it
would have crashed for anything except `OSError` previously. So limit to
only these exceptions instead of blanket `BaseException`.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
