### PR TITLE
Some type annotations, doc improvements

### DIFF
--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -287,7 +287,7 @@ Bug Fixes
 - `#6646 <https://github.com/pytest-dev/pytest/issues/6646>`_: Assertion rewriting hooks are (re)stored for the current item, which fixes them being still used after e.g. pytester's :func:`testdir.runpytest <_pytest.pytester.Testdir.runpytest>` etc.
 
 
-- `#6660 <https://github.com/pytest-dev/pytest/issues/6660>`_: :func:`pytest.exit() <_pytest.outcomes.exit>` is handled when emitted from the :func:`pytest_sessionfinish <_pytest.hookspec.pytest_sessionfinish>` hook.  This includes quitting from a debugger.
+- `#6660 <https://github.com/pytest-dev/pytest/issues/6660>`_: :py:func:`pytest.exit` is handled when emitted from the :func:`pytest_sessionfinish <_pytest.hookspec.pytest_sessionfinish>` hook.  This includes quitting from a debugger.
 
 
 - `#6752 <https://github.com/pytest-dev/pytest/issues/6752>`_: When :py:func:`pytest.raises` is used as a function (as opposed to a context manager),
@@ -399,7 +399,7 @@ Improvements
 - `#6231 <https://github.com/pytest-dev/pytest/issues/6231>`_: Improve check for misspelling of :ref:`pytest.mark.parametrize ref`.
 
 
-- `#6257 <https://github.com/pytest-dev/pytest/issues/6257>`_: Handle :py:func:`_pytest.outcomes.exit` being used via :py:func:`~_pytest.hookspec.pytest_internalerror`, e.g. when quitting pdb from post mortem.
+- `#6257 <https://github.com/pytest-dev/pytest/issues/6257>`_: Handle :py:func:`pytest.exit` being used via :py:func:`~_pytest.hookspec.pytest_internalerror`, e.g. when quitting pdb from post mortem.
 
 
 

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -15,41 +15,41 @@ Functions
 pytest.approx
 ~~~~~~~~~~~~~
 
-.. autofunction:: _pytest.python_api.approx
+.. autofunction:: pytest.approx
 
 pytest.fail
 ~~~~~~~~~~~
 
 **Tutorial**: :ref:`skipping`
 
-.. autofunction:: _pytest.outcomes.fail
+.. autofunction:: pytest.fail
 
 pytest.skip
 ~~~~~~~~~~~
 
-.. autofunction:: _pytest.outcomes.skip(msg, [allow_module_level=False])
+.. autofunction:: pytest.skip(msg, [allow_module_level=False])
 
 .. _`pytest.importorskip ref`:
 
 pytest.importorskip
 ~~~~~~~~~~~~~~~~~~~
 
-.. autofunction:: _pytest.outcomes.importorskip
+.. autofunction:: pytest.importorskip
 
 pytest.xfail
 ~~~~~~~~~~~~
 
-.. autofunction:: _pytest.outcomes.xfail
+.. autofunction:: pytest.xfail
 
 pytest.exit
 ~~~~~~~~~~~
 
-.. autofunction:: _pytest.outcomes.exit
+.. autofunction:: pytest.exit
 
 pytest.main
 ~~~~~~~~~~~
 
-.. autofunction:: _pytest.config.main
+.. autofunction:: pytest.main
 
 pytest.param
 ~~~~~~~~~~~~

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -644,8 +644,8 @@ Initialization hooks called for plugins and ``conftest.py`` files.
 
 .. autofunction:: pytest_plugin_registered
 
-Test running hooks
-~~~~~~~~~~~~~~~~~~
+Test running (runtest) hooks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 All runtest related hooks receive a :py:class:`pytest.Item <_pytest.main.Item>` object.
 
@@ -663,9 +663,6 @@ these hooks in :py:mod:`_pytest.runner` and maybe also
 in :py:mod:`_pytest.pdb` which interacts with :py:mod:`_pytest.capture`
 and its input/output capturing in order to immediately drop
 into interactive debugging when a test failure occurs.
-
-The :py:mod:`_pytest.terminal` reported specifically uses
-the reporting hook to print information about a test run.
 
 .. autofunction:: pytest_pyfunc_call
 
@@ -765,7 +762,7 @@ Collector
 CollectReport
 ~~~~~~~~~~~~~
 
