### PR TITLE
running stdlib asyncio unittests again

### DIFF
--- a/changelog/6924.bugfix.rst
+++ b/changelog/6924.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure a ``unittest.IsolatedAsyncioTestCase`` is actually awaited.

--- a/testing/example_scripts/pytest.ini
+++ b/testing/example_scripts/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+# dummy pytest.ini to ease direct running of example scripts

--- a/testing/example_scripts/unittest/test_unittest_asyncio.py
+++ b/testing/example_scripts/unittest/test_unittest_asyncio.py
@@ -1,0 +1,15 @@
+from unittest import IsolatedAsyncioTestCase  # type: ignore
+
+
+class AsyncArguments(IsolatedAsyncioTestCase):
+    async def test_something_async(self):
+        async def addition(x, y):
+            return x + y
+
+        self.assertEqual(await addition(2, 2), 4)
+
+    async def test_something_async_fails(self):
+        async def addition(x, y):
+            return x + y
+
+        self.assertEqual(await addition(2, 2), 3)

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1129,3 +1129,11 @@ def test_trace(testdir, monkeypatch):
     result = testdir.runpytest("--trace", str(p1))
     assert len(calls) == 2
     assert result.ret == 0
+
+
+def test_async_support(testdir):
+    pytest.importorskip("unittest.async_case")
+
+    testdir.copy_example("unittest/test_unittest_asyncio.py")
+    reprec = testdir.inline_run()
+    reprec.assertoutcome(failed=1, passed=1)


### PR DESCRIPTION
fixes #6924 

opting out of the warning+skip revealed that the generators currently don't execute, while on 5.3 they do by accidennt