### PR TITLE
Fix "A xfail" typo

### DIFF
--- a/doc/en/skipping.rst
+++ b/doc/en/skipping.rst
@@ -14,7 +14,7 @@ otherwise pytest should skip running the test altogether. Common examples are sk
 windows-only tests on non-windows platforms, or skipping tests that depend on an external
 resource which is not available at the moment (for example a database).
 
-A **xfail** means that you expect a test to fail for some reason.
+An **xfail** means that you expect a test to fail for some reason.
 A common example is a test for a feature not yet implemented, or a bug not yet fixed.
 When a test passes despite being expected to fail (marked with ``pytest.mark.xfail``),
 it's an **xpass** and will be reported in the test summary.


### PR DESCRIPTION
* Change from "A xfail" to "An xfail".

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
