### PR TITLE
Issue 7076 - Fix relative paths for nodes

### DIFF
--- a/changelog/7076.trivial.rst
+++ b/changelog/7076.trivial.rst
@@ -1,0 +1,1 @@
+Location of item is relative to invocation directory.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -401,7 +401,7 @@ class Session(nodes.FSCollector):
         self._collection_pkg_roots = {}  # type: Dict[py.path.local, Package]
 
         self._bestrelpathcache = _bestrelpath_cache(
-            config.rootdir
+            config.invocation_dir
         )  # type: Dict[py.path.local, str]
 
         self.config.pluginmanager.register(self, name="session")

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -198,7 +198,7 @@ class TestTerminal:
         result = testdir.runpytest("-vv", "-rA", "tests/test_p2.py", "--rootdir=tests")
         result.stdout.fnmatch_lines(
             [
-                "tests/test_p2.py::TestMore::test_p1 <- test_p1.py PASSED *",
+                "tests/test_p2.py::TestMore::test_p1 <- tests/test_p1.py PASSED *",
                 "*= short test summary info =*",
                 "PASSED tests/test_p2.py::TestMore::test_p1",
             ]
@@ -206,7 +206,7 @@ class TestTerminal:
         result = testdir.runpytest("-vv", "-rA", "tests/test_p3.py", "--rootdir=tests")
         result.stdout.fnmatch_lines(
             [
-                "tests/test_p3.py::TestMore::test_p1 <- test_p1.py FAILED *",
+                "tests/test_p3.py::TestMore::test_p1 <- tests/test_p1.py FAILED *",
                 "*_ TestMore.test_p1 _*",
                 "    def test_p1(self):",
                 ">       if self.fail: assert 0",


### PR DESCRIPTION
It solves #7076. I decided to change `rootdir` to `invocation dir`  in `_bestrelpathcache`, because we want to have path for nodes relative to invocation directory. As I've seen,  that function is used only for nodes  (`_node_location_to_relpath`), so this change shouldn't mess other functionalities.