### PR TITLE
Preserve newlines when captured with capfd

### DIFF
--- a/changelog/7517.bugfix.rst
+++ b/changelog/7517.bugfix.rst
@@ -1,0 +1,1 @@
+Preserve line endings when captured via ``capfd``.

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -388,6 +388,7 @@ class FDCaptureBinary:
                 TemporaryFile(buffering=0),  # type: ignore[arg-type]
                 encoding="utf-8",
                 errors="replace",
+                newline="",
                 write_through=True,
             )
             if targetfd in patchsysdict:

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -514,6 +514,12 @@ class TestCaptureFixture:
         )
         reprec.assertoutcome(passed=1)
 
+    @pytest.mark.parametrize("nl", ("\n", "\r\n", "\r"))
+    def test_cafd_preserves_newlines(self, capfd, nl):
+        print("test", end=nl)
+        out, err = capfd.readouterr()
+        assert out.endswith(nl)
+
     def test_capfdbinary(self, testdir):
         reprec = testdir.inline_runsource(
             """\


### PR DESCRIPTION
Resolves #7517