### PR TITLE
Fix typo in capture.rst documentation

### DIFF
--- a/doc/en/capture.rst
+++ b/doc/en/capture.rst
@@ -145,7 +145,7 @@ The return value from ``readouterr`` changed to a ``namedtuple`` with two attrib
 
 If the code under test writes non-textual data, you can capture this using
 the ``capsysbinary`` fixture which instead returns ``bytes`` from
-the ``readouterr`` method.  The ``capfsysbinary`` fixture is currently only
+the ``readouterr`` method.  The ``capsysbinary`` fixture is currently only
 available in python 3.
 
 

--- a/doc/en/capture.rst
+++ b/doc/en/capture.rst
@@ -145,8 +145,7 @@ The return value from ``readouterr`` changed to a ``namedtuple`` with two attrib
 
 If the code under test writes non-textual data, you can capture this using
 the ``capsysbinary`` fixture which instead returns ``bytes`` from
-the ``readouterr`` method.  The ``capsysbinary`` fixture is currently only
-available in Python 3.
+the ``readouterr`` method.
 
 
 

--- a/doc/en/capture.rst
+++ b/doc/en/capture.rst
@@ -146,7 +146,7 @@ The return value from ``readouterr`` changed to a ``namedtuple`` with two attrib
 If the code under test writes non-textual data, you can capture this using
 the ``capsysbinary`` fixture which instead returns ``bytes`` from
 the ``readouterr`` method.  The ``capsysbinary`` fixture is currently only
-available in python 3.
+available in Python 3.
 
 
 


### PR DESCRIPTION
Rename ``capfsysbinary`` to ``capsysbinary`` as the former does not exist as far as i can see.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
