### PR TITLE
ci: twisted and oldattrs tox envs are now incompatible, don't run the…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
           - name: "windows-py37"
             python: "3.7"
             os: windows-latest
-            tox_env: "py37-twisted-numpy"
+            tox_env: "py37-numpy"
           - name: "windows-py37-pluggy"
             python: "3.7"
             os: windows-latest
@@ -70,7 +70,7 @@ jobs:
           - name: "windows-py38"
             python: "3.8"
             os: windows-latest
-            tox_env: "py38"
+            tox_env: "py38-twisted"
             use_coverage: true
 
           - name: "ubuntu-py35"
@@ -84,7 +84,7 @@ jobs:
           - name: "ubuntu-py37"
             python: "3.7"
             os: ubuntu-latest
-            tox_env: "py37-lsof-numpy-oldattrs-pexpect-twisted"
+            tox_env: "py37-lsof-numpy-oldattrs-pexpect"
             use_coverage: true
           - name: "ubuntu-py37-pluggy"
             python: "3.7"


### PR DESCRIPTION
…m together

twisted started to use `attr.s(eq)` argument which was added recently,
so it fails with oldattrs. One of the CI jobs ran twisted and oldattrs
together, so it started to fail.

Make the twisted code be already covered by another job, and remove it from
the job with the oldattrs.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
