### PR TITLE
Use abspath for errors when cwd changes during testing

### DIFF
--- a/changelog/6428.bugfix.rst
+++ b/changelog/6428.bugfix.rst
@@ -1,0 +1,2 @@
+Paths appearing in error messages are now correct in case the current working directory has
+changed since the start of the session.

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -29,6 +29,7 @@ from _pytest.mark.structures import Mark
 from _pytest.mark.structures import MarkDecorator
 from _pytest.mark.structures import NodeKeywords
 from _pytest.outcomes import fail
+from _pytest.pathlib import Path
 from _pytest.store import Store
 
 if TYPE_CHECKING:
@@ -361,8 +362,14 @@ class Node(metaclass=NodeMeta):
         else:
             truncate_locals = True
 
+        # excinfo.getrepr() formats paths relative to the CWD if `abspath` is False.
+        # It is possible for a fixture/test to change the CWD while this code runs, which
+        # would then result in the user seeing confusing paths in the failure message.
+        # To fix this, if the CWD changed, always display the full absolute path.
+        # It will be better to just always display paths relative to invocation_dir, but
+        # this requires a lot of plumbing (#6428).
         try:
-            abspath = os.getcwd() != str(self.config.invocation_dir)
+            abspath = Path(os.getcwd()) != Path(self.config.invocation_dir)
         except OSError:
             abspath = True
 

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -362,8 +362,7 @@ class Node(metaclass=NodeMeta):
             truncate_locals = True
 
         try:
-            os.getcwd()
-            abspath = False
+            abspath = os.getcwd() != str(self.config.invocation_dir)
         except OSError:
             abspath = True
 


### PR DESCRIPTION
Fixes #6428

Supersedes https://github.com/pytest-dev/pytest/pull/6429