### PR TITLE
doc: document inversed lines with terminal report hooks

### DIFF
--- a/doc/en/writing_plugins.rst
+++ b/doc/en/writing_plugins.rst
@@ -561,6 +561,7 @@ that result but it's probably better to avoid it.
 For more information, consult the
 :ref:`pluggy documentation about hookwrappers <pluggy:hookwrappers>`.
 
+.. _plugin-hookorder:
 
 Hook function ordering / call example
 -------------------------------------

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -523,10 +523,12 @@ def pytest_report_header(config, startdir):
     :param _pytest.config.Config config: pytest config object
     :param startdir: py.path object with the starting dir
 
-    .. note:
+    .. note::
 
-        The returned (set of) lines is reversed, i.e. `trylast=True` has to
-        be used when you want to have your line(s) at the beginning.
+        Lines returned by a plugin are displayed before those of plugins which
+        ran before it.
+        If you want to have your line(s) displayed first, use
+        :ref:`trylast=True <plugin-hookorder>`.
 
     .. note::
 
@@ -544,10 +546,12 @@ def pytest_report_collectionfinish(config, startdir, items):
 
     These strings will be displayed after the standard "collected X items" message.
 
-    .. note:
+    .. note::
 
-        The returned (set of) lines is reversed, i.e. `trylast=True` has to
-        be used when you want to have your line(s) at the beginning.
+        Lines returned by a plugin are displayed before those of plugins which
+        ran before it.
+        If you want to have your line(s) displayed first, use
+        :ref:`trylast=True <plugin-hookorder>`.
 
     :param _pytest.config.Config config: pytest config object
     :param startdir: py.path object with the starting dir

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -546,16 +546,16 @@ def pytest_report_collectionfinish(config, startdir, items):
 
     These strings will be displayed after the standard "collected X items" message.
 
+    :param _pytest.config.Config config: pytest config object
+    :param startdir: py.path object with the starting dir
+    :param items: list of pytest items that are going to be executed; this list should not be modified.
+
     .. note::
 
         Lines returned by a plugin are displayed before those of plugins which
         ran before it.
         If you want to have your line(s) displayed first, use
         :ref:`trylast=True <plugin-hookorder>`.
-
-    :param _pytest.config.Config config: pytest config object
-    :param startdir: py.path object with the starting dir
-    :param items: list of pytest items that are going to be executed; this list should not be modified.
     """
 
 

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -523,6 +523,11 @@ def pytest_report_header(config, startdir):
     :param _pytest.config.Config config: pytest config object
     :param startdir: py.path object with the starting dir
 
+    .. note:
+
+        The returned (set of) lines is reversed, i.e. `trylast=True` has to
+        be used when you want to have your line(s) at the beginning.
+
     .. note::
 
         This function should be implemented only in plugins or ``conftest.py``
@@ -537,7 +542,12 @@ def pytest_report_collectionfinish(config, startdir, items):
 
     return a string or list of strings to be displayed after collection has finished successfully.
 
-    This strings will be displayed after the standard "collected X items" message.
+    These strings will be displayed after the standard "collected X items" message.
+
+    .. note:
+
+        The returned (set of) lines is reversed, i.e. `trylast=True` has to
+        be used when you want to have your line(s) at the beginning.
 
     :param _pytest.config.Config config: pytest config object
     :param startdir: py.path object with the starting dir


### PR DESCRIPTION
It was surprising that `tryfirst=True` would not result in lines being
added to the beginning with `pytest_report_header`.
This is due to lines being reversed, and therefore the same applies to
`pytest_report_collectionfinish`.