### PR TITLE
testing: fix warning issued by test_cache_writefail_cachfile_silent

### DIFF
--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -31,7 +31,7 @@ class TestNewAPI:
         val = config.cache.get("key/name", -2)
         assert val == -2
 
-    @pytest.mark.filterwarnings("default")
+    @pytest.mark.filterwarnings("ignore:could not create cache path")
     def test_cache_writefail_cachfile_silent(self, testdir):
         testdir.makeini("[pytest]")
         testdir.tmpdir.join(".pytest_cache").write("gone wrong")


### PR DESCRIPTION
Remove this message from the warning summary of pytest's own testsuite:

    testing/test_cacheprovider.py::TestNewAPI::test_cache_writefail_cachfile_silent
      testing/test_cacheprovider.py:40: PytestCacheWarning: could not create cache path /tmp/pytest-of-ran/pytest-2/test_cache_writefail_cachfile_silent0/.pytest_cache/v/test/broken
        cache.set("test/broken", [])

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
