### PR TITLE
[WIP] Correct weird output in long string assertions

### DIFF
--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -67,7 +67,7 @@ def safeformat(obj: Any) -> str:
     with a short exception info.
     """
     try:
-        return pprint.pformat(obj)
+        return repr(obj)
     except Exception as exc:
         return _format_repr_exception(exc, obj)
 

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -67,7 +67,7 @@ def safeformat(obj: Any) -> str:
     with a short exception info.
     """
     try:
-        return pprint.pformat(obj, width=1_000_000)
+        return pprint.pformat(obj, width=1000000)
     except Exception as exc:
         return _format_repr_exception(exc, obj)
 

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -67,7 +67,7 @@ def safeformat(obj: Any) -> str:
     with a short exception info.
     """
     try:
-        return repr(obj)
+        return pprint.pformat(obj, width=1_000_000)
     except Exception as exc:
         return _format_repr_exception(exc, obj)
 

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1044,12 +1044,12 @@ class TestTruncateExplanation:
         result.stdout.fnmatch_lines(["* 6*"])
 
     @pytest.mark.parametrize(
-        argnames=['n'],
+        argnames=["n"],
         argvalues=[[26], [27]],
     )
     def test_more_than_52_not_garbage(self, n, monkeypatch, testdir):
-        a = 'a\n' * n
-        b = 'b\n' * n
+        a = "a\n" * n
+        b = "b\n" * n
 
         testdir.makepyfile(
             r"""
@@ -1057,11 +1057,13 @@ class TestTruncateExplanation:
                 a = {a!r}
                 b = {b!r}
                 assert a == b
-        """.format(a=a, b=b)
+        """.format(
+                a=a, b=b
+            )
         )
         monkeypatch.delenv("CI", raising=False)
 
-        result = testdir.runpytest('-vv')
+        result = testdir.runpytest("-vv")
 
         assert any(
             "AssertionError: assert {a!r} == {b!r}".format(a=a, b=b) in line

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1044,8 +1044,7 @@ class TestTruncateExplanation:
         result.stdout.fnmatch_lines(["* 6*"])
 
     @pytest.mark.parametrize(
-        argnames=["n"],
-        argvalues=[[26], [27]],
+        argnames=["n"], argvalues=[[26], [27]],
     )
     def test_more_than_52_not_garbage(self, n, monkeypatch, testdir):
         a = "a\n" * n


### PR DESCRIPTION
#7127

WIP for:
- [ ] a fix...
- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.