### PR TITLE
[5.4] Merge pull request #7186 from asottile/is_setup_py_encoding_agnostic

### DIFF
--- a/changelog/7180.bugfix.rst
+++ b/changelog/7180.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``_is_setup_py`` for files encoded differently than locale.

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -108,20 +108,20 @@ def pytest_unconfigure():
     RUNNER_CLASS = None
 
 
-def pytest_collect_file(path, parent):
+def pytest_collect_file(path: py.path.local, parent):
     config = parent.config
     if path.ext == ".py":
-        if config.option.doctestmodules and not _is_setup_py(config, path, parent):
+        if config.option.doctestmodules and not _is_setup_py(path):
             return DoctestModule.from_parent(parent, fspath=path)
     elif _is_doctest(config, path, parent):
         return DoctestTextfile.from_parent(parent, fspath=path)
 
 
-def _is_setup_py(config, path, parent):
+def _is_setup_py(path: py.path.local) -> bool:
     if path.basename != "setup.py":
         return False
-    contents = path.read()
-    return "setuptools" in contents or "distutils" in contents
+    contents = path.read_binary()
+    return b"setuptools" in contents or b"distutils" in contents
 
 
 def _is_doctest(config, path, parent):

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -5,6 +5,7 @@ import pytest
 from _pytest.compat import MODULE_NOT_FOUND_ERROR
 from _pytest.doctest import _get_checker
 from _pytest.doctest import _is_mocked
+from _pytest.doctest import _is_setup_py
 from _pytest.doctest import _patch_unwrap_mock_aware
 from _pytest.doctest import DoctestItem
 from _pytest.doctest import DoctestModule
@@ -1487,3 +1488,27 @@ def test_warning_on_unwrap_of_broken_object(stop):
             with pytest.raises(KeyError):
                 inspect.unwrap(bad_instance, stop=stop)
     assert inspect.unwrap.__module__ == "inspect"
+
+
+def test_is_setup_py_not_named_setup_py(tmpdir):
+    not_setup_py = tmpdir.join("not_setup.py")
+    not_setup_py.write('from setuptools import setup; setup(name="foo")')
+    assert not _is_setup_py(not_setup_py)
+
+
+@pytest.mark.parametrize("mod", ("setuptools", "distutils.core"))
+def test_is_setup_py_is_a_setup_py(tmpdir, mod):
+    setup_py = tmpdir.join("setup.py")
+    setup_py.write('from {} import setup; setup(name="foo")'.format(mod))
+    assert _is_setup_py(setup_py)
+
+
+@pytest.mark.parametrize("mod", ("setuptools", "distutils.core"))
+def test_is_setup_py_different_encoding(tmpdir, mod):
+    setup_py = tmpdir.join("setup.py")
+    contents = (
+        "# -*- coding: cp1252 -*-\n"
+        'from {} import setup; setup(name="foo", description="€")\n'.format(mod)
+    )
+    setup_py.write_binary(contents.encode("cp1252"))
+    assert _is_setup_py(setup_py)


### PR DESCRIPTION
Fix _is_setup_py for files encoded differently than locale

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
