### PR TITLE
Introduce --import-mode=importlib

### DIFF
--- a/changelog/7245.feature.rst
+++ b/changelog/7245.feature.rst
@@ -1,0 +1,14 @@
+New ``--import-mode=importlib`` option that uses `importlib <https://docs.python.org/3/library/importlib.html>`__ to import test modules.
+
+Traditionally pytest used ``__import__`` while changing ``sys.path`` to import test modules (which
+also changes ``sys.modules`` as a side-effect), which works but has a number of drawbacks, like requiring test modules
+that don't live in packages to have unique names (as they need to reside under a unique name in ``sys.modules``).
+
+``--import-mode=importlib`` uses more fine grained import mechanisms from ``importlib`` which don't
+require pytest to change ``sys.path`` or ``sys.modules`` at all, eliminating much of the drawbacks
+of the previous mode.
+
+We intend to make ``--import-mode=importlib`` the default in future versions, so users are encouraged
+to try the new mode and provide feedback (both positive or negative) in issue `#7245 <https://github.com/pytest-dev/pytest/issues/7245>`__.
+
+You can read more about this option in `the documentation <https://docs.pytest.org/en/latest/pythonpath.html#import-modes>`__.

--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -91,7 +91,8 @@ This has the following benefits:
     See :ref:`pytest vs python -m pytest` for more information about the difference between calling ``pytest`` and
     ``python -m pytest``.
 
-Note that using this scheme your test files must have **unique names**, because
+Note that this scheme has a drawback if you are using ``prepend`` :ref:`import mode <import-modes>`
+(which is the default): your test files must have **unique names**, because
 ``pytest`` will import them as *top-level* modules since there are no packages
 to derive a full package name from. In other words, the test files in the example above will
 be imported as ``test_app`` and ``test_view`` top-level modules by adding ``tests/`` to
@@ -118,8 +119,11 @@ Now pytest will load the modules as ``tests.foo.test_view`` and ``tests.bar.test
 you to have modules with the same name. But now this introduces a subtle problem: in order to load
 the test modules from the ``tests`` directory, pytest prepends the root of the repository to
 ``sys.path``, which adds the side-effect that now ``mypkg`` is also importable.
+
 This is problematic if you are using a tool like `tox`_ to test your package in a virtual environment,
 because you want to test the *installed* version of your package, not the local code from the repository.
+
+.. _`src-layout`:
 
 In this situation, it is **strongly** suggested to use a ``src`` layout where application root package resides in a
 sub-directory of your root:
@@ -144,6 +148,15 @@ sub-directory of your root:
 
 This layout prevents a lot of common pitfalls and has many benefits, which are better explained in this excellent
 `blog post by Ionel Cristian Mărieș <https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure>`_.
+
+.. note::
+    The new ``--import-mode=importlib`` (see :ref:`import-modes`) doesn't have
+    any of the drawbacks above because ``sys.path`` and ``sys.modules`` are not changed when importing
+    test modules, so users that run
+    into this issue are strongly encouraged to try it and report if the new option works well for them.
+
+    The ``src`` directory layout is still strongly recommended however.
+
 
 Tests as part of application code
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -190,8 +203,8 @@ Note that this layout also works in conjunction with the ``src`` layout mentione
 
 .. note::
 
-    If ``pytest`` finds an "a/b/test_module.py" test file while
-    recursing into the filesystem it determines the import name
+    In ``prepend`` and ``append`` import-modes, if pytest finds a ``"a/b/test_module.py"``
+    test file while recursing into the filesystem it determines the import name
     as follows:
 
     * determine ``basedir``: this is the first "upward" (towards the root)
@@ -211,6 +224,10 @@ Note that this layout also works in conjunction with the ``src`` layout mentione
     that in larger projects multiple test modules might import
     from each other and thus deriving a canonical import name helps
     to avoid surprises such as a test module getting imported twice.
+
+    With ``--import-mode=importlib`` things are less convoluted because
+    pytest doesn't need to change ``sys.path`` or ``sys.modules``, making things
+    much less surprising.
 
 
 .. _`virtualenv`: https://pypi.org/project/virtualenv/

--- a/doc/en/pythonpath.rst
+++ b/doc/en/pythonpath.rst
@@ -8,7 +8,7 @@ pytest import mechanisms and ``sys.path``/``PYTHONPATH``
 Import modes
 ------------
 
-pytest as a testing framework needs to import test moduels and ``conftest.py`` files for execution.
+pytest as a testing framework needs to import test modules and ``conftest.py`` files for execution.
 
 Importing files in Python (at least until recently) is a non-trivial processes, often requiring
 changing `sys.path <https://docs.python.org/3/library/sys.html#sys.path>`__. Some aspects of the

