### PR TITLE
Update text and links in announce templates

### DIFF
--- a/scripts/release.minor.rst
+++ b/scripts/release.minor.rst
@@ -3,23 +3,20 @@ pytest-{version}
 
 The pytest team is proud to announce the {version} release!
 
-pytest is a mature Python testing tool with more than a 2000 tests
-against itself, passing on many different interpreters and platforms.
+This release contains new features, improvements, bug fixes, and breaking changes, so users
+are encouraged to take a look at the CHANGELOG carefully:
 
-This release contains a number of bug fixes and improvements, so users are encouraged
-to take a look at the CHANGELOG:
-
-    https://docs.pytest.org/en/latest/changelog.html
+    https://docs.pytest.org/en/stable/changelog.html
 
 For complete documentation, please visit:
 
-    https://docs.pytest.org/en/latest/
+    https://docs.pytest.org/en/stable/
 
 As usual, you can upgrade from PyPI via:
 
     pip install -U pytest
 
-Thanks to all who contributed to this release, among them:
+Thanks to all of the contributors to this release:
 
 {contributors}
 

--- a/scripts/release.patch.rst
+++ b/scripts/release.patch.rst
@@ -7,9 +7,9 @@ This is a bug-fix release, being a drop-in replacement. To upgrade::
 
   pip install --upgrade pytest
 
-The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 
-Thanks to all who contributed to this release, among them:
+Thanks to all of the contributors to this release:
 
 {contributors}
 


### PR DESCRIPTION
The links were still pointing to the latest version (instead of stable) and also took the opportunity to update the text a bit.
