### PR TITLE
Fix flaky TestDurations test

### DIFF
--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -2,8 +2,8 @@
 import bdb
 import os
 import sys
-from time import perf_counter
-from time import time
+from time import perf_counter  # Intentionally not `import time` to avoid being
+from time import time  # affected by tests which monkeypatch `time` (issue #185).
 from typing import Callable
 from typing import Dict
 from typing import List


### PR DESCRIPTION
Fixes #7024.

`TestDurations` tests the `--durations=N` functionality which reports N slowest tests, with durations <= 0.005s not shown by default.

The test relies on real `time.sleep()` (in addition to the code which uses `time.perf_counter()`) which makes it flaky and inconsistent between platforms.

Instead of trying to tweak it more, make it use fake time instead. The way it is done is a little hacky but seems to work.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
