### PR TITLE
doc: internal: remove references to old "newinterpret" module

### DIFF
--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -114,7 +114,7 @@ def pytest_collection(session: "Session") -> None:
 def pytest_runtest_protocol(item):
     """Setup the pytest_assertrepr_compare and pytest_assertion_pass hooks
 
-    The newinterpret and rewrite modules will use util._reprcompare if
+    The rewrite module will use util._reprcompare if
     it exists to use custom reporting via the
     pytest_assertrepr_compare hook.  This sets up this custom
     comparison for the test.

--- a/src/_pytest/freeze_support.py
+++ b/src/_pytest/freeze_support.py
@@ -21,13 +21,10 @@ def _iter_all_modules(package, prefix=""):
     """
     Iterates over the names of all modules that can be found in the given
     package, recursively.
-    Example:
-        _iter_all_modules(_pytest) ->
-            ['_pytest.assertion.newinterpret',
-             '_pytest.capture',
-             '_pytest.core',
-             ...
-            ]
+
+        >>> import _pytest
+        >>> list(_iter_all_modules(_pytest))
+        ['_pytest._argcomplete', '_pytest._code.code', ...]
     """
     import os
     import pkgutil


### PR DESCRIPTION
This has been merged into the (only) assertrewrite mode.