### PR TITLE
config: improve typing

### DIFF
--- a/src/_pytest/_code/__init__.py
+++ b/src/_pytest/_code/__init__.py
@@ -6,6 +6,7 @@ from .code import Frame
 from .code import getfslineno
 from .code import getrawcode
 from .code import Traceback
+from .code import TracebackEntry
 from .source import compile_ as compile
 from .source import Source
 
@@ -17,6 +18,7 @@ __all__ = [
     "getfslineno",
     "getrawcode",
     "Traceback",
+    "TracebackEntry",
     "compile",
     "Source",
 ]

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -213,7 +213,7 @@ class TracebackEntry:
         return source.getstatement(self.lineno)
 
     @property
-    def path(self):
+    def path(self) -> Union[py.path.local, str]:
         """ path to the source code """
         return self.frame.code.path
 

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -96,7 +96,7 @@ def pytest_addoption(parser: Parser) -> None:
 @pytest.hookimpl(hookwrapper=True)
 def pytest_cmdline_parse():
     outcome = yield
-    config = outcome.get_result()
+    config = outcome.get_result()  # type: Config
     if config.option.debug:
         path = os.path.abspath("pytestdebug.log")
         debugfile = open(path, "w")
@@ -124,7 +124,7 @@ def pytest_cmdline_parse():
         config.add_cleanup(unset_tracing)
 
 
-def showversion(config):
+def showversion(config: Config) -> None:
     if config.option.version > 1:
         sys.stderr.write(
             "This is pytest version {}, imported from {}\n".format(
@@ -224,7 +224,7 @@ def showhelp(config: Config) -> None:
 conftest_options = [("pytest_plugins", "list of plugin names to load")]
 
 
-def getpluginversioninfo(config):
+def getpluginversioninfo(config: Config) -> List[str]:
     lines = []
     plugininfo = config.pluginmanager.list_plugin_distinfo()
     if plugininfo:

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -143,7 +143,7 @@ def pytest_configure(config: "Config") -> None:
 @hookspec(firstresult=True)
 def pytest_cmdline_parse(
     pluginmanager: "PytestPluginManager", args: List[str]
-) -> Optional[object]:
+) -> Optional["Config"]:
     """return initialized config object, parsing the specified args.
 
     Stops at first non-None result, see :ref:`firstresult`

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -141,9 +141,14 @@ class PercentStyleMultiline(logging.PercentStyle):
 
         if auto_indent_option is None:
             return 0
-        elif type(auto_indent_option) is int:
+        elif isinstance(auto_indent_option, bool):
+            if auto_indent_option:
+                return -1
+            else:
+                return 0
+        elif isinstance(auto_indent_option, int):
             return int(auto_indent_option)
-        elif type(auto_indent_option) is str:
+        elif isinstance(auto_indent_option, str):
             try:
                 return int(auto_indent_option)
             except ValueError:
@@ -153,9 +158,6 @@ class PercentStyleMultiline(logging.PercentStyle):
                     return -1
             except ValueError:
                 return 0
-        elif type(auto_indent_option) is bool:
-            if auto_indent_option:
-                return -1
 
         return 0
 

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -466,7 +466,7 @@ def import_path(
     """
     mode = ImportMode(mode)
 
-    path = Path(p)
+    path = Path(str(p))
 
     if not path.exists():
         raise ImportError(path)

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1054,7 +1054,7 @@ class Testdir:
             args.append("--basetemp=%s" % self.tmpdir.dirpath("basetemp"))
         return args
 
-    def parseconfig(self, *args: Union[str, py.path.local]) -> Config:
+    def parseconfig(self, *args) -> Config:
         """Return a new pytest Config instance from given commandline args.
 
         This invokes the pytest bootstrapping code in _pytest.config to create
@@ -1070,14 +1070,14 @@ class Testdir:
 
         import _pytest.config
 
-        config = _pytest.config._prepareconfig(args, self.plugins)  # type: Config
+        config = _pytest.config._prepareconfig(args, self.plugins)  # type: ignore[arg-type]
         # we don't know what the test will do with this half-setup config
         # object and thus we make sure it gets unconfigured properly in any
         # case (otherwise capturing could still be active, for example)
         self.request.addfinalizer(config._ensure_unconfigure)
         return config
 
-    def parseconfigure(self, *args):
+    def parseconfigure(self, *args) -> Config:
         """Return a new pytest configured Config instance.
 
         This returns a new :py:class:`_pytest.config.Config` instance like
@@ -1318,7 +1318,7 @@ class Testdir:
         Returns a :py:class:`RunResult`.
         """
         __tracebackhide__ = True
-        p = make_numbered_dir(root=Path(self.tmpdir), prefix="runpytest-")
+        p = make_numbered_dir(root=Path(str(self.tmpdir)), prefix="runpytest-")
         args = ("--basetemp=%s" % p,) + args
         plugins = [x for x in self.plugins if isinstance(x, str)]
         if plugins:

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -13,6 +13,7 @@ from .pathlib import LOCK_TIMEOUT
 from .pathlib import make_numbered_dir
 from .pathlib import make_numbered_dir_with_cleanup
 from .pathlib import Path
+from _pytest.config import Config
 from _pytest.fixtures import FixtureRequest
 from _pytest.monkeypatch import MonkeyPatch
 
@@ -135,7 +136,7 @@ def get_user() -> Optional[str]:
         return None
 
 
-def pytest_configure(config) -> None:
+def pytest_configure(config: Config) -> None:
     """Create a TempdirFactory and attach it to the config object.
 
     This is to comply with existing plugins which expect the handler to be

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -585,11 +585,11 @@ class TestInvocationVariants:
         # Type ignored because `py.test` is not and will not be typed.
         assert pytest.main == py.test.cmdline.main  # type: ignore[attr-defined]
 
-    def test_invoke_with_invalid_type(self):
+    def test_invoke_with_invalid_type(self) -> None:
         with pytest.raises(
             TypeError, match="expected to be a list of strings, got: '-h'"
         ):
-            pytest.main("-h")
+            pytest.main("-h")  # type: ignore[arg-type]
 
     def test_invoke_with_path(self, tmpdir, capsys):
         retcode = pytest.main(tmpdir)

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -372,7 +372,7 @@ def test_excinfo_no_python_sourcecode(tmpdir):
     for item in excinfo.traceback:
         print(item)  # XXX: for some reason jinja.Template.render is printed in full
         item.source  # shouldn't fail
-        if item.path.basename == "test.txt":
+        if isinstance(item.path, py.path.local) and item.path.basename == "test.txt":
             assert str(item.source) == "{{ h()}}:"
 
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1778,5 +1778,7 @@ def test_conftest_import_error_repr(tmpdir):
     ):
         try:
             raise RuntimeError("some error")
