### PR TITLE
junitxml: convert from py.xml to xml.etree.ElementTree

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,9 +70,11 @@ repos:
                 _code\.|
                 builtin\.|
                 code\.|
-                io\.(BytesIO|saferepr|TerminalWriter)|
+                io\.|
                 path\.local\.sysfind|
                 process\.|
-                std\.
+                std\.|
+                error\.|
+                xml\.
             )
         types: [python]

--- a/changelog/7536.trivial.rst
+++ b/changelog/7536.trivial.rst
@@ -1,0 +1,3 @@
+The internal ``junitxml`` plugin has rewritten to use ``xml.etree.ElementTree``.
+The order of attributes in XML elements might differ. Some unneeded escaping is
+no longer performed.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -68,8 +68,6 @@ del _legal_chars
 del _legal_ranges
 del _legal_xml_re
 
-_py_ext_re = re.compile(r"\.py$")
-
 
 def bin_xml_escape(arg: object) -> py.xml.raw:
     def repl(matchobj: Match[str]) -> str:
@@ -473,7 +471,7 @@ def mangle_test_address(address: str) -> List[str]:
         pass
     # convert file path to dotted path
     names[0] = names[0].replace(nodes.SEP, ".")
-    names[0] = _py_ext_re.sub("", names[0])
+    names[0] = re.sub(r"\.py$", "", names[0])
     # put any params back
     names[-1] += possible_open_bracket + params
     return names

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -323,8 +323,9 @@ class TestPython:
         node = dom.find_first_by_tag("testsuite")
         node.assert_attr(errors=1, failures=1, tests=1)
         first, second = dom.find_by_tag("testcase")
-        if not first or not second or first == second:
-            assert 0
+        assert first
+        assert second
+        assert first != second
         fnode = first.find_first_by_tag("failure")
         fnode.assert_attr(message="Exception: Call Exception")
         snode = second.find_first_by_tag("error")
@@ -535,7 +536,7 @@ class TestPython:
         node = dom.find_first_by_tag("testsuite")
         tnode = node.find_first_by_tag("testcase")
         fnode = tnode.find_first_by_tag("failure")
-        fnode.assert_attr(message="AssertionError: An error assert 0")
+        fnode.assert_attr(message="AssertionError: An error\nassert 0")
 
     @parametrize_families
     def test_failure_escape(self, testdir, run_and_parse, xunit_family):
@@ -995,14 +996,14 @@ def test_invalid_xml_escape():
     # 0xD, 0xD7FF, 0xE000, 0xFFFD, 0x10000, 0x10FFFF)
 
     for i in invalid:
-        got = bin_xml_escape(chr(i)).uniobj
+        got = bin_xml_escape(chr(i))
         if i <= 0xFF:
             expected = "#x%02X" % i
         else:
             expected = "#x%04X" % i
         assert got == expected
     for i in valid:
-        assert chr(i) == bin_xml_escape(chr(i)).uniobj
+        assert chr(i) == bin_xml_escape(chr(i))
 
 
 def test_logxml_path_expansion(tmpdir, monkeypatch):


### PR DESCRIPTION
This PR has a couple preparatory commits and then the conversion.

Part of the effort to reduce dependency on the py library.

Besides that, py.xml implements its own XML serialization which is pretty scary.

I tried to keep the code with minimal changes (though it could use some cleanups). The differences in behavior I have noticed are:

- Attributes in the output are not sorted.

- Some unneeded escaping is no longer performed, for example escaping `"` to `&quot;` in a text node.

Fixes #4970.
Fixes #1218.
Refs #7259.