### PR TITLE
Allow tests to override "global" `log_level`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -237,6 +237,7 @@ Romain Dorgueil
 Roman Bolshakov
 Ronny Pfannschmidt
 Ross Lawley
+Ruaridh Williamson
 Russel Winder
 Ryan Wooden
 Samuel Dion-Girardeau

--- a/changelog/7133.improvement.rst
+++ b/changelog/7133.improvement.rst
@@ -1,0 +1,1 @@
+``caplog.set_level()`` will now override any :confval:`log_level` set via the CLI or ``.ini``.

--- a/doc/en/logging.rst
+++ b/doc/en/logging.rst
@@ -250,6 +250,9 @@ made in ``3.4`` after community feedback:
 
 * Log levels are no longer changed unless explicitly requested by the :confval:`log_level` configuration
   or ``--log-level`` command-line options. This allows users to configure logger objects themselves.
+  Setting :confval:`log_level` will set the level that is captured globally so if a specific test requires
+  a lower level than this, use the ``caplog.set_level()`` functionality otherwise that test will be prone to
+  failure.
 * :ref:`Live Logs <live_logs>` is now disabled by default and can be enabled setting the
   :confval:`log_cli` configuration option to ``true``. When enabled, the verbosity is increased so logging for each
   test is visible.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -321,7 +321,8 @@ class LogCaptureFixture:
         """Creates a new funcarg."""
         self._item = item
         # dict of log name -> log level
-        self._initial_log_levels = {}  # type: Dict[str, int]
+        self._initial_logger_levels = {}  # type: Dict[str, int]
+        self._initial_handler_level = None  # type: Optional[int]
 
     def _finalize(self) -> None:
         """Finalizes the fixture.
@@ -329,7 +330,10 @@ class LogCaptureFixture:
         This restores the log levels changed by :meth:`set_level`.
         """
         # restore log levels
-        for logger_name, level in self._initial_log_levels.items():
+        if self._initial_handler_level is not None:
+            self.handler.setLevel(self._initial_handler_level)
+
+        for logger_name, level in self._initial_logger_levels.items():
             logger = logging.getLogger(logger_name)
             logger.setLevel(level)
 
@@ -413,8 +417,10 @@ class LogCaptureFixture:
         logger_name = logger
         logger = logging.getLogger(logger_name)
         # save the original log-level to restore it during teardown
-        self._initial_log_levels.setdefault(logger_name, logger.level)
+        self._initial_logger_levels.setdefault(logger_name, logger.level)
         logger.setLevel(level)
+        self._initial_handler_level = self.handler.level
+        self.handler.setLevel(level)
 
     @contextmanager
     def at_level(self, level, logger=None):
@@ -427,10 +433,13 @@ class LogCaptureFixture:
         logger = logging.getLogger(logger)
         orig_level = logger.level
         logger.setLevel(level)
+        handler_orig_level = self.handler.level
+        self.handler.setLevel(level)
         try:
             yield
         finally:
             logger.setLevel(orig_level)
+            self.handler.setLevel(handler_orig_level)
 
 
 @pytest.fixture

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -322,7 +322,6 @@ class LogCaptureFixture:
         self._item = item
         # dict of log name -> log level
         self._initial_logger_levels = {}  # type: Dict[str, int]
-        self._initial_handler_level = None  # type: Optional[int]
 
     def _finalize(self) -> None:
         """Finalizes the fixture.
@@ -330,9 +329,6 @@ class LogCaptureFixture:
         This restores the log levels changed by :meth:`set_level`.
         """
         # restore log levels
-        if self._initial_handler_level is not None:
-            self.handler.setLevel(self._initial_handler_level)
-
         for logger_name, level in self._initial_logger_levels.items():
             logger = logging.getLogger(logger_name)
             logger.setLevel(level)
@@ -419,7 +415,6 @@ class LogCaptureFixture:
         # save the original log-level to restore it during teardown
         self._initial_logger_levels.setdefault(logger_name, logger.level)
         logger.setLevel(level)
-        self._initial_handler_level = self.handler.level
         self.handler.setLevel(level)
 
     @contextmanager

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -147,8 +147,9 @@ def test_ini_controls_global_log_level(testdir):
         def test_log_level_override(request, caplog):
             plugin = request.config.pluginmanager.getplugin('logging-plugin')
             assert plugin.log_level == logging.ERROR
