### PR TITLE
Document pytester fixtures so --fixtures makes more sense

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -358,7 +358,7 @@ class HookRecorder:
 @pytest.fixture
 def linecomp() -> "LineComp":
     """
-    Return a :class" `LineComp`instance usable to check that the input linearly contains a sequence of strings.
+    A :class" `LineComp` instance for checking that an input linearly contains a sequence of strings.
 
     see: https://docs.pytest.org/en/latest/_modules/_pytest/pytester.html
     """
@@ -368,8 +368,10 @@ def linecomp() -> "LineComp":
 @pytest.fixture(name="LineMatcher")
 def LineMatcher_fixture(request: FixtureRequest) -> "Type[LineMatcher]":
     """
-    Return a :class: `LineMatcher` reference. This is instantiable with a list of lines (without their
-    trailing newlines).  This is a convenience class used for testing large texts, such as the output from commands.
+    A reference to the a :class: `LineMatcher` class.
+    
+    This is instantiable with a list of lines (without their trailing newlines).
+    This is a convenience class used for testing large texts, such as the output of commands.
 
     see: https://docs.pytest.org/en/latest/_modules/_pytest/pytester.html
     """
@@ -379,9 +381,10 @@ def LineMatcher_fixture(request: FixtureRequest) -> "Type[LineMatcher]":
 @pytest.fixture
 def testdir(request: FixtureRequest, tmpdir_factory) -> "Testdir":
     """
-    Return a :class: TestDir instance, this instance can be used to test/run pytest itself.  It is very useful
-    for testing plugins.  This is based on the ``tmpdir`` fixture but provides a number of methods which aid in
-    testing pytest itself.
+    A :class: `TestDir` instance, that can be used to run and test pytest itself.
+    
+    It is particularly useful for testing plugins. It is similar to the ``tmpdir`` fixture
+    but provides methods which aid in testing pytest itself.
 
     see: https://docs.pytest.org/en/latest/_modules/_pytest/pytester.html
     """

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -359,8 +359,6 @@ class HookRecorder:
 def linecomp() -> "LineComp":
     """
     A :class" `LineComp` instance for checking that an input linearly contains a sequence of strings.
-
-    see: https://docs.pytest.org/en/latest/_modules/_pytest/pytester.html
     """
     return LineComp()
 
@@ -369,11 +367,9 @@ def linecomp() -> "LineComp":
 def LineMatcher_fixture(request: FixtureRequest) -> "Type[LineMatcher]":
     """
     A reference to the a :class: `LineMatcher` class.
-    
+
     This is instantiable with a list of lines (without their trailing newlines).
     This is a convenience class used for testing large texts, such as the output of commands.
-
-    see: https://docs.pytest.org/en/latest/_modules/_pytest/pytester.html
     """
     return LineMatcher
 
@@ -382,11 +378,10 @@ def LineMatcher_fixture(request: FixtureRequest) -> "Type[LineMatcher]":
 def testdir(request: FixtureRequest, tmpdir_factory) -> "Testdir":
     """
     A :class: `TestDir` instance, that can be used to run and test pytest itself.
-    
+
     It is particularly useful for testing plugins. It is similar to the ``tmpdir`` fixture
     but provides methods which aid in testing pytest itself.
 
-    see: https://docs.pytest.org/en/latest/_modules/_pytest/pytester.html
     """
     return Testdir(request, tmpdir_factory)
 

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -358,7 +358,8 @@ class HookRecorder:
 @pytest.fixture
 def linecomp() -> "LineComp":
     """
-    A :class" `LineComp` instance for checking that an input linearly contains a sequence of strings.
+    A :class: `LineComp` instance for checking that an input linearly
+    contains a sequence of strings.
     """
     return LineComp()
 
@@ -366,10 +367,10 @@ def linecomp() -> "LineComp":
 @pytest.fixture(name="LineMatcher")
 def LineMatcher_fixture(request: FixtureRequest) -> "Type[LineMatcher]":
     """
-    A reference to the a :class: `LineMatcher` class.
+    A reference to the :class: `LineMatcher`.
 
     This is instantiable with a list of lines (without their trailing newlines).
-    This is a convenience class used for testing large texts, such as the output of commands.
+    This is useful for testing large texts, such as the output of commands.
     """
     return LineMatcher
 
@@ -379,7 +380,7 @@ def testdir(request: FixtureRequest, tmpdir_factory) -> "Testdir":
     """
     A :class: `TestDir` instance, that can be used to run and test pytest itself.
 
-    It is particularly useful for testing plugins. It is similar to the ``tmpdir`` fixture
+    It is particularly useful for testing plugins. It is similar to the `tmpdir` fixture
     but provides methods which aid in testing pytest itself.
 
     """

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -357,16 +357,34 @@ class HookRecorder:
 
 @pytest.fixture
 def linecomp() -> "LineComp":
+    """
+    Return a :class" `LineComp`instance usable to check that the input linearly contains a sequence of strings.
+
+    see: https://docs.pytest.org/en/latest/_modules/_pytest/pytester.html
+    """
     return LineComp()
 
 
 @pytest.fixture(name="LineMatcher")
 def LineMatcher_fixture(request: FixtureRequest) -> "Type[LineMatcher]":
+    """
+    Return a :class: `LineMatcher` reference. This is instantiable with a list of lines (without their
+    trailing newlines).  This is a convenience class used for testing large texts, such as the output from commands.
+
+    see: https://docs.pytest.org/en/latest/_modules/_pytest/pytester.html
+    """
     return LineMatcher
 
 
 @pytest.fixture
 def testdir(request: FixtureRequest, tmpdir_factory) -> "Testdir":
+    """
+    Return a :class: TestDir instance, this instance can be used to test/run pytest itself.  It is very useful
+    for testing plugins.  This is based on the ``tmpdir`` fixture but provides a number of methods which aid in
+    testing pytest itself.
+
+    see: https://docs.pytest.org/en/latest/_modules/_pytest/pytester.html
+    """
     return Testdir(request, tmpdir_factory)
 
 


### PR DESCRIPTION
Good morning, I'm just getting started with contributing so i thought i would go after some low hanging fruit, when doing some plugin development the pytest plugin (while cool was kind of new to me, checking out --fixtures for it yielded the following:

```
linecomp
    .tox/py37/lib/python3.7/site-packages/_pytest/pytester.py:355: no docstring available

LineMatcher
    .tox/py37/lib/python3.7/site-packages/_pytest/pytester.py:360: no docstring available

testdir
    .tox/py37/lib/python3.7/site-packages/_pytest/pytester.py:365: no docstring available
```

So this PR adds some brief documentation to the fixture docstrings for those 3 empty ones.  Maybe it was intentional not to have any as its the 'pytester' plugin, but they are shown to end users so I think its a worthwhile improvement

- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Thanks for your time, and have a great day 👍 

