### PR TITLE
[4.6] Fix test_getfslineno for Python 3.9

### DIFF
--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -501,7 +501,7 @@ def test_getfslineno():
     class B(object):
         pass
 
-    B.__name__ = "B2"
+    B.__name__ = B.__qualname__ = "B2"
     assert getfslineno(B)[1] == -1
 
 


### PR DESCRIPTION
`inspect.getsource` improved in Python 3.9 (utilizing the `ast` and `__qualname__`)
See https://bugs.python.org/issue35113

Resolves https://github.com/pytest-dev/pytest/issues/7161

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
