### PR TITLE
doc: fix/remove leftovers from removing `versionadded`

### DIFF
--- a/doc/en/assert.rst
+++ b/doc/en/assert.rst
@@ -342,15 +342,3 @@ If this is the case you have two options:
   ``PYTEST_DONT_REWRITE`` to its docstring.
 
 * Disable rewriting for all modules by using ``--assert=plain``.
-
-
-
-   Add assert rewriting as an alternate introspection technique.
-
-
-   Introduce the ``--assert`` option. Deprecate ``--no-assert`` and
-   ``--nomagic``.
-
-
-   Removes the ``--no-assert`` and ``--nomagic`` options.
-   Removes the ``--assert=reinterp`` option.


### PR DESCRIPTION
Ref: 9c5da9c (https://github.com/pytest-dev/pytest/pull/5184)

Fixes https://docs.pytest.org/en/latest/assert.html#disabling-assert-rewriting.