### PR TITLE
doc: note about mutation of parametrized values

### DIFF
--- a/doc/en/parametrize.rst
+++ b/doc/en/parametrize.rst
@@ -83,7 +83,7 @@ them in turn:
 
     Parameter values are passed as-is to tests (no copy whatsoever).
 
-    For example, if you pass a list or a dict as a parameter value, and 
+    For example, if you pass a list or a dict as a parameter value, and
     the test case code mutates it, the mutations will be reflected in subsequent
     test case calls.
 

--- a/doc/en/parametrize.rst
+++ b/doc/en/parametrize.rst
@@ -81,7 +81,8 @@ them in turn:
 
 .. note::
 
-    Parameter values are passed as-is to tests (no copy whatsoever), so if you mutate them,
+    Parameter values are passed as-is to tests (no copy whatsoever).
+    For example, if you pass a list or a dict as a parameter value, and mutate it,
     the mutations will be reflected in subsequent test case calls.
 
 .. note::

--- a/doc/en/parametrize.rst
+++ b/doc/en/parametrize.rst
@@ -81,23 +81,25 @@ them in turn:
 
 .. note::
 
-    1. Parameter values are passed as-is to tests (no copy whatsoever), so if you mutate them,
-       the mutations will be reflected in subsequent test case calls.
+    Parameter values are passed as-is to tests (no copy whatsoever), so if you mutate them,
+    the mutations will be reflected in subsequent test case calls.
 
-    2. pytest by default escapes any non-ascii characters used in unicode strings
-       for the parametrization because it has several downsides.
-       If however you would like to use unicode strings in parametrization
-       and see them in the terminal as is (non-escaped), use this option
-       in your ``pytest.ini``:
+.. note::
 
-       .. code-block:: ini
+    pytest by default escapes any non-ascii characters used in unicode strings
+    for the parametrization because it has several downsides.
+    If however you would like to use unicode strings in parametrization
+    and see them in the terminal as is (non-escaped), use this option
+    in your ``pytest.ini``:
 
-           [pytest]
-           disable_test_id_escaping_and_forfeit_all_rights_to_community_support = True
+    .. code-block:: ini
 
-       Keep in mind however that this might cause unwanted side effects and
-       even bugs depending on the OS used and plugins currently installed,
-       so use it at your own risk.
+        [pytest]
+        disable_test_id_escaping_and_forfeit_all_rights_to_community_support = True
+
+    Keep in mind however that this might cause unwanted side effects and
+    even bugs depending on the OS used and plugins currently installed,
+    so use it at your own risk.
 
 
 As designed in this example, only one pair of input/output values fails

--- a/doc/en/parametrize.rst
+++ b/doc/en/parametrize.rst
@@ -82,8 +82,10 @@ them in turn:
 .. note::
 
     Parameter values are passed as-is to tests (no copy whatsoever).
-    For example, if you pass a list or a dict as a parameter value, and mutate it,
-    the mutations will be reflected in subsequent test case calls.
+
+    For example, if you pass a list or a dict as a parameter value, and 
+    the test case code mutates it, the mutations will be reflected in subsequent
+    test case calls.
 
 .. note::
 

--- a/doc/en/parametrize.rst
+++ b/doc/en/parametrize.rst
@@ -81,17 +81,26 @@ them in turn:
 
 .. note::
 
-    pytest by default escapes any non-ascii characters used in unicode strings
-    for the parametrization because it has several downsides.
-    If however you would like to use unicode strings in parametrization and see them in the terminal as is (non-escaped), use this option in your ``pytest.ini``:
-
-    .. code-block:: ini
-
-        [pytest]
-        disable_test_id_escaping_and_forfeit_all_rights_to_community_support = True
-
-    Keep in mind however that this might cause unwanted side effects and
-    even bugs depending on the OS used and plugins currently installed, so use it at your own risk.
+    1. Paramater values are passed as-is to tests, and if you mutate them,
+       the mutations will be reflected in subsequent test case calls.
+   
+       Specifically, pytest doesn't do any copying of the values, since that would
+       put constraints on the possible parametrizable values, cause unexpected behaviour
+       due to broken copy/deepcopy, degrade performance, etc.
+   
+    2. pytest by default escapes any non-ascii characters used in unicode strings
+       for the parametrization because it has several downsides.
+       If however you would like to use unicode strings in parametrization
+       and see them in the terminal as is (non-escaped), use this option
+       in your ``pytest.ini``:
+   
+       .. code-block:: ini
+   
+           [pytest]
+           disable_test_id_escaping_and_forfeit_all_rights_to_community_support = True
+   
+       Keep in mind however that this might cause unwanted side effects and
+       even bugs depending on the OS used and plugins currently installed, so use it at your own risk.
 
 
 As designed in this example, only one pair of input/output values fails

--- a/doc/en/parametrize.rst
+++ b/doc/en/parametrize.rst
@@ -81,26 +81,27 @@ them in turn:
 
 .. note::
 
-    1. Paramater values are passed as-is to tests, and if you mutate them,
+    1. Parameter values are passed as-is to tests, and if you mutate them,
        the mutations will be reflected in subsequent test case calls.
-   
+
        Specifically, pytest doesn't do any copying of the values, since that would
        put constraints on the possible parametrizable values, cause unexpected behaviour
        due to broken copy/deepcopy, degrade performance, etc.
-   
+
     2. pytest by default escapes any non-ascii characters used in unicode strings
        for the parametrization because it has several downsides.
        If however you would like to use unicode strings in parametrization
        and see them in the terminal as is (non-escaped), use this option
        in your ``pytest.ini``:
-   
+
        .. code-block:: ini
-   
+
            [pytest]
            disable_test_id_escaping_and_forfeit_all_rights_to_community_support = True
-   
+
        Keep in mind however that this might cause unwanted side effects and
-       even bugs depending on the OS used and plugins currently installed, so use it at your own risk.
+       even bugs depending on the OS used and plugins currently installed,
+       so use it at your own risk.
 
 
 As designed in this example, only one pair of input/output values fails

--- a/doc/en/parametrize.rst
+++ b/doc/en/parametrize.rst
@@ -81,12 +81,8 @@ them in turn:
 
 .. note::
 
-    1. Parameter values are passed as-is to tests, and if you mutate them,
+    1. Parameter values are passed as-is to tests (no copy whatsoever), so if you mutate them,
        the mutations will be reflected in subsequent test case calls.
-
-       Specifically, pytest doesn't do any copying of the values, since that would
-       put constraints on the possible parametrizable values, cause unexpected behaviour
-       due to broken copy/deepcopy, degrade performance, etc.
 
     2. pytest by default escapes any non-ascii characters used in unicode strings
        for the parametrization because it has several downsides.


### PR DESCRIPTION
Fix #7514 by augmenting Note with behaviour when parametrized values are mutated
(changes are reflected in subsequent test-case calls).

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
