### PR TITLE
Remove warning about development/outdated docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,6 @@
 Changelog
 =========
 
-The pytest CHANGELOG is located `here <https://docs.pytest.org/en/latest/changelog.html>`__.
+The pytest CHANGELOG is located `here <https://docs.pytest.org/en/stable/changelog.html>`__.
 
 The source document can be found at: https://github.com/pytest-dev/pytest/blob/master/doc/en/changelog.rst

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -294,7 +294,7 @@ Here is a simple overview, with pytest-specific bits:
 Writing Tests
 ~~~~~~~~~~~~~
 
-Writing tests for plugins or for pytest itself is often done using the `testdir fixture <https://docs.pytest.org/en/latest/reference.html#testdir>`_, as a "black-box" test.
+Writing tests for plugins or for pytest itself is often done using the `testdir fixture <https://docs.pytest.org/en/stable/reference.html#testdir>`_, as a "black-box" test.
 
 For example, to ensure a simple test passes you can write:
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://docs.pytest.org/en/latest/_static/pytest1.png
-   :target: https://docs.pytest.org/en/latest/
+.. image:: https://docs.pytest.org/en/stable/_static/pytest1.png
+   :target: https://docs.pytest.org/en/stable/
    :align: center
    :alt: pytest
 
@@ -71,23 +71,23 @@ To execute it::
     ========================== 1 failed in 0.04 seconds ===========================
 
 
-Due to ``pytest``'s detailed assertion introspection, only plain ``assert`` statements are used. See `getting-started <https://docs.pytest.org/en/latest/getting-started.html#our-first-test-run>`_ for more examples.
+Due to ``pytest``'s detailed assertion introspection, only plain ``assert`` statements are used. See `getting-started <https://docs.pytest.org/en/stable/getting-started.html#our-first-test-run>`_ for more examples.
 
 
 Features
 --------
 
-- Detailed info on failing `assert statements <https://docs.pytest.org/en/latest/assert.html>`_ (no need to remember ``self.assert*`` names);
+- Detailed info on failing `assert statements <https://docs.pytest.org/en/stable/assert.html>`_ (no need to remember ``self.assert*`` names);
 
 - `Auto-discovery
-  <https://docs.pytest.org/en/latest/goodpractices.html#python-test-discovery>`_
+  <https://docs.pytest.org/en/stable/goodpractices.html#python-test-discovery>`_
   of test modules and functions;
 
-- `Modular fixtures <https://docs.pytest.org/en/latest/fixture.html>`_ for
+- `Modular fixtures <https://docs.pytest.org/en/stable/fixture.html>`_ for
   managing small or parametrized long-lived test resources;
 
-- Can run `unittest <https://docs.pytest.org/en/latest/unittest.html>`_ (or trial),
-  `nose <https://docs.pytest.org/en/latest/nose.html>`_ test suites out of the box;
+- Can run `unittest <https://docs.pytest.org/en/stable/unittest.html>`_ (or trial),
+  `nose <https://docs.pytest.org/en/stable/nose.html>`_ test suites out of the box;
 
 - Python 3.5+ and PyPy3;
 
@@ -97,7 +97,7 @@ Features
 Documentation
 -------------
 
-For full documentation, including installation, tutorials and PDF documents, please see https://docs.pytest.org/en/latest/.
+For full documentation, including installation, tutorials and PDF documents, please see https://docs.pytest.org/en/stable/.
 
 
 Bugs/Requests
@@ -109,7 +109,7 @@ Please use the `GitHub issue tracker <https://github.com/pytest-dev/pytest/issue
 Changelog
 ---------
 
-Consult the `Changelog <https://docs.pytest.org/en/latest/changelog.html>`__ page for fixes and enhancements of each version.
+Consult the `Changelog <https://docs.pytest.org/en/stable/changelog.html>`__ page for fixes and enhancements of each version.
 
 
 Support pytest

