### PR TITLE
Create subdirectories if they do not exist when specified for log file

### DIFF
--- a/changelog/7467.improvement.rst
+++ b/changelog/7467.improvement.rst
@@ -1,1 +1,1 @@
-``--log-file`` CLI option and ``log_file`` ini marker now creates subdirectories if specified.
+``--log-file`` CLI option and ``log_file`` ini marker now create subdirectories if needed.

--- a/changelog/7467.improvement.rst
+++ b/changelog/7467.improvement.rst
@@ -1,0 +1,1 @@
+``--log-file`` CLI option and ``log_file`` ini marker now creates subdirectories if specified.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -531,11 +531,17 @@ class LoggingPlugin:
         # File logging.
         self.log_file_level = get_log_level_for_setting(config, "log_file_level")
         log_file = get_option_ini(config, "log_file") or os.devnull
+        if log_file != os.devnull:
+            directory = os.path.dirname(os.path.abspath(log_file))
+            if not os.path.isdir(directory):
+                os.makedirs(directory)
+
         self.log_file_handler = _FileHandler(log_file, mode="w", encoding="UTF-8")
         log_file_format = get_option_ini(config, "log_file_format", "log_format")
         log_file_date_format = get_option_ini(
             config, "log_file_date_format", "log_date_format"
         )
+
         log_file_formatter = logging.Formatter(
             log_file_format, datefmt=log_file_date_format
         )

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1157,7 +1157,7 @@ def test_logging_emit_error_supressed(testdir: Testdir) -> None:
 
 def test_log_file_cli_subdirectories_are_successfully_created(testdir):
     path = testdir.makepyfile(""" def test_logger(): pass """)
-    expected = os.path.join(os.path.dirname(path), "foo", "bar")
+    expected = os.path.join(os.path.dirname(str(path)), "foo", "bar")
     result = testdir.runpytest("--log-file=foo/bar/logf.log")
     assert "logf.log" in os.listdir(expected)
     assert result.ret == ExitCode.OK

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1161,39 +1161,3 @@ def test_log_file_cli_subdirectories_are_successfully_created(testdir):
     result = testdir.runpytest("--log-file=foo/bar/logf.log")
     assert "logf.log" in os.listdir(expected)
     assert result.ret == ExitCode.OK
-
-
-def test_log_file_cli_no_subdirectories_works_ok(testdir):
-    path = testdir.makepyfile(""" def test_logger(): pass """)
-    expected = os.path.join(os.path.dirname(path))
-    result = testdir.runpytest("--log-file=logf.log")
-    assert "logf.log" in os.listdir(expected)
-    assert result.ret == ExitCode.OK
-
-
-def test_log_file_marker_subdirectories_are_successfully_created(testdir):
-    path = testdir.makeini(
-        """
-        [pytest]
-        log_file = sub/logf.log
-        """,
-    )
-    testdir.makepyfile(""" def test_logger(): pass """)
-    expected = os.path.join(os.path.dirname(path), "sub")
-    result = testdir.runpytest()
-    assert "logf.log" in os.listdir(expected)
-    assert result.ret == ExitCode.OK
-
-
-def test_log_file_marker_no_subdirectories_works_ok(testdir):
-    path = testdir.makeini(
-        """
-        [pytest]
-        log_file = logf.log
-        """,
-    )
-    testdir.makepyfile(""" def test_logger(): pass """)
-    expected = os.path.join(os.path.dirname(path))
-    result = testdir.runpytest()
-    assert "logf.log" in os.listdir(expected)
-    assert result.ret == ExitCode.OK

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -5,6 +5,7 @@ from typing import cast
 
 import pytest
 from _pytest.capture import CaptureManager
+from _pytest.config import ExitCode
 from _pytest.pytester import Testdir
 from _pytest.terminal import TerminalReporter
 
@@ -1152,3 +1153,46 @@ def test_logging_emit_error_supressed(testdir: Testdir) -> None:
     )
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)
+
+
+def test_log_file_cli_subdirectories_are_successfully_created(testdir):
+    path = testdir.makepyfile(""" def test_logger(): pass """)
+    expected = os.path.join(os.path.dirname(path), "foo", "bar")
+    result = testdir.runpytest("--log-file=foo/bar/logf.log")
+    assert "logf.log" in os.listdir(expected)
+    assert result.ret == ExitCode.OK
+
+
+def test_log_file_cli_no_subdirectories_works_ok(testdir):
+    path = testdir.makepyfile(""" def test_logger(): pass """)
+    expected = os.path.join(os.path.dirname(path))
+    result = testdir.runpytest("--log-file=logf.log")
+    assert "logf.log" in os.listdir(expected)
+    assert result.ret == ExitCode.OK
+
+
+def test_log_file_marker_subdirectories_are_successfully_created(testdir):
+    path = testdir.makeini(
+        """
+        [pytest]
+        log_file = sub/logf.log
+        """,
+    )
+    expected = os.path.join(os.path.dirname(path), "sub")
+    result = testdir.runpytest()
+    assert "logf.log" in os.listdir(expected)
+    assert result.ret == ExitCode.OK
+
+
+def test_log_file_marker_no_subdirectories_works_ok(testdir):
+    path = testdir.makeini(
+        """
+        [pytest]
+        log_file = logf.log
+        """,
+    )
+    testdir.makepyfile(""" def test_logger(): pass """)
+    expected = os.path.join(os.path.dirname(path))
+    result = testdir.runpytest()
+    assert "logf.log" in os.listdir(expected)
+    assert result.ret == ExitCode.OK

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1178,6 +1178,7 @@ def test_log_file_marker_subdirectories_are_successfully_created(testdir):
         log_file = sub/logf.log
         """,
     )
+    testdir.makepyfile(""" def test_logger(): pass """)
     expected = os.path.join(os.path.dirname(path), "sub")
     result = testdir.runpytest()
     assert "logf.log" in os.listdir(expected)


### PR DESCRIPTION
Creates subdirectories if they do not exist for both --log-file and appropriate log_file ini marker for the log file.

closes #7467 

