### PR TITLE
[4.6.x] Add a fallback for the term report letter

### DIFF
--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -179,6 +179,7 @@ def getreportopt(config):
 
 @pytest.hookimpl(trylast=True)  # after _pytest.runner
 def pytest_report_teststatus(report):
+    letter = "F"
     if report.passed:
         letter = "."
     elif report.skipped:


### PR DESCRIPTION
When plugins return report objects in an unconventional state,
`_pytest.terminal.pytest_report_teststatus()` may skip
entering if-block branches that declare the `letter` variable.
It would lead to `UnboundLocalError: local variable 'letter'
referenced before assignment` being raised.

This change fixes this by setting the initial value of the
`letter` before the if-block cascade so that it always has
a value.

Fixes #7310

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [ ] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.