### PR TITLE
Fix bot trigger event

### DIFF
--- a/.github/workflows/release-on-comment.yml
+++ b/.github/workflows/release-on-comment.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    if: (github.event.comment && contains(github.event.comment.body, '@pytestbot please')) || (github.event.issue && contains(github.event.issue.body, '@pytestbot please'))
+    if: (github.event.comment && startsWith(github.event.comment.body, '@pytestbot please')) || (github.event.issue && !github.event.comment && startsWith(github.event.issue.body, '@pytestbot please'))
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Issue events don't contain a 'comment' entry:
https://developer.github.com/v3/issues/events/#response-2

Issue comments also contain the original issue body:
https://developer.github.com/v3/activity/events/types/#issuecommentevent

That's why it was triggering even for comments on the issue.

Also changed to startsWith because there's no need to support
the command anywhere in the body IMO.

Fix #6895
