### PR TITLE
New testdir-like fixture using pathlib

### DIFF
--- a/changelog/7425.feature.rst
+++ b/changelog/7425.feature.rst
@@ -1,0 +1,3 @@
+New :fixture:`test_path` fixture, which is identical to :fixture:`testdir` but its methods return :class:`pathlib.Path` when appropriate instead of ``py.path.local``.
+
+This is part of the movement to use :class:`pathlib.Path` objects internally, in order to remove the dependency to ``py`` in the future.

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -494,17 +494,19 @@ monkeypatch
     :members:
 
 
-.. fixture:: testdir
+.. fixture:: test_path
 
-testdir
-~~~~~~~
+test_path
+~~~~~~~~~
 
 .. currentmodule:: _pytest.pytester
 
-This fixture provides a :class:`Testdir` instance useful for black-box testing of test files, making it ideal to
-test plugins.
+Provides a :class:`TestPath` instance that can be used to run and test pytest itself.
 
-To use it, include in your top-most ``conftest.py`` file:
+It provides an empty folder where pytest can be executed in isolation, and contains facilities
+to write test, configuration files, and match against expected output.
+
+To use it, include in your topmost ``conftest.py`` file:
 
 .. code-block:: python
 
@@ -512,7 +514,7 @@ To use it, include in your top-most ``conftest.py`` file:
 
 
 
-.. autoclass:: Testdir()
+.. autoclass:: TestPath()
     :members:
 
 .. autoclass:: RunResult()
@@ -521,6 +523,15 @@ To use it, include in your top-most ``conftest.py`` file:
 .. autoclass:: LineMatcher()
     :members:
 
+.. fixture:: testdir
+
+testdir
+~~~~~~~
+
+Identical to :fixture:`test_path`, but provides an instance whose methods return
+legacy ``py.path.local`` objects instead when applicable.
+
+New code should avoid using :fixture:`testdir` in favor of :fixture:`test_path`.
 
 .. fixture:: recwarn
 

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -499,11 +499,13 @@ monkeypatch
 test_path
 ~~~~~~~~~
 
+.. versionadded:: 6.0
+
 .. currentmodule:: _pytest.pytester
 
 Provides a :class:`TestPath` instance that can be used to run and test pytest itself.
 
-It provides an empty folder where pytest can be executed in isolation, and contains facilities
+It provides an empty directory where pytest can be executed in isolation, and contains facilities
 to write test, configuration files, and match against expected output.
 
 To use it, include in your topmost ``conftest.py`` file:

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -579,9 +579,6 @@ class TestPath:
 
     :ivar Path tmp_path: temporary directory path used to create files/run tests from, etc.
 
-        For backward compatibility, the read-only property ``tmpdir`` returns
-        a ``py.path.local`` instance.
-
     :ivar plugins: A list of plugins to use with :py:meth:`parseconfig` and
        :py:meth:`runpytest`.  Initially this is an empty list but plugins can
        be added to the list.  The type of items to add to the list depends on
@@ -844,7 +841,7 @@ class TestPath:
         if example_path.is_dir() and not example_path.joinpath("__init__.py").is_file():
             # TODO: py.path.local.copy can copy files to existing directories,
             # while with shutil.copytree the destination directory cannot exist,
-            # we will need to roll our in order to drop py.path.local completely
+            # we will need to roll our own in order to drop py.path.local completely
             py.path.local(str(example_path)).copy(py.path.local(str(self.tmp_path)))
             return self.tmp_path
         elif example_path.is_file():

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -9,7 +9,7 @@ import pytest
 from _pytest.compat import importlib_metadata
 from _pytest.config import ExitCode
 from _pytest.pathlib import symlink_or_skip
-from _pytest.pytester import Testdir
+from _pytest.pytester import TestPath
 
 
 def prepend_pythonpath(*dirs):
@@ -1291,14 +1291,14 @@ def test_tee_stdio_captures_and_live_prints(testdir):
     sys.platform == "win32",
     reason="Windows raises `OSError: [Errno 22] Invalid argument` instead",
 )
-def test_no_brokenpipeerror_message(testdir: Testdir) -> None:
+def test_no_brokenpipeerror_message(test_path: TestPath) -> None:
     """Ensure that the broken pipe error message is supressed.
 
     In some Python versions, it reaches sys.unraisablehook, in others
     a BrokenPipeError exception is propagated, but either way it prints
     to stderr on shutdown, so checking nothing is printed is enough.
     """
-    popen = testdir.popen((*testdir._getpytestargs(), "--help"))
+    popen = test_path.popen((*test_path._getpytestargs(), "--help"))
     popen.stdout.close()
     ret = popen.wait()
     assert popen.stderr.read() == b""

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -148,10 +148,10 @@ class TestDoctests:
         "   test_string,    encoding",
         [("foo", "ascii"), ("öäü", "latin1"), ("öäü", "utf-8")],
     )
-    def test_encoding(self, testdir, test_string, encoding):
+    def test_encoding(self, test_path, test_string, encoding):
         """Test support for doctest_encoding ini option.
         """
