### PR TITLE
[4.6.x][backport of PR #6337] Make 'S' and 'F' aliases to 's' and 'f' respectively

### DIFF
--- a/changelog/6334.bugfix.rst
+++ b/changelog/6334.bugfix.rst
@@ -1,0 +1,3 @@
+Fix summary entries appearing twice when ``f/F`` and ``s/S`` report chars were used at the same time in the ``-r`` command-line option (for example ``-rFf``).
+
+The upper case variants were never documented and the preferred form should be the lower case.

--- a/changelog/7310.bugfix.rst
+++ b/changelog/7310.bugfix.rst
@@ -1,0 +1,9 @@
+Fix ``UnboundLocalError: local variable 'letter' referenced before
+assignment`` in ``_pytest.terminal.pytest_report_teststatus()``
+when plugins return report objects in an unconventional state.
+
+This was making ``pytest_report_teststatus()`` skip
+entering if-block branches that declare the ``letter`` variable.
+
+The fix was to set the initial value of the ``letter`` before
+the if-block cascade so that it always has a value.

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -759,6 +759,35 @@ class TestTerminalFunctional(object):
         result = testdir.runpytest(*params)
         result.stdout.fnmatch_lines(["collected 3 items", "hello from hook: 3 items"])
 
+    def test_summary_f_alias(self, testdir):
+        """Test that 'f' and 'F' report chars are aliases and don't show up twice in the summary (#6334)"""
+        testdir.makepyfile(
+            """
+            def test():
+                assert False
+            """
+        )
+        result = testdir.runpytest("-rfF")
+        expected = "FAILED test_summary_f_alias.py::test - assert False"
+        result.stdout.fnmatch_lines([expected])
+        assert result.stdout.lines.count(expected) == 1
+
+    def test_summary_s_alias(self, testdir):
+        """Test that 's' and 'S' report chars are aliases and don't show up twice in the summary"""
+        testdir.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.skip
+            def test():
+                pass
+            """
+        )
+        result = testdir.runpytest("-rsS")
+        expected = "SKIPPED [1] test_summary_s_alias.py:3: unconditional skip"
+        result.stdout.fnmatch_lines([expected])
+        assert result.stdout.lines.count(expected) == 1
+
 
 def test_fail_extra_reporting(testdir, monkeypatch):
     monkeypatch.setenv("COLUMNS", "80")
@@ -1551,12 +1580,16 @@ class TestProgressWithTeardown(object):
         testdir.makepyfile(
             """
             def test_foo(fail_teardown):
-                assert False
+                assert 0
         """
         )
-        output = testdir.runpytest()
+        output = testdir.runpytest("-rfE")
         output.stdout.re_match_lines(
-            [r"test_teardown_with_test_also_failing.py FE\s+\[100%\]"]
+            [
+                r"test_teardown_with_test_also_failing.py FE\s+\[100%\]",
+                "FAILED test_teardown_with_test_also_failing.py::test_foo - assert 0",
+                "ERROR test_teardown_with_test_also_failing.py::test_foo - assert False",
+            ]
         )
 
     def test_teardown_many(self, testdir, many_files):


### PR DESCRIPTION
This is a backport of #6337 (by @nicoddemus) with an extra change
note on top of it. It fixes #7310 and ~supersedes~ closes #7311 (as an
alternative to a smaller patch as suggested by @RonnyPfannschmidt).

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [ ] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.