### PR TITLE
[Backport #6910] Handle unknown stats in pytest_report_teststatus hook

### DIFF
--- a/changelog/6910.bugfix.rst
+++ b/changelog/6910.bugfix.rst
@@ -1,0 +1,1 @@
+Fix crash when plugins return an unknown stats while using the ``--reportlog`` option.

--- a/src/_pytest/resultlog.py
+++ b/src/_pytest/resultlog.py
@@ -77,10 +77,10 @@ class ResultLog:
             longrepr = ""
         elif report.passed:
             longrepr = ""
-        elif report.failed:
-            longrepr = str(report.longrepr)
         elif report.skipped:
             longrepr = str(report.longrepr[2])
+        else:
+            longrepr = str(report.longrepr)
         self.log_outcome(report, code, longrepr)
 
     def pytest_collectreport(self, report):


### PR DESCRIPTION
Btw should we follow the protocol for 4.6 releases of using the `needs backport` labels?