### PR TITLE
Show invalid ini keys sorted

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1074,7 +1074,7 @@ class Config:
                 )
 
     def _validatekeys(self):
-        for key in self._get_unknown_ini_keys():
+        for key in sorted(self._get_unknown_ini_keys()):
             message = "Unknown config ini key: {}\n".format(key)
             if self.known_args_namespace.strict_config:
                 fail(message, pytrace=False)

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -158,10 +158,10 @@ class TestParseIni:
           """,
                 ["unknown_ini", "another_unknown_ini"],
                 [
-                    "WARNING: Unknown config ini key: unknown_ini",
                     "WARNING: Unknown config ini key: another_unknown_ini",
+                    "WARNING: Unknown config ini key: unknown_ini",
                 ],
-                "Unknown config ini key: unknown_ini",
+                "Unknown config ini key: another_unknown_ini",
             ),
             (
                 """
@@ -200,9 +200,7 @@ class TestParseIni:
     ):
         testdir.tmpdir.join("pytest.ini").write(textwrap.dedent(ini_file_text))
         config = testdir.parseconfig()
-        assert config._get_unknown_ini_keys() == invalid_keys, str(
-            config._get_unknown_ini_keys()
-        )
+        assert sorted(config._get_unknown_ini_keys()) == sorted(invalid_keys)
 
         result = testdir.runpytest()
         result.stderr.fnmatch_lines(stderr_output)


### PR DESCRIPTION
Otherwise this relies on the dictionary order of `config.inicfg`, which
is insertion order in py36+ but "random" order in py35.

This lead to an unrelated failure in https://github.com/pytest-dev/pytest/pull/7247/checks?check_run_id=732077801.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
