### PR TITLE
BACKPORT: Introduction of Config.invocation_args.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -92,6 +92,7 @@ Evan Kepner
 Fabien Zarifian
 Fabio Zadrozny
 Feng Ma
+Fernando Mezzabotta Rey
 Florian Bruhin
 Floris Bruynooghe
 Gabriel Reis

--- a/changelog/6869.feature.rst
+++ b/changelog/6869.feature.rst
@@ -1,0 +1,1 @@
+New ``Config.invocation_args`` attribute containing the unchanged arguments passed to ``pytest.main()``.

--- a/doc/en/py27-py34-deprecation.rst
+++ b/doc/en/py27-py34-deprecation.rst
@@ -17,9 +17,9 @@ are available on PyPI.
 
 While pytest ``5.0`` will be the new mainstream and development version, until **January 2020**
 the pytest core team plans to make bug-fix releases of the pytest ``4.6`` series by
-back-porting patches to the ``4.6-maintenance`` branch that affect Python 2 users.
+back-porting patches to the ``4.6.x`` branch that affect Python 2 users.
 
-**After 2020**, the core team will no longer actively backport patches, but the ``4.6-maintenance``
+**After 2020**, the core team will no longer actively backport patches, but the ``4.6.x``
 branch will continue to exist so the community itself can contribute patches. The core team will
 be happy to accept those patches and make new ``4.6`` releases **until mid-2020**.
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -19,6 +19,7 @@ from _pytest.main import EXIT_NOTESTSCOLLECTED
 from _pytest.main import EXIT_OK
 from _pytest.main import EXIT_TESTSFAILED
 from _pytest.main import EXIT_USAGEERROR
+from _pytest.pathlib import Path
 
 
 class TestParseIni(object):
@@ -1220,6 +1221,29 @@ def test_config_does_not_load_blocked_plugin_from_args(testdir):
     result = testdir.runpytest(str(p), "-pno:capture", "-s")
     result.stderr.fnmatch_lines(["*: error: unrecognized arguments: -s"])
     assert result.ret == EXIT_USAGEERROR
+
+
+def test_invocation_args(testdir):
+    """Ensure that Config.invocation_* arguments are correctly defined"""
+
+    class DummyPlugin:
+        pass
+
+    p = testdir.makepyfile("def test(): pass")
+    plugin = DummyPlugin()
+    rec = testdir.inline_run(p, "-v", plugins=[plugin])
+    calls = rec.getcalls("pytest_runtest_protocol")
+    assert len(calls) == 1
+    call = calls[0]
+    config = call.item.config
+
+    assert config.invocation_params.args == [p, "-v"]
+    assert config.invocation_params.dir == Path(str(testdir.tmpdir))
+
+    plugins = config.invocation_params.plugins
+    assert len(plugins) == 2
+    assert plugins[0] is plugin
+    assert type(plugins[1]).__name__ == "Collect"  # installed by testdir.inline_run()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->

This change was first introduced in https://github.com/pytest-dev/pytest/pull/5564 but, logically, only in the `5.x.x` version. I'm back-porting it into the `4.6.x` branch since many people still use it in the meantime they migrate to Python 3.