### PR TITLE
Remove unused Function.__init__ 'args' parameter

### DIFF
--- a/changelog/7226.breaking.rst
+++ b/changelog/7226.breaking.rst
@@ -1,0 +1,1 @@
+Removed the unused ``args`` parameter from ``pytest.Function.__init__``.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1386,7 +1386,6 @@ class Function(PyobjMixin, nodes.Item):
         self,
         name,
         parent,
-        args=None,
         config=None,
         callspec: Optional[CallSpec2] = None,
         callobj=NOTSET,
@@ -1399,7 +1398,6 @@ class Function(PyobjMixin, nodes.Item):
         param name: the full function name, including any decorations like those
             added by parametrization (``my_func[my_param]``).
         param parent: the parent Node.
-        param args: (unused)
         param config: the pytest Config object
         param callspec: if given, this is function has been parametrized and the callspec contains
             meta information about the parametrization.
@@ -1415,7 +1413,7 @@ class Function(PyobjMixin, nodes.Item):
             (``my_func[my_param]``).
         """
         super().__init__(name, parent, config=config, session=session)
-        self._args = args
+
         if callobj is not NOTSET:
             self.obj = callobj
 

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -294,9 +294,11 @@ class TestFunction:
         def func2():
             pass
 
-        f1 = self.make_function(testdir, name="name", args=(1,), callobj=func1)
+        f1 = self.make_function(testdir, name="name", callobj=func1)
         assert f1 == f1
-        f2 = self.make_function(testdir, name="name", callobj=func2)
+        f2 = self.make_function(
+            testdir, name="name", callobj=func2, originalname="foobar"
+        )
         assert f1 != f2
 
     def test_repr_produces_actual_test_id(self, testdir):


### PR DESCRIPTION
Noticed while documenting `Function.__init__` in https://github.com/pytest-dev/pytest/pull/7035.