### PR TITLE
Docs: Update tense, the final Python 2.7 was released in April

### DIFF
--- a/doc/en/py27-py34-deprecation.rst
+++ b/doc/en/py27-py34-deprecation.rst
@@ -9,7 +9,7 @@ In case of Python 2 and 3, the difference between the languages makes it even mo
 because many new Python 3 features cannot be used in a Python 2/3 compatible code base.
 
 Python 2.7 EOL has been reached `in 2020 <https://legacy.python.org/dev/peps/pep-0373/#id4>`__, with
-the last release planned for mid-April, 2020.
+the last release made in April, 2020.
 
 Python 3.4 EOL has been reached `in 2019 <https://www.python.org/dev/peps/pep-0429/#release-schedule>`__, with the last release made in March, 2019.
 


### PR DESCRIPTION
The final Python 2.7 release (2.7.18) was indeed in April 2020, on the 20th.

https://mail.python.org/archives/list/python-dev@python.org/thread/OFCIETIXLX34X7FVK5B5WPZH22HXV342/#OFCIETIXLX34X7FVK5B5WPZH22HXV342

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [x] Include documentation when adding new features.
- [n/a] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [n/a] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [small documentation fix] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
-->

---

Whilst we're here, it's now mid-2020. Does the following need any update (and the info about maintenance of 4.6.X versions in general), or is it okay to keep it as is for a while longer?

> The core team will be happy to accept those patches, and make new 4.6.X releases **until mid-2020** (but consider that date as a ballpark, after that date the team might still decide to make new releases for critical bugs).


