### PR TITLE
Fix exception causes in config/__init__.py

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -641,7 +641,7 @@ class PytestPluginManager(PluginManager):
         except ImportError as e:
             raise ImportError(
                 'Error importing plugin "{}": {}'.format(modname, str(e.args[0]))
-            ).with_traceback(e.__traceback__)
+            ).with_traceback(e.__traceback__) from e
 
         except Skipped as e:
             from _pytest.warnings import _issue_warning_captured
@@ -1197,12 +1197,12 @@ class Config:
         for ini_config in self._override_ini:
             try:
                 key, user_ini_value = ini_config.split("=", 1)
-            except ValueError:
+            except ValueError as e:
                 raise UsageError(
                     "-o/--override-ini expects option=value style (got: {!r}).".format(
                         ini_config
                     )
-                )
+                ) from e
             else:
                 if key == name:
                     value = user_ini_value


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 