--- a/doc/en/pythonpath.rst
+++ b/doc/en/pythonpath.rst
@@ -3,11 +3,62 @@
 pytest import mechanisms and ``sys.path``/``PYTHONPATH``
 ========================================================
 
-Here's a list of scenarios where pytest may need to change ``sys.path`` in order
-to import test modules or ``conftest.py`` files.
+.. _`import-modes`:
+
+Import modes
+------------
+
+pytest as a testing framework needs to import test moduels and ``conftest.py`` files for execution.
+
+Importing files in Python (at least until recently) is a non-trivial processes, often requiring
+changing `sys.path <https://docs.python.org/3/library/sys.html#sys.path>`__. Some aspects of the
+import process can be controlled through the ``--import-mode`` command-line flag, which can assume
+these values:
+
+* ``prepend`` (default): the directory path containing each module will be inserted into the *beginning*
+  of ``sys.path`` if not already there, and then imported with the `__import__ <https://docs.python.org/3/library/functions.html#__import__>`__ builtin.
+
+  This requires test module names to be unique when the test directory tree is not arranged in
+  packages, because the modules will put in ``sys.modules`` after importing.
+
+  This is the classic mechanism, dating back from the time Python 2 was still supported.
+
+* ``append``: the directory containing each module is appended to the end of ``sys.path`` if not already
+  there, and imported with ``__import__``.
+
+  This better allows to run test modules against installed versions of a package even if the
+  package under test has the same import root. For example:
+
+  ::
+
+        testing/__init__.py
+        testing/test_pkg_under_test.py
+        pkg_under_test/
+
+  the tests will run against the installed version
+  of ``pkg_under_test`` when ``--import-mode=append`` is used whereas
+  with ``prepend`` they would pick up the local version. This kind of confusion is why
+  we advocate for using :ref:`src <src-layout>` layouts.
+
+  Same as ``prepend``, requires test module names to be unique when the test directory tree is
+  not arranged in packages, because the modules will put in ``sys.modules`` after importing.
+
+* ``importlib``: new in pytest-6.0, this mode uses `importlib <https://docs.python.org/3/library/importlib.html>`__ to import test modules. This gives full control over the import process, and doesn't require
+  changing ``sys.path`` or ``sys.modules`` at all.
+
+  For this reason this doesn't require test module names to be unique at all.
+
+  We intend to make ``importlib`` the default in future releases.
+
+``prepend`` and ``append`` import modes scenarios
+-------------------------------------------------
+
+Here's a list of scenarios when using ``prepend`` or ``append`` import modes where pytest needs to
+change ``sys.path`` in order to import test modules or ``conftest.py`` files, and the issues users
+might encounter because of that.
 
 Test modules / ``conftest.py`` files inside packages
-----------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Consider this file and directory layout::
 
@@ -28,8 +79,6 @@ When executing:
 
     pytest root/
 
