### PR TITLE
unittest: fix the `_GetOutOf_testPartExecutor` exception kind. Fixes …

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -220,6 +220,7 @@ Pieter Mulder
 Piotr Banaszkiewicz
 Pulkit Goyal
 Punyashloka Biswal
+Quentin Bey
 Quentin Pradet
 Ralf Schmitt
 Ralph Giles

--- a/changelog/6947.bugfix.rst
+++ b/changelog/6947.bugfix.rst
@@ -1,0 +1,1 @@
+Unittest cleanup functions are called even if a test fails.


### PR DESCRIPTION
…https://github.com/pytest-dev/pytest/issues/6947

`_GetOutOf_testPartExecutor` was introduced in
https://github.com/pytest-dev/pytest/commit/04f27d4eb469fb9c76fd2d100564a0f7d30028df
and allow to catch Exception from a unittest TestCase, but as it
inheritate from `KeyboardInterrupt` it is managed differently by
unittest (see.
https://github.com/python/cpython/blob/032de7324e30c6b44ef272cea3be205a3d768759/Lib/unittest/case.py#L61-L62)
as the `testPartExecutor` reraise it directly. This prevent unittest to
run the cleanup functions properly.

Since this change enable the teardown methods to be ran properly bu
unittest, the explicit teardown is not required anymore.

Checklist:
- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [X] Add yourself to `AUTHORS` in alphabetical order.
