### PR TITLE
7018: Use internal version of make_numbered_dir

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -150,6 +150,7 @@ Karl O. Pinc
 Katarzyna Jachim
 Katarzyna Król
 Katerina Koukiou
+Keri Volans
 Kevin Cox
 Kevin J. Foley
 Kodi B. Arfer

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -35,6 +35,7 @@ from _pytest.main import Session
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.nodes import Collector
 from _pytest.nodes import Item
+from _pytest.pathlib import make_numbered_dir
 from _pytest.pathlib import Path
 from _pytest.python import Module
 from _pytest.reports import TestReport
@@ -1256,9 +1257,7 @@ class Testdir:
         Returns a :py:class:`RunResult`.
         """
         __tracebackhide__ = True
-        p = py.path.local.make_numbered_dir(
-            prefix="runpytest-", keep=None, rootdir=self.tmpdir
-        )
+        p = make_numbered_dir(root=Path(self.tmpdir), prefix="runpytest-")
         args = ("--basetemp=%s" % p,) + args
         plugins = [x for x in self.plugins if isinstance(x, str)]
         if plugins:

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -10,8 +10,6 @@ import textwrap
 import zipfile
 from functools import partial
 
-import py
-
 import _pytest._code
 import pytest
 from _pytest.assertion import util
@@ -22,6 +20,7 @@ from _pytest.assertion.rewrite import PYC_TAIL
 from _pytest.assertion.rewrite import PYTEST_TAG
 from _pytest.assertion.rewrite import rewrite_asserts
 from _pytest.config import ExitCode
+from _pytest.pathlib import make_numbered_dir
 from _pytest.pathlib import Path
 
 
@@ -822,9 +821,7 @@ def test_rewritten():
                 "hello"
                 assert test_optimized.__doc__ is None"""
         )
-        p = py.path.local.make_numbered_dir(
-            prefix="runpytest-", keep=None, rootdir=testdir.tmpdir
-        )
+        p = make_numbered_dir(root=Path(testdir.tmpdir), prefix="runpytest-")
         tmp = "--basetemp=%s" % p
         monkeypatch.setenv("PYTHONOPTIMIZE", "2")
         monkeypatch.delenv("PYTHONDONTWRITEBYTECODE", raising=False)


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X ] Include documentation when adding new features.
- [ X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X ] Add yourself to `AUTHORS` in alphabetical order.
-->

Fixes #7018

No changelog as it's trivial, but happy to add if you like. 
e.g.
"Replace usage of py.path.local.make_numbered_dir with version from _pytest.pathlib"
