### PR TITLE
mark/structure: fix pylint complaining that builtin marks are not callable

### DIFF
--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -4,6 +4,7 @@ import typing
 import warnings
 from typing import Any
 from typing import Callable
+from typing import cast
 from typing import Iterable
 from typing import List
 from typing import Mapping
@@ -467,12 +468,14 @@ class MarkGenerator:
 
     # See TYPE_CHECKING above.
     if TYPE_CHECKING:
-        skip = None  # type: _SkipMarkDecorator
-        skipif = None  # type: _SkipifMarkDecorator
-        xfail = None  # type: _XfailMarkDecorator
-        parametrize = None  # type: _ParametrizeMarkDecorator
-        usefixtures = None  # type: _UsefixturesMarkDecorator
-        filterwarnings = None  # type: _FilterwarningsMarkDecorator
+        # Using casts instead of type comments intentionally - issue #7473.
+        # TODO(py36): Change to builtin annotation syntax.
+        skip = cast(_SkipMarkDecorator, None)
+        skipif = cast(_SkipifMarkDecorator, None)
+        xfail = cast(_XfailMarkDecorator, None)
+        parametrize = cast(_ParametrizeMarkDecorator, None)
+        usefixtures = cast(_UsefixturesMarkDecorator, None)
+        filterwarnings = cast(_FilterwarningsMarkDecorator, None)
 
     def __getattr__(self, name: str) -> MarkDecorator:
         if name[0] == "_":


### PR DESCRIPTION
This fixes #7473.

It seems that pylint doesn't understand TYPE_CHECKING and/or the type comments, and thinks `parametrize` and friends are `None`, and then complains that they are not callable.

The solution is a little uglier but seems to do the trick. On Python 3.6 we can use the nice syntax, which I also tested and will work.