### PR TITLE
Prepare release 5.4.2

### DIFF
--- a/changelog/6871.bugfix.rst
+++ b/changelog/6871.bugfix.rst
@@ -1,1 +1,0 @@
-Fix crash with captured output when using the :fixture:`capsysbinary fixture <capsysbinary>`.

--- a/changelog/6924.bugfix.rst
+++ b/changelog/6924.bugfix.rst
@@ -1,1 +1,0 @@
-Ensure a ``unittest.IsolatedAsyncioTestCase`` is actually awaited.

--- a/changelog/6925.bugfix.rst
+++ b/changelog/6925.bugfix.rst
@@ -1,1 +1,0 @@
-Fix TerminalRepr instances to be hashable again.

--- a/changelog/6947.bugfix.rst
+++ b/changelog/6947.bugfix.rst
@@ -1,1 +1,0 @@
-Fix regression where functions registered with ``TestCase.addCleanup`` were not being called on test failures.

--- a/changelog/6951.bugfix.rst
+++ b/changelog/6951.bugfix.rst
@@ -1,1 +1,0 @@
-Allow users to still set the deprecated ``TerminalReporter.writer`` attribute.

--- a/changelog/6992.bugfix.rst
+++ b/changelog/6992.bugfix.rst
@@ -1,1 +1,0 @@
-Revert "tmpdir: clean up indirection via config for factories" #6767 as it breaks pytest-xdist.

--- a/changelog/7110.bugfix.rst
+++ b/changelog/7110.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed regression: ``asyncbase.TestCase`` tests are executed correctly again.

--- a/changelog/7143.bugfix.rst
+++ b/changelog/7143.bugfix.rst
@@ -1,1 +1,0 @@
-Fix ``File.from_constructor`` so it forwards extra keyword arguments to the constructor.

--- a/changelog/7145.bugfix.rst
+++ b/changelog/7145.bugfix.rst
@@ -1,1 +1,0 @@
-Classes with broken ``__getattribute__`` methods are displayed correctly during failures.

--- a/changelog/7180.bugfix.rst
+++ b/changelog/7180.bugfix.rst
@@ -1,1 +1,0 @@
-Fix ``_is_setup_py`` for files encoded differently than locale.

--- a/doc/en/announce/index.rst
+++ b/doc/en/announce/index.rst
@@ -6,6 +6,7 @@ Release announcements
    :maxdepth: 2
 
 
+   release-5.4.2
    release-5.4.1
    release-5.4.0
    release-5.3.5

--- a/doc/en/announce/release-5.4.2.rst
+++ b/doc/en/announce/release-5.4.2.rst
@@ -1,0 +1,22 @@
+pytest-5.4.2
+=======================================
+
+pytest 5.4.2 has just been released to PyPI.
+
+This is a bug-fix release, being a drop-in replacement. To upgrade::
+
+  pip install --upgrade pytest
+
+The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+
+Thanks to all who contributed to this release, among them:
+
+* Anthony Sottile
+* Bruno Oliveira
+* Daniel Hahler
+* Ran Benita
+* Ronny Pfannschmidt
+
+
+Happy testing,
+The pytest Development Team

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -28,6 +28,42 @@ with advance notice in the **Deprecations** section of releases.
 
 .. towncrier release notes start
 
+pytest 5.4.2 (2020-05-08)
+=========================
+
+Bug Fixes
+---------
+
+- `#6871 <https://github.com/pytest-dev/pytest/issues/6871>`_: Fix crash with captured output when using the :fixture:`capsysbinary fixture <capsysbinary>`.
+
+
+- `#6924 <https://github.com/pytest-dev/pytest/issues/6924>`_: Ensure a ``unittest.IsolatedAsyncioTestCase`` is actually awaited.
+
+
+- `#6925 <https://github.com/pytest-dev/pytest/issues/6925>`_: Fix TerminalRepr instances to be hashable again.
+
+
+- `#6947 <https://github.com/pytest-dev/pytest/issues/6947>`_: Fix regression where functions registered with ``TestCase.addCleanup`` were not being called on test failures.
+
+
+- `#6951 <https://github.com/pytest-dev/pytest/issues/6951>`_: Allow users to still set the deprecated ``TerminalReporter.writer`` attribute.
+
+
+- `#6992 <https://github.com/pytest-dev/pytest/issues/6992>`_: Revert "tmpdir: clean up indirection via config for factories" #6767 as it breaks pytest-xdist.
+
+
+- `#7110 <https://github.com/pytest-dev/pytest/issues/7110>`_: Fixed regression: ``asyncbase.TestCase`` tests are executed correctly again.
+
+
+- `#7143 <https://github.com/pytest-dev/pytest/issues/7143>`_: Fix ``File.from_constructor`` so it forwards extra keyword arguments to the constructor.
+
+
+- `#7145 <https://github.com/pytest-dev/pytest/issues/7145>`_: Classes with broken ``__getattribute__`` methods are displayed correctly during failures.
+
+
+- `#7180 <https://github.com/pytest-dev/pytest/issues/7180>`_: Fix ``_is_setup_py`` for files encoded differently than locale.
+
+
 pytest 5.4.1 (2020-03-13)
 =========================
 

--- a/doc/en/writing_plugins.rst
+++ b/doc/en/writing_plugins.rst
@@ -443,9 +443,9 @@ additionally it is possible to copy examples for an example folder before runnin
         testdir.copy_example("test_example.py")
 
     test_example.py::test_plugin
-      $PYTHON_PREFIX/lib/python3.8/site-packages/_pytest/terminal.py:287: PytestDeprecationWarning: TerminalReporter.writer attribute is deprecated, use TerminalReporter._tw instead at your own risk.
+      $PYTHON_PREFIX/lib/python3.8/site-packages/_pytest/compat.py:333: PytestDeprecationWarning: The TerminalReporter.writer attribute is deprecated, use TerminalReporter._tw instead at your own risk.
       See https://docs.pytest.org/en/latest/deprecations.html#terminalreporter-writer for more information.
-        warnings.warn(
+        return getattr(object, name, default)
 
     -- Docs: https://docs.pytest.org/en/latest/warnings.html
     ====================== 2 passed, 2 warnings in 0.12s =======================


### PR DESCRIPTION
Created automatically from https://github.com/pytest-dev/pytest/issues/7192.

Once all builds pass and it has been **approved** by one or more maintainers, the build
can be released by pushing a tag `5.4.2` to this repository.
