### PR TITLE
logging: some simplifications/cleanups

### DIFF
--- a/changelog/7224.breaking.rst
+++ b/changelog/7224.breaking.rst
@@ -1,0 +1,2 @@
+The `item.catch_log_handler` and `item.catch_log_handlers` attributes, set by the
+logging plugin and never meant to be public , are no longer available.

--- a/changelog/7224.breaking.rst
+++ b/changelog/7224.breaking.rst
@@ -1,2 +1,4 @@
 The `item.catch_log_handler` and `item.catch_log_handlers` attributes, set by the
 logging plugin and never meant to be public , are no longer available.
+
+The deprecated ``--no-print-logs`` option is removed. Use ``--show-capture`` instead.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -37,10 +37,10 @@ a public API and may break in the future.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. deprecated:: 5.4
+.. versionremoved:: 6.0
 
 
-Option ``--no-print-logs`` is deprecated and meant to be removed in a future release. If you use ``--no-print-logs``, please try out ``--show-capture`` and
-provide feedback.
+Option ``--no-print-logs`` is removed. If you used ``--no-print-logs``, please use ``--show-capture`` instead.
 
 ``--show-capture`` command-line option was added in ``pytest 3.5.0`` and allows to specify how to
 display captured output when tests fail: ``no``, ``stdout``, ``stderr``, ``log`` or ``all`` (the default).

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -54,11 +54,6 @@ JUNIT_XML_DEFAULT_FAMILY = PytestDeprecationWarning(
     "for more information."
 )
 
