### PR TITLE
cacheprovider: speed up NFPlugin when --nf is not enabled

### DIFF
--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -74,7 +74,7 @@ class TestNewAPI:
                     "*/cacheprovider.py:*",
                     "  */cacheprovider.py:*: PytestCacheWarning: could not create cache path "
                     "{}/v/cache/nodeids".format(cache_dir),
-                    '    config.cache.set("cache/nodeids", self.cached_nodeids)',
+                    '    config.cache.set("cache/nodeids", sorted(self.cached_nodeids))',
                     "*1 failed, 3 warnings in*",
                 ]
             )


### PR DESCRIPTION
The code used an O(n^2) loop. Replace list with set to make it O(n).

For backward compatibility the filesystem cache still remains a list.

On this test:

    import pytest
    @pytest.mark.parametrize("x", range(5000))
    def test_foo(x): pass

run with `pytest --collect-only`:

Before: 0m1.251s
After:  0m0.921s

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
