### PR TITLE
Prepare release 5.4.3

### DIFF
--- a/changelog/6428.bugfix.rst
+++ b/changelog/6428.bugfix.rst
@@ -1,2 +1,0 @@
-Paths appearing in error messages are now correct in case the current working directory has
-changed since the start of the session.

--- a/changelog/6755.bugfix.rst
+++ b/changelog/6755.bugfix.rst
@@ -1,1 +1,0 @@
-Support deleting paths longer than 260 characters on windows created inside tmpdir.

--- a/changelog/6956.bugfix.rst
+++ b/changelog/6956.bugfix.rst
@@ -1,1 +1,0 @@
-Prevent pytest from printing ConftestImportFailure traceback to stdout.

--- a/changelog/7150.bugfix.rst
+++ b/changelog/7150.bugfix.rst
@@ -1,1 +1,0 @@
-Prevent hiding the underlying exception when ``ConfTestImportFailure`` is raised.

--- a/changelog/7215.bugfix.rst
+++ b/changelog/7215.bugfix.rst
@@ -1,2 +1,0 @@
-Fix regression where running with ``--pdb`` would call the ``tearDown`` methods of ``unittest.TestCase``
-subclasses for skipped tests.

--- a/doc/en/announce/index.rst
+++ b/doc/en/announce/index.rst
@@ -6,6 +6,7 @@ Release announcements
    :maxdepth: 2
 
 
+   release-5.4.3
    release-5.4.2
    release-5.4.1
    release-5.4.0

--- a/doc/en/announce/release-5.4.3.rst
+++ b/doc/en/announce/release-5.4.3.rst
@@ -1,0 +1,21 @@
+pytest-5.4.3
+=======================================
+
+pytest 5.4.3 has just been released to PyPI.
+
+This is a bug-fix release, being a drop-in replacement. To upgrade::
+
+  pip install --upgrade pytest
+
+The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+
+Thanks to all who contributed to this release, among them:
+
+* Anthony Sottile
+* Bruno Oliveira
+* Ran Benita
+* Tor Colvin
+
+
+Happy testing,
+The pytest Development Team

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -28,6 +28,29 @@ with advance notice in the **Deprecations** section of releases.
 
 .. towncrier release notes start
 
+pytest 5.4.3 (2020-06-02)
+=========================
+
+Bug Fixes
+---------
+
+- `#6428 <https://github.com/pytest-dev/pytest/issues/6428>`_: Paths appearing in error messages are now correct in case the current working directory has
+  changed since the start of the session.
+
+
+- `#6755 <https://github.com/pytest-dev/pytest/issues/6755>`_: Support deleting paths longer than 260 characters on windows created inside tmpdir.
+
+
+- `#6956 <https://github.com/pytest-dev/pytest/issues/6956>`_: Prevent pytest from printing ConftestImportFailure traceback to stdout.
+
+
+- `#7150 <https://github.com/pytest-dev/pytest/issues/7150>`_: Prevent hiding the underlying exception when ``ConfTestImportFailure`` is raised.
+
+
+- `#7215 <https://github.com/pytest-dev/pytest/issues/7215>`_: Fix regression where running with ``--pdb`` would call the ``tearDown`` methods of ``unittest.TestCase``
+  subclasses for skipped tests.
+
+
 pytest 5.4.2 (2020-05-08)
 =========================
 

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -481,11 +481,10 @@ Running it results in some skips if we don't have all the python interpreters in
 .. code-block:: pytest
 
    . $ pytest -rs -q multipython.py
-   ssssssssssss...ssssssssssss                                          [100%]
+   ssssssssssss......sss......                                          [100%]
    ========================= short test summary info ==========================
-   SKIPPED [12] $REGENDOC_TMPDIR/CWD/multipython.py:29: 'python3.5' not found
-   SKIPPED [12] $REGENDOC_TMPDIR/CWD/multipython.py:29: 'python3.7' not found
-   3 passed, 24 skipped in 0.12s
+   SKIPPED [15] $REGENDOC_TMPDIR/CWD/multipython.py:29: 'python3.5' not found
+   12 passed, 15 skipped in 0.12s
 
 Indirect parametrization of optional implementations/imports
 --------------------------------------------------------------------


### PR DESCRIPTION
Created automatically from https://github.com/pytest-dev/pytest/issues/7300.

Once all builds pass and it has been **approved** by one or more maintainers, the build
can be released by pushing a tag `5.4.3` to this repository.
