### PR TITLE
Reduce overhead of Node.iter_markers_with_node

### DIFF
--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -147,7 +147,7 @@ class KeywordMatcher:
         # Add the names of the current item and any parent items
         import pytest
 
-        for node in item.listchain():
+        for node in item.iterchain():
             if not isinstance(node, (pytest.Instance, pytest.Session)):
                 mapped_names.add(node.name)
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 from functools import partial
 from typing import Callable
 from typing import Dict
+from typing import Generator
 from typing import Iterable
 from typing import List
 from typing import Mapping
@@ -263,6 +264,9 @@ class PyobjMixin:
         def listchain(self) -> List[nodes.Node]:
             ...
 
+        def iterchain(self) -> Generator[nodes.Node, None, None]:
+            ...
+
     @property
     def module(self):
         """Python module object this node was collected from (can be None)."""
@@ -306,10 +310,8 @@ class PyobjMixin:
 
     def getmodpath(self, stopatmodule=True, includemodule=False):
         """ return python path relative to the containing module. """
-        chain = self.listchain()
-        chain.reverse()
         parts = []
-        for node in chain:
+        for node in self.iterchain():
             if isinstance(node, Instance):
                 continue
             name = node.name


### PR DESCRIPTION
While degugging some unrelated performance issues I noticed that `Node.listchain` is often iterated over in reverse. This PR adds `Node.iterchain` which iterates over all parent collectors up to root of collection tree, starting from `self`.  This method is then used by `Node.listchain` and removes the need create intermediate lists in `Node.iter_markers_with_node` or in methods that don't rely on the iteration order.