### PR TITLE
Quick doc fix on xfail reason parameter

### DIFF
--- a/doc/en/skipping.rst
+++ b/doc/en/skipping.rst
@@ -283,8 +283,7 @@ Note that you have to pass a reason as well (see the parameter description at
 ``reason`` parameter
 ~~~~~~~~~~~~~~~~~~~~
 
-As with skipif_ you can also mark your expectation of a failure
-on a particular platform:
+You can specify the motive of an expected failure with the ``reason`` parameter:
 
 .. code-block:: python
 


### PR DESCRIPTION
As per https://github.com/pytest-dev/pytest/pull/6957/files#r399564043
