### PR TITLE
Stop using Python's eval() for -m and -k

### DIFF
--- a/changelog/7122.breaking.rst
+++ b/changelog/7122.breaking.rst
@@ -1,0 +1,3 @@
+Expressions given to the ``-m`` and ``-k`` options are no longer evaluated using Python's ``eval()``.
+The format supports ``or``, ``and``, ``not``, parenthesis and general identifiers to match against.
+Python constants, keywords or other operators are no longer evaluated differently.

--- a/doc/en/example/markers.rst
+++ b/doc/en/example/markers.rst
@@ -141,14 +141,14 @@ Or select multiple nodes:
 Using ``-k expr`` to select tests based on their name
 -------------------------------------------------------
 
-.. versionadded: 2.0/2.3.4
+.. versionadded:: 2.0/2.3.4
 
 You can use the ``-k`` command line option to specify an expression
 which implements a substring match on the test names instead of the
 exact match on markers that ``-m`` provides.  This makes it easy to
 select tests based on their names:
 
-.. versionadded: 5.4
+.. versionchanged:: 5.4
 
 The expression matching is now case-insensitive.
 
@@ -198,20 +198,8 @@ Or to select "http" and "quick" tests:
 
     ===================== 2 passed, 2 deselected in 0.12s ======================
 
-.. note::
+You can use ``and``, ``or``, ``not`` and parentheses.
 
