### PR TITLE
fix mypy issue by using typing Match instead of re.Match

### DIFF
--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -16,6 +16,7 @@ import sys
 from datetime import datetime
 from typing import Dict
 from typing import List
+from typing import Match
 from typing import Optional
 from typing import Tuple
 from typing import Union
@@ -70,7 +71,7 @@ _py_ext_re = re.compile(r"\.py$")
 
 
 def bin_xml_escape(arg: str) -> py.xml.raw:
-    def repl(matchobj: "re.Match[str]") -> str:
+    def repl(matchobj: "Match[str]") -> str:
         i = ord(matchobj.group())
         if i <= 0xFF:
             return "#x%02X" % i

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -71,7 +71,7 @@ _py_ext_re = re.compile(r"\.py$")
 
 
 def bin_xml_escape(arg: str) -> py.xml.raw:
-    def repl(matchobj: "Match[str]") -> str:
+    def repl(matchobj: Match[str]) -> str:
         i = ord(matchobj.group())
         if i <= 0xFF:
             return "#x%02X" % i


### PR DESCRIPTION
Closes https://github.com/pytest-dev/pytest/issues/7439

Use the `Match` in `Typing` instead of `re.Match` for junitxml.py to fix mypy error
