### PR TITLE
Don't treat ini keys defined in conftest.py as invalid

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1054,7 +1054,6 @@ class Config:
             args, namespace=copy.copy(self.option)
         )
         self._validate_plugins()
-        self._validate_keys()
         if self.known_args_namespace.confcutdir is None and self.inifile:
             confcutdir = py.path.local(self.inifile).dirname
             self.known_args_namespace.confcutdir = confcutdir
@@ -1077,6 +1076,7 @@ class Config:
                 )
             else:
                 raise
+        self._validate_keys()
 
     def _checkversion(self):
         import pytest

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -236,7 +236,7 @@ class TestParseIni:
         result = testdir.runpytest()
         result.stderr.fnmatch_lines(stderr_output)
 
-        if stderr_output:
+        if exception_text:
             with pytest.raises(pytest.fail.Exception, match=exception_text):
                 testdir.runpytest("--strict-config")
         else:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -208,12 +208,28 @@ class TestParseIni:
                 [],
                 "",
             ),
+            (
+                """
+          [pytest]
+          conftest_ini_key = 1
+          """,
+                [],
+                [],
+                "",
+            ),
         ],
     )
     def test_invalid_ini_keys(
         self, testdir, ini_file_text, invalid_keys, stderr_output, exception_text
     ):
+        testdir.makeconftest(
+            """
+            def pytest_addoption(parser):
+                parser.addini("conftest_ini_key", "")
+        """
+        )
         testdir.tmpdir.join("pytest.ini").write(textwrap.dedent(ini_file_text))
+
         config = testdir.parseconfig()
         assert sorted(config._get_unknown_ini_keys()) == sorted(invalid_keys)
 
@@ -223,6 +239,8 @@ class TestParseIni:
         if stderr_output:
             with pytest.raises(pytest.fail.Exception, match=exception_text):
                 testdir.runpytest("--strict-config")
+        else:
+            testdir.runpytest("--strict-config")
 
     @pytest.mark.parametrize(
         "ini_file_text, exception_text",


### PR DESCRIPTION
The warning/error output of invalid plugins introduced here: https://github.com/pytest-dev/pytest/pull/7286 ( sorry ) does not properly respect ini keys defined in `conftest.py`. This change fixes that, and adds a test case that catches this bug.

I didn't add a changelog entry, since the feature still isn't released: https://github.com/pytest-dev/pytest/blob/master/changelog/6856.feature.rst

Closes https://github.com/pytest-dev/pytest/issues/7383