### PR TITLE
Write helpful information to log-file

### DIFF
--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -639,6 +639,7 @@ class LoggingPlugin:
     @pytest.hookimpl(hookwrapper=True, tryfirst=True)
     def pytest_sessionstart(self) -> Generator[None, None, None]:
         self.log_cli_handler.set_when("sessionstart")
+        self.log_file_handler.set_when("sessionstart")
 
         with catching_logs(self.log_cli_handler, level=self.log_cli_level):
             with catching_logs(self.log_file_handler, level=self.log_file_level):
@@ -647,6 +648,7 @@ class LoggingPlugin:
     @pytest.hookimpl(hookwrapper=True, tryfirst=True)
     def pytest_collection(self) -> Generator[None, None, None]:
         self.log_cli_handler.set_when("collection")
+        self.log_file_handler.set_when("collection")
 
         with catching_logs(self.log_cli_handler, level=self.log_cli_level):
             with catching_logs(self.log_file_handler, level=self.log_file_level):
@@ -670,10 +672,23 @@ class LoggingPlugin:
     def pytest_runtest_logstart(self) -> None:
         self.log_cli_handler.reset()
         self.log_cli_handler.set_when("start")
+        self.log_file_handler.set_when("start")
 
     @pytest.hookimpl
-    def pytest_runtest_logreport(self) -> None:
+    def pytest_runtest_logreport(self, report) -> None:
         self.log_cli_handler.set_when("logreport")
+        self.log_file_handler.set_when("logreport", report.nodeid)
+        # this is a stripped-down version of the logreport hook used in
+        # junitxml.
+        if report.failed:
+            if report.when == "call":
+                if not hasattr(report, "wasxfail"):
+                    messages = [
+                        "\n".join(reprentry.lines)
+                        for reprentry in report.longrepr.reprtraceback.reprentries
+                    ]
+                    message = "\n\n".join(messages)
+                    logging.error("Exception:\n" + message)
 
     def _runtest_for(self, item: nodes.Item, when: str) -> Generator[None, None, None]:
         """Implement the internals of the pytest_runtest_xxx() hooks."""
@@ -695,6 +710,7 @@ class LoggingPlugin:
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_setup(self, item: nodes.Item) -> Generator[None, None, None]:
         self.log_cli_handler.set_when("setup")
+        self.log_file_handler.set_when("setup", item.nodeid)
 
         empty = {}  # type: Dict[str, List[logging.LogRecord]]
         item._store[caplog_records_key] = empty
@@ -703,12 +719,14 @@ class LoggingPlugin:
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_call(self, item: nodes.Item) -> Generator[None, None, None]:
         self.log_cli_handler.set_when("call")
+        self.log_file_handler.set_when("call", item.nodeid)
 
         yield from self._runtest_for(item, "call")
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_teardown(self, item: nodes.Item) -> Generator[None, None, None]:
         self.log_cli_handler.set_when("teardown")
+        self.log_file_handler.set_when("teardown", item.nodeid)
 
         yield from self._runtest_for(item, "teardown")
         del item._store[caplog_records_key]
@@ -717,10 +735,12 @@ class LoggingPlugin:
     @pytest.hookimpl
     def pytest_runtest_logfinish(self) -> None:
         self.log_cli_handler.set_when("finish")
+        self.log_file_handler.set_when("finish")
 
     @pytest.hookimpl(hookwrapper=True, tryfirst=True)
     def pytest_sessionfinish(self) -> Generator[None, None, None]:
         self.log_cli_handler.set_when("sessionfinish")
+        self.log_file_handler.set_when("sessionfinish")
 
         with catching_logs(self.log_cli_handler, level=self.log_cli_level):
             with catching_logs(self.log_file_handler, level=self.log_file_level):
@@ -736,9 +756,29 @@ class LoggingPlugin:
 class _FileHandler(logging.FileHandler):
     """A logging FileHandler with pytest tweaks."""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._when = None
+        self._name = None
+        self._section_name_shown = False
+
     def handleError(self, record: logging.LogRecord) -> None:
         # Handled by LogCaptureHandler.
         pass
+
+    def set_when(self, when, name=""):
+        self._when = when
+        self._name = name
+        self._section_name_shown = False
+
+    def emit(self, record):
+        if not self._section_name_shown and self._when:
+            suffix = ": {}".format(self._name) if self._name else ""
+            self.stream.write(
+                str.center(" {}{} ".format(self._when, suffix), 80, "-") + "\n"
+            )
+            self._section_name_shown = True
+        super().emit(record)
 
 
 class _LiveLoggingStreamHandler(logging.StreamHandler):


### PR DESCRIPTION
This adds separators like the one used in the live-log-output, e.g. `---
live log setup ---`, to the generated log file. In addition to that
also the traceback is written to the log file now.

Fixes: #7307

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