-NO_PRINT_LOGS = PytestDeprecationWarning(
-    "--no-print-logs is deprecated and scheduled for removal in pytest 6.0.\n"
-    "Please use --show-capture instead."
-)
-
 COLLECT_DIRECTORY_HOOK = PytestDeprecationWarning(
     "The pytest_collect_directory hook is not working.\n"
     "Please use collect_ignore in conftests or pytest_collection_modifyitems."

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -191,15 +191,6 @@ def pytest_addoption(parser):
         group.addoption(option, dest=dest, **kwargs)
 
     add_option_ini(
-        "--no-print-logs",
-        dest="log_print",
-        action="store_const",
-        const=False,
-        default=True,
-        type="bool",
-        help="disable printing caught logs on failed tests.",
-    )
-    add_option_ini(
         "--log-level",
         dest="log_level",
         default=None,
@@ -499,13 +490,6 @@ class LoggingPlugin:
         """
         self._config = config
 
-        self.print_logs = get_option_ini(config, "log_print")
-        if not self.print_logs:
-            from _pytest.warnings import _issue_warning_captured
-            from _pytest.deprecated import NO_PRINT_LOGS
-
-            _issue_warning_captured(NO_PRINT_LOGS, self._config.hook, stacklevel=2)
-
         # Report logging.
         self.formatter = self._create_formatter(
             get_option_ini(config, "log_format"),
@@ -630,10 +614,8 @@ class LoggingPlugin:
 
             yield
 
-            if self.print_logs:
-                # Add a captured log section to the report.
-                log = log_handler.stream.getvalue().strip()
-                item.add_report_section(when, "log", log)
+            log = log_handler.stream.getvalue().strip()
+            item.add_report_section(when, "log", log)
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_setup(self, item):

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -678,10 +678,6 @@ class LoggingPlugin:
             with catching_logs(self.log_file_handler, level=self.log_file_level):
                 yield
 
-        # Close the FileHandler explicitly.
-        # (logging.shutdown might have lost the weakref?!)
-        self.log_file_handler.close()
-
     @pytest.hookimpl(hookwrapper=True, tryfirst=True)
     def pytest_sessionstart(self):
         self.log_cli_handler.set_when("sessionstart")
@@ -705,6 +701,12 @@ class LoggingPlugin:
         with catching_logs(self.log_cli_handler, level=self.log_cli_level):
             with catching_logs(self.log_file_handler, level=self.log_file_level):
                 yield  # run all the tests
+
+    @pytest.hookimpl
+    def pytest_unconfigure(self):
+        # Close the FileHandler explicitly.
+        # (logging.shutdown might have lost the weakref?!)
+        self.log_file_handler.close()
 
 
 class _LiveLoggingStreamHandler(logging.StreamHandler):

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -625,7 +625,6 @@ class LoggingPlugin:
                 with catching_logs(logging.NullHandler()):
                     yield
 
-    @contextmanager
     def _runtest_for(
         self, item: Optional[nodes.Item], when: str
     ) -> Generator[None, None, None]:
@@ -662,35 +661,29 @@ class LoggingPlugin:
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_setup(self, item):
-        with self._runtest_for(item, "setup"):
-            yield
+        yield from self._runtest_for(item, "setup")
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_call(self, item):
-        with self._runtest_for(item, "call"):
-            yield
+        yield from self._runtest_for(item, "call")
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_teardown(self, item):
-        with self._runtest_for(item, "teardown"):
-            yield
+        yield from self._runtest_for(item, "teardown")
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_logstart(self):
         if self.log_cli_handler:
             self.log_cli_handler.reset()
-        with self._runtest_for(None, "start"):
-            yield
+        yield from self._runtest_for(None, "start")
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_logfinish(self):
-        with self._runtest_for(None, "finish"):
-            yield
+        yield from self._runtest_for(None, "finish")
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_logreport(self):
-        with self._runtest_for(None, "logreport"):
-            yield
+        yield from self._runtest_for(None, "logreport")
 
     @pytest.hookimpl(hookwrapper=True, tryfirst=True)
     def pytest_sessionfinish(self):

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -117,47 +117,6 @@ def test_node_direct_ctor_warning():
     assert w[0].filename == __file__
 
 
-def assert_no_print_logs(testdir, args):
-    result = testdir.runpytest(*args)
-    result.stdout.fnmatch_lines(
-        [
-            "*--no-print-logs is deprecated and scheduled for removal in pytest 6.0*",
-            "*Please use --show-capture instead.*",
-        ]
-    )
-
-
-@pytest.mark.filterwarnings("default")
-def test_noprintlogs_is_deprecated_cmdline(testdir):
-    testdir.makepyfile(
-        """
-        def test_foo():
-            pass
-        """
-    )
-
-    assert_no_print_logs(testdir, ("--no-print-logs",))
-
-
-@pytest.mark.filterwarnings("default")
-def test_noprintlogs_is_deprecated_ini(testdir):
-    testdir.makeini(
-        """
-        [pytest]
-        log_print=False
-        """
-    )
-
-    testdir.makepyfile(
-        """
-        def test_foo():
-            pass
-        """
-    )
-
-    assert_no_print_logs(testdir, ())
-
-
 def test__fillfuncargs_is_deprecated() -> None:
     with pytest.warns(
         pytest.PytestDeprecationWarning,

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -1,6 +1,7 @@
 import logging
 
 import pytest
+from _pytest.logging import catch_log_handlers_key
 
 logger = logging.getLogger(__name__)
 sublogger = logging.getLogger(__name__ + ".baz")
@@ -136,4 +137,4 @@ def test_caplog_captures_for_all_stages(caplog, logging_during_setup_and_teardow
     assert [x.message for x in caplog.get_records("setup")] == ["a_setup_log"]
 
     # This reaches into private API, don't use this type of thing in real tests!
-    assert set(caplog._item.catch_log_handlers.keys()) == {"setup", "call"}
+    assert set(caplog._item._store[catch_log_handlers_key]) == {"setup", "call"}

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -166,60 +166,6 @@ def test_teardown_logging(testdir):
     )
 
 
-def test_disable_log_capturing(testdir):
-    testdir.makepyfile(
-        """
-        import sys
-        import logging
-
-        logger = logging.getLogger(__name__)
-
-        def test_foo():
-            sys.stdout.write('text going to stdout')
-            logger.warning('catch me if you can!')
-            sys.stderr.write('text going to stderr')
-            assert False
-        """
-    )
-    result = testdir.runpytest("--no-print-logs")
-    print(result.stdout)
-    assert result.ret == 1
-    result.stdout.fnmatch_lines(["*- Captured stdout call -*", "text going to stdout"])
-    result.stdout.fnmatch_lines(["*- Captured stderr call -*", "text going to stderr"])
-    with pytest.raises(pytest.fail.Exception):
-        result.stdout.fnmatch_lines(["*- Captured *log call -*"])
-
-
-def test_disable_log_capturing_ini(testdir):
-    testdir.makeini(
-        """
-        [pytest]
-        log_print=False
-        """
-    )
-    testdir.makepyfile(
-        """
-        import sys
-        import logging
-
-        logger = logging.getLogger(__name__)
-
-        def test_foo():
-            sys.stdout.write('text going to stdout')
-            logger.warning('catch me if you can!')
-            sys.stderr.write('text going to stderr')
-            assert False
-        """
-    )
-    result = testdir.runpytest()
-    print(result.stdout)
-    assert result.ret == 1
-    result.stdout.fnmatch_lines(["*- Captured stdout call -*", "text going to stdout"])
-    result.stdout.fnmatch_lines(["*- Captured stderr call -*", "text going to stderr"])
-    with pytest.raises(pytest.fail.Exception):
-        result.stdout.fnmatch_lines(["*- Captured *log call -*"])
-
-
 @pytest.mark.parametrize("enabled", [True, False])
 def test_log_cli_enabled_disabled(testdir, enabled):
     msg = "critical message logged by test"


### PR DESCRIPTION
While looking at optimizing the logging plugin (since it shows up in profiles), and also at some issues and open PRs, I collected some simplifications and cleanups. I think they make the file a little cleaner and easier to understand and modify, and also a little faster, though this isn't the goal of this PR.

<details>
<summary>Benchmark</summary>

On this benchmark

```py
import pytest
@pytest.mark.parametrize("x", range(5000))
def test_foo(x): pass
```

Before:

    ============================ 5000 passed in 13.66s =============================
            13345882 function calls (12431103 primitive calls) in 14.054 seconds

After:

    ============================ 5000 passed in 12.53s =============================
            11271238 function calls (10716458 primitive calls) in 12.938 seconds
</details>

It is better to review each commit separately -- one of the commits reorders some methods so the PR diff will be unreadable.

Includes a few breaking changes to private attributes, and one deprecation removal (`--no-print-logs`) that was planned for 6.0.

This will cause conflicts with some open PRs. This is intentional, since I think they will be easier to evaluate after these changes (and some others). I will comment on them separately once it becomes relevant.