### PR TITLE
Minor formatting fix in xunit_setup.rst

### DIFF
--- a/doc/en/xunit_setup.rst
+++ b/doc/en/xunit_setup.rst
@@ -12,7 +12,7 @@ fixtures (setup and teardown test state) on a per-module/class/function basis.
 .. note::
 
     While these setup/teardown methods are simple and familiar to those
-    coming from a ``unittest`` or nose ``background``, you may also consider
+    coming from a ``unittest`` or ``nose`` background, you may also consider
     using pytest's more powerful :ref:`fixture mechanism
     <fixture>` which leverages the concept of dependency injection, allowing
     for a more modular and more scalable approach for managing test state,


### PR DESCRIPTION
Fixed location of double-backquote for verbatim text.

(Thanks for pytest, y'all!)

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
