### PR TITLE
Revert change to traceback repr

### DIFF
--- a/changelog/7534.bugfix.rst
+++ b/changelog/7534.bugfix.rst
@@ -1,0 +1,1 @@
+Restored the previous formatting of ``TracebackEntry.__str__`` which was changed by accident.

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -262,7 +262,12 @@ class TracebackEntry:
             raise
         except BaseException:
             line = "???"
-        return "  File %r:%d in %s\n  %s\n" % (self.path, self.lineno + 1, name, line)
+        return "  File %r:%d in %s\n  %s\n" % (
+            str(self.path),
+            self.lineno + 1,
+            name,
+            line,
+        )
 
     @property
     def name(self) -> str:

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -262,7 +262,10 @@ class TracebackEntry:
             raise
         except BaseException:
             line = "???"
-        return "  File '%s':%d in %s\n  %s\n" % (
+        # This output does not quite match Python's repr for traceback entries,
+        # but changing it to do so would break certain plugins.  See
+        # https://github.com/pytest-dev/pytest/pull/7535/ for details.
+        return "  File %r:%d in %s\n  %s\n" % (
             str(self.path),
             self.lineno + 1,
             name,

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -262,7 +262,7 @@ class TracebackEntry:
             raise
         except BaseException:
             line = "???"
-        return "  File %r:%d in %s\n  %s\n" % (
+        return "  File '%s':%d in %s\n  %s\n" % (
             str(self.path),
             self.lineno + 1,
             name,

--- a/testing/code/test_code.py
+++ b/testing/code/test_code.py
@@ -176,12 +176,9 @@ class TestTracebackEntry:
             assert False
         except AssertionError:
             exci = ExceptionInfo.from_current()
-        entry = exci.traceback[0]
-        s = str(entry)
-        print(repr(s))
-        assert re.match(
-            r"  File '.*test_code.py':\d+ in test_tb_entry_str\n  assert False", s
-        )
+        pattern = r"  File '.*test_code.py':\d+ in test_tb_entry_str\n  assert False"
+        entry = str(exci.traceback[0])
+        assert re.match(pattern, entry)
 
 
 class TestReprFuncArgs:

--- a/testing/code/test_code.py
+++ b/testing/code/test_code.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from types import FrameType
 from unittest import mock
@@ -169,6 +170,18 @@ class TestTracebackEntry:
         assert source is not None
         assert len(source) == 6
         assert "assert False" in source[5]
+
+    def test_tb_entry_str(self):
+        try:
+            assert False
+        except AssertionError:
+            exci = ExceptionInfo.from_current()
+        entry = exci.traceback[0]
+        s = str(entry)
+        print(repr(s))
+        assert re.match(
+            r"  File '.*test_code.py':\d+ in test_tb_entry_str\n  assert False", s
+        )
 
 
 class TestReprFuncArgs:


### PR DESCRIPTION
This PR ammends #7274, undoing an incidental change to the output string and therefore fixes #7534.

cc @nicoddemus @hroncok 