### PR TITLE
mark: deprecate a couple undocumented -k syntaxes

### DIFF
--- a/changelog/7210.deprecation.rst
+++ b/changelog/7210.deprecation.rst
@@ -1,0 +1,5 @@
+The special ``-k '-expr'`` syntax to ``-k`` is deprecated. Use ``-k 'not expr'``
+instead.
+
+The special ``-k 'expr:'`` syntax to ``-k`` is deprecated. Please open an issue
+if you use this and want a replacement.

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -75,3 +75,13 @@ TERMINALWRITER_WRITER = PytestDeprecationWarning(
     "The TerminalReporter.writer attribute is deprecated, use TerminalReporter._tw instead at your own risk.\n"
     "See https://docs.pytest.org/en/latest/deprecations.html#terminalreporter-writer for more information."
 )
+
+
+MINUS_K_DASH = PytestDeprecationWarning(
+    "The `-k '-expr'` syntax to -k is deprecated.\nUse `-k 'not expr'` instead."
+)
+
+MINUS_K_COLON = PytestDeprecationWarning(
+    "The `-k 'expr:'` syntax to -k is deprecated.\n"
+    "Please open an issue if you use this and want a replacement."
+)

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -1,4 +1,5 @@
 """ generic mechanism for marking and selecting python functions. """
+import warnings
 from typing import Optional
 
 from .legacy import matchkeyword
@@ -13,6 +14,8 @@ from .structures import ParameterSet
 from _pytest.config import Config
 from _pytest.config import hookimpl
 from _pytest.config import UsageError
+from _pytest.deprecated import MINUS_K_COLON
+from _pytest.deprecated import MINUS_K_DASH
 from _pytest.store import StoreKey
 
 __all__ = ["Mark", "MarkDecorator", "MarkGenerator", "get_empty_parameterset_mark"]
@@ -107,9 +110,13 @@ def deselect_by_keyword(items, config):
         return
 
     if keywordexpr.startswith("-"):
+        # To be removed in pytest 7.0.0.
+        warnings.warn(MINUS_K_DASH, stacklevel=2)
         keywordexpr = "not " + keywordexpr[1:]
     selectuntil = False
     if keywordexpr[-1:] == ":":
+        # To be removed in pytest 7.0.0.
+        warnings.warn(MINUS_K_COLON, stacklevel=2)
         selectuntil = True
         keywordexpr = keywordexpr[:-1]
 

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -164,3 +164,27 @@ def test__fillfuncargs_is_deprecated() -> None:
         match="The `_fillfuncargs` function is deprecated",
     ):
         pytest._fillfuncargs(mock.Mock())
+
+
+def test_minus_k_dash_is_deprecated(testdir) -> None:
+    threepass = testdir.makepyfile(
+        test_threepass="""
+        def test_one(): assert 1
+        def test_two(): assert 1
+        def test_three(): assert 1
+    """
+    )
+    result = testdir.runpytest("-k=-test_two", threepass)
+    result.stdout.fnmatch_lines(["*The `-k '-expr'` syntax*deprecated*"])
+
+
+def test_minus_k_colon_is_deprecated(testdir) -> None:
+    threepass = testdir.makepyfile(
+        test_threepass="""
+        def test_one(): assert 1
+        def test_two(): assert 1
+        def test_three(): assert 1
+    """
+    )
+    result = testdir.runpytest("-k", "test_two:", threepass)
+    result.stdout.fnmatch_lines(["*The `-k 'expr:'` syntax*deprecated*"])


### PR DESCRIPTION
The `-k '-expr'` syntax is an old alias to `-k 'not expr'`. It's also not very convenient to have syntax that start with `-` on the CLI. Deprecate it and suggest replacing with `not`.

---

The `-k 'expr:'` syntax discards all items until the first match and keeps all subsequent, e.g. `-k foo` with

    test_bar
    test_foo
    test_baz

results in `test_foo`, `test_baz`. That's a bit weird, so deprecate it without a replacement. If someone complains we can reconsider or devise a better alternative.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