-    If you are using expressions such as ``"X and Y"`` then both ``X`` and ``Y``
-    need to be simple non-keyword names. For example, ``"pass"`` or ``"from"``
-    will result in SyntaxErrors because ``"-k"`` evaluates the expression using
-    Python's `eval`_ function.
-
-.. _`eval`: https://docs.python.org/3.6/library/functions.html#eval
-
-
-    However, if the ``"-k"`` argument is a simple string, no such restrictions
-    apply. Also ``"-k 'not STRING'"`` has no restrictions.  You can also
-    specify numbers like ``"-k 1.3"`` to match tests which are parametrized
-    with the float ``"1.3"``.
 
 Registering markers
 -------------------------------------

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -1,0 +1,173 @@
+r"""
+Evaluate match expressions, as used by `-k` and `-m`.
+
+The grammar is:
+
+expression: expr? EOF
+expr:       and_expr ('or' and_expr)*
+and_expr:   not_expr ('and' not_expr)*
+not_expr:   'not' not_expr | '(' expr ')' | ident
+ident:      (\w|:|\+|-|\.|\[|\])+
+
+The semantics are:
+
+- Empty expression evaluates to False.
+- ident evaluates to True of False according to a provided matcher function.
+- or/and/not evaluate according to the usual boolean semantics.
+"""
+import enum
+import re
+from typing import Callable
+from typing import Iterator
+from typing import Optional
+from typing import Sequence
+
+import attr
+
+from _pytest.compat import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import NoReturn
+
+
+__all__ = [
+    "evaluate",
+    "ParseError",
+]
+
+
+class TokenType(enum.Enum):
+    LPAREN = "left parenthesis"
+    RPAREN = "right parenthesis"
+    OR = "or"
+    AND = "and"
+    NOT = "not"
+    IDENT = "identifier"
+    EOF = "end of input"
+
+
+@attr.s(frozen=True, slots=True)
+class Token:
+    type = attr.ib(type=TokenType)
+    value = attr.ib(type=str)
+    pos = attr.ib(type=int)
+
+
+class ParseError(Exception):
+    """The expression contains invalid syntax.
+
+    :param column: The column in the line where the error occurred (1-based).
+    :param message: A description of the error.
+    """
+
+    def __init__(self, column: int, message: str) -> None:
+        self.column = column
+        self.message = message
+
+    def __str__(self) -> str:
+        return "at column {}: {}".format(self.column, self.message)
+
+
+class Scanner:
+    __slots__ = ("tokens", "current")
+
+    def __init__(self, input: str) -> None:
+        self.tokens = self.lex(input)
+        self.current = next(self.tokens)
+
+    def lex(self, input: str) -> Iterator[Token]:
+        pos = 0
+        while pos < len(input):
+            if input[pos] in (" ", "\t"):
+                pos += 1
+            elif input[pos] == "(":
+                yield Token(TokenType.LPAREN, "(", pos)
+                pos += 1
+            elif input[pos] == ")":
+                yield Token(TokenType.RPAREN, ")", pos)
+                pos += 1
+            else:
+                match = re.match(r"(:?\w|:|\+|-|\.|\[|\])+", input[pos:])
+                if match:
+                    value = match.group(0)
+                    if value == "or":
+                        yield Token(TokenType.OR, value, pos)
+                    elif value == "and":
+                        yield Token(TokenType.AND, value, pos)
+                    elif value == "not":
+                        yield Token(TokenType.NOT, value, pos)
+                    else:
+                        yield Token(TokenType.IDENT, value, pos)
+                    pos += len(value)
+                else:
+                    raise ParseError(
+                        pos + 1, 'unexpected character "{}"'.format(input[pos]),
+                    )
+        yield Token(TokenType.EOF, "", pos)
+
+    def accept(self, type: TokenType, *, reject: bool = False) -> Optional[Token]:
+        if self.current.type is type:
+            token = self.current
+            if token.type is not TokenType.EOF:
+                self.current = next(self.tokens)
+            return token
+        if reject:
+            self.reject((type,))
+        return None
+
+    def reject(self, expected: Sequence[TokenType]) -> "NoReturn":
+        raise ParseError(
+            self.current.pos + 1,
+            "expected {}; got {}".format(
+                " OR ".join(type.value for type in expected), self.current.type.value,
+            ),
+        )
+
+
+def expression(s: Scanner, matcher: Callable[[str], bool]) -> bool:
+    if s.accept(TokenType.EOF):
+        return False
+    ret = expr(s, matcher)
+    s.accept(TokenType.EOF, reject=True)
+    return ret
+
+
+def expr(s: Scanner, matcher: Callable[[str], bool]) -> bool:
+    ret = and_expr(s, matcher)
+    while s.accept(TokenType.OR):
+        rhs = and_expr(s, matcher)
+        ret = ret or rhs
+    return ret
+
+
+def and_expr(s: Scanner, matcher: Callable[[str], bool]) -> bool:
+    ret = not_expr(s, matcher)
+    while s.accept(TokenType.AND):
+        rhs = not_expr(s, matcher)
+        ret = ret and rhs
+    return ret
+
+
+def not_expr(s: Scanner, matcher: Callable[[str], bool]) -> bool:
+    if s.accept(TokenType.NOT):
+        return not not_expr(s, matcher)
+    if s.accept(TokenType.LPAREN):
+        ret = expr(s, matcher)
+        s.accept(TokenType.RPAREN, reject=True)
+        return ret
+    ident = s.accept(TokenType.IDENT)
+    if ident:
+        return matcher(ident.value)
+    s.reject((TokenType.NOT, TokenType.LPAREN, TokenType.IDENT))
+
+
+def evaluate(input: str, matcher: Callable[[str], bool]) -> bool:
+    """Evaluate a match expression as used by -k and -m.
+
+    :param input: The input expression - one line.
+    :param matcher: Given an identifier, should return whether it matches or not.
+                    Should be prepared to handle arbitrary strings as input.
+
+    Returns whether the entire expression matches or not.
+    """
+    return expression(Scanner(input), matcher)

