### PR TITLE
Remove Python 2 compat check in test_monkeypatch.py

### DIFF
--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -4,7 +4,11 @@ import sys
 import textwrap
 
 import pytest
+from _pytest.compat import TYPE_CHECKING
 from _pytest.monkeypatch import MonkeyPatch
+
+if TYPE_CHECKING:
+    from typing import Type
 
 
 @pytest.fixture
@@ -331,33 +335,20 @@ def test_importerror(testdir):
     )
 
 
-class SampleNew:
+class Sample:
     @staticmethod
-    def hello():
+    def hello() -> bool:
         return True
 
 
-class SampleNewInherit(SampleNew):
-    pass
-
-
-class SampleOld:
-    # oldstyle on python2
-    @staticmethod
-    def hello():
-        return True
-
-
-class SampleOldInherit(SampleOld):
+class SampleInherit(Sample):
     pass
 
 
 @pytest.mark.parametrize(
-    "Sample",
-    [SampleNew, SampleNewInherit, SampleOld, SampleOldInherit],
-    ids=["new", "new-inherit", "old", "old-inherit"],
+    "Sample", [Sample, SampleInherit], ids=["new", "new-inherit"],
 )
-def test_issue156_undo_staticmethod(Sample):
+def test_issue156_undo_staticmethod(Sample: "Type[Sample]") -> None:
     monkeypatch = MonkeyPatch()
 
     monkeypatch.setattr(Sample, "hello", None)


### PR DESCRIPTION
Presumably it used to test old-style vs. new-style classes, but in the Python 3 conversion `SampleNew` and `SampleOld` became the same.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
