### PR TITLE
Separate log report from caplog

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -237,6 +237,7 @@ Romain Dorgueil
 Roman Bolshakov
 Ronny Pfannschmidt
 Ross Lawley
+Ruaridh Williamson
 Russel Winder
 Ryan Wooden
 Samuel Dion-Girardeau

--- a/changelog/7133.improvement.rst
+++ b/changelog/7133.improvement.rst
@@ -1,0 +1,1 @@
+``caplog.set_level()`` will now override any :confval:`log_level` set via the CLI or ``.ini``.

--- a/doc/en/logging.rst
+++ b/doc/en/logging.rst
@@ -250,6 +250,9 @@ made in ``3.4`` after community feedback:
 
 * Log levels are no longer changed unless explicitly requested by the :confval:`log_level` configuration
   or ``--log-level`` command-line options. This allows users to configure logger objects themselves.
+  Setting :confval:`log_level` will set the level that is captured globally so if a specific test requires
+  a lower level than this, use the ``caplog.set_level()`` functionality otherwise that test will be prone to
+  failure.
 * :ref:`Live Logs <live_logs>` is now disabled by default and can be enabled setting the
   :confval:`log_cli` configuration option to ``true``. When enabled, the verbosity is increased so logging for each
   test is visible.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -321,7 +321,8 @@ class LogCaptureFixture:
         """Creates a new funcarg."""
         self._item = item
         # dict of log name -> log level
-        self._initial_log_levels = {}  # type: Dict[str, int]
+        self._initial_logger_levels = {}  # type: Dict[str, int]
+        self._initial_handler_level = None  # type: Optional[int]
 
     def _finalize(self) -> None:
         """Finalizes the fixture.
@@ -329,7 +330,10 @@ class LogCaptureFixture:
         This restores the log levels changed by :meth:`set_level`.
         """
         # restore log levels
-        for logger_name, level in self._initial_log_levels.items():
+        if self._initial_handler_level is not None:
+            self.handler.setLevel(self._initial_handler_level)
+
+        for logger_name, level in self._initial_logger_levels.items():
             logger = logging.getLogger(logger_name)
             logger.setLevel(level)
 
@@ -413,8 +417,10 @@ class LogCaptureFixture:
         logger_name = logger
         logger = logging.getLogger(logger_name)
         # save the original log-level to restore it during teardown
-        self._initial_log_levels.setdefault(logger_name, logger.level)
+        self._initial_logger_levels.setdefault(logger_name, logger.level)
         logger.setLevel(level)
+        self._initial_handler_level = self.handler.level
+        self.handler.setLevel(level)
 
     @contextmanager
     def at_level(self, level, logger=None):
@@ -427,10 +433,13 @@ class LogCaptureFixture:
         logger = logging.getLogger(logger)
         orig_level = logger.level
         logger.setLevel(level)
+        handler_orig_level = self.handler.level
+        self.handler.setLevel(level)
         try:
             yield
         finally:
             logger.setLevel(orig_level)
+            self.handler.setLevel(handler_orig_level)
 
 
 @pytest.fixture

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -635,7 +635,9 @@ class LoggingPlugin:
         """Implements the internals of pytest_runtest_xxx() hook."""
         with catching_logs(
             LogCaptureHandler(), formatter=self.formatter, level=self.log_level
-        ) as log_handler:
+        ) as caplog_handler, catching_logs(
+            LogCaptureHandler(), formatter=self.formatter, level=self.log_level
+        ) as report_handler:
             if self.log_cli_handler:
                 self.log_cli_handler.set_when(when)
 
@@ -645,8 +647,8 @@ class LoggingPlugin:
 
             if not hasattr(item, "catch_log_handlers"):
                 item.catch_log_handlers = {}  # type: ignore[attr-defined]  # noqa: F821
-            item.catch_log_handlers[when] = log_handler  # type: ignore[attr-defined]  # noqa: F821
-            item.catch_log_handler = log_handler  # type: ignore[attr-defined]  # noqa: F821
+            item.catch_log_handlers[when] = caplog_handler  # type: ignore[attr-defined]  # noqa: F821
+            item.catch_log_handler = caplog_handler  # type: ignore[attr-defined]  # noqa: F821
             try:
                 yield  # run test
             finally:
@@ -656,7 +658,7 @@ class LoggingPlugin:
 
             if self.print_logs:
                 # Add a captured log section to the report.
-                log = log_handler.stream.getvalue().strip()
+                log = report_handler.stream.getvalue().strip()
                 item.add_report_section(when, "log", log)
 
     @pytest.hookimpl(hookwrapper=True)

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -322,7 +322,6 @@ class LogCaptureFixture:
         self._item = item
         # dict of log name -> log level
         self._initial_logger_levels = {}  # type: Dict[str, int]
