### PR TITLE
assertoutcomes() only accepts plural forms

### DIFF
--- a/changelog/6505.breaking.rst
+++ b/changelog/6505.breaking.rst
@@ -1,0 +1,20 @@
+``Testdir.run().parseoutcomes()`` now always returns the parsed nouns in plural form.
+
+Originally ``parseoutcomes()`` would always returns the nouns in plural form, but a change
+meant to improve the terminal summary by using singular form single items (``1 warning`` or ``1 error``)
+caused an unintended regression by changing the keys returned by ``parseoutcomes()``.
+
+Now the API guarantees to always return the plural form, so calls like this:
+
+.. code-block:: python
+
+    result = testdir.runpytest()
+    result.assert_outcomes(error=1)
+
+Need to be changed to:
+
+
+.. code-block:: python
+
+    result = testdir.runpytest()
+    result.assert_outcomes(errors=1)

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -4342,6 +4342,6 @@ def test_yield_fixture_with_no_value(testdir):
     )
     expected = "E               ValueError: custom did not yield a value"
     result = testdir.runpytest()
-    result.assert_outcomes(error=1)
+    result.assert_outcomes(errors=1)
     result.stdout.fnmatch_lines([expected])
     assert result.ret == ExitCode.TESTS_FAILED

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -763,9 +763,38 @@ def test_testdir_outcomes_with_multiple_errors(testdir):
     """
     )
     result = testdir.runpytest(str(p1))
-    result.assert_outcomes(error=2)
+    result.assert_outcomes(errors=2)
 
-    assert result.parseoutcomes() == {"error": 2}
+    assert result.parseoutcomes() == {"errors": 2}
+
+
+def test_parse_summary_line_always_plural():
+    """Parsing summaries always returns plural nouns (#6505)"""
+    lines = [
+        "some output 1",
+        "some output 2",
+        "======= 1 failed, 1 passed, 1 warning, 1 error in 0.13s ====",
+        "done.",
+    ]
+    assert pytester.RunResult.parse_summary_nouns(lines) == {
+        "errors": 1,
+        "failed": 1,
+        "passed": 1,
+        "warnings": 1,
+    }
+
+    lines = [
+        "some output 1",
+        "some output 2",
+        "======= 1 failed, 1 passed, 2 warnings, 2 errors in 0.13s ====",
+        "done.",
+    ]
+    assert pytester.RunResult.parse_summary_nouns(lines) == {
+        "errors": 2,
+        "failed": 1,
+        "passed": 1,
+        "warnings": 2,
+    }
 
 
 def test_makefile_joins_absolute_path(testdir: Testdir) -> None:


### PR DESCRIPTION
As discussed in #6505, this changes `assertoutcomes` to always work with the plural form of the nouns.

Fix #6505

Close #6905

cc @altendky