### PR TITLE
Enable colours on GitHub Actions by default

### DIFF
--- a/changelog/7443.improvement.rst
+++ b/changelog/7443.improvement.rst
@@ -1,0 +1,1 @@
+Detect if running on GitHub Actions and enable colors by default.

--- a/src/_pytest/_io/terminalwriter.py
+++ b/src/_pytest/_io/terminalwriter.py
@@ -27,9 +27,11 @@ def should_do_markup(file: TextIO) -> bool:
         return True
     if os.environ.get("PY_COLORS") == "0":
         return False
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        return True
     return (
         hasattr(file, "isatty") and file.isatty() and os.environ.get("TERM") != "dumb"
-    ) or os.environ.get("GITHUB_ACTIONS") == "true"
+    )
 
 
 class TerminalWriter:

--- a/src/_pytest/_io/terminalwriter.py
+++ b/src/_pytest/_io/terminalwriter.py
@@ -32,7 +32,7 @@ def should_do_markup(file: TextIO) -> bool:
         and file.isatty()
         and os.environ.get("TERM") != "dumb"
         and not (sys.platform.startswith("java") and os._name == "nt")
-    )
+    ) or os.environ.get("GITHUB_ACTIONS") == "true"
 
 
 class TerminalWriter:

--- a/src/_pytest/_io/terminalwriter.py
+++ b/src/_pytest/_io/terminalwriter.py
@@ -28,10 +28,7 @@ def should_do_markup(file: TextIO) -> bool:
     if os.environ.get("PY_COLORS") == "0":
         return False
     return (
-        hasattr(file, "isatty")
-        and file.isatty()
-        and os.environ.get("TERM") != "dumb"
-        and not (sys.platform.startswith("java") and os._name == "nt")
+        hasattr(file, "isatty") and file.isatty() and os.environ.get("TERM") != "dumb"
     ) or os.environ.get("GITHUB_ACTIONS") == "true"
 
 

--- a/testing/io/test_terminalwriter.py
+++ b/testing/io/test_terminalwriter.py
@@ -177,6 +177,18 @@ def test_should_do_markup_PY_COLORS_eq_0(monkeypatch: MonkeyPatch) -> None:
     assert s == "hello\n"
 
 
+def test_should_do_markup_GITHUB_ACTIONS_eq_true(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setitem(os.environ, "GITHUB_ACTIONS", "true")
+    file = io.StringIO()
+    tw = terminalwriter.TerminalWriter(file)
+    assert tw.hasmarkup
+    tw.line("hello", bold=True)
+    s = file.getvalue()
+    assert len(s) > len("hello\n")
+    assert "\x1b[1m" in s
+    assert "\x1b[0m" in s
+
+
 class TestTerminalWriterLineWidth:
     def test_init(self) -> None:
         tw = terminalwriter.TerminalWriter()

--- a/testing/io/test_terminalwriter.py
+++ b/testing/io/test_terminalwriter.py
@@ -154,8 +154,7 @@ def test_attr_hasmarkup() -> None:
     assert "\x1b[0m" in s
 
 
-def test_should_do_markup_PY_COLORS_eq_1(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setitem(os.environ, "PY_COLORS", "1")
+def assert_color_set():
     file = io.StringIO()
     tw = terminalwriter.TerminalWriter(file)
     assert tw.hasmarkup
@@ -166,8 +165,7 @@ def test_should_do_markup_PY_COLORS_eq_1(monkeypatch: MonkeyPatch) -> None:
     assert "\x1b[0m" in s
 
 
-def test_should_do_markup_PY_COLORS_eq_0(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setitem(os.environ, "PY_COLORS", "0")
+def assert_color_not_set():
     f = io.StringIO()
     f.isatty = lambda: True  # type: ignore
     tw = terminalwriter.TerminalWriter(file=f)
@@ -177,16 +175,19 @@ def test_should_do_markup_PY_COLORS_eq_0(monkeypatch: MonkeyPatch) -> None:
     assert s == "hello\n"
 
 
+def test_should_do_markup_PY_COLORS_eq_1(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setitem(os.environ, "PY_COLORS", "1")
+    assert_color_set()
+
+
+def test_should_not_do_markup_PY_COLORS_eq_0(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setitem(os.environ, "PY_COLORS", "0")
+    assert_color_not_set()
+
+
 def test_should_do_markup_GITHUB_ACTIONS_eq_true(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setitem(os.environ, "GITHUB_ACTIONS", "true")
-    file = io.StringIO()
-    tw = terminalwriter.TerminalWriter(file)
-    assert tw.hasmarkup
-    tw.line("hello", bold=True)
-    s = file.getvalue()
-    assert len(s) > len("hello\n")
-    assert "\x1b[1m" in s
-    assert "\x1b[0m" in s
+    assert_color_set()
 
 
 class TestTerminalWriterLineWidth:


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
-->

Workaround to fix https://github.com/pytest-dev/pytest/issues/7443.

GitHub Actions doesn't provide a tty, so many tools that normally output in colour instead output in monochrome: https://github.com/actions/runner/issues/241.
 
GitHub say it's low in their backlog and they have no plans to fix it (https://github.com/actions/runner/issues/241#issuecomment-580480162), so instead of requiring every pytest user to explicitly force colours for pytest, improve the pytest colour detection using the `GITHUB_ACTIONS` env var:

> **`GITHUB_ACTIONS`** Always set to **`true`** when GitHub Actions is running the workflow. You can use this variable to differentiate when tests are being run locally or by GitHub Actions.

https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables

---

Test using this branch:

* https://github.com/hugovk/test/runs/848991439?check_suite_focus=true#step:5:11

![image](https://user-images.githubusercontent.com/1324225/86898304-35d55680-c111-11ea-9690-3ccdc67527c8.png)
