### PR TITLE
Fix-6906: Added code-highlight option to disable highlighting optionally

### DIFF
--- a/changelog/6906.feature.rst
+++ b/changelog/6906.feature.rst
@@ -1,0 +1,1 @@
+Added `--code-highlight` command line option to enable/disable code highlighting in terminal output.

--- a/src/_pytest/_io/terminalwriter.py
+++ b/src/_pytest/_io/terminalwriter.py
@@ -74,6 +74,7 @@ class TerminalWriter:
         self.hasmarkup = should_do_markup(file)
         self._current_line = ""
         self._terminal_width = None  # type: Optional[int]
+        self.code_highlight = True
 
     @property
     def fullwidth(self) -> int:
@@ -180,7 +181,7 @@ class TerminalWriter:
 
     def _highlight(self, source: str) -> str:
         """Highlight the given source code if we have markup support."""
-        if not self.hasmarkup:
+        if not self.hasmarkup or not self.code_highlight:
             return source
         try:
             from pygments.formatters.terminal import TerminalFormatter

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1389,8 +1389,13 @@ def create_terminal_writer(
     tw = TerminalWriter(file=file)
     if config.option.color == "yes":
         tw.hasmarkup = True
-    if config.option.color == "no":
+    elif config.option.color == "no":
         tw.hasmarkup = False
+
+    if config.option.code_highlight == "yes":
+        tw.code_highlight = True
+    elif config.option.code_highlight == "no":
+        tw.code_highlight = False
     return tw
 
 

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -208,6 +208,12 @@ def pytest_addoption(parser: Parser) -> None:
         choices=["yes", "no", "auto"],
         help="color terminal output (yes/no/auto).",
     )
+    group._addoption(
+        "--code-highlight",
+        default="yes",
+        choices=["yes", "no"],
+        help="Whether code should be highlighted (only if --color is also enabled)",
+    )
 
     parser.addini(
         "console_output_style",

--- a/testing/io/test_terminalwriter.py
+++ b/testing/io/test_terminalwriter.py
@@ -213,19 +213,32 @@ class TestTerminalWriterLineWidth:
 
 
 @pytest.mark.parametrize(
-    "has_markup, expected",
+    ("has_markup", "code_highlight", "expected"),
     [
         pytest.param(
-            True, "{kw}assert{hl-reset} {number}0{hl-reset}\n", id="with markup"
+            True,
+            True,
+            "{kw}assert{hl-reset} {number}0{hl-reset}\n",
+            id="with markup and code_highlight",
         ),
-        pytest.param(False, "assert 0\n", id="no markup"),
+        pytest.param(
+            True, False, "assert 0\n", id="with markup but no code_highlight",
+        ),
+        pytest.param(
+            False, True, "assert 0\n", id="without markup but with code_highlight",
+        ),
+        pytest.param(
+            False, False, "assert 0\n", id="neither markup nor code_highlight",
+        ),
     ],
 )
-def test_code_highlight(has_markup, expected, color_mapping):
+def test_code_highlight(has_markup, code_highlight, expected, color_mapping):
     f = io.StringIO()
     tw = terminalwriter.TerminalWriter(f)
     tw.hasmarkup = has_markup
+    tw.code_highlight = code_highlight
     tw._write_source(["assert 0"])
+
     assert f.getvalue().splitlines(keepends=True) == color_mapping.format([expected])
 
     with pytest.raises(


### PR DESCRIPTION
Closes #6906 
code-highlight has default value to True, this value is used in `TerminalWriter`
in order to control highlighting of the code.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
