### PR TITLE
fixtures: deprecate pytest._fillfuncargs function

### DIFF
--- a/changelog/7097.deprecation.rst
+++ b/changelog/7097.deprecation.rst
@@ -1,0 +1,6 @@
+The ``pytest._fillfuncargs`` function is now deprecated. This function was kept
+for backward compatibility with an older plugin.
+
+It's functionality is not meant to be used directly, but if you must replace
+it, use `function._request._fillfixtures()` instead, though note this is not
+a public API and may break in the future.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -20,6 +20,19 @@ Below is a complete list of all pytest features which are considered deprecated.
 :ref:`standard warning filters <warnings>`.
 
 
+The ``pytest._fillfuncargs`` function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 5.5
+
+This function was kept for backward compatibility with an older plugin.
+
+It's functionality is not meant to be used directly, but if you must replace
+it, use `function._request._fillfixtures()` instead, though note this is not
+a public API and may break in the future.
+
+
+
 ``--no-print-logs`` command-line option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -27,7 +27,7 @@ FUNCARGNAMES = PytestDeprecationWarning(
 
 FILLFUNCARGS = PytestDeprecationWarning(
     "The `_fillfuncargs` function is deprecated, use "
-    "function._request._fillfixtures() instead if you must."
+    "function._request._fillfixtures() instead if you cannot avoid reaching into internals."
 )
 
 RESULT_LOG = PytestDeprecationWarning(

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -25,6 +25,11 @@ FUNCARGNAMES = PytestDeprecationWarning(
     "since pytest 2.3 - use the newer attribute instead."
 )
 
+FILLFUNCARGS = PytestDeprecationWarning(
+    "The `_fillfuncargs` function is deprecated, use "
+    "function._request._fillfixtures() instead if you must."
+)
+
 RESULT_LOG = PytestDeprecationWarning(
     "--result-log is deprecated, please try the new pytest-reportlog plugin.\n"
     "See https://docs.pytest.org/en/latest/deprecations.html#result-log-result-log for more information."

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -28,6 +28,7 @@ from _pytest.compat import is_generator
 from _pytest.compat import NOTSET
 from _pytest.compat import safe_getattr
 from _pytest.compat import TYPE_CHECKING
+from _pytest.deprecated import FILLFUNCARGS
 from _pytest.deprecated import FIXTURE_POSITIONAL_ARGUMENTS
 from _pytest.deprecated import FUNCARGNAMES
 from _pytest.mark import ParameterSet
@@ -276,6 +277,7 @@ def reorder_items_atscope(items, argkeys_cache, items_by_argkey, scopenum):
 
 def fillfixtures(function):
     """ fill missing funcargs for a test function. """
+    warnings.warn(FILLFUNCARGS, stacklevel=2)
     try:
         request = function._request
     except AttributeError:

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1535,7 +1535,7 @@ class Function(PyobjMixin, nodes.Item):
         if isinstance(self.parent, Instance):
             self.parent.newinstance()
             self.obj = self._getobj()
-        fixtures.fillfixtures(self)
+        self._request._fillfixtures()
 
     def _prunetraceback(self, excinfo: ExceptionInfo) -> None:
         if hasattr(self, "_obj") and not self.config.getoption("fulltrace", False):

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -1,4 +1,5 @@
 import inspect
+from unittest import mock
 
 import pytest
 from _pytest import deprecated
@@ -146,3 +147,11 @@ def test_noprintlogs_is_deprecated_ini(testdir):
     )
 
     assert_no_print_logs(testdir, ())
+
+
+def test__fillfuncargs_is_deprecated() -> None:
+    with pytest.warns(
+        pytest.PytestDeprecationWarning,
+        match="The `_fillfuncargs` function is deprecated",
+    ):
+        pytest._fillfuncargs(mock.Mock())

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -110,7 +110,7 @@ class TestFillFixtures:
     def test_funcarg_basic(self, testdir):
         testdir.copy_example()
         item = testdir.getitem(Path("test_funcarg_basic.py"))
-        fixtures.fillfixtures(item)
+        item._request._fillfixtures()
         del item.funcargs["request"]
         assert len(get_public_names(item.funcargs)) == 2
         assert item.funcargs["some"] == "test_func"
@@ -664,7 +664,7 @@ class TestRequestBasic:
         assert val2 == 2
         val2 = req.getfixturevalue("other")  # see about caching
         assert val2 == 2
-        pytest._fillfuncargs(item)
+        item._request._fillfixtures()
         assert item.funcargs["something"] == 1
         assert len(get_public_names(item.funcargs)) == 2
         assert "request" in item.funcargs
@@ -681,7 +681,7 @@ class TestRequestBasic:
         """
         )
         item.session._setupstate.prepare(item)
-        pytest._fillfuncargs(item)
+        item._request._fillfixtures()
         # successively check finalization calls
         teardownlist = item.getparent(pytest.Module).obj.teardownlist
         ss = item.session._setupstate

--- a/testing/python/integration.py
+++ b/testing/python/integration.py
@@ -4,7 +4,7 @@ from _pytest import runner
 
 
 class TestOEJSKITSpecials:
-    def test_funcarg_non_pycollectobj(self, testdir):  # rough jstests usage
+    def test_funcarg_non_pycollectobj(self, testdir, recwarn):  # rough jstests usage
         testdir.makeconftest(
             """
             import pytest
@@ -34,7 +34,7 @@ class TestOEJSKITSpecials:
         pytest._fillfuncargs(clscol)
         assert clscol.funcargs["arg1"] == 42
 
-    def test_autouse_fixture(self, testdir):  # rough jstests usage
+    def test_autouse_fixture(self, testdir, recwarn):  # rough jstests usage
         testdir.makeconftest(
             """
             import pytest


### PR DESCRIPTION
This function is exposed and kept alive for the oejskit plugin which is abandoned and no longer works with recent plugins, so let's prepare to completely remove it.

Replaces #7097 with just the deprecation.