### PR TITLE
docs: support Sphinx>=3.1 and require it

### DIFF
--- a/doc/en/goodpractices.rst
+++ b/doc/en/goodpractices.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: python
+.. highlight:: python
 .. _`goodpractices`:
 
 Good Integration Practices

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -138,7 +138,7 @@ pytest.mark.parametrize
 
 **Tutorial**: :doc:`parametrize`.
 
-.. automethod:: _pytest.python.Metafunc.parametrize
+This mark has the same signature as :py:meth:`_pytest.python.Metafunc.parametrize`; see there.
 
 
 .. _`pytest.mark.skip ref`:

--- a/doc/en/requirements.txt
+++ b/doc/en/requirements.txt
@@ -1,5 +1,5 @@
 pallets-sphinx-themes
 pygments-pytest>=1.1.0
 sphinx-removed-in>=0.2.0
-sphinx>=1.8.2,<2.1
+sphinx>=3.1,<4
 sphinxcontrib-trio


### PR DESCRIPTION
Previously was restricted to >=1.8.2,<2.1, but newer versions have some nice improvements I'd like to be able to use in upcoming changes.

Changelog: https://www.sphinx-doc.org/en/master/changes.html#release-3-1-0-released-jun-08-2020

There are two issues that came up:

1. `highlightlang` is deprecated for `highlight`.

2. Doesn't like having two `automethod` generated for the same `Metafunc.parametrize` method. Gives this warning:

   `pytest/doc/en/reference.rst:846: WARNING: duplicate object description of _pytest.python.Metafunc.parametrize, other instance in reference, use :noindex: for one of them`

   To work around this I make `pytest.mark.parametrize` link to `Metafunc.parametrize` instead of repeating it.