### PR TITLE
[Port from 5.4.x] Revert "[parametrize] enforce explicit argnames declaration (#6330)"

### DIFF
--- a/changelog/6909.bugfix.rst
+++ b/changelog/6909.bugfix.rst
@@ -1,0 +1,3 @@
+Revert the change introduced by `#6330 <https://github.com/pytest-dev/pytest/pull/6330>`_, which required all arguments to ``@pytest.mark.parametrize`` to be explicitly defined in the function signature.
+
+The intention of the original change was to remove what was expected to be an unintended/surprising behavior, but it turns out many people relied on it, so the restriction has been reverted.

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -402,9 +402,6 @@ The result of this test will be successful:
 
 .. regendoc:wipe
 
-Note, that each argument in `parametrize` list should be explicitly declared in corresponding
-python test function or via `indirect`.
-
 Parametrizing test methods through per-class configuration
 --------------------------------------------------------------
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -936,8 +936,6 @@ class Metafunc:
 
         arg_values_types = self._resolve_arg_value_types(argnames, indirect)
 
-        self._validate_explicit_parameters(argnames, indirect)
-
         # Use any already (possibly) generated ids with parametrize Marks.
         if _param_mark and _param_mark._param_ids_from:
             generated_ids = _param_mark._param_ids_from._param_ids_generated
@@ -1109,39 +1107,6 @@ class Metafunc:
                         "In {}: function uses no {} '{}'".format(func_name, name, arg),
                         pytrace=False,
                     )
-
-    def _validate_explicit_parameters(
-        self,
-        argnames: typing.Sequence[str],
-        indirect: Union[bool, typing.Sequence[str]],
-    ) -> None:
-        """
-        The argnames in *parametrize* should either be declared explicitly via
-        indirect list or in the function signature
-
-        :param List[str] argnames: list of argument names passed to ``parametrize()``.
-        :param indirect: same ``indirect`` parameter of ``parametrize()``.
-        :raise ValueError: if validation fails
-        """
-        if isinstance(indirect, bool):
-            parametrized_argnames = [] if indirect else argnames
-        else:
-            parametrized_argnames = [arg for arg in argnames if arg not in indirect]
-
-        if not parametrized_argnames:
-            return
-
-        funcargnames = _pytest.compat.getfuncargnames(self.function)
-        usefixtures = fixtures.get_use_fixtures_for_node(self.definition)
-
-        for arg in parametrized_argnames:
-            if arg not in funcargnames and arg not in usefixtures:
-                func_name = self.function.__name__
-                msg = (
-                    'In function "{func_name}":\n'
-                    'Parameter "{arg}" should be declared explicitly via indirect or in function itself'
-                ).format(func_name=func_name, arg=arg)
-                fail(msg, pytrace=False)
 
 
 def _find_parametrized_scope(argnames, arg2fixturedefs, indirect):

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -463,7 +463,7 @@ class TestFunction:
                return '3'
 
             @pytest.mark.parametrize('fix2', ['2'])
-            def test_it(fix1, fix2):
+            def test_it(fix1):
                assert fix1 == '21'
                assert not fix3_instantiated
         """

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -36,9 +36,6 @@ class TestMetafunc:
         class DefinitionMock(python.FunctionDefinition):
             obj = attr.ib()
 
-            def listchain(self):
-                return []
-
         names = fixtures.getfuncargnames(func)
         fixtureinfo = FuncFixtureInfoMock(names)  # type: Any
         definition = DefinitionMock._create(func)  # type: Any
@@ -1900,53 +1897,5 @@ class TestMarkersWithParametrization:
                 "test_parametrize_iterator.py::test_converted_to_str[0] PASSED",
                 "test_parametrize_iterator.py::test_converted_to_str[1] PASSED",
                 "*= 6 passed in *",
-            ]
-        )
-
-    def test_parametrize_explicit_parameters_func(self, testdir: Testdir) -> None:
-        testdir.makepyfile(
-            """
-            import pytest
-
-
-            @pytest.fixture
-            def fixture(arg):
-                return arg
-
-            @pytest.mark.parametrize("arg", ["baz"])
-            def test_without_arg(fixture):
-                assert "baz" == fixture
-        """
-        )
-        result = testdir.runpytest()
-        result.assert_outcomes(error=1)
-        result.stdout.fnmatch_lines(
-            [
-                '*In function "test_without_arg"*',
-                '*Parameter "arg" should be declared explicitly via indirect or in function itself*',
-            ]
-        )
-
-    def test_parametrize_explicit_parameters_method(self, testdir: Testdir) -> None:
-        testdir.makepyfile(
-            """
-            import pytest
-
-            class Test:
-                @pytest.fixture
-                def test_fixture(self, argument):
-                    return argument
-
-                @pytest.mark.parametrize("argument", ["foobar"])
-                def test_without_argument(self, test_fixture):
-                    assert "foobar" == test_fixture
-        """
-        )
-        result = testdir.runpytest()
-        result.assert_outcomes(error=1)
-        result.stdout.fnmatch_lines(
-            [
-                '*In function "test_without_argument"*',
-                '*Parameter "argument" should be declared explicitly via indirect or in function itself*',
             ]
         )


### PR DESCRIPTION
Port from 5.4.x.

This was done by mistake directly into `5.4.x`, instead of the correct procedure which is to fix on `master` and *then* backporting it into `5.4.x`.