### PR TITLE
Issue 6866 - reason is optional in skipif marker

### DIFF
--- a/changelog/6866.breaking.rst
+++ b/changelog/6866.breaking.rst
@@ -1,0 +1,1 @@
+Reason is now an optional argument in ``@pytest.mark.skipif``.

--- a/src/_pytest/mark/evaluate.py
+++ b/src/_pytest/mark/evaluate.py
@@ -95,13 +95,6 @@ class MarkEvaluator:
                         d = self._getglobals()
                         result = cached_eval(self.item.config, expr, d)
                     else:
-                        if "reason" not in mark.kwargs:
-                            # XXX better be checked at collection time
-                            msg = (
-                                "you need to specify reason=STRING "
-                                "when using booleans as conditions."
-                            )
-                            fail(msg)
                         result = bool(expr)
                     if result:
                         self.result = True
@@ -123,7 +116,7 @@ class MarkEvaluator:
     def getexplanation(self):
         expl = getattr(self, "reason", None) or self.get("reason", None)
         if not expl:
-            if not hasattr(self, "expr"):
+            if not hasattr(self, "expr") or isinstance(self.expr, bool):
                 return ""
             else:
                 return "condition: " + str(self.expr)

--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -53,8 +53,8 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
-        "skipif(condition): skip the given test function if eval(condition) "
-        "results in a True value.  Evaluation happens within the "
+        "skipif(condition, reason=None): skip the given test function if eval(condition) "
+        "results in a True value, reason is optional.  Evaluation happens within the "
         "module global context. Example: skipif('sys.platform == \"win32\"') "
         "skips the test if we are on the win32 platform. see "
         "https://docs.pytest.org/en/latest/skipping.html",

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -98,22 +98,6 @@ class TestEvaluator:
         expl = ev.getexplanation()
         assert expl == "condition: not hasattr(os, 'murks')"
 
-    def test_marked_skip_with_not_string(self, testdir):
-        item = testdir.getitem(
-            """
-            import pytest
-            @pytest.mark.skipif(False)
-            def test_func():
-                pass
-        """
-        )
-        ev = MarkEvaluator(item, "skipif")
-        exc = pytest.raises(pytest.fail.Exception, ev.istrue)
-        assert (
-            """Failed: you need to specify reason=STRING when using booleans as conditions."""
-            in exc.value.msg
-        )
-
     def test_skipif_class(self, testdir):
         (item,) = testdir.getitems(
             """
@@ -932,7 +916,7 @@ def test_direct_gives_error(testdir):
     """
     )
     result = testdir.runpytest()
-    result.stdout.fnmatch_lines(["*1 error*"])
+    result.stdout.fnmatch_lines(["*1 skipped*"])
 
 
 def test_default_markers(testdir):
@@ -1028,7 +1012,7 @@ class TestBooleanCondition:
         result = testdir.runpytest("-rs")
         result.stdout.fnmatch_lines(
             """
-            *1 error*
+            SKIPPED [[]1[]] test_skipif_noreason.py:2: <Skipped instance>
         """
         )
 


### PR DESCRIPTION
It is implementation of proposition from #6866. The default reason is the same like in ``@pytest.mark.skipif`` with no argument.

Fixes #6866.