### PR TITLE
Fix tests for python3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
           "ubuntu-py37-pluggy",
           "ubuntu-py37-freeze",
           "ubuntu-py38",
+          "ubuntu-py39",
           "ubuntu-pypy3",
 
           "macos-py37",
@@ -98,6 +99,10 @@ jobs:
             python: "3.8"
             os: ubuntu-latest
             tox_env: "py38-xdist"
+          - name: "ubuntu-py39"
+            python: "3.8"
+            os: ubuntu-latest
+            tox_env: "py39-xdist"
           - name: "ubuntu-pypy3"
             python: "pypy3"
             os: ubuntu-latest
@@ -133,6 +138,12 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python }}
+    - name: install python3.9
+      if: matrix.tox_env == 'py39-xdist'
+      run: |
+        sudo add-apt-repository ppa:deadsnakes/nightly
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends python3.9-dev python3.9-distutils
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 platforms = unix, linux, osx, cygwin, win32
 
 [options]

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -122,7 +122,8 @@ def test_syntaxerror_rerepresentation() -> None:
     assert ex is not None
     assert ex.value.lineno == 1
     assert ex.value.offset in {5, 7}  # cpython: 7, pypy3.6 7.1.1: 5
-    assert ex.value.text == "xyz xyz\n"
+    assert ex.value.text
+    assert ex.value.text.rstrip("\n") == "xyz xyz"
 
 
 def test_isparseable() -> None:
@@ -521,7 +522,7 @@ def test_getfslineno() -> None:
     class B:
         pass
 
-    B.__name__ = "B2"
+    B.__name__ = B.__qualname__ = "B2"
     assert getfslineno(B)[1] == -1
 
     co = compile("...", "", "eval")

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     py36
     py37
     py38
+    py39
     pypy3
     py37-{pexpect,xdist,unittestextras,numpy,pluggymaster}
     doctesting


### PR DESCRIPTION
Resolves #7161

- the text of `SyntaxError`s changed as part of the PEG parser rewrite ([bpo-40334](https://bugs.python.org/issue40334))
- `inspect.getsource` improved in python3.9 (utilizing the `ast` and `__qualname__`) ([bpo-35113](https://bugs.python.org/issue35113))