### PR TITLE
Inaccessible lock files now imply temporary directories can't be removed

### DIFF
--- a/changelog/7491.bugfix.rst
+++ b/changelog/7491.bugfix.rst
@@ -1,0 +1,2 @@
+:fixture:`tmpdir` and :fixture:`tmp_path` no longer raise an error if the lock to check for
+stale temporary directories is not accessible.

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -286,7 +286,7 @@ def maybe_delete_a_numbered_dir(path: Path) -> None:
 
 
 def ensure_deletable(path: Path, consider_lock_dead_if_created_before: float) -> bool:
-    """checks if `path` is deletable based if the lock file is expired"""
+    """checks if `path` is deletable based on whether the lock file is expired"""
     if path.is_symlink():
         return False
     lock = get_lock_path(path)

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -365,16 +365,18 @@ def test_suppress_error_removing_lock(tmp_path):
     lock.touch()
     mtime = lock.stat().st_mtime
 
-    with unittest.mock.patch.object(Path, "unlink", side_effect=OSError):
+    with unittest.mock.patch.object(Path, "unlink", side_effect=OSError) as m:
         assert not ensure_deletable(
             path, consider_lock_dead_if_created_before=mtime + 30
         )
+        assert m.call_count == 1
     assert lock.is_file()
 
-    with unittest.mock.patch.object(Path, "is_file", side_effect=OSError):
+    with unittest.mock.patch.object(Path, "is_file", side_effect=OSError) as m:
         assert not ensure_deletable(
             path, consider_lock_dead_if_created_before=mtime + 30
         )
+        assert m.call_count == 1
     assert lock.is_file()
 
     # check now that we can remove the lock file in normal circumstances

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -358,7 +358,7 @@ def test_get_extended_length_path_str():
 
 
 def test_suppress_error_removing_lock(tmp_path):
-    """ensure_deletable should not be resilient if lock file cannot be removed (#5456, #7491)"""
+    """ensure_deletable should be resilient if lock file cannot be removed (#5456, #7491)"""
     path = tmp_path / "dir"
     path.mkdir()
     lock = get_lock_path(path)


### PR DESCRIPTION
Fix #7491
