### PR TITLE
Add new hook pytest_warning_recorded

### DIFF
--- a/changelog/7255.feature.rst
+++ b/changelog/7255.feature.rst
@@ -1,0 +1,3 @@
+Introduced a new hook named `pytest_warning_recorded` to convey information about warnings captured by the internal `pytest` warnings plugin.
+
+This hook is meant to replace `pytest_warning_captured`, which will be removed in a future release.

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -711,6 +711,7 @@ Session related reporting hooks:
 .. autofunction:: pytest_fixture_setup
 .. autofunction:: pytest_fixture_post_finalizer
 .. autofunction:: pytest_warning_captured
+.. autofunction:: pytest_warning_record
 
 Central hook for reporting about test execution:
 

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -711,7 +711,7 @@ Session related reporting hooks:
 .. autofunction:: pytest_fixture_setup
 .. autofunction:: pytest_fixture_post_finalizer
 .. autofunction:: pytest_warning_captured
-.. autofunction:: pytest_warning_record
+.. autofunction:: pytest_warning_recorded
 
 Central hook for reporting about test execution:
 

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -80,3 +80,8 @@ MINUS_K_COLON = PytestDeprecationWarning(
     "The `-k 'expr:'` syntax to -k is deprecated.\n"
     "Please open an issue if you use this and want a replacement."
 )
+
+WARNING_CAPTURED_HOOK = PytestDeprecationWarning(
+    "The pytest_warning_captured is deprecated and will be removed in a future release.\n"
+    "Please use pytest_warning_recorded instead."
+)

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -8,6 +8,7 @@ from typing import Union
 from pluggy import HookspecMarker
 
 from .deprecated import COLLECT_DIRECTORY_HOOK
+from .deprecated import WARNING_CAPTURED_HOOK
 from _pytest.compat import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -621,12 +622,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     """
 
 
-@hookspec(
-    historic=True,
-    warn_on_impl=DeprecationWarning(
-        "pytest_warning_captured is deprecated and will be removed soon"
-    ),
-)
+@hookspec(historic=True, warn_on_impl=WARNING_CAPTURED_HOOK)
 def pytest_warning_captured(warning_message, when, item, location):
     """(**Deprecated**) Process a warning captured by the internal pytest warnings plugin.
 

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -620,7 +620,12 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     """
 
 
-@hookspec(historic=True)
+@hookspec(
+    historic=True,
+    warn_on_impl=DeprecationWarning(
+        "pytest_warning_captured is deprecated and will be removed soon"
+    ),
+)
 def pytest_warning_captured(warning_message, when, item, location):
     """(**Deprecated**) Process a warning captured by the internal pytest warnings plugin.
 

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -11,6 +11,7 @@ from .deprecated import COLLECT_DIRECTORY_HOOK
 from _pytest.compat import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    import warnings
     from _pytest.config import Config
     from _pytest.main import Session
     from _pytest.reports import BaseReport
@@ -653,7 +654,12 @@ def pytest_warning_captured(warning_message, when, item, location):
 
 
 @hookspec(historic=True)
-def pytest_warning_recorded(warning_message, when, nodeid, location):
+def pytest_warning_recorded(
+    warning_message: "warnings.WarningMessage",
+    when: str,
+    nodeid: str,
+    location: Tuple[str, int, str],
+):
     """
     Process a warning captured by the internal pytest warnings plugin.
 

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -625,7 +625,7 @@ def pytest_warning_captured(warning_message, when, item, location):
     """(**Deprecated**) Process a warning captured by the internal pytest warnings plugin.
 
     This hook is considered deprecated and will be removed in a future pytest version.
-    Use :func:`pytest_warning_record` instead.
+    Use :func:`pytest_warning_recorded` instead.
 
     :param warnings.WarningMessage warning_message:
         The captured warning. This is the same object produced by :py:func:`warnings.catch_warnings`, and contains
@@ -648,7 +648,7 @@ def pytest_warning_captured(warning_message, when, item, location):
 
 
 @hookspec(historic=True)
