### PR TITLE
Increase test_faulthandler.py::test_timeout sleep duration on CI

### DIFF
--- a/testing/test_faulthandler.py
+++ b/testing/test_faulthandler.py
@@ -58,7 +58,7 @@ def test_timeout(testdir, enabled):
         """
     import os, time
     def test_timeout():
-        time.sleep(1 if "CI" in os.environ else 0.1)
+        time.sleep(10 if "CI" in os.environ else 0.1)
     """
     )
     testdir.makeini(
@@ -71,8 +71,6 @@ def test_timeout(testdir, enabled):
 
     result = testdir.runpytest_subprocess(*args)
     tb_output = "most recent call first"
-    if sys.version_info[:2] == (3, 3):
-        tb_output = "Thread"
     if enabled:
         result.stderr.fnmatch_lines(["*%s*" % tb_output])
     else:


### PR DESCRIPTION
This might help fix some flakiness.

Let's say it Fixes #7022 and reopen if not.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