--- a/doc/en/_templates/layout.html
+++ b/doc/en/_templates/layout.html
@@ -1,0 +1,52 @@
+{#
+
+    Copied from:
+
+     https://raw.githubusercontent.com/pallets/pallets-sphinx-themes/b0c6c41849b4e15cbf62cc1d95c05ef2b3e155c8/src/pallets_sphinx_themes/themes/pocoo/layout.html
+
+    And removed the warning version (see #7331).
+
+#}
+
+{% extends "basic/layout.html" %}
+
+{% set metatags %}
+  {{- metatags }}
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+{%- endset %}
+
+{% block extrahead %}
+  {%- if page_canonical_url %}
+    <link rel="canonical" href="{{ page_canonical_url }}">
+  {%- endif %}
+  <script>DOCUMENTATION_OPTIONS.URL_ROOT = '{{ url_root }}';</script>
+  {{ super() }}
+{%- endblock %}
+
+{% block sidebarlogo %}
+  {% if pagename != "index" or theme_index_sidebar_logo %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
+{% block relbar2 %}{% endblock %}
+
+{% block sidebar2 %}
+  <span id="sidebar-top"></span>
+  {{- super() }}
+{%- endblock %}
+
+{% block footer %}
+  {{ super() }}
+  {%- if READTHEDOCS and not readthedocs_docsearch %}
+    <script>
+      if (typeof READTHEDOCS_DATA !== 'undefined') {
+        if (!READTHEDOCS_DATA.features) {
+          READTHEDOCS_DATA.features = {};
+        }
+        READTHEDOCS_DATA.features.docsearch_disabled = true;
+      }
+    </script>
+  {%- endif %}
+  {{ js_tag("_static/version_warning_offset.js") }}
+{% endblock %}

--- a/doc/en/announce/release-2.0.0.rst
+++ b/doc/en/announce/release-2.0.0.rst
@@ -7,7 +7,7 @@ see below for summary and detailed lists.  A lot of long-deprecated code
 has been removed, resulting in a much smaller and cleaner
 implementation.  See the new docs with examples here:
 
-    http://pytest.org/en/latest/index.html
+    http://pytest.org/en/stable/index.html
 
 A note on packaging: pytest used to part of the "py" distribution up
 until version py-1.3.4 but this has changed now:  pytest-2.0.0 only
@@ -36,12 +36,12 @@ New Features
 
     import pytest ; pytest.main(arglist, pluginlist)
 
-  see http://pytest.org/en/latest/usage.html for details.
+  see http://pytest.org/en/stable/usage.html for details.
 
 - new and better reporting information in assert expressions
   if comparing lists, sequences or strings.
 
-  see http://pytest.org/en/latest/assert.html#newreport
+  see http://pytest.org/en/stable/assert.html#newreport
 
 - new configuration through ini-files (setup.cfg or tox.ini recognized),
   for example::
@@ -50,7 +50,7 @@ New Features
     norecursedirs = .hg data*  # don't ever recurse in such dirs
     addopts = -x --pyargs      # add these command line options by default
 
-  see http://pytest.org/en/latest/customize.html
+  see http://pytest.org/en/stable/customize.html
 
 - improved standard unittest support.  In general py.test should now
   better be able to run custom unittest.TestCases like twisted trial

--- a/doc/en/announce/release-2.0.1.rst
+++ b/doc/en/announce/release-2.0.1.rst
@@ -57,7 +57,7 @@ Changes between 2.0.0 and 2.0.1
 - refinements to "collecting" output on non-ttys
 - refine internal plugin registration and --traceconfig output
 - introduce a mechanism to prevent/unregister plugins from the
-  command line, see http://pytest.org/en/latest/plugins.html#cmdunregister
+  command line, see http://pytest.org/en/stable/plugins.html#cmdunregister
 - activate resultlog plugin by default
 - fix regression wrt yielded tests which due to the
   collection-before-running semantics were not

--- a/doc/en/announce/release-2.1.0.rst
+++ b/doc/en/announce/release-2.1.0.rst
@@ -12,7 +12,7 @@ courtesy of Benjamin Peterson.  You can now safely use ``assert``
 statements in test modules without having to worry about side effects
 or python optimization ("-OO") options.  This is achieved by rewriting
 assert statements in test modules upon import, using a PEP302 hook.
-See https://docs.pytest.org/en/latest/assert.html for
+See https://docs.pytest.org/en/stable/assert.html for
 detailed information.  The work has been partly sponsored by my company,
 merlinux GmbH.
 

--- a/doc/en/announce/release-2.2.0.rst
+++ b/doc/en/announce/release-2.2.0.rst
@@ -9,7 +9,7 @@ with these improvements:
 
   - new @pytest.mark.parametrize decorator to run tests with different arguments
   - new metafunc.parametrize() API for parametrizing arguments independently
-  - see examples at http://pytest.org/en/latest/example/parametrize.html
+  - see examples at http://pytest.org/en/stable/example/parametrize.html
   - NOTE that parametrize() related APIs are still a bit experimental
     and might change in future releases.
 
@@ -18,7 +18,7 @@ with these improvements:
   - "-m markexpr" option for selecting tests according to their mark
   - a new "markers" ini-variable for registering test markers for your project
   - the new "--strict" bails out with an error if using unregistered markers.
-  - see examples at http://pytest.org/en/latest/example/markers.html
+  - see examples at http://pytest.org/en/stable/example/markers.html
 
 * duration profiling: new "--duration=N" option showing the N slowest test
   execution or setup/teardown calls. This is most useful if you want to
@@ -78,7 +78,7 @@ Changes between 2.1.3 and 2.2.0
   or through plugin hooks.  Also introduce a "--strict" option which
   will treat unregistered markers as errors
   allowing to avoid typos and maintain a well described set of markers
-  for your test suite.  See examples at http://pytest.org/en/latest/mark.html
+  for your test suite.  See examples at http://pytest.org/en/stable/mark.html
   and its links.
 - issue50: introduce "-m marker" option to select tests based on markers
   (this is a stricter and more predictable version of "-k" in that "-m"

--- a/doc/en/announce/release-2.3.0.rst
+++ b/doc/en/announce/release-2.3.0.rst
@@ -13,12 +13,12 @@ re-usable fixture design.
 
 For detailed info and tutorial-style examples, see:
 
-    http://pytest.org/en/latest/fixture.html
+    http://pytest.org/en/stable/fixture.html
 
 Moreover, there is now support for using pytest fixtures/funcargs with
 unittest-style suites, see here for examples:
 
-    http://pytest.org/en/latest/unittest.html
+    http://pytest.org/en/stable/unittest.html
 
 Besides, more unittest-test suites are now expected to "simply work"
 with pytest.
@@ -29,11 +29,11 @@ pytest-2.2.4.
 
 If you are interested in the precise reasoning (including examples) of the
 pytest-2.3 fixture evolution, please consult
-http://pytest.org/en/latest/funcarg_compare.html
+http://pytest.org/en/stable/funcarg_compare.html
 
 For general info on installation and getting started:
 
-    http://pytest.org/en/latest/getting-started.html
+    http://pytest.org/en/stable/getting-started.html
 
 Docs and PDF access as usual at:
 
@@ -94,7 +94,7 @@ Changes between 2.2.4 and 2.3.0
 - pluginmanager.register(...) now raises ValueError if the
   plugin has been already registered or the name is taken
 
-- fix issue159: improve http://pytest.org/en/latest/faq.html
+- fix issue159: improve http://pytest.org/en/stable/faq.html
   especially with respect to the "magic" history, also mention
   pytest-django, trial and unittest integration.
 

--- a/doc/en/announce/release-2.3.4.rst
+++ b/doc/en/announce/release-2.3.4.rst
@@ -16,7 +16,7 @@ comes with the following fixes and features:
 - yielded test functions will now have autouse-fixtures active but
   cannot accept fixtures as funcargs - it's anyway recommended to
   rather use the post-2.0 parametrize features instead of yield, see:
-  http://pytest.org/en/latest/example/parametrize.html
+  http://pytest.org/en/stable/example/parametrize.html
 - fix autouse-issue where autouse-fixtures would not be discovered
   if defined in an a/conftest.py file and tests in a/tests/test_some.py
 - fix issue226 - LIFO ordering for fixture teardowns

--- a/doc/en/announce/release-2.4.0.rst
+++ b/doc/en/announce/release-2.4.0.rst
@@ -7,7 +7,7 @@ from a few supposedly very minor incompatibilities.  See below for
 a full list of details.  A few feature highlights:
 
 - new yield-style fixtures `pytest.yield_fixture
-  <http://pytest.org/en/latest/yieldfixture.html>`_, allowing to use
+  <http://pytest.org/en/stable/yieldfixture.html>`_, allowing to use
   existing with-style context managers in fixture functions.
 
 - improved pdb support: ``import pdb ; pdb.set_trace()`` now works

--- a/doc/en/announce/release-2.7.0.rst
+++ b/doc/en/announce/release-2.7.0.rst
@@ -52,7 +52,7 @@ holger krekel
 - add ability to set command line options by environment variable PYTEST_ADDOPTS.
 
 - added documentation on the new pytest-dev teams on bitbucket and
-  github.  See https://pytest.org/en/latest/contributing.html .
+  github.  See https://pytest.org/en/stable/contributing.html .
   Thanks to Anatoly for pushing and initial work on this.
 
 - fix issue650: new option ``--docttest-ignore-import-errors`` which

--- a/doc/en/announce/release-2.9.0.rst
+++ b/doc/en/announce/release-2.9.0.rst
@@ -131,7 +131,7 @@ The py.test Development Team
   with same name.
 
 
-.. _`traceback style docs`: https://pytest.org/en/latest/usage.html#modifying-python-traceback-printing
+.. _`traceback style docs`: https://pytest.org/en/stable/usage.html#modifying-python-traceback-printing
 
 .. _#1422: https://github.com/pytest-dev/pytest/issues/1422
 .. _#1379: https://github.com/pytest-dev/pytest/issues/1379

--- a/doc/en/announce/release-3.0.1.rst
+++ b/doc/en/announce/release-3.0.1.rst
@@ -8,7 +8,7 @@ drop-in replacement. To upgrade:
 
   pip install --upgrade pytest
 
-The changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.0.2.rst
+++ b/doc/en/announce/release-3.0.2.rst
@@ -8,7 +8,7 @@ drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.0.3.rst
+++ b/doc/en/announce/release-3.0.3.rst
@@ -8,7 +8,7 @@ being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.0.4.rst
+++ b/doc/en/announce/release-3.0.4.rst
@@ -8,7 +8,7 @@ being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.0.5.rst
+++ b/doc/en/announce/release-3.0.5.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.0.6.rst
+++ b/doc/en/announce/release-3.0.6.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 
 Thanks to all who contributed to this release, among them:

--- a/doc/en/announce/release-3.0.7.rst
+++ b/doc/en/announce/release-3.0.7.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.1.0.rst
+++ b/doc/en/announce/release-3.1.0.rst
@@ -9,7 +9,7 @@ against itself, passing on many different interpreters and platforms.
 This release contains a bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-http://doc.pytest.org/en/latest/changelog.html
+http://doc.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 

--- a/doc/en/announce/release-3.1.1.rst
+++ b/doc/en/announce/release-3.1.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.1.2.rst
+++ b/doc/en/announce/release-3.1.2.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.1.3.rst
+++ b/doc/en/announce/release-3.1.3.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.10.0.rst
+++ b/doc/en/announce/release-3.10.0.rst
@@ -9,11 +9,11 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    https://docs.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 
-    https://docs.pytest.org/en/latest/
+    https://docs.pytest.org/en/stable/
 
 As usual, you can upgrade from pypi via:
 

--- a/doc/en/announce/release-3.10.1.rst
+++ b/doc/en/announce/release-3.10.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.2.0.rst
+++ b/doc/en/announce/release-3.2.0.rst
@@ -9,7 +9,7 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    http://doc.pytest.org/en/latest/changelog.html
+    http://doc.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 

--- a/doc/en/announce/release-3.2.1.rst
+++ b/doc/en/announce/release-3.2.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.2.2.rst
+++ b/doc/en/announce/release-3.2.2.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.2.3.rst
+++ b/doc/en/announce/release-3.2.3.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.2.4.rst
+++ b/doc/en/announce/release-3.2.4.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.2.5.rst
+++ b/doc/en/announce/release-3.2.5.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.3.0.rst
+++ b/doc/en/announce/release-3.3.0.rst
@@ -9,7 +9,7 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    http://doc.pytest.org/en/latest/changelog.html
+    http://doc.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 

--- a/doc/en/announce/release-3.3.1.rst
+++ b/doc/en/announce/release-3.3.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.3.2.rst
+++ b/doc/en/announce/release-3.3.2.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.4.0.rst
+++ b/doc/en/announce/release-3.4.0.rst
@@ -9,7 +9,7 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    http://doc.pytest.org/en/latest/changelog.html
+    http://doc.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 

--- a/doc/en/announce/release-3.4.1.rst
+++ b/doc/en/announce/release-3.4.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.4.2.rst
+++ b/doc/en/announce/release-3.4.2.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.5.0.rst
+++ b/doc/en/announce/release-3.5.0.rst
@@ -9,7 +9,7 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    http://doc.pytest.org/en/latest/changelog.html
+    http://doc.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 

--- a/doc/en/announce/release-3.5.1.rst
+++ b/doc/en/announce/release-3.5.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.6.0.rst
+++ b/doc/en/announce/release-3.6.0.rst
@@ -9,7 +9,7 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    http://doc.pytest.org/en/latest/changelog.html
+    http://doc.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 

--- a/doc/en/announce/release-3.6.1.rst
+++ b/doc/en/announce/release-3.6.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.6.2.rst
+++ b/doc/en/announce/release-3.6.2.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.6.3.rst
+++ b/doc/en/announce/release-3.6.3.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.6.4.rst
+++ b/doc/en/announce/release-3.6.4.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.7.0.rst
+++ b/doc/en/announce/release-3.7.0.rst
@@ -9,7 +9,7 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    http://doc.pytest.org/en/latest/changelog.html
+    http://doc.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 

--- a/doc/en/announce/release-3.7.1.rst
+++ b/doc/en/announce/release-3.7.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.7.2.rst
+++ b/doc/en/announce/release-3.7.2.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.7.3.rst
+++ b/doc/en/announce/release-3.7.3.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at http://doc.pytest.org/en/latest/changelog.html.
+The full changelog is available at http://doc.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.7.4.rst
+++ b/doc/en/announce/release-3.7.4.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.8.0.rst
+++ b/doc/en/announce/release-3.8.0.rst
@@ -9,11 +9,11 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    https://docs.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 
-    https://docs.pytest.org/en/latest/
+    https://docs.pytest.org/en/stable/
 
 As usual, you can upgrade from pypi via:
 

--- a/doc/en/announce/release-3.8.1.rst
+++ b/doc/en/announce/release-3.8.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.8.2.rst
+++ b/doc/en/announce/release-3.8.2.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.9.0.rst
+++ b/doc/en/announce/release-3.9.0.rst
@@ -9,11 +9,11 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    https://docs.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 
-    https://docs.pytest.org/en/latest/
+    https://docs.pytest.org/en/stable/
 
 As usual, you can upgrade from pypi via:
 

--- a/doc/en/announce/release-3.9.1.rst
+++ b/doc/en/announce/release-3.9.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.9.2.rst
+++ b/doc/en/announce/release-3.9.2.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-3.9.3.rst
+++ b/doc/en/announce/release-3.9.3.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-4.0.0.rst
+++ b/doc/en/announce/release-4.0.0.rst
@@ -9,11 +9,11 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    https://docs.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 
-    https://docs.pytest.org/en/latest/
+    https://docs.pytest.org/en/stable/
 
 As usual, you can upgrade from pypi via:
 

--- a/doc/en/announce/release-4.0.1.rst
+++ b/doc/en/announce/release-4.0.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-4.0.2.rst
+++ b/doc/en/announce/release-4.0.2.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-4.1.0.rst
+++ b/doc/en/announce/release-4.1.0.rst
@@ -9,11 +9,11 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    https://docs.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 
-    https://docs.pytest.org/en/latest/
+    https://docs.pytest.org/en/stable/
 
 As usual, you can upgrade from pypi via:
 

--- a/doc/en/announce/release-4.1.1.rst
+++ b/doc/en/announce/release-4.1.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-4.2.0.rst
+++ b/doc/en/announce/release-4.2.0.rst
@@ -9,11 +9,11 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    https://docs.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 
-    https://docs.pytest.org/en/latest/
+    https://docs.pytest.org/en/stable/
 
 As usual, you can upgrade from pypi via:
 

--- a/doc/en/announce/release-4.2.1.rst
+++ b/doc/en/announce/release-4.2.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-4.3.0.rst
+++ b/doc/en/announce/release-4.3.0.rst
@@ -9,11 +9,11 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    https://docs.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 
-    https://docs.pytest.org/en/latest/
+    https://docs.pytest.org/en/stable/
 
 As usual, you can upgrade from pypi via:
 

--- a/doc/en/announce/release-4.3.1.rst
+++ b/doc/en/announce/release-4.3.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-4.4.0.rst
+++ b/doc/en/announce/release-4.4.0.rst
@@ -9,11 +9,11 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    https://docs.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 
-    https://docs.pytest.org/en/latest/
+    https://docs.pytest.org/en/stable/
 
 As usual, you can upgrade from pypi via:
 

--- a/doc/en/announce/release-4.4.1.rst
+++ b/doc/en/announce/release-4.4.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-4.4.2.rst
+++ b/doc/en/announce/release-4.4.2.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-4.5.0.rst
+++ b/doc/en/announce/release-4.5.0.rst
@@ -9,11 +9,11 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    https://docs.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 
-    https://docs.pytest.org/en/latest/
+    https://docs.pytest.org/en/stable/
 
 As usual, you can upgrade from pypi via:
 

--- a/doc/en/announce/release-4.6.0.rst
+++ b/doc/en/announce/release-4.6.0.rst
@@ -9,11 +9,11 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    https://docs.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 
-    https://docs.pytest.org/en/latest/
+    https://docs.pytest.org/en/stable/
 
 As usual, you can upgrade from pypi via:
 

--- a/doc/en/announce/release-4.6.1.rst
+++ b/doc/en/announce/release-4.6.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-4.6.2.rst
+++ b/doc/en/announce/release-4.6.2.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-4.6.3.rst
+++ b/doc/en/announce/release-4.6.3.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-4.6.4.rst
+++ b/doc/en/announce/release-4.6.4.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-4.6.5.rst
+++ b/doc/en/announce/release-4.6.5.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-4.6.6.rst
+++ b/doc/en/announce/release-4.6.6.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-4.6.7.rst
+++ b/doc/en/announce/release-4.6.7.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-4.6.8.rst
+++ b/doc/en/announce/release-4.6.8.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-4.6.9.rst
+++ b/doc/en/announce/release-4.6.9.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-5.0.0.rst
+++ b/doc/en/announce/release-5.0.0.rst
@@ -9,11 +9,11 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    https://docs.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 
-    https://docs.pytest.org/en/latest/
+    https://docs.pytest.org/en/stable/
 
 As usual, you can upgrade from pypi via:
 

--- a/doc/en/announce/release-5.0.1.rst
+++ b/doc/en/announce/release-5.0.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-5.1.0.rst
+++ b/doc/en/announce/release-5.1.0.rst
@@ -9,11 +9,11 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    https://docs.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 
-    https://docs.pytest.org/en/latest/
+    https://docs.pytest.org/en/stable/
 
 As usual, you can upgrade from pypi via:
 

--- a/doc/en/announce/release-5.1.1.rst
+++ b/doc/en/announce/release-5.1.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-5.1.2.rst
+++ b/doc/en/announce/release-5.1.2.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-5.1.3.rst
+++ b/doc/en/announce/release-5.1.3.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-5.2.0.rst
+++ b/doc/en/announce/release-5.2.0.rst
@@ -9,11 +9,11 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    https://docs.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 
-    https://docs.pytest.org/en/latest/
+    https://docs.pytest.org/en/stable/
 
 As usual, you can upgrade from pypi via:
 

--- a/doc/en/announce/release-5.2.1.rst
+++ b/doc/en/announce/release-5.2.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-5.2.2.rst
+++ b/doc/en/announce/release-5.2.2.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-5.2.3.rst
+++ b/doc/en/announce/release-5.2.3.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-5.2.4.rst
+++ b/doc/en/announce/release-5.2.4.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-5.3.0.rst
+++ b/doc/en/announce/release-5.3.0.rst
@@ -9,11 +9,11 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bugs fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    https://docs.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 
-    https://docs.pytest.org/en/latest/
+    https://docs.pytest.org/en/stable/
 
 As usual, you can upgrade from pypi via:
 

--- a/doc/en/announce/release-5.3.1.rst
+++ b/doc/en/announce/release-5.3.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-5.3.2.rst
+++ b/doc/en/announce/release-5.3.2.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-5.3.3.rst
+++ b/doc/en/announce/release-5.3.3.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-5.3.4.rst
+++ b/doc/en/announce/release-5.3.4.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-5.3.5.rst
+++ b/doc/en/announce/release-5.3.5.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-5.4.0.rst
+++ b/doc/en/announce/release-5.4.0.rst
@@ -9,11 +9,11 @@ against itself, passing on many different interpreters and platforms.
 This release contains a number of bug fixes and improvements, so users are encouraged
 to take a look at the CHANGELOG:
 
-    https://docs.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 
-    https://docs.pytest.org/en/latest/
+    https://docs.pytest.org/en/stable/
 
 As usual, you can upgrade from PyPI via:
 

--- a/doc/en/announce/release-5.4.1.rst
+++ b/doc/en/announce/release-5.4.1.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-5.4.2.rst
+++ b/doc/en/announce/release-5.4.2.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/announce/release-5.4.3.rst
+++ b/doc/en/announce/release-5.4.3.rst
@@ -7,7 +7,7 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
 Thanks to all who contributed to this release, among them:
 

--- a/doc/en/assert.rst
+++ b/doc/en/assert.rst
@@ -303,7 +303,7 @@ modules directly discovered by its test collection process, so **asserts in
 supporting modules which are not themselves test modules will not be rewritten**.
 
 You can manually enable assertion rewriting for an imported module by calling
-`register_assert_rewrite <https://docs.pytest.org/en/latest/writing_plugins.html#assertion-rewriting>`_
+`register_assert_rewrite <https://docs.pytest.org/en/stable/writing_plugins.html#assertion-rewriting>`_
 before you import it (a good place to do that is in your root ``conftest.py``).
 
 For further information, Benjamin Peterson wrote up `Behind the scenes of pytest's new assertion rewriting <http://pybites.blogspot.com/2011/07/behind-scenes-of-pytests-new-assertion.html>`_.

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -433,7 +433,7 @@ Deprecations
   In order to smooth the transition, pytest will issue a warning in case the ``--junitxml`` option
   is given in the command line but :confval:`junit_family` is not explicitly configured in ``pytest.ini``.
 
-  For more information, `see the docs <https://docs.pytest.org/en/latest/deprecations.html#junit-family-default-value-change-to-xunit2>`__.
+  For more information, `see the docs <https://docs.pytest.org/en/stable/deprecations.html#junit-family-default-value-change-to-xunit2>`__.
 
 
 
@@ -700,7 +700,7 @@ Features
 
 - `#1682 <https://github.com/pytest-dev/pytest/issues/1682>`_: The ``scope`` parameter of ``@pytest.fixture`` can now be a callable that receives
   the fixture name and the ``config`` object as keyword-only parameters.
-  See `the docs <https://docs.pytest.org/en/latest/fixture.html#dynamic-scope>`__ for more information.
+  See `the docs <https://docs.pytest.org/en/stable/fixture.html#dynamic-scope>`__ for more information.
 
 
 - `#5764 <https://github.com/pytest-dev/pytest/issues/5764>`_: New behavior of the ``--pastebin`` option: failures to connect to the pastebin server are reported, without failing the pytest run
@@ -805,7 +805,7 @@ Removals
 
 
   For more information consult
-  `Deprecations and Removals <https://docs.pytest.org/en/latest/deprecations.html>`__ in the docs.
+  `Deprecations and Removals <https://docs.pytest.org/en/stable/deprecations.html>`__ in the docs.
 
 
 - `#5565 <https://github.com/pytest-dev/pytest/issues/5565>`_: Removed unused support code for `unittest2 <https://pypi.org/project/unittest2/>`__.
@@ -839,7 +839,7 @@ Features
 - `#5564 <https://github.com/pytest-dev/pytest/issues/5564>`_: New ``Config.invocation_args`` attribute containing the unchanged arguments passed to ``pytest.main()``.
 
 
-- `#5576 <https://github.com/pytest-dev/pytest/issues/5576>`_: New `NUMBER <https://docs.pytest.org/en/latest/doctest.html#using-doctest-options>`__
+- `#5576 <https://github.com/pytest-dev/pytest/issues/5576>`_: New `NUMBER <https://docs.pytest.org/en/stable/doctest.html#using-doctest-options>`__
   option for doctests to ignore irrelevant differences in floating-point numbers.
   Inspired by Sébastien Boisgérault's `numtest <https://github.com/boisgera/numtest>`__
   extension for doctest.
@@ -959,7 +959,7 @@ Important
 
 This release is a Python3.5+ only release.
 
-For more details, see our `Python 2.7 and 3.4 support plan <https://docs.pytest.org/en/latest/py27-py34-deprecation.html>`__.
+For more details, see our `Python 2.7 and 3.4 support plan <https://docs.pytest.org/en/stable/py27-py34-deprecation.html>`__.
 
 Removals
 --------
@@ -980,7 +980,7 @@ Removals
   instead of warning messages.
 
   **The affected features will be effectively removed in pytest 5.1**, so please consult the
-  `Deprecations and Removals <https://docs.pytest.org/en/latest/deprecations.html>`__
+  `Deprecations and Removals <https://docs.pytest.org/en/stable/deprecations.html>`__
   section in the docs for directions on how to update existing code.
 
   In the pytest ``5.0.X`` series, it is possible to change the errors back into warnings as a stop
@@ -1036,7 +1036,7 @@ Deprecations
 Features
 --------
 
-- `#3457 <https://github.com/pytest-dev/pytest/issues/3457>`_: New `pytest_assertion_pass <https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_assertion_pass>`__
+- `#3457 <https://github.com/pytest-dev/pytest/issues/3457>`_: New `pytest_assertion_pass <https://docs.pytest.org/en/stable/reference.html#_pytest.hookspec.pytest_assertion_pass>`__
   hook, called with context information when an assertion *passes*.
 
   This hook is still **experimental** so use it with caution.
@@ -1049,7 +1049,7 @@ Features
   `pytest-faulthandler <https://github.com/pytest-dev/pytest-faulthandler>`__ plugin into the core,
   so users should remove that plugin from their requirements if used.
 
-  For more information see the docs: https://docs.pytest.org/en/latest/usage.html#fault-handler
+  For more information see the docs: https://docs.pytest.org/en/stable/usage.html#fault-handler
 
 
 - `#5452 <https://github.com/pytest-dev/pytest/issues/5452>`_: When warnings are configured as errors, pytest warnings now appear as originating from ``pytest.`` instead of the internal ``_pytest.warning_types.`` module.
@@ -1318,7 +1318,7 @@ Important
 
 The ``4.6.X`` series will be the last series to support **Python 2 and Python 3.4**.
 
-For more details, see our `Python 2.7 and 3.4 support plan <https://docs.pytest.org/en/latest/py27-py34-deprecation.html>`__.
+For more details, see our `Python 2.7 and 3.4 support plan <https://docs.pytest.org/en/stable/py27-py34-deprecation.html>`__.
 
 
 Features
@@ -1408,7 +1408,7 @@ Features
 
   The existing ``--strict`` option has the same behavior currently, but can be augmented in the future for additional checks.
 
-  .. _`markers option`: https://docs.pytest.org/en/latest/reference.html#confval-markers
+  .. _`markers option`: https://docs.pytest.org/en/stable/reference.html#confval-markers
 
 
 - `#5026 <https://github.com/pytest-dev/pytest/issues/5026>`_: Assertion failure messages for sequences and dicts contain the number of different items now.
@@ -1465,7 +1465,7 @@ Features
 
       CRITICAL root:test_log_cli_enabled_disabled.py:3 critical message logged by test
 
-  The formatting can be changed through the `log_format <https://docs.pytest.org/en/latest/reference.html#confval-log_format>`__ configuration option.
+  The formatting can be changed through the `log_format <https://docs.pytest.org/en/stable/reference.html#confval-log_format>`__ configuration option.
 
 
 - `#5220 <https://github.com/pytest-dev/pytest/issues/5220>`_: ``--fixtures`` now also shows fixture scope for scopes other than ``"function"``.
@@ -1601,7 +1601,7 @@ Features
   .. _pdb++: https://pypi.org/project/pdbpp/
 
 
-- `#4875 <https://github.com/pytest-dev/pytest/issues/4875>`_: The `testpaths <https://docs.pytest.org/en/latest/reference.html#confval-testpaths>`__ configuration option is now displayed next
+- `#4875 <https://github.com/pytest-dev/pytest/issues/4875>`_: The `testpaths <https://docs.pytest.org/en/stable/reference.html#confval-testpaths>`__ configuration option is now displayed next
   to the ``rootdir`` and ``inifile`` lines in the pytest header if the option is in effect, i.e., directories or file names were
   not explicitly passed in the command line.
 
@@ -1856,7 +1856,7 @@ pytest 4.2.0 (2019-01-30)
 Features
 --------
 
-- `#3094 <https://github.com/pytest-dev/pytest/issues/3094>`_: `Classic xunit-style <https://docs.pytest.org/en/latest/xunit_setup.html>`__ functions and methods
+- `#3094 <https://github.com/pytest-dev/pytest/issues/3094>`_: `Classic xunit-style <https://docs.pytest.org/en/stable/xunit_setup.html>`__ functions and methods
   now obey the scope of *autouse* fixtures.
 
   This fixes a number of surprising issues like ``setup_method`` being called before session-scoped
@@ -1974,27 +1974,27 @@ Removals
 
 - `#3078 <https://github.com/pytest-dev/pytest/issues/3078>`_: Remove legacy internal warnings system: ``config.warn``, ``Node.warn``. The ``pytest_logwarning`` now issues a warning when implemented.
 
-  See our `docs <https://docs.pytest.org/en/latest/deprecations.html#config-warn-and-node-warn>`__ on information on how to update your code.
+  See our `docs <https://docs.pytest.org/en/stable/deprecations.html#config-warn-and-node-warn>`__ on information on how to update your code.
 
 
 - `#3079 <https://github.com/pytest-dev/pytest/issues/3079>`_: Removed support for yield tests - they are fundamentally broken because they don't support fixtures properly since collection and test execution were separated.
 
-  See our `docs <https://docs.pytest.org/en/latest/deprecations.html#yield-tests>`__ on information on how to update your code.
+  See our `docs <https://docs.pytest.org/en/stable/deprecations.html#yield-tests>`__ on information on how to update your code.
 
 
 - `#3082 <https://github.com/pytest-dev/pytest/issues/3082>`_: Removed support for applying marks directly to values in ``@pytest.mark.parametrize``. Use ``pytest.param`` instead.
 
-  See our `docs <https://docs.pytest.org/en/latest/deprecations.html#marks-in-pytest-mark-parametrize>`__ on information on how to update your code.
+  See our `docs <https://docs.pytest.org/en/stable/deprecations.html#marks-in-pytest-mark-parametrize>`__ on information on how to update your code.
 
 
 - `#3083 <https://github.com/pytest-dev/pytest/issues/3083>`_: Removed ``Metafunc.addcall``. This was the predecessor mechanism to ``@pytest.mark.parametrize``.
 
-  See our `docs <https://docs.pytest.org/en/latest/deprecations.html#metafunc-addcall>`__ on information on how to update your code.
+  See our `docs <https://docs.pytest.org/en/stable/deprecations.html#metafunc-addcall>`__ on information on how to update your code.
 
 
 - `#3085 <https://github.com/pytest-dev/pytest/issues/3085>`_: Removed support for passing strings to ``pytest.main``. Now, always pass a list of strings instead.
 
-  See our `docs <https://docs.pytest.org/en/latest/deprecations.html#passing-command-line-string-to-pytest-main>`__ on information on how to update your code.
+  See our `docs <https://docs.pytest.org/en/stable/deprecations.html#passing-command-line-string-to-pytest-main>`__ on information on how to update your code.
 
 
 - `#3086 <https://github.com/pytest-dev/pytest/issues/3086>`_: ``[pytest]`` section in **setup.cfg** files is no longer supported, use ``[tool:pytest]`` instead. ``setup.cfg`` files
@@ -2005,17 +2005,17 @@ Removals
 
 - `#3616 <https://github.com/pytest-dev/pytest/issues/3616>`_: Removed the deprecated compat properties for ``node.Class/Function/Module`` - use ``pytest.Class/Function/Module`` now.
 
-  See our `docs <https://docs.pytest.org/en/latest/deprecations.html#internal-classes-accessed-through-node>`__ on information on how to update your code.
+  See our `docs <https://docs.pytest.org/en/stable/deprecations.html#internal-classes-accessed-through-node>`__ on information on how to update your code.
 
 
 - `#4421 <https://github.com/pytest-dev/pytest/issues/4421>`_: Removed the implementation of the ``pytest_namespace`` hook.
 
-  See our `docs <https://docs.pytest.org/en/latest/deprecations.html#pytest-namespace>`__ on information on how to update your code.
+  See our `docs <https://docs.pytest.org/en/stable/deprecations.html#pytest-namespace>`__ on information on how to update your code.
 
 
 - `#4489 <https://github.com/pytest-dev/pytest/issues/4489>`_: Removed ``request.cached_setup``. This was the predecessor mechanism to modern fixtures.
 
-  See our `docs <https://docs.pytest.org/en/latest/deprecations.html#cached-setup>`__ on information on how to update your code.
+  See our `docs <https://docs.pytest.org/en/stable/deprecations.html#cached-setup>`__ on information on how to update your code.
 
 
 - `#4535 <https://github.com/pytest-dev/pytest/issues/4535>`_: Removed the deprecated ``PyCollector.makeitem`` method. This method was made public by mistake a long time ago.
@@ -2023,12 +2023,12 @@ Removals
 
 - `#4543 <https://github.com/pytest-dev/pytest/issues/4543>`_: Removed support to define fixtures using the ``pytest_funcarg__`` prefix. Use the ``@pytest.fixture`` decorator instead.
 
-  See our `docs <https://docs.pytest.org/en/latest/deprecations.html#pytest-funcarg-prefix>`__ on information on how to update your code.
+  See our `docs <https://docs.pytest.org/en/stable/deprecations.html#pytest-funcarg-prefix>`__ on information on how to update your code.
 
 
 - `#4545 <https://github.com/pytest-dev/pytest/issues/4545>`_: Calling fixtures directly is now always an error instead of a warning.
 
-  See our `docs <https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly>`__ on information on how to update your code.
+  See our `docs <https://docs.pytest.org/en/stable/deprecations.html#calling-fixtures-directly>`__ on information on how to update your code.
 
 
 - `#4546 <https://github.com/pytest-dev/pytest/issues/4546>`_: Remove ``Node.get_marker(name)`` the return value was not usable for more than a existence check.
@@ -2038,12 +2038,12 @@ Removals
 
 - `#4547 <https://github.com/pytest-dev/pytest/issues/4547>`_: The deprecated ``record_xml_property`` fixture has been removed, use the more generic ``record_property`` instead.
 
-  See our `docs <https://docs.pytest.org/en/latest/deprecations.html#record-xml-property>`__ for more information.
+  See our `docs <https://docs.pytest.org/en/stable/deprecations.html#record-xml-property>`__ for more information.
 
 
 - `#4548 <https://github.com/pytest-dev/pytest/issues/4548>`_: An error is now raised if the ``pytest_plugins`` variable is defined in a non-top-level ``conftest.py`` file (i.e., not residing in the ``rootdir``).
 
-  See our `docs <https://docs.pytest.org/en/latest/deprecations.html#pytest-plugins-in-non-top-level-conftest-files>`__ for more information.
+  See our `docs <https://docs.pytest.org/en/stable/deprecations.html#pytest-plugins-in-non-top-level-conftest-files>`__ for more information.
 
 
 - `#891 <https://github.com/pytest-dev/pytest/issues/891>`_: Remove ``testfunction.markername`` attributes - use ``Node.iter_markers(name=None)`` to iterate them.
@@ -2055,7 +2055,7 @@ Deprecations
 
 - `#3050 <https://github.com/pytest-dev/pytest/issues/3050>`_: Deprecated the ``pytest.config`` global.
 
-  See https://docs.pytest.org/en/latest/deprecations.html#pytest-config-global for rationale.
+  See https://docs.pytest.org/en/stable/deprecations.html#pytest-config-global for rationale.
 
 
 - `#3974 <https://github.com/pytest-dev/pytest/issues/3974>`_: Passing the ``message`` parameter of ``pytest.raises`` now issues a ``DeprecationWarning``.
@@ -2070,7 +2070,7 @@ Deprecations
 
 - `#4435 <https://github.com/pytest-dev/pytest/issues/4435>`_: Deprecated ``raises(..., 'code(as_a_string)')`` and ``warns(..., 'code(as_a_string)')``.
 
-  See https://docs.pytest.org/en/latest/deprecations.html#raises-warns-exec for rationale and examples.
+  See https://docs.pytest.org/en/stable/deprecations.html#raises-warns-exec for rationale and examples.
 
 
 
@@ -2264,7 +2264,7 @@ Removals
   instead of warning messages.
 
   **The affected features will be effectively removed in pytest 4.1**, so please consult the
-  `Deprecations and Removals <https://docs.pytest.org/en/latest/deprecations.html>`__
+  `Deprecations and Removals <https://docs.pytest.org/en/stable/deprecations.html>`__
   section in the docs for directions on how to update existing code.
 
   In the pytest ``4.0.X`` series, it is possible to change the errors back into warnings as a stop
@@ -2364,7 +2364,7 @@ Features
   existing ``pytest_enter_pdb`` hook.
 
 
-- `#4147 <https://github.com/pytest-dev/pytest/issues/4147>`_: Add ``--sw``, ``--stepwise`` as an alternative to ``--lf -x`` for stopping at the first failure, but starting the next test invocation from that test.  See `the documentation <https://docs.pytest.org/en/latest/cache.html#stepwise>`__ for more info.
+- `#4147 <https://github.com/pytest-dev/pytest/issues/4147>`_: Add ``--sw``, ``--stepwise`` as an alternative to ``--lf -x`` for stopping at the first failure, but starting the next test invocation from that test.  See `the documentation <https://docs.pytest.org/en/stable/cache.html#stepwise>`__ for more info.
 
 
 - `#4188 <https://github.com/pytest-dev/pytest/issues/4188>`_: Make ``--color`` emit colorful dots when not running in verbose mode. Earlier, it would only colorize the test-by-test output if ``--verbose`` was also passed.
@@ -2516,7 +2516,7 @@ Deprecations
     Users should just ``import pytest`` and access those objects using the ``pytest`` module.
 
   * ``request.cached_setup``, this was the precursor of the setup/teardown mechanism available to fixtures. You can
-    consult `funcarg comparison section in the docs <https://docs.pytest.org/en/latest/funcarg_compare.html>`_.
+    consult `funcarg comparison section in the docs <https://docs.pytest.org/en/stable/funcarg_compare.html>`_.
 
   * Using objects named ``"Class"`` as a way to customize the type of nodes that are collected in ``Collector``
     subclasses has been deprecated. Users instead should use ``pytest_collect_make_item`` to customize node types during
@@ -2729,7 +2729,7 @@ Bug Fixes
 Improved Documentation
 ----------------------
 
-- `#3996 <https://github.com/pytest-dev/pytest/issues/3996>`_: New `Deprecations and Removals <https://docs.pytest.org/en/latest/deprecations.html>`_ page shows all currently
+- `#3996 <https://github.com/pytest-dev/pytest/issues/3996>`_: New `Deprecations and Removals <https://docs.pytest.org/en/stable/deprecations.html>`_ page shows all currently
   deprecated features, the rationale to do so, and alternatives to update your code. It also list features removed
   from pytest in past major releases to help those with ancient pytest versions to upgrade.
 
@@ -2751,7 +2751,7 @@ Deprecations and Removals
 -------------------------
 
 - `#2452 <https://github.com/pytest-dev/pytest/issues/2452>`_: ``Config.warn`` and ``Node.warn`` have been
-  deprecated, see `<https://docs.pytest.org/en/latest/deprecations.html#config-warn-and-node-warn>`_ for rationale and
+  deprecated, see `<https://docs.pytest.org/en/stable/deprecations.html#config-warn-and-node-warn>`_ for rationale and
   examples.
 
 - `#3936 <https://github.com/pytest-dev/pytest/issues/3936>`_: ``@pytest.mark.filterwarnings`` second parameter is no longer regex-escaped,
@@ -2769,13 +2769,13 @@ Features
   the standard warnings filters to manage those warnings. This introduces ``PytestWarning``,
   ``PytestDeprecationWarning`` and ``RemovedInPytest4Warning`` warning types as part of the public API.
 
-  Consult `the documentation <https://docs.pytest.org/en/latest/warnings.html#internal-pytest-warnings>`__ for more info.
+  Consult `the documentation <https://docs.pytest.org/en/stable/warnings.html#internal-pytest-warnings>`__ for more info.
 
 
 - `#2908 <https://github.com/pytest-dev/pytest/issues/2908>`_: ``DeprecationWarning`` and ``PendingDeprecationWarning`` are now shown by default if no other warning filter is
   configured. This makes pytest more compliant with
   `PEP-0506 <https://www.python.org/dev/peps/pep-0565/#recommended-filter-settings-for-test-runners>`_. See
-  `the docs <https://docs.pytest.org/en/latest/warnings.html#deprecationwarning-and-pendingdeprecationwarning>`_ for
+  `the docs <https://docs.pytest.org/en/stable/warnings.html#deprecationwarning-and-pendingdeprecationwarning>`_ for
   more info.
 
 
@@ -2969,10 +2969,10 @@ pytest 3.7.0 (2018-07-30)
 Deprecations and Removals
 -------------------------
 
-- `#2639 <https://github.com/pytest-dev/pytest/issues/2639>`_: ``pytest_namespace`` has been `deprecated <https://docs.pytest.org/en/latest/deprecations.html#pytest-namespace>`_.
+- `#2639 <https://github.com/pytest-dev/pytest/issues/2639>`_: ``pytest_namespace`` has been `deprecated <https://docs.pytest.org/en/stable/deprecations.html#pytest-namespace>`_.
 
 
-- `#3661 <https://github.com/pytest-dev/pytest/issues/3661>`_: Calling a fixture function directly, as opposed to request them in a test function, now issues a ``RemovedInPytest4Warning``. See `the documentation for rationale and examples <https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly>`_.
+- `#3661 <https://github.com/pytest-dev/pytest/issues/3661>`_: Calling a fixture function directly, as opposed to request them in a test function, now issues a ``RemovedInPytest4Warning``. See `the documentation for rationale and examples <https://docs.pytest.org/en/stable/deprecations.html#calling-fixtures-directly>`_.
 
 
 
@@ -3196,9 +3196,9 @@ Features
   design. This introduces new ``Node.iter_markers(name)`` and
   ``Node.get_closest_marker(name)`` APIs. Users are **strongly encouraged** to
   read the `reasons for the revamp in the docs
-  <https://docs.pytest.org/en/latest/historical-notes.html#marker-revamp-and-iteration>`_,
+  <https://docs.pytest.org/en/stable/historical-notes.html#marker-revamp-and-iteration>`_,
   or jump over to details about `updating existing code to use the new APIs
-  <https://docs.pytest.org/en/latest/historical-notes.html#updating-code>`_.
+  <https://docs.pytest.org/en/stable/historical-notes.html#updating-code>`_.
   (`#3317 <https://github.com/pytest-dev/pytest/issues/3317>`_)
 
 - Now when ``@pytest.fixture`` is applied more than once to the same function a
@@ -3208,7 +3208,7 @@ Features
 
 - Support for Python 3.7's builtin ``breakpoint()`` method, see `Using the
   builtin breakpoint function
-  <https://docs.pytest.org/en/latest/usage.html#breakpoint-builtin>`_ for
+  <https://docs.pytest.org/en/stable/usage.html#breakpoint-builtin>`_ for
   details. (`#3180 <https://github.com/pytest-dev/pytest/issues/3180>`_)
 
 - ``monkeypatch`` now supports a ``context()`` function which acts as a context
@@ -3334,7 +3334,7 @@ Deprecations and Removals
   <https://github.com/pytest-dev/pytest/issues/2770>`_)
 
 - Defining ``pytest_plugins`` is now deprecated in non-top-level conftest.py
-  files, because they "leak" to the entire directory tree. `See the docs <https://docs.pytest.org/en/latest/deprecations.html#pytest-plugins-in-non-top-level-conftest-files>`_ for the rationale behind this decision (`#3084
+  files, because they "leak" to the entire directory tree. `See the docs <https://docs.pytest.org/en/stable/deprecations.html#pytest-plugins-in-non-top-level-conftest-files>`_ for the rationale behind this decision (`#3084
   <https://github.com/pytest-dev/pytest/issues/3084>`_)
 
 
@@ -3348,7 +3348,7 @@ Features
 
 - New ``--rootdir`` command-line option to override the rules for discovering
   the root directory. See `customize
-  <https://docs.pytest.org/en/latest/customize.html>`_ in the documentation for
+  <https://docs.pytest.org/en/stable/customize.html>`_ in the documentation for
   details. (`#1642 <https://github.com/pytest-dev/pytest/issues/1642>`_)
 
 - Fixtures are now instantiated based on their scopes, with higher-scoped
@@ -3435,7 +3435,7 @@ Bug Fixes
 Improved Documentation
 ----------------------
 
-- Added a `reference <https://docs.pytest.org/en/latest/reference.html>`_ page
+- Added a `reference <https://docs.pytest.org/en/stable/reference.html>`_ page
   to the docs. (`#1713 <https://github.com/pytest-dev/pytest/issues/1713>`_)
 
 
@@ -3595,9 +3595,9 @@ Features
   <https://github.com/pytest-dev/pytest/issues/2527>`_)
 
 - **Incompatible change**: after community feedback the `logging
-  <https://docs.pytest.org/en/latest/logging.html>`_ functionality has
+  <https://docs.pytest.org/en/stable/logging.html>`_ functionality has
   undergone some changes. Please consult the `logging documentation
-  <https://docs.pytest.org/en/latest/logging.html#incompatible-changes-in-pytest-3-4>`_
+  <https://docs.pytest.org/en/stable/logging.html#incompatible-changes-in-pytest-3-4>`_
   for details. (`#3013 <https://github.com/pytest-dev/pytest/issues/3013>`_)
 
 - Console output falls back to "classic" mode when capturing is disabled (``-s``),
@@ -3605,10 +3605,10 @@ Features
   <https://github.com/pytest-dev/pytest/issues/3038>`_)
 
 - New `pytest_runtest_logfinish
-  <https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_runtest_logfinish>`_
+  <https://docs.pytest.org/en/stable/reference.html#_pytest.hookspec.pytest_runtest_logfinish>`_
   hook which is called when a test item has finished executing, analogous to
   `pytest_runtest_logstart
-  <https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_runtest_logstart>`_.
+  <https://docs.pytest.org/en/stable/reference.html#_pytest.hookspec.pytest_runtest_logstart>`_.
   (`#3101 <https://github.com/pytest-dev/pytest/issues/3101>`_)
 
 - Improve performance when collecting tests using many fixtures. (`#3107
@@ -3850,7 +3850,7 @@ Features
   markers. Also, a ``caplog`` fixture is available that enables users to test
   the captured log during specific tests (similar to ``capsys`` for example).
   For more information, please see the `logging docs
-  <https://docs.pytest.org/en/latest/logging.html>`_. This feature was
+  <https://docs.pytest.org/en/stable/logging.html>`_. This feature was
   introduced by merging the popular `pytest-catchlog
   <https://pypi.org/project/pytest-catchlog/>`_ plugin, thanks to `Thomas Hisch
   <https://github.com/thisch>`_. Be advised that during the merging the
@@ -4146,7 +4146,7 @@ Deprecations and Removals
 
 - ``pytest.approx`` no longer supports ``>``, ``>=``, ``<`` and ``<=``
   operators to avoid surprising/inconsistent behavior. See `the approx docs
-  <https://docs.pytest.org/en/latest/reference.html#pytest-approx>`_ for more
+  <https://docs.pytest.org/en/stable/reference.html#pytest-approx>`_ for more
   information. (`#2003 <https://github.com/pytest-dev/pytest/issues/2003>`_)
 
 - All old-style specific behavior in current classes in the pytest's API is
@@ -4192,13 +4192,13 @@ Features
 - Introduce the ``PYTEST_CURRENT_TEST`` environment variable that is set with
   the ``nodeid`` and stage (``setup``, ``call`` and ``teardown``) of the test
   being currently executed. See the `documentation
-  <https://docs.pytest.org/en/latest/example/simple.html#pytest-current-test-
+  <https://docs.pytest.org/en/stable/example/simple.html#pytest-current-test-
   environment-variable>`_ for more info. (`#2583 <https://github.com/pytest-
   dev/pytest/issues/2583>`_)
 
 - Introduced ``@pytest.mark.filterwarnings`` mark which allows overwriting the
   warnings filter on a per test, class or module level. See the `docs
-  <https://docs.pytest.org/en/latest/warnings.html#pytest-mark-
+  <https://docs.pytest.org/en/stable/warnings.html#pytest-mark-
   filterwarnings>`_ for more information. (`#2598 <https://github.com/pytest-
   dev/pytest/issues/2598>`_)
 
@@ -4428,7 +4428,7 @@ New Features
       [pytest]
       addopts = -p no:warnings
 
-    See the `warnings documentation page <https://docs.pytest.org/en/latest/warnings.html>`_ for more
+    See the `warnings documentation page <https://docs.pytest.org/en/stable/warnings.html>`_ for more
     information.
 
   Thanks `@nicoddemus`_ for the PR.
@@ -5502,7 +5502,7 @@ time or change existing behaviors in order to make them less surprising/more use
 * Fix (`#1422`_): junit record_xml_property doesn't allow multiple records
   with same name.
 
-.. _`traceback style docs`: https://pytest.org/en/latest/usage.html#modifying-python-traceback-printing
+.. _`traceback style docs`: https://pytest.org/en/stable/usage.html#modifying-python-traceback-printing
 
 .. _#1609: https://github.com/pytest-dev/pytest/issues/1609
 .. _#1422: https://github.com/pytest-dev/pytest/issues/1422
@@ -6020,7 +6020,7 @@ time or change existing behaviors in order to make them less surprising/more use
 - add ability to set command line options by environment variable PYTEST_ADDOPTS.
 
 - added documentation on the new pytest-dev teams on bitbucket and
-  github.  See https://pytest.org/en/latest/contributing.html .
+  github.  See https://pytest.org/en/stable/contributing.html .
   Thanks to Anatoly for pushing and initial work on this.
 
 - fix issue650: new option ``--docttest-ignore-import-errors`` which
@@ -6761,7 +6761,7 @@ Bug fixes:
 - yielded test functions will now have autouse-fixtures active but
   cannot accept fixtures as funcargs - it's anyway recommended to
   rather use the post-2.0 parametrize features instead of yield, see:
-  http://pytest.org/en/latest/example/parametrize.html
+  http://pytest.org/en/stable/example/parametrize.html
 - fix autouse-issue where autouse-fixtures would not be discovered
   if defined in an a/conftest.py file and tests in a/tests/test_some.py
 - fix issue226 - LIFO ordering for fixture teardowns
@@ -6894,7 +6894,7 @@ Bug fixes:
 - pluginmanager.register(...) now raises ValueError if the
   plugin has been already registered or the name is taken
 
-- fix issue159: improve http://pytest.org/en/latest/faq.html
+- fix issue159: improve http://pytest.org/en/stable/faq.html
   especially with respect to the "magic" history, also mention
   pytest-django, trial and unittest integration.
 
@@ -7007,7 +7007,7 @@ Bug fixes:
   or through plugin hooks.  Also introduce a "--strict" option which
   will treat unregistered markers as errors
   allowing to avoid typos and maintain a well described set of markers
-  for your test suite.  See exaples at http://pytest.org/en/latest/mark.html
+  for your test suite.  See exaples at http://pytest.org/en/stable/mark.html
   and its links.
 - issue50: introduce "-m marker" option to select tests based on markers
   (this is a stricter and more predictable version of '-k' in that "-m"
@@ -7190,7 +7190,7 @@ Bug fixes:
 - refinements to "collecting" output on non-ttys
 - refine internal plugin registration and --traceconfig output
 - introduce a mechanism to prevent/unregister plugins from the
-  command line, see http://pytest.org/en/latest/plugins.html#cmdunregister
+  command line, see http://pytest.org/en/stable/plugins.html#cmdunregister
 - activate resultlog plugin by default
 - fix regression wrt yielded tests which due to the
   collection-before-running semantics were not

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -404,7 +404,7 @@ This should be updated to make use of standard fixture mechanisms:
         session.close()
 
 
-You can consult `funcarg comparison section in the docs <https://docs.pytest.org/en/latest/funcarg_compare.html>`_ for
+You can consult `funcarg comparison section in the docs <https://docs.pytest.org/en/stable/funcarg_compare.html>`_ for
 more information.
 
 

--- a/doc/en/example/markers.rst
+++ b/doc/en/example/markers.rst
@@ -224,17 +224,17 @@ You can ask which markers exist for your test suite - the list includes our just
     $ pytest --markers
     @pytest.mark.webtest: mark a test as a webtest.
 
-    @pytest.mark.filterwarnings(warning): add a warning filter to the given test. see https://docs.pytest.org/en/latest/warnings.html#pytest-mark-filterwarnings
+    @pytest.mark.filterwarnings(warning): add a warning filter to the given test. see https://docs.pytest.org/en/stable/warnings.html#pytest-mark-filterwarnings
 
     @pytest.mark.skip(reason=None): skip the given test function with an optional reason. Example: skip(reason="no way of currently testing this") skips the test.
 
-    @pytest.mark.skipif(condition): skip the given test function if eval(condition) results in a True value.  Evaluation happens within the module global context. Example: skipif('sys.platform == "win32"') skips the test if we are on the win32 platform. see https://docs.pytest.org/en/latest/skipping.html
+    @pytest.mark.skipif(condition): skip the given test function if eval(condition) results in a True value.  Evaluation happens within the module global context. Example: skipif('sys.platform == "win32"') skips the test if we are on the win32 platform. see https://docs.pytest.org/en/stable/skipping.html
 
-    @pytest.mark.xfail(condition, reason=None, run=True, raises=None, strict=False): mark the test function as an expected failure if eval(condition) has a True value. Optionally specify a reason for better reporting and run=False if you don't even want to execute the test function. If only specific exception(s) are expected, you can list them in raises, and if the test fails in other ways, it will be reported as a true failure. See https://docs.pytest.org/en/latest/skipping.html
+    @pytest.mark.xfail(condition, reason=None, run=True, raises=None, strict=False): mark the test function as an expected failure if eval(condition) has a True value. Optionally specify a reason for better reporting and run=False if you don't even want to execute the test function. If only specific exception(s) are expected, you can list them in raises, and if the test fails in other ways, it will be reported as a true failure. See https://docs.pytest.org/en/stable/skipping.html
 
-    @pytest.mark.parametrize(argnames, argvalues): call a test function multiple times passing in different arguments in turn. argvalues generally needs to be a list of values if argnames specifies only one name or a list of tuples of values if argnames specifies multiple names. Example: @parametrize('arg1', [1,2]) would lead to two calls of the decorated test function, one with arg1=1 and another with arg1=2.see https://docs.pytest.org/en/latest/parametrize.html for more info and examples.
+    @pytest.mark.parametrize(argnames, argvalues): call a test function multiple times passing in different arguments in turn. argvalues generally needs to be a list of values if argnames specifies only one name or a list of tuples of values if argnames specifies multiple names. Example: @parametrize('arg1', [1,2]) would lead to two calls of the decorated test function, one with arg1=1 and another with arg1=2.see https://docs.pytest.org/en/stable/parametrize.html for more info and examples.
 
-    @pytest.mark.usefixtures(fixturename1, fixturename2, ...): mark tests as needing all of the specified fixtures. see https://docs.pytest.org/en/latest/fixture.html#usefixtures
+    @pytest.mark.usefixtures(fixturename1, fixturename2, ...): mark tests as needing all of the specified fixtures. see https://docs.pytest.org/en/stable/fixture.html#usefixtures
 
     @pytest.mark.tryfirst: mark a hook implementation function such that the plugin machinery will try to call it first/as early as possible.
 
@@ -429,17 +429,17 @@ The ``--markers`` option always gives you a list of available markers:
     $ pytest --markers
     @pytest.mark.env(name): mark test to run only on named environment
 
-    @pytest.mark.filterwarnings(warning): add a warning filter to the given test. see https://docs.pytest.org/en/latest/warnings.html#pytest-mark-filterwarnings
+    @pytest.mark.filterwarnings(warning): add a warning filter to the given test. see https://docs.pytest.org/en/stable/warnings.html#pytest-mark-filterwarnings
 
     @pytest.mark.skip(reason=None): skip the given test function with an optional reason. Example: skip(reason="no way of currently testing this") skips the test.
 
-    @pytest.mark.skipif(condition): skip the given test function if eval(condition) results in a True value.  Evaluation happens within the module global context. Example: skipif('sys.platform == "win32"') skips the test if we are on the win32 platform. see https://docs.pytest.org/en/latest/skipping.html
+    @pytest.mark.skipif(condition): skip the given test function if eval(condition) results in a True value.  Evaluation happens within the module global context. Example: skipif('sys.platform == "win32"') skips the test if we are on the win32 platform. see https://docs.pytest.org/en/stable/skipping.html
 
-    @pytest.mark.xfail(condition, reason=None, run=True, raises=None, strict=False): mark the test function as an expected failure if eval(condition) has a True value. Optionally specify a reason for better reporting and run=False if you don't even want to execute the test function. If only specific exception(s) are expected, you can list them in raises, and if the test fails in other ways, it will be reported as a true failure. See https://docs.pytest.org/en/latest/skipping.html
+    @pytest.mark.xfail(condition, reason=None, run=True, raises=None, strict=False): mark the test function as an expected failure if eval(condition) has a True value. Optionally specify a reason for better reporting and run=False if you don't even want to execute the test function. If only specific exception(s) are expected, you can list them in raises, and if the test fails in other ways, it will be reported as a true failure. See https://docs.pytest.org/en/stable/skipping.html
 
-    @pytest.mark.parametrize(argnames, argvalues): call a test function multiple times passing in different arguments in turn. argvalues generally needs to be a list of values if argnames specifies only one name or a list of tuples of values if argnames specifies multiple names. Example: @parametrize('arg1', [1,2]) would lead to two calls of the decorated test function, one with arg1=1 and another with arg1=2.see https://docs.pytest.org/en/latest/parametrize.html for more info and examples.
+    @pytest.mark.parametrize(argnames, argvalues): call a test function multiple times passing in different arguments in turn. argvalues generally needs to be a list of values if argnames specifies only one name or a list of tuples of values if argnames specifies multiple names. Example: @parametrize('arg1', [1,2]) would lead to two calls of the decorated test function, one with arg1=1 and another with arg1=2.see https://docs.pytest.org/en/stable/parametrize.html for more info and examples.
 
-    @pytest.mark.usefixtures(fixturename1, fixturename2, ...): mark tests as needing all of the specified fixtures. see https://docs.pytest.org/en/latest/fixture.html#usefixtures
+    @pytest.mark.usefixtures(fixturename1, fixturename2, ...): mark tests as needing all of the specified fixtures. see https://docs.pytest.org/en/stable/fixture.html#usefixtures
 
     @pytest.mark.tryfirst: mark a hook implementation function such that the plugin machinery will try to call it first/as early as possible.
 

--- a/doc/en/flaky.rst
+++ b/doc/en/flaky.rst
@@ -28,7 +28,7 @@ Flaky tests sometimes appear when a test suite is run in parallel (such as use o
 Overly strict assertion
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Overly strict assertions can cause problems with floating point comparison as well as timing issues. `pytest.approx <https://docs.pytest.org/en/latest/reference.html#pytest-approx>`_ is useful here.
+Overly strict assertions can cause problems with floating point comparison as well as timing issues. `pytest.approx <https://docs.pytest.org/en/stable/reference.html#pytest-approx>`_ is useful here.
 
 
 Pytest features

--- a/doc/en/funcarg_compare.rst
+++ b/doc/en/funcarg_compare.rst
@@ -7,7 +7,7 @@ pytest-2.3: reasoning for fixture/funcarg evolution
 
 **Target audience**: Reading this document requires basic knowledge of
 python testing, xUnit setup methods and the (previous) basic pytest
-funcarg mechanism, see https://docs.pytest.org/en/latest/historical-notes.html#funcargs-and-pytest-funcarg.
+funcarg mechanism, see https://docs.pytest.org/en/stable/historical-notes.html#funcargs-and-pytest-funcarg.
 If you are new to pytest, then you can simply ignore this
 section and read the other sections.
 

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -207,7 +207,7 @@ This is outlined below:
 Request a unique temporary directory for functional tests
 --------------------------------------------------------------
 
-``pytest`` provides `Builtin fixtures/function arguments <https://docs.pytest.org/en/latest/builtin.html>`_ to request arbitrary resources, like a unique temporary directory:
+``pytest`` provides `Builtin fixtures/function arguments <https://docs.pytest.org/en/stable/builtin.html>`_ to request arbitrary resources, like a unique temporary directory:
 
 .. code-block:: python
 

--- a/doc/en/usage.rst
+++ b/doc/en/usage.rst
@@ -698,7 +698,7 @@ by the `PyPy-test`_ web page to show test results over several revisions.
 
     If you use this option, consider using the new `pytest-reportlog <https://github.com/pytest-dev/pytest-reportlog>`__ plugin instead.
 
-    See `the deprecation docs <https://docs.pytest.org/en/latest/deprecations.html#result-log-result-log>`__
+    See `the deprecation docs <https://docs.pytest.org/en/stable/deprecations.html#result-log-result-log>`__
     for more information.
 
 

--- a/doc/en/warnings.rst
+++ b/doc/en/warnings.rst
@@ -40,7 +40,7 @@ Running pytest now produces this output:
       $REGENDOC_TMPDIR/test_show_warnings.py:5: UserWarning: api v1, should use functions from v2
         warnings.warn(UserWarning("api v1, should use functions from v2"))
 
-    -- Docs: https://docs.pytest.org/en/latest/warnings.html
+    -- Docs: https://docs.pytest.org/en/stable/warnings.html
     ======================= 1 passed, 1 warning in 0.12s =======================
 
 The ``-W`` flag can be passed to control which warnings will be displayed or even turn
@@ -407,7 +407,7 @@ defines an ``__init__`` constructor, as this prevents the class from being insta
       $REGENDOC_TMPDIR/test_pytest_warnings.py:1: PytestCollectionWarning: cannot collect test class 'Test' because it has a __init__ constructor (from: test_pytest_warnings.py)
         class Test:
 
-    -- Docs: https://docs.pytest.org/en/latest/warnings.html
+    -- Docs: https://docs.pytest.org/en/stable/warnings.html
     1 warning in 0.12s
 
 These warnings might be filtered using the same builtin mechanisms used to filter other types of warnings.

--- a/doc/en/writing_plugins.rst
+++ b/doc/en/writing_plugins.rst
@@ -444,10 +444,10 @@ additionally it is possible to copy examples for an example folder before runnin
 
     test_example.py::test_plugin
       $PYTHON_PREFIX/lib/python3.8/site-packages/_pytest/compat.py:333: PytestDeprecationWarning: The TerminalReporter.writer attribute is deprecated, use TerminalReporter._tw instead at your own risk.
-      See https://docs.pytest.org/en/latest/deprecations.html#terminalreporter-writer for more information.
+      See https://docs.pytest.org/en/stable/deprecations.html#terminalreporter-writer for more information.
         return getattr(object, name, default)
 
-    -- Docs: https://docs.pytest.org/en/latest/warnings.html
+    -- Docs: https://docs.pytest.org/en/stable/warnings.html
     ====================== 2 passed, 2 warnings in 0.12s =======================
 
 For more information about the result object that ``runpytest()`` returns, and

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -42,7 +42,7 @@ which provides the `--lf` and `--ff` options, as well as the `cache` fixture.
 
 **Do not** commit this to version control.
 
-See [the docs](https://docs.pytest.org/en/latest/cache.html) for more information.
+See [the docs](https://docs.pytest.org/en/stable/cache.html) for more information.
 """
 
 CACHEDIR_TAG_CONTENT = b"""\

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -589,7 +589,7 @@ class PytestPluginManager(PluginManager):
                 "Please move it to a top level conftest file at the rootdir:\n"
                 "  {}\n"
                 "For more information, visit:\n"
-                "  https://docs.pytest.org/en/latest/deprecations.html#pytest-plugins-in-non-top-level-conftest-files"
+                "  https://docs.pytest.org/en/stable/deprecations.html#pytest-plugins-in-non-top-level-conftest-files"
             )
             fail(msg.format(conftestpath, self._confcutdir), pytrace=False)
 

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -32,7 +32,7 @@ FILLFUNCARGS = PytestDeprecationWarning(
 
 RESULT_LOG = PytestDeprecationWarning(
     "--result-log is deprecated, please try the new pytest-reportlog plugin.\n"
-    "See https://docs.pytest.org/en/latest/deprecations.html#result-log-result-log for more information."
+    "See https://docs.pytest.org/en/stable/deprecations.html#result-log-result-log for more information."
 )
 
 FIXTURE_POSITIONAL_ARGUMENTS = PytestDeprecationWarning(
@@ -44,13 +44,13 @@ NODE_USE_FROM_PARENT = UnformattedWarning(
     PytestDeprecationWarning,
     "Direct construction of {name} has been deprecated, please use {name}.from_parent.\n"
     "See "
-    "https://docs.pytest.org/en/latest/deprecations.html#node-construction-changed-to-node-from-parent"
+    "https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent"
     " for more details.",
 )
 
 JUNIT_XML_DEFAULT_FAMILY = PytestDeprecationWarning(
     "The 'junit_family' default value will change to 'xunit2' in pytest 6.0. See:\n"
-    "  https://docs.pytest.org/en/latest/deprecations.html#junit-family-default-value-change-to-xunit2\n"
+    "  https://docs.pytest.org/en/stable/deprecations.html#junit-family-default-value-change-to-xunit2\n"
     "for more information."
 )
 
@@ -68,7 +68,7 @@ PYTEST_COLLECT_MODULE = UnformattedWarning(
 
 TERMINALWRITER_WRITER = PytestDeprecationWarning(
     "The TerminalReporter.writer attribute is deprecated, use TerminalReporter._tw instead at your own risk.\n"
-    "See https://docs.pytest.org/en/latest/deprecations.html#terminalreporter-writer for more information."
+    "See https://docs.pytest.org/en/stable/deprecations.html#terminalreporter-writer for more information."
 )
 
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1148,8 +1148,8 @@ def wrap_function_to_error_out_if_called_directly(function, fixture_marker):
     message = (
         'Fixture "{name}" called directly. Fixtures are not meant to be called directly,\n'
         "but are created automatically when test functions request them as parameters.\n"
-        "See https://docs.pytest.org/en/latest/fixture.html for more information about fixtures, and\n"
-        "https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly about how to update your code."
+        "See https://docs.pytest.org/en/stable/fixture.html for more information about fixtures, and\n"
+        "https://docs.pytest.org/en/stable/deprecations.html#calling-fixtures-directly about how to update your code."
     ).format(name=fixture_marker.name or function.__name__)
 
     @functools.wraps(function)

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -507,7 +507,7 @@ class MarkGenerator:
                 warnings.warn(
                     "Unknown pytest.mark.%s - is this a typo?  You can register "
                     "custom marks to avoid this warning - for details, see "
-                    "https://docs.pytest.org/en/latest/mark.html" % name,
+                    "https://docs.pytest.org/en/stable/mark.html" % name,
                     PytestUnknownMarkWarning,
                     2,
                 )

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -143,14 +143,14 @@ def pytest_configure(config: Config) -> None:
         "or a list of tuples of values if argnames specifies multiple names. "
         "Example: @parametrize('arg1', [1,2]) would lead to two calls of the "
         "decorated test function, one with arg1=1 and another with arg1=2."
-        "see https://docs.pytest.org/en/latest/parametrize.html for more info "
+        "see https://docs.pytest.org/en/stable/parametrize.html for more info "
         "and examples.",
     )
     config.addinivalue_line(
         "markers",
         "usefixtures(fixturename1, fixturename2, ...): mark tests as needing "
         "all of the specified fixtures. see "
-        "https://docs.pytest.org/en/latest/fixture.html#usefixtures ",
+        "https://docs.pytest.org/en/stable/fixture.html#usefixtures ",
     )
 
 

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -958,7 +958,7 @@ class TerminalReporter:
                     message = message.rstrip()
                 self._tw.line(message)
                 self._tw.line()
-            self._tw.line("-- Docs: https://docs.pytest.org/en/latest/warnings.html")
+            self._tw.line("-- Docs: https://docs.pytest.org/en/stable/warnings.html")
 
     def summary_passes(self) -> None:
         if self.config.option.tbstyle != "no":

--- a/src/_pytest/warning_types.py
+++ b/src/_pytest/warning_types.py
@@ -78,7 +78,7 @@ class PytestUnhandledCoroutineWarning(PytestWarning):
 class PytestUnknownMarkWarning(PytestWarning):
     """Warning emitted on use of unknown markers.
 
-    See https://docs.pytest.org/en/latest/mark.html for details.
+    See https://docs.pytest.org/en/stable/mark.html for details.
     """
 
     __module__ = "pytest"

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -76,7 +76,7 @@ def pytest_configure(config: Config) -> None:
     config.addinivalue_line(
         "markers",
         "filterwarnings(warning): add a warning filter to the given test. "
-        "see https://docs.pytest.org/en/latest/warnings.html#pytest-mark-filterwarnings ",
+        "see https://docs.pytest.org/en/stable/warnings.html#pytest-mark-filterwarnings ",
     )
 
 

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -23,7 +23,7 @@ def test_resultlog_is_deprecated(testdir):
     result.stdout.fnmatch_lines(
         [
             "*--result-log is deprecated, please try the new pytest-reportlog plugin.",
-            "*See https://docs.pytest.org/en/latest/deprecations.html#result-log-result-log for more information*",
+            "*See https://docs.pytest.org/en/stable/deprecations.html#result-log-result-log for more information*",
         ]
     )
 

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -363,7 +363,7 @@ class TestPytestPluginManagerBootstrapming:
         self, pytestpm
     ):
         """ From PR #4304 : The only way to unregister a module is documented at
-        the end of https://docs.pytest.org/en/latest/plugins.html.
+        the end of https://docs.pytest.org/en/stable/plugins.html.
 
         When unregister cacheprovider, then unregister stepwise too
         """


### PR DESCRIPTION
Unfortunately couldn't figure out how to fix the generated link, so at least
for now remove it to avoid confusion.

While at it, In the 2nd commit I replaced all references from `pytest.org/en/latest` to `pytest.org/en/stable` given that now our `master` contains features for the next release. 

Fix #7331