### PR TITLE
code: remove last usage of py.error

### DIFF
--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -268,10 +268,6 @@ class TracebackEntry:
         return tbh
 
     def __str__(self) -> str:
-        try:
-            fn = str(self.path)
-        except py.error.Error:
-            fn = "???"
         name = self.frame.code.name
         try:
             line = str(self.statement).lstrip()
@@ -279,7 +275,7 @@ class TracebackEntry:
             raise
         except BaseException:
             line = "???"
-        return "  File %r:%d in %s\n  %s\n" % (fn, self.lineno + 1, name, line)
+        return "  File %r:%d in %s\n  %s\n" % (self.path, self.lineno + 1, name, line)
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
`str(self.path)` can't raise at all, so it can just be removed.

https://github.com/pytest-dev/pytest/blob/b3db440d4c41c91dd761dee98d7014149e1d7c08/src/_pytest/_code/code.py#L74-L90