### PR TITLE
testing: use a tighter check if `bash` is available

### DIFF
--- a/testing/test_parseopt.py
+++ b/testing/test_parseopt.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 import shlex
-import shutil
+import subprocess
 import sys
 
 import py
@@ -288,8 +288,19 @@ class TestParser:
 
 
 def test_argcomplete(testdir, monkeypatch) -> None:
-    if not shutil.which("bash"):
-        pytest.skip("bash not available")
+    try:
+        bash_version = subprocess.run(
+            ["bash", "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        ).stdout
+    except OSError:
+        pytest.skip("bash is not available")
+    if "GNU bash" not in bash_version:
+        # See #7518.
+        pytest.skip("not a real bash")
+
     script = str(testdir.tmpdir.join("test_argcomplete"))
 
     with open(str(script), "w") as fp:


### PR DESCRIPTION
Fixes #7518.

This fixes CI on Windows since GitHub Actions started installing WSL on their images which apparently installs some wrapper `bash` which does not run actual bash.