### PR TITLE
Reduce calls to item.ihook

### DIFF
--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -124,6 +124,8 @@ def pytest_runtest_protocol(item: Item) -> Generator[None, None, None]:
     comparison for the test.
     """
 
+    ihook = item.ihook
+
     def callbinrepr(op, left: object, right: object) -> Optional[str]:
         """Call the pytest_assertrepr_compare hook and prepare the result
 
@@ -139,7 +141,7 @@ def pytest_runtest_protocol(item: Item) -> Generator[None, None, None]:
         The result can be formatted by util.format_explanation() for
         pretty printing.
         """
-        hook_result = item.ihook.pytest_assertrepr_compare(
+        hook_result = ihook.pytest_assertrepr_compare(
             config=item.config, op=op, left=left, right=right
         )
         for new_expl in hook_result:
@@ -155,12 +157,10 @@ def pytest_runtest_protocol(item: Item) -> Generator[None, None, None]:
     saved_assert_hooks = util._reprcompare, util._assertion_pass
     util._reprcompare = callbinrepr
 
-    if item.ihook.pytest_assertion_pass.get_hookimpls():
+    if ihook.pytest_assertion_pass.get_hookimpls():
 
         def call_assertion_pass_hook(lineno: int, orig: str, expl: str) -> None:
-            item.ihook.pytest_assertion_pass(
-                item=item, lineno=lineno, orig=orig, expl=expl
-            )
+            ihook.pytest_assertion_pass(item=item, lineno=lineno, orig=orig, expl=expl)
 
         util._assertion_pass = call_assertion_pass_hook
 

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -95,9 +95,10 @@ def pytest_sessionfinish(session: "Session") -> None:
 
 
 def pytest_runtest_protocol(item: Item, nextitem: Optional[Item]) -> bool:
-    item.ihook.pytest_runtest_logstart(nodeid=item.nodeid, location=item.location)
+    ihook = item.ihook
+    ihook.pytest_runtest_logstart(nodeid=item.nodeid, location=item.location)
     runtestprotocol(item, nextitem=nextitem)
-    item.ihook.pytest_runtest_logfinish(nodeid=item.nodeid, location=item.location)
+    ihook.pytest_runtest_logfinish(nodeid=item.nodeid, location=item.location)
     return True
 
 


### PR DESCRIPTION
When scrolling through #7338 I noticed that the `item.ihook` property is called fairly often. There are two place where this access can be cached with trivial changes. When running [`empty.py`](https://github.com/pytest-dev/pytest/blob/master/bench/empty.py) calls to ihook are reduced from 14039 to 13039. While this doesn't result in significant performance gains I think it might still be useful to include since it doesn't increase code complexity.