### PR TITLE
Remove start_doc_server.sh script

### DIFF
--- a/doc/en/start_doc_server.sh
+++ b/doc/en/start_doc_server.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd "${MY_DIR}"/_build/html || exit
-python -m http.server 8000


### PR DESCRIPTION
In #7321 , I forgot to add a note about the utility script `start_doc_server` in the contrubuting.rst.

This add it back..  

cc: @nicoddemus 

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
