### PR TITLE
pre-commit: update flake8 3.7.7 -> 3.8.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,11 @@ repos:
         exclude: _pytest/debugging.py
         language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.7
+    rev: 3.8.1
     hooks:
     -   id: flake8
         language_version: python3
-        additional_dependencies: [flake8-typing-imports==1.3.0]
+        additional_dependencies: [flake8-typing-imports==1.9.0]
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v1.4.0
     hooks:

--- a/extra/get_issues.py
+++ b/extra/get_issues.py
@@ -45,7 +45,7 @@ def main(args):
 
 
 def _get_kind(issue):
-    labels = [l["name"] for l in issue["labels"]]
+    labels = [label["name"] for label in issue["labels"]]
     for key in ("bug", "enhancement", "proposal"):
         if key in labels:
             return key

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -277,7 +277,7 @@ class TracebackEntry:
             line = str(self.statement).lstrip()
         except KeyboardInterrupt:
             raise
-        except:  # noqa
+        except BaseException:
             line = "???"
         return "  File %r:%d in %s\n  %s\n" % (fn, self.lineno + 1, name, line)
 
@@ -667,12 +667,12 @@ class FormattedExcinfo:
             s = str(source.getstatement(len(source) - 1))
         except KeyboardInterrupt:
             raise
-        except:  # noqa
+        except BaseException:
             try:
                 s = str(source[-1])
             except KeyboardInterrupt:
                 raise
-            except:  # noqa
+            except BaseException:
                 return 0
         return 4 + (len(s) - len(s.lstrip()))
 

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -44,7 +44,7 @@ from _pytest.compat import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Type
     from typing_extensions import Literal
-    from weakref import ReferenceType  # noqa: F401
+    from weakref import ReferenceType
 
     _TracebackStyle = Literal["long", "short", "line", "no", "native"]
 

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -669,7 +669,7 @@ class SysCaptureBinary:
 
 
 class SysCapture(SysCaptureBinary):
-    EMPTY_BUFFER = ""  # type: ignore[assignment]  # noqa: F821
+    EMPTY_BUFFER = ""  # type: ignore[assignment]
 
     def snap(self):
         res = self.tmpfile.getvalue()

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -32,7 +32,7 @@ else:
 
 
 if TYPE_CHECKING:
-    from typing import Type  # noqa: F401 (used in type string)
+    from typing import Type
 
 
 _T = TypeVar("_T")

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -21,7 +21,7 @@ from _pytest.config.exceptions import UsageError
 
 if TYPE_CHECKING:
     from typing import NoReturn
-    from typing_extensions import Literal  # noqa: F401
+    from typing_extensions import Literal
 
 FILE_OR_DIR = "file_or_dir"
 

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -12,7 +12,7 @@ from _pytest.compat import TYPE_CHECKING
 from _pytest.outcomes import fail
 
 if TYPE_CHECKING:
-    from . import Config  # noqa: F401
+    from . import Config
 
 
 def exists(path, ignore=OSError):

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -338,7 +338,7 @@ class LogCaptureFixture:
         """
         :rtype: LogCaptureHandler
         """
-        return self._item.catch_log_handler  # type: ignore[no-any-return]  # noqa: F723
+        return self._item.catch_log_handler  # type: ignore[no-any-return]
 
     def get_records(self, when: str) -> List[logging.LogRecord]:
         """
@@ -354,7 +354,7 @@ class LogCaptureFixture:
         """
         handler = self._item.catch_log_handlers.get(when)
         if handler:
-            return handler.records  # type: ignore[no-any-return]  # noqa: F723
+            return handler.records  # type: ignore[no-any-return]
         else:
             return []
 
@@ -640,15 +640,15 @@ class LoggingPlugin:
                 return
 
             if not hasattr(item, "catch_log_handlers"):
-                item.catch_log_handlers = {}  # type: ignore[attr-defined]  # noqa: F821
-            item.catch_log_handlers[when] = log_handler  # type: ignore[attr-defined]  # noqa: F821
-            item.catch_log_handler = log_handler  # type: ignore[attr-defined]  # noqa: F821
+                item.catch_log_handlers = {}  # type: ignore[attr-defined]
+            item.catch_log_handlers[when] = log_handler  # type: ignore[attr-defined]
+            item.catch_log_handler = log_handler  # type: ignore[attr-defined]
             try:
                 yield  # run test
             finally:
                 if when == "teardown":
-                    del item.catch_log_handler  # type: ignore[attr-defined]  # noqa: F821
-                    del item.catch_log_handlers  # type: ignore[attr-defined]  # noqa: F821
+                    del item.catch_log_handler  # type: ignore[attr-defined]
+                    del item.catch_log_handlers  # type: ignore[attr-defined]
 
             if self.print_logs:
                 # Add a captured log section to the report.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -206,7 +206,7 @@ def wrap_session(
                     )
             config.hook.pytest_keyboard_interrupt(excinfo=excinfo)
             session.exitstatus = exitstatus
-        except:  # noqa
+        except BaseException:
             session.exitstatus = ExitCode.INTERNAL_ERROR
             excinfo = _pytest._code.ExceptionInfo.from_current()
             try:

--- a/src/_pytest/mark/legacy.py
+++ b/src/_pytest/mark/legacy.py
@@ -12,7 +12,7 @@ from _pytest.mark.expression import evaluate
 from _pytest.mark.expression import ParseError
 
 if TYPE_CHECKING:
-    from _pytest.nodes import Item  # noqa: F401 (used in type string)
+    from _pytest.nodes import Item
 
 
 @attr.s

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -33,7 +33,7 @@ from _pytest.store import Store
 
 if TYPE_CHECKING:
     # Imported here due to circular import.
