### PR TITLE
code/source: some cleanups

### DIFF
--- a/changelog/7438.breaking.rst
+++ b/changelog/7438.breaking.rst
@@ -1,0 +1,11 @@
+Some changes were made to the internal ``_pytest._code.source``, listed here
+for the benefit of plugin authors who may be using it:
+
+- The ``deindent`` argument to ``Source()`` has been removed, now it is always true.
+- Support for zero or multiple arguments to ``Source()`` has been removed.
+- Support for comparing ``Source`` with an ``str`` has been removed.
+- The methods ``Source.isparseable()`` and ``Source.putaround()`` have been removed.
+- The method ``Source.compile()`` and function ``_pytest._code.compile()`` have
+  been removed; use plain ``compile()`` instead.
+- The function ``_pytest._code.source.getsource()`` has been removed; use
+  ``Source()`` directly instead.

--- a/src/_pytest/_code/__init__.py
+++ b/src/_pytest/_code/__init__.py
@@ -7,7 +7,6 @@ from .code import getfslineno
 from .code import getrawcode
 from .code import Traceback
 from .code import TracebackEntry
-from .source import compile_ as compile
 from .source import Source
 
 __all__ = [
@@ -19,6 +18,5 @@ __all__ = [
     "getrawcode",
     "Traceback",
     "TracebackEntry",
-    "compile",
     "Source",
 ]

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -132,21 +132,6 @@ class Source:
         newsource.lines[:] = deindent(self.lines)
         return newsource
 
-    def isparseable(self, deindent: bool = True) -> bool:
-        """ return True if source is parseable, heuristically
-            deindenting it by default.
-        """
-        if deindent:
-            source = str(self.deindent())
-        else:
-            source = str(self)
-        try:
-            ast.parse(source)
-        except (SyntaxError, ValueError, TypeError):
-            return False
-        else:
-            return True
-
     def __str__(self) -> str:
         return "\n".join(self.lines)
 

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -308,10 +308,7 @@ def getrawcode(obj, trycall: bool = True):
 
 def getsource(obj) -> Source:
     obj = getrawcode(obj)
-    try:
-        strsrc = inspect.getsource(obj)
-    except IndentationError:
-        strsrc = '"Buggy python version consider upgrading, cannot get source"'
+    strsrc = inspect.getsource(obj)
     assert isinstance(strsrc, str)
     return Source(strsrc)
 

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -31,9 +31,8 @@ class Source:
 
     _compilecounter = 0
 
-    def __init__(self, *parts, **kwargs) -> None:
+    def __init__(self, *parts, deindent: bool = True) -> None:
         self.lines = lines = []  # type: List[str]
-        de = kwargs.get("deindent", True)
         for part in parts:
             if not part:
                 partlines = []  # type: List[str]
@@ -44,9 +43,9 @@ class Source:
             elif isinstance(part, str):
                 partlines = part.split("\n")
             else:
-                partlines = getsource(part, deindent=de).lines
-            if de:
-                partlines = deindent(partlines)
+                partlines = getsource(part, deindent=deindent).lines
+            if deindent:
+                partlines = _deindent_function(partlines)
             lines.extend(partlines)
 
     def __eq__(self, other):
@@ -307,18 +306,22 @@ def getrawcode(obj, trycall: bool = True):
         return obj
 
 
-def getsource(obj, **kwargs) -> Source:
+def getsource(obj, *, deindent: bool = True) -> Source:
     obj = getrawcode(obj)
     try:
         strsrc = inspect.getsource(obj)
     except IndentationError:
         strsrc = '"Buggy python version consider upgrading, cannot get source"'
     assert isinstance(strsrc, str)
-    return Source(strsrc, **kwargs)
+    return Source(strsrc, deindent=deindent)
 
 
 def deindent(lines: Sequence[str]) -> List[str]:
     return textwrap.dedent("\n".join(lines)).splitlines()
+
+
+# Internal alias to avoid shadowing with `deindent` parameter.
+_deindent_function = deindent
 
 
 def get_statement_startend2(lineno: int, node: ast.AST) -> Tuple[int, Optional[int]]:

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -309,7 +309,6 @@ def getrawcode(obj, trycall: bool = True):
 def getsource(obj) -> Source:
     obj = getrawcode(obj)
     strsrc = inspect.getsource(obj)
-    assert isinstance(strsrc, str)
     return Source(strsrc)
 
 

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -44,13 +44,10 @@ class Source:
         else:
             self.lines = deindent(getsource(obj).lines)
 
-    def __eq__(self, other):
-        try:
-            return self.lines == other.lines
-        except AttributeError:
-            if isinstance(other, str):
-                return str(self) == other
-            return False
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Source):
+            return NotImplemented
+        return self.lines == other.lines
 
     # Ignore type because of https://github.com/python/mypy/issues/4266.
     __hash__ = None  # type: ignore

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -8,10 +8,10 @@ import warnings
 from bisect import bisect_right
 from types import CodeType
 from types import FrameType