-        testdir.makeini(
+        test_path.makeini(
             """
             [pytest]
             doctest_encoding={}
@@ -165,9 +165,10 @@ class TestDoctests:
         """.format(
             test_string, repr(test_string)
         )
-        testdir._makefile(".txt", [doctest], {}, encoding=encoding)
+        fn = test_path.tmp_path / "test_encoding.txt"
+        fn.write_text(doctest, encoding=encoding)
 
-        result = testdir.runpytest()
+        result = test_path.runpytest()
 
         result.stdout.fnmatch_lines(["*1 passed*"])
 

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -3,6 +3,8 @@ import textwrap
 from typing import Callable
 from typing import Optional
 
+import py
+
 import pytest
 from _pytest.compat import MODULE_NOT_FOUND_ERROR
 from _pytest.doctest import _get_checker
@@ -15,9 +17,9 @@ from _pytest.doctest import DoctestTextfile
 
 
 class TestDoctests:
-    def test_collect_testtextfile(self, testdir):
-        w = testdir.maketxtfile(whatever="")
-        checkfile = testdir.maketxtfile(
+    def test_collect_testtextfile(self, test_path):
+        w = test_path.maketxtfile(whatever="")
+        checkfile = test_path.maketxtfile(
             test_something="""
             alskdjalsdk
             >>> i = 5
@@ -26,48 +28,48 @@ class TestDoctests:
         """
         )
 
-        for x in (testdir.tmpdir, checkfile):
+        for x in (test_path.tmp_path, checkfile):
             # print "checking that %s returns custom items" % (x,)
-            items, reprec = testdir.inline_genitems(x)
+            items, reprec = test_path.inline_genitems(x)
             assert len(items) == 1
             assert isinstance(items[0], DoctestItem)
             assert isinstance(items[0].parent, DoctestTextfile)
         # Empty file has no items.
-        items, reprec = testdir.inline_genitems(w)
+        items, reprec = test_path.inline_genitems(w)
         assert len(items) == 0
 
-    def test_collect_module_empty(self, testdir):
-        path = testdir.makepyfile(whatever="#")
-        for p in (path, testdir.tmpdir):
-            items, reprec = testdir.inline_genitems(p, "--doctest-modules")
+    def test_collect_module_empty(self, test_path):
+        path = test_path.makepyfile(whatever="#")
+        for p in (path, test_path.tmp_path):
+            items, reprec = test_path.inline_genitems(p, "--doctest-modules")
             assert len(items) == 0
 
-    def test_collect_module_single_modulelevel_doctest(self, testdir):
-        path = testdir.makepyfile(whatever='""">>> pass"""')
-        for p in (path, testdir.tmpdir):
-            items, reprec = testdir.inline_genitems(p, "--doctest-modules")
+    def test_collect_module_single_modulelevel_doctest(self, test_path):
+        path = test_path.makepyfile(whatever='""">>> pass"""')
+        for p in (path, test_path.tmp_path):
+            items, reprec = test_path.inline_genitems(p, "--doctest-modules")
             assert len(items) == 1
             assert isinstance(items[0], DoctestItem)
             assert isinstance(items[0].parent, DoctestModule)
 
-    def test_collect_module_two_doctest_one_modulelevel(self, testdir):
-        path = testdir.makepyfile(
+    def test_collect_module_two_doctest_one_modulelevel(self, test_path):
+        path = test_path.makepyfile(
             whatever="""
             '>>> x = None'
             def my_func():
                 ">>> magic = 42 "
         """
         )
-        for p in (path, testdir.tmpdir):
-            items, reprec = testdir.inline_genitems(p, "--doctest-modules")
+        for p in (path, test_path.tmp_path):
+            items, reprec = test_path.inline_genitems(p, "--doctest-modules")
             assert len(items) == 2
             assert isinstance(items[0], DoctestItem)
             assert isinstance(items[1], DoctestItem)
             assert isinstance(items[0].parent, DoctestModule)
             assert items[0].parent is items[1].parent
 
-    def test_collect_module_two_doctest_no_modulelevel(self, testdir):
-        path = testdir.makepyfile(
+    def test_collect_module_two_doctest_no_modulelevel(self, test_path):
+        path = test_path.makepyfile(
             whatever="""
             '# Empty'
             def my_func():
@@ -84,64 +86,64 @@ class TestDoctests:
                 '''
         """
         )
-        for p in (path, testdir.tmpdir):
-            items, reprec = testdir.inline_genitems(p, "--doctest-modules")
+        for p in (path, test_path.tmp_path):
+            items, reprec = test_path.inline_genitems(p, "--doctest-modules")
             assert len(items) == 2
             assert isinstance(items[0], DoctestItem)
             assert isinstance(items[1], DoctestItem)
             assert isinstance(items[0].parent, DoctestModule)
             assert items[0].parent is items[1].parent
 
-    def test_simple_doctestfile(self, testdir):
-        p = testdir.maketxtfile(
+    def test_simple_doctestfile(self, test_path):
+        p = test_path.maketxtfile(
             test_doc="""
             >>> x = 1
             >>> x == 1
             False
         """
         )
-        reprec = testdir.inline_run(p)
+        reprec = test_path.inline_run(p)
         reprec.assertoutcome(failed=1)
 
-    def test_new_pattern(self, testdir):
-        p = testdir.maketxtfile(
+    def test_new_pattern(self, test_path):
+        p = test_path.maketxtfile(
             xdoc="""
             >>> x = 1
             >>> x == 1
             False
         """
         )
-        reprec = testdir.inline_run(p, "--doctest-glob=x*.txt")
+        reprec = test_path.inline_run(p, "--doctest-glob=x*.txt")
         reprec.assertoutcome(failed=1)
 
-    def test_multiple_patterns(self, testdir):
+    def test_multiple_patterns(self, test_path):
         """Test support for multiple --doctest-glob arguments (#1255).
         """
-        testdir.maketxtfile(
+        test_path.maketxtfile(
             xdoc="""
             >>> 1
             1
         """
         )
-        testdir.makefile(
+        test_path.makefile(
             ".foo",
             test="""
             >>> 1
             1
         """,
         )
-        testdir.maketxtfile(
+        test_path.maketxtfile(
             test_normal="""
             >>> 1
             1
         """
         )
         expected = {"xdoc.txt", "test.foo", "test_normal.txt"}
-        assert {x.basename for x in testdir.tmpdir.listdir()} == expected
+        assert {x.name for x in test_path.tmp_path.iterdir()} == expected
         args = ["--doctest-glob=xdoc*.txt", "--doctest-glob=*.foo"]
-        result = testdir.runpytest(*args)
+        result = test_path.runpytest(*args)
         result.stdout.fnmatch_lines(["*test.foo *", "*xdoc.txt *", "*2 passed*"])
-        result = testdir.runpytest()
+        result = test_path.runpytest()
         result.stdout.fnmatch_lines(["*test_normal.txt *", "*1 passed*"])
 
     @pytest.mark.parametrize(
@@ -172,15 +174,15 @@ class TestDoctests:
 
         result.stdout.fnmatch_lines(["*1 passed*"])
 
-    def test_doctest_unexpected_exception(self, testdir):
-        testdir.maketxtfile(
+    def test_doctest_unexpected_exception(self, test_path):
+        test_path.maketxtfile(
             """
             >>> i = 0
             >>> 0 / i
             2
         """
         )
-        result = testdir.runpytest("--doctest-modules")
+        result = test_path.runpytest("--doctest-modules")
         result.stdout.fnmatch_lines(
             [
                 "test_doctest_unexpected_exception.txt F *",
@@ -200,8 +202,8 @@ class TestDoctests:
             consecutive=True,
         )
 
-    def test_doctest_outcomes(self, testdir):
-        testdir.maketxtfile(
+    def test_doctest_outcomes(self, test_path):
+        test_path.maketxtfile(
             test_skip="""
             >>> 1
             1
@@ -223,7 +225,7 @@ class TestDoctests:
             bar
             """,
         )
-        result = testdir.runpytest("--doctest-modules")
+        result = test_path.runpytest("--doctest-modules")
         result.stdout.fnmatch_lines(
             [
                 "collected 3 items",
@@ -236,11 +238,11 @@ class TestDoctests:
             ]
         )
 
-    def test_docstring_partial_context_around_error(self, testdir):
+    def test_docstring_partial_context_around_error(self, test_path):
         """Test that we show some context before the actual line of a failing
         doctest.
         """
-        testdir.makepyfile(
+        test_path.makepyfile(
             '''
             def foo():
                 """
@@ -262,7 +264,7 @@ class TestDoctests:
                 """
         '''
         )
-        result = testdir.runpytest("--doctest-modules")
+        result = test_path.runpytest("--doctest-modules")
         result.stdout.fnmatch_lines(
             [
                 "*docstring_partial_context_around_error*",
@@ -280,11 +282,11 @@ class TestDoctests:
         result.stdout.no_fnmatch_line("*text-line-2*")
         result.stdout.no_fnmatch_line("*text-line-after*")
 
-    def test_docstring_full_context_around_error(self, testdir):
+    def test_docstring_full_context_around_error(self, test_path):
         """Test that we show the whole context before the actual line of a failing
         doctest, provided that the context is up to 10 lines long.
         """
-        testdir.makepyfile(
+        test_path.makepyfile(
             '''
             def foo():
                 """
@@ -296,7 +298,7 @@ class TestDoctests:
                 """
         '''
         )
-        result = testdir.runpytest("--doctest-modules")
+        result = test_path.runpytest("--doctest-modules")
         result.stdout.fnmatch_lines(
             [
                 "*docstring_full_context_around_error*",
@@ -310,8 +312,8 @@ class TestDoctests:
             ]
         )
 
-    def test_doctest_linedata_missing(self, testdir):
-        testdir.tmpdir.join("hello.py").write(
+    def test_doctest_linedata_missing(self, test_path):
+        test_path.tmp_path.joinpath("hello.py").write_text(
             textwrap.dedent(
                 """\
                 class Fun(object):
@@ -324,13 +326,13 @@ class TestDoctests:
                 """
             )
         )
-        result = testdir.runpytest("--doctest-modules")
+        result = test_path.runpytest("--doctest-modules")
         result.stdout.fnmatch_lines(
             ["*hello*", "006*>>> 1/0*", "*UNEXPECTED*ZeroDivision*", "*1 failed*"]
         )
 
-    def test_doctest_linedata_on_property(self, testdir):
-        testdir.makepyfile(
+    def test_doctest_linedata_on_property(self, test_path):
+        test_path.makepyfile(
             """
             class Sample(object):
                 @property
@@ -342,7 +344,7 @@ class TestDoctests:
                     return 'something'
             """
         )
-        result = testdir.runpytest("--doctest-modules")
+        result = test_path.runpytest("--doctest-modules")
         result.stdout.fnmatch_lines(
             [
                 "*= FAILURES =*",
@@ -359,8 +361,8 @@ class TestDoctests:
             ]
         )
 
-    def test_doctest_no_linedata_on_overriden_property(self, testdir):
-        testdir.makepyfile(
+    def test_doctest_no_linedata_on_overriden_property(self, test_path):
+        test_path.makepyfile(
             """
             class Sample(object):
                 @property
@@ -373,7 +375,7 @@ class TestDoctests:
                 some_property = property(some_property.__get__, None, None, some_property.__doc__)
             """
         )
-        result = testdir.runpytest("--doctest-modules")
+        result = test_path.runpytest("--doctest-modules")
         result.stdout.fnmatch_lines(
             [
                 "*= FAILURES =*",
@@ -390,14 +392,14 @@ class TestDoctests:
             ]
         )
 
-    def test_doctest_unex_importerror_only_txt(self, testdir):
-        testdir.maketxtfile(
+    def test_doctest_unex_importerror_only_txt(self, test_path):
+        test_path.maketxtfile(
             """
             >>> import asdalsdkjaslkdjasd
             >>>
         """
         )
-        result = testdir.runpytest()
+        result = test_path.runpytest()
         # doctest is never executed because of error during hello.py collection
         result.stdout.fnmatch_lines(
             [
@@ -407,21 +409,21 @@ class TestDoctests:
             ]
         )
 
-    def test_doctest_unex_importerror_with_module(self, testdir):
-        testdir.tmpdir.join("hello.py").write(
+    def test_doctest_unex_importerror_with_module(self, test_path):
+        test_path.tmp_path.joinpath("hello.py").write_text(
             textwrap.dedent(
                 """\
                 import asdalsdkjaslkdjasd
                 """
             )
         )
-        testdir.maketxtfile(
+        test_path.maketxtfile(
             """
             >>> import hello
             >>>
         """
         )
-        result = testdir.runpytest("--doctest-modules")
+        result = test_path.runpytest("--doctest-modules")
         # doctest is never executed because of error during hello.py collection
         result.stdout.fnmatch_lines(
             [
@@ -431,8 +433,8 @@ class TestDoctests:
             ]
         )
 
-    def test_doctestmodule(self, testdir):
-        p = testdir.makepyfile(
+    def test_doctestmodule(self, test_path):
+        p = test_path.makepyfile(
             """
             '''
                 >>> x = 1
@@ -442,12 +444,12 @@ class TestDoctests:
             '''
         """
         )
-        reprec = testdir.inline_run(p, "--doctest-modules")
+        reprec = test_path.inline_run(p, "--doctest-modules")
         reprec.assertoutcome(failed=1)
 
-    def test_doctestmodule_external_and_issue116(self, testdir):
-        p = testdir.mkpydir("hello")
-        p.join("__init__.py").write(
+    def test_doctestmodule_external_and_issue116(self, test_path):
+        p = test_path.mkpydir("hello")
+        p.joinpath("__init__.py").write_text(
             textwrap.dedent(
                 """\
                 def somefunc():
@@ -459,7 +461,7 @@ class TestDoctests:
                 """
             )
         )
-        result = testdir.runpytest(p, "--doctest-modules")
+        result = test_path.runpytest(p, "--doctest-modules")
         result.stdout.fnmatch_lines(
             [
                 "003 *>>> i = 0",
@@ -472,15 +474,15 @@ class TestDoctests:
             ]
         )
 
-    def test_txtfile_failing(self, testdir):
-        p = testdir.maketxtfile(
+    def test_txtfile_failing(self, test_path):
+        p = test_path.maketxtfile(
             """
             >>> i = 0
             >>> i + 1
             2
         """
         )
-        result = testdir.runpytest(p, "-s")
+        result = test_path.runpytest(p, "-s")
         result.stdout.fnmatch_lines(
             [
                 "001 >>> i = 0",
@@ -493,25 +495,25 @@ class TestDoctests:
             ]
         )
 
-    def test_txtfile_with_fixtures(self, testdir):
-        p = testdir.maketxtfile(
+    def test_txtfile_with_fixtures(self, test_path):
+        p = test_path.maketxtfile(
             """
-            >>> dir = getfixture('tmpdir')
-            >>> type(dir).__name__
-            'LocalPath'
+            >>> p = getfixture('tmp_path')
+            >>> p.is_dir()
+            True
         """
         )
-        reprec = testdir.inline_run(p)
+        reprec = test_path.inline_run(p)
         reprec.assertoutcome(passed=1)
 
-    def test_txtfile_with_usefixtures_in_ini(self, testdir):
-        testdir.makeini(
+    def test_txtfile_with_usefixtures_in_ini(self, test_path):
+        test_path.makeini(
             """
             [pytest]
             usefixtures = myfixture
         """
         )
-        testdir.makeconftest(
+        test_path.makeconftest(
             """
             import pytest
             @pytest.fixture
@@ -520,36 +522,36 @@ class TestDoctests:
         """
         )
 
-        p = testdir.maketxtfile(
+        p = test_path.maketxtfile(
             """
             >>> import os
             >>> os.environ["HELLO"]
             'WORLD'
         """
         )
-        reprec = testdir.inline_run(p)
+        reprec = test_path.inline_run(p)
         reprec.assertoutcome(passed=1)
 
-    def test_doctestmodule_with_fixtures(self, testdir):
-        p = testdir.makepyfile(
+    def test_doctestmodule_with_fixtures(self, test_path):
+        p = test_path.makepyfile(
             """
             '''
-                >>> dir = getfixture('tmpdir')
-                >>> type(dir).__name__
-                'LocalPath'
+                >>> p = getfixture('tmp_path')
+                >>> p.is_dir()
+                True
             '''
         """
         )
-        reprec = testdir.inline_run(p, "--doctest-modules")
+        reprec = test_path.inline_run(p, "--doctest-modules")
         reprec.assertoutcome(passed=1)
 
-    def test_doctestmodule_three_tests(self, testdir):
-        p = testdir.makepyfile(
+    def test_doctestmodule_three_tests(self, test_path):
+        p = test_path.makepyfile(
             """
             '''
-            >>> dir = getfixture('tmpdir')
-            >>> type(dir).__name__
-            'LocalPath'
+            >>> p = getfixture('tmp_path')
+            >>> p.is_dir()
+            True
             '''
             def my_func():
                 '''
@@ -567,11 +569,11 @@ class TestDoctests:
                 '''
         """
         )
-        reprec = testdir.inline_run(p, "--doctest-modules")
+        reprec = test_path.inline_run(p, "--doctest-modules")
         reprec.assertoutcome(passed=3)
 
-    def test_doctestmodule_two_tests_one_fail(self, testdir):
-        p = testdir.makepyfile(
+    def test_doctestmodule_two_tests_one_fail(self, test_path):
+        p = test_path.makepyfile(
             """
             class MyClass(object):
                 def bad_meth(self):
@@ -588,17 +590,17 @@ class TestDoctests:
                     '''
         """
         )
-        reprec = testdir.inline_run(p, "--doctest-modules")
+        reprec = test_path.inline_run(p, "--doctest-modules")
         reprec.assertoutcome(failed=1, passed=1)
 
-    def test_ignored_whitespace(self, testdir):
-        testdir.makeini(
+    def test_ignored_whitespace(self, test_path):
+        test_path.makeini(
             """
             [pytest]
             doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE
         """
         )
-        p = testdir.makepyfile(
+        p = test_path.makepyfile(
             """
             class MyClass(object):
                 '''
@@ -609,17 +611,17 @@ class TestDoctests:
                 pass
         """
         )
-        reprec = testdir.inline_run(p, "--doctest-modules")
+        reprec = test_path.inline_run(p, "--doctest-modules")
         reprec.assertoutcome(passed=1)
 
-    def test_non_ignored_whitespace(self, testdir):
-        testdir.makeini(
+    def test_non_ignored_whitespace(self, test_path):
+        test_path.makeini(
             """
             [pytest]
             doctest_optionflags = ELLIPSIS
         """
         )
-        p = testdir.makepyfile(
+        p = test_path.makepyfile(
             """
             class MyClass(object):
                 '''
@@ -630,47 +632,47 @@ class TestDoctests:
                 pass
         """
         )
-        reprec = testdir.inline_run(p, "--doctest-modules")
+        reprec = test_path.inline_run(p, "--doctest-modules")
         reprec.assertoutcome(failed=1, passed=0)
 
-    def test_ignored_whitespace_glob(self, testdir):
-        testdir.makeini(
+    def test_ignored_whitespace_glob(self, test_path):
+        test_path.makeini(
             """
             [pytest]
             doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE
         """
         )
-        p = testdir.maketxtfile(
+        p = test_path.maketxtfile(
             xdoc="""
             >>> a = "foo    "
             >>> print(a)
             foo
         """
         )
-        reprec = testdir.inline_run(p, "--doctest-glob=x*.txt")
+        reprec = test_path.inline_run(p, "--doctest-glob=x*.txt")
         reprec.assertoutcome(passed=1)
 
-    def test_non_ignored_whitespace_glob(self, testdir):
-        testdir.makeini(
+    def test_non_ignored_whitespace_glob(self, test_path):
+        test_path.makeini(
             """
             [pytest]
             doctest_optionflags = ELLIPSIS
         """
         )
-        p = testdir.maketxtfile(
+        p = test_path.maketxtfile(
             xdoc="""
             >>> a = "foo    "
             >>> print(a)
             foo
         """
         )
-        reprec = testdir.inline_run(p, "--doctest-glob=x*.txt")
+        reprec = test_path.inline_run(p, "--doctest-glob=x*.txt")
         reprec.assertoutcome(failed=1, passed=0)
 
-    def test_contains_unicode(self, testdir):
+    def test_contains_unicode(self, test_path):
         """Fix internal error with docstrings containing non-ascii characters.
         """
-        testdir.makepyfile(
+        test_path.makepyfile(
             '''\
             def foo():
                 """
@@ -679,11 +681,11 @@ class TestDoctests:
                 """
             '''
         )
-        result = testdir.runpytest("--doctest-modules")
+        result = test_path.runpytest("--doctest-modules")
         result.stdout.fnmatch_lines(["Got nothing", "* 1 failed in*"])
 
-    def test_ignore_import_errors_on_doctest(self, testdir):
-        p = testdir.makepyfile(
+    def test_ignore_import_errors_on_doctest(self, test_path):
+        p = test_path.makepyfile(
             """
             import asdf
 
@@ -696,16 +698,16 @@ class TestDoctests:
         """
         )
 
-        reprec = testdir.inline_run(
+        reprec = test_path.inline_run(
             p, "--doctest-modules", "--doctest-ignore-import-errors"
         )
         reprec.assertoutcome(skipped=1, failed=1, passed=0)
 
-    def test_junit_report_for_doctest(self, testdir):
+    def test_junit_report_for_doctest(self, test_path):
         """
         #713: Fix --junit-xml option when used with --doctest-modules.
         """
-        p = testdir.makepyfile(
+        p = test_path.makepyfile(
             """
             def foo():
                 '''
@@ -715,15 +717,15 @@ class TestDoctests:
                 pass
         """
         )
-        reprec = testdir.inline_run(p, "--doctest-modules", "--junit-xml=junit.xml")
+        reprec = test_path.inline_run(p, "--doctest-modules", "--junit-xml=junit.xml")
         reprec.assertoutcome(failed=1)
 
-    def test_unicode_doctest(self, testdir):
+    def test_unicode_doctest(self, test_path):
         """
         Test case for issue 2434: DecodeError on Python 2 when doctest contains non-ascii
         characters.
         """
-        p = testdir.maketxtfile(
+        p = test_path.maketxtfile(
             test_unicode_doctest="""
             .. doctest::
 
@@ -736,17 +738,17 @@ class TestDoctests:
                 1
         """
         )
-        result = testdir.runpytest(p)
+        result = test_path.runpytest(p)
         result.stdout.fnmatch_lines(
             ["*UNEXPECTED EXCEPTION: ZeroDivisionError*", "*1 failed*"]
         )
 
-    def test_unicode_doctest_module(self, testdir):
+    def test_unicode_doctest_module(self, test_path):
         """
         Test case for issue 2434: DecodeError on Python 2 when doctest docstring
         contains non-ascii characters.
         """
-        p = testdir.makepyfile(
+        p = test_path.makepyfile(
             test_unicode_doctest_module="""
             def fix_bad_unicode(text):
                 '''
@@ -756,15 +758,15 @@ class TestDoctests:
                 return "único"
         """
         )
-        result = testdir.runpytest(p, "--doctest-modules")
+        result = test_path.runpytest(p, "--doctest-modules")
         result.stdout.fnmatch_lines(["* 1 passed *"])
 
-    def test_print_unicode_value(self, testdir):
+    def test_print_unicode_value(self, test_path):
         """
         Test case for issue 3583: Printing Unicode in doctest under Python 2.7
         doesn't work
         """
-        p = testdir.maketxtfile(
+        p = test_path.maketxtfile(
             test_print_unicode_value=r"""
             Here is a doctest::
 
@@ -772,14 +774,14 @@ class TestDoctests:
                 åéîøü
         """
         )
-        result = testdir.runpytest(p)
+        result = test_path.runpytest(p)
         result.stdout.fnmatch_lines(["* 1 passed *"])
 
-    def test_reportinfo(self, testdir):
+    def test_reportinfo(self, test_path):
         """
         Test case to make sure that DoctestItem.reportinfo() returns lineno.
         """
-        p = testdir.makepyfile(
+        p = test_path.makepyfile(
             test_reportinfo="""
             def foo(x):
                 '''
@@ -789,16 +791,16 @@ class TestDoctests:
                 return 'c'
         """
         )
-        items, reprec = testdir.inline_genitems(p, "--doctest-modules")
+        items, reprec = test_path.inline_genitems(p, "--doctest-modules")
         reportinfo = items[0].reportinfo()
         assert reportinfo[1] == 1
 
-    def test_valid_setup_py(self, testdir):
+    def test_valid_setup_py(self, test_path):
         """
         Test to make sure that pytest ignores valid setup.py files when ran
         with --doctest-modules
         """
-        p = testdir.makepyfile(
+        p = test_path.makepyfile(
             setup="""
             from setuptools import setup, find_packages
             setup(name='sample',
@@ -808,33 +810,33 @@ class TestDoctests:
             )
         """
         )
-        result = testdir.runpytest(p, "--doctest-modules")
+        result = test_path.runpytest(p, "--doctest-modules")
         result.stdout.fnmatch_lines(["*collected 0 items*"])
 
-    def test_invalid_setup_py(self, testdir):
+    def test_invalid_setup_py(self, test_path):
         """
         Test to make sure that pytest reads setup.py files that are not used
         for python packages when ran with --doctest-modules
         """
-        p = testdir.makepyfile(
+        p = test_path.makepyfile(
             setup="""
             def test_foo():
                 return 'bar'
         """
         )
-        result = testdir.runpytest(p, "--doctest-modules")
+        result = test_path.runpytest(p, "--doctest-modules")
         result.stdout.fnmatch_lines(["*collected 1 item*"])
 
 
 class TestLiterals:
     @pytest.mark.parametrize("config_mode", ["ini", "comment"])
-    def test_allow_unicode(self, testdir, config_mode):
+    def test_allow_unicode(self, test_path, config_mode):
         """Test that doctests which output unicode work in all python versions
         tested by pytest when the ALLOW_UNICODE option is used (either in
         the ini file or by an inline comment).
         """
         if config_mode == "ini":
-            testdir.makeini(
+            test_path.makeini(
                 """
             [pytest]
             doctest_optionflags = ALLOW_UNICODE
@@ -844,7 +846,7 @@ class TestLiterals:
         else:
             comment = "#doctest: +ALLOW_UNICODE"
 
-        testdir.maketxtfile(
+        test_path.maketxtfile(
             test_doc="""
             >>> b'12'.decode('ascii') {comment}
             '12'
@@ -852,7 +854,7 @@ class TestLiterals:
                 comment=comment
             )
         )
-        testdir.makepyfile(
+        test_path.makepyfile(
             foo="""
             def foo():
               '''
@@ -863,17 +865,17 @@ class TestLiterals:
                 comment=comment
             )
         )
-        reprec = testdir.inline_run("--doctest-modules")
+        reprec = test_path.inline_run("--doctest-modules")
         reprec.assertoutcome(passed=2)
 
     @pytest.mark.parametrize("config_mode", ["ini", "comment"])
-    def test_allow_bytes(self, testdir, config_mode):
+    def test_allow_bytes(self, test_path, config_mode):
         """Test that doctests which output bytes work in all python versions
         tested by pytest when the ALLOW_BYTES option is used (either in
         the ini file or by an inline comment)(#1287).
         """
         if config_mode == "ini":
-            testdir.makeini(
+            test_path.makeini(
                 """
             [pytest]
             doctest_optionflags = ALLOW_BYTES
@@ -883,7 +885,7 @@ class TestLiterals:
         else:
             comment = "#doctest: +ALLOW_BYTES"
 
-        testdir.maketxtfile(
+        test_path.maketxtfile(
             test_doc="""
             >>> b'foo'  {comment}
             'foo'
@@ -891,7 +893,7 @@ class TestLiterals:
                 comment=comment
             )
         )
-        testdir.makepyfile(
+        test_path.makepyfile(
             foo="""
             def foo():
               '''
@@ -902,34 +904,34 @@ class TestLiterals:
                 comment=comment
             )
         )
-        reprec = testdir.inline_run("--doctest-modules")
+        reprec = test_path.inline_run("--doctest-modules")
         reprec.assertoutcome(passed=2)
 
-    def test_unicode_string(self, testdir):
+    def test_unicode_string(self, test_path):
         """Test that doctests which output unicode fail in Python 2 when
         the ALLOW_UNICODE option is not used. The same test should pass
         in Python 3.
         """
-        testdir.maketxtfile(
+        test_path.maketxtfile(
             test_doc="""
             >>> b'12'.decode('ascii')
             '12'
         """
         )
-        reprec = testdir.inline_run()
+        reprec = test_path.inline_run()
         reprec.assertoutcome(passed=1)
 
-    def test_bytes_literal(self, testdir):
+    def test_bytes_literal(self, test_path):
         """Test that doctests which output bytes fail in Python 3 when
         the ALLOW_BYTES option is not used. (#1287).
         """
-        testdir.maketxtfile(
+        test_path.maketxtfile(
             test_doc="""
             >>> b'foo'
             'foo'
         """
         )
-        reprec = testdir.inline_run()
+        reprec = test_path.inline_run()
         reprec.assertoutcome(failed=1)
 
     def test_number_re(self) -> None:
@@ -963,10 +965,10 @@ class TestLiterals:
             assert _number_re.match(s) is None
 
     @pytest.mark.parametrize("config_mode", ["ini", "comment"])
-    def test_number_precision(self, testdir, config_mode):
+    def test_number_precision(self, test_path, config_mode):
         """Test the NUMBER option."""
         if config_mode == "ini":
-            testdir.makeini(
+            test_path.makeini(
                 """
                 [pytest]
                 doctest_optionflags = NUMBER
@@ -976,7 +978,7 @@ class TestLiterals:
         else:
             comment = "#doctest: +NUMBER"
 
-        testdir.maketxtfile(
+        test_path.maketxtfile(
             test_doc="""
 
             Scalars:
@@ -1033,7 +1035,7 @@ class TestLiterals:
                 comment=comment
             )
         )
-        reprec = testdir.inline_run()
+        reprec = test_path.inline_run()
         reprec.assertoutcome(passed=1)
 
     @pytest.mark.parametrize(
@@ -1057,8 +1059,8 @@ class TestLiterals:
             pytest.param("'3.1416'", "'3.14'", marks=pytest.mark.xfail),  # type: ignore
         ],
     )
-    def test_number_non_matches(self, testdir, expression, output):
-        testdir.maketxtfile(
+    def test_number_non_matches(self, test_path, expression, output):
+        test_path.maketxtfile(
             test_doc="""
             >>> {expression} #doctest: +NUMBER
             {output}
@@ -1066,11 +1068,11 @@ class TestLiterals:
                 expression=expression, output=output
             )
         )
-        reprec = testdir.inline_run()
+        reprec = test_path.inline_run()
         reprec.assertoutcome(passed=0, failed=1)
 
-    def test_number_and_allow_unicode(self, testdir):
-        testdir.maketxtfile(
+    def test_number_and_allow_unicode(self, test_path):
+        test_path.maketxtfile(
             test_doc="""
             >>> from collections import namedtuple
             >>> T = namedtuple('T', 'a b c')
@@ -1078,7 +1080,7 @@ class TestLiterals:
             T(a=0.233, b=u'str', c='bytes')
             """
         )
-        reprec = testdir.inline_run()
+        reprec = test_path.inline_run()
         reprec.assertoutcome(passed=1)
 
 
@@ -1089,18 +1091,18 @@ class TestDoctestSkips:
     """
 
     @pytest.fixture(params=["text", "module"])
-    def makedoctest(self, testdir, request):
+    def makedoctest(self, test_path, request):
         def makeit(doctest):
             mode = request.param
             if mode == "text":
-                testdir.maketxtfile(doctest)
+                test_path.maketxtfile(doctest)
             else:
                 assert mode == "module"
-                testdir.makepyfile('"""\n%s"""' % doctest)
+                test_path.makepyfile('"""\n%s"""' % doctest)
 
         return makeit
 
-    def test_one_skipped(self, testdir, makedoctest):
+    def test_one_skipped(self, test_path, makedoctest):
         makedoctest(
             """
             >>> 1 + 1  # doctest: +SKIP
@@ -1109,10 +1111,10 @@ class TestDoctestSkips:
             4
         """
         )
-        reprec = testdir.inline_run("--doctest-modules")
+        reprec = test_path.inline_run("--doctest-modules")
         reprec.assertoutcome(passed=1)
 
-    def test_one_skipped_failed(self, testdir, makedoctest):
+    def test_one_skipped_failed(self, test_path, makedoctest):
         makedoctest(
             """
             >>> 1 + 1  # doctest: +SKIP
@@ -1121,10 +1123,10 @@ class TestDoctestSkips:
             200
         """
         )
-        reprec = testdir.inline_run("--doctest-modules")
+        reprec = test_path.inline_run("--doctest-modules")
         reprec.assertoutcome(failed=1)
 
-    def test_all_skipped(self, testdir, makedoctest):
+    def test_all_skipped(self, test_path, makedoctest):
         makedoctest(
             """
             >>> 1 + 1  # doctest: +SKIP
@@ -1133,16 +1135,16 @@ class TestDoctestSkips:
             200
         """
         )
-        reprec = testdir.inline_run("--doctest-modules")
+        reprec = test_path.inline_run("--doctest-modules")
         reprec.assertoutcome(skipped=1)
 
-    def test_vacuous_all_skipped(self, testdir, makedoctest):
+    def test_vacuous_all_skipped(self, test_path, makedoctest):
         makedoctest("")
-        reprec = testdir.inline_run("--doctest-modules")
+        reprec = test_path.inline_run("--doctest-modules")
         reprec.assertoutcome(passed=0, skipped=0)
 
-    def test_continue_on_failure(self, testdir):
-        testdir.maketxtfile(
+    def test_continue_on_failure(self, test_path):
+        test_path.maketxtfile(
             test_something="""
             >>> i = 5
             >>> def foo():
@@ -1154,7 +1156,9 @@ class TestDoctestSkips:
             >>> i + 1
         """
         )
-        result = testdir.runpytest("--doctest-modules", "--doctest-continue-on-failure")
+        result = test_path.runpytest(
+            "--doctest-modules", "--doctest-continue-on-failure"
+        )
         result.assert_outcomes(passed=0, failed=1)
         # The lines that contains the failure are 4, 5, and 8.  The first one
         # is a stack trace and the other two are mismatches.
@@ -1167,12 +1171,12 @@ class TestDoctestAutoUseFixtures:
 
     SCOPES = ["module", "session", "class", "function"]
 
-    def test_doctest_module_session_fixture(self, testdir):
+    def test_doctest_module_session_fixture(self, test_path):
         """Test that session fixtures are initialized for doctest modules (#768)
         """
         # session fixture which changes some global data, which will
         # be accessed by doctests in a module
-        testdir.makeconftest(
+        test_path.makeconftest(
             """
             import pytest
             import sys
@@ -1185,7 +1189,7 @@ class TestDoctestAutoUseFixtures:
                 del sys.pytest_session_data
         """
         )
-        testdir.makepyfile(
+        test_path.makepyfile(
             foo="""
             import sys
 
@@ -1200,16 +1204,16 @@ class TestDoctestAutoUseFixtures:
               '''
         """
         )
-        result = testdir.runpytest("--doctest-modules")
+        result = test_path.runpytest("--doctest-modules")
         result.stdout.fnmatch_lines(["*2 passed*"])
 
     @pytest.mark.parametrize("scope", SCOPES)
     @pytest.mark.parametrize("enable_doctest", [True, False])
-    def test_fixture_scopes(self, testdir, scope, enable_doctest):
+    def test_fixture_scopes(self, test_path, scope, enable_doctest):
         """Test that auto-use fixtures work properly with doctest modules.
         See #1057 and #1100.
         """
-        testdir.makeconftest(
+        test_path.makeconftest(
             """
             import pytest
 
@@ -1220,7 +1224,7 @@ class TestDoctestAutoUseFixtures:
                 scope=scope
             )
         )
-        testdir.makepyfile(
+        test_path.makepyfile(
             test_1='''
             def test_foo():
                 """
@@ -1233,19 +1237,19 @@ class TestDoctestAutoUseFixtures:
         )
         params = ("--doctest-modules",) if enable_doctest else ()
         passes = 3 if enable_doctest else 2
-        result = testdir.runpytest(*params)
+        result = test_path.runpytest(*params)
         result.stdout.fnmatch_lines(["*=== %d passed in *" % passes])
 
     @pytest.mark.parametrize("scope", SCOPES)
     @pytest.mark.parametrize("autouse", [True, False])
     @pytest.mark.parametrize("use_fixture_in_doctest", [True, False])
     def test_fixture_module_doctest_scopes(
-        self, testdir, scope, autouse, use_fixture_in_doctest
+        self, test_path, scope, autouse, use_fixture_in_doctest
     ):
         """Test that auto-use fixtures work properly with doctest files.
         See #1057 and #1100.
         """
-        testdir.makeconftest(
+        test_path.makeconftest(
             """
             import pytest
 
@@ -1257,29 +1261,29 @@ class TestDoctestAutoUseFixtures:
             )
         )
         if use_fixture_in_doctest:
-            testdir.maketxtfile(
+            test_path.maketxtfile(
                 test_doc="""
                 >>> getfixture('auto')
                 99
             """
             )
         else:
-            testdir.maketxtfile(
+            test_path.maketxtfile(
                 test_doc="""
                 >>> 1 + 1
                 2
             """
             )
-        result = testdir.runpytest("--doctest-modules")
+        result = test_path.runpytest("--doctest-modules")
         result.stdout.no_fnmatch_line("*FAILURES*")
         result.stdout.fnmatch_lines(["*=== 1 passed in *"])
 
     @pytest.mark.parametrize("scope", SCOPES)
-    def test_auto_use_request_attributes(self, testdir, scope):
+    def test_auto_use_request_attributes(self, test_path, scope):
         """Check that all attributes of a request in an autouse fixture
         behave as expected when requested for a doctest item.
         """
-        testdir.makeconftest(
+        test_path.makeconftest(
             """
             import pytest
 
@@ -1296,13 +1300,13 @@ class TestDoctestAutoUseFixtures:
                 scope=scope
             )
         )
-        testdir.maketxtfile(
+        test_path.maketxtfile(
             test_doc="""
             >>> 1 + 1
             2
         """
         )
-        result = testdir.runpytest("--doctest-modules")
+        result = test_path.runpytest("--doctest-modules")
         str(result.stdout.no_fnmatch_line("*FAILURES*"))
         result.stdout.fnmatch_lines(["*=== 1 passed in *"])
 
@@ -1312,12 +1316,12 @@ class TestDoctestNamespaceFixture:
     SCOPES = ["module", "session", "class", "function"]
 
     @pytest.mark.parametrize("scope", SCOPES)
-    def test_namespace_doctestfile(self, testdir, scope):
+    def test_namespace_doctestfile(self, test_path, scope):
         """
         Check that inserting something into the namespace works in a
         simple text file doctest
         """
-        testdir.makeconftest(
+        test_path.makeconftest(
             """
             import pytest
             import contextlib
@@ -1329,22 +1333,22 @@ class TestDoctestNamespaceFixture:
                 scope=scope
             )
         )
-        p = testdir.maketxtfile(
+        p = test_path.maketxtfile(
             """
             >>> print(cl.__name__)
             contextlib
         """
         )
-        reprec = testdir.inline_run(p)
+        reprec = test_path.inline_run(p)
         reprec.assertoutcome(passed=1)
 
     @pytest.mark.parametrize("scope", SCOPES)
-    def test_namespace_pyfile(self, testdir, scope):
+    def test_namespace_pyfile(self, test_path, scope):
         """
         Check that inserting something into the namespace works in a
         simple Python file docstring doctest
         """
-        testdir.makeconftest(
+        test_path.makeconftest(
             """
             import pytest
             import contextlib
@@ -1356,7 +1360,7 @@ class TestDoctestNamespaceFixture:
                 scope=scope
             )
         )
-        p = testdir.makepyfile(
+        p = test_path.makepyfile(
             """
             def foo():
                 '''
@@ -1365,13 +1369,13 @@ class TestDoctestNamespaceFixture:
                 '''
         """
         )
-        reprec = testdir.inline_run(p, "--doctest-modules")
+        reprec = test_path.inline_run(p, "--doctest-modules")
         reprec.assertoutcome(passed=1)
 
 
 class TestDoctestReportingOption:
-    def _run_doctest_report(self, testdir, format):
-        testdir.makepyfile(
+    def _run_doctest_report(self, test_path, format):
+        test_path.makepyfile(
             """
             def foo():
                 '''
@@ -1387,17 +1391,17 @@ class TestDoctestReportingOption:
                       '2  3  6')
             """
         )
-        return testdir.runpytest("--doctest-modules", "--doctest-report", format)
+        return test_path.runpytest("--doctest-modules", "--doctest-report", format)
 
     @pytest.mark.parametrize("format", ["udiff", "UDIFF", "uDiFf"])
-    def test_doctest_report_udiff(self, testdir, format):
-        result = self._run_doctest_report(testdir, format)
+    def test_doctest_report_udiff(self, test_path, format):
+        result = self._run_doctest_report(test_path, format)
         result.stdout.fnmatch_lines(
             ["     0  1  4", "    -1  2  4", "    +1  2  5", "     2  3  6"]
         )
 
-    def test_doctest_report_cdiff(self, testdir):
-        result = self._run_doctest_report(testdir, "cdiff")
+    def test_doctest_report_cdiff(self, test_path):
+        result = self._run_doctest_report(test_path, "cdiff")
         result.stdout.fnmatch_lines(
             [
                 "         a  b",
@@ -1412,8 +1416,8 @@ class TestDoctestReportingOption:
             ]
         )
 
-    def test_doctest_report_ndiff(self, testdir):
-        result = self._run_doctest_report(testdir, "ndiff")
+    def test_doctest_report_ndiff(self, test_path):
+        result = self._run_doctest_report(test_path, "ndiff")
         result.stdout.fnmatch_lines(
             [
                 "         a  b",
@@ -1427,8 +1431,8 @@ class TestDoctestReportingOption:
         )
 
     @pytest.mark.parametrize("format", ["none", "only_first_failure"])
-    def test_doctest_report_none_or_only_first_failure(self, testdir, format):
-        result = self._run_doctest_report(testdir, format)
+    def test_doctest_report_none_or_only_first_failure(self, test_path, format):
+        result = self._run_doctest_report(test_path, format)
         result.stdout.fnmatch_lines(
             [
                 "Expected:",
@@ -1444,8 +1448,8 @@ class TestDoctestReportingOption:
             ]
         )
 
-    def test_doctest_report_invalid(self, testdir):
-        result = self._run_doctest_report(testdir, "obviously_invalid_format")
+    def test_doctest_report_invalid(self, test_path):
+        result = self._run_doctest_report(test_path, "obviously_invalid_format")
         result.stderr.fnmatch_lines(
             [
                 "*error: argument --doctest-report: invalid choice: 'obviously_invalid_format' (choose from*"
@@ -1454,9 +1458,9 @@ class TestDoctestReportingOption:
 
 
 @pytest.mark.parametrize("mock_module", ["mock", "unittest.mock"])
-def test_doctest_mock_objects_dont_recurse_missbehaved(mock_module, testdir):
+def test_doctest_mock_objects_dont_recurse_missbehaved(mock_module, test_path):
     pytest.importorskip(mock_module)
-    testdir.makepyfile(
+    test_path.makepyfile(
         """
         from {mock_module} import call
         class Example(object):
@@ -1468,7 +1472,7 @@ def test_doctest_mock_objects_dont_recurse_missbehaved(mock_module, testdir):
             mock_module=mock_module
         )
     )
-    result = testdir.runpytest("--doctest-modules")
+    result = test_path.runpytest("--doctest-modules")
     result.stdout.fnmatch_lines(["* 1 passed *"])
 
 
@@ -1495,25 +1499,25 @@ def test_warning_on_unwrap_of_broken_object(
     assert inspect.unwrap.__module__ == "inspect"
 
 
-def test_is_setup_py_not_named_setup_py(tmpdir):
-    not_setup_py = tmpdir.join("not_setup.py")
-    not_setup_py.write('from setuptools import setup; setup(name="foo")')
-    assert not _is_setup_py(not_setup_py)
+def test_is_setup_py_not_named_setup_py(tmp_path):
+    not_setup_py = tmp_path.joinpath("not_setup.py")
+    not_setup_py.write_text('from setuptools import setup; setup(name="foo")')
+    assert not _is_setup_py(py.path.local(str(not_setup_py)))
 
 
 @pytest.mark.parametrize("mod", ("setuptools", "distutils.core"))
-def test_is_setup_py_is_a_setup_py(tmpdir, mod):
-    setup_py = tmpdir.join("setup.py")
-    setup_py.write('from {} import setup; setup(name="foo")'.format(mod))
-    assert _is_setup_py(setup_py)
+def test_is_setup_py_is_a_setup_py(tmp_path, mod):
+    setup_py = tmp_path.joinpath("setup.py")
+    setup_py.write_text('from {} import setup; setup(name="foo")'.format(mod))
+    assert _is_setup_py(py.path.local(str(setup_py)))
 
 
 @pytest.mark.parametrize("mod", ("setuptools", "distutils.core"))
-def test_is_setup_py_different_encoding(tmpdir, mod):
-    setup_py = tmpdir.join("setup.py")
+def test_is_setup_py_different_encoding(tmp_path, mod):
+    setup_py = tmp_path.joinpath("setup.py")
     contents = (
         "# -*- coding: cp1252 -*-\n"
         'from {} import setup; setup(name="foo", description="€")\n'.format(mod)
     )
-    setup_py.write_binary(contents.encode("cp1252"))
-    assert _is_setup_py(setup_py)
+    setup_py.write_bytes(contents.encode("cp1252"))
+    assert _is_setup_py(py.path.local(str(setup_py)))

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -612,7 +612,7 @@ def test_pytester_addopts_before_testdir(request, monkeypatch) -> None:
     monkeypatch.setenv("PYTEST_ADDOPTS", "--orig-unused")
     testdir = request.getfixturevalue("testdir")
     assert "PYTEST_ADDOPTS" not in os.environ
-    testdir.finalize()
+    testdir._test_path._finalize()
     assert os.environ.get("PYTEST_ADDOPTS") == "--orig-unused"
     monkeypatch.undo()
     assert os.environ.get("PYTEST_ADDOPTS") == orig

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -799,9 +799,5 @@ def test_parse_summary_line_always_plural():
 
 def test_makefile_joins_absolute_path(testdir: Testdir) -> None:
     absfile = testdir.tmpdir / "absfile"
-    if sys.platform == "win32":
-        with pytest.raises(OSError):
-            testdir.makepyfile(**{str(absfile): ""})
-    else:
-        p1 = testdir.makepyfile(**{str(absfile): ""})
-        assert str(p1) == (testdir.tmpdir / absfile) + ".py"
+    p1 = testdir.makepyfile(**{str(absfile): ""})
+    assert str(p1) == str(testdir.tmpdir / "absfile.py")


### PR DESCRIPTION
As a step towards getting rid of `py.local`.

This simple experiment shows to me how *painful* this will be to end-users and plugin authors to completely drop this interface: we can see from our own test suite how heavily we rely on `py.path.local`'s interface, for example all `make*` functions return a `py.path` object which test suites often use.