-            logging.getLogger('catchlog').warning("WARNING message won't be shown")
-            logging.getLogger('catchlog').error("ERROR message will be shown")
+            logger = logging.getLogger('catchlog')
+            logger.warning("WARNING message won't be shown")
+            logger.error("ERROR message will be shown")
             assert 'WARNING' not in caplog.text
             assert 'ERROR' in caplog.text
     """
@@ -171,24 +172,24 @@ def test_caplog_can_override_global_log_level(testdir):
         import pytest
         import logging
         def test_log_level_override(request, caplog):
-            logger = 'catchlog'
+            logger = logging.getLogger('catchlog')
             plugin = request.config.pluginmanager.getplugin('logging-plugin')
             assert plugin.log_level == logging.WARNING
 
-            logging.getLogger(logger).info("INFO message won't be shown")
+            logger.info("INFO message won't be shown")
 
-            caplog.set_level(logging.INFO, logger)
+            caplog.set_level(logging.INFO, logger.name)
 
-            with caplog.at_level(logging.DEBUG, logger):
-                logging.getLogger(logger).debug("DEBUG message will be shown")
+            with caplog.at_level(logging.DEBUG, logger.name):
+                logger.debug("DEBUG message will be shown")
 
-            logging.getLogger(logger).debug("DEBUG message won't be shown")
+            logger.debug("DEBUG message won't be shown")
 
-            with caplog.at_level(logging.CRITICAL, logger):
-                logging.getLogger(logger).warning("WARNING message won't be shown")
+            with caplog.at_level(logging.CRITICAL, logger.name):
+                logger.warning("WARNING message won't be shown")
 
-            logging.getLogger(logger).debug("DEBUG message won't be shown")
-            logging.getLogger(logger).info("INFO message will be shown")
+            logger.debug("DEBUG message won't be shown")
+            logger.info("INFO message will be shown")
 
             assert "message won't be shown" not in caplog.text
     """

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -137,3 +137,68 @@ def test_caplog_captures_for_all_stages(caplog, logging_during_setup_and_teardow
 
     # This reaches into private API, don't use this type of thing in real tests!
     assert set(caplog._item.catch_log_handlers.keys()) == {"setup", "call"}
+
+
+def test_ini_controls_global_log_level(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        import logging
+        def test_log_level_override(request, caplog):
+            plugin = request.config.pluginmanager.getplugin('logging-plugin')
+            assert plugin.log_level == logging.ERROR
+            logging.getLogger('catchlog').warning("WARNING message won't be shown")
+            logging.getLogger('catchlog').error("ERROR message will be shown")
+            assert 'WARNING' not in caplog.text
+            assert 'ERROR' in caplog.text
+    """
+    )
+    testdir.makeini(
+        """
+        [pytest]
+        log_level=ERROR
+    """
+    )
+
+    result = testdir.runpytest()
+    # make sure that that we get a '0' exit code for the testsuite
+    assert result.ret == 0
+
+
+def test_caplog_can_override_global_log_level(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        import logging
+        def test_log_level_override(request, caplog):
+            logger = 'catchlog'
+            plugin = request.config.pluginmanager.getplugin('logging-plugin')
+            assert plugin.log_level == logging.WARNING
+
+            logging.getLogger(logger).info("INFO message won't be shown")
+
+            caplog.set_level(logging.INFO, logger)
+
+            with caplog.at_level(logging.DEBUG, logger):
+                logging.getLogger(logger).debug("DEBUG message will be shown")
+
+            logging.getLogger(logger).debug("DEBUG message won't be shown")
+
+            with caplog.at_level(logging.CRITICAL, logger):
+                logging.getLogger(logger).warning("WARNING message won't be shown")
+
+            logging.getLogger(logger).debug("DEBUG message won't be shown")
+            logging.getLogger(logger).info("INFO message will be shown")
+
+            assert "message won't be shown" not in caplog.text
+    """
+    )
+    testdir.makeini(
+        """
+        [pytest]
+        log_level=WARNING
+    """
+    )
+
+    result = testdir.runpytest()
+    assert result.ret == 0

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -203,3 +203,34 @@ def test_caplog_can_override_global_log_level(testdir):
 
     result = testdir.runpytest()
     assert result.ret == 0
+
+
+def test_caplog_captures_despite_exception(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        import logging
+        def test_log_level_override(request, caplog):
+            logger = logging.getLogger('catchlog')
+            plugin = request.config.pluginmanager.getplugin('logging-plugin')
+            assert plugin.log_level == logging.WARNING
+
+            logger.info("INFO message won't be shown")
+
+            caplog.set_level(logging.INFO, logger.name)
+
+            with caplog.at_level(logging.DEBUG, logger.name):
+                logger.debug("DEBUG message will be shown")
+                raise Exception()
+    """
+    )
+    testdir.makeini(
+        """
+        [pytest]
+        log_level=WARNING
+    """
+    )
+
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(["*DEBUG message will be shown*"])
+    assert result.ret == 1


### PR DESCRIPTION
- Setting `log_level` via the CLI or `.ini` will control the "global" handler's log level
- This means any tests that rely on a lower level, cannot access those logs even if they wanted to
- It seems reasonable to set a "default" via the `.ini` but that the final say is given to `caplog`
- Fixes #7133

#### PR Checklist
- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Add yourself to `AUTHORS` in alphabetical order.
