### PR TITLE
docs: Add a note about -q option used in getting started guide

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -81,6 +81,7 @@ David Paul Röthlisberger
 David Szotten
 David Vierra
 Daw-Ran Liou
+Debi Mishra
 Denis Kirisov
 Dhiren Serai
 Diego Russo

--- a/changelog/7441.doc.rst
+++ b/changelog/7441.doc.rst
@@ -1,0 +1,1 @@
+Add a note about ``-q`` option used in getting started guide.

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -112,6 +112,10 @@ Execute the test function with “quiet” reporting mode:
     .                                                                    [100%]
     1 passed in 0.12s
 
+.. note::
+
+    The ``-q/--quiet`` flag keeps the output brief in this and following examples.
+
 Group multiple tests in a class
 --------------------------------------------------------------
 


### PR DESCRIPTION
Closes #7441 . Updated documentation to add a note about usage of `-q`in getting started guide as mentioned in the issue. Please review and let me know if anything is needed to be changed. Thank you.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
