### PR TITLE
Publish MonkeyPatch for typing

### DIFF
--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -13,10 +13,10 @@ from typing import Tuple
 from typing import TypeVar
 from typing import Union
 
-import pytest
 from _pytest.compat import overload
 from _pytest.fixtures import fixture
 from _pytest.pathlib import Path
+from _pytest.warning_types import PytestWarning
 
 RE_IMPORT_ERROR_NAME = re.compile(r"^No module named (.*)$")
 
@@ -272,7 +272,7 @@ class MonkeyPatch:
         and prepend the ``value`` adjoined with the ``prepend`` character."""
         if not isinstance(value, str):
             warnings.warn(
-                pytest.PytestWarning(
+                PytestWarning(
                     "Value of environment variable {name} type should be str, but got "
                     "{value!r} (type: {type}); converted to str implicitly".format(
                         name=name, value=value, type=type(value).__name__

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -21,6 +21,7 @@ from _pytest.freeze_support import freeze_includes
 from _pytest.main import Session
 from _pytest.mark import MARK_GEN as mark
 from _pytest.mark import param
+from _pytest.monkeypatch import MonkeyPatch
 from _pytest.nodes import Collector
 from _pytest.nodes import File
 from _pytest.nodes import Item
@@ -76,6 +77,7 @@ __all__ = [
     "main",
     "mark",
     "Module",
+    "MonkeyPatch",
     "Package",
     "param",
     "PytestAssertRewriteWarning",


### PR DESCRIPTION
This builds on the work done in 2bcad38fbd1fb4022e2dc261817b9918cfbda43e
to add `MonkeyPatch` to pytest's public API. This will allow users of
pytest to annotation their tests like

    def test_some_code(monkeypatch: MonkeyPatch) -> None:
        ...

To make this possible, the `monkeypatch` module can't import `pytest`
anymore. Instead it will import `PytestWarning` directly from
`_pytest.warning_types`.
