### PR TITLE
logging: some optimizations

### DIFF
--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -619,7 +619,6 @@ class LoggingPlugin:
             else:
                 yield
 
-    @contextmanager
     def _runtest_for(
         self, item: Optional[nodes.Item], when: str
     ) -> Generator[None, None, None]:
@@ -656,35 +655,29 @@ class LoggingPlugin:
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_setup(self, item):
-        with self._runtest_for(item, "setup"):
-            yield
+        yield from self._runtest_for(item, "setup")
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_call(self, item):
-        with self._runtest_for(item, "call"):
-            yield
+        yield from self._runtest_for(item, "call")
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_teardown(self, item):
-        with self._runtest_for(item, "teardown"):
-            yield
+        yield from self._runtest_for(item, "teardown")
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_logstart(self):
         if self.log_cli_handler:
             self.log_cli_handler.reset()
-        with self._runtest_for(None, "start"):
-            yield
+        yield from self._runtest_for(None, "start")
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_logfinish(self):
-        with self._runtest_for(None, "finish"):
-            yield
+        yield from self._runtest_for(None, "finish")
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_logreport(self):
-        with self._runtest_for(None, "logreport"):
-            yield
+        yield from self._runtest_for(None, "logreport")
 
     @pytest.hookimpl(hookwrapper=True, tryfirst=True)
     def pytest_sessionfinish(self):

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -620,17 +620,8 @@ class LoggingPlugin:
                 yield
 
     @contextmanager
