### PR TITLE
logging: reuse LoggingCaptureHandler instance since it's expensive to create

### DIFF
--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -1,7 +1,7 @@
 import logging
 
 import pytest
-from _pytest.logging import catch_log_handlers_key
+from _pytest.logging import catch_log_records_key
 
 logger = logging.getLogger(__name__)
 sublogger = logging.getLogger(__name__ + ".baz")
@@ -137,4 +137,4 @@ def test_caplog_captures_for_all_stages(caplog, logging_during_setup_and_teardow
     assert [x.message for x in caplog.get_records("setup")] == ["a_setup_log"]
 
     # This reaches into private API, don't use this type of thing in real tests!
-    assert set(caplog._item._store[catch_log_handlers_key]) == {"setup", "call"}
+    assert set(caplog._item._store[catch_log_records_key]) == {"setup", "call"}


### PR DESCRIPTION
Previously, a LoggingCaptureHandler was instantiated for each test's setup/call/teardown which turns out to be expensive.

Instead, only keep one instance and reset it between runs.

(Previously in #7214. Now I'm pretty sure it will interact well with the other PRs).

<details>
<summary>Benchmark</summary>

```py
import pytest
@pytest.mark.parametrize("x", range(5000))
def test_foo(x): pass
```

Before:
```
============================ 5000 passed in 11.87s =============================
         10866808 function calls (10313462 primitive calls) in 12.163 seconds
```

After:

```
============================ 5000 passed in 11.25s =============================
         10431870 function calls (9878523 primitive calls) in 11.541 seconds
````
</details>