-    from _pytest.main import Session  # noqa: F401
+    from _pytest.main import Session
 
 SEP = "/"
 

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -15,7 +15,7 @@ TYPE_CHECKING = False  # avoid circular import through compat
 
 if TYPE_CHECKING:
     from typing import NoReturn
-    from typing import Type  # noqa: F401 (Used in string type annotation.)
+    from typing import Type  # noqa: F401 (used in type string)
     from typing_extensions import Protocol
 else:
     # typing.Protocol is only available starting from Python 3.8. It is also

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -136,7 +136,7 @@ def pytest_cmdline_main(config):
 def pytest_generate_tests(metafunc: "Metafunc") -> None:
     for marker in metafunc.definition.iter_markers(name="parametrize"):
         # TODO: Fix this type-ignore (overlapping kwargs).
-        metafunc.parametrize(*marker.args, **marker.kwargs, _param_mark=marker)  # type: ignore[misc] # noqa: F821
+        metafunc.parametrize(*marker.args, **marker.kwargs, _param_mark=marker)  # type: ignore[misc]
 
 
 def pytest_configure(config):
@@ -1013,7 +1013,7 @@ class Metafunc:
         func_name: str,
     ) -> List[Union[None, str]]:
         try:
-            num_ids = len(ids)  # type: ignore[arg-type] # noqa: F821
+            num_ids = len(ids)  # type: ignore[arg-type]
         except TypeError:
             try:
                 iter(ids)

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -123,7 +123,7 @@ class ApproxNumpy(ApproxBase):
         if not np.isscalar(actual):
             try:
                 actual = np.asarray(actual)
-            except:  # noqa
+            except BaseException:
                 raise TypeError("cannot compare '{}' to numpy.ndarray".format(actual))
 
         if not np.isscalar(actual) and actual.shape != self.expected.shape:

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -123,8 +123,10 @@ class ApproxNumpy(ApproxBase):
         if not np.isscalar(actual):
             try:
                 actual = np.asarray(actual)
-            except BaseException:
-                raise TypeError("cannot compare '{}' to numpy.ndarray".format(actual))
+            except Exception as e:
+                raise TypeError(
+                    "cannot compare '{}' to numpy.ndarray".format(actual)
+                ) from e
 
         if not np.isscalar(actual) and actual.shape != self.expected.shape:
             return False

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -27,7 +27,7 @@ from _pytest.compat import TYPE_CHECKING
 from _pytest.outcomes import fail
 
 if TYPE_CHECKING:
-    from typing import Type  # noqa: F401 (used in type string)
+    from typing import Type
 
 
 BASE_TYPE = (type, STRING_TYPES)

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -258,7 +258,7 @@ class CallInfo:
         precise_start = perf_counter()
         try:
             result = func()
-        except:  # noqa
+        except BaseException:
             excinfo = ExceptionInfo.from_current()
             if reraise is not None and excinfo.errisinstance(reraise):
                 raise

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -151,7 +151,7 @@ class TestCaseFunction(Function):
                     fail("".join(values), pytrace=False)
                 except (fail.Exception, KeyboardInterrupt):
                     raise
-                except:  # noqa
+                except BaseException:
                     fail(
                         "ERROR: Unknown Incompatible Exception "
                         "representation:\n%r" % (rawexcinfo,),

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -239,7 +239,7 @@ class TestTraceback_f_g_h:
         def f(n: int) -> None:
             try:
                 do_stuff()
-            except:  # noqa
+            except BaseException:
                 reraise_me()
 
         excinfo = pytest.raises(RuntimeError, f, 8)
@@ -445,7 +445,7 @@ class TestFormattedExcinfo:
             exec(source.compile())
         except KeyboardInterrupt:
             raise
-        except:  # noqa
+        except BaseException:
             return _pytest._code.ExceptionInfo.from_current()
         assert 0, "did not raise"
 

--- a/testing/test_error_diffs.py
+++ b/testing/test_error_diffs.py
@@ -267,7 +267,7 @@ if sys.version_info[:2] >= (3, 7):
 
 @pytest.mark.parametrize("code, expected", TESTCASES)
 def test_error_diff(code, expected, testdir):
-    expected = [l.lstrip() for l in expected.splitlines()]
+    expected = [line.lstrip() for line in expected.splitlines()]
     p = testdir.makepyfile(code)
     result = testdir.runpytest(p, "-vv")
     result.stdout.fnmatch_lines(expected)

--- a/testing/test_setupplan.py
+++ b/testing/test_setupplan.py
@@ -101,10 +101,14 @@ def test_show_multi_test_fixture_setup_and_teardown_same_as_setup_show(testdir):
 
     # the number and text of these lines should be identical
     plan_lines = [
-        l for l in plan_result.stdout.lines if "SETUP" in l or "TEARDOWN" in l
+        line
+        for line in plan_result.stdout.lines
+        if "SETUP" in line or "TEARDOWN" in line
     ]
     show_lines = [
-        l for l in show_result.stdout.lines if "SETUP" in l or "TEARDOWN" in l
+        line
+        for line in show_result.stdout.lines
+        if "SETUP" in line or "TEARDOWN" in line
     ]
 
     assert plan_lines == show_lines


### PR DESCRIPTION
~~[flake8 3.8.0 is not released yet, only an alpha -- marked WIP until it is released officially.]~~

The new flake8 (or more correctly the pyflakes version it uses) fixes several issues that come up a lot with type annotations, so I'm eager to update so I can stop typing all of those noqa's :)