-        self._initial_handler_level = None  # type: Optional[int]
 
     def _finalize(self) -> None:
         """Finalizes the fixture.
@@ -330,9 +329,6 @@ class LogCaptureFixture:
         This restores the log levels changed by :meth:`set_level`.
         """
         # restore log levels
-        if self._initial_handler_level is not None:
-            self.handler.setLevel(self._initial_handler_level)
-
         for logger_name, level in self._initial_logger_levels.items():
             logger = logging.getLogger(logger_name)
             logger.setLevel(level)
@@ -419,7 +415,6 @@ class LogCaptureFixture:
         # save the original log-level to restore it during teardown
         self._initial_logger_levels.setdefault(logger_name, logger.level)
         logger.setLevel(level)
-        self._initial_handler_level = self.handler.level
         self.handler.setLevel(level)
 
     @contextmanager

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -147,8 +147,9 @@ def test_ini_controls_global_log_level(testdir):
         def test_log_level_override(request, caplog):
             plugin = request.config.pluginmanager.getplugin('logging-plugin')
             assert plugin.log_level == logging.ERROR
-            logging.getLogger('catchlog').warning("WARNING message won't be shown")
-            logging.getLogger('catchlog').error("ERROR message will be shown")
+            logger = logging.getLogger('catchlog')
+            logger.warning("WARNING message won't be shown")
+            logger.error("ERROR message will be shown")
             assert 'WARNING' not in caplog.text
             assert 'ERROR' in caplog.text
     """
@@ -171,24 +172,24 @@ def test_caplog_can_override_global_log_level(testdir):
         import pytest
         import logging
         def test_log_level_override(request, caplog):
-            logger = 'catchlog'
+            logger = logging.getLogger('catchlog')
             plugin = request.config.pluginmanager.getplugin('logging-plugin')
             assert plugin.log_level == logging.WARNING
 
-            logging.getLogger(logger).info("INFO message won't be shown")
+            logger.info("INFO message won't be shown")
 
-            caplog.set_level(logging.INFO, logger)
+            caplog.set_level(logging.INFO, logger.name)
 
-            with caplog.at_level(logging.DEBUG, logger):
-                logging.getLogger(logger).debug("DEBUG message will be shown")
+            with caplog.at_level(logging.DEBUG, logger.name):
+                logger.debug("DEBUG message will be shown")
 
-            logging.getLogger(logger).debug("DEBUG message won't be shown")
+            logger.debug("DEBUG message won't be shown")
 
-            with caplog.at_level(logging.CRITICAL, logger):
-                logging.getLogger(logger).warning("WARNING message won't be shown")
+            with caplog.at_level(logging.CRITICAL, logger.name):
+                logger.warning("WARNING message won't be shown")
 
-            logging.getLogger(logger).debug("DEBUG message won't be shown")
-            logging.getLogger(logger).info("INFO message will be shown")
+            logger.debug("DEBUG message won't be shown")
+            logger.info("INFO message will be shown")
 
             assert "message won't be shown" not in caplog.text
     """

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -233,3 +233,43 @@ def test_caplog_captures_despite_exception(testdir):
     result.stdout.fnmatch_lines(["*ERROR message will be shown*"])
     result.stdout.no_fnmatch_line("*DEBUG message won't be shown*")
     assert result.ret == 1
+
+
+def test_log_report_captures_according_to_config_option_upon_failure(testdir):
+    """ Test that upon failure:
+    (1) `caplog` succeeded to capture the DEBUG message and assert on it => No `Exception` is raised
+    (2) The `DEBUG` message does NOT appear in the `Captured log call` report
+    (3) The stdout, `INFO`, and `WARNING` messages DO appear in the test reports due to `--log-level=INFO`
+    """
+    testdir.makepyfile(
+        """
+        import pytest
+        import logging
+
+        def function_that_logs():
+            logging.debug('DEBUG log ' + 'message')
+            logging.info('INFO log ' + 'message')
+            logging.warning('WARNING log ' + 'message')
+            print('Print ' + 'message')
+
+        def test_that_fails(request, caplog):
+            plugin = request.config.pluginmanager.getplugin('logging-plugin')
+            assert plugin.log_level == logging.INFO
+
+            with caplog.at_level(logging.DEBUG):
+                function_that_logs()
+
+            if 'DEBUG log ' + 'message' not in caplog.text:
+                raise Exception('caplog failed to ' + 'capture DEBUG')
+
+            assert False
+    """
+    )
+
+    result = testdir.runpytest("--log-level=INFO")
+    result.stdout.no_fnmatch_line("*Exception: caplog failed to capture DEBUG*")
+    result.stdout.no_fnmatch_line("*DEBUG log message*")
+    result.stdout.fnmatch_lines(
+        ["*Print message*", "*INFO log message*", "*WARNING log message*"]
+    )
+    assert result.ret == 1

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -215,12 +215,10 @@ def test_caplog_captures_despite_exception(testdir):
             plugin = request.config.pluginmanager.getplugin('logging-plugin')
             assert plugin.log_level == logging.WARNING
 
