### PR TITLE
#7336 make --log-file relative to inifile if it exists

### DIFF
--- a/changelog/7336.breaking.rst
+++ b/changelog/7336.breaking.rst
@@ -1,0 +1,1 @@
+The pytest ``--log-file`` cli or ``log_file`` ini marker is now relative to the configs ``inifile`` directory, as it was always the intention. It was originally introduced as relative to the current working directory unintentionally.

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -161,7 +161,7 @@ def determine_setup(
     args: List[str],
     rootdir_cmd_arg: Optional[str] = None,
     config: Optional["Config"] = None,
-) -> Tuple[py.path.local, Optional[str], Dict[str, Union[str, List[str]]]]:
+) -> Tuple[py.path.local, Optional[py.path.local], Dict[str, Union[str, List[str]]]]:
     rootdir = None
     dirs = get_dirs_from_args(args)
     if inifile:

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -165,7 +165,8 @@ def determine_setup(
     rootdir = None
     dirs = get_dirs_from_args(args)
     if inifile:
-        inicfg = load_config_dict_from_file(py.path.local(inifile)) or {}
+        inifile = py.path.local(inifile)
+        inicfg = load_config_dict_from_file(inifile) or {}
         if rootdir_cmd_arg is None:
             rootdir = get_common_ancestor(dirs)
     else:

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -527,9 +527,11 @@ class LoggingPlugin:
         # File logging.
         self.log_file_level = get_log_level_for_setting(config, "log_file_level")
         log_file = get_option_ini(config, "log_file") or os.devnull
+
         # Keep the log file relative to the inidir file (if it exists) (#7336)
-        if log_file != os.devnull and getattr(config, "inifile"):
-            log_file = os.path.join(config.inifile.dirname, log_file)  # type: ignore[union-attr]
+        inidir = getattr(getattr(config, "inifile", None), "dirname", None)
+        if log_file != os.devnull and inidir:
+            log_file = os.path.join(inidir, log_file)
         self.log_file_handler = _FileHandler(log_file, mode="w", encoding="UTF-8")
         log_file_format = get_option_ini(config, "log_file_format", "log_format")
         log_file_date_format = get_option_ini(

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -527,6 +527,9 @@ class LoggingPlugin:
         # File logging.
         self.log_file_level = get_log_level_for_setting(config, "log_file_level")
         log_file = get_option_ini(config, "log_file") or os.devnull
+        # Keep the log file relative to the inidir file (if it exists) (#7336)
+        if log_file != os.devnull and getattr(config, "inifile", None):
+            log_file = os.path.join(config.inifile.dirname, log_file)  # type: ignore[union-attr]
         self.log_file_handler = _FileHandler(log_file, mode="w", encoding="UTF-8")
         log_file_format = get_option_ini(config, "log_file_format", "log_format")
         log_file_date_format = get_option_ini(

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -528,7 +528,7 @@ class LoggingPlugin:
         self.log_file_level = get_log_level_for_setting(config, "log_file_level")
         log_file = get_option_ini(config, "log_file") or os.devnull
         # Keep the log file relative to the inidir file (if it exists) (#7336)
-        if log_file != os.devnull and getattr(config, "inifile", None):
+        if log_file != os.devnull and getattr(config, "inifile"):
             log_file = os.path.join(config.inifile.dirname, log_file)  # type: ignore[union-attr]
         self.log_file_handler = _FileHandler(log_file, mode="w", encoding="UTF-8")
         log_file_format = get_option_ini(config, "log_file_format", "log_format")

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -529,9 +529,8 @@ class LoggingPlugin:
         log_file = get_option_ini(config, "log_file") or os.devnull
 
         # Keep the log file relative to the inidir file (if it exists) (#7336)
-        inidir = getattr(getattr(config, "inifile", None), "dirname", None)
-        if log_file != os.devnull and inidir:
-            log_file = os.path.join(inidir, log_file)
+        if log_file != os.devnull and config.inifile is not None:
+            log_file = os.path.join(config.inifile.dirname, log_file)
         self.log_file_handler = _FileHandler(log_file, mode="w", encoding="UTF-8")
         log_file_format = get_option_ini(config, "log_file_format", "log_format")
         log_file_date_format = get_option_ini(

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1152,3 +1152,82 @@ def test_logging_emit_error_supressed(testdir: Testdir) -> None:
     )
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)
+
+
+def test_log_file_is_in_pytest_ini_rootdir(testdir):
+    # as per https://docs.pytest.org/en/5.4.3/reference.html log_file
+    # the file should be relative to the pytest inifile
+    testdir.makefile(
+        ".ini",
+        pytest="""
+        [pytest]
+        log_cli = True
+        log_cli_level = DEBUG
+        log_file = logfile.txt
+        log_file_level = DEBUG
+        """,
+    )
+    sub = testdir.mkdir("sub")
+    p = testdir.makepyfile(
+        """
+        def test_this():
+            import logging
+            logging.getLogger().info("Normal message")
+    """
+    )
+    p.move(sub.join(p.basename))
+    os.chdir(sub.strpath)
+    testdir.runpytest()
+    testdir.chdir()
+    files = set(os.listdir())
+    assert {"logfile.txt", "pytest.ini"}.issubset(files)
+
+
+def test_log_file_can_be_specified_to_child_dir(testdir):
+    testdir.makefile(
+        ".ini",
+        pytest="""
+        [pytest]
+        log_cli = True
+        log_cli_level = DEBUG
+        log_file = sub/logfile.txt
+        log_file_level = DEBUG
+        """,
+    )
+    sub = testdir.mkdir("sub")
+    p = testdir.makepyfile(
+        """
+        def test_this():
+            import logging
+            logging.getLogger().info("Normal message")
+    """
+    )
+    p.move(sub.join(p.basename))
+    os.chdir(sub.strpath)
+    testdir.runpytest()
+    files = set(os.listdir())
+    assert "logfile.txt" in files
+    assert "pytest.ini" not in files
+
+
+def test_log_file_cli_is_also_relative(testdir):
+    testdir.makefile(
+        ".ini",
+        pytest="""
+        [pytest]
+        """,
+    )
+    sub = testdir.mkdir("sub")
+    p = testdir.makepyfile(
+        """
+        def test_this():
+            import logging
+            logging.getLogger().info("Normal message")
+    """
+    )
+    p.move(sub.join(p.basename))
+    os.chdir(sub.strpath)
+    testdir.runpytest("--log-file", "sub{}logfile.txt".format(os.sep))
+    files = set(os.listdir())
+    assert "logfile.txt" in files
+    assert "pytest.ini" not in files

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1154,9 +1154,10 @@ def test_logging_emit_error_supressed(testdir: Testdir) -> None:
     result.assert_outcomes(passed=1)
 
 
-def test_log_file_is_in_pytest_ini_rootdir(testdir):
-    # as per https://docs.pytest.org/en/5.4.3/reference.html log_file
-    # the file should be relative to the pytest inifile
+def test_log_file_is_in_pytest_ini_rootdir(testdir, monkeypatch):
+    """
+    #7336|#7350 - log_file should be relative to the config inifile
+    """
     testdir.makefile(
         ".ini",
         pytest="""
@@ -1176,14 +1177,17 @@ def test_log_file_is_in_pytest_ini_rootdir(testdir):
     """
     )
     p.move(sub.join(p.basename))
-    os.chdir(sub.strpath)
+    monkeypatch.chdir(sub.strpath)
     testdir.runpytest()
     testdir.chdir()
     files = set(os.listdir())
     assert {"logfile.txt", "pytest.ini"}.issubset(files)
 
 
-def test_log_file_can_be_specified_to_child_dir(testdir):
+def test_log_file_can_be_specified_to_child_dir(testdir, monkeypatch):
+    """
+    #7336|#7350 - log_file should be relative to the config inifile
+    """
     testdir.makefile(
         ".ini",
         pytest="""
@@ -1198,19 +1202,21 @@ def test_log_file_can_be_specified_to_child_dir(testdir):
     p = testdir.makepyfile(
         """
         def test_this():
-            import logging
-            logging.getLogger().info("Normal message")
+            pass
     """
     )
     p.move(sub.join(p.basename))
-    os.chdir(sub.strpath)
+    monkeypatch.chdir(sub.strpath)
     testdir.runpytest()
     files = set(os.listdir())
     assert "logfile.txt" in files
     assert "pytest.ini" not in files
 
 
-def test_log_file_cli_is_also_relative(testdir):
+def test_log_file_cli_is_also_relative(testdir, monkeypatch):
+    """
+    #7336|#7350 - log_file should be relative to the config inifile
+    """
     testdir.makefile(
         ".ini",
         pytest="""
@@ -1221,12 +1227,11 @@ def test_log_file_cli_is_also_relative(testdir):
     p = testdir.makepyfile(
         """
         def test_this():
-            import logging
-            logging.getLogger().info("Normal message")
+            pass
     """
     )
     p.move(sub.join(p.basename))
-    os.chdir(sub.strpath)
+    monkeypatch.chdir(sub.strpath)
     testdir.runpytest("--log-file", "sub{}logfile.txt".format(os.sep))
     files = set(os.listdir())
     assert "logfile.txt" in files


### PR DESCRIPTION
As per #7336, I think the correct behaviour is to keep the --log-file relative to the inifile?  From what I _gather_ the inifile can be None; so this PR makes the --log-file relative to that directory in the event that it exists;  not sure how to proceed if it is None in a good manner. (assume the current behaviour of putting the log file in the execution directory?)

Close #7336