### PR TITLE
Output a warning to stderr when an invalid key is read from an INI config file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -109,6 +109,7 @@ Gabriel Reis
 Gene Wood
 George Kussumoto
 Georgy Dyuldin
+Gleb Nikonorov
 Graham Horler
 Greg Price
 Gregory Lee

--- a/changelog/6856.feature.rst
+++ b/changelog/6856.feature.rst
@@ -1,0 +1,3 @@
+A warning is now shown when an unknown key is read from a config INI file.
+
+The `--strict-config` flag has been added to treat these warnings as errors.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1020,7 +1020,7 @@ class Config:
             )
 
         self._checkversion()
-        self._validatekeys()
+        self._validatekeys(args)
         self._consider_importhook(args)
         self.pluginmanager.consider_preparse(args, exclude_only=False)
         if not os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
@@ -1073,9 +1073,12 @@ class Config:
                     )
                 )
 
-    def _validatekeys(self):
+    def _validatekeys(self, args: Sequence[str]):
         for key in self._get_unknown_ini_keys():
-            sys.stderr.write("WARNING: unknown config ini key: {}\n".format(key))
+            message = "Unknown config ini key: {}\n".format(key)
+            if "--strict-config" in args:
+                fail(message, pytrace=False)
+            sys.stderr.write("WARNING: {}".format(message))
 
     def _get_unknown_ini_keys(self) -> List[str]:
         parser_inicfg = self._parser._inidict

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1020,6 +1020,7 @@ class Config:
             )
 
         self._checkversion()
+        self._validatekeys()
         self._consider_importhook(args)
         self.pluginmanager.consider_preparse(args, exclude_only=False)
         if not os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
@@ -1071,6 +1072,14 @@ class Config:
                         pytest.__version__,
                     )
                 )
+
+    def _validatekeys(self):
+        for key in self._get_unknown_ini_keys():
+            sys.stderr.write("WARNING: unknown config ini key: {}\n".format(key))
+
+    def _get_unknown_ini_keys(self) -> List[str]:
+        parser_inicfg = self._parser._inidict
+        return [name for name in self.inicfg if name not in parser_inicfg]
 
     def parse(self, args: List[str], addopts: bool = True) -> None:
         # parse given cmdline arguments into this config object.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1020,7 +1020,6 @@ class Config:
             )
 
         self._checkversion()
-        self._validatekeys(args)
         self._consider_importhook(args)
         self.pluginmanager.consider_preparse(args, exclude_only=False)
         if not os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
@@ -1031,6 +1030,7 @@ class Config:
         self.known_args_namespace = ns = self._parser.parse_known_args(
             args, namespace=copy.copy(self.option)
         )
+        self._validatekeys()
         if self.known_args_namespace.confcutdir is None and self.inifile:
             confcutdir = py.path.local(self.inifile).dirname
             self.known_args_namespace.confcutdir = confcutdir
@@ -1073,10 +1073,10 @@ class Config:
                     )
                 )
 
-    def _validatekeys(self, args: Sequence[str]):
+    def _validatekeys(self):
         for key in self._get_unknown_ini_keys():
             message = "Unknown config ini key: {}\n".format(key)
-            if "--strict-config" in args:
+            if self.known_args_namespace.strict_config:
                 fail(message, pytrace=False)
             sys.stderr.write("WARNING: {}".format(message))
 

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -71,6 +71,11 @@ def pytest_addoption(parser):
         help="exit after first num failures or errors.",
     )
     group._addoption(
+        "--strict-config",
+        action="store_true",
+        help="invalid ini keys for the `pytest` section of the configuration file raise errors.",
+    )
+    group._addoption(
         "--strict-markers",
         "--strict",
         action="store_true",

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -173,6 +173,16 @@ class TestParseIni:
             ),
             (
                 """
+          [some_other_header]
+          unknown_ini = value1
+          [pytest]
+          minversion = 5.0.0
+          """,
+                [],
+                [],
+            ),
+            (
+                """
           [pytest]
           minversion = 5.0.0
           """,


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Implementation of https://github.com/pytest-dev/pytest/issues/6856. 
Changes:
- Show a warning when an invalid `INI` key is read from a config ini file.
- Add the `--strict-config` which forces warnings to become errors