### PR TITLE
'saferepr' handles classes with broken __getattribute__

### DIFF
--- a/changelog/7145.bugfix.rst
+++ b/changelog/7145.bugfix.rst
@@ -1,0 +1,1 @@
+Classes with broken ``__getattribute__`` methods are displayed correctly during failures.

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -20,7 +20,7 @@ def _format_repr_exception(exc: BaseException, obj: Any) -> str:
     except BaseException as exc:
         exc_info = "unpresentable exception ({})".format(_try_repr_or_str(exc))
     return "<[{} raised in repr()] {} object at 0x{:x}>".format(
-        exc_info, obj.__class__.__name__, id(obj)
+        exc_info, type(obj).__name__, id(obj)
     )
 
 

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -154,3 +154,20 @@ def test_pformat_dispatch():
     assert _pformat_dispatch("a") == "'a'"
     assert _pformat_dispatch("a" * 10, width=5) == "'aaaaaaaaaa'"
     assert _pformat_dispatch("foo bar", width=5) == "('foo '\n 'bar')"
+
+
+def test_broken_getattribute():
+    """saferepr() can create proper representations of classes with
+    broken __getattribute__ (#7145)
+    """
+
+    class SomeClass:
+        def __getattribute__(self, attr):
+            raise RuntimeError
+
+        def __repr__(self):
+            raise RuntimeError
+
+    assert saferepr(SomeClass()).startswith(
+        "<[RuntimeError() raised in repr()] SomeClass object at 0x"
+    )


### PR DESCRIPTION
Fix #7145

Credit goes to @bluetech. 👍 