-        except Exception as e:
-            raise ConftestImportFailure(path, sys.exc_info()) from e
+        except Exception as exc:
+            assert exc.__traceback__ is not None
+            exc_info = (type(exc), exc, exc.__traceback__)
+            raise ConftestImportFailure(path, exc_info) from exc

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -11,6 +11,7 @@ import py.path
 import _pytest._code
 import pytest
 from _pytest.compat import importlib_metadata
+from _pytest.config import _get_plugin_specs_as_list
 from _pytest.config import _iter_rewritable_modules
 from _pytest.config import Config
 from _pytest.config import ConftestImportFailure
@@ -1115,21 +1116,17 @@ def test_load_initial_conftest_last_ordering(_config_for_test):
     assert [x.function.__module__ for x in values] == expected
 
 
-def test_get_plugin_specs_as_list():
-    from _pytest.config import _get_plugin_specs_as_list
-
-    def exp_match(val):
+def test_get_plugin_specs_as_list() -> None:
+    def exp_match(val: object) -> str:
         return (
-            "Plugin specs must be a ','-separated string"
-            " or a list/tuple of strings for plugin names. Given: {}".format(
-                re.escape(repr(val))
-            )
+            "Plugins may be specified as a sequence or a ','-separated string of plugin names. Got: %s"
+            % re.escape(repr(val))
         )
 
     with pytest.raises(pytest.UsageError, match=exp_match({"foo"})):
-        _get_plugin_specs_as_list({"foo"})
+        _get_plugin_specs_as_list({"foo"})  # type: ignore[arg-type]
     with pytest.raises(pytest.UsageError, match=exp_match({})):
-        _get_plugin_specs_as_list(dict())
+        _get_plugin_specs_as_list(dict())  # type: ignore[arg-type]
 
     assert _get_plugin_specs_as_list(None) == []
     assert _get_plugin_specs_as_list("") == []


### PR DESCRIPTION
This improves the typing around `_pytest.config`, and also makes pytest completely clean with regards to the py typings in https://github.com/pytest-dev/py/pull/232.