### PR TITLE
Assume os.dup is always available

### DIFF
--- a/changelog/6903.breaking.rst
+++ b/changelog/6903.breaking.rst
@@ -1,0 +1,2 @@
+The ``os.dup()`` function is now assumed to exist. We are not aware of any
+supported Python 3 implementations which do not provide it.

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -34,7 +34,7 @@ def pytest_addoption(parser):
     group._addoption(
         "--capture",
         action="store",
-        default="fd" if hasattr(os, "dup") else "sys",
+        default="fd",
         metavar="method",
         choices=["fd", "sys", "no", "tee-sys"],
         help="per-test capturing method: one of fd|sys|no|tee-sys.",
@@ -304,10 +304,6 @@ def capfd(request):
     calls, which return a ``(out, err)`` namedtuple.
     ``out`` and ``err`` will be ``text`` objects.
     """
-    if not hasattr(os, "dup"):
-        pytest.skip(
-            "capfd fixture needs os.dup function which is not available in this system"
-        )
     capman = request.config.pluginmanager.getplugin("capturemanager")
     with capman._capturing_for_request(request) as fixture:
         yield fixture
@@ -321,10 +317,6 @@ def capfdbinary(request):
     calls, which return a ``(out, err)`` namedtuple.
     ``out`` and ``err`` will be ``byte`` objects.
     """
-    if not hasattr(os, "dup"):
-        pytest.skip(
-            "capfdbinary fixture needs os.dup function which is not available in this system"
-        )
     capman = request.config.pluginmanager.getplugin("capturemanager")
     with capman._capturing_for_request(request) as fixture:
         yield fixture


### PR DESCRIPTION
The commit which added the checks for os.dup a15afb5e4879d68033a723129e6 suggests it was done for Jython. But pytest doesn't support Jython anymore (Jython is Python 2 only).

Furthermore, it looks like the faulthandler plugin (bundled in pytest and enabled by default) uses os.dup() unprotected and there have not been any complaints.

So seems better to just remove these checks, and only add if someone with a legitimate use case complains.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
