### PR TITLE
logging: propagate errors during log message emits

### DIFF
--- a/changelog/6433.feature.rst
+++ b/changelog/6433.feature.rst
@@ -1,0 +1,10 @@
+If an error is encountered while formatting the message in a logging call, for
+example ``logging.warning("oh no!: %s: %s", "first")`` (a second argument is
+missing), pytest now propagates the error, likely causing the test to fail.
+
+Previously, such a mistake would cause an error to be printed to stderr, which
+is not displayed by default for passing tests. This change makes the mistake
+visible during testing.
+
+You may supress this behavior temporarily or permanently by setting
+``logging.raiseExceptions = False``.


### PR DESCRIPTION
Fixes #6433.

Currently, a bad logging call, e.g.

    logger.info('oops', 'first', 2)

triggers the default logging handling, which is printing an error to
stderr but otherwise continuing.

For regular programs this behavior makes sense, a bad log message
shouldn't take down the program. But during tests, it is better not to
skip over such mistakes, but propagate them to the user.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
