### PR TITLE
Make --strict imply both strictness options

### DIFF
--- a/changelog/7503.breaking.rst
+++ b/changelog/7503.breaking.rst
@@ -1,0 +1,1 @@
+The ``--strict`` flag now implies both ``--strict-markers`` (added as recommended alternative for ``--strict`` in pytest 4.5.0) and ``--strict-config`` (new in this release).

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -1463,9 +1463,8 @@ passed multiple times. The expected format is ``name=value``. For example::
             serial
 
     .. note::
-        The use of ``--strict-markers`` is highly preferred. ``--strict`` was kept for
-        backward compatibility only and may be confusing for others as it only applies to
-        markers and not to other options.
+        The ``--strict`` argument implies both ``--strict-markers`` and
+        ``--strict-config``.
 
 .. confval:: minversion
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1180,7 +1180,7 @@ class Config:
             )
 
     def _warn_or_fail_if_strict(self, message: str) -> None:
-        if self.known_args_namespace.strict_config:
+        if self.known_args_namespace.strict_config or self.known_args_namespace.strict:
             fail(message, pytrace=False)
 
         from _pytest.warnings import _issue_warning_captured

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -84,9 +84,13 @@ def pytest_addoption(parser: Parser) -> None:
     )
     group._addoption(
         "--strict-markers",
-        "--strict",
         action="store_true",
         help="markers not registered in the `markers` section of the configuration file raise errors.",
+    )
+    group._addoption(
+        "--strict",
+        action="store_true",
+        help="turn on strictness flags (--strict-config and --strict-markers).",
     )
     group._addoption(
         "-c",

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -501,7 +501,7 @@ class MarkGenerator:
             # If the name is not in the set of known marks after updating,
             # then it really is time to issue a warning or an error.
             if name not in self._markers:
-                if self._config.option.strict_markers:
+                if self._config.option.strict_markers or self._config.option.strict:
                     fail(
                         "{!r} not found in `markers` configuration option".format(name),
                         pytrace=False,

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -225,8 +225,15 @@ class TestParseIni:
             ),
         ],
     )
+    @pytest.mark.parametrize("option_name", ["--strict", "--strict-config"])
     def test_invalid_ini_keys(
-        self, testdir, ini_file_text, invalid_keys, warning_output, exception_text
+        self,
+        testdir,
+        ini_file_text,
+        invalid_keys,
+        warning_output,
+        exception_text,
+        option_name,
     ):
         testdir.makeconftest(
             """
@@ -244,9 +251,9 @@ class TestParseIni:
 
         if exception_text:
             with pytest.raises(pytest.fail.Exception, match=exception_text):
-                testdir.runpytest("--strict-config")
+                testdir.runpytest(option_name)
         else:
-            testdir.runpytest("--strict-config")
+            testdir.runpytest(option_name)
 
     @pytest.mark.parametrize(
         "ini_file_text, exception_text",


### PR DESCRIPTION
RFC for #7503. It looks like there was a consensus that this is the right thing to do, but not on whether this can still go to pytest 6 in such a late stage or should wait for pytest 7.

IMHO it's fine to have in pytest 6 since we already documented this possibility in the changelog for pytest 4.5.0 (*"The existing --strict option has the same behavior currently, but can be augmented in the future for additional checks."*) and discouraged it in the documentation (*The use of ``--strict-markers`` is highly preferred. ``--strict`` was kept for backward compatibility only and may be confusing for others as it only applies to markers and not to other options.*)

Let me know what you think.