### PR TITLE
ci: update github action versions, remove outdated comment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,6 +123,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    # For setuptools_scm.
+    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v2
       with:
@@ -164,6 +166,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    # For setuptools_scm.
+    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,3 @@
-# evaluating GitHub actions for CI, disregard failures when evaluating PRs
-#
-# this is still missing:
-# - deploy
-# - upload github notes
-#
 name: main
 
 on:
@@ -128,9 +122,9 @@ jobs:
             use_coverage: true
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
     - name: Install dependencies
@@ -169,9 +163,9 @@ jobs:
     needs: [build]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: "3.7"
     - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,8 +123,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    # For setuptools_scm.
-    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    # For setuptools-scm.
+    - run: git fetch --prune --unshallow
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v2
       with:
@@ -166,8 +166,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    # For setuptools_scm.
-    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    # For setuptools-scm.
+    - run: git fetch --prune --unshallow
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/release-on-comment.yml
+++ b/.github/workflows/release-on-comment.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    # For setuptools_scm.
+    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/release-on-comment.yml
+++ b/.github/workflows/release-on-comment.yml
@@ -15,8 +15,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    # For setuptools_scm.
-    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    # For setuptools-scm.
+    - run: git fetch --prune --unshallow
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/release-on-comment.yml
+++ b/.github/workflows/release-on-comment.yml
@@ -14,9 +14,9 @@ jobs:
     if: (github.event.comment && startsWith(github.event.comment.body, '@pytestbot please')) || (github.event.issue && !github.event.comment && startsWith(github.event.issue.body, '@pytestbot please'))
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: "3.8"
     - name: Install dependencies


### PR DESCRIPTION
Hoping this will fix the "rerun jobs" option which currently always fails.

Changelogs:
- https://github.com/actions/checkout#whats-new
- https://github.com/actions/setup-python#whats-new (note: says "Ability to download, install and set up Python packages from actions/python-versions that do not come preinstalled on runners " -- maybe relevant for #7161)

Also remove the top comment which I think is entirely outdated.