### PR TITLE
Prevent pytest from printing ConftestImportFailure traceback

### DIFF
--- a/changelog/6956.bugfix.rst
+++ b/changelog/6956.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent pytest from printing ConftestImportFailure traceback to stdout.

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -29,7 +29,6 @@ from _pytest.mark.structures import Mark
 from _pytest.mark.structures import MarkDecorator
 from _pytest.mark.structures import NodeKeywords
 from _pytest.outcomes import fail
-from _pytest.outcomes import Failed
 from _pytest.store import Store
 
 if TYPE_CHECKING:
@@ -332,19 +331,15 @@ class Node(metaclass=NodeMeta):
         pass
 
     def _repr_failure_py(
-        self,
-        excinfo: ExceptionInfo[
-            Union[Failed, FixtureLookupError, ConftestImportFailure]
-        ],
-        style=None,
+        self, excinfo: ExceptionInfo[BaseException], style=None,
     ) -> Union[str, ReprExceptionInfo, ExceptionChainRepr, FixtureLookupErrorRepr]:
+        if isinstance(excinfo.value, ConftestImportFailure):
+            excinfo = ExceptionInfo(excinfo.value.excinfo)
         if isinstance(excinfo.value, fail.Exception):
             if not excinfo.value.pytrace:
                 return str(excinfo.value)
         if isinstance(excinfo.value, FixtureLookupError):
             return excinfo.value.formatrepr()
-        if isinstance(excinfo.value, ConftestImportFailure):
-            excinfo = ExceptionInfo(excinfo.value.excinfo)  # type: ignore
         if self.config.getoption("fulltrace", False):
             style = "long"
         else:

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -19,6 +19,7 @@ from _pytest._code.code import ReprExceptionInfo
 from _pytest.compat import cached_property
 from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
+from _pytest.config import ConftestImportFailure
 from _pytest.config import PytestPluginManager
 from _pytest.deprecated import NODE_USE_FROM_PARENT
 from _pytest.fixtures import FixtureDef
@@ -340,6 +341,8 @@ class Node(metaclass=NodeMeta):
             return excinfo.value.formatrepr()
         if self.config.getoption("fulltrace", False):
             style = "long"
+        if excinfo.type is ConftestImportFailure:  # type: ignore
+            excinfo = ExceptionInfo.from_exc_info(excinfo.value.excinfo)  # type: ignore
         else:
             tb = _pytest._code.Traceback([excinfo.traceback[-1]])
             self._prunetraceback(excinfo)

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -332,17 +332,21 @@ class Node(metaclass=NodeMeta):
         pass
 
     def _repr_failure_py(
-        self, excinfo: ExceptionInfo[Union[Failed, FixtureLookupError]], style=None
+        self,
+        excinfo: ExceptionInfo[
+            Union[Failed, FixtureLookupError, ConftestImportFailure]
+        ],
+        style=None,
     ) -> Union[str, ReprExceptionInfo, ExceptionChainRepr, FixtureLookupErrorRepr]:
         if isinstance(excinfo.value, fail.Exception):
             if not excinfo.value.pytrace:
                 return str(excinfo.value)
         if isinstance(excinfo.value, FixtureLookupError):
             return excinfo.value.formatrepr()
+        if isinstance(excinfo.value, ConftestImportFailure):
+            excinfo = ExceptionInfo(excinfo.value.excinfo)  # type: ignore
         if self.config.getoption("fulltrace", False):
             style = "long"
-        if excinfo.type is ConftestImportFailure:  # type: ignore
-            excinfo = ExceptionInfo.from_exc_info(excinfo.value.excinfo)  # type: ignore
         else:
             tb = _pytest._code.Traceback([excinfo.traceback[-1]])
             self._prunetraceback(excinfo)

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -1251,7 +1251,7 @@ def test_syntax_error_with_non_ascii_chars(testdir):
     result.stdout.fnmatch_lines(["*ERROR collecting*", "*SyntaxError*", "*1 error in*"])
 
 
-def test_collecterror_with_fulltrace(testdir):
+def test_collect_error_with_fulltrace(testdir):
     testdir.makepyfile("assert 0")
     result = testdir.runpytest("--fulltrace")
     result.stdout.fnmatch_lines(
@@ -1259,15 +1259,12 @@ def test_collecterror_with_fulltrace(testdir):
             "collected 0 items / 1 error",
             "",
             "*= ERRORS =*",
-            "*_ ERROR collecting test_collecterror_with_fulltrace.py _*",
-            "",
-            "*/_pytest/python.py:*: ",
-            "_ _ _ _ _ _ _ _ *",
+            "*_ ERROR collecting test_collect_error_with_fulltrace.py _*",
             "",
             ">   assert 0",
             "E   assert 0",
             "",
-            "test_collecterror_with_fulltrace.py:1: AssertionError",
+            "test_collect_error_with_fulltrace.py:1: AssertionError",
             "*! Interrupted: 1 error during collection !*",
         ]
     )

--- a/testing/test_reports.py
+++ b/testing/test_reports.py
@@ -404,9 +404,7 @@ class TestReportSerialization:
         result.stdout.fnmatch_lines(
             ["E   ModuleNotFoundError: No module named 'unknown'"]
         )
-        result.stdout.no_fnmatch_line(
-            "ERROR  - _pytest.config.ConftestImportFailure: ModuleNotFoundError:*"
-        )
+        result.stdout.no_fnmatch_line("ERROR  - *ConftestImportFailure*")
 
 
 class TestHooks:

--- a/testing/test_reports.py
+++ b/testing/test_reports.py
@@ -401,9 +401,7 @@ class TestReportSerialization:
         sub_dir.join("conftest").new(ext=".py").write("import unknown")
 
         result = testdir.runpytest_subprocess(".")
-        result.stdout.fnmatch_lines(
-            ["E   ModuleNotFoundError: No module named 'unknown'"]
-        )
+        result.stdout.fnmatch_lines(["E   *Error: No module named 'unknown'"])
         result.stdout.no_fnmatch_line("ERROR  - *ConftestImportFailure*")
 
 

--- a/testing/test_reports.py
+++ b/testing/test_reports.py
@@ -396,6 +396,18 @@ class TestReportSerialization:
         # for same reasons as previous test, ensure we don't blow up here
         loaded_report.longrepr.toterminal(tw_mock)
 
+    def test_report_prevent_ConftestImportFailure_hiding_exception(self, testdir):
+        sub_dir = testdir.tmpdir.join("ns").ensure_dir()
+        sub_dir.join("conftest").new(ext=".py").write("import unknown")
+
+        result = testdir.runpytest_subprocess(".")
+        result.stdout.fnmatch_lines(
+            ["E   ModuleNotFoundError: No module named 'unknown'"]
+        )
+        result.stdout.no_fnmatch_line(
+            "ERROR  - _pytest.config.ConftestImportFailure: ModuleNotFoundError:*"
+        )
+
 
 class TestHooks:
     """Test that the hooks are working correctly for plugins"""


### PR DESCRIPTION
Closes: #6956 

@asottile I was not able to satisfy mypy so I added `# type: ignore` to the two lines. Let me know what you think :)

- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`