### PR TITLE
Remove pypy (2) environment from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ envlist =
     py36
     py37
     py38
-    pypy
     pypy3
     py37-{pexpect,xdist,twisted,numpy,pluggymaster}
     doctesting


### PR DESCRIPTION
`pypy` refers to Pypy 2 which implements Python 2 which pytest no longer supports. Keep only `pypy3`.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
