### PR TITLE
Updated compatible python versions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -187,6 +187,7 @@ Matt Duck
 Matt Williams
 Matthias Hafner
 Maxim Filipenko
+Maximilian Cosmo Sitter
 mbyt
 Michael Aquilina
 Michael Birtwell

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -1,7 +1,7 @@
 Installation and Getting Started
 ===================================
 
-**Pythons**: Python 3.5, 3.6, 3.7, PyPy3
+**Pythons**: Python 3.5, 3.6, 3.7, 3.8, 3.9, PyPy3
 
 **Platforms**: Linux and Windows
 


### PR DESCRIPTION
As indicated on pypi and in the README pytest supports python version 3.8 and 3.9. The documentation should match.

This is my first pull request to a big repo like this one. I saw the wrong information on the [getting started page](https://docs.pytest.org/en/latest/getting-started.html). I read the contributing guidelines and hope this is fine.

- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [X] Add yourself to `AUTHORS` in alphabetical order.