-    def _runtest_for(self, item, when):
-        with self._runtest_for_main(item, when):
-            if self.log_file_handler is not None:
-                with catching_logs(self.log_file_handler, level=self.log_file_level):
-                    yield
-            else:
-                yield
-
-    @contextmanager
-    def _runtest_for_main(
-        self, item: nodes.Item, when: str
+    def _runtest_for(
+        self, item: Optional[nodes.Item], when: str
     ) -> Generator[None, None, None]:
         """Implements the internals of pytest_runtest_xxx() hook."""
         with catching_logs(
@@ -639,21 +630,26 @@ class LoggingPlugin:
             if self.log_cli_handler:
                 self.log_cli_handler.set_when(when)
 
-            if item is None:
-                yield  # run the test
-                return
-
-            empty = {}  # type: Dict[str, LogCaptureHandler]
-            item._store.setdefault(catch_log_handlers_key, empty)[when] = log_handler
-            item._store[catch_log_handler_key] = log_handler
+            if item is not None:
+                empty = {}  # type: Dict[str, LogCaptureHandler]
+                item._store.setdefault(catch_log_handlers_key, empty)[
+                    when
+                ] = log_handler
+                item._store[catch_log_handler_key] = log_handler
             try:
-                yield  # run test
+                if self.log_file_handler is not None:
+                    with catching_logs(
+                        self.log_file_handler, level=self.log_file_level
+                    ):
+                        yield
+                else:
+                    yield
             finally:
-                if when == "teardown":
+                if item is not None and when == "teardown":
                     del item._store[catch_log_handlers_key]
                     del item._store[catch_log_handler_key]
 
-            if self.print_logs:
+            if item is not None and self.print_logs:
                 # Add a captured log section to the report.
                 log = log_handler.stream.getvalue().strip()
                 item.add_report_section(when, "log", log)

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -17,10 +17,14 @@ from _pytest.config import _strtobool
 from _pytest.config import Config
 from _pytest.config import create_terminal_writer
 from _pytest.pathlib import Path
+from _pytest.store import StoreKey
+
 
 DEFAULT_LOG_FORMAT = "%(levelname)-8s %(name)s:%(filename)s:%(lineno)d %(message)s"
 DEFAULT_LOG_DATE_FORMAT = "%H:%M:%S"
 _ANSI_ESCAPE_SEQ = re.compile(r"\x1b\[[\d;]+m")
+catch_log_handler_key = StoreKey["LogCaptureHandler"]()
+catch_log_handlers_key = StoreKey[Dict[str, "LogCaptureHandler"]]()
 
 
 def _remove_ansi_escape_sequences(text):
@@ -317,7 +321,7 @@ class LogCaptureHandler(logging.StreamHandler):
 class LogCaptureFixture:
     """Provides access and control of log capturing."""
 
-    def __init__(self, item) -> None:
+    def __init__(self, item: nodes.Node) -> None:
         """Creates a new funcarg."""
         self._item = item
         # dict of log name -> log level
@@ -338,7 +342,7 @@ class LogCaptureFixture:
         """
         :rtype: LogCaptureHandler
         """
-        return self._item.catch_log_handler  # type: ignore[no-any-return]
+        return self._item._store[catch_log_handler_key]
 
     def get_records(self, when: str) -> List[logging.LogRecord]:
         """
@@ -352,9 +356,9 @@ class LogCaptureFixture:
 
         .. versionadded:: 3.4
         """
-        handler = self._item.catch_log_handlers.get(when)
+        handler = self._item._store[catch_log_handlers_key].get(when)
         if handler:
-            return handler.records  # type: ignore[no-any-return]
+            return handler.records
         else:
             return []
 
@@ -639,16 +643,15 @@ class LoggingPlugin:
                 yield  # run the test
                 return
 
-            if not hasattr(item, "catch_log_handlers"):
-                item.catch_log_handlers = {}  # type: ignore[attr-defined]
-            item.catch_log_handlers[when] = log_handler  # type: ignore[attr-defined]
-            item.catch_log_handler = log_handler  # type: ignore[attr-defined]
+            empty = {}  # type: Dict[str, LogCaptureHandler]
+            item._store.setdefault(catch_log_handlers_key, empty)[when] = log_handler
+            item._store[catch_log_handler_key] = log_handler
             try:
                 yield  # run test
             finally:
                 if when == "teardown":
-                    del item.catch_log_handler  # type: ignore[attr-defined]
-                    del item.catch_log_handlers  # type: ignore[attr-defined]
+                    del item._store[catch_log_handlers_key]
+                    del item._store[catch_log_handler_key]
 
             if self.print_logs:
                 # Add a captured log section to the report.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -660,25 +660,22 @@ class LoggingPlugin:
         del item._store[catch_log_records_key]
         del item._store[catch_log_handler_key]
 
-    @pytest.hookimpl(hookwrapper=True)
+    @pytest.hookimpl
     def pytest_runtest_logstart(self):
         if self.log_cli_handler:
             self.log_cli_handler.reset()
         if self.log_cli_handler is not None:
             self.log_cli_handler.set_when("start")
-        yield
 
-    @pytest.hookimpl(hookwrapper=True)
+    @pytest.hookimpl
     def pytest_runtest_logfinish(self):
         if self.log_cli_handler is not None:
             self.log_cli_handler.set_when("finish")
-        yield
 
-    @pytest.hookimpl(hookwrapper=True)
+    @pytest.hookimpl
     def pytest_runtest_logreport(self):
         if self.log_cli_handler is not None:
             self.log_cli_handler.set_when("logreport")
-        yield
 
     @pytest.hookimpl(hookwrapper=True, tryfirst=True)
     def pytest_sessionfinish(self):

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -1,7 +1,7 @@
 import logging
 
 import pytest
-from _pytest.logging import catch_log_handlers_key
+from _pytest.logging import catch_log_records_key
 
 logger = logging.getLogger(__name__)
 sublogger = logging.getLogger(__name__ + ".baz")
@@ -137,4 +137,4 @@ def test_caplog_captures_for_all_stages(caplog, logging_during_setup_and_teardow
     assert [x.message for x in caplog.get_records("setup")] == ["a_setup_log"]
 
     # This reaches into private API, don't use this type of thing in real tests!
-    assert set(caplog._item._store[catch_log_handlers_key].keys()) == {"setup", "call"}
+    assert set(caplog._item._store[catch_log_records_key].keys()) == {"setup", "call"}

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -1,6 +1,7 @@
 import logging
 
 import pytest
+from _pytest.logging import catch_log_handlers_key
 
 logger = logging.getLogger(__name__)
 sublogger = logging.getLogger(__name__ + ".baz")
@@ -136,4 +137,4 @@ def test_caplog_captures_for_all_stages(caplog, logging_during_setup_and_teardow
     assert [x.message for x in caplog.get_records("setup")] == ["a_setup_log"]
 
     # This reaches into private API, don't use this type of thing in real tests!
-    assert set(caplog._item.catch_log_handlers.keys()) == {"setup", "call"}
+    assert set(caplog._item._store[catch_log_handlers_key].keys()) == {"setup", "call"}


### PR DESCRIPTION
Please see the commit messages for details.

On this benchmark:

```py
import pytest
@pytest.mark.parametrize("x", range(5000))
def test_foo(x): pass
```

Before (only relevant entries shown):

```
============================ 5000 passed in 14.13s =============================
         13465818 function calls (12550967 primitive calls) in 14.571 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
140003/60003 0.109    0.000    2.435    0.000 contextlib.py:108(__enter__)
    80000    0.098    0.000    2.224    0.000 logging.py:618(_runtest_for)
140003/60003 0.143    0.000    2.194    0.000 contextlib.py:117(__exit__)
    80000    0.257    0.000    1.721    0.000 logging.py:627(_runtest_for_main)
    30000    0.046    0.000    0.972    0.000 logging.py:685(pytest_runtest_logreport)
    40000    0.096    0.000    0.711    0.000 logging.py:302(__init__)
    10000    0.014    0.000    0.456    0.000 logging.py:668(pytest_runtest_teardown)
    80000    0.137    0.000    0.434    0.000 logging.py:271(catching_logs)
    10000    0.017    0.000    0.323    0.000 logging.py:673(pytest_runtest_logstart)
    10000    0.014    0.000    0.301    0.000 logging.py:680(pytest_runtest_logfinish)
    10000    0.013    0.000    0.285    0.000 logging.py:658(pytest_runtest_setup)
    10000    0.012    0.000    0.258    0.000 logging.py:663(pytest_runtest_call)
```

After:

```
============================ 5000 passed in 11.86s =============================
         10476806 function calls (9908460 primitive calls) in 12.164 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    35003    0.053    0.000    1.430    0.000 contextlib.py:117(__exit__)
    35003    0.037    0.000    1.155    0.000 contextlib.py:108(__enter__)
    30000    0.143    0.000    0.563    0.000 logging.py:622(_runtest_for)
    30000    0.067    0.000    0.223    0.000 logging.py:275(catching_logs)
    10000    0.020    0.000    0.222    0.000 logging.py:647(pytest_runtest_setup)
    10000    0.024    0.000    0.222    0.000 logging.py:657(pytest_runtest_teardown)
    10000    0.011    0.000    0.184    0.000 logging.py:653(pytest_runtest_call)
    15000    0.006    0.000    0.006    0.000 logging.py:675(pytest_runtest_logreport)
     5000    0.003    0.000    0.003    0.000 logging.py:663(pytest_runtest_logstart)
     5000    0.003    0.000    0.003    0.000 logging.py:670(pytest_runtest_logfinish)
```