### PR TITLE
Require py>=1.8.2 so we can rely on correct hash() of py.path.local n Windows

### DIFF
--- a/changelog/7357.trivial.rst
+++ b/changelog/7357.trivial.rst
@@ -1,0 +1,1 @@
+py>=1.8.2 is now required.

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     more-itertools>=4.0.0
     packaging
     pluggy>=0.12,<1.0
-    py>=1.5.0
+    py>=1.8.2
     toml
     atomicwrites>=1.0;sys_platform=="win32"
     colorama;sys_platform=="win32"


### PR DESCRIPTION
See https://github.com/pytest-dev/py/blob/1.8.2/CHANGELOG#L4.
Fixes #7357.