### PR TITLE
Fix TestReport.longreprtext when TestReport.longrepr is not a string

### DIFF
--- a/changelog/7559.bugfix.rst
+++ b/changelog/7559.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression in plugins using ``TestReport.longreprtext`` (such as ``pytest-html``) when ``TestReport.longrepr`` is not a string.

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -82,9 +82,10 @@ class BaseReport:
             longrepr.toterminal(out)
         else:
             try:
-                out.line(longrepr)
+                s = str(longrepr)
             except UnicodeEncodeError:
-                out.line("<unprintable longrepr>")
+                s = "<unprintable longrepr>"
+            out.line(s)
 
     def get_sections(self, prefix: str) -> Iterator[Tuple[str, str]]:
         for name, content in self.sections:

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -951,6 +951,33 @@ class TestReportContents:
         rep = reports[1]
         assert rep.longreprtext == ""
 
+    def test_longreprtext_skip(self, testdir) -> None:
+        """TestReport.longreprtext can handle non-str ``longrepr`` attributes (#7559)"""
+        reports = testdir.runitem(
+            """
+            import pytest
+            def test_func():
+                pytest.skip()
+            """
+        )
+        _, call_rep, _ = reports
+        assert isinstance(call_rep.longrepr, tuple)
+        assert "Skipped" in call_rep.longreprtext
+
+    def test_longreprtext_collect_skip(self, testdir) -> None:
+        """CollectReport.longreprtext can handle non-str ``longrepr`` attributes (#7559)"""
+        testdir.makepyfile(
+            """
+            import pytest
+            pytest.skip(allow_module_level=True)
+            """
+        )
+        rec = testdir.inline_run()
+        calls = rec.getcalls("pytest_collectreport")
+        _, call = calls
+        assert isinstance(call.report.longrepr, tuple)
+        assert "Skipped" in call.report.longreprtext
+
     def test_longreprtext_failure(self, testdir) -> None:
         reports = testdir.runitem(
             """


### PR DESCRIPTION
Fix #7559 