### PR TITLE
Stop using more-itertools

### DIFF
--- a/changelog/7587.trivial.rst
+++ b/changelog/7587.trivial.rst
@@ -1,0 +1,1 @@
+The dependency on the ``more-itertools`` package has been removed.

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ packages =
 install_requires =
     attrs>=17.4.0
     iniconfig
-    more-itertools>=4.0.0
     packaging
     pluggy>=0.12,<1.0
     py>=1.8.2

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1,6 +1,5 @@
 import functools
 import inspect
-import itertools
 import sys
 import warnings
 from collections import defaultdict
@@ -1489,10 +1488,10 @@ class FixtureManager:
         else:
             argnames = ()
 
-        usefixtures = itertools.chain.from_iterable(
-            mark.args for mark in node.iter_markers(name="usefixtures")
+        usefixtures = tuple(
+            arg for mark in node.iter_markers(name="usefixtures") for arg in mark.args
         )
-        initialnames = tuple(usefixtures) + argnames
+        initialnames = usefixtures + argnames
         fm = node.session._fixturemanager
         initialnames, names_closure, arg2fixturedefs = fm.getfixtureclosure(
             initialnames, node, ignore_args=self._get_direct_parametrize_args(node)

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -25,7 +25,6 @@ from typing import Union
 import attr
 import pluggy
 import py
-from more_itertools import collapse
 
 import pytest
 from _pytest import nodes
@@ -715,11 +714,14 @@ class TerminalReporter:
             self._write_report_lines_from_hooks(lines)
 
     def _write_report_lines_from_hooks(
-        self, lines: List[Union[str, List[str]]]
+        self, lines: Sequence[Union[str, Sequence[str]]]
     ) -> None:
-        lines.reverse()
-        for line in collapse(lines):
-            self.write_line(line)
+        for line_or_lines in reversed(lines):
+            if isinstance(line_or_lines, str):
+                self.write_line(line_or_lines)
+            else:
+                for line in line_or_lines:
+                    self.write_line(line)
 
     def pytest_report_header(self, config: Config) -> List[str]:
         line = "rootdir: %s" % config.rootdir

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -283,3 +283,22 @@ class TestRaises:
             with pytest.raises(Exception, foo="bar"):  # type: ignore[call-overload]
                 pass
         assert "Unexpected keyword arguments" in str(excinfo.value)
+
+    def test_expected_exception_is_not_a_baseexception(self) -> None:
+        with pytest.raises(TypeError) as excinfo:
+            with pytest.raises("hello"):  # type: ignore[call-overload]
+                pass  # pragma: no cover
+        assert "must be a BaseException type, not str" in str(excinfo.value)
+
+        class NotAnException:
+            pass
+
+        with pytest.raises(TypeError) as excinfo:
+            with pytest.raises(NotAnException):  # type: ignore[type-var]
+                pass  # pragma: no cover
+        assert "must be a BaseException type, not NotAnException" in str(excinfo.value)
+
+        with pytest.raises(TypeError) as excinfo:
+            with pytest.raises(("hello", NotAnException)):  # type: ignore[arg-type]
+                pass  # pragma: no cover
+        assert "must be a BaseException type, not str" in str(excinfo.value)


### PR DESCRIPTION
We barely use it; the couple places that do are not really worth the extra dependency, I think the code is clearer without it.

Also simplifies one (regular) itertools usage.

Also improves a check and an error message in `pytest.raises`.