### PR TITLE
Don't use reserved keywords as var names in config/__init__.py and helpconfig.py

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1239,7 +1239,7 @@ class Config:
 
     def _getini(self, name: str):
         try:
-            description, type, default = self._parser._inidict[name]
+            description, ini_type, default = self._parser._inidict[name]
         except KeyError as e:
             raise ValueError("unknown configuration value: {!r}".format(name)) from e
         override_value = self._get_override_ini_value(name)
@@ -1249,7 +1249,7 @@ class Config:
             except KeyError:
                 if default is not None:
                     return default
-                if type is None:
+                if ini_type is None:
                     return ""
                 return []
         else:
@@ -1268,23 +1268,23 @@ class Config:
         #     a_line_list = ["tests", "acceptance"]
         #   in this case, we already have a list ready to use
         #
-        if type == "pathlist":
+        if ini_type == "pathlist":
             # TODO: This assert is probably not valid in all cases.
             assert self.inifile is not None
             dp = py.path.local(self.inifile).dirpath()
             input_values = shlex.split(value) if isinstance(value, str) else value
             return [dp.join(x, abs=True) for x in input_values]
-        elif type == "args":
+        elif ini_type == "args":
             return shlex.split(value) if isinstance(value, str) else value
-        elif type == "linelist":
+        elif ini_type == "linelist":
             if isinstance(value, str):
                 return [t for t in map(lambda x: x.strip(), value.split("\n")) if t]
             else:
                 return value
-        elif type == "bool":
+        elif ini_type == "bool":
             return _strtobool(str(value).strip())
         else:
-            assert type is None
+            assert ini_type is None
             return value
 
     def _getconftest_pathlist(

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -167,17 +167,17 @@ def showhelp(config: Config) -> None:
     indent_len = 24  # based on argparse's max_help_position=24
     indent = " " * indent_len
     for name in config._parser._ininames:
-        help, type, default = config._parser._inidict[name]
-        if type is None:
-            type = "string"
-        spec = "{} ({}):".format(name, type)
+        help_text, ini_type, default = config._parser._inidict[name]
+        if ini_type is None:
+            ini_type = "string"
+        spec = "{} ({}):".format(name, ini_type)
         tw.write("  %s" % spec)
         spec_len = len(spec)
         if spec_len > (indent_len - 3):
             # Display help starting at a new line.
             tw.line()
             helplines = textwrap.wrap(
-                help,
+                help_text,
                 columns,
                 initial_indent=indent,
                 subsequent_indent=indent,
@@ -189,7 +189,9 @@ def showhelp(config: Config) -> None:
         else:
             # Display help starting after the spec, following lines indented.
             tw.write(" " * (indent_len - spec_len - 2))
-            wrapped = textwrap.wrap(help, columns - indent_len, break_on_hyphens=False)
+            wrapped = textwrap.wrap(
+                help_text, columns - indent_len, break_on_hyphens=False
+            )
 
             tw.line(wrapped[0])
             for line in wrapped[1:]:
@@ -203,8 +205,8 @@ def showhelp(config: Config) -> None:
         ("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "set to disable plugin auto-loading"),
         ("PYTEST_DEBUG", "set to enable debug tracing of pytest's internals"),
     ]
-    for name, help in vars:
-        tw.line("  {:<24} {}".format(name, help))
+    for name, help_text in vars:
+        tw.line("  {:<24} {}".format(name, help_text))
     tw.line()
     tw.line()
 


### PR DESCRIPTION
Stop using reserved keywords for local variables noted in ` src/_pytest/config/__init__.py ` and `src/_pytest/helpconfig.py`. Came here after having it block another change I was making.

No changelog entry, as this change is trivial