### PR TITLE
Check invalid operations for -k

### DIFF
--- a/src/_pytest/mark/legacy.py
+++ b/src/_pytest/mark/legacy.py
@@ -106,5 +106,5 @@ def matchkeyword(colitem, keywordexpr):
             )
     try:
         return eval(keywordexpr, {}, mapping)
-    except SyntaxError:
+    except Exception:
         raise UsageError("Wrong expression passed to '-k': {}".format(keywordexpr))


### PR DESCRIPTION
#6822  `KeywordMapping` returns a bool on lookup which when passed to eval
fail on certain operations such as index access and attribute access.
Check has been added to raise a UsageError if such operations are passed
to -k

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
