### PR TITLE
Prepare release 5.4.1

### DIFF
--- a/changelog/6909.bugfix.rst
+++ b/changelog/6909.bugfix.rst
@@ -1,3 +1,0 @@
-Revert the change introduced by `#6330 <https://github.com/pytest-dev/pytest/pull/6330>`_, which required all arguments to ``@pytest.mark.parametrize`` to be explicitly defined in the function signature.
-
-The intention of the original change was to remove what was expected to be an unintended/surprising behavior, but it turns out many people relied on it, so the restriction has been reverted.

--- a/changelog/6910.bugfix.rst
+++ b/changelog/6910.bugfix.rst
@@ -1,1 +1,0 @@
-Fix crash when plugins return an unknown stats while using the ``--reportlog`` option.

--- a/doc/en/announce/index.rst
+++ b/doc/en/announce/index.rst
@@ -6,6 +6,7 @@ Release announcements
    :maxdepth: 2
 
 
+   release-5.4.1
    release-5.4.0
    release-5.3.5
    release-5.3.4

--- a/doc/en/announce/release-5.4.1.rst
+++ b/doc/en/announce/release-5.4.1.rst
@@ -1,0 +1,18 @@
+pytest-5.4.1
+=======================================
+
+pytest 5.4.1 has just been released to PyPI.
+
+This is a bug-fix release, being a drop-in replacement. To upgrade::
+
+  pip install --upgrade pytest
+
+The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+
+Thanks to all who contributed to this release, among them:
+
+* Bruno Oliveira
+
+
+Happy testing,
+The pytest Development Team

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -28,6 +28,20 @@ with advance notice in the **Deprecations** section of releases.
 
 .. towncrier release notes start
 
+pytest 5.4.1 (2020-03-13)
+=========================
+
+Bug Fixes
+---------
+
+- `#6909 <https://github.com/pytest-dev/pytest/issues/6909>`_: Revert the change introduced by `#6330 <https://github.com/pytest-dev/pytest/pull/6330>`_, which required all arguments to ``@pytest.mark.parametrize`` to be explicitly defined in the function signature.
+
+  The intention of the original change was to remove what was expected to be an unintended/surprising behavior, but it turns out many people relied on it, so the restriction has been reverted.
+
+
+- `#6910 <https://github.com/pytest-dev/pytest/issues/6910>`_: Fix crash when plugins return an unknown stats while using the ``--reportlog`` option.
+
+
 pytest 5.4.0 (2020-03-12)
 =========================
 


### PR DESCRIPTION
Created automatically from https://github.com/pytest-dev/pytest/issues/6915#issuecomment-598720944.

Once all builds pass and it has been **approved** by one or more maintainers, the build
can be released by pushing a tag `5.4.1` to this repository.