-
-
 pytest will find ``foo/bar/tests/test_foo.py`` and realize it is part of a package given that
 there's an ``__init__.py`` file in the same folder. It will then search upwards until it can find the
 last folder which still contains an ``__init__.py`` file in order to find the package *root* (in
@@ -44,7 +93,7 @@ and allow test modules to have duplicated names. This is also discussed in detai
 :ref:`test discovery`.
 
 Standalone test modules / ``conftest.py`` files
------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Consider this file and directory layout::
 

--- a/doc/en/pythonpath.rst
+++ b/doc/en/pythonpath.rst
@@ -46,7 +46,10 @@ these values:
 * ``importlib``: new in pytest-6.0, this mode uses `importlib <https://docs.python.org/3/library/importlib.html>`__ to import test modules. This gives full control over the import process, and doesn't require
   changing ``sys.path`` or ``sys.modules`` at all.
 
-  For this reason this doesn't require test module names to be unique at all.
+  For this reason this doesn't require test module names to be unique at all, but also makes test
+  modules non-importable by each other. This was made possible in previous modes, for tests not residing
+  in Python packages, because of the side-effects of changing ``sys.path`` and ``sys.modules``
+  mentioned above. Users which require this should turn their tests into proper packages instead.
 
   We intend to make ``importlib`` the default in future releases.
 

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -1204,7 +1204,10 @@ _PY_DIR = py.path.local(py.__file__).dirpath()
 
 
 def filter_traceback(entry: TracebackEntry) -> bool:
-    """Return True if a TracebackEntry instance should be removed from tracebacks:
+    """Return True if a TracebackEntry instance should be included in tracebacks.
+
+    We hide traceback entries of:
+
     * dynamically generated code (no code to show up for it);
     * internal traceback from pytest or its internal libraries, py and pluggy.
     """

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -33,6 +33,7 @@ else:
 
 
 if TYPE_CHECKING:
+    from typing import NoReturn
     from typing import Type
     from typing_extensions import Final
 
@@ -401,3 +402,38 @@ else:
     from collections import OrderedDict
 
     order_preserving_dict = OrderedDict
+
+
+# Perform exhaustiveness checking.
+#
+# Consider this example:
+#
+#     MyUnion = Union[int, str]
+#
+#     def handle(x: MyUnion) -> int {
+#         if isinstance(x, int):
+#             return 1
+#         elif isinstance(x, str):
+#             return 2
+#         else:
+#             raise Exception('unreachable')
+#
+# Now suppose we add a new variant:
+#
+#     MyUnion = Union[int, str, bytes]
+#
+# After doing this, we must remember ourselves to go and update the handle
+# function to handle the new variant.
+#
+# With `assert_never` we can do better:
+#
+#     // throw new Error('unreachable');
+#     return assert_never(x)
+#
+# Now, if we forget to handle the new variant, the type-checker will emit a
+# compile-time error, instead of the runtime error we would have gotten
+# previously.
+#
+# This also work for Enums (if you use `is` to compare) and Literals.
+def assert_never(value: "NoReturn") -> "NoReturn":
+    assert False, "Unhandled value: {} ({})".format(value, type(value).__name__)

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -41,7 +41,7 @@ from _pytest.compat import importlib_metadata
 from _pytest.compat import TYPE_CHECKING
 from _pytest.outcomes import fail
 from _pytest.outcomes import Skipped
-from _pytest.pathlib import import_module
+from _pytest.pathlib import import_path
 from _pytest.pathlib import Path
 from _pytest.store import Store
 from _pytest.warning_types import PytestConfigWarning
@@ -513,7 +513,7 @@ class PytestPluginManager(PluginManager):
             _ensure_removed_sysmodule(conftestpath.purebasename)
 
         try:
-            mod = import_module(conftestpath, mode=importmode)
+            mod = import_path(conftestpath, mode=importmode)
         except Exception as e:
             raise ConftestImportFailure(conftestpath, sys.exc_info()) from e
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -513,7 +513,7 @@ class PytestPluginManager(PluginManager):
             _ensure_removed_sysmodule(conftestpath.purebasename)
 
         try:
-            mod = import_module(conftestpath, ensuresyspath=importmode)
+            mod = import_module(conftestpath, mode=importmode)
         except Exception as e:
             raise ConftestImportFailure(conftestpath, sys.exc_info()) from e
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -41,6 +41,7 @@ from _pytest.compat import importlib_metadata
 from _pytest.compat import TYPE_CHECKING
 from _pytest.outcomes import fail
 from _pytest.outcomes import Skipped
+from _pytest.pathlib import import_module
 from _pytest.pathlib import Path
 from _pytest.store import Store
 from _pytest.warning_types import PytestConfigWarning
@@ -512,7 +513,7 @@ class PytestPluginManager(PluginManager):
             _ensure_removed_sysmodule(conftestpath.purebasename)
 
         try:
-            mod = conftestpath.pyimport(ensuresyspath=importmode)
+            mod = import_module(conftestpath, ensuresyspath=importmode)
         except Exception as e:
             raise ConftestImportFailure(conftestpath, sys.exc_info()) from e
 

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -531,7 +531,9 @@ class DoctestModule(pytest.Module):
                     )
 
         if self.fspath.basename == "conftest.py":
-            module = self.config.pluginmanager._importconftest(self.fspath)
+            module = self.config.pluginmanager._importconftest(
+                self.fspath, self.config.getoption("importmode")
+            )
         else:
             try:
                 module = import_module(self.fspath)

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -33,6 +33,7 @@ from _pytest.config import Config
 from _pytest.config.argparsing import Parser
 from _pytest.fixtures import FixtureRequest
 from _pytest.outcomes import OutcomeException
+from _pytest.pathlib import import_module
 from _pytest.python_api import approx
 from _pytest.warning_types import PytestWarning
 
@@ -533,7 +534,7 @@ class DoctestModule(pytest.Module):
             module = self.config.pluginmanager._importconftest(self.fspath)
         else:
             try:
-                module = self.fspath.pyimport()
+                module = import_module(self.fspath)
             except ImportError:
                 if self.config.getvalue("doctest_ignore_import_errors"):
                     pytest.skip("unable to import module %r" % self.fspath)

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -33,7 +33,7 @@ from _pytest.config import Config
 from _pytest.config.argparsing import Parser
 from _pytest.fixtures import FixtureRequest
 from _pytest.outcomes import OutcomeException
-from _pytest.pathlib import import_module
+from _pytest.pathlib import import_path
 from _pytest.python_api import approx
 from _pytest.warning_types import PytestWarning
 
@@ -536,7 +536,7 @@ class DoctestModule(pytest.Module):
             )
         else:
             try:
-                module = import_module(self.fspath)
+                module = import_path(self.fspath)
             except ImportError:
                 if self.config.getvalue("doctest_ignore_import_errors"):
                     pytest.skip("unable to import module %r" % self.fspath)

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -173,6 +173,14 @@ def pytest_addoption(parser: Parser) -> None:
         default=False,
         help="Don't ignore tests in a local virtualenv directory",
     )
+    group.addoption(
+        "--import-mode",
+        default="prepend",
+        choices=["prepend", "append", "importlib"],
+        dest="importmode",
+        help="prepend/append to sys.path when importing test modules and conftest files, "
+        "default is to prepend.",
+    )
 
     group = parser.getgroup("debugconfig", "test session debugging and configuration")
     group.addoption(

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -547,7 +547,9 @@ class FSCollector(Collector):
         # check if we have the common case of running
         # hooks with all conftest.py files
         pm = self.config.pluginmanager
-        my_conftestmodules = pm._getconftestmodules(fspath)
+        my_conftestmodules = pm._getconftestmodules(
+            fspath, self.config.getoption("importmode")
+        )
         remove_mods = pm._conftest_plugins.difference(my_conftestmodules)
         if remove_mods:
             # one or more conftests are not in use at this fspath

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -520,7 +520,7 @@ def import_module(
         if path.name != "__init__.py":
             modfile = modfile[: -(len("__init__.py") + 1)]
     try:
-        issame = os.path.samefile(path, modfile)
+        issame = os.path.samefile(str(path), modfile)
     except FileNotFoundError:
         issame = False
     if not issame:

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -1,6 +1,7 @@
 import atexit
 import contextlib
 import fnmatch
+import importlib.util
 import itertools
 import os
 import shutil
@@ -470,8 +471,6 @@ def import_path(
         raise ImportError(path)
 
     if mode == ImportMode.importlib:
-        import importlib.util
-
         module_name = path.stem
 
         for meta_importer in sys.meta_path:
@@ -511,7 +510,7 @@ def import_path(
         if str(pkg_root) != sys.path[0]:
             sys.path.insert(0, str(pkg_root))
 
-    __import__(module_name)
+    importlib.import_module(module_name)
 
     mod = sys.modules[module_name]
     if path.name == "__init__.py":

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -446,7 +446,17 @@ def import_module(path, modname=None, ensuresyspath=True):
 
         if modname is None:
             modname = path.purebasename
-        spec = importlib.util.spec_from_file_location(modname, str(path))
+
+        for meta_importer in sys.meta_path:
+            loader = meta_importer.find_module(modname, str(path))
+            if loader is not None:
+                spec = importlib.util.spec_from_file_location(
+                    modname, str(path), loader=loader
+                )
+                break
+        else:
+            spec = importlib.util.spec_from_file_location(modname, str(path))
+
         if spec is None:
             raise ImportError(
                 "Can't find module {} at location {}".format(modname, str(path))

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -22,10 +22,9 @@ from typing import Set
 from typing import TypeVar
 from typing import Union
 
-
-from _pytest.outcomes import skip
 import py
 
+from _pytest.outcomes import skip
 from _pytest.warning_types import PytestWarning
 
 if sys.version_info[:2] >= (3, 6):

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -448,11 +448,8 @@ def import_module(path, modname=None, ensuresyspath=True):
             modname = path.purebasename
 
         for meta_importer in sys.meta_path:
-            loader = meta_importer.find_module(modname, str(path))
-            if loader is not None:
-                spec = importlib.util.spec_from_file_location(
-                    modname, str(path), loader=loader
-                )
+            spec = meta_importer.find_spec(modname, [path.dirname])
+            if spec is not None:
                 break
         else:
             spec = importlib.util.spec_from_file_location(modname, str(path))

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -478,7 +478,7 @@ def import_module(
         spec.loader.exec_module(mod)  # type: ignore[union-attr]
         return mod
 
-    pkgpath = path.pypkgpath()
+    pkgpath = resolve_package_path(path)
     if pkgpath is not None:
         pkgroot = pkgpath.dirpath()
         names = path.new(ext="").relto(pkgroot).split(path.sep)
@@ -519,3 +519,19 @@ def import_module(
         if ignore != "1":
             raise path.ImportMismatchError(modname, modfile, path)
     return mod
+
+
+def resolve_package_path(path):
+    """ return the Python package path by looking for the last
+    directory upwards which still contains an __init__.py.
+    Return None if a pkgpath can not be determined.
+    """
+    pkgpath = None
+    for parent in path.parts(reverse=True):
+        if parent.isdir():
+            if not parent.join("__init__.py").exists():
+                break
+            if not parent.basename.isidentifier():
+                break
+            pkgpath = parent
+    return pkgpath

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -503,7 +503,7 @@ def import_module(
         if str(pkgroot) not in sys.path:
             sys.path.append(str(pkgroot))
     else:
-        assert mode == ImportMode.prepend, "unexpedted mode: {}".format(mode)
+        assert mode == ImportMode.prepend, "unexpected mode: {}".format(mode)
         if str(pkgroot) != sys.path[0]:
             sys.path.insert(0, str(pkgroot))
 

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -501,6 +501,9 @@ def import_path(
         pkg_root = path.parent
         module_name = path.stem
 
+    # change sys.path permanently: restoring it at the end of this function would cause surprising
+    # problems because of delayed imports: for example, a conftest.py file imported by this function
+    # might have local imports, which would fail at runtime if we restored sys.path.
     if mode == ImportMode.append:
         if str(pkg_root) not in sys.path:
             sys.path.append(str(pkg_root))

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -25,6 +25,7 @@ from typing import Union
 
 import py
 
+from _pytest.compat import assert_never
 from _pytest.outcomes import skip
 from _pytest.warning_types import PytestWarning
 
@@ -470,7 +471,7 @@ def import_path(
     if not path.exists():
         raise ImportError(path)
 
-    if mode == ImportMode.importlib:
+    if mode is ImportMode.importlib:
         module_name = path.stem
 
         for meta_importer in sys.meta_path:
@@ -502,13 +503,14 @@ def import_path(
     # change sys.path permanently: restoring it at the end of this function would cause surprising
     # problems because of delayed imports: for example, a conftest.py file imported by this function
     # might have local imports, which would fail at runtime if we restored sys.path.
-    if mode == ImportMode.append:
+    if mode is ImportMode.append:
         if str(pkg_root) not in sys.path:
             sys.path.append(str(pkg_root))
-    else:
-        assert mode == ImportMode.prepend, "unexpected mode: {}".format(mode)
+    elif mode is ImportMode.prepend:
         if str(pkg_root) != sys.path[0]:
             sys.path.insert(0, str(pkg_root))
+    else:
+        assert_never(mode)
 
     importlib.import_module(module_name)
 

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -511,22 +511,27 @@ def import_module(
 
     mod = sys.modules[modname]
     if path.name == "__init__.py":
-        return mod  # we don't check anything as we might
-        # be in a namespace package ... too icky to check
-    modfile = mod.__file__
-    if modfile.endswith((".pyc", ".pyo")):
-        modfile = modfile[:-1]
-    if modfile.endswith(os.path.sep + "__init__.py"):
+        # we don't check anything as we might be in a namespace package...
+        # still not clear how to handle this correctly
+        return mod
+
+    module_file = mod.__file__
+    if module_file.endswith((".pyc", ".pyo")):
+        module_file = module_file[:-1]
+    if module_file.endswith(os.path.sep + "__init__.py"):
         if path.name != "__init__.py":
-            modfile = modfile[: -(len("__init__.py") + 1)]
-    try:
-        issame = os.path.samefile(str(path), modfile)
-    except FileNotFoundError:
-        issame = False
-    if not issame:
-        ignore = os.environ.get("PY_IGNORE_IMPORTMISMATCH", "")
-        if ignore != "1":
-            raise ImportPathMismatchError(modname, modfile, path)
+            module_file = module_file[: -(len(os.path.sep + "__init__.py"))]
+
+    ignore = os.environ.get("PY_IGNORE_IMPORTMISMATCH", "")
+    if ignore != "1":
+        try:
+            is_same = os.path.samefile(str(path), module_file)
+        except FileNotFoundError:
+            is_same = False
+
+        if not is_same:
+            raise ImportPathMismatchError(modname, module_file, path)
+
     return mod
 
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -118,7 +118,7 @@ def pytest_addoption(parser: Parser) -> None:
     group.addoption(
         "--import-mode",
         default="prepend",
-        choices=["prepend", "append"],
+        choices=["prepend", "append", "importlib"],
         dest="importmode",
         help="prepend/append to sys.path when importing test modules, "
         "default is to prepend.",

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -60,6 +60,7 @@ from _pytest.mark.structures import normalize_mark_list
 from _pytest.outcomes import fail
 from _pytest.outcomes import skip
 from _pytest.pathlib import import_module
+from _pytest.pathlib import ImportPathMismatchError
 from _pytest.pathlib import parts
 from _pytest.reports import TerminalRepr
 from _pytest.warning_types import PytestCollectionWarning
@@ -552,7 +553,7 @@ class Module(nodes.File, PyCollector):
             mod = import_module(self.fspath, mode=importmode)
         except SyntaxError:
             raise self.CollectError(ExceptionInfo.from_current().getrepr(style="short"))
-        except self.fspath.ImportMismatchError as e:
+        except ImportPathMismatchError as e:
             raise self.CollectError(
                 "import file mismatch:\n"
                 "imported module %r has this __file__ attribute:\n"

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -59,6 +59,7 @@ from _pytest.mark.structures import MarkDecorator
 from _pytest.mark.structures import normalize_mark_list
 from _pytest.outcomes import fail
 from _pytest.outcomes import skip
+from _pytest.pathlib import import_module
 from _pytest.pathlib import parts
 from _pytest.reports import TerminalRepr
 from _pytest.warning_types import PytestCollectionWarning
@@ -557,7 +558,7 @@ class Module(nodes.File, PyCollector):
         # we assume we are only called once per module
         importmode = self.config.getoption("--import-mode")
         try:
-            mod = self.fspath.pyimport(ensuresyspath=importmode)
+            mod = import_module(self.fspath, ensuresyspath=importmode)
         except SyntaxError:
             raise self.CollectError(ExceptionInfo.from_current().getrepr(style="short"))
         except self.fspath.ImportMismatchError as e:

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -59,7 +59,7 @@ from _pytest.mark.structures import MarkDecorator
 from _pytest.mark.structures import normalize_mark_list
 from _pytest.outcomes import fail
 from _pytest.outcomes import skip
-from _pytest.pathlib import import_module
+from _pytest.pathlib import import_path
 from _pytest.pathlib import ImportPathMismatchError
 from _pytest.pathlib import parts
 from _pytest.reports import TerminalRepr
@@ -550,7 +550,7 @@ class Module(nodes.File, PyCollector):
         # we assume we are only called once per module
         importmode = self.config.getoption("--import-mode")
         try:
-            mod = import_module(self.fspath, mode=importmode)
+            mod = import_path(self.fspath, mode=importmode)
         except SyntaxError:
             raise self.CollectError(ExceptionInfo.from_current().getrepr(style="short"))
         except ImportPathMismatchError as e:

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -549,7 +549,7 @@ class Module(nodes.File, PyCollector):
         # we assume we are only called once per module
         importmode = self.config.getoption("--import-mode")
         try:
-            mod = import_module(self.fspath, ensuresyspath=importmode)
+            mod = import_module(self.fspath, mode=importmode)
         except SyntaxError:
             raise self.CollectError(ExceptionInfo.from_current().getrepr(style="short"))
         except self.fspath.ImportMismatchError as e:

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -116,15 +116,6 @@ def pytest_addoption(parser: Parser) -> None:
         "side effects(use at your own risk)",
     )
 
-    group.addoption(
-        "--import-mode",
-        default="prepend",
-        choices=["prepend", "append", "importlib"],
-        dest="importmode",
-        help="prepend/append to sys.path when importing test modules, "
-        "default is to prepend.",
-    )
-
 
 def pytest_cmdline_main(config: Config) -> Optional[Union[int, ExitCode]]:
     if config.option.showfixtures:

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -147,7 +147,8 @@ class TestGeneralUsage:
         else:
             assert loaded == ["myplugin1", "myplugin2", "mycov"]
 
-    def test_assertion_magic(self, testdir):
+    @pytest.mark.parametrize("import_mode", ["prepend", "append", "importlib"])
+    def test_assertion_rewrite(self, testdir, import_mode):
         p = testdir.makepyfile(
             """
             def test_this():
@@ -155,7 +156,7 @@ class TestGeneralUsage:
                 assert x
         """
         )
-        result = testdir.runpytest(p)
+        result = testdir.runpytest(p, "--import-mode={}".format(import_mode))
         result.stdout.fnmatch_lines([">       assert x", "E       assert 0"])
         assert result.ret == 1
 

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import textwrap
 from typing import Any
@@ -109,11 +108,10 @@ class TestModule:
         assert result.ret == 2
 
         stdout = result.stdout.str()
-        for name in ("_pytest", os.path.join("py", "_path")):
-            if verbose == 2:
-                assert name in stdout
-            else:
-                assert name not in stdout
+        if verbose == 2:
+            assert "_pytest" in stdout
+        else:
+            assert "_pytest" not in stdout
 
     def test_show_traceback_import_error_unicode(self, testdir):
         """Check test modules collected which raise ImportError with unicode messages

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1894,7 +1894,9 @@ class TestAutouseManagement:
         reprec = testdir.inline_run("-v", "-s", confcut)
         reprec.assertoutcome(passed=8)
         config = reprec.getcalls("pytest_unconfigure")[0].config
-        values = config.pluginmanager._getconftestmodules(p)[0].values
+        values = config.pluginmanager._getconftestmodules(p, importmode="prepend")[
+            0
+        ].values
         assert values == ["fin_a1", "fin_a2", "fin_b1", "fin_b2"] * 2
 
     def test_scope_ordering(self, testdir):

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -1412,10 +1412,13 @@ class TestImportModeImportlib:
         """
         self.setup_conftest_and_foo(testdir)
         result = testdir.runpytest("-v", "--import-mode=importlib")
+        exc_name = (
+            "ModuleNotFoundError" if sys.version_info[:2] > (3, 5) else "ImportError"
+        )
         result.stdout.fnmatch_lines(
             [
-                "*ModuleNotFoundError: No module named 'foo'",
-                "tests?test_foo.py:2: ModuleNotFoundError",
+                "*{}: No module named 'foo'".format(exc_name),
+                "tests?test_foo.py:2: {}".format(exc_name),
                 "* 1 failed in *",
             ]
         )

--- a/testing/test_compat.py
+++ b/testing/test_compat.py
@@ -1,15 +1,22 @@
+import enum
 import sys
 from functools import partial
 from functools import wraps
+from typing import Union
 
 import pytest
 from _pytest.compat import _PytestWrapper
+from _pytest.compat import assert_never
 from _pytest.compat import cached_property
 from _pytest.compat import get_real_func
 from _pytest.compat import is_generator
 from _pytest.compat import safe_getattr
 from _pytest.compat import safe_isclass
+from _pytest.compat import TYPE_CHECKING
 from _pytest.outcomes import OutcomeException
+
+if TYPE_CHECKING:
+    from typing_extensions import Literal
 
 
 def test_is_generator():
@@ -205,3 +212,55 @@ def test_cached_property() -> None:
     assert ncalls == 1
     assert c2.prop == 2
     assert c1.prop == 1
+
+
+def test_assert_never_union() -> None:
+    x = 10  # type: Union[int, str]
+
+    if isinstance(x, int):
+        pass
+    else:
+        with pytest.raises(AssertionError):
+            assert_never(x)  # type: ignore[arg-type]
+
+    if isinstance(x, int):
+        pass
+    elif isinstance(x, str):
+        pass
+    else:
+        assert_never(x)
+
+
+def test_assert_never_enum() -> None:
+    E = enum.Enum("E", "a b")
+    x = E.a  # type: E
+
+    if x is E.a:
+        pass
+    else:
+        with pytest.raises(AssertionError):
+            assert_never(x)  # type: ignore[arg-type]
+
+    if x is E.a:
+        pass
+    elif x is E.b:
+        pass
+    else:
+        assert_never(x)
+
+
+def test_assert_never_literal() -> None:
+    x = "a"  # type: Literal["a", "b"]
+
+    if x == "a":
+        pass
+    else:
+        with pytest.raises(AssertionError):
+            assert_never(x)  # type: ignore[arg-type]
+
+    if x == "a":
+        pass
+    elif x == "b":
+        pass
+    else:
+        assert_never(x)

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -144,7 +144,7 @@ class TestImport:
 
     def test_smoke_test(self, path1):
         obj = import_module(path1.join("execfile.py"))
-        assert obj.x == 42
+        assert obj.x == 42  # type: ignore[attr-defined]
         assert obj.__name__ == "execfile"
 
     def test_renamed_dir_creates_mismatch(self, tmpdir, monkeypatch):
@@ -180,24 +180,24 @@ class TestImport:
     def test_a(self, path1):
         otherdir = path1.join("otherdir")
         mod = import_module(otherdir.join("a.py"))
-        assert mod.result == "got it"
+        assert mod.result == "got it"  # type: ignore[attr-defined]
         assert mod.__name__ == "otherdir.a"
 
     def test_b(self, path1):
         otherdir = path1.join("otherdir")
         mod = import_module(otherdir.join("b.py"))
-        assert mod.stuff == "got it"
+        assert mod.stuff == "got it"  # type: ignore[attr-defined]
         assert mod.__name__ == "otherdir.b"
 
     def test_c(self, path1):
         otherdir = path1.join("otherdir")
         mod = import_module(otherdir.join("c.py"))
-        assert mod.value == "got it"
+        assert mod.value == "got it"  # type: ignore[attr-defined]
 
     def test_d(self, path1):
         otherdir = path1.join("otherdir")
         mod = import_module(otherdir.join("d.py"))
-        assert mod.value2 == "got it"
+        assert mod.value2 == "got it"  # type: ignore[attr-defined]
 
     def test_import_after(self, tmpdir):
         tmpdir.ensure("xxxpackage", "__init__.py")
@@ -269,7 +269,7 @@ class TestImport:
     def test_importmode_importlib(self, simple_module):
         """importlib mode does not change sys.path"""
         module = import_module(simple_module, mode="importlib")
-        assert module.foo(2) == 42
+        assert module.foo(2) == 42  # type: ignore[attr-defined]
         assert simple_module.dirname not in sys.path
 
     def test_importmode_twice_is_different_module(self, simple_module):
@@ -282,7 +282,7 @@ class TestImport:
         """Even without any meta_path should still import module"""
         monkeypatch.setattr(sys, "meta_path", [])
         module = import_module(simple_module, mode="importlib")
-        assert module.foo(2) == 42
+        assert module.foo(2) == 42  # type: ignore[attr-defined]
 
         # mode='importlib' fails if no spec is found to load the module
         import importlib.util

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -16,7 +16,7 @@ from _pytest.pathlib import maybe_delete_a_numbered_dir
 from _pytest.pathlib import Path
 
 
-class TestPort:
+class TestFNMatcherPort:
     """Test that our port of py.common.FNMatcher (fnmatch_ex) produces the same results as the
     original py.path.local.fnmatch method.
     """
@@ -216,7 +216,7 @@ class TestImport:
         name = "pointsback123"
         ModuleType = type(os)
         p = tmpdir.ensure(name + ".py")
-        for ending in (".pyc", "$py.class", ".pyo"):
+        for ending in (".pyc", ".pyo"):
             mod = ModuleType(name)
             pseudopath = tmpdir.ensure(name + ending)
             mod.__file__ = str(pseudopath)

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -244,7 +244,7 @@ class TestImport:
         root1 = tmpdir.mkdir("root1")
         file1 = root1.ensure("x123.py")
         assert str(root1) not in sys.path
-        import_module(file1, ensuresyspath="append")
+        import_module(file1, mode="append")
         assert str(root1) == sys.path[-1]
         assert str(root1) not in sys.path[:-1]
 

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -176,11 +176,6 @@ class TestImport:
         m = import_module(p_init)
         assert m.__name__ == "hello_123"
 
-    def test_pyimport_execfile_different_name(self, path1):
-        obj = import_module(path1.join("execfile.py"), modname="0x.y.z")
-        assert obj.x == 42
-        assert obj.__name__ == "0x.y.z"
-
     def test_pyimport_a(self, path1):
         otherdir = path1.join("otherdir")
         mod = import_module(otherdir.join("a.py"))

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -14,6 +14,7 @@ from _pytest.pathlib import get_lock_path
 from _pytest.pathlib import import_module
 from _pytest.pathlib import maybe_delete_a_numbered_dir
 from _pytest.pathlib import Path
+from _pytest.pathlib import resolve_package_path
 
 
 class TestFNMatcherPort:
@@ -290,6 +291,23 @@ class TestImport:
         )
         with pytest.raises(ImportError):
             import_module(simple_module, mode="importlib")
+
+
+def test_resolve_package_path(tmpdir):
+    pkg = tmpdir.ensure("pkg1", dir=1)
+    pkg.ensure("__init__.py")
+    pkg.ensure("subdir/__init__.py")
+    assert resolve_package_path(pkg) == pkg
+    assert resolve_package_path(pkg.join("subdir", "__init__.py")) == pkg
+
+
+def test_package_unimportable(tmpdir):
+    pkg = tmpdir.ensure("pkg1-1", dir=1)
+    pkg.ensure("__init__.py")
+    subdir = pkg.ensure("subdir/__init__.py").dirpath()
+    assert resolve_package_path(subdir) == subdir
+    assert resolve_package_path(subdir.ensure("xyz.py")) == subdir
+    assert not resolve_package_path(pkg)
 
 
 def test_access_denied_during_cleanup(tmp_path, monkeypatch):

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -1,6 +1,5 @@
 import os.path
 import sys
-
 import unittest.mock
 from textwrap import dedent
 

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -37,7 +37,7 @@ class TestPytestPluginInteractions:
         pm.hook.pytest_addhooks.call_historic(
             kwargs=dict(pluginmanager=config.pluginmanager)
         )
-        config.pluginmanager._importconftest(conf)
+        config.pluginmanager._importconftest(conf, importmode="prepend")
         # print(config.pluginmanager.get_plugins())
         res = config.hook.pytest_myhook(xyz=10)
         assert res == [11]
@@ -64,7 +64,7 @@ class TestPytestPluginInteractions:
                     default=True)
         """
         )
-        config.pluginmanager._importconftest(p)
+        config.pluginmanager._importconftest(p, importmode="prepend")
         assert config.option.test123
 
     def test_configure(self, testdir):
@@ -129,10 +129,10 @@ class TestPytestPluginInteractions:
         conftest1 = testdir.tmpdir.join("tests/conftest.py")
         conftest2 = testdir.tmpdir.join("tests/subdir/conftest.py")
 
-        config.pluginmanager._importconftest(conftest1)
+        config.pluginmanager._importconftest(conftest1, importmode="prepend")
         ihook_a = session.gethookproxy(testdir.tmpdir.join("tests"))
         assert ihook_a is not None
-        config.pluginmanager._importconftest(conftest2)
+        config.pluginmanager._importconftest(conftest2, importmode="prepend")
         ihook_b = session.gethookproxy(testdir.tmpdir.join("tests"))
         assert ihook_a is not ihook_b
 


### PR DESCRIPTION
This introduces --import-mode=importlib, which uses fine-grained facilities
from importlib to import test modules and conftest files, bypassing
the need to change sys.path and sys.modules as side-effect of that.

I've also opened #7245 to gather feedback on the new import mode.

Fix #5821