### PR TITLE
Re-harden test_typeerror_encodedfile_write

### DIFF
--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1548,7 +1548,7 @@ def test_typeerror_encodedfile_write(testdir):
     result_with_capture.stdout.fnmatch_lines(
         [
             '>       sys.stdout.write(b"foo")',
-            ">           raise TypeError*",
+            "    def write*",
             "E           TypeError: write() argument must be str, not bytes",
             "FAILED test_typeerror_encodedfile_write.py::test_fails - *",
         ]

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1533,7 +1533,10 @@ def test_capture_with_live_logging(testdir, capture_fixture):
 
 
 def test_typeerror_encodedfile_write(testdir):
-    """It should behave the same with and without output capturing (#4861)."""
+    """It should behave the same with and without output capturing (#4861).
+
+    The reported location differs however.
+    """
     p = testdir.makepyfile(
         """
         def test_fails():
@@ -1541,12 +1544,24 @@ def test_typeerror_encodedfile_write(testdir):
             sys.stdout.write(b"foo")
     """
     )
-    result_without_capture = testdir.runpytest("-s", str(p))
     result_with_capture = testdir.runpytest(str(p))
-
-    assert result_with_capture.ret == result_without_capture.ret
     result_with_capture.stdout.fnmatch_lines(
-        ["E * TypeError: write() argument must be str, not bytes"]
+        [
+            '>       sys.stdout.write(b"foo")',
+            ">           raise TypeError*",
+            "E           TypeError: write() argument must be str, not bytes",
+            "FAILED test_typeerror_encodedfile_write.py:3::test_fails"
+            " - TypeError: write() argument must be str, not bytes",
+        ]
+    )
+    result_without_capture = testdir.runpytest("-s", str(p))
+    result_without_capture.stdout.fnmatch_lines(
+        [
+            '>       sys.stdout.write(b"foo")',
+            "E       TypeError: write() argument must be str, not bytes",
+            "FAILED test_typeerror_encodedfile_write.py:3::test_fails"
+            " - TypeError: write() argument must be str, not bytes",
+        ]
     )
 
 

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1554,10 +1554,14 @@ def test_typeerror_encodedfile_write(testdir):
         ]
     )
     result_without_capture = testdir.runpytest("-s", str(p))
+    if getattr(sys, "pypy_version_info", None):
+        exp_exc = "TypeError: unicode argument expected, got 'bytes'"
+    else:
+        exp_exc = "TypeError: write() argument must be str, not bytes"
     result_without_capture.stdout.fnmatch_lines(
         [
             '>       sys.stdout.write(b"foo")',
-            "E       TypeError: write() argument must be str, not bytes",
+            "E       " + exp_exc,
             "FAILED test_typeerror_encodedfile_write.py::test_fails - *",
         ]
     )

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1550,8 +1550,7 @@ def test_typeerror_encodedfile_write(testdir):
             '>       sys.stdout.write(b"foo")',
             ">           raise TypeError*",
             "E           TypeError: write() argument must be str, not bytes",
-            "FAILED test_typeerror_encodedfile_write.py:3::test_fails"
-            " - TypeError: write() argument must be str, not bytes",
+            "FAILED test_typeerror_encodedfile_write.py::test_fails - *",
         ]
     )
     result_without_capture = testdir.runpytest("-s", str(p))
@@ -1559,8 +1558,7 @@ def test_typeerror_encodedfile_write(testdir):
         [
             '>       sys.stdout.write(b"foo")',
             "E       TypeError: write() argument must be str, not bytes",
-            "FAILED test_typeerror_encodedfile_write.py:3::test_fails"
-            " - TypeError: write() argument must be str, not bytes",
+            "FAILED test_typeerror_encodedfile_write.py::test_fails - *",
         ]
     )
 


### PR DESCRIPTION
Changed in 60ceec6eb.  This ensures the crash gets reported for the
`sys.stdout.write`.

Ref: https://github.com/pytest-dev/pytest/issues/6871 reminded me of this.