### PR TITLE
Remove note saying faulthandler_timeout is not available on Windows

### DIFF
--- a/src/_pytest/faulthandler.py
+++ b/src/_pytest/faulthandler.py
@@ -13,8 +13,7 @@ fault_handler_stderr_key = StoreKey[TextIO]()
 def pytest_addoption(parser):
     help = (
         "Dump the traceback of all threads if a test takes "
-        "more than TIMEOUT seconds to finish.\n"
-        "Not available on Windows."
+        "more than TIMEOUT seconds to finish."
     )
     parser.addini("faulthandler_timeout", help, default=0.0)
 


### PR DESCRIPTION
I think it is available in all Python versions we support, but at least
since Python 3.7 the docs[0] say:

    Changed in version 3.7: This function is now always available.

so let's just remove the note.

[0] https://docs.python.org/3/library/faulthandler.html#faulthandler.dump_traceback_later

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
