### PR TITLE
[5.4.x] Merge pull request #7244 from DahlitzFlorian/fix-issue-7150

### DIFF
--- a/changelog/7150.bugfix.rst
+++ b/changelog/7150.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent hiding the underlying exception when ``ConfTestImportFailure`` is raised.

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -4,6 +4,7 @@ import functools
 import sys
 
 from _pytest import outcomes
+from _pytest.config import ConftestImportFailure
 from _pytest.config import hookimpl
 from _pytest.config.exceptions import UsageError
 
@@ -338,6 +339,10 @@ def _postmortem_traceback(excinfo):
         # A doctest.UnexpectedException is not useful for post_mortem.
         # Use the underlying exception instead:
         return excinfo.value.exc_info[2]
+    elif isinstance(excinfo.value, ConftestImportFailure):
+        # A config.ConftestImportFailure is not useful for post_mortem.
+        # Use the underlying exception instead:
+        return excinfo.value.excinfo[2]
     else:
         return excinfo._excinfo[2]
 

--- a/testing/test_debugging.py
+++ b/testing/test_debugging.py
@@ -342,6 +342,15 @@ class TestPDB:
         child.sendeof()
         self.flush(child)
 
+    def test_pdb_prevent_ConftestImportFailure_hiding_exception(self, testdir):
+        testdir.makepyfile("def test_func(): pass")
+        sub_dir = testdir.tmpdir.join("ns").ensure_dir()
+        sub_dir.join("conftest").new(ext=".py").write("import unknown")
+        sub_dir.join("test_file").new(ext=".py").write("def test_func(): pass")
+
+        result = testdir.runpytest_subprocess("--pdb", ".")
+        result.stdout.fnmatch_lines(["-> import unknown"])
+
     def test_pdb_interaction_capturing_simple(self, testdir):
         p1 = testdir.makepyfile(
             """


### PR DESCRIPTION
Prevent hiding underlying exception when ConfTestImportFailure is raised

(cherry picked from commit 45f53266e6fa1539b702df315847cfbce3e3f19e)