### PR TITLE
RFC: runner: don't try to teardown previous items from pytest_runtest_setup

### DIFF
--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -409,16 +409,15 @@ class SetupState:
             raise exc
 
     def prepare(self, colitem) -> None:
-        """ setup objects along the collector chain to the test-method
-            and teardown previously setup objects."""
-        needed_collectors = colitem.listchain()
-        self._teardown_towards(needed_collectors)
+        """Setup objects along the collector chain to the test-method."""
 
         # check if the last collection node has raised an error
         for col in self.stack:
             if hasattr(col, "_prepare_exc"):
                 exc = col._prepare_exc  # type: ignore[attr-defined] # noqa: F821
                 raise exc
+
+        needed_collectors = colitem.listchain()
         for col in needed_collectors[len(self.stack) :]:
             self.stack.append(col)
             try:


### PR DESCRIPTION
[This is more of an RFC/question in a form of a PR, at least ATM.]

---

While working on improving the documentation of the runtest hooks, I came up with this text for `pytest_runtest_setup`:

> Called to perform the setup phase of the test item.
>
> The default implementation runs ``setup()`` on item and all of its parents (which haven't been setup yet). This includes obtaining the values of fixtures required by the item (which haven't been obtained yet).

But upon closer inspection, I noticed this line at the start of `SetupState.prepare` (which is what does the actual work for `pytest_runtest_setup`):

https://github.com/pytest-dev/pytest/blob/ab6dacf1d1e1ff0c5be70a3c5f48e63168168721/src/_pytest/runner.py#L411-L417

which implies that the setup phase of one item might trigger teardowns of *previous* items. This complicates the simple explanation. It also seems like a completely undesirable thing to do, because it breaks isolation between tests -- e.g. a failed teardown of one item shouldn't cause the failure of some other items just because it happens to run after it.

So the first thing I tried was to remove that line and see if anything breaks -- nothing did. At least pytest's own test suite runs fine. So maybe it's just dead code? Does anyone know/guess why it exists? Git blame points to issue #90 and commit a5e7b2760db81c1dec6e68c9a74edca5381925fd but that only left me more confused :grinning: 