### PR TITLE
mark: fix extraneous spaces in dummy type-checking marks

### DIFF
--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -476,9 +476,9 @@ class MarkGenerator:
         skip = _SkipMarkDecorator(Mark("skip", (), {}))
         skipif = _SkipifMarkDecorator(Mark("skipif", (), {}))
         xfail = _XfailMarkDecorator(Mark("xfail", (), {}))
-        parametrize = _ParametrizeMarkDecorator(Mark("parametrize ", (), {}))
-        usefixtures = _UsefixturesMarkDecorator(Mark("usefixtures ", (), {}))
-        filterwarnings = _FilterwarningsMarkDecorator(Mark("filterwarnings ", (), {}))
+        parametrize = _ParametrizeMarkDecorator(Mark("parametrize", (), {}))
+        usefixtures = _UsefixturesMarkDecorator(Mark("usefixtures", (), {}))
+        filterwarnings = _FilterwarningsMarkDecorator(Mark("filterwarnings", (), {}))
 
     def __getattr__(self, name: str) -> MarkDecorator:
         if name[0] == "_":


### PR DESCRIPTION
Fixup to #7565 found after merge by @graingert.