-def pytest_warning_record(warning_message, when, nodeid, location):
+def pytest_warning_recorded(warning_message, when, nodeid, location):
     """
     Process a warning captured by the internal pytest warnings plugin.
 

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -622,6 +622,33 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
 @hookspec(historic=True)
 def pytest_warning_captured(warning_message, when, item, location):
+    """(**Deprecated**) Process a warning captured by the internal pytest warnings plugin.
+
+    This hook is considered deprecated and will be removed in a future pytest version.
+    Use :func:`pytest_warning_record` instead.
+
+    :param warnings.WarningMessage warning_message:
+        The captured warning. This is the same object produced by :py:func:`warnings.catch_warnings`, and contains
+        the same attributes as the parameters of :py:func:`warnings.showwarning`.
+
+    :param str when:
+        Indicates when the warning was captured. Possible values:
+
+        * ``"config"``: during pytest configuration/initialization stage.
+        * ``"collect"``: during test collection.
+        * ``"runtest"``: during test execution.
+
+    :param pytest.Item|None item:
+        The item being executed if ``when`` is ``"runtest"``, otherwise ``None``.
+
+    :param tuple location:
+        Holds information about the execution context of the captured warning (filename, linenumber, function).
+        ``function`` evaluates to <module> when the execution context is at the module level.
+    """
+
+
+@hookspec(historic=True)
+def pytest_warning_record(warning_message, when, nodeid, location):
     """
     Process a warning captured by the internal pytest warnings plugin.
 
@@ -636,11 +663,7 @@ def pytest_warning_captured(warning_message, when, item, location):
         * ``"collect"``: during test collection.
         * ``"runtest"``: during test execution.
 
-    :param pytest.Item|None item:
-        **DEPRECATED**: This parameter is incompatible with ``pytest-xdist``, and will always receive ``None``
-        in a future release.
-
-        The item being executed if ``when`` is ``"runtest"``, otherwise ``None``.
+    :param str nodeid: full id of the item
 
     :param tuple location:
         Holds information about the execution context of the captured warning (filename, linenumber, function).

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -227,7 +227,7 @@ def pytest_report_teststatus(report: TestReport) -> Tuple[str, str, str]:
 @attr.s
 class WarningReport:
     """
-    Simple structure to hold warnings information captured by ``pytest_warning_record``.
+    Simple structure to hold warnings information captured by ``pytest_warning_recorded``.
 
     :ivar str message: user friendly message about the warning
     :ivar str|None nodeid: node id that generated the warning (see ``get_location``).
@@ -414,7 +414,7 @@ class TerminalReporter:
     def pytest_warning_captured(self, warning_message, item):
         pass
 
-    def pytest_warning_record(self, warning_message, nodeid):
+    def pytest_warning_recorded(self, warning_message, nodeid):
         from _pytest.warnings import warning_record_to_str
 
         fslocation = warning_message.filename, warning_message.lineno

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -411,9 +411,6 @@ class TerminalReporter:
             self.write_line("INTERNALERROR> " + line)
         return 1
 
-    def pytest_warning_captured(self, warning_message, item):
-        pass
-
     def pytest_warning_recorded(self, warning_message, nodeid):
         from _pytest.warnings import warning_record_to_str
 

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -227,7 +227,7 @@ def pytest_report_teststatus(report: TestReport) -> Tuple[str, str, str]:
 @attr.s
 class WarningReport:
     """
-    Simple structure to hold warnings information captured by ``pytest_warning_captured``.
+    Simple structure to hold warnings information captured by ``pytest_warning_record``.
 
     :ivar str message: user friendly message about the warning
     :ivar str|None nodeid: node id that generated the warning (see ``get_location``).
@@ -412,13 +412,14 @@ class TerminalReporter:
         return 1
 
     def pytest_warning_captured(self, warning_message, item):
-        # from _pytest.nodes import get_fslocation_from_item
+        pass
+
+    def pytest_warning_record(self, warning_message, nodeid):
         from _pytest.warnings import warning_record_to_str
 
         fslocation = warning_message.filename, warning_message.lineno
         message = warning_record_to_str(warning_message)
 
-        nodeid = item.nodeid if item is not None else ""
         warning_report = WarningReport(
             fslocation=fslocation, message=message, nodeid=nodeid
         )

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -111,6 +111,9 @@ def catch_warnings_for_item(config, ihook, when, item):
         yield
 
         for warning_message in log:
+            ihook.pytest_warning_captured.call_historic(
+                kwargs=dict(warning_message=warning_message, when=when, item=item)
+            )
             ihook.pytest_warning_recorded.call_historic(
                 kwargs=dict(warning_message=warning_message, nodeid=nodeid, when=when)
             )
@@ -181,6 +184,11 @@ def _issue_warning_captured(warning, hook, stacklevel):
     assert records is not None
     frame = sys._getframe(stacklevel - 1)
     location = frame.f_code.co_filename, frame.f_lineno, frame.f_code.co_name
