### PR TITLE
Remove blueyed from TIDELIFT

### DIFF
--- a/TIDELIFT.rst
+++ b/TIDELIFT.rst
@@ -23,7 +23,7 @@ members of the `contributors team`_ interested in receiving funding.
 
 The current list of contributors receiving funding are:
 
-* `@blueyed`_
+*
 
 Contributors interested in receiving a part of the funds just need to submit a PR adding their
 name to the list. Contributors that want to stop receiving the funds should also submit a PR
@@ -53,5 +53,4 @@ funds. Just drop a line to one of the `@pytest-dev/tidelift-admins`_ or use the 
 .. _`@pytest-dev/tidelift-admins`: https://github.com/orgs/pytest-dev/teams/tidelift-admins/members
 .. _`agreement`: https://tidelift.com/docs/lifting/agreement
 
-.. _`@blueyed`: https://github.com/blueyed
 .. _`@nicoddemus`: https://github.com/nicoddemus


### PR DESCRIPTION
@blueyed is no longer a member of the pytest-dev organization.