### PR TITLE
Issue 7126 - "saferepr" to avoid BytesWarning when using --setup-show

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -216,6 +216,7 @@ Ondřej Súkup
 Oscar Benjamin
 Patrick Hayes
 Pauli Virtanen
+Pavel Karateev
 Paweł Adamczak
 Pedro Algarvio
 Philipp Loose

--- a/changelog/7126.bugfix.rst
+++ b/changelog/7126.bugfix.rst
@@ -1,3 +1,3 @@
-Use ``saferepr`` to format bytes ``parametrize`` parameters  for ``--setup-show``
-output to prevent errors when Python is called with ``-bb`` to catch bytearray with
-unicode comparison.
+Switched to ``saferepr`` to format bytes ``parametrize`` parameters
+for ``--setup-show`` output to prevent errors when Python is called with ``-bb``
+to catch bytearray with unicode comparison.

--- a/changelog/7126.bugfix.rst
+++ b/changelog/7126.bugfix.rst
@@ -1,0 +1,3 @@
+Use ``saferepr`` to format bytes ``parametrize`` parameters  for ``--setup-show``
+output to prevent errors when Python is called with ``-bb`` to catch bytearray with
+unicode comparison.

--- a/changelog/7126.bugfix.rst
+++ b/changelog/7126.bugfix.rst
@@ -1,3 +1,2 @@
-Switched to ``saferepr`` to format bytes ``parametrize`` parameters
-for ``--setup-show`` output to prevent errors when Python is called with ``-bb``
-to catch bytearray with unicode comparison.
+``--setup-show`` now doesn't raise an error if bytearray is used as ``parametrize``
+parameter when Python is called with ``-bb`` flag.

--- a/changelog/7126.bugfix.rst
+++ b/changelog/7126.bugfix.rst
@@ -1,2 +1,2 @@
-``--setup-show`` now doesn't raise an error if bytearray is used as ``parametrize``
-parameter when Python is called with ``-bb`` flag.
+``--setup-show`` now doesn't raise an error when a bytes value is used as a ``parametrize``
+parameter when Python is called with the ``-bb`` flag.

--- a/src/_pytest/setuponly.py
+++ b/src/_pytest/setuponly.py
@@ -1,4 +1,5 @@
 import pytest
+from _pytest._io.saferepr import saferepr
 
 
 def pytest_addoption(parser):
@@ -66,7 +67,11 @@ def _show_fixture_action(fixturedef, msg):
             tw.write(" (fixtures used: {})".format(", ".join(deps)))
 
     if hasattr(fixturedef, "cached_param"):
-        tw.write("[{}]".format(fixturedef.cached_param))
+        if isinstance(fixturedef.cached_param, bytes):
+            param = saferepr(fixturedef.cached_param, maxsize=42)
+        else:
+            param = fixturedef.cached_param
+        tw.write("[{}]".format(param))
 
     tw.flush()
 

--- a/src/_pytest/setuponly.py
+++ b/src/_pytest/setuponly.py
@@ -67,11 +67,7 @@ def _show_fixture_action(fixturedef, msg):
             tw.write(" (fixtures used: {})".format(", ".join(deps)))
 
     if hasattr(fixturedef, "cached_param"):
-        if isinstance(fixturedef.cached_param, bytes):
-            param = saferepr(fixturedef.cached_param, maxsize=42)
-        else:
-            param = fixturedef.cached_param
-        tw.write("[{}]".format(param))
+        tw.write("[{}]".format(saferepr(fixturedef.cached_param, maxsize=42)))
 
     tw.flush()
 

--- a/testing/test_setuponly.py
+++ b/testing/test_setuponly.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 from _pytest.config import ExitCode
 
@@ -292,3 +294,19 @@ def test_setup_show_with_KeyboardInterrupt_in_test(testdir):
         ]
     )
     assert result.ret == ExitCode.INTERRUPTED
+
+
+def test_parametrize_no_comparing_bytearray_error(testdir):
+    test_file = testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.parametrize('data', [b'Hello World'])
+        def test_data(data):
+            pass
+        """
+    )
+    result = testdir.run(
+        sys.executable, "-bb", "-m", "pytest", "--setup-show", str(test_file)
+    )
+    assert result.ret == 0

--- a/testing/test_setuponly.py
+++ b/testing/test_setuponly.py
@@ -298,7 +298,7 @@ def test_setup_show_with_KeyboardInterrupt_in_test(testdir):
     assert result.ret == ExitCode.INTERRUPTED
 
 
-def test_show_fixture_action_with_bytearrays(testdir):
+def test_show_fixture_action_with_bytes(testdir):
     # Issue 7126, BytesWarning when using --setup-show with bytes parameter
     test_file = testdir.makepyfile(
         """

--- a/testing/test_setuponly.py
+++ b/testing/test_setuponly.py
@@ -148,10 +148,10 @@ def test_show_fixtures_with_parameters(testdir, mode):
 
     result.stdout.fnmatch_lines(
         [
-            "SETUP    S arg_same?foo?",
-            "TEARDOWN S arg_same?foo?",
-            "SETUP    S arg_same?bar?",
-            "TEARDOWN S arg_same?bar?",
+            "SETUP    S arg_same?'foo'?",
+            "TEARDOWN S arg_same?'foo'?",
+            "SETUP    S arg_same?'bar'?",
+            "TEARDOWN S arg_same?'bar'?",
         ]
     )
 
@@ -181,7 +181,7 @@ def test_show_fixtures_with_parameter_ids(testdir, mode):
     assert result.ret == 0
 
     result.stdout.fnmatch_lines(
-        ["SETUP    S arg_same?spam?", "SETUP    S arg_same?ham?"]
+        ["SETUP    S arg_same?'spam'?", "SETUP    S arg_same?'ham'?"]
     )
 
 
@@ -200,7 +200,9 @@ def test_show_fixtures_with_parameter_ids_function(testdir, mode):
     result = testdir.runpytest(mode, p)
     assert result.ret == 0
 
-    result.stdout.fnmatch_lines(["*SETUP    F foobar?FOO?", "*SETUP    F foobar?BAR?"])
+    result.stdout.fnmatch_lines(
+        ["*SETUP    F foobar?'FOO'?", "*SETUP    F foobar?'BAR'?"]
+    )
 
 
 def test_dynamic_fixture_request(testdir):

--- a/testing/test_setuponly.py
+++ b/testing/test_setuponly.py
@@ -296,7 +296,8 @@ def test_setup_show_with_KeyboardInterrupt_in_test(testdir):
     assert result.ret == ExitCode.INTERRUPTED
 
 
-def test_parametrize_no_comparing_bytearray_error(testdir):
+def test_show_fixture_action_with_bytearrays(testdir):
+    # Issue 7126, BytesWarning when using --setup-show with bytes parameter
     test_file = testdir.makepyfile(
         """
         import pytest


### PR DESCRIPTION
Fix for #7126

I added a special case for bytes only as `saferepr` adds quotes to pure string literals. A bunch of tests depend on the original behavior, so I was not comfortable changing it globally. Scrapping `saferepr` output to match the original behavior doesn't sound as a trouble-proof solution too. Please correct me if it was a wrong idea.

Thank you for your time reviewing the PR 🙏

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
