### PR TITLE
Inline PyobjContext

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -249,13 +249,10 @@ def pytest_pycollect_makeitem(collector, name, obj):
             outcome.force_result(res)
 
 
-class PyobjContext:
+class PyobjMixin:
     module = pyobj_property("Module")
     cls = pyobj_property("Class")
     instance = pyobj_property("Instance")
-
-
-class PyobjMixin(PyobjContext):
     _ALLOW_MARKERS = True
 
     @property


### PR DESCRIPTION
When it was introduced in 8adac2878f183e2250d1ed53457b60f19e7316f9 it seems to have had some use, but now it doesn't.