### PR TITLE
CONTRIBUTING: sync changelog types

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -173,8 +173,10 @@ Short version
    The test environments above are usually enough to cover most cases locally.
 
 #. Write a ``changelog`` entry: ``changelog/2574.bugfix.rst``, use issue id number
-   and one of ``bugfix``, ``removal``, ``feature``, ``vendor``, ``doc`` or
-   ``trivial`` for the issue type.
+   and one of ``feature``, ``improvement``, ``bugfix``, ``doc``, ``deprecation``,
+   ``breaking``, ``vendor`` or ``trivial`` for the issue type.
+
+
 #. Unless your change is a trivial or a documentation fix (e.g., a typo or reword of a small section) please
    add yourself to the ``AUTHORS`` file, in alphabetical order.
 
@@ -274,8 +276,9 @@ Here is a simple overview, with pytest-specific bits:
 
 #. Create a new changelog entry in ``changelog``. The file should be named ``<issueid>.<type>.rst``,
    where *issueid* is the number of the issue related to the change and *type* is one of
-   ``bugfix``, ``removal``, ``feature``, ``vendor``, ``doc`` or ``trivial``. You may not create a
-   changelog entry if the change doesn't affect the documented behaviour of Pytest.
+   ``feature``, ``improvement``, ``bugfix``, ``doc``, ``deprecation``, ``breaking``, ``vendor``
+   or ``trivial``. You may skip creating the changelog entry if the change doesn't affect the
+   documented behaviour of pytest.
 
 #. Add yourself to ``AUTHORS`` file if not there yet, in alphabetical order.
 


### PR DESCRIPTION
The got out of date with the actual ones we use.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
