### PR TITLE
Warn about --basetemp removing the entire directory

### DIFF
--- a/doc/en/tmpdir.rst
+++ b/doc/en/tmpdir.rst
@@ -192,7 +192,7 @@ You can override the default temporary directory setting like this:
 
     pytest --basetemp=mydir
 
-**Warning**: The contents of ``mydir`` will be deleted.
+.. warning:: The contents of ``mydir`` will be deleted.
 When distributing tests on the local machine, ``pytest`` takes care to
 configure a basetemp directory for the sub processes such that all temporary
 data lands below a single per-test run basetemp directory.

--- a/doc/en/tmpdir.rst
+++ b/doc/en/tmpdir.rst
@@ -192,9 +192,13 @@ You can override the default temporary directory setting like this:
 
     pytest --basetemp=mydir
 
-.. warning:: The contents of ``mydir`` will be deleted.
-When distributing tests on the local machine, ``pytest`` takes care to
-configure a basetemp directory for the sub processes such that all temporary
+.. warning:: 
+    
+    The contents of ``mydir`` will be completely removed, so make sure to use a directory
+    for that purpose only.
+    
+When distributing tests on the local machine using ``pytest-xdist``, care is taken to
+automatically configure a basetemp directory for the sub processes such that all temporary
 data lands below a single per-test run basetemp directory.
 
 .. _`py.path.local`: https://py.readthedocs.io/en/latest/path.html

--- a/doc/en/tmpdir.rst
+++ b/doc/en/tmpdir.rst
@@ -192,11 +192,11 @@ You can override the default temporary directory setting like this:
 
     pytest --basetemp=mydir
 
-.. warning:: 
-    
+.. warning::
+
     The contents of ``mydir`` will be completely removed, so make sure to use a directory
     for that purpose only.
-    
+
 When distributing tests on the local machine using ``pytest-xdist``, care is taken to
 automatically configure a basetemp directory for the sub processes such that all temporary
 data lands below a single per-test run basetemp directory.

--- a/doc/en/tmpdir.rst
+++ b/doc/en/tmpdir.rst
@@ -192,6 +192,7 @@ You can override the default temporary directory setting like this:
 
     pytest --basetemp=mydir
 
+**Warning**: The contents of ``mydir`` will be deleted.
 When distributing tests on the local machine, ``pytest`` takes care to
 configure a basetemp directory for the sub processes such that all temporary
 data lands below a single per-test run basetemp directory.


### PR DESCRIPTION
Added warning about deletion of data in the documentation of the base temporary directory

Fix #7554