### PR TITLE
fixtures: remove special cases when deciding when pytest.fixture() is a direct decoration

### DIFF
--- a/changelog/7253.bugfix.rst
+++ b/changelog/7253.bugfix.rst
@@ -1,0 +1,3 @@
+When using ``pytest.fixture`` on a function directly, as in ``pytest.fixture(func)``,
+if the ``autouse`` or ``params`` arguments are also passed, the function is no longer
+ignored, but is marked as a fixture.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1152,13 +1152,15 @@ def fixture(
     if params is not None:
         params = list(params)
 
-    if fixture_function and params is None and autouse is False:
-        # direct decoration
-        return FixtureFunctionMarker(scope, params, autouse, name=name)(
-            fixture_function
-        )
+    fixture_marker = FixtureFunctionMarker(
+        scope=scope, params=params, autouse=autouse, ids=ids, name=name,
+    )
 
-    return FixtureFunctionMarker(scope, params, autouse, ids=ids, name=name)
+    # Direct decoration.
+    if fixture_function:
+        return fixture_marker(fixture_function)
+
+    return fixture_marker
 
 
 def yield_fixture(


### PR DESCRIPTION
pytest.fixture() can be used either as

    @pytest.fixture
    def func(): ...

or as

    @pytest.fixture()
    def func(): ...

or (while maybe not intended)

    func = pytest.fixture(func)

so it needs to inspect internally whether it got a function in the first positional argument or not.

Previously, there were was an oddity. In the following,

    func = pytest.fixture(func, autouse=True)
    # OR
    func = pytest.fixture(func, parms=['a', 'b'])

The result is as if `func` wasn't passed.

There isn't any reason for this special that I can understand, so remove it.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
