### PR TITLE
Fix crash that happened under --runxfail -o empty_parameter_set_mark=…

### DIFF
--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -37,7 +37,10 @@ def get_empty_parameterset_mark(config, argnames, func):
     if requested_mark in ("", None, "skip"):
         mark = MARK_GEN.skip
     elif requested_mark == "xfail":
-        mark = MARK_GEN.xfail(run=False)
+        if config.getoption("runxfail", default=False):
+            mark = MARK_GEN.skip
+        else:
+            mark = MARK_GEN.xfail(run=False)
     elif requested_mark == "fail_at_collect":
         f_name = func.__name__
         _, lineno = getfslineno(func)

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -885,15 +885,19 @@ class TestMarkDecorator:
         assert md.kwargs == {"three": 3}
 
 
-@pytest.mark.parametrize("mark", [None, "", "skip", "xfail"])
-def test_parameterset_for_parametrize_marks(testdir, mark):
+@pytest.mark.parametrize(
+    "mark, addopts",
+    [(None, ""), ("", ""), ("skip", ""), ("xfail", ""), ("xfail", "--runxfail")],
+)
+def test_parameterset_for_parametrize_marks(testdir, mark, addopts):
     if mark is not None:
         testdir.makeini(
             """
         [pytest]
         {}={}
+        addopts={}
         """.format(
-                EMPTY_PARAMETERSET_OPTION, mark
+                EMPTY_PARAMETERSET_OPTION, mark, addopts
             )
         )
 
@@ -902,7 +906,7 @@ def test_parameterset_for_parametrize_marks(testdir, mark):
 
     pytest_configure(config)
     result_mark = get_empty_parameterset_mark(config, ["a"], all)
-    if mark in (None, ""):
+    if mark in (None, "") or (mark == "xfail" and addopts == "--runxfail"):
         # normalize to the requested name
         mark = "skip"
     assert result_mark.name == mark
@@ -955,7 +959,7 @@ def test_parameterset_for_fail_at_collect(testdir):
 
 def test_parameterset_for_parametrize_bad_markname(testdir):
     with pytest.raises(pytest.UsageError):
-        test_parameterset_for_parametrize_marks(testdir, "bad")
+        test_parameterset_for_parametrize_marks(testdir, "bad", False)
 
 
 def test_mark_expressions_no_smear(testdir):


### PR DESCRIPTION
…xfail

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Fix issue that was reported in https://github.com/pytest-dev/pytest/issues/4497 by making sure `runxfail` plays nicely with `empty_parameter_set_mark = xfail`