### PR TITLE
Auto generate excessive long parametrized ids

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -6,6 +6,7 @@ import itertools
 import os
 import sys
 import typing
+import uuid
 import warnings
 from collections import Counter
 from collections import defaultdict
@@ -1230,8 +1231,15 @@ def idmaker(
         _idvalset(valindex, parameterset, argnames, idfn, ids, config=config, item=item)
         for valindex, parameterset in enumerate(parametersets)
     ]
+    # rewrite parametrized ids greater than the overridable limit on windows
+    if os.name == "nt":
+        limit = 100
+        rewrite_template = "auto-generated-{}"
+        resolved_ids = [
+            x if len(x) < limit else rewrite_template.format(uuid.uuid4())
+            for x in resolved_ids
+        ]
 
-    # All IDs must be unique!
     unique_ids = set(resolved_ids)
     if len(unique_ids) != len(resolved_ids):
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1194,9 +1194,9 @@ def _idval(
         # name of a class, function, module, etc.
         modified_val = getattr(val, "__name__")
 
-    # Check if the post-checks value is greater than 100 chars in length and use auto id gen if so
-    # isinstance checks can return empty strings which is considered valid, so we explicitly check None on modified_val
-    # for example @pytest.mark.parametrize('x', ('', ' ')) is acceptable
+    # val does not always enter the isinstance checks due to its type
+    # when it does we will check the string length returned and use auto generation of ids when over 100 chars
+    # on types which do not match isinstance checks pytest uses auto generate of ids automatically anyway
     if modified_val is None or len(modified_val) > 100:
         return str(argname) + str(idx)
     return modified_val

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1231,7 +1231,7 @@ def idmaker(
         _idvalset(valindex, parameterset, argnames, idfn, ids, config=config, item=item)
         for valindex, parameterset in enumerate(parametersets)
     ]
-    # rewrite parametrized ids greater than the overridable limit on windows
+    # rewrite parametrized ids greater than a 100 limit
     if os.name == "nt":
         limit = 100
         rewrite_template = "auto-generated-{}"

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1181,25 +1181,25 @@ def _idval(
         if hook_id:
             return hook_id
 
-    actual_val = None  # empty strings are valid as val
+    modified_val = None  # empty strings are valid as val
     if isinstance(val, STRING_TYPES):
-        actual_val = _ascii_escaped_by_config(val, config)
+        modified_val = _ascii_escaped_by_config(val, config)
     elif val is None or isinstance(val, (float, int, bool)):
-        actual_val = str(val)
+        modified_val = str(val)
     elif isinstance(val, REGEX_TYPE):
-        actual_val = ascii_escaped(val.pattern)
+        modified_val = ascii_escaped(val.pattern)
     elif isinstance(val, enum.Enum):
-        actual_val = str(val)
+        modified_val = str(val)
     elif isinstance(getattr(val, "__name__", None), str):
         # name of a class, function, module, etc.
-        actual_val = getattr(val, "__name__")
+        modified_val = getattr(val, "__name__")
 
     # Check if the post-checks value is greater than 100 chars in length and use auto id gen if so
-    # isinstance checks can return empty strings which is considered valid, so we explicitly check None on actual_val
+    # isinstance checks can return empty strings which is considered valid, so we explicitly check None on modified_val
     # for example @pytest.mark.parametrize('x', ('', ' ')) is acceptable
-    if actual_val is None or len(actual_val) > 100:
+    if modified_val is None or len(modified_val) > 100:
         return str(argname) + str(idx)
-    return actual_val
+    return modified_val
 
 
 def _idvalset(

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1240,6 +1240,7 @@ def idmaker(
             for x in resolved_ids
         ]
 
+    # All IDs must be unique!
     unique_ids = set(resolved_ids)
     if len(unique_ids) != len(resolved_ids):
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1231,14 +1231,13 @@ def idmaker(
         _idvalset(valindex, parameterset, argnames, idfn, ids, config=config, item=item)
         for valindex, parameterset in enumerate(parametersets)
     ]
-    # rewrite parametrized ids greater than a 100 limit
-    if os.name == "nt":
-        limit = 100
-        rewrite_template = "auto-generated-{}"
-        resolved_ids = [
-            x if len(x) < limit else rewrite_template.format(uuid.uuid4())
-            for x in resolved_ids
-        ]
+    # rewrite extremely long parametrized ids
+    limit = 100
+    rewrite_template = "auto-generated-{}"
+    resolved_ids = [
+        x if len(x) < limit else rewrite_template.format(uuid.uuid4())
+        for x in resolved_ids
+    ]
 
     # All IDs must be unique!
     unique_ids = set(resolved_ids)

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1,5 +1,4 @@
 import itertools
-import os
 import re
 import sys
 import textwrap
@@ -1902,11 +1901,9 @@ class TestMarkersWithParametrization:
         )
 
 
-@pytest.mark.skipif(os.name != "nt", reason="relies solely on windows based OS")
-def test_windows_autogen_result(monkeypatch, testdir):
+def test_auto_generated_long_parametrized_ids(testdir):
     # we use '93 in test 2 instead of 99 as parametrization is going to append '-False' onto the resolved_id.
     # likewise true uses '95' as '-True' will be appended by resolved_id.
-    monkeypatch.setattr(os, "name", "nt")
     testdir.makepyfile(
         """
         import pytest

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1905,7 +1905,6 @@ class TestMarkersWithParametrization:
 def test_windows_autogen_result(monkeypatch, testdir):
     # we use '93 in test 2 instead of 99 as parametrization is going to append '-False' onto the resolved_id.
     # likewise true uses '95' as '-True' will be appended by resolved_id.
-    # This test implicitly covers the --win-long-id-limit default.
     monkeypatch.setattr(os, "name", "nt")
     testdir.makepyfile(
         """

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1902,6 +1902,7 @@ class TestMarkersWithParametrization:
         )
 
 
+@pytest.mark.skipif(os.name != "nt", reason="relies solely on windows based OS")
 def test_windows_autogen_result(monkeypatch, testdir):
     # we use '93 in test 2 instead of 99 as parametrization is going to append '-False' onto the resolved_id.
     # likewise true uses '95' as '-True' will be appended by resolved_id.

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1917,7 +1917,6 @@ def test_windows_autogen_result(monkeypatch, testdir):
             ])
         def test_something(request, value, expected):
             node_id = request.node.nodeid
-            print('data was: {} ~ {}'.format(value, expected))
             result = 'auto-generated-' in node_id
             assert result == expected
         """


### PR DESCRIPTION
Fixes #6881

Evening maintainers, I've opened this PR to get some feedback on this approach.  I'm not entirely sure on the best area to solve this problem, using parameterised with very large datasets gets automatically appended onto the generated/resolved ids.  This poses a problem later when trying to update the PYTEST_CURRENT_TEST environment variable on a windows based system, doing so will raise a ValueError from __setitem__.  This attempt at patching it checks for a windows based operating system and enforces a 100 char limit, exceeding the limit for an individual id will rewrite using uuid4 based auto-generated template name.

Looking some maintainer feedback on the following:

- Is this the right area to solve the problem?
- I wanted to make an opt for overriding the limit here but struggled with guaranteeing MetaFunc has access to the pytest config consistently
- is this even an appropriate kind of solution / is there a preferred way of auto generating instead of the one outlined here
- This area of the system seems massively used, I'm sure there are tons of edge cases I haven't considered here

The code base is very big, so I'm relying solely on local test failure(s) to detect anything chaotic, but I would appreciate any tips / feedback for a new comer here.