+from typing import Iterable
 from typing import Iterator
 from typing import List
 from typing import Optional
-from typing import Sequence
 from typing import Tuple
 from typing import Union
 
@@ -32,21 +32,17 @@ class Source:
 
     _compilecounter = 0
 
-    def __init__(self, *parts) -> None:
-        self.lines = lines = []  # type: List[str]
-        for part in parts:
-            if not part:
-                partlines = []  # type: List[str]
-            elif isinstance(part, Source):
-                partlines = part.lines
-            elif isinstance(part, (tuple, list)):
-                partlines = [x.rstrip("\n") for x in part]
-            elif isinstance(part, str):
-                partlines = part.split("\n")
-            else:
-                partlines = getsource(part).lines
-            partlines = deindent(partlines)
-            lines.extend(partlines)
+    def __init__(self, obj: object = None) -> None:
+        if not obj:
+            self.lines = []  # type: List[str]
+        elif isinstance(obj, Source):
+            self.lines = obj.lines
+        elif isinstance(obj, (tuple, list)):
+            self.lines = deindent(x.rstrip("\n") for x in obj)
+        elif isinstance(obj, str):
+            self.lines = deindent(obj.split("\n"))
+        else:
+            self.lines = deindent(getsource(obj).lines)
 
     def __eq__(self, other):
         try:
@@ -312,7 +308,7 @@ def getsource(obj) -> Source:
     return Source(strsrc)
 
 
-def deindent(lines: Sequence[str]) -> List[str]:
+def deindent(lines: Iterable[str]) -> List[str]:
     return textwrap.dedent("\n".join(lines)).splitlines()
 
 

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -89,19 +89,6 @@ class Source:
         source.lines[:] = self.lines[start:end]
         return source
 
-    def putaround(
-        self, before: str = "", after: str = "", indent: str = " " * 4
-    ) -> "Source":
-        """ return a copy of the source object with
-            'before' and 'after' wrapped around it.
-        """
-        beforesource = Source(before)
-        aftersource = Source(after)
-        newsource = Source()
-        lines = [(indent + line) for line in self.lines]
-        newsource.lines = beforesource.lines + lines + aftersource.lines
-        return newsource
-
     def indent(self, indent: str = " " * 4) -> "Source":
         """ return a copy of the source object with
             all lines indented by the given indent-string.

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -25,13 +25,14 @@ if TYPE_CHECKING:
 
 
 class Source:
-    """ an immutable object holding a source code fragment,
-        possibly deindenting it.
+    """An immutable object holding a source code fragment.
+
+    When using Source(...), the source lines are deindented.
     """
 
     _compilecounter = 0
 
-    def __init__(self, *parts, deindent: bool = True) -> None:
+    def __init__(self, *parts) -> None:
         self.lines = lines = []  # type: List[str]
         for part in parts:
             if not part:
@@ -43,9 +44,8 @@ class Source:
             elif isinstance(part, str):
                 partlines = part.split("\n")
             else:
-                partlines = getsource(part, deindent=deindent).lines
-            if deindent:
-                partlines = _deindent_function(partlines)
+                partlines = getsource(part).lines
+            partlines = deindent(partlines)
             lines.extend(partlines)
 
     def __eq__(self, other):
