### PR TITLE
Perform FD capturing even if the FD is invalid

### DIFF
--- a/changelog/7091.improvement.rst
+++ b/changelog/7091.improvement.rst
@@ -1,0 +1,4 @@
+When ``fd`` capturing is used, through ``--capture=fd`` or the ``capfd`` and
+``capfdbinary`` fixtures, and the file descriptor (0, 1, 2) cannot be
+duplicated, FD capturing is still performed. Previously, direct writes to the
+file descriptors would fail or be lost in this case.


### PR DESCRIPTION
The `FDCapture`/`FDCaptureBinary` classes, used by `capfd`/`capfdbinary`
fixtures and the `--capture=fd` option (set by default), redirect FDs
1/2 (stdout/stderr) to a temporary file. To do this, they need to save
the old file by duplicating the FD before redirecting it, to be restored
once finished.

Previously, if this duplicating (`os.dup()`) failed, most likely due to
that FD being invalid, the FD redirection would silently not be done. The
FD capturing also performs python-level redirection (monkeypatching
`sys.stdout`/`sys.stderr`) which would still be done, but direct writes
to the FDs would fail.

This is not great. If pytest is run with `--capture=fd`, or a test is
using `capfd`, it expects writes to the FD to work and be captured,
regardless of external circumstances.

So, instead of disabling FD capturing, keep the redirection to a
temporary file, just don't restore it after closing, because there is
nothing to restore to.