### PR TITLE
Remove broken _reprcompare disabling fixture in test_assertrewrite.py

### DIFF
--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -25,16 +25,6 @@ from _pytest.config import ExitCode
 from _pytest.pathlib import Path
 
 
-def setup_module(mod):
-    mod._old_reprcompare = util._reprcompare
-    _pytest._code._reprcompare = None
-
-
-def teardown_module(mod):
-    util._reprcompare = mod._old_reprcompare
-    del mod._old_reprcompare
-
-
 def rewrite(src):
     tree = ast.parse(src)
     rewrite_asserts(tree, src.encode())


### PR DESCRIPTION
The `_pytest._code._reprcompare` that was referred to previously doesn't
exist -- it was moved to other places but wasn't update.

This regressed in f423ce9c016aff0d84c4a68f6d972833d032181e.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
