### PR TITLE
Skip flaky test test_faulthandler.py::test_timeout[True]

### DIFF
--- a/testing/test_faulthandler.py
+++ b/testing/test_faulthandler.py
@@ -49,8 +49,16 @@ def test_disabled(testdir):
     assert result.ret == 0
 
 
-@pytest.mark.parametrize("enabled", [True, False])
-def test_timeout(testdir, enabled):
+@pytest.mark.parametrize(
+    "enabled",
+    [
+        pytest.param(
+            True, marks=pytest.mark.skip(reason="sometimes crashes on CI (#7022)")
+        ),
+        False,
+    ],
+)
+def test_timeout(testdir, enabled: bool) -> None:
     """Test option to dump tracebacks after a certain timeout.
     If faulthandler is disabled, no traceback will be dumped.
     """


### PR DESCRIPTION
It occasionally crashes on CI, the reason seems out of our control, or at least we can't figure it out.

Refs #7022.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
