### PR TITLE
tests: fix TypeError with test_mark_closest

### DIFF
--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -53,8 +53,8 @@ class TestCollector:
     def test_getparent(self, testdir):
         modcol = testdir.getmodulecol(
             """
-            class TestClass(object):
-                 def test_foo():
+            class TestClass:
+                 def test_foo(self):
                      pass
         """
         )

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -533,10 +533,10 @@ class TestFunctional:
             @pytest.mark.c(location="class")
             class Test:
                 @pytest.mark.c(location="function")
-                def test_has_own():
+                def test_has_own(self):
                     pass
 
-                def test_has_inherited():
+                def test_has_inherited(self):
                     pass
 
         """


### PR DESCRIPTION
It fails when trying to run it actually:

> TypeError: test_has_inherited() takes 0 positional arguments but 1 was given