-.. autoclass:: _pytest.runner.CollectReport()
+.. autoclass:: _pytest.reports.CollectReport()
     :members:
     :show-inheritance:
     :inherited-members:
@@ -889,7 +886,7 @@ Session
 TestReport
 ~~~~~~~~~~
 
-.. autoclass:: _pytest.runner.TestReport()
+.. autoclass:: _pytest.reports.TestReport()
     :members:
     :show-inheritance:
     :inherited-members:

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -644,28 +644,6 @@ Initialization hooks called for plugins and ``conftest.py`` files.
 
 .. autofunction:: pytest_plugin_registered
 
-Test running (runtest) hooks
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-All runtest related hooks receive a :py:class:`pytest.Item <_pytest.main.Item>` object.
-
-.. autofunction:: pytest_runtestloop
-.. autofunction:: pytest_runtest_protocol
-.. autofunction:: pytest_runtest_logstart
-.. autofunction:: pytest_runtest_logfinish
-.. autofunction:: pytest_runtest_setup
-.. autofunction:: pytest_runtest_call
-.. autofunction:: pytest_runtest_teardown
-.. autofunction:: pytest_runtest_makereport
-
-For deeper understanding you may look at the default implementation of
-these hooks in :py:mod:`_pytest.runner` and maybe also
-in :py:mod:`_pytest.pdb` which interacts with :py:mod:`_pytest.capture`
-and its input/output capturing in order to immediately drop
-into interactive debugging when a test failure occurs.
-
-.. autofunction:: pytest_pyfunc_call
-
 Collection hooks
 ~~~~~~~~~~~~~~~~
 
@@ -690,6 +668,28 @@ items, delete or otherwise amend the test items:
 .. autofunction:: pytest_collection_modifyitems
 
 .. autofunction:: pytest_collection_finish
+
+Test running (runtest) hooks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All runtest related hooks receive a :py:class:`pytest.Item <_pytest.main.Item>` object.
+
+.. autofunction:: pytest_runtestloop
+.. autofunction:: pytest_runtest_protocol
+.. autofunction:: pytest_runtest_logstart
+.. autofunction:: pytest_runtest_logfinish
+.. autofunction:: pytest_runtest_setup
+.. autofunction:: pytest_runtest_call
+.. autofunction:: pytest_runtest_teardown
+.. autofunction:: pytest_runtest_makereport
+
+For deeper understanding you may look at the default implementation of
+these hooks in :py:mod:`_pytest.runner` and maybe also
+in :py:mod:`_pytest.pdb` which interacts with :py:mod:`_pytest.capture`
+and its input/output capturing in order to immediately drop
+into interactive debugging when a test failure occurs.
+
+.. autofunction:: pytest_pyfunc_call
 
 Reporting hooks
 ~~~~~~~~~~~~~~~

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -762,6 +762,14 @@ Collector
     :members:
     :show-inheritance:
 
+CollectReport
+~~~~~~~~~~~~~
+
+.. autoclass:: _pytest.runner.CollectReport()
+    :members:
+    :show-inheritance:
+    :inherited-members:
+
 Config
 ~~~~~~
 

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -437,7 +437,9 @@ def pytest_runtest_teardown(item: "Item", nextitem: "Optional[Item]") -> None:
 
 
 @hookspec(firstresult=True)
-def pytest_runtest_makereport(item: "Item", call: "CallInfo[None]") -> Optional[object]:
+def pytest_runtest_makereport(
+    item: "Item", call: "CallInfo[None]"
+) -> Optional["TestReport"]:
     """ return a :py:class:`_pytest.runner.TestReport` object
     for the given :py:class:`pytest.Item <_pytest.main.Item>` and
     :py:class:`_pytest.runner.CallInfo`.

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -396,7 +396,9 @@ def pytest_runtest_protocol(
     Stops at first non-None result, see :ref:`firstresult` """
 
 
-def pytest_runtest_logstart(nodeid, location):
+def pytest_runtest_logstart(
+    nodeid: str, location: Tuple[str, Optional[int], str]
+) -> None:
     """ signal the start of running a single test item.
 
     This hook will be called **before** :func:`pytest_runtest_setup`, :func:`pytest_runtest_call` and
@@ -407,7 +409,9 @@ def pytest_runtest_logstart(nodeid, location):
     """
 
 
