### PR TITLE
7229 allow multiple -k / -m expressions on CLI and append them using 'and'

### DIFF
--- a/changelog/7229.improvement.rst
+++ b/changelog/7229.improvement.rst
@@ -1,0 +1,7 @@
+``-k`` and ``-m`` now append duplicate cli options using an 'and' approach.
+
+for example:
+
+``pytest -m 'marker_a' -m 'marker_b'`` will result in a marker expression of `marker_a and marker_b`
+
+``pytest -k 'myclass' -k 'mytest'`` will result in a keyword expression of `myclass and mytest`

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -77,7 +77,6 @@ def pytest_addoption(parser):
         "-m",
         action="append",
         dest="markexpr",
-        nargs="+",
         metavar="MARKEXPR",
         help="only run tests matching given mark expression.\n"
         "For example: -m 'mark1 and not mark2'.\n"
@@ -225,7 +224,8 @@ def deselect_by_mark(items, config):
         return
 
     try:
-        matchexpr = " and ".join(expr[0] for expr in matchexpr)
+        # Not sure if a set() is completely suitable for the use case here, insertion order is necessary?
+        matchexpr = " and ".join(matchexpr)
         expression = Expression.compile(matchexpr)
     except ParseError as e:
         raise UsageError(

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -80,7 +80,8 @@ def pytest_addoption(parser):
         nargs="+",
         metavar="MARKEXPR",
         help="only run tests matching given mark expression.\n"
-        "For example: -m 'mark1 and not mark2'.",
+        "For example: -m 'mark1 and not mark2'.\n"
+        "Multiple -m CLI options are appended with 'and'.\n",
     )
 
     group.addoption(

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -75,9 +75,9 @@ def pytest_addoption(parser):
 
     group._addoption(
         "-m",
-        action="store",
+        action="append",
         dest="markexpr",
-        default="",
+        nargs="+",
         metavar="MARKEXPR",
         help="only run tests matching given mark expression.\n"
         "For example: -m 'mark1 and not mark2'.",
@@ -224,6 +224,7 @@ def deselect_by_mark(items, config):
         return
 
     try:
+        matchexpr = " and ".join(expr[0] for expr in matchexpr)
         expression = Expression.compile(matchexpr)
     except ParseError as e:
         raise UsageError(

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -69,7 +69,7 @@ def pytest_addoption(parser):
         "Additionally keywords are matched to classes and functions "
         "containing extra names in their 'extra_keyword_matches' set, "
         "as well as functions which have names assigned directly to them. "
-        "The matching is case-insensitive."
+        "The matching is case-insensitive. "
         "Multiple -k cli options are appended with 'and'.",
     )
 
@@ -80,7 +80,7 @@ def pytest_addoption(parser):
         metavar="MARKEXPR",
         help="only run tests matching given mark expression.\n"
         "For example: -m 'mark1 and not mark2'.\n"
-        "Multiple -m cli options are appended with 'and'.\n",
+        "Multiple -m cli options are appended with 'and'.",
     )
 
     group.addoption(

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -19,8 +19,10 @@ def test_help(testdir):
     assert result.ret == 0
     result.stdout.fnmatch_lines(
         """
-          -m MARKEXPR           only run tests matching given mark expression.
+          -m MARKEXPR [MARKEXPR ...]
+                                only run tests matching given mark expression.
                                 For example: -m 'mark1 and not mark2'.
+                                Multiple -m CLI options are appended with 'and'.
         reporting:
           --durations=N *
         *setup.cfg*

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -60,7 +60,7 @@ def test_help_keywordexpr(testdir):
                                 and functions containing extra names in their
                                 'extra_keyword_matches' set, as well as functions which
                                 have names assigned directly to them. The matching is
-                                case-insensitive.Multiple -k cli options are appended
+                                case-insensitive. Multiple -k cli options are appended
                                 with 'and'.
         *
         """

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -19,10 +19,6 @@ def test_help(testdir):
     assert result.ret == 0
     result.stdout.fnmatch_lines(
         """
-          -m MARKEXPR [MARKEXPR ...]
-                                only run tests matching given mark expression.
-                                For example: -m 'mark1 and not mark2'.
-                                Multiple -m CLI options are appended with 'and'.
         reporting:
           --durations=N *
         *setup.cfg*
@@ -30,6 +26,44 @@ def test_help(testdir):
         *to see*markers*pytest --markers*
         *to see*fixtures*pytest --fixtures*
     """
+    )
+
+
+def test_help_matchexpr(testdir):
+    result = testdir.runpytest("--help")
+    assert result.ret == 0
+    result.stdout.fnmatch_lines(
+        """
+          -m MARKEXPR           only run tests matching given mark expression.
+                                For example: -m 'mark1 and not mark2'.
+                                Multiple -m cli options are appended with 'and'.
+        *
+        """
+    )
+
+
+def test_help_keywordexpr(testdir):
+    result = testdir.runpytest("--help")
+    assert result.ret == 0
+    result.stdout.fnmatch_lines(
+        """
+          -k EXPRESSION         only run tests which match the given substring
+                                expression. An expression is a python evaluatable
+                                expression where all names are substring-matched against
+                                test names and their parent classes. Example: -k
+                                'test_method or test_other' matches all test functions
+                                and classes whose name contains 'test_method' or
+                                'test_other', while -k 'not test_method' matches those
+                                that don't contain 'test_method' in their names. -k 'not
+                                test_method and not test_other' will eliminate the
+                                matches. Additionally keywords are matched to classes
+                                and functions containing extra names in their
+                                'extra_keyword_matches' set, as well as functions which
+                                have names assigned directly to them. The matching is
+                                case-insensitive.Multiple -k cli options are appended
+                                with 'and'.
+        *
+        """
     )
 
 

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1101,8 +1101,6 @@ def test_markexpr_multiple(testdir):
 def test_keywordexpr_multiple(testdir):
     testdir.makepyfile(
         """
-        import pytest
-
         def test_this_thing():
             pass
         def test_another_thing():

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1071,3 +1071,23 @@ def test_marker_expr_eval_failure_handling(testdir, expr):
     result = testdir.runpytest(foo, "-m", expr)
     result.stderr.fnmatch_lines([expected])
     assert result.ret == ExitCode.USAGE_ERROR
+
+
+def test_mark_multiple(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        pytestmark = pytest.mark.c
+
+        @pytest.mark.a
+        def test_a():
+            pass
+
+        @pytest.mark.b
+        def test_b():
+            pass
+        """
+    )
+    result = testdir.runpytest("-m", "a or b", "-m", "c")
+    result.assert_outcomes(passed=2)

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1073,7 +1073,7 @@ def test_marker_expr_eval_failure_handling(testdir, expr):
     assert result.ret == ExitCode.USAGE_ERROR
 
 
-def test_mark_multiple(testdir):
+def test_markexpr_multiple(testdir):
     testdir.makepyfile(
         """
         import pytest
@@ -1087,7 +1087,30 @@ def test_mark_multiple(testdir):
         @pytest.mark.b
         def test_b():
             pass
+
+        @pytest.mark.d
+        def test_d():
+            pass
         """
     )
-    result = testdir.runpytest("-m", "a or b", "-m", "c")
+    result = testdir.runpytest("-m", "  a or b", "-m", "c")
     result.assert_outcomes(passed=2)
+    result.stdout.fnmatch_lines("collected 3 items / 1 deselected / 2 selected")
+
+
+def test_keywordexpr_multiple(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        def test_this_thing():
+            pass
+        def test_another_thing():
+            pass
+        def test_with_this_thing():
+            pass
+        """
+    )
+    result = testdir.runpytest("-k", "  test_", "-k", " not another")
+    result.assert_outcomes(passed=2)
+    result.stdout.fnmatch_lines("collected 3 items / 1 deselected / 2 selected")


### PR DESCRIPTION
Good evening and thanks for your time on reviewing.  I have started implementing this -k / -m duplicate options on the command line, referencing issue: #7229.

This is heavily a work in progress, but I wanted to at least create a draft to scope out if you think its 

- Even a good idea
- Remotely viable with this kind of approach
- Tips and guidance based on your repo knowledge (which I have none :D )

I think for a start it needs a lot more test coverage, but to summarise:

 - append both -k / -m from the cli
 - join them into appropriate expression strings using 'and'
 - update help docs to explain the change

tests are passing locally so that's a good start.