### PR TITLE
Handle unknown stats in pytest_report_teststatus hook

### DIFF
--- a/changelog/6910.bugfix.rst
+++ b/changelog/6910.bugfix.rst
@@ -1,0 +1,1 @@
+Fix crash when plugins return an unknown stats while using the ``--reportlog`` option.

--- a/src/_pytest/resultlog.py
+++ b/src/_pytest/resultlog.py
@@ -77,10 +77,10 @@ class ResultLog:
             longrepr = ""
         elif report.passed:
             longrepr = ""
-        elif report.failed:
-            longrepr = str(report.longrepr)
         elif report.skipped:
             longrepr = str(report.longrepr[2])
+        else:
+            longrepr = str(report.longrepr)
         self.log_outcome(report, code, longrepr)
 
     def pytest_collectreport(self, report):


### PR DESCRIPTION
Noticed that the pytest_report_teststatus of reportlog was not properly
handling unknown statuses while taking a look at:

https://github.com/pytest-dev/pytest-rerunfailures/issues/103
