### PR TITLE
Let unittest frameworks deal with async functions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
           - name: "windows-py38"
             python: "3.8"
             os: windows-latest
-            tox_env: "py38-twisted"
+            tox_env: "py38-unittestextras"
             use_coverage: true
 
           - name: "ubuntu-py35"

--- a/changelog/7110.bugfix.rst
+++ b/changelog/7110.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed regression: ``asyncbase.TestCase`` tests are executed correctly again.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -93,6 +93,13 @@ def iscoroutinefunction(func: object) -> bool:
     return inspect.iscoroutinefunction(func) or getattr(func, "_is_coroutine", False)
 
 
+def is_async_function(func: object) -> bool:
+    """Return True if the given function seems to be an async function or async generator"""
+    return iscoroutinefunction(func) or (
+        sys.version_info >= (3, 6) and inspect.isasyncgenfunction(func)
+    )
+
+
 def getlocation(function, curdir=None) -> str:
     function = get_real_func(function)
     fn = py.path.local(inspect.getfile(function))

--- a/testing/example_scripts/unittest/test_unittest_asyncio.py
+++ b/testing/example_scripts/unittest/test_unittest_asyncio.py
@@ -1,7 +1,13 @@
 from unittest import IsolatedAsyncioTestCase  # type: ignore
 
 
+teardowns = []
+
+
 class AsyncArguments(IsolatedAsyncioTestCase):
+    async def asyncTearDown(self):
+        teardowns.append(None)
+
     async def test_something_async(self):
         async def addition(x, y):
             return x + y
@@ -13,3 +19,6 @@ class AsyncArguments(IsolatedAsyncioTestCase):
             return x + y
 
         self.assertEqual(await addition(2, 2), 3)
+
+    def test_teardowns(self):
+        assert len(teardowns) == 2

--- a/testing/example_scripts/unittest/test_unittest_asynctest.py
+++ b/testing/example_scripts/unittest/test_unittest_asynctest.py
@@ -1,0 +1,22 @@
+"""Issue #7110"""
+import asyncio
+
+import asynctest
+
+
+teardowns = []
+
+
+class Test(asynctest.TestCase):
+    async def tearDown(self):
+        teardowns.append(None)
+
+    async def test_error(self):
+        await asyncio.sleep(0)
+        self.fail("failing on purpose")
+
+    async def test_ok(self):
+        await asyncio.sleep(0)
+
+    def test_teardowns(self):
+        assert len(teardowns) == 2

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1136,4 +1136,13 @@ def test_async_support(testdir):
 
     testdir.copy_example("unittest/test_unittest_asyncio.py")
     reprec = testdir.inline_run()
-    reprec.assertoutcome(failed=1, passed=1)
+    reprec.assertoutcome(failed=1, passed=2)
+
+
+def test_asynctest_support(testdir):
+    """Check asynctest support (#7110)"""
+    pytest.importorskip("asynctest")
+
+    testdir.copy_example("unittest/test_unittest_asynctest.py")
+    reprec = testdir.inline_run()
+    reprec.assertoutcome(failed=1, passed=2)

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist =
     py37
     py38
     pypy3
-    py37-{pexpect,xdist,twisted,numpy,pluggymaster}
+    py37-{pexpect,xdist,unittestextras,numpy,pluggymaster}
     doctesting
     py37-freeze
     docs
@@ -49,7 +49,8 @@ deps =
     pexpect: pexpect
     pluggymaster: git+https://github.com/pytest-dev/pluggy.git@master
     pygments
-    twisted: twisted
+    unittestextras: twisted
+    unittestextras: asynctest
     xdist: pytest-xdist>=1.13
     {env:_PYTEST_TOX_EXTRA_DEP:}
 


### PR DESCRIPTION
Instead of trying to handle unittest-async functions in `pytest_pyfunc_call`,
let the `unittest` framework handle them instead.

This lets us remove the hack in `pytest_pyfunc_call`, with the upside that
we should support any unittest-async based framework.

Also included `asynctest` as test dependency for `py37-twisted`, and renamed
`twisted` to `unittestextras` to better reflect that we install `twisted` and
`asynctest` now instead of only `twisted`.

This also fixes the problem of cleanUp functions not being properly called for async functions.

Fix #7110
Fix #6924