### PR TITLE
7291: Replace py.iniconfig with iniconfig

### DIFF
--- a/changelog/7291.trivial.rst
+++ b/changelog/7291.trivial.rst
@@ -1,0 +1,1 @@
+Replaced usages of py.iniconfig with iniconfig.

--- a/changelog/7291.trivial.rst
+++ b/changelog/7291.trivial.rst
@@ -1,1 +1,1 @@
-Replaced usages of py.iniconfig with iniconfig.
+Replaced ``py.iniconfig`` with `iniconfig <https://pypi.org/project/iniconfig/>`__.

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ INSTALL_REQUIRES = [
     'colorama;sys_platform=="win32"',
     "pluggy>=0.12,<1.0",
     'importlib-metadata>=0.12;python_version<"3.8"',
+    "iniconfig",
 ]
 
 

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -6,6 +6,8 @@ from typing import Optional
 from typing import Tuple
 
 import py
+from iniconfig import IniConfig
+from iniconfig import ParseError
 
 from .exceptions import UsageError
 from _pytest.compat import TYPE_CHECKING
@@ -40,8 +42,8 @@ def getcfg(args, config=None):
                 p = base.join(inibasename)
                 if exists(p):
                     try:
-                        iniconfig = py.iniconfig.IniConfig(p)
-                    except py.iniconfig.ParseError as exc:
+                        iniconfig = IniConfig(p)
+                    except ParseError as exc:
                         raise UsageError(str(exc))
 
                     if (
@@ -119,7 +121,7 @@ def determine_setup(
 ) -> Tuple[py.path.local, Optional[str], Any]:
     dirs = get_dirs_from_args(args)
     if inifile:
-        iniconfig = py.iniconfig.IniConfig(inifile)
+        iniconfig = IniConfig(inifile)
         is_cfg_file = str(inifile).endswith(".cfg")
         sections = ["tool:pytest", "pytest"] if is_cfg_file else ["pytest"]
         for section in sections:

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -22,6 +22,7 @@ from typing import Union
 from weakref import WeakKeyDictionary
 
 import py
+from iniconfig import IniConfig
 
 import pytest
 from _pytest._code import Source
@@ -683,7 +684,7 @@ class Testdir:
     def getinicfg(self, source):
         """Return the pytest section from the tox.ini config file."""
         p = self.makeini(source)
-        return py.iniconfig.IniConfig(p)["pytest"]
+        return IniConfig(p)["pytest"]
 
     def makepyfile(self, *args, **kwargs):
         r"""Shortcut for .makefile() with a .py extension.


### PR DESCRIPTION
Fix #7291


<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [N/A] Include documentation when adding new features.
- [N/A] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [Already there] Add yourself to `AUTHORS` in alphabetical order.
-->