@@ -306,22 +306,18 @@ def getrawcode(obj, trycall: bool = True):
         return obj
 
 
-def getsource(obj, *, deindent: bool = True) -> Source:
+def getsource(obj) -> Source:
     obj = getrawcode(obj)
     try:
         strsrc = inspect.getsource(obj)
     except IndentationError:
         strsrc = '"Buggy python version consider upgrading, cannot get source"'
     assert isinstance(strsrc, str)
-    return Source(strsrc, deindent=deindent)
+    return Source(strsrc)
 
 
 def deindent(lines: Sequence[str]) -> List[str]:
     return textwrap.dedent("\n".join(lines)).splitlines()
-
-
-# Internal alias to avoid shadowing with `deindent` parameter.
-_deindent_function = deindent
 
 
 def get_statement_startend2(lineno: int, node: ast.AST) -> Tuple[int, Optional[int]]:

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -30,7 +30,9 @@ class Source:
         elif isinstance(obj, str):
             self.lines = deindent(obj.split("\n"))
         else:
-            self.lines = deindent(getsource(obj).lines)
+            rawcode = getrawcode(obj)
+            src = inspect.getsource(rawcode)
+            self.lines = deindent(src.split("\n"))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Source):
@@ -139,12 +141,6 @@ def getrawcode(obj, trycall: bool = True):
                 if hasattr(x, "co_firstlineno"):
                     return x
         return obj
-
-
-def getsource(obj) -> Source:
-    obj = getrawcode(obj)
-    strsrc = inspect.getsource(obj)
-    return Source(strsrc)
 
 
 def deindent(lines: Iterable[str]) -> List[str]:

--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -9,7 +9,6 @@ from typing import Tuple
 
 import attr
 
-import _pytest._code
 from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.config import hookimpl
