### PR TITLE
Prepare release 6.0.1

### DIFF
--- a/changelog/7394.bugfix.rst
+++ b/changelog/7394.bugfix.rst
@@ -1,2 +1,0 @@
-Passing an empty ``help`` value to ``Parser.add_option`` is now accepted instead of crashing when running ``pytest --help``.
-Passing ``None`` raises a more informative ``TypeError``.

--- a/changelog/7558.bugfix.rst
+++ b/changelog/7558.bugfix.rst
@@ -1,2 +1,0 @@
-Fix pylint ``not-callable`` lint on ``pytest.mark.parametrize()`` and the other builtin marks:
-``skip``, ``skipif``, ``xfail``, ``usefixtures``, ``filterwarnings``.

--- a/changelog/7559.bugfix.rst
+++ b/changelog/7559.bugfix.rst
@@ -1,1 +1,0 @@
-Fix regression in plugins using ``TestReport.longreprtext`` (such as ``pytest-html``) when ``TestReport.longrepr`` is not a string.

--- a/changelog/7569.bugfix.rst
+++ b/changelog/7569.bugfix.rst
@@ -1,1 +1,0 @@
-Fix logging capture handler's level not reset on teardown after a call to ``caplog.set_level()``.

--- a/doc/en/announce/index.rst
+++ b/doc/en/announce/index.rst
@@ -6,6 +6,7 @@ Release announcements
    :maxdepth: 2
 
 
+   release-6.0.1
    release-6.0.0
    release-6.0.0rc1
    release-5.4.3

--- a/doc/en/announce/release-6.0.1.rst
+++ b/doc/en/announce/release-6.0.1.rst
@@ -1,0 +1,21 @@
+pytest-6.0.1
+=======================================
+
+pytest 6.0.1 has just been released to PyPI.
+
+This is a bug-fix release, being a drop-in replacement. To upgrade::
+
+  pip install --upgrade pytest
+
+The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+
+Thanks to all who contributed to this release, among them:
+
+* Bruno Oliveira
+* Mattreex
+* Ran Benita
+* hp310780
+
+
+Happy testing,
+The pytest Development Team

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -28,6 +28,26 @@ with advance notice in the **Deprecations** section of releases.
 
 .. towncrier release notes start
 
+pytest 6.0.1 (2020-07-30)
+=========================
+
+Bug Fixes
+---------
+
+- `#7394 <https://github.com/pytest-dev/pytest/issues/7394>`_: Passing an empty ``help`` value to ``Parser.add_option`` is now accepted instead of crashing when running ``pytest --help``.
+  Passing ``None`` raises a more informative ``TypeError``.
+
+
+- `#7558 <https://github.com/pytest-dev/pytest/issues/7558>`_: Fix pylint ``not-callable`` lint on ``pytest.mark.parametrize()`` and the other builtin marks:
+  ``skip``, ``skipif``, ``xfail``, ``usefixtures``, ``filterwarnings``.
+
+
+- `#7559 <https://github.com/pytest-dev/pytest/issues/7559>`_: Fix regression in plugins using ``TestReport.longreprtext`` (such as ``pytest-html``) when ``TestReport.longrepr`` is not a string.
+
+
+- `#7569 <https://github.com/pytest-dev/pytest/issues/7569>`_: Fix logging capture handler's level not reset on teardown after a call to ``caplog.set_level()``.
+
+
 pytest 6.0.0 (2020-07-28)
 =========================
 

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -28,7 +28,7 @@ Install ``pytest``
 .. code-block:: bash
 
     $ pytest --version
-    pytest 6.0.0
+    pytest 6.0.1
 
 .. _`simpletest`:
 


### PR DESCRIPTION
Created automatically from https://github.com/pytest-dev/pytest/issues/7583.

Once all builds pass and it has been **approved** by one or more maintainers, the build
can be released by pushing a tag `6.0.1` to this repository.
