### PR TITLE
[5.4.x] Fix crash when printing while capsysbinary is active

### DIFF
--- a/changelog/6871.bugfix.rst
+++ b/changelog/6871.bugfix.rst
@@ -1,0 +1,1 @@
+Fix crash with captured output when using the :fixture:`capsysbinary fixture <capsysbinary>`.

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -610,8 +610,6 @@ class FDCaptureBinary:
 
     def writeorg(self, data):
         """ write to original file descriptor. """
-        if isinstance(data, str):
-            data = data.encode("utf8")  # XXX use encoding of original stream
         os.write(self.targetfd_save, data)
 
 
@@ -630,6 +628,11 @@ class FDCapture(FDCaptureBinary):
         if enc and isinstance(res, bytes):
             res = str(res, enc, "replace")
         return res
+
+    def writeorg(self, data):
+        """ write to original file descriptor. """
+        data = data.encode("utf-8")  # XXX use encoding of original stream
+        os.write(self.targetfd_save, data)
 
 
 class SysCaptureBinary:
@@ -682,8 +685,9 @@ class SysCaptureBinary:
         self._state = "resumed"
 
     def writeorg(self, data):
-        self._old.write(data)
         self._old.flush()
+        self._old.buffer.write(data)
+        self._old.buffer.flush()
 
 
 class SysCapture(SysCaptureBinary):
@@ -694,6 +698,10 @@ class SysCapture(SysCaptureBinary):
         self.tmpfile.seek(0)
         self.tmpfile.truncate()
         return res
+
+    def writeorg(self, data):
+        self._old.write(data)
+        self._old.flush()
 
 
 class TeeSysCapture(SysCapture):


### PR DESCRIPTION
Backport of 1fda86119055f7a5db8a30d867b26e802f6067ab from master.