@@ -105,7 +104,8 @@ def evaluate_condition(item: Item, mark: Mark, condition: object) -> Tuple[bool,
         if hasattr(item, "obj"):
             globals_.update(item.obj.__globals__)  # type: ignore[attr-defined]
         try:
-            condition_code = _pytest._code.compile(condition, mode="eval")
+            filename = "<{} condition>".format(mark.name)
+            condition_code = compile(condition, filename, "eval")
             result = eval(condition_code, globals_)
         except SyntaxError as exc:
             msglines = [

--- a/testing/code/test_code.py
+++ b/testing/code/test_code.py
@@ -6,6 +6,7 @@ import pytest
 from _pytest._code import Code
 from _pytest._code import ExceptionInfo
 from _pytest._code import Frame
+from _pytest._code import Source
 from _pytest._code.code import ExceptionChainRepr
 from _pytest._code.code import ReprFuncArgs
 
@@ -67,7 +68,7 @@ def test_getstatement_empty_fullsource() -> None:
 
     f = Frame(func())
     with mock.patch.object(f.code.__class__, "fullsource", None):
-        assert f.statement == ""
+        assert f.statement == Source("")
 
 
 def test_code_from_func() -> None:

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -131,7 +131,7 @@ class TestTraceback_f_g_h:
             try:
                 raise ValueError
             except somenoname:  # type: ignore[name-defined] # noqa: F821
-                pass
+                pass  # pragma: no cover
 
         try:
             xyz()
@@ -475,7 +475,7 @@ class TestFormattedExcinfo:
         except BaseException:
             excinfo = _pytest._code.ExceptionInfo.from_current()
         else:
-            assert 0, "did not raise"
+            assert False, "did not raise"
 
         pr = FormattedExcinfo()
         source = pr._getentrysource(excinfo.traceback[-1])

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -127,24 +127,28 @@ class TestTraceback_f_g_h:
         assert s.endswith("raise ValueError")
 
     def test_traceback_entry_getsource_in_construct(self):
-        source = _pytest._code.Source(
-            """\
-            def xyz():
-                try:
-                    raise ValueError
-                except somenoname:
-                    pass
-            xyz()
-            """
-        )
+        def xyz():
+            try:
+                raise ValueError
+            except somenoname:  # type: ignore[name-defined] # noqa: F821
+                pass
+
         try:
-            exec(source.compile())
+            xyz()
         except NameError:
-            tb = _pytest._code.ExceptionInfo.from_current().traceback
-            print(tb[-1].getsource())
-            s = str(tb[-1].getsource())
-            assert s.startswith("def xyz():\n    try:")
-            assert s.strip().endswith("except somenoname:")
+            excinfo = _pytest._code.ExceptionInfo.from_current()
+        else:
+            assert False, "did not raise NameError"
+
+        tb = excinfo.traceback
+        source = tb[-1].getsource()
+        assert source is not None
+        assert source.deindent().lines == [
+            "def xyz():",
+            "    try:",
+            "        raise ValueError",
+            "    except somenoname:  # type: ignore[name-defined] # noqa: F821",
+        ]
 
     def test_traceback_cut(self):
         co = _pytest._code.Code(f)
@@ -445,16 +449,6 @@ class TestFormattedExcinfo:
 
         return importasmod
 
-    def excinfo_from_exec(self, source):
-        source = _pytest._code.Source(source).strip()
-        try:
-            exec(source.compile())
-        except KeyboardInterrupt:
-            raise
-        except BaseException:
-            return _pytest._code.ExceptionInfo.from_current()
-        assert 0, "did not raise"
-
     def test_repr_source(self):
         pr = FormattedExcinfo()
         source = _pytest._code.Source(
@@ -471,19 +465,29 @@ class TestFormattedExcinfo:
 
     def test_repr_source_excinfo(self) -> None:
         """ check if indentation is right """
-        pr = FormattedExcinfo()
-        excinfo = self.excinfo_from_exec(
-            """
-                def f():
-                    assert 0
-                f()
-        """
-        )
+        try:
+
+            def f():
+                1 / 0
+
+            f()
+
+        except BaseException:
+            excinfo = _pytest._code.ExceptionInfo.from_current()
+        else:
+            assert 0, "did not raise"
+
         pr = FormattedExcinfo()
         source = pr._getentrysource(excinfo.traceback[-1])
         assert source is not None
         lines = pr.get_source(source, 1, excinfo)
-        assert lines == ["    def f():", ">       assert 0", "E       AssertionError"]
+        for line in lines:
+            print(line)
+        assert lines == [
+            "    def f():",
+            ">       1 / 0",
+            "E       ZeroDivisionError: division by zero",
+        ]
 
     def test_repr_source_not_existing(self):
         pr = FormattedExcinfo()

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -227,9 +227,9 @@ class TestSourceParsingAndCompiling:
         ''')"""
         )
         s = source.getstatement(0)
-        assert s == str(source)
+        assert s == source
         s = source.getstatement(1)
-        assert s == str(source)
+        assert s == source
 
     def test_getstatementrange_within_constructs(self) -> None:
         source = Source(
@@ -445,7 +445,7 @@ def test_getsource_fallback() -> None:
     expected = """def x():
     pass"""
     src = getsource(x)
-    assert src == expected
+    assert str(src) == expected
 
 
 def test_idem_compile_and_getsource() -> None:
@@ -454,7 +454,7 @@ def test_idem_compile_and_getsource() -> None:
     expected = "def x(): pass"
     co = _pytest._code.compile(expected)
     src = getsource(co)
-    assert src == expected
+    assert str(src) == expected
 
 
 def test_compile_ast() -> None:

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -125,15 +125,6 @@ def test_syntaxerror_rerepresentation() -> None:
     assert ex.value.text.rstrip("\n") == "xyz xyz"
 
 
-def test_isparseable() -> None:
-    assert Source("hello").isparseable()
-    assert Source("if 1:\n  pass").isparseable()
-    assert Source(" \nif 1:\n  pass").isparseable()
-    assert not Source("if 1:\n").isparseable()
-    assert not Source(" \nif 1:\npass").isparseable()
-    assert not Source(chr(0)).isparseable()
-
-
 class TestAccesses:
     def setup_class(self) -> None:
         self.source = Source(
@@ -147,7 +138,6 @@ class TestAccesses:
 
     def test_getrange(self) -> None:
         x = self.source[0:2]
-        assert x.isparseable()
         assert len(x.lines) == 2
         assert str(x) == "def f(x):\n    pass"
 

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -69,39 +69,6 @@ def test_source_from_inner_function() -> None:
     assert str(source).startswith("def f():")
 
 
-def test_source_putaround_simple() -> None:
-    source = Source("raise ValueError")
-    source = source.putaround(
-        "try:",
-        """\
-        except ValueError:
-            x = 42
-        else:
-            x = 23""",
-    )
-    assert (
-        str(source)
-        == """\
-try:
-    raise ValueError
-except ValueError:
-    x = 42
-else:
-    x = 23"""
-    )
-
-
-def test_source_putaround() -> None:
-    source = Source()
-    source = source.putaround(
-        """
-        if 1:
-            x=1
-    """
-    )
-    assert str(source).strip() == "if 1:\n    x=1"
-
-
 def test_source_strips() -> None:
     source = Source("")
     assert source == Source()

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -307,12 +307,10 @@ if True:
         pass
 
 
-def test_getsource_fallback() -> None:
-    from _pytest._code.source import getsource
-
+def test_source_fallback() -> None:
+    src = Source(x)
     expected = """def x():
     pass"""
-    src = getsource(x)
     assert str(src) == expected
 
 

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -4,6 +4,7 @@
 import ast
 import inspect
 import sys
+import textwrap
 from types import CodeType
 from typing import Any
 from typing import Dict
@@ -64,8 +65,6 @@ def test_source_from_inner_function() -> None:
     def f():
         pass
 
-    source = _pytest._code.Source(f, deindent=False)
-    assert str(source).startswith("    def f():")
     source = _pytest._code.Source(f)
     assert str(source).startswith("def f():")
 
@@ -557,7 +556,7 @@ def test_code_of_object_instance_with_call() -> None:
 def getstatement(lineno: int, source) -> Source:
     from _pytest._code.source import getstatementrange_ast
 
-    src = _pytest._code.Source(source, deindent=False)
+    src = _pytest._code.Source(source)
     ast, start, end = getstatementrange_ast(lineno, src)
     return src[start:end]
 
@@ -633,7 +632,7 @@ def test_source_with_decorator() -> None:
         assert False
 
     src = inspect.getsource(deco_mark)
-    assert str(Source(deco_mark, deindent=False)) == src
+    assert textwrap.indent(str(Source(deco_mark)), "    ") + "\n" == src
     assert src.startswith("    @pytest.mark.foo")
 
     @pytest.fixture
@@ -646,7 +645,9 @@ def test_source_with_decorator() -> None:
     # existing behavior here for explicitness, but perhaps we should revisit/change this
     # in the future
     assert str(Source(deco_fixture)).startswith("@functools.wraps(function)")
-    assert str(Source(get_real_func(deco_fixture), deindent=False)) == src
+    assert (
+        textwrap.indent(str(Source(get_real_func(deco_fixture))), "    ") + "\n" == src
+    )
 
 
 def test_single_line_else() -> None:

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -56,7 +56,7 @@ def test_source_from_lines() -> None:
 
 def test_source_from_inner_function() -> None:
     def f():
-        pass
+        raise NotImplementedError()
 
     source = _pytest._code.Source(f)
     assert str(source).startswith("def f():")
@@ -245,15 +245,15 @@ def test_getline_finally() -> None:
 
 def test_getfuncsource_dynamic() -> None:
     def f():
-        raise ValueError
+        raise NotImplementedError()
 
     def g():
-        pass
+        pass  # pragma: no cover
 
     f_source = _pytest._code.Source(f)
     g_source = _pytest._code.Source(g)
-    assert str(f_source).strip() == "def f():\n    raise ValueError"
-    assert str(g_source).strip() == "def g():\n    pass"
+    assert str(f_source).strip() == "def f():\n    raise NotImplementedError()"
+    assert str(g_source).strip() == "def g():\n    pass  # pragma: no cover"
 
 
 def test_getfuncsource_with_multine_string() -> None:


### PR DESCRIPTION
These commits clean up the  `_pytest._code.source` module, particularly removing a bunch of code we don't need.

I think it's a good idea to remove stuff we don't use because it reduces the amount of code we need to maintain and understand.