### PR TITLE
Add pytest-twisted to list of async def handling plugins

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -166,7 +166,8 @@ def async_warn(nodeid: str) -> None:
     )
     msg += "  - pytest-asyncio\n"
     msg += "  - pytest-trio\n"
-    msg += "  - pytest-tornasync"
+    msg += "  - pytest-tornasync\n"
+    msg += "  - pytest-twisted"
     warnings.warn(PytestUnhandledCoroutineWarning(msg.format(nodeid)))
     skip(msg="async def function and no async plugin installed (see warnings)")
 


### PR DESCRIPTION
https://github.com/pytest-dev/pytest-twisted/tree/v1.12#ensuredeferred

[pytest-twisted](https://github.com/pytest-dev/pytest-twisted) supports `async def` test functions and fixtures as well as `async def`/`yield` fixtures.
