### PR TITLE
testing: avoid pytest_collect_directory message in warning summary

### DIFF
--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -223,7 +223,7 @@ class TestGeneralUsage:
             "E   {}: No module named 'qwerty'".format(exc_name),
         ]
 
-    @pytest.mark.filterwarnings("always::pytest.PytestDeprecationWarning")
+    @pytest.mark.filterwarnings("ignore::pytest.PytestDeprecationWarning")
     def test_early_skip(self, testdir):
         testdir.mkdir("xyz")
         testdir.makeconftest(


### PR DESCRIPTION
Currently this test issues a warning which is displayed in the warning summary (of pytest's own test suite):

```
  testing/acceptance_test.py::TestGeneralUsage::test_early_skip
    /tmp/pytest-of-ran/pytest-396/test_early_skip0/conftest.py:2: PytestDeprecationWarning: The pytest_collect_directory hook is not working.
    Please use collect_ignore in conftests or pytest_collection_modifyitems.
      def pytest_collect_directory():
```

I think the filter was meant to be `ignore` in the first place, and not `always` which is not a valid action AFAIK.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