-def pytest_runtest_logfinish(nodeid, location):
+def pytest_runtest_logfinish(
+    nodeid: str, location: Tuple[str, Optional[int], str]
+) -> None:
     """ signal the complete finish of running a single test item.
 
     This hook will be called **after** :func:`pytest_runtest_setup`, :func:`pytest_runtest_call` and

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -653,12 +653,12 @@ class LoggingPlugin:
                 yield  # run all the tests
 
     @pytest.hookimpl
-    def pytest_runtest_logstart(self):
+    def pytest_runtest_logstart(self) -> None:
         self.log_cli_handler.reset()
         self.log_cli_handler.set_when("start")
 
     @pytest.hookimpl
-    def pytest_runtest_logreport(self):
+    def pytest_runtest_logreport(self) -> None:
         self.log_cli_handler.set_when("logreport")
 
     def _runtest_for(self, item: nodes.Item, when: str) -> Generator[None, None, None]:

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -335,6 +335,8 @@ class TestReport(BaseReport):
 
 
 class CollectReport(BaseReport):
+    """Collection report object."""
+
     when = "collect"
 
     def __init__(
@@ -346,11 +348,24 @@ class CollectReport(BaseReport):
         sections: Iterable[Tuple[str, str]] = (),
         **extra
     ) -> None:
+        #: normalized collection node id
         self.nodeid = nodeid
+
+        #: test outcome, always one of "passed", "failed", "skipped".
         self.outcome = outcome
+
+        #: None or a failure representation.
         self.longrepr = longrepr
+
+        #: The collected items and collection nodes.
         self.result = result or []
+
+        #: list of pairs ``(str, str)`` of extra information which needs to
+        #: marshallable. Used by pytest to add captured text
+        #: from ``stdout`` and ``stderr``, but may be used by other plugins
+        #: to add arbitrary information to reports.
         self.sections = list(sections)
+
         self.__dict__.update(extra)
 
     @property

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -502,7 +502,9 @@ class TerminalReporter:
     def pytest_deselected(self, items) -> None:
         self._add_stats("deselected", items)
 
-    def pytest_runtest_logstart(self, nodeid, location) -> None:
+    def pytest_runtest_logstart(
+        self, nodeid: str, location: Tuple[str, Optional[int], str]
+    ) -> None:
         # ensure that the path is printed before the
         # 1st test of a module starts running
         if self.showlongtestinfo:
@@ -569,7 +571,7 @@ class TerminalReporter:
         assert self._session is not None
         return len(self._progress_nodeids_reported) == self._session.testscollected
 
-    def pytest_runtest_logfinish(self, nodeid) -> None:
+    def pytest_runtest_logfinish(self, nodeid: str) -> None:
         assert self._session
         if self.verbosity <= 0 and self._show_progress_info:
             if self._show_progress_info == "count":

--- a/src/pytest/collect.py
+++ b/src/pytest/collect.py
@@ -1,6 +1,8 @@
 import sys
 import warnings
 from types import ModuleType
+from typing import Any
+from typing import List
 
 import pytest
 from _pytest.deprecated import PYTEST_COLLECT_MODULE
@@ -20,15 +22,15 @@ COLLECT_FAKEMODULE_ATTRIBUTES = [
 
 
 class FakeCollectModule(ModuleType):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("pytest.collect")
         self.__all__ = list(COLLECT_FAKEMODULE_ATTRIBUTES)
         self.__pytest = pytest
 
-    def __dir__(self):
+    def __dir__(self) -> List[str]:
         return dir(super()) + self.__all__
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         if name not in self.__all__:
             raise AttributeError(name)
         warnings.warn(PYTEST_COLLECT_MODULE.format(name=name), stacklevel=2)


### PR DESCRIPTION
Here's a summary of each commit:

Type annotations:
- Type annotate the `pytest.collect` backward-compat module (only to satisfy typing coverage)
- Fix return type annotation of `pytest_runtest_makereport`
- Type annotate `pytest_runtest_log{start,finish}`

Docs:
- Refer to function public names instead of internal _pytest names
- Add `CollectReport` to the API reference
- Improve the `pytest_runtest_*` hooks documentation, including a complete layout of the runtest protocol
- Move "Collection hooks" before "Test running hooks" in the API reference