### PR TITLE
nodes: fix string possibly stored in Node.keywords instead of MarkDecorator

### DIFF
--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -276,7 +276,7 @@ class Node(metaclass=NodeMeta):
             marker_ = getattr(MARK_GEN, marker)
         else:
             raise ValueError("is not a string or pytest.mark.* Marker")
-        self.keywords[marker_.name] = marker
+        self.keywords[marker_.name] = marker_
         if append:
             self.own_markers.append(marker_.mark)
         else:


### PR DESCRIPTION
This mistake was introduced in 7259c453d6c1dba6727cd328e6db5635ccf5821c.