+    hook.pytest_warning_captured.call_historic(
+        kwargs=dict(
+            warning_message=records[0], when="config", item=None, location=location
+        )
+    )
     hook.pytest_warning_recorded.call_historic(
         kwargs=dict(
             warning_message=records[0], when="config", nodeid="", location=location

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -111,7 +111,6 @@ def catch_warnings_for_item(config, ihook, when, item):
         yield
 
         for warning_message in log:
-            # raise ValueError(ihook.pytest_warning_record)
             ihook.pytest_warning_record.call_historic(
                 kwargs=dict(warning_message=warning_message, nodeid=nodeid, when=when)
             )
@@ -168,9 +167,8 @@ def pytest_sessionfinish(session):
 def _issue_warning_captured(warning, hook, stacklevel):
     """
     This function should be used instead of calling ``warnings.warn`` directly when we are in the "configure" stage:
-    at this point the actual options might not have been set, so we manually trigger the pytest_warning_record hooks
-    so we can display these warnings in the terminal.
-    This is a hack until we can sort out #2891.
+    at this point the actual options might not have been set, so we manually trigger the pytest_warning_record
+    hook so we can display these warnings in the terminal. This is a hack until we can sort out #2891.
 
     :param warning: the warning instance.
     :param hook: the hook caller

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -115,7 +115,12 @@ def catch_warnings_for_item(config, ihook, when, item):
                 kwargs=dict(warning_message=warning_message, when=when, item=item)
             )
             ihook.pytest_warning_recorded.call_historic(
-                kwargs=dict(warning_message=warning_message, nodeid=nodeid, when=when)
+                kwargs=dict(
+                    warning_message=warning_message,
+                    nodeid=nodeid,
+                    when=when,
+                    location=None,
+                )
             )
 
 

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -81,7 +81,7 @@ def catch_warnings_for_item(config, ihook, when, item):
 
     ``item`` can be None if we are not in the context of an item execution.
 
-    Each warning captured triggers the ``pytest_warning_record`` hook.
+    Each warning captured triggers the ``pytest_warning_recorded`` hook.
     """
     cmdline_filters = config.getoption("pythonwarnings") or []
     inifilters = config.getini("filterwarnings")
@@ -111,7 +111,7 @@ def catch_warnings_for_item(config, ihook, when, item):
         yield
 
         for warning_message in log:
-            ihook.pytest_warning_record.call_historic(
+            ihook.pytest_warning_recorded.call_historic(
                 kwargs=dict(warning_message=warning_message, nodeid=nodeid, when=when)
             )
 
@@ -167,7 +167,7 @@ def pytest_sessionfinish(session):
 def _issue_warning_captured(warning, hook, stacklevel):
     """
     This function should be used instead of calling ``warnings.warn`` directly when we are in the "configure" stage:
-    at this point the actual options might not have been set, so we manually trigger the pytest_warning_record
+    at this point the actual options might not have been set, so we manually trigger the pytest_warning_recorded
     hook so we can display these warnings in the terminal. This is a hack until we can sort out #2891.
 
     :param warning: the warning instance.
@@ -181,7 +181,7 @@ def _issue_warning_captured(warning, hook, stacklevel):
     assert records is not None
     frame = sys._getframe(stacklevel - 1)
     location = frame.f_code.co_filename, frame.f_lineno, frame.f_code.co_name
-    hook.pytest_warning_record.call_historic(
+    hook.pytest_warning_recorded.call_historic(
         kwargs=dict(
             warning_message=records[0], when="config", nodeid="", location=location
         )

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -1,5 +1,4 @@
 import os
-import re
 import warnings
 
 import pytest
@@ -276,25 +275,11 @@ def test_warning_captured_hook(testdir):
     result.stdout.fnmatch_lines(["*1 passed*"])
 
     expected = [
-        (
-            "config warning",
-            "config",
-            "",
-            (
-                r"/tmp/pytest-of-.+/pytest-\d+/test_warning_captured_hook0/conftest.py",
-                3,
-                "pytest_configure",
-            ),
-        ),
-        ("collect warning", "collect", "", None),
-        ("setup warning", "runtest", "test_warning_captured_hook.py::test_func", None),
-        ("call warning", "runtest", "test_warning_captured_hook.py::test_func", None),
-        (
-            "teardown warning",
-            "runtest",
-            "test_warning_captured_hook.py::test_func",
-            None,
-        ),
+        ("config warning", "config", "",),
+        ("collect warning", "collect", ""),
+        ("setup warning", "runtest", "test_warning_captured_hook.py::test_func"),
+        ("call warning", "runtest", "test_warning_captured_hook.py::test_func"),
+        ("teardown warning", "runtest", "test_warning_captured_hook.py::test_func"),
     ]
     for index in range(len(expected)):
         collected_result = collected[index]
@@ -304,14 +289,15 @@ def test_warning_captured_hook(testdir):
         assert collected_result[1] == expected_result[1], str(collected)
         assert collected_result[2] == expected_result[2], str(collected)
 
-        if expected_result[3] is not None:
-            assert re.match(expected_result[3][0], collected_result[3][0]), str(
-                collected
-            )
-            assert collected_result[3][1] == expected_result[3][1], str(collected)
-            assert collected_result[3][2] == expected_result[3][2], str(collected)
+        # NOTE: collected_result[3] is location, which differs based on the platform you are on
+        #       thus, the best we can do here is assert the types of the paremeters match what we expect
+        #       and not try and preload it in the expected array
+        if collected_result[3] is not None:
+            assert type(collected_result[3][0]) is str, str(collected)
+            assert type(collected_result[3][1]) is int, str(collected)
+            assert type(collected_result[3][2]) is str, str(collected)
         else:
-            assert expected_result[3] == collected_result[3], str(collected)
+            assert collected_result[3] is None, str(collected)
 
 
 @pytest.mark.filterwarnings("always")

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -275,7 +275,7 @@ def test_warning_captured_hook(testdir):
     result.stdout.fnmatch_lines(["*1 passed*"])
 
     expected = [
-        ("config warning", "config", "",),
+        ("config warning", "config", ""),
         ("collect warning", "collect", ""),
         ("setup warning", "runtest", "test_warning_captured_hook.py::test_func"),
         ("call warning", "runtest", "test_warning_captured_hook.py::test_func"),

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -268,9 +268,8 @@ def test_warning_captured_hook(testdir):
     collected = []
 
     class WarningCollector:
-        def pytest_warning_captured(self, warning_message, when, item):
-            imge_name = item.name if item is not None else ""
-            collected.append((str(warning_message.message), when, imge_name))
+        def pytest_warning_record(self, warning_message, when, nodeid):
+            collected.append((str(warning_message.message), when, nodeid))
 
     result = testdir.runpytest(plugins=[WarningCollector()])
     result.stdout.fnmatch_lines(["*1 passed*"])
@@ -278,11 +277,11 @@ def test_warning_captured_hook(testdir):
     expected = [
         ("config warning", "config", ""),
         ("collect warning", "collect", ""),
-        ("setup warning", "runtest", "test_func"),
-        ("call warning", "runtest", "test_func"),
-        ("teardown warning", "runtest", "test_func"),
+        ("setup warning", "runtest", "test_warning_captured_hook.py::test_func"),
+        ("call warning", "runtest", "test_warning_captured_hook.py::test_func"),
+        ("teardown warning", "runtest", "test_warning_captured_hook.py::test_func"),
     ]
-    assert collected == expected
+    assert collected == expected, str(collected)
 
 
 @pytest.mark.filterwarnings("always")
@@ -649,7 +648,7 @@ class TestStackLevel:
             captured = []
 
             @classmethod
-            def pytest_warning_captured(cls, warning_message, when, item, location):
+            def pytest_warning_record(cls, warning_message, when, nodeid, location):
                 cls.captured.append((warning_message, location))
 
         testdir.plugins = [CapturedWarnings()]

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -268,7 +268,7 @@ def test_warning_captured_hook(testdir):
     collected = []
 
     class WarningCollector:
-        def pytest_warning_record(self, warning_message, when, nodeid):
+        def pytest_warning_recorded(self, warning_message, when, nodeid):
             collected.append((str(warning_message.message), when, nodeid))
 
     result = testdir.runpytest(plugins=[WarningCollector()])
@@ -648,7 +648,7 @@ class TestStackLevel:
             captured = []
 
             @classmethod
-            def pytest_warning_record(cls, warning_message, when, nodeid, location):
+            def pytest_warning_recorded(cls, warning_message, when, nodeid, location):
                 cls.captured.append((warning_message, location))
 
         testdir.plugins = [CapturedWarnings()]


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X ] Include documentation when adding new features.
- [X ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

As per https://github.com/pytest-dev/pytest/issues/4049, introduce a new hook named `pytest_warning_recorded` to replace `pytest_warning_captured`.

Parameter choice was determined by comments left on https://github.com/pytest-dev/pytest-xdist/issues/341.

Testing was accomplished via `tox -e py37`

PR Checklist:
- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.