--- a/testing/test_mark_expression.py
+++ b/testing/test_mark_expression.py
@@ -1,0 +1,162 @@
+import pytest
+from _pytest.mark.expression import evaluate
+from _pytest.mark.expression import ParseError
+
+
+def test_empty_is_false() -> None:
+    assert not evaluate("", lambda ident: False)
+    assert not evaluate("", lambda ident: True)
+    assert not evaluate("   ", lambda ident: False)
+    assert not evaluate("\t", lambda ident: False)
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected"),
+    (
+        ("true", True),
+        ("true", True),
+        ("false", False),
+        ("not true", False),
+        ("not false", True),
+        ("not not true", True),
+        ("not not false", False),
+        ("true and true", True),
+        ("true and false", False),
+        ("false and true", False),
+        ("true and true and true", True),
+        ("true and true and false", False),
+        ("true and true and not true", False),
+        ("false or false", False),
+        ("false or true", True),
+        ("true or true", True),
+        ("true or true or false", True),
+        ("true and true or false", True),
+        ("not true or true", True),
+        ("(not true) or true", True),
+        ("not (true or true)", False),
+        ("true and true or false and false", True),
+        ("true and (true or false) and false", False),
+        ("true and (true or (not (not false))) and false", False),
+    ),
+)
+def test_basic(expr: str, expected: bool) -> None:
+    matcher = {"true": True, "false": False}.__getitem__
+    assert evaluate(expr, matcher) is expected
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected"),
+    (
+        ("               true           ", True),
+        ("               ((((((true))))))           ", True),
+        ("     (         ((\t  (((true)))))  \t   \t)", True),
+        ("(     true     and   (((false))))", False),
+        ("not not not not true", True),
+        ("not not not not not true", False),
+    ),
+)
+def test_syntax_oddeties(expr: str, expected: bool) -> None:
+    matcher = {"true": True, "false": False}.__getitem__
+    assert evaluate(expr, matcher) is expected
+
+
+@pytest.mark.parametrize(
+    ("expr", "column", "message"),
+    (
+        ("(", 2, "expected not OR left parenthesis OR identifier; got end of input"),
+        (" (", 3, "expected not OR left parenthesis OR identifier; got end of input",),
+        (
+            ")",
+            1,
+            "expected not OR left parenthesis OR identifier; got right parenthesis",
+        ),
+        (
+            ") ",
+            1,
+            "expected not OR left parenthesis OR identifier; got right parenthesis",
+        ),
+        ("not", 4, "expected not OR left parenthesis OR identifier; got end of input",),
+        (
+            "not not",
+            8,
+            "expected not OR left parenthesis OR identifier; got end of input",
+        ),
+        (
+            "(not)",
+            5,
+            "expected not OR left parenthesis OR identifier; got right parenthesis",
+        ),
+        ("and", 1, "expected not OR left parenthesis OR identifier; got and"),
+        (
+            "ident and",
+            10,
+            "expected not OR left parenthesis OR identifier; got end of input",
+        ),
+        ("ident and or", 11, "expected not OR left parenthesis OR identifier; got or",),
+        ("ident ident", 7, "expected end of input; got identifier"),
+    ),
+)
+def test_syntax_errors(expr: str, column: int, message: str) -> None:
+    with pytest.raises(ParseError) as excinfo:
+        evaluate(expr, lambda ident: True)
+    assert excinfo.value.column == column
+    assert excinfo.value.message == message
+
+
+@pytest.mark.parametrize(
+    "ident",
+    (
+        ".",
+        "...",
+        ":::",
+        "a:::c",
+        "a+-b",
+        "אבגד",
+        "aaאבגדcc",
+        "a[bcd]",
+        "1234",
+        "1234abcd",
+        "1234and",
+        "notandor",
+        "not_and_or",
+        "not[and]or",
+        "1234+5678",
+        "123.232",
+        "True",
+        "False",
+        "if",
+        "else",
+        "while",
+    ),
+)
+def test_valid_idents(ident: str) -> None:
+    assert evaluate(ident, {ident: True}.__getitem__)
+
+
+@pytest.mark.parametrize(
+    "ident",
+    (
+        "/",
+        "\\",
+        "^",
+        "*",
+        "=",
+        "&",
+        "%",
+        "$",
+        "#",
+        "@",
+        "!",
+        "~",
+        "{",
+        "}",
+        '"',
+        "'",
+        "|",
+        ";",
+        "←",
+    ),
+)
+def test_invalid_idents(ident: str) -> None:
+    with pytest.raises(ParseError):
+        evaluate(ident, lambda ident: True)


### PR DESCRIPTION
Previously, the expressions given to the `-m` and `-k` options were evaluated with `eval`. This causes a few issues:

- Python keywords cannot be used.

- Constants like numbers, None, True, False are not handled correctly.

- Various syntax like numeric operators and `X if Y else Z` is supported
  unintentionally.

- `eval()` is somewhat dangerous for arbitrary input.

- Can fail in many ways so requires `except Exception`.

The format we want to support is quite simple, so change to a custom parser. This fixes the issues above, and gives us full control of the format, so can be documented comprehensively and even be extended in the future if we wish.

Fixes #1141.
Fixes #3573.
Fixes #5881.
Fixes #6822.
Fixes #7112.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
