### PR TITLE
Feature/raises clearer guidance

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -164,6 +164,7 @@ Kyle Altendorf
 Lawrence Mitchell
 Lee Kamentsky
 Lev Maximov
+Lewis Cowles
 Llandy Riveron Del Risco
 Loic Esteve
 Lukas Bednar

--- a/changelog/7489.improvement.rst
+++ b/changelog/7489.improvement.rst
@@ -1,0 +1,1 @@
+The :func:`pytest.raises` function has a clearer error message when ``match`` matches the obtained string but is not regex-escaped.

--- a/changelog/7489.improvement.rst
+++ b/changelog/7489.improvement.rst
@@ -1,1 +1,1 @@
-The :func:`pytest.raises` function has a clearer error message when ``match`` matches the obtained string but is not regex-escaped.
+The :func:`pytest.raises` function has a clearer error message when ``match`` equals the obtained string but is not a regex match. In this case it is suggested to escape the regex.

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -609,9 +609,11 @@ class ExceptionInfo(Generic[_E]):
         If it matches `True` is returned, otherwise an `AssertionError` is raised.
         """
         __tracebackhide__ = True
-        assert re.search(
-            regexp, str(self.value)
-        ), "Pattern {!r} does not match {!r}".format(regexp, str(self.value))
+        regextest = re.search(regexp, str(self.value))
+        msg = "Regex pattern {!r} does not match {!r}."
+        if regexp == str(self.value):
+            msg += " Did you mean to `re.escape()` the regex?"
+        assert regextest, msg.format(regexp, str(self.value))
         # Return True to allow for "assert excinfo.match()".
         return True
 

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -609,11 +609,10 @@ class ExceptionInfo(Generic[_E]):
         If it matches `True` is returned, otherwise an `AssertionError` is raised.
         """
         __tracebackhide__ = True
-        regextest = re.search(regexp, str(self.value))
         msg = "Regex pattern {!r} does not match {!r}."
         if regexp == str(self.value):
             msg += " Did you mean to `re.escape()` the regex?"
-        assert regextest, msg.format(regexp, str(self.value))
+        assert re.search(regexp, str(self.value)), msg.format(regexp, str(self.value))
         # Return True to allow for "assert excinfo.match()".
         return True
 

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -423,7 +423,7 @@ def test_match_raises_error(testdir):
     result = testdir.runpytest()
     assert result.ret != 0
 
-    exc_msg = "Pattern '[[]123[]]+' does not match 'division by zero'"
+    exc_msg = "Regex pattern '[[]123[]]+' does not match 'division by zero'."
     result.stdout.fnmatch_lines(["E * AssertionError: {}".format(exc_msg)])
     result.stdout.no_fnmatch_line("*__tracebackhide__ = True*")
 

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -197,7 +197,7 @@ class TestRaises:
             int("asdf")
 
         msg = "with base 16"
-        expr = "Pattern {!r} does not match \"invalid literal for int() with base 10: 'asdf'\"".format(
+        expr = "Regex pattern {!r} does not match \"invalid literal for int() with base 10: 'asdf'\".".format(
             msg
         )
         with pytest.raises(AssertionError, match=re.escape(expr)):
@@ -223,7 +223,19 @@ class TestRaises:
             with pytest.raises(AssertionError, match="'foo"):
                 raise AssertionError("'bar")
         (msg,) = excinfo.value.args
-        assert msg == 'Pattern "\'foo" does not match "\'bar"'
+        assert msg == 'Regex pattern "\'foo" does not match "\'bar".'
+
+    def test_match_failure_exact_string_message(self):
+        message = "Oh here is a message with (42) numbers in parameters"
+        with pytest.raises(AssertionError) as excinfo:
+            with pytest.raises(AssertionError, match=message):
+                raise AssertionError(message)
+        (msg,) = excinfo.value.args
+        assert msg == (
+            "Regex pattern 'Oh here is a message with (42) numbers in "
+            "parameters' does not match 'Oh here is a message with (42) "
+            "numbers in parameters'. Did you mean to `re.escape()` the regex?"
+        )
 
     def test_raises_match_wrong_type(self):
         """Raising an exception with the wrong type and match= given.


### PR DESCRIPTION
- [ ] ~Include documentation when adding new features.~
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Fixes #7489 

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. (pending)
- [x] Add yourself to `AUTHORS` in alphabetical order. (pending)

I need to work out the `did you mean` part. I see an example, but it seems to use `mark`. I did make my own version of the assertion, which fulfilled enough of a change to make me happy outside of pytest using `__tracebackhide__ = True` with a patched `contextlib` to avoid the class.

Is some of the boilerplate for legacy python versions?