### PR TITLE
Suppress errors while removing tmpdir's lock files

### DIFF
--- a/changelog/5456.bugfix.rst
+++ b/changelog/5456.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a possible race condition when trying to remove lock files used to control access to folders
+created by ``tmp_path`` and ``tmpdir``.

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -1,9 +1,11 @@
 import os.path
 import sys
+import unittest.mock
 
 import py
 
 import pytest
+from _pytest.pathlib import ensure_deletable
 from _pytest.pathlib import fnmatch_ex
 from _pytest.pathlib import get_extended_length_path_str
 from _pytest.pathlib import get_lock_path
@@ -113,3 +115,22 @@ def test_get_extended_length_path_str():
     assert get_extended_length_path_str(r"\\share\foo") == r"\\?\UNC\share\foo"
     assert get_extended_length_path_str(r"\\?\UNC\share\foo") == r"\\?\UNC\share\foo"
     assert get_extended_length_path_str(r"\\?\c:\foo") == r"\\?\c:\foo"
+
+
+def test_suppress_error_removing_lock(tmp_path):
+    """ensure_deletable should not raise an exception if the lock file cannot be removed (#5456)"""
+    path = tmp_path / "dir"
+    path.mkdir()
+    lock = get_lock_path(path)
+    lock.touch()
+    mtime = lock.stat().st_mtime
+
+    with unittest.mock.patch.object(Path, "unlink", side_effect=OSError):
+        assert not ensure_deletable(
+            path, consider_lock_dead_if_created_before=mtime + 30
+        )
+    assert lock.is_file()
+
+    # check now that we can remove the lock file in normal circumstances
+    assert ensure_deletable(path, consider_lock_dead_if_created_before=mtime + 30)
+    assert not lock.is_file()


### PR DESCRIPTION
Fix #5456