### PR TITLE
Improve output for missing config keys

### DIFF
--- a/changelog/7572.improvement.rst
+++ b/changelog/7572.improvement.rst
@@ -1,1 +1,1 @@
-When a plugin listed in ``required_plugins`` is missing, a simple error message is now shown instead of a stacktrace.
+When a plugin listed in ``required_plugins`` is missing or an unknown config key is used with ``--strict-config``, a simple error message is now shown instead of a stacktrace.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1252,7 +1252,7 @@ class Config:
 
     def _warn_or_fail_if_strict(self, message: str) -> None:
         if self.known_args_namespace.strict_config:
-            fail(message, pytrace=False)
+            raise UsageError(message)
 
         self.issue_config_time_warning(PytestConfigWarning(message), stacklevel=3)
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -258,8 +258,10 @@ class TestParseIni:
         result.stdout.fnmatch_lines(warning_output)
 
         if exception_text:
-            result = testdir.runpytest("--strict-config")
-            result.stdout.fnmatch_lines("INTERNALERROR>*" + exception_text)
+            with pytest.raises(pytest.UsageError, match=exception_text):
+                testdir.runpytest("--strict-config")
+        else:
+            testdir.runpytest("--strict-config")
 
     @pytest.mark.filterwarnings("default")
     def test_silence_unknown_key_warning(self, testdir: Testdir) -> None:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -181,12 +181,12 @@ class TestParseIni:
     @pytest.mark.parametrize(
         "ini_file_text, invalid_keys, warning_output, exception_text",
         [
-            (
+            pytest.param(
                 """
-          [pytest]
-          unknown_ini = value1
-          another_unknown_ini = value2
-          """,
+                [pytest]
+                unknown_ini = value1
+                another_unknown_ini = value2
+                """,
                 ["unknown_ini", "another_unknown_ini"],
                 [
                     "=*= warnings summary =*=",
@@ -194,48 +194,53 @@ class TestParseIni:
                     "*PytestConfigWarning:*Unknown config option: unknown_ini",
                 ],
                 "Unknown config option: another_unknown_ini",
+                id="2-unknowns",
             ),
-            (
+            pytest.param(
                 """
-          [pytest]
-          unknown_ini = value1
-          minversion = 5.0.0
-          """,
+                [pytest]
+                unknown_ini = value1
+                minversion = 5.0.0
+                """,
                 ["unknown_ini"],
                 [
                     "=*= warnings summary =*=",
                     "*PytestConfigWarning:*Unknown config option: unknown_ini",
                 ],
                 "Unknown config option: unknown_ini",
+                id="1-unknown",
             ),
-            (
+            pytest.param(
                 """
-          [some_other_header]
-          unknown_ini = value1
-          [pytest]
-          minversion = 5.0.0
-          """,
+                [some_other_header]
+                unknown_ini = value1
+                [pytest]
+                minversion = 5.0.0
+                """,
                 [],
                 [],
                 "",
+                id="unknown-in-other-header",
             ),
-            (
+            pytest.param(
                 """
-          [pytest]
-          minversion = 5.0.0
-          """,
+                [pytest]
+                minversion = 5.0.0
+                """,
                 [],
                 [],
                 "",
+                id="no-unknowns",
             ),
-            (
+            pytest.param(
                 """
-          [pytest]
-          conftest_ini_key = 1
-          """,
+                [pytest]
+                conftest_ini_key = 1
+                """,
                 [],
                 [],
                 "",
+                id="1-known",
             ),
         ],
     )


### PR DESCRIPTION
Before:

```
Traceback (most recent call last):
  File "./.tox/py38/bin/pytest", line 33, in <module>
    sys.exit(load_entry_point('pytest', 'console_scripts', 'pytest')())
  File "/home/florian/proj/pytest/src/_pytest/config/__init__.py", line 180, in console_main
    code = main()
  File "/home/florian/proj/pytest/src/_pytest/config/__init__.py", line 136, in main
    config = _prepareconfig(args, plugins)
  File "/home/florian/proj/pytest/src/_pytest/config/__init__.py", line 313, in _prepareconfig
    config = pluginmanager.hook.pytest_cmdline_parse(
  File "/home/florian/proj/qutebrowser/git/.tox/py38/lib/python3.8/site-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/home/florian/proj/qutebrowser/git/.tox/py38/lib/python3.8/site-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/home/florian/proj/qutebrowser/git/.tox/py38/lib/python3.8/site-packages/pluggy/manager.py", line 84, in <lambda>
    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
  File "/home/florian/proj/qutebrowser/git/.tox/py38/lib/python3.8/site-packages/pluggy/callers.py", line 203, in _multicall
    gen.send(outcome)
  File "/home/florian/proj/pytest/src/_pytest/helpconfig.py", line 99, in pytest_cmdline_parse
    config = outcome.get_result()  # type: Config
  File "/home/florian/proj/qutebrowser/git/.tox/py38/lib/python3.8/site-packages/pluggy/callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/home/florian/proj/qutebrowser/git/.tox/py38/lib/python3.8/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/home/florian/proj/pytest/src/_pytest/config/__init__.py", line 932, in pytest_cmdline_parse
    self.parse(args)
  File "/home/florian/proj/pytest/src/_pytest/config/__init__.py", line 1204, in parse
    self._preparse(args, addopts=addopts)
  File "/home/florian/proj/pytest/src/_pytest/config/__init__.py", line 1102, in _preparse
    self._validate_plugins()
  File "/home/florian/proj/pytest/src/_pytest/config/__init__.py", line 1177, in _validate_plugins
    fail(
  File "/home/florian/proj/pytest/src/_pytest/outcomes.py", line 156, in fail
    raise Failed(msg=msg, pytrace=pytrace)
Failed: Missing required plugins: pytest-bdd
```

after:

```
ERROR: Missing required plugins: pytest-bdd
```

(in red)