### PR TITLE
Configure setuptools_scm using pyproject.toml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,12 @@
+version: 2
+
+python:
+   version: 3.7
+   install:
+      - requirements: doc/en/requirements.txt
+      - method: pip
+        path: .
+
+formats:
+  - epub
+  - pdf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,13 @@
 requires = [
   # sync with setup.py until we discard non-pep-517/518
   "setuptools>=40.0",
-  "setuptools-scm",
+  "setuptools-scm>=3.4",
   "wheel",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "src/_pytest/_version.py"
 
 [tool.pytest.ini_options]
 minversion = "2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   # sync with setup.py until we discard non-pep-517/518
   "setuptools>=42.0",
-  "setuptools-scm>=3.4",
+  "setuptools-scm[toml]>=3.4",
   "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
   # sync with setup.py until we discard non-pep-517/518
-  "setuptools>=40.0",
+  "setuptools>=42.0",
   "setuptools-scm>=3.4",
   "wheel",
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,4 @@
 from setuptools import setup
 
-
-def main():
-    setup(use_scm_version={"write_to": "src/_pytest/_version.py"})
-
-
 if __name__ == "__main__":
-    main()
+    setup()


### PR DESCRIPTION
@RonnyPfannschmidt locally this doesn't seem to work, `pip list` says `pytest 0.0.0` is installed after running `pip install -e .`. Any hints?