-            logger.info("INFO message won't be shown")
-
-            caplog.set_level(logging.INFO, logger.name)
+            logger.error("ERROR message " + "will be shown")
 
             with caplog.at_level(logging.DEBUG, logger.name):
-                logger.debug("DEBUG message will be shown")
+                logger.debug("DEBUG message " + "won't be shown")
                 raise Exception()
     """
     )
@@ -232,5 +230,6 @@ def test_caplog_captures_despite_exception(testdir):
     )
 
     result = testdir.runpytest()
-    result.stdout.fnmatch_lines(["*DEBUG message will be shown*"])
+    result.stdout.fnmatch_lines(["*ERROR message will be shown*"])
+    result.stdout.no_fnmatch_line("*DEBUG message won't be shown*")
     assert result.ret == 1

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -137,3 +137,68 @@ def test_caplog_captures_for_all_stages(caplog, logging_during_setup_and_teardow
 
     # This reaches into private API, don't use this type of thing in real tests!
     assert set(caplog._item.catch_log_handlers.keys()) == {"setup", "call"}
+
+
+def test_ini_controls_global_log_level(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        import logging
+        def test_log_level_override(request, caplog):
+            plugin = request.config.pluginmanager.getplugin('logging-plugin')
+            assert plugin.log_level == logging.ERROR
+            logging.getLogger('catchlog').warning("WARNING message won't be shown")
+            logging.getLogger('catchlog').error("ERROR message will be shown")
+            assert 'WARNING' not in caplog.text
+            assert 'ERROR' in caplog.text
+    """
+    )
+    testdir.makeini(
+        """
+        [pytest]
+        log_level=ERROR
+    """
+    )
+
+    result = testdir.runpytest()
+    # make sure that that we get a '0' exit code for the testsuite
+    assert result.ret == 0
+
+
+def test_caplog_can_override_global_log_level(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        import logging
+        def test_log_level_override(request, caplog):
+            logger = 'catchlog'
+            plugin = request.config.pluginmanager.getplugin('logging-plugin')
+            assert plugin.log_level == logging.WARNING
+
+            logging.getLogger(logger).info("INFO message won't be shown")
+
+            caplog.set_level(logging.INFO, logger)
+
+            with caplog.at_level(logging.DEBUG, logger):
+                logging.getLogger(logger).debug("DEBUG message will be shown")
+
+            logging.getLogger(logger).debug("DEBUG message won't be shown")
+
+            with caplog.at_level(logging.CRITICAL, logger):
+                logging.getLogger(logger).warning("WARNING message won't be shown")
+
+            logging.getLogger(logger).debug("DEBUG message won't be shown")
+            logging.getLogger(logger).info("INFO message will be shown")
+
+            assert "message won't be shown" not in caplog.text
+    """
+    )
+    testdir.makeini(
+        """
+        [pytest]
+        log_level=WARNING
+    """
+    )
+
+    result = testdir.runpytest()
+    assert result.ret == 0

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -203,3 +203,34 @@ def test_caplog_can_override_global_log_level(testdir):
 
     result = testdir.runpytest()
     assert result.ret == 0
+
+
+def test_caplog_captures_despite_exception(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        import logging
+        def test_log_level_override(request, caplog):
+            logger = logging.getLogger('catchlog')
+            plugin = request.config.pluginmanager.getplugin('logging-plugin')
+            assert plugin.log_level == logging.WARNING
+
+            logger.info("INFO message won't be shown")
+
+            caplog.set_level(logging.INFO, logger.name)
+
+            with caplog.at_level(logging.DEBUG, logger.name):
+                logger.debug("DEBUG message will be shown")
+                raise Exception()
+    """
+    )
+    testdir.makeini(
+        """
+        [pytest]
+        log_level=WARNING
+    """
+    )
+
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(["*DEBUG message will be shown*"])
+    assert result.ret == 1


### PR DESCRIPTION
- Extends #7139 (see [here](https://github.com/pytest-dev/pytest/pull/7139#discussion_r417975714) for context)
- Setting `log_level` via the CLI or `.ini` will control the log level of the report that is dumped upon failure of a test
- If `caplog` modified the log level during the execution of that test, it should not impact the level that is displayed upon failure.

#### PR Checklist
- [ ] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
- [x] Add yourself to `AUTHORS` in alphabetical order.
