### PR TITLE
Remove extraneous traceback and simplify string repr of ConftestImportFailure

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -88,9 +88,14 @@ class ExitCode(enum.IntEnum):
 
 class ConftestImportFailure(Exception):
     def __init__(self, path, excinfo):
-        Exception.__init__(self, path, excinfo)
+        super().__init__(path, excinfo)
         self.path = path
         self.excinfo = excinfo  # type: Tuple[Type[Exception], Exception, TracebackType]
+
+    def __str__(self):
+        return "{}: {} (from {})".format(
+            self.excinfo[0].__name__, self.excinfo[1], self.path
+        )
 
 
 def main(args=None, plugins=None) -> Union[int, ExitCode]:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -10,6 +10,7 @@ import pytest
 from _pytest.compat import importlib_metadata
 from _pytest.config import _iter_rewritable_modules
 from _pytest.config import Config
+from _pytest.config import ConftestImportFailure
 from _pytest.config import ExitCode
 from _pytest.config.exceptions import UsageError
 from _pytest.config.findpaths import determine_setup
@@ -1471,3 +1472,19 @@ class TestPytestPluginsVariable:
         assert res.ret == 0
         msg = "Defining 'pytest_plugins' in a non-top-level conftest is no longer supported"
         assert msg not in res.stdout.str()
+
+
+def test_conftest_import_error_repr(tmpdir):
+    """
+    ConftestImportFailure should use a short error message and readable path to the failed
+    conftest.py file
+    """
+    path = tmpdir.join("foo/conftest.py")
+    with pytest.raises(
+        ConftestImportFailure,
+        match=re.escape("RuntimeError: some error (from {})".format(path)),
+    ):
+        try:
+            raise RuntimeError("some error")
+        except Exception:
+            raise ConftestImportFailure(path, sys.exc_info())


### PR DESCRIPTION
This removes the `KeyError` traceback from the chain when an conftest fails to import:

```
return self._conftestpath2mod[key]
E   KeyError: WindowsPath('D:/projects/pytest/.tmp/root/foo/conftest.py')

During handling of the above exception, another exception occurred:
...
    raise RuntimeError("some error")
E   RuntimeError: some error

During handling of the above exception, another exception occurred:
...
E   _pytest.config.ConftestImportFailure: (local('D:\\projects\\pytest\\.tmp\\root\\foo\\conftest.py'), (<class 'RuntimeError'>, RuntimeError('some error',), <traceback object at 0x000001CCC3E39348>))
```

By slightly changing the code, we can remove the first chain, which is often confusing to users and doesn't help with anything.

Also while at it, simplified the string representation of `ConftestImportFailure` from:

```
E   _pytest.config.ConftestImportFailure: (local('D:\\projects\\pytest\\.tmp\\root\\foo\\conftest.py'), (<class 'RuntimeError'>, RuntimeError('some error',), <traceback object at 0x000001CCC3E39348>))
```

To:

```
E   _pytest.config.ConftestImportFailure: RuntimeError: some error (from D:\projects\pytest\.tmp\root\foo\conftest.py)
```

Fix #7223