### PR TITLE
Add note about --strict and --strict-markers to references

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -102,6 +102,7 @@ Fabio Zadrozny
 Felix Nieuwenhuizen
 Feng Ma
 Florian Bruhin
+Florian Dahlitz
 Floris Bruynooghe
 Gabriel Reis
 Gene Wood

--- a/changelog/7233.doc.rst
+++ b/changelog/7233.doc.rst
@@ -1,0 +1,1 @@
+Add a note about ``--strict`` and ``--strict-markers`` and the preference for the latter one.

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -1447,6 +1447,11 @@ passed multiple times. The expected format is ``name=value``. For example::
             slow
             serial
 
+    .. note::
+        The use of ``--strict-markers`` is highly preferred. ``--strict`` was kept for
+        backward compatibility only and may be confusing for others as it only applies to
+        markers and not to other options.
+
 .. confval:: minversion
 
    Specifies a minimal pytest version required for running tests.


### PR DESCRIPTION
As discussed in #7233, I added a note to references stating the preference for `--strict-markers`.

- [x] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`
- [X] Add yourself to `AUTHORS` in alphabetical order.

@nicoddemus I hope I did not forget anything and the proposed note is sufficient. Let me know if I need to change something.