### PR TITLE
typing: resultlog, pytester, longrepr

### DIFF
--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -25,6 +25,7 @@ from _pytest import deprecated
 from _pytest import nodes
 from _pytest import timing
 from _pytest._code.code import ExceptionRepr
+from _pytest._code.code import ReprFileLocation
 from _pytest.config import Config
 from _pytest.config import filename_arg
 from _pytest.config.argparsing import Parser
@@ -200,8 +201,11 @@ class _NodeReporter:
             self._add_simple("skipped", "xfail-marked test passes unexpectedly")
         else:
             assert report.longrepr is not None
-            if getattr(report.longrepr, "reprcrash", None) is not None:
-                message = report.longrepr.reprcrash.message
+            reprcrash = getattr(
+                report.longrepr, "reprcrash", None
+            )  # type: Optional[ReprFileLocation]
+            if reprcrash is not None:
+                message = reprcrash.message
             else:
                 message = str(report.longrepr)
             message = bin_xml_escape(message)
@@ -217,8 +221,11 @@ class _NodeReporter:
 
     def append_error(self, report: TestReport) -> None:
         assert report.longrepr is not None
-        if getattr(report.longrepr, "reprcrash", None) is not None:
-            reason = report.longrepr.reprcrash.message
+        reprcrash = getattr(
+            report.longrepr, "reprcrash", None
+        )  # type: Optional[ReprFileLocation]
+        if reprcrash is not None:
+            reason = reprcrash.message
         else:
             reason = str(report.longrepr)
 
@@ -237,7 +244,7 @@ class _NodeReporter:
             skipped = ET.Element("skipped", type="pytest.xfail", message=xfailreason)
             self.append(skipped)
         else:
-            assert report.longrepr is not None
+            assert isinstance(report.longrepr, tuple)
             filename, lineno, skipreason = report.longrepr
             if skipreason.startswith("Skipped: "):
                 skipreason = skipreason[9:]

--- a/src/_pytest/resultlog.py
+++ b/src/_pytest/resultlog.py
@@ -85,7 +85,7 @@ class ResultLog:
         elif report.passed:
             longrepr = ""
         elif report.skipped:
-            assert report.longrepr is not None
+            assert isinstance(report.longrepr, tuple)
             longrepr = str(report.longrepr[2])
         else:
             longrepr = str(report.longrepr)

--- a/src/_pytest/resultlog.py
+++ b/src/_pytest/resultlog.py
@@ -1,5 +1,7 @@
 """log machine-parseable test session result information to a plain text file."""
 import os
+from typing import IO
+from typing import Union
 
 import py
 
@@ -52,16 +54,18 @@ def pytest_unconfigure(config: Config) -> None:
 
 
 class ResultLog:
-    def __init__(self, config, logfile):
+    def __init__(self, config: Config, logfile: IO[str]) -> None:
         self.config = config
         self.logfile = logfile  # preferably line buffered
 
-    def write_log_entry(self, testpath, lettercode, longrepr):
+    def write_log_entry(self, testpath: str, lettercode: str, longrepr: str) -> None:
         print("{} {}".format(lettercode, testpath), file=self.logfile)
         for line in longrepr.splitlines():
             print(" %s" % line, file=self.logfile)
 
-    def log_outcome(self, report, lettercode, longrepr):
+    def log_outcome(
+        self, report: Union[TestReport, CollectReport], lettercode: str, longrepr: str
+    ) -> None:
         testpath = getattr(report, "nodeid", None)
         if testpath is None:
             testpath = report.fspath
@@ -73,7 +77,7 @@ class ResultLog:
         res = self.config.hook.pytest_report_teststatus(
             report=report, config=self.config
         )
-        code = res[1]
+        code = res[1]  # type: str
         if code == "x":
             longrepr = str(report.longrepr)
         elif code == "X":

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -2,7 +2,6 @@
 import bdb
 import os
 import sys
-from typing import Any
 from typing import Callable
 from typing import cast
 from typing import Dict
@@ -22,6 +21,7 @@ from .reports import TestReport
 from _pytest import timing
 from _pytest._code.code import ExceptionChainRepr
 from _pytest._code.code import ExceptionInfo
+from _pytest._code.code import TerminalRepr
 from _pytest.compat import TYPE_CHECKING
 from _pytest.config.argparsing import Parser
 from _pytest.nodes import Collector
@@ -327,8 +327,7 @@ def pytest_runtest_makereport(item: Item, call: CallInfo[None]) -> TestReport:
 
 def pytest_make_collect_report(collector: Collector) -> CollectReport:
     call = CallInfo.from_call(lambda: list(collector.collect()), "collect")
-    # TODO: Better typing for longrepr.
-    longrepr = None  # type: Optional[Any]
+    longrepr = None  # type: Union[None, Tuple[str, int, str], str, TerminalRepr]
     if not call.excinfo:
         outcome = "passed"  # type: Literal["passed", "skipped", "failed"]
     else:
@@ -348,6 +347,7 @@ def pytest_make_collect_report(collector: Collector) -> CollectReport:
             outcome = "failed"
             errorinfo = collector.repr_failure(call.excinfo)
             if not hasattr(errorinfo, "toterminal"):
+                assert isinstance(errorinfo, str)
                 errorinfo = CollectErrorRepr(errorinfo)
             longrepr = errorinfo
     result = call.result if not call.excinfo else None

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1247,6 +1247,7 @@ def _folded_skips(
     d = {}  # type: Dict[Tuple[str, Optional[int], str], List[CollectReport]]
     for event in skipped:
         assert event.longrepr is not None
+        assert isinstance(event.longrepr, tuple), (event, event.longrepr)
         assert len(event.longrepr) == 3, (event, event.longrepr)
         fspath, lineno, reason = event.longrepr
         # For consistency, report all fspaths in relative form.


### PR DESCRIPTION
The first two commits are in service of the third, which type annotates the `TestReport`/`CollectRepor` (and related) `longrepr` fields. That would have caught #7559.

The type of `longrepr` is a union with 5 possibilities, which is not great IMO. Perhaps one day we can clean it up, at least this should make it a little easier.