### PR TITLE
Fix incorrect xml escaping

### DIFF
--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -58,9 +58,9 @@ def bin_xml_escape(arg):
     def repl(matchobj):
         i = ord(matchobj.group())
         if i <= 0xFF:
-            return "#x%02X" % i
+            return "&#x%02X;" % i
         else:
-            return "#x%04X" % i
+            return "&#x%04X;" % i
 
     return py.xml.raw(illegal_xml_re.sub(repl, py.xml.escape(arg)))
 

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -644,7 +644,7 @@ class LogXML:
             + self.stats["error"]
             - self.cnt_double_fail_tests
         )
-        logfile.write('<?xml version="1.0" encoding="utf-8"?>')
+        logfile.write('<?xml version="1.1" encoding="utf-8"?>')
 
         suite_node = Junit.testsuite(
             self._get_global_properties_node(),

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -989,9 +989,9 @@ def test_invalid_xml_escape():
     for i in invalid:
         got = bin_xml_escape(chr(i)).uniobj
         if i <= 0xFF:
-            expected = "#x%02X" % i
+            expected = "&#x%02X;" % i
         else:
-            expected = "#x%04X" % i
+            expected = "&#x%04X;" % i
         assert got == expected
     for i in valid:
         assert chr(i) == bin_xml_escape(chr(i)).uniobj


### PR DESCRIPTION
Closes #2560

This has been present since 1c1918eb222ba4ed04aeb221f4e8580e4b62a39a

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
