### PR TITLE
document autouse scope fixture priority 

### DIFF
--- a/doc/en/example/fixtures/test_fixtures_autouse_order.py
+++ b/doc/en/example/fixtures/test_fixtures_autouse_order.py
@@ -16,9 +16,6 @@ def non_autouse_function_fixture():
 def test_fixture_autouse_ordering(
     non_autouse_function_fixture, autouse_function_fixture
 ):
-    """
-    You may (mistakenly) expect the test declaration order of fixtures to hold true here.
-    However autouse=True fixtures are always given priority on a per scope basis.
-    """
-    assert items == ["non_auto_use_fixture", "auto_use_fixture"]  # failure
-    assert items == ["auto_use_fixture", "non_auto_use_fixture"]  # pass
+    # You may (mistakenly) expect the test declaration order of fixtures to hold true here.
+    # However autouse=True fixtures are always given priority on a per scope basis.
+    assert items == ["auto_use_fixture", "non_auto_use_fixture"]

--- a/doc/en/example/fixtures/test_fixtures_autouse_order.py
+++ b/doc/en/example/fixtures/test_fixtures_autouse_order.py
@@ -1,0 +1,24 @@
+import pytest
+
+items = []
+
+
+@pytest.fixture(autouse=True)
+def autouse_function_fixture():
+    items.append("auto_use_fixture")
+
+
+@pytest.fixture()
+def non_autouse_function_fixture():
+    items.append("non_auto_use_fixture")
+
+
+def test_fixture_autouse_ordering(
+    non_autouse_function_fixture, autouse_function_fixture
+):
+    """
+    You may (mistakenly) expect the test declaration order of fixtures to hold true here.
+    However autouse=True fixtures are always given priority on a per scope basis.
+    """
+    assert items == ["non_auto_use_fixture", "auto_use_fixture"]  # failure
+    assert items == ["auto_use_fixture", "non_auto_use_fixture"]  # pass

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -434,8 +434,9 @@ The fixtures requested by ``test_order`` will be instantiated in the following o
 5. ``f1``: is the first ``function``-scoped fixture in ``test_order`` parameter list.
 6. ``f2``: is the last ``function``-scoped fixture in ``test_order`` parameter list.
 
-Something to be aware of, when passing autouse fixture(s) directly into tests, they are always executed first.
-Consider the example below where an autouse function scoped fixture is declared after a non auto use one:
+Something to be aware of, auto use fixtures are always called with priority over non auto use fixtures for the
+same scope.  For example if you pass 2 function scoped fixtures into a test with the non auto use fixture named first
+the autouse fixture will still be executed first.  This is outlined in the example below:
 
 .. literalinclude:: example/fixtures/test_fixtures_autouse_order.py
 

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -434,6 +434,13 @@ The fixtures requested by ``test_order`` will be instantiated in the following o
 5. ``f1``: is the first ``function``-scoped fixture in ``test_order`` parameter list.
 6. ``f2``: is the last ``function``-scoped fixture in ``test_order`` parameter list.
 
+Something to be aware of, when passing autouse fixture(s) directly into tests, they are always executed first.
+Consider the example below where an autouse function scoped fixture is declared after a non auto use one:
+
+.. literalinclude:: example/fixtures/test_fixtures_autouse_order.py
+
+..
+
 
 .. _`finalization`:
 


### PR DESCRIPTION
Hi team, added some brief documentation explaining that autouse fixtures will be prioritized even when declared after non auto use fixtures in a test signature.  closes #3404