### PR TITLE
Make docs reflect that `yield`-based tests are now completely unsupported

### DIFF
--- a/doc/en/nose.rst
+++ b/doc/en/nose.rst
@@ -26,7 +26,6 @@ Supported nose Idioms
 * setup and teardown at module/class/method level
 * SkipTest exceptions and markers
 * setup/teardown decorators
-* ``yield``-based tests and their setup (considered deprecated as of pytest 3.0)
 * ``__test__`` attribute on modules/classes/functions
 * general usage of nose utilities
 
@@ -65,10 +64,8 @@ Unsupported idioms / known issues
 
 - no nose-configuration is recognized.
 
-- ``yield``-based methods don't support ``setup`` properly because
-  the ``setup`` method is always called in the same class instance.
-  There are no plans to fix this currently because ``yield``-tests
-  are deprecated in pytest 3.0, with ``pytest.mark.parametrize``
-  being the recommended alternative.
+- ``yield``-based methods are unsupported as of pytest 4.1.0.  They are
+  fundamentally incompatible with pytest because they don't support fixtures
+  properly since collection and test execution are separated.
 
 .. _nose: https://nose.readthedocs.io/en/latest/


### PR DESCRIPTION
The docs for Nose-style tests say that some types/parts of `yield`-based tests are supported:

https://github.com/pytest-dev/pytest/blob/master/doc/en/nose.rst#supported-nose-idioms

but the changelog for 4.1.0 is unambiguous that `yield`-based tests are entirely deprecated:

https://docs.pytest.org/en/latest/changelog.html#pytest-4-1-0-2019-01-05

and that's what I've found while using pytest: `yield`-based tests do not work and must be upgraded.  I've therefore deleted the `yield` entry in the "supported" subsection and made the `yield` entry in "unsupported" more unequivocal, with phrasing taken from the above-linked changelog entry for simplicity's sake.

I didn't bother adding a changelog entry or myself to AUTHORS.  Please let me know if you'd like me to do either.

By the way, I just got done converting a 12-year-old, 20,000-test Django project from Nose to pytest and this PR is the only "bug" I found in pytest.  It was a real pleasure to use: all our use cases had pytest equivalents, including weird, hacky things in Nose that we were able to convert to vanilla pytest.  I found I actually enjoyed reading the pytest docs to find what new features I could use.  That's a huge testament to how well designed and implemented this library is, and y'all should be very proud!