### PR TITLE
Allow tests to override "global" `log_level` (rebased)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -244,6 +244,7 @@ Romain Dorgueil
 Roman Bolshakov
 Ronny Pfannschmidt
 Ross Lawley
+Ruaridh Williamson
 Russel Winder
 Ryan Wooden
 Samuel Dion-Girardeau

--- a/changelog/7133.improvement.rst
+++ b/changelog/7133.improvement.rst
@@ -1,0 +1,1 @@
+``caplog.set_level()`` will now override any :confval:`log_level` set via the CLI or ``.ini``.

--- a/doc/en/logging.rst
+++ b/doc/en/logging.rst
@@ -250,6 +250,9 @@ made in ``3.4`` after community feedback:
 
 * Log levels are no longer changed unless explicitly requested by the :confval:`log_level` configuration
   or ``--log-level`` command-line options. This allows users to configure logger objects themselves.
+  Setting :confval:`log_level` will set the level that is captured globally so if a specific test requires
+  a lower level than this, use the ``caplog.set_level()`` functionality otherwise that test will be prone to
+  failure.
 * :ref:`Live Logs <live_logs>` is now disabled by default and can be enabled setting the
   :confval:`log_cli` configuration option to ``true``. When enabled, the verbosity is increased so logging for each
   test is visible.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -344,7 +344,6 @@ class LogCaptureFixture:
         self._item = item
         # dict of log name -> log level
         self._initial_logger_levels = {}  # type: Dict[Optional[str], int]
-        self._initial_handler_level = None  # type: Optional[int]
 
     def _finalize(self) -> None:
         """Finalizes the fixture.
@@ -352,9 +351,6 @@ class LogCaptureFixture:
         This restores the log levels changed by :meth:`set_level`.
         """
         # restore log levels
-        if self._initial_handler_level is not None:
-            self.handler.setLevel(self._initial_handler_level)
-
         for logger_name, level in self._initial_logger_levels.items():
             logger = logging.getLogger(logger_name)
             logger.setLevel(level)
@@ -436,7 +432,6 @@ class LogCaptureFixture:
         # save the original log-level to restore it during teardown
         self._initial_logger_levels.setdefault(logger, logger_obj.level)
         logger_obj.setLevel(level)
-        self._initial_handler_level = self.handler.level
         self.handler.setLevel(level)
 
     @contextmanager

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -148,8 +148,9 @@ def test_ini_controls_global_log_level(testdir):
         def test_log_level_override(request, caplog):
             plugin = request.config.pluginmanager.getplugin('logging-plugin')
             assert plugin.log_level == logging.ERROR
-            logging.getLogger('catchlog').warning("WARNING message won't be shown")
-            logging.getLogger('catchlog').error("ERROR message will be shown")
+            logger = logging.getLogger('catchlog')
+            logger.warning("WARNING message won't be shown")
+            logger.error("ERROR message will be shown")
             assert 'WARNING' not in caplog.text
             assert 'ERROR' in caplog.text
     """
@@ -172,24 +173,24 @@ def test_caplog_can_override_global_log_level(testdir):
         import pytest
         import logging
         def test_log_level_override(request, caplog):
-            logger = 'catchlog'
+            logger = logging.getLogger('catchlog')
             plugin = request.config.pluginmanager.getplugin('logging-plugin')
             assert plugin.log_level == logging.WARNING
 
-            logging.getLogger(logger).info("INFO message won't be shown")
+            logger.info("INFO message won't be shown")
 
-            caplog.set_level(logging.INFO, logger)
+            caplog.set_level(logging.INFO, logger.name)
 
-            with caplog.at_level(logging.DEBUG, logger):
-                logging.getLogger(logger).debug("DEBUG message will be shown")
+            with caplog.at_level(logging.DEBUG, logger.name):
+                logger.debug("DEBUG message will be shown")
 
-            logging.getLogger(logger).debug("DEBUG message won't be shown")
+            logger.debug("DEBUG message won't be shown")
 
-            with caplog.at_level(logging.CRITICAL, logger):
-                logging.getLogger(logger).warning("WARNING message won't be shown")
+            with caplog.at_level(logging.CRITICAL, logger.name):
+                logger.warning("WARNING message won't be shown")
 
-            logging.getLogger(logger).debug("DEBUG message won't be shown")
-            logging.getLogger(logger).info("INFO message will be shown")
+            logger.debug("DEBUG message won't be shown")
+            logger.info("INFO message will be shown")
 
             assert "message won't be shown" not in caplog.text
     """

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -235,4 +235,3 @@ def test_caplog_captures_despite_exception(testdir):
     result = testdir.runpytest()
     result.stdout.fnmatch_lines(["*DEBUG message will be shown*"])
     assert result.ret == 1
-


### PR DESCRIPTION
Rebased #7139 on `master` as I have no permission to push to the fork.


cc @ruaridhw @thisch

Closes #7139