### PR TITLE
Handle SIGPIPE/BrokenPipeError in pytest's CLI

### DIFF
--- a/changelog/4375.improvement.rst
+++ b/changelog/4375.improvement.rst
@@ -1,0 +1,3 @@
+The ``pytest`` command now supresses the ``BrokenPipeError`` error message that
+is printed to stderr when the output of ``pytest`` is piped and and the pipe is
+closed by the piped-to program (common examples are ``less`` and ``head``).

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,8 +43,8 @@ python_requires = >=3.5
 
 [options.entry_points]
 console_scripts =
-	pytest=pytest:main
-	py.test=pytest:main
+	pytest=pytest:console_main
+	py.test=pytest:console_main
 
 [build_sphinx]
 source-dir = doc/en/

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -6,6 +6,7 @@ from . import collect
 from _pytest import __version__
 from _pytest.assertion import register_assert_rewrite
 from _pytest.config import cmdline
+from _pytest.config import console_main
 from _pytest.config import ExitCode
 from _pytest.config import hookimpl
 from _pytest.config import hookspec
@@ -57,6 +58,7 @@ __all__ = [
     "cmdline",
     "collect",
     "Collector",
+    "console_main",
     "deprecated_call",
     "exit",
     "ExitCode",

--- a/src/pytest/__main__.py
+++ b/src/pytest/__main__.py
@@ -4,4 +4,4 @@ pytest entry point
 import pytest
 
 if __name__ == "__main__":
-    raise SystemExit(pytest.main())
+    raise SystemExit(pytest.console_main())


### PR DESCRIPTION
Running `pytest | head -1` and similar causes an annoying error to be
printed to stderr:

    Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
    BrokenPipeError: [Errno 32] Broken pipe

(or possibly even a propagating exception in older/other Python versions).

The standard UNIX behavior is to handle the SIGPIPE silently. To
recommended method to do this in Python is described here:
https://docs.python.org/3/library/signal.html#note-on-sigpipe

It is not appropriate to apply this recommendation to `pytest.main()`,
which is used programmatically for in-process runs. Hence, change
pytest's entrypoint to a new `pytest.console_main()` function, to be
used exclusively by pytest's CLI, and add the SIGPIPE code there.

Fixes #4375.