### PR TITLE
Gracefully handle eval() failure(s) for marker expressions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -246,6 +246,7 @@ Segev Finer
 Serhii Mozghovyi
 Seth Junot
 Simon Gomizelj
+Simon Kerr
 Skylar Downes
 Srinivas Reddy Thatiparthy
 Stefan Farmbauer

--- a/changelog/4583.bugfix.rst
+++ b/changelog/4583.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent crashing and provide user friendly error(s) when marker expressions (-m) invoking of eval() raises a SyntaxError or TypeError

--- a/changelog/4583.bugfix.rst
+++ b/changelog/4583.bugfix.rst
@@ -1,1 +1,1 @@
-Prevent crashing and provide user friendly error(s) when marker expressions (-m) invoking of eval() raises a SyntaxError or TypeError
+Prevent crashing and provide a user-friendly error when a marker expression (-m) invoking of eval() raises any exception.

--- a/src/_pytest/mark/legacy.py
+++ b/src/_pytest/mark/legacy.py
@@ -84,8 +84,13 @@ def matchmark(colitem, markexpr):
     """Tries to match on any marker names, attached to the given colitem."""
     try:
         return eval(markexpr, {}, MarkMapping.from_item(colitem))
-    except SyntaxError as e:
-        raise SyntaxError(str(e) + "\nMarker expression must be valid Python!")
+    except (SyntaxError, TypeError):
+        raise UsageError(
+            "Marker expression provided to -m:{} was not valid python syntax."
+            " Please check the syntax provided and ensure it is correct".format(
+                markexpr
+            )
+        )
 
 
 def matchkeyword(colitem, keywordexpr):

--- a/src/_pytest/mark/legacy.py
+++ b/src/_pytest/mark/legacy.py
@@ -84,13 +84,8 @@ def matchmark(colitem, markexpr):
     """Tries to match on any marker names, attached to the given colitem."""
     try:
         return eval(markexpr, {}, MarkMapping.from_item(colitem))
-    except (SyntaxError, TypeError):
-        raise UsageError(
-            "Marker expression provided to -m:{} was not valid python syntax."
-            " Please check the syntax provided and ensure it is correct".format(
-                markexpr
-            )
-        )
+    except Exception:
+        raise UsageError("Wrong expression passed to '-m': {}".format(markexpr))
 
 
 def matchkeyword(colitem, keywordexpr):


### PR DESCRIPTION
Hello pytest devs, great project thanks and I look forward to growing my contributions, tho its quite the code base to understand!  from #4583 this provides a nicer error message to the user when invoking eval() for marker expressions does not go quite successfully, raising a USAGE_ERROR rather than the crash/INTERNAL_ERROR at present.

Thank you very much for taking your time to review my PR, look forward to addressing any feedback, have a great day.

- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.
- [X] Add yourself to `AUTHORS` in alphabetical order.
