### PR TITLE
code: fix import cycles between code.py and source.py

### DIFF
--- a/src/_pytest/_code/__init__.py
+++ b/src/_pytest/_code/__init__.py
@@ -1,10 +1,22 @@
-""" python inspection/code generation API """
-from .code import Code  # noqa
-from .code import ExceptionInfo  # noqa
-from .code import filter_traceback  # noqa
-from .code import Frame  # noqa
-from .code import getrawcode  # noqa
-from .code import Traceback  # noqa
-from .source import compile_ as compile  # noqa
-from .source import getfslineno  # noqa
-from .source import Source  # noqa
+"""Python inspection/code generation API."""
+from .code import Code
+from .code import ExceptionInfo
+from .code import filter_traceback
+from .code import Frame
+from .code import getfslineno
+from .code import getrawcode
+from .code import Traceback
+from .source import compile_ as compile
+from .source import Source
+
+__all__ = [
+    "Code",
+    "ExceptionInfo",
+    "filter_traceback",
+    "Frame",
+    "getfslineno",
+    "getrawcode",
+    "Traceback",
+    "compile",
+    "Source",
+]

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -13,9 +13,9 @@ import attr
 import py
 
 import _pytest
+from _pytest._code import getfslineno
 from _pytest._code.code import FormattedExcinfo
 from _pytest._code.code import TerminalRepr
-from _pytest._code.source import getfslineno
 from _pytest._io import TerminalWriter
 from _pytest.compat import _format_args
 from _pytest.compat import _PytestWrapper

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -14,7 +14,7 @@ from typing import Union
 
 import attr
 
-from .._code.source import getfslineno
+from .._code import getfslineno
 from ..compat import ascii_escaped
 from ..compat import NOTSET
 from _pytest.outcomes import fail

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -12,10 +12,10 @@ from typing import Union
 import py
 
 import _pytest._code
+from _pytest._code import getfslineno
 from _pytest._code.code import ExceptionChainRepr
 from _pytest._code.code import ExceptionInfo
 from _pytest._code.code import ReprExceptionInfo
-from _pytest._code.source import getfslineno
 from _pytest.compat import cached_property
 from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -25,8 +25,8 @@ import _pytest
 from _pytest import fixtures
 from _pytest import nodes
 from _pytest._code import filter_traceback
+from _pytest._code import getfslineno
 from _pytest._code.code import ExceptionInfo
-from _pytest._code.source import getfslineno
 from _pytest._io import TerminalWriter
 from _pytest._io.saferepr import saferepr
 from _pytest.compat import ascii_escaped


### PR DESCRIPTION
These two files were really intertwined. Make it so code.py depends on source.py without a reverse dependency.

No functional changes.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
