### PR TITLE
Fix test_no_warnings to handle e.g. `_pytest.async`

### DIFF
--- a/testing/test_meta.py
+++ b/testing/test_meta.py
@@ -14,12 +14,10 @@ import pytest
 
 
 def _modules() -> List[str]:
-    assert _pytest.__path__
+    pytest_pkg = _pytest.__path__  # type: ignore
     return sorted(
         n
-        for _, n, _ in pkgutil.walk_packages(
-            _pytest.__path__, prefix=_pytest.__name__ + "."
-        )
+        for _, n, _ in pkgutil.walk_packages(pytest_pkg, prefix=_pytest.__name__ + ".")
     )
 
 

--- a/testing/test_meta.py
+++ b/testing/test_meta.py
@@ -7,12 +7,14 @@ namespace being set, which is critical for the initialization of xdist.
 import pkgutil
 import subprocess
 import sys
+from typing import List
 
 import _pytest
 import pytest
 
 
-def _modules():
+def _modules() -> List[str]:
+    assert _pytest.__path__
     return sorted(
         n
         for _, n, _ in pkgutil.walk_packages(
@@ -23,13 +25,13 @@ def _modules():
 
 @pytest.mark.slow
 @pytest.mark.parametrize("module", _modules())
-def test_no_warnings(module):
+def test_no_warnings(module: str) -> None:
     # fmt: off
     subprocess.check_call((
         sys.executable,
         "-W", "error",
         # https://github.com/pytest-dev/pytest/issues/5901
         "-W", "ignore:The usage of `cmp` is deprecated and will be removed on or after 2021-06-01.  Please use `eq` and `order` instead.:DeprecationWarning",  # noqa: E501
-        "-c", "import {}".format(module),
+        "-c", "__import__({!r})".format(module),
     ))
     # fmt: on

--- a/testing/test_meta.py
+++ b/testing/test_meta.py
@@ -14,7 +14,7 @@ import pytest
 
 
 def _modules() -> List[str]:
-    pytest_pkg = _pytest.__path__  # type: ignore
+    pytest_pkg = _pytest.__path__  # type: str  # type: ignore
     return sorted(
         n
         for _, n, _ in pkgutil.walk_packages(pytest_pkg, prefix=_pytest.__name__ + ".")


### PR DESCRIPTION
This would result in an SyntaxError with `import _pytest.async`.