### PR TITLE
Add .gitblameignore

### DIFF
--- a/.gitblameignore
+++ b/.gitblameignore
@@ -1,0 +1,28 @@
+# List of revisions that can be ignored with git-blame(1).
+#
+# See `blame.ignoreRevsFile` in git-config(1) to enable it by default, or
+# use it with `--ignore-revs-file` manually with git-blame.
+#
+# To "install" it:
+#
+#   git config --local blame.ignoreRevsFile .gitblameignore
+
+# run black
+703e4b11ba76171eccd3f13e723c47b810ded7ef
+# switched to src layout
+eaa882f3d5340956beb176aa1753e07e3f3f2190
+# pre-commit run pyupgrade --all-files
+a91fe1feddbded535a4322ab854429e3a3961fb4
+# move node base classes from main to nodes
+afc607cfd81458d4e4f3b1f3cf8cc931b933907e
+# [?] split most fixture related code into own plugin
+8c49561470708761f7321504f5e8343811be87ac
+# run pyupgrade
+9aacb4635e81edd6ecf281d4f6c0cfc8e94ab301
+# run blacken-docs
+5f95dce95602921a70bfbc7d8de2f7712c5e4505
+# ran pyupgrade-docs again
+75d0b899bbb56d6849e9d69d83a9426ed3f43f8b
+
+# move argument parser to own file
+c9df77cbd6a365dcb73c39618e4842711817e871


### PR DESCRIPTION
Updates to/for it should be collected / accumulated here then maybe for the future to be committed in batches.

List of revisions that can be ignored with git-blame(1).

See `blame.ignoreRevsFile` in git-config(1) to enable it by default, or
use it with `--ignore-revs-file` manually with git-blame.

To "install" it:

  git config --local blame.ignoreRevsFile .gitblameignore

# run black
703e4b11ba76171eccd3f13e723c47b810ded7ef
# switched to src layout
eaa882f3d5340956beb176aa1753e07e3f3f2190
# pre-commit run pyupgrade --all-files
a91fe1feddbded535a4322ab854429e3a3961fb4
# move node base classes from main to nodes
afc607cfd81458d4e4f3b1f3cf8cc931b933907e
# [?] split most fixture related code into own plugin
8c49561470708761f7321504f5e8343811be87ac
# run pyupgrade
9aacb4635e81edd6ecf281d4f6c0cfc8e94ab301
# run blacken-docs
5f95dce95602921a70bfbc7d8de2f7712c5e4505
# ran pyupgrade-docs again
75d0b899bbb56d6849e9d69d83a9426ed3f43f8b

# move argument parser to own file
c9df77cbd6a365dcb73c39618e4842711817e871