### PR TITLE
pre-commit: black: --target-version py35

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,6 @@ template = "changelog/_template.rst"
   directory = "trivial"
   name = "Trivial/Internal Changes"
   showcontent = true
+
+[tool.black]
+target-version = ['py35']

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1141,7 +1141,7 @@ def fixture(
         params=params,
         autouse=autouse,
         ids=ids,
-        name=name
+        name=name,
     )
     scope = arguments.get("scope")
     params = arguments.get("params")
@@ -1179,7 +1179,7 @@ def yield_fixture(
         params=params,
         autouse=autouse,
         ids=ids,
-        name=name
+        name=name,
     )
 
 

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -439,7 +439,7 @@ class TestCaptureFixture:
                 out, err = capsys.readouterr()
                 assert out.startswith("42")
             """,
-            *opt
+            *opt,
         )
         reprec.assertoutcome(passed=1)
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -702,7 +702,7 @@ def test_plugin_loading_order(testdir):
                 config = session.config
                 terminal_plugin.append(bool(config.pluginmanager.get_plugin("terminalreporter")))
             """
-        }
+        },
     )
     testdir.syspathinsert()
     result = testdir.runpytest("-p", "myplugin", str(p1))
@@ -781,7 +781,7 @@ def test_config_in_subdirectory_colon_command_line_issue2148(testdir):
 
     testdir.makefile(
         ".ini",
-        **{"pytest": "[pytest]\nfoo = root", "subdir/pytest": "[pytest]\nfoo = subdir"}
+        **{"pytest": "[pytest]\nfoo = root", "subdir/pytest": "[pytest]\nfoo = subdir"},
     )
 
     testdir.makepyfile(


### PR DESCRIPTION
 This is meant to avoid having trailing commas after `**kwargs`, which
 only works in Python 3.5.2+.

Ref: https://github.com/pytest-dev/pytest/commit/2e756d698, https://github.com/pytest-dev/pytest/pull/5611

Might make more sense to add config for it: https://github.com/blueyed/pytest/pull/275