### PR TITLE
Convert a couple of places to use config store

### DIFF
--- a/src/_pytest/mark/evaluate.py
+++ b/src/_pytest/mark/evaluate.py
@@ -2,21 +2,28 @@ import os
 import platform
 import sys
 import traceback
+from typing import Any
+from typing import Dict
 
 from ..outcomes import fail
 from ..outcomes import TEST_OUTCOME
+from _pytest.config import Config
+from _pytest.store import StoreKey
 
 
-def cached_eval(config, expr, d):
-    if not hasattr(config, "_evalcache"):
-        config._evalcache = {}
+evalcache_key = StoreKey[Dict[str, Any]]()
+
+
+def cached_eval(config: Config, expr: str, d: Dict[str, object]) -> Any:
+    default = {}  # type: Dict[str, object]
+    evalcache = config._store.setdefault(evalcache_key, default)
     try:
-        return config._evalcache[expr]
+        return evalcache[expr]
     except KeyError:
         import _pytest._code
 
         exprcode = _pytest._code.compile(expr, mode="eval")
-        config._evalcache[expr] = x = eval(exprcode, d)
+        evalcache[expr] = x = eval(exprcode, d)
         return x
 
 

--- a/src/_pytest/store.py
+++ b/src/_pytest/store.py
@@ -104,6 +104,15 @@ class Store:
         except KeyError:
             return default
 
+    def setdefault(self, key: StoreKey[T], default: T) -> T:
+        """Return the value of key if already set, otherwise set the value
+        of key to default and return default."""
+        try:
+            return self[key]
+        except KeyError:
+            self[key] = default
+            return default
+
     def __delitem__(self, key: StoreKey[T]) -> None:
         """Delete the value for key.
 

--- a/testing/test_store.py
+++ b/testing/test_store.py
@@ -37,6 +37,14 @@ def test_store() -> None:
     with pytest.raises(KeyError):
         store[key1]
 
+    # setdefault
+    store[key1] = "existing"
+    assert store.setdefault(key1, "default") == "existing"
+    assert store[key1] == "existing"
+    key_setdefault = StoreKey[bytes]()
+    assert store.setdefault(key_setdefault, b"default") == b"default"
+    assert store[key_setdefault] == b"default"
+
     # Can't accidentally add attributes to store object itself.
     with pytest.raises(AttributeError):
         store.foo = "nope"  # type: ignore[attr-defined] # noqa: F821


### PR DESCRIPTION
Continuation of #6836.

One is the `AssertionState` used by the assertion rewriter, second is the mark expression evaluation cache.

There is also a commit to add `setdefault` to `Store` which I then use.