### PR TITLE
Allow users to provide version information to the required_plugins INI key

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,12 +42,12 @@ repos:
     -   id: setup-cfg-fmt
         # TODO: when upgrading setup-cfg-fmt this can be removed
         args: [--max-py-version=3.9]
-        #-   repo: https://github.com/pre-commit/mirrors-mypy
-        #rev: v0.780  # NOTE: keep this in sync with setup.cfg.
-        #hooks:
-        #-   id: mypy
-        #files: ^(src/|testing/)
-        #args: []
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.780  # NOTE: keep this in sync with setup.cfg.
+    hooks:
+    -   id: mypy
+        files: ^(src/|testing/)
+        args: []
 -   repo: local
     hooks:
     -   id: rst

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,12 +42,12 @@ repos:
     -   id: setup-cfg-fmt
         # TODO: when upgrading setup-cfg-fmt this can be removed
         args: [--max-py-version=3.9]
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.780  # NOTE: keep this in sync with setup.cfg.
-    hooks:
-    -   id: mypy
-        files: ^(src/|testing/)
-        args: []
+        #-   repo: https://github.com/pre-commit/mirrors-mypy
+        #rev: v0.780  # NOTE: keep this in sync with setup.cfg.
+        #hooks:
+        #-   id: mypy
+        #files: ^(src/|testing/)
+        #args: []
 -   repo: local
     hooks:
     -   id: rst

--- a/changelog/7346.feature.rst
+++ b/changelog/7346.feature.rst
@@ -1,0 +1,1 @@
+Version information as defined by `PEP 440 <https://www.python.org/dev/peps/pep-0440/#version-specifiers>`_ may now be included when providing plugins to the ``required_plugins`` configuration option.

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -1562,12 +1562,14 @@ passed multiple times. The expected format is ``name=value``. For example::
 .. confval:: required_plugins
 
    A space separated list of plugins that must be present for pytest to run.
+   Plugins can be listed with or without version specifiers directly following
+   their name. Whitespace between different version specifiers is not allowed.
    If any one of the plugins is not found, emit an error.
 
    .. code-block:: ini
 
        [pytest]
-       required_plugins = pytest-html pytest-xdist
+       required_plugins = pytest-django>=3.0.0,<4.0.0 pytest-html pytest-xdist>=1.0.0
 
 
 .. confval:: testpaths

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1101,7 +1101,7 @@ class Config:
         plugin_info = self.pluginmanager.list_plugin_distinfo()
         plugin_dist_info = {dist.project_name: dist.version for _, dist in plugin_info}
 
-        missing_plugins = ["a"]
+        missing_plugins = []
         for required_plugin in required_plugins:
             spec = None
             try:

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1088,13 +1088,26 @@ class Config:
         if not required_plugins:
             return
 
+        # Imported lazily to improve start-up time.
+        from packaging.version import Version
+        from packaging.requirements import InvalidRequirement, Requirement
+
         plugin_info = self.pluginmanager.list_plugin_distinfo()
-        plugin_dist_names = [dist.project_name for _, dist in plugin_info]
+        plugin_dist_info = {dist.project_name: dist.version for _, dist in plugin_info}
 
         missing_plugins = []
-        for plugin in required_plugins:
-            if plugin not in plugin_dist_names:
-                missing_plugins.append(plugin)
+        for required_plugin in required_plugins:
+            spec = None
+            try:
+                spec = Requirement(required_plugin)
+            except InvalidRequirement:
+                missing_plugins.append(required_plugin)
+                continue
+
+            if spec.name not in plugin_dist_info:
+                missing_plugins.append(required_plugin)
+            elif Version(plugin_dist_info[spec.name]) not in spec.specifier:
+                missing_plugins.append(required_plugin)
 
         if missing_plugins:
             fail(

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1101,7 +1101,7 @@ class Config:
         plugin_info = self.pluginmanager.list_plugin_distinfo()
         plugin_dist_info = {dist.project_name: dist.version for _, dist in plugin_info}
 
-        missing_plugins = []
+        missing_plugins = ["a"]
         for required_plugin in required_plugins:
             spec = None
             try:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -250,6 +250,63 @@ class TestParseIni:
             ),
             (
                 """
+          [pytest]
+          required_plugins = pytest-xdist
+          """,
+                "",
+            ),
+            (
+                """
+          [pytest]
+          required_plugins = pytest-xdist==1.32.0
+          """,
+                "",
+            ),
+            (
+                """
+          [pytest]
+          required_plugins = pytest-xdist~=1.32.0 pytest-xdist==1.32.0 pytest-xdist!=0.0.1 pytest-xdist<=99.99.0
+            pytest-xdist>=1.32.0 pytest-xdist<9.9.9 pytest-xdist>1.30.0 pytest-xdist===1.32.0
+          """,
+                "",
+            ),
+            (
+                """
+          [pytest]
+          required_plugins = pytest-xdist>9.9.9 pytest-xdist==1.32.0 pytest-xdist==8.8.8
+          """,
+                "Missing required plugins: pytest-xdist==8.8.8, pytest-xdist>9.9.9",
+            ),
+            (
+                """
+          [pytest]
+          required_plugins = pytest-xdist==aegsrgrsgs
+          """,
+                "Missing required plugins: pytest-xdist==aegsrgrsgs",
+            ),
+            (
+                """
+          [pytest]
+          required_plugins = pytest-xdist==-1
+          """,
+                "Missing required plugins: pytest-xdist==-1",
+            ),
+            (
+                """
+          [pytest]
+          required_plugins = pytest-xdist== pytest-xdist<=
+          """,
+                "Missing required plugins: pytest-xdist<=, pytest-xdist==",
+            ),
+            (
+                """
+          [pytest]
+          required_plugins = pytest-xdist= pytest-xdist<
+          """,
+                "Missing required plugins: pytest-xdist<, pytest-xdist=",
+            ),
+            (
+                """
           [some_other_header]
           required_plugins = wont be triggered
           [pytest]

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -265,6 +265,13 @@ class TestParseIni:
             (
                 """
           [pytest]
+          required_plugins = pytest-xdist>1.0.0,<2.0.0
+          """,
+                "",
+            ),
+            (
+                """
+          [pytest]
           required_plugins = pytest-xdist~=1.32.0 pytest-xdist==1.32.0 pytest-xdist!=0.0.1 pytest-xdist<=99.99.0
             pytest-xdist>=1.32.0 pytest-xdist<9.9.9 pytest-xdist>1.30.0 pytest-xdist===1.32.0
           """,
@@ -280,16 +287,9 @@ class TestParseIni:
             (
                 """
           [pytest]
-          required_plugins = pytest-xdist==aegsrgrsgs
+          required_plugins = pytest-xdist==aegsrgrsgs pytest-xdist==-1 pytest-xdist>2.1.1,>3.0.0
           """,
-                "Missing required plugins: pytest-xdist==aegsrgrsgs",
-            ),
-            (
-                """
-          [pytest]
-          required_plugins = pytest-xdist==-1
-          """,
-                "Missing required plugins: pytest-xdist==-1",
+                "Missing required plugins: pytest-xdist==-1, pytest-xdist==aegsrgrsgs, pytest-xdist>2.1.1,>3.0.0",
             ),
             (
                 """


### PR DESCRIPTION
Closes https://github.com/pytest-dev/pytest/issues/7346

Add in the ability to specify versioning information for the `required_plugins` INI key
