### PR TITLE
docs: Do not use automatic title in fixture reference

### DIFF
--- a/doc/en/cache.rst
+++ b/doc/en/cache.rst
@@ -194,7 +194,7 @@ The new config.cache object
 
 Plugins or conftest.py support code can get a cached value using the
 pytest ``config`` object.  Here is a basic example plugin which
-implements a :ref:`fixture` which re-uses previously created state
+implements a :ref:`fixture <fixture>` which re-uses previously created state
 across pytest invocations:
 
 .. code-block:: python

--- a/doc/en/example/index.rst
+++ b/doc/en/example/index.rst
@@ -15,7 +15,7 @@ For basic examples, see
 
 - :doc:`../getting-started` for basic introductory examples
 - :ref:`assert` for basic assertion examples
-- :ref:`fixtures` for basic fixture/setup examples
+- :ref:`Fixtures <fixtures>` for basic fixture/setup examples
 - :ref:`parametrize` for basic test function parametrization
 - :doc:`../unittest` for basic unittest integration
 - :doc:`../nose` for basic nosetests integration

--- a/doc/en/faq.rst
+++ b/doc/en/faq.rst
@@ -32,7 +32,7 @@ just run your tests even if you return Deferreds.  In addition,
 there also is a dedicated `pytest-twisted
 <https://pypi.org/project/pytest-twisted/>`_ plugin which allows you to
 return deferreds from pytest-style tests, allowing the use of
-:ref:`fixtures` and other features.
+:ref:`fixtures <fixtures>` and other features.
 
 how does pytest work with Django?
 ++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
It creates odd wording otherwise. Keep the reference, update the title
using Sphinx notation.

For example, [in the cache section](https://docs.pytest.org/en/latest/cache.html#the-new-config-cache-object) it reads: 

>  Here is a basic example plugin which implements a pytest fixtures: explicit, modular, scalable which re-uses previously created state across pytest invocations:

With this change it reads:

> Here is a basic example plugin which implements a fixture which re-uses previously created state across pytest invocations:

This PR doesn't address all the references to fixtures (I checked them all!), because in some other situations it does read fine.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
