### PR TITLE
Enforce some pydocstyle lints with flake8-docstrings & docstring fixes in testing/

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,9 @@ repos:
     hooks:
     -   id: flake8
         language_version: python3
-        additional_dependencies: [flake8-typing-imports==1.9.0]
+        additional_dependencies:
+          - flake8-typing-imports==1.9.0
+          - flake8-docstrings==1.5.0
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v2.3.0
     hooks:

--- a/doc/en/example/nonpython/conftest.py
+++ b/doc/en/example/nonpython/conftest.py
@@ -9,7 +9,8 @@ def pytest_collect_file(parent, path):
 
 class YamlFile(pytest.File):
     def collect(self):
-        import yaml  # we need a yaml parser, e.g. PyYAML
+        # We need a yaml parser, e.g. PyYAML.
+        import yaml
 
         raw = yaml.safe_load(self.fspath.open())
         for name, spec in sorted(raw.items()):
@@ -23,12 +24,12 @@ class YamlItem(pytest.Item):
 
     def runtest(self):
         for name, value in sorted(self.spec.items()):
-            # some custom test execution (dumb example follows)
+            # Some custom test execution (dumb example follows).
             if name != value:
                 raise YamlException(self, name, value)
 
     def repr_failure(self, excinfo):
-        """ called when self.runtest() raises an exception. """
+        """Called when self.runtest() raises an exception."""
         if isinstance(excinfo.value, YamlException):
             return "\n".join(
                 [
@@ -43,4 +44,4 @@ class YamlItem(pytest.Item):
 
 
 class YamlException(Exception):
-    """ custom exception for error reporting. """
+    """Custom exception for error reporting."""

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,6 +1,4 @@
-"""
-Invoke development tasks.
-"""
+"""Invoke development tasks."""
 import argparse
 import os
 from pathlib import Path

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -403,15 +403,12 @@ class TestGeneralUsage:
         result.stdout.fnmatch_lines(["pytest_sessionfinish_called"])
         assert result.ret == ExitCode.USAGE_ERROR
 
-    @pytest.mark.usefixtures("recwarn")
     def test_namespace_import_doesnt_confuse_import_hook(self, testdir):
-        """
-        Ref #383. Python 3.3's namespace package messed with our import hooks
+        """Ref #383.
+
+        Python 3.3's namespace package messed with our import hooks.
         Importing a module that didn't exist, even if the ImportError was
         gracefully handled, would make our test crash.
-
-        Use recwarn here to silence this warning in Python 2.7:
-            ImportWarning: Not importing directory '...\not_a_package': missing __init__.py
         """
         testdir.mkdir("not_a_package")
         p = testdir.makepyfile(
@@ -457,10 +454,8 @@ class TestGeneralUsage:
         )
 
     def test_plugins_given_as_strings(self, tmpdir, monkeypatch, _sys_snapshot):
-        """test that str values passed to main() as `plugins` arg
-        are interpreted as module names to be imported and registered.
-        #855.
-        """
+        """Test that str values passed to main() as `plugins` arg are
+        interpreted as module names to be imported and registered (#855)."""
         with pytest.raises(ImportError) as excinfo:
             pytest.main([str(tmpdir)], plugins=["invalid.module"])
         assert "invalid" in str(excinfo.value)
@@ -664,8 +659,7 @@ class TestInvocationVariants:
         result.stderr.fnmatch_lines(["*not*found*test_missing*"])
 
     def test_cmdline_python_namespace_package(self, testdir, monkeypatch):
-        """
-        test --pyargs option with namespace packages (#1567)
+        """Test --pyargs option with namespace packages (#1567).
 
         Ref: https://packaging.python.org/guides/packaging-namespace-packages/
         """
@@ -1011,9 +1005,7 @@ def test_pytest_plugins_as_module(testdir):
 
 
 def test_deferred_hook_checking(testdir):
-    """
-    Check hooks as late as possible (#1821).
-    """
+    """Check hooks as late as possible (#1821)."""
     testdir.syspathinsert()
     testdir.makepyfile(
         **{
@@ -1089,8 +1081,7 @@ def test_fixture_values_leak(testdir):
 
 
 def test_fixture_order_respects_scope(testdir):
-    """Ensure that fixtures are created according to scope order, regression test for #2405
-    """
+    """Ensure that fixtures are created according to scope order (#2405)."""
     testdir.makepyfile(
         """
         import pytest
@@ -1115,7 +1106,8 @@ def test_fixture_order_respects_scope(testdir):
 
 
 def test_frame_leak_on_failing_test(testdir):
-    """pytest would leak garbage referencing the frames of tests that failed that could never be reclaimed (#2798)
+    """Pytest would leak garbage referencing the frames of tests that failed
+    that could never be reclaimed (#2798).
 
     Unfortunately it was not possible to remove the actual circles because most of them
     are made of traceback objects which cannot be weakly referenced. Those objects at least

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -464,7 +464,7 @@ class TestFormattedExcinfo:
         assert lines[1] == "        pass"
 
     def test_repr_source_excinfo(self) -> None:
-        """ check if indentation is right """
+        """Check if indentation is right."""
         try:
 
             def f():

--- a/testing/freeze/create_executable.py
+++ b/testing/freeze/create_executable.py
@@ -1,6 +1,4 @@
-"""
-Generates an executable with pytest runner embedded using PyInstaller.
-"""
+"""Generate an executable with pytest runner embedded using PyInstaller."""
 if __name__ == "__main__":
     import pytest
     import subprocess

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -268,10 +268,10 @@ def test_caplog_captures_despite_exception(testdir):
 
 
 def test_log_report_captures_according_to_config_option_upon_failure(testdir):
-    """ Test that upon failure:
-    (1) `caplog` succeeded to capture the DEBUG message and assert on it => No `Exception` is raised
-    (2) The `DEBUG` message does NOT appear in the `Captured log call` report
-    (3) The stdout, `INFO`, and `WARNING` messages DO appear in the test reports due to `--log-level=INFO`
+    """Test that upon failure:
+    (1) `caplog` succeeded to capture the DEBUG message and assert on it => No `Exception` is raised.
+    (2) The `DEBUG` message does NOT appear in the `Captured log call` report.
+    (3) The stdout, `INFO`, and `WARNING` messages DO appear in the test reports due to `--log-level=INFO`.
     """
     testdir.makepyfile(
         """

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1066,10 +1066,8 @@ def test_log_set_path(testdir):
 
 
 def test_colored_captured_log(testdir):
-    """
-    Test that the level names of captured log messages of a failing test are
-    colored.
-    """
+    """Test that the level names of captured log messages of a failing test
+    are colored."""
     testdir.makepyfile(
         """
         import logging
@@ -1092,9 +1090,7 @@ def test_colored_captured_log(testdir):
 
 
 def test_colored_ansi_esc_caplogtext(testdir):
-    """
-    Make sure that caplog.text does not contain ANSI escape sequences.
-    """
+    """Make sure that caplog.text does not contain ANSI escape sequences."""
     testdir.makepyfile(
         """
         import logging
@@ -1111,8 +1107,7 @@ def test_colored_ansi_esc_caplogtext(testdir):
 
 
 def test_logging_emit_error(testdir: Testdir) -> None:
-    """
-    An exception raised during emit() should fail the test.
+    """An exception raised during emit() should fail the test.
 
     The default behavior of logging is to print "Logging error"
     to stderr with the call stack and some extra details.
@@ -1138,10 +1133,8 @@ def test_logging_emit_error(testdir: Testdir) -> None:
 
 
 def test_logging_emit_error_supressed(testdir: Testdir) -> None:
-    """
-    If logging is configured to silently ignore errors, pytest
-    doesn't propagate errors either.
-    """
+    """If logging is configured to silently ignore errors, pytest
+    doesn't propagate errors either."""
     testdir.makepyfile(
         """
         import logging

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -488,9 +488,7 @@ class TestApprox:
         ],
     )
     def test_comparison_operator_type_error(self, op):
-        """
-        pytest.approx should raise TypeError for operators other than == and != (#2003).
-        """
+        """pytest.approx should raise TypeError for operators other than == and != (#2003)."""
         with pytest.raises(TypeError):
             op(1, approx(1, rel=1e-6, abs=1e-12))
 

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -984,8 +984,7 @@ class TestTracebackCutting:
         result.stdout.fnmatch_lines([">*asd*", "E*NameError*"])
 
     def test_traceback_filter_error_during_fixture_collection(self, testdir):
-        """integration test for issue #995.
-        """
+        """Integration test for issue #995."""
         testdir.makepyfile(
             """
             import pytest
@@ -1011,8 +1010,9 @@ class TestTracebackCutting:
         result.stdout.fnmatch_lines(["*ValueError: fail me*", "* 1 error in *"])
 
     def test_filter_traceback_generated_code(self) -> None:
-        """test that filter_traceback() works with the fact that
+        """Test that filter_traceback() works with the fact that
         _pytest._code.code.Code.path attribute might return an str object.
+
         In this case, one of the entries on the traceback was produced by
         dynamically generated code.
         See: https://bitbucket.org/pytest-dev/py/issues/71
@@ -1033,8 +1033,9 @@ class TestTracebackCutting:
         assert not filter_traceback(traceback[-1])
 
     def test_filter_traceback_path_no_longer_valid(self, testdir) -> None:
-        """test that filter_traceback() works with the fact that
+        """Test that filter_traceback() works with the fact that
         _pytest._code.code.Code.path attribute might return an str object.
+
         In this case, one of the files in the traceback no longer exists.
         This fixes #1133.
         """
@@ -1250,8 +1251,7 @@ def test_class_injection_does_not_break_collection(testdir):
 
 
 def test_syntax_error_with_non_ascii_chars(testdir):
-    """Fix decoding issue while formatting SyntaxErrors during collection (#578)
-    """
+    """Fix decoding issue while formatting SyntaxErrors during collection (#578)."""
     testdir.makepyfile("☃")
     result = testdir.runpytest()
     result.stdout.fnmatch_lines(["*ERROR collecting*", "*SyntaxError*", "*1 error in*"])

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1684,10 +1684,8 @@ class TestAutouseDiscovery:
         reprec.assertoutcome(passed=2)
 
     def test_callables_nocode(self, testdir):
-        """
-        an imported mock.call would break setup/factory discovery
-        due to it being callable and __code__ not being a code object
-        """
+        """An imported mock.call would break setup/factory discovery due to
+        it being callable and __code__ not being a code object."""
         testdir.makepyfile(
             """
            class _call(tuple):
@@ -3333,9 +3331,7 @@ class TestShowFixtures:
         )
 
     def test_show_fixtures_different_files(self, testdir):
-        """
-        #833: --fixtures only shows fixtures from first file
-        """
+        """`--fixtures` only shows fixtures from first file (#833)."""
         testdir.makepyfile(
             test_a='''
             import pytest

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -29,9 +29,9 @@ from _pytest.python import idmaker
 
 class TestMetafunc:
     def Metafunc(self, func, config=None) -> python.Metafunc:
-        # the unit tests of this class check if things work correctly
+        # The unit tests of this class check if things work correctly
         # on the funcarg level, so we don't need a full blown
-        # initialization
+        # initialization.
         class FuncFixtureInfoMock:
             name2fixturedefs = None
 
@@ -136,7 +136,7 @@ class TestMetafunc:
             metafunc.parametrize("request", [1])
 
     def test_find_parametrized_scope(self) -> None:
-        """unittest for _find_parametrized_scope (#3941)"""
+        """Unit test for _find_parametrized_scope (#3941)."""
         from _pytest.python import _find_parametrized_scope
 
         @attr.s
@@ -285,30 +285,29 @@ class TestMetafunc:
         escaped.encode("ascii")
 
     def test_unicode_idval(self) -> None:
-        """This tests that Unicode strings outside the ASCII character set get
+        """Test that Unicode strings outside the ASCII character set get
         escaped, using byte escapes if they're in that range or unicode
         escapes if they're not.
 
         """
         values = [
-            ("", ""),
-            ("ascii", "ascii"),
-            ("ação", "a\\xe7\\xe3o"),
-            ("josé@blah.com", "jos\\xe9@blah.com"),
+            ("", r""),
+            ("ascii", r"ascii"),
+            ("ação", r"a\xe7\xe3o"),
+            ("josé@blah.com", r"jos\xe9@blah.com"),
             (
-                "δοκ.ιμή@παράδειγμα.δοκιμή",
-                "\\u03b4\\u03bf\\u03ba.\\u03b9\\u03bc\\u03ae@\\u03c0\\u03b1\\u03c1\\u03ac\\u03b4\\u03b5\\u03b9\\u03b3"
-                "\\u03bc\\u03b1.\\u03b4\\u03bf\\u03ba\\u03b9\\u03bc\\u03ae",
+                r"δοκ.ιμή@παράδειγμα.δοκιμή",
+                r"\u03b4\u03bf\u03ba.\u03b9\u03bc\u03ae@\u03c0\u03b1\u03c1\u03ac\u03b4\u03b5\u03b9\u03b3"
+                r"\u03bc\u03b1.\u03b4\u03bf\u03ba\u03b9\u03bc\u03ae",
             ),
         ]
         for val, expected in values:
             assert _idval(val, "a", 6, None, nodeid=None, config=None) == expected
 
     def test_unicode_idval_with_config(self) -> None:
-        """unittest for expected behavior to obtain ids with
+        """Unit test for expected behavior to obtain ids with
         disable_test_id_escaping_and_forfeit_all_rights_to_community_support
-        option. (#5294)
-        """
+        option (#5294)."""
 
         class MockConfig:
             def __init__(self, config):
@@ -335,25 +334,20 @@ class TestMetafunc:
             assert actual == expected
 
     def test_bytes_idval(self) -> None:
-        """unittest for the expected behavior to obtain ids for parametrized
-        bytes values:
-        - python2: non-ascii strings are considered bytes and formatted using
-        "binary escape", where any byte < 127 is escaped into its hex form.
-        - python3: bytes objects are always escaped using "binary escape".
-        """
+        """Unit test for the expected behavior to obtain ids for parametrized
+        bytes values: bytes objects are always escaped using "binary escape"."""
         values = [
-            (b"", ""),
-            (b"\xc3\xb4\xff\xe4", "\\xc3\\xb4\\xff\\xe4"),
-            (b"ascii", "ascii"),
-            ("αρά".encode(), "\\xce\\xb1\\xcf\\x81\\xce\\xac"),
+            (b"", r""),
+            (b"\xc3\xb4\xff\xe4", r"\xc3\xb4\xff\xe4"),
+            (b"ascii", r"ascii"),
+            ("αρά".encode(), r"\xce\xb1\xcf\x81\xce\xac"),
         ]
         for val, expected in values:
             assert _idval(val, "a", 6, idfn=None, nodeid=None, config=None) == expected
 
     def test_class_or_function_idval(self) -> None:
-        """unittest for the expected behavior to obtain ids for parametrized
-        values that are classes or functions: their __name__.
-        """
+        """Unit test for the expected behavior to obtain ids for parametrized
+        values that are classes or functions: their __name__."""
 
         class TestClass:
             pass
@@ -484,9 +478,9 @@ class TestMetafunc:
         assert result == ["a-a0", "a-a1", "a-a2"]
 
     def test_idmaker_with_idfn_and_config(self) -> None:
-        """unittest for expected behavior to create ids with idfn and
+        """Unit test for expected behavior to create ids with idfn and
         disable_test_id_escaping_and_forfeit_all_rights_to_community_support
-        option. (#5294)
+        option (#5294).
         """
 
         class MockConfig:
@@ -516,9 +510,9 @@ class TestMetafunc:
             assert result == [expected]
 
     def test_idmaker_with_ids_and_config(self) -> None:
-        """unittest for expected behavior to create ids with ids and
+        """Unit test for expected behavior to create ids with ids and
         disable_test_id_escaping_and_forfeit_all_rights_to_community_support
-        option. (#5294)
+        option (#5294).
         """
 
         class MockConfig:
@@ -1420,9 +1414,8 @@ class TestMetafuncFunctional:
 
 
 class TestMetafuncFunctionalAuto:
-    """
-    Tests related to automatically find out the correct scope for parametrized tests (#1832).
-    """
+    """Tests related to automatically find out the correct scope for
+    parametrized tests (#1832)."""
 
     def test_parametrize_auto_scope(self, testdir: Testdir) -> None:
         testdir.makepyfile(

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -157,9 +157,7 @@ class TestRaises:
 
     @pytest.mark.parametrize("method", ["function", "function_match", "with"])
     def test_raises_cyclic_reference(self, method):
-        """
-        Ensure pytest.raises does not leave a reference cycle (#1965).
-        """
+        """Ensure pytest.raises does not leave a reference cycle (#1965)."""
         import gc
 
         class T:

--- a/testing/test_argcomplete.py
+++ b/testing/test_argcomplete.py
@@ -3,7 +3,7 @@ import sys
 
 import pytest
 
-# test for _argcomplete but not specific for any application
+# Test for _argcomplete but not specific for any application.
 
 
 def equal_with_bash(prefix, ffc, fc, out=None):
@@ -18,9 +18,9 @@ def equal_with_bash(prefix, ffc, fc, out=None):
     return retval
 
 
-# copied from argcomplete.completers as import from there
-# also pulls in argcomplete.__init__ which opens filedescriptor 9
-# this gives an OSError at the end of testrun
+# Copied from argcomplete.completers as import from there.
+# Also pulls in argcomplete.__init__ which opens filedescriptor 9.
+# This gives an OSError at the end of testrun.
 
 
 def _wrapcall(*args, **kargs):
@@ -31,7 +31,7 @@ def _wrapcall(*args, **kargs):
 
 
 class FilesCompleter:
-    "File completer class, optionally takes a list of allowed extensions"
+    """File completer class, optionally takes a list of allowed extensions."""
 
     def __init__(self, allowednames=(), directories=True):
         # Fix if someone passes in a string instead of a list
@@ -91,9 +91,7 @@ class TestArgComplete:
 
     @pytest.mark.skipif("sys.platform in ('win32', 'darwin')")
     def test_remove_dir_prefix(self):
-        """this is not compatible with compgen but it is with bash itself:
-        ls /usr/<TAB>
-        """
+        """This is not compatible with compgen but it is with bash itself: ls /usr/<TAB>."""
         from _pytest._argcomplete import FastFilesCompleter
 
         ffc = FastFilesCompleter()

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -29,9 +29,7 @@ class TestImportHookInstallation:
     @pytest.mark.parametrize("initial_conftest", [True, False])
     @pytest.mark.parametrize("mode", ["plain", "rewrite"])
     def test_conftest_assertion_rewrite(self, testdir, initial_conftest, mode):
-        """Test that conftest files are using assertion rewrite on import.
-        (#1619)
-        """
+        """Test that conftest files are using assertion rewrite on import (#1619)."""
         testdir.tmpdir.join("foo/tests").ensure(dir=1)
         conftest_path = "conftest.py" if initial_conftest else "foo/conftest.py"
         contents = {
@@ -569,7 +567,7 @@ class TestAssert_reprcompare:
             assert "b" not in line
 
     def test_dict_omitting_with_verbosity_1(self) -> None:
-        """ Ensure differing items are visible for verbosity=1 (#1512) """
+        """Ensure differing items are visible for verbosity=1 (#1512)."""
         lines = callequal({"a": 0, "b": 1}, {"a": 1, "b": 1}, verbose=1)
         assert lines is not None
         assert lines[1].startswith("Omitting 1 identical item")
@@ -719,10 +717,7 @@ class TestAssert_reprcompare:
         ]
 
     def test_one_repr_empty(self):
-        """
-        the faulty empty string repr did trigger
-        an unbound local error in _diff_text
-        """
+        """The faulty empty string repr did trigger an unbound local error in _diff_text."""
 
         class A(str):
             def __repr__(self):
@@ -1135,7 +1130,7 @@ class TestTruncateExplanation:
         assert last_line_before_trunc_msg.endswith("...")
 
     def test_full_output_truncated(self, monkeypatch, testdir):
-        """ Test against full runpytest() output. """
+        """Test against full runpytest() output."""
 
         line_count = 7
         line_len = 100
@@ -1370,9 +1365,7 @@ def test_traceback_failure(testdir):
 
 
 def test_exception_handling_no_traceback(testdir):
-    """
-    Handle chain exceptions in tasks submitted by the multiprocess module (#1984).
-    """
+    """Handle chain exceptions in tasks submitted by the multiprocess module (#1984)."""
     p1 = testdir.makepyfile(
         """
         from multiprocessing import Pool

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -233,7 +233,7 @@ class TestAssertionRewrite:
 
     def test_dont_rewrite_if_hasattr_fails(self, request) -> None:
         class Y:
-            """ A class whos getattr fails, but not with `AttributeError` """
+            """A class whose getattr fails, but not with `AttributeError`."""
 
             def __getattr__(self, attribute_name):
                 raise KeyError()
@@ -911,10 +911,8 @@ def test_rewritten():
         assert testdir.runpytest_subprocess().ret == 0
 
     def test_remember_rewritten_modules(self, pytestconfig, testdir, monkeypatch):
-        """
-        AssertionRewriteHook should remember rewritten modules so it
-        doesn't give false positives (#2005).
-        """
+        """`AssertionRewriteHook` should remember rewritten modules so it
+        doesn't give false positives (#2005)."""
         monkeypatch.syspath_prepend(testdir.tmpdir)
         testdir.makepyfile(test_remember_rewritten_modules="")
         warnings = []
@@ -1091,8 +1089,7 @@ class TestAssertionRewriteHookDetails:
         result.stdout.fnmatch_lines(["* 1 passed*"])
 
     def test_get_data_support(self, testdir):
-        """Implement optional PEP302 api (#808).
-        """
+        """Implement optional PEP302 api (#808)."""
         path = testdir.mkpydir("foo")
         path.join("test_foo.py").write(
             textwrap.dedent(

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -643,9 +643,7 @@ class TestLastFailed:
         return sorted(config.cache.get("cache/lastfailed", {}))
 
     def test_cache_cumulative(self, testdir):
-        """
-        Test workflow where user fixes errors gradually file by file using --lf.
-        """
+        """Test workflow where user fixes errors gradually file by file using --lf."""
         # 1. initial run
         test_bar = testdir.makepyfile(
             test_bar="""

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -635,9 +635,8 @@ class TestCaptureFixture:
 
     @pytest.mark.parametrize("fixture", ["capsys", "capfd"])
     def test_fixture_use_by_other_fixtures(self, testdir, fixture):
-        """
-        Ensure that capsys and capfd can be used by other fixtures during setup and teardown.
-        """
+        """Ensure that capsys and capfd can be used by other fixtures during
+        setup and teardown."""
         testdir.makepyfile(
             """\
             import sys
@@ -1109,8 +1108,8 @@ class TestTeeStdCapture(TestStdCapture):
     captureclass = staticmethod(TeeStdCapture)
 
     def test_capturing_error_recursive(self):
-        """ for TeeStdCapture since we passthrough stderr/stdout, cap1
-        should get all output, while cap2 should only get "cap2\n" """
+        r"""For TeeStdCapture since we passthrough stderr/stdout, cap1
+        should get all output, while cap2 should only get "cap2\n"."""
 
         with self.getcapture() as cap1:
             print("cap1")

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -725,10 +725,8 @@ class Test_genitems:
         print(s)
 
     def test_class_and_functions_discovery_using_glob(self, testdir):
-        """
-        tests that python_classes and python_functions config options work
-        as prefixes and glob-like patterns (issue #600).
-        """
+        """Test that Python_classes and Python_functions config options work
+        as prefixes and glob-like patterns (#600)."""
         testdir.makeini(
             """
             [pytest]

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -47,7 +47,7 @@ class TestParseIni:
         assert config.inicfg["name"] == "value"
 
     def test_getcfg_empty_path(self):
-        """correctly handle zero length arguments (a la pytest '')"""
+        """Correctly handle zero length arguments (a la pytest '')."""
         locate_config([""])
 
     def test_setupcfg_uses_toolpytest_with_pytest(self, testdir):
@@ -1006,8 +1006,8 @@ def test_cmdline_processargs_simple(testdir):
 
 
 def test_invalid_options_show_extra_information(testdir):
-    """display extra information when pytest exits due to unrecognized
-    options in the command-line"""
+    """Display extra information when pytest exits due to unrecognized
+    options in the command-line."""
     testdir.makeini(
         """
         [pytest]
@@ -1441,7 +1441,7 @@ class TestOverrideIniArgs:
         )
 
     def test_addopts_from_ini_not_concatenated(self, testdir):
-        """addopts from ini should not take values from normal args (#4265)."""
+        """`addopts` from ini should not take values from normal args (#4265)."""
         testdir.makeini(
             """
             [pytest]
@@ -1777,10 +1777,8 @@ class TestPytestPluginsVariable:
 
 
 def test_conftest_import_error_repr(tmpdir):
-    """
-    ConftestImportFailure should use a short error message and readable path to the failed
-    conftest.py file
-    """
+    """`ConftestImportFailure` should use a short error message and readable
+    path to the failed conftest.py file."""
     path = tmpdir.join("foo/conftest.py")
     with pytest.raises(
         ConftestImportFailure,

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -196,9 +196,7 @@ def test_conftest_confcutdir(testdir):
 
 
 def test_conftest_symlink(testdir):
-    """
-    conftest.py discovery follows normal path resolution and does not resolve symlinks.
-    """
+    """`conftest.py` discovery follows normal path resolution and does not resolve symlinks."""
     # Structure:
     # /real
     # /real/conftest.py

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -115,8 +115,7 @@ class TestDoctests:
         reprec.assertoutcome(failed=1)
 
     def test_multiple_patterns(self, testdir):
-        """Test support for multiple --doctest-glob arguments (#1255).
-        """
+        """Test support for multiple --doctest-glob arguments (#1255)."""
         testdir.maketxtfile(
             xdoc="""
             >>> 1
@@ -149,8 +148,7 @@ class TestDoctests:
         [("foo", "ascii"), ("öäü", "latin1"), ("öäü", "utf-8")],
     )
     def test_encoding(self, testdir, test_string, encoding):
-        """Test support for doctest_encoding ini option.
-        """
+        """Test support for doctest_encoding ini option."""
         testdir.makeini(
             """
             [pytest]
@@ -667,8 +665,7 @@ class TestDoctests:
         reprec.assertoutcome(failed=1, passed=0)
 
     def test_contains_unicode(self, testdir):
-        """Fix internal error with docstrings containing non-ascii characters.
-        """
+        """Fix internal error with docstrings containing non-ascii characters."""
         testdir.makepyfile(
             '''\
             def foo():
@@ -701,9 +698,7 @@ class TestDoctests:
         reprec.assertoutcome(skipped=1, failed=1, passed=0)
 
     def test_junit_report_for_doctest(self, testdir):
-        """
-        #713: Fix --junit-xml option when used with --doctest-modules.
-        """
+        """#713: Fix --junit-xml option when used with --doctest-modules."""
         p = testdir.makepyfile(
             """
             def foo():
@@ -775,9 +770,7 @@ class TestDoctests:
         result.stdout.fnmatch_lines(["* 1 passed *"])
 
     def test_reportinfo(self, testdir):
-        """
-        Test case to make sure that DoctestItem.reportinfo() returns lineno.
-        """
+        """Make sure that DoctestItem.reportinfo() returns lineno."""
         p = testdir.makepyfile(
             test_reportinfo="""
             def foo(x):
@@ -1167,8 +1160,7 @@ class TestDoctestAutoUseFixtures:
     SCOPES = ["module", "session", "class", "function"]
 
     def test_doctest_module_session_fixture(self, testdir):
-        """Test that session fixtures are initialized for doctest modules (#768)
-        """
+        """Test that session fixtures are initialized for doctest modules (#768)."""
         # session fixture which changes some global data, which will
         # be accessed by doctests in a module
         testdir.makeconftest(

--- a/testing/test_faulthandler.py
+++ b/testing/test_faulthandler.py
@@ -19,8 +19,7 @@ def test_enabled(testdir):
 
 def test_crash_near_exit(testdir):
     """Test that fault handler displays crashes that happen even after
-    pytest is exiting (for example, when the interpreter is shutting down).
-    """
+    pytest is exiting (for example, when the interpreter is shutting down)."""
     testdir.makepyfile(
         """
     import faulthandler
@@ -35,8 +34,7 @@ def test_crash_near_exit(testdir):
 
 
 def test_disabled(testdir):
-    """Test option to disable fault handler in the command line.
-    """
+    """Test option to disable fault handler in the command line."""
     testdir.makepyfile(
         """
     import faulthandler
@@ -60,6 +58,7 @@ def test_disabled(testdir):
 )
 def test_timeout(testdir, enabled: bool) -> None:
     """Test option to dump tracebacks after a certain timeout.
+
     If faulthandler is disabled, no traceback will be dumped.
     """
     testdir.makepyfile(
@@ -90,9 +89,8 @@ def test_timeout(testdir, enabled: bool) -> None:
 @pytest.mark.parametrize("hook_name", ["pytest_enter_pdb", "pytest_exception_interact"])
 def test_cancel_timeout_on_hook(monkeypatch, hook_name):
     """Make sure that we are cancelling any scheduled traceback dumping due
-    to timeout before entering pdb (pytest-dev/pytest-faulthandler#12) or any other interactive
-    exception (pytest-dev/pytest-faulthandler#14).
-    """
+    to timeout before entering pdb (pytest-dev/pytest-faulthandler#12) or any
+    other interactive exception (pytest-dev/pytest-faulthandler#14)."""
     import faulthandler
     from _pytest.faulthandler import FaultHandlerHooks
 
@@ -111,7 +109,7 @@ def test_cancel_timeout_on_hook(monkeypatch, hook_name):
 
 @pytest.mark.parametrize("faulthandler_timeout", [0, 2])
 def test_already_initialized(faulthandler_timeout, testdir):
-    """Test for faulthandler being initialized earlier than pytest (#6575)"""
+    """Test for faulthandler being initialized earlier than pytest (#6575)."""
     testdir.makepyfile(
         """
         def test():

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -39,8 +39,7 @@ def test_help(testdir):
 
 
 def test_none_help_param_raises_exception(testdir):
-    """Tests a None help param raises a TypeError.
-    """
+    """Test that a None help param raises a TypeError."""
     testdir.makeconftest(
         """
         def pytest_addoption(parser):
@@ -54,8 +53,7 @@ def test_none_help_param_raises_exception(testdir):
 
 
 def test_empty_help_param(testdir):
-    """Tests an empty help param is displayed correctly.
-    """
+    """Test that an empty help param is displayed correctly."""
     testdir.makeconftest(
         """
         def pytest_addoption(parser):

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -22,7 +22,7 @@ from _pytest.store import Store
 
 @pytest.fixture(scope="session")
 def schema():
-    """Returns a xmlschema.XMLSchema object for the junit-10.xsd file"""
+    """Return an xmlschema.XMLSchema object for the junit-10.xsd file."""
     fn = Path(__file__).parent / "example_scripts/junit-10.xsd"
     with fn.open() as f:
         return xmlschema.XMLSchema(f)
@@ -30,9 +30,8 @@ def schema():
 
 @pytest.fixture
 def run_and_parse(testdir, schema):
-    """
-    Fixture that returns a function that can be used to execute pytest and return
-    the parsed ``DomNode`` of the root xml node.
+    """Fixture that returns a function that can be used to execute pytest and
+    return the parsed ``DomNode`` of the root xml node.
 
     The ``family`` parameter is used to configure the ``junit_family`` of the written report.
     "xunit2" is also automatically validated against the schema.
@@ -720,7 +719,7 @@ class TestPython:
         assert "hx" in fnode.toxml()
 
     def test_assertion_binchars(self, testdir, run_and_parse):
-        """this test did fail when the escaping wasnt strict"""
+        """This test did fail when the escaping wasn't strict."""
         testdir.makepyfile(
             """
 
@@ -1212,8 +1211,7 @@ def test_record_attribute(testdir, run_and_parse):
 @pytest.mark.filterwarnings("default")
 @pytest.mark.parametrize("fixture_name", ["record_xml_attribute", "record_property"])
 def test_record_fixtures_xunit2(testdir, fixture_name, run_and_parse):
-    """Ensure record_xml_attribute and record_property drop values when outside of legacy family
-    """
+    """Ensure record_xml_attribute and record_property drop values when outside of legacy family."""
     testdir.makeini(
         """
         [pytest]
@@ -1250,10 +1248,9 @@ def test_record_fixtures_xunit2(testdir, fixture_name, run_and_parse):
 
 
 def test_random_report_log_xdist(testdir, monkeypatch, run_and_parse):
-    """xdist calls pytest_runtest_logreport as they are executed by the workers,
+    """`xdist` calls pytest_runtest_logreport as they are executed by the workers,
     with nodes from several nodes overlapping, so junitxml must cope with that
-    to produce correct reports. #1064
-    """
+    to produce correct reports (#1064)."""
     pytest.importorskip("xdist")
     monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
     testdir.makepyfile(

--- a/testing/test_link_resolve.py
+++ b/testing/test_link_resolve.py
@@ -50,9 +50,7 @@ def subst_path_linux(filename):
 
 
 def test_link_resolve(testdir: pytester.Testdir) -> None:
-    """
-    See: https://github.com/pytest-dev/pytest/issues/5965
-    """
+    """See: https://github.com/pytest-dev/pytest/issues/5965."""
     sub1 = testdir.mkpydir("sub1")
     p = sub1.join("test_foo.py")
     p.write(

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -370,9 +370,8 @@ def test_keyword_option_wrong_arguments(
 
 
 def test_parametrized_collected_from_command_line(testdir):
-    """Parametrized test not collected if test named specified
-       in command line issue#649.
-    """
+    """Parametrized test not collected if test named specified in command
+    line issue#649."""
     py_file = testdir.makepyfile(
         """
         import pytest
@@ -430,7 +429,7 @@ def test_parametrized_with_kwargs(testdir):
 
 
 def test_parametrize_iterator(testdir):
-    """parametrize should work with generators (#5354)."""
+    """`parametrize` should work with generators (#5354)."""
     py_file = testdir.makepyfile(
         """\
         import pytest
@@ -669,13 +668,12 @@ class TestFunctional:
         reprec.assertoutcome(passed=1)
 
     def assert_markers(self, items, **expected):
-        """assert that given items have expected marker names applied to them.
-        expected should be a dict of (item name -> seq of expected marker names)
+        """Assert that given items have expected marker names applied to them.
+        expected should be a dict of (item name -> seq of expected marker names).
 
-        .. note:: this could be moved to ``testdir`` if proven to be useful
+        Note: this could be moved to ``testdir`` if proven to be useful
         to other modules.
         """
-
         items = {x.name: x for x in items}
         for name, expected_markers in expected.items():
             markers = {m.name for m in items[name].iter_markers()}
@@ -866,9 +864,7 @@ class TestKeywordSelection:
         assert len(deselected_tests) == 1
 
     def test_no_match_directories_outside_the_suite(self, testdir):
-        """
-        -k should not match against directories containing the test suite (#7040).
-        """
+        """`-k` should not match against directories containing the test suite (#7040)."""
         test_contents = """
             def test_aaa(): pass
             def test_ddd(): pass

--- a/testing/test_meta.py
+++ b/testing/test_meta.py
@@ -1,5 +1,4 @@
-"""
-Test importing of all internal packages and modules.
+"""Test importing of all internal packages and modules.
 
 This ensures all internal packages can be imported without needing the pytest
 namespace being set, which is critical for the initialization of xdist.

--- a/testing/test_pastebin.py
+++ b/testing/test_pastebin.py
@@ -87,9 +87,7 @@ class TestPaste:
 
     @pytest.fixture
     def mocked_urlopen_fail(self, monkeypatch):
-        """
-        monkeypatch the actual urlopen call to emulate a HTTP Error 400
-        """
+        """Monkeypatch the actual urlopen call to emulate a HTTP Error 400."""
         calls = []
 
         import urllib.error
@@ -104,11 +102,9 @@ class TestPaste:
 
     @pytest.fixture
     def mocked_urlopen_invalid(self, monkeypatch):
-        """
-        monkeypatch the actual urlopen calls done by the internal plugin
+        """Monkeypatch the actual urlopen calls done by the internal plugin
         function that connects to bpaste service, but return a url in an
-        unexpected format
-        """
+        unexpected format."""
         calls = []
 
         def mocked(url, data):
@@ -128,10 +124,8 @@ class TestPaste:
 
     @pytest.fixture
     def mocked_urlopen(self, monkeypatch):
-        """
-        monkeypatch the actual urlopen calls done by the internal plugin
-        function that connects to bpaste service.
-        """
+        """Monkeypatch the actual urlopen calls done by the internal plugin
+        function that connects to bpaste service."""
         calls = []
 
         def mocked(url, data):

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -18,9 +18,8 @@ from _pytest.pathlib import resolve_package_path
 
 
 class TestFNMatcherPort:
-    """Test that our port of py.common.FNMatcher (fnmatch_ex) produces the same results as the
-    original py.path.local.fnmatch method.
-    """
+    """Test that our port of py.common.FNMatcher (fnmatch_ex) produces the
+    same results as the original py.path.local.fnmatch method."""
 
     @pytest.fixture(params=["pathlib", "py.path"])
     def match(self, request):
@@ -268,19 +267,19 @@ class TestImportPath:
         return fn
 
     def test_importmode_importlib(self, simple_module):
-        """importlib mode does not change sys.path"""
+        """`importlib` mode does not change sys.path."""
         module = import_path(simple_module, mode="importlib")
         assert module.foo(2) == 42  # type: ignore[attr-defined]
         assert simple_module.dirname not in sys.path
 
     def test_importmode_twice_is_different_module(self, simple_module):
-        """importlib mode always returns a new module"""
+        """`importlib` mode always returns a new module."""
         module1 = import_path(simple_module, mode="importlib")
         module2 = import_path(simple_module, mode="importlib")
         assert module1 is not module2
 
     def test_no_meta_path_found(self, simple_module, monkeypatch):
-        """Even without any meta_path should still import module"""
+        """Even without any meta_path should still import module."""
         monkeypatch.setattr(sys, "meta_path", [])
         module = import_path(simple_module, mode="importlib")
         assert module.foo(2) == 42  # type: ignore[attr-defined]

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -362,10 +362,10 @@ class TestPytestPluginManagerBootstrapming:
     def test_plugin_prevent_register_stepwise_on_cacheprovider_unregister(
         self, pytestpm
     ):
-        """ From PR #4304 : The only way to unregister a module is documented at
+        """From PR #4304: The only way to unregister a module is documented at
         the end of https://docs.pytest.org/en/stable/plugins.html.
 
-        When unregister cacheprovider, then unregister stepwise too
+        When unregister cacheprovider, then unregister stepwise too.
         """
         pytestpm.register(42, name="cacheprovider")
         pytestpm.register(43, name="stepwise")

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -166,18 +166,18 @@ def test_xpassed_with_strict_is_considered_a_failure(testdir) -> None:
 def make_holder():
     class apiclass:
         def pytest_xyz(self, arg):
-            "x"
+            """X"""
 
         def pytest_xyz_noarg(self):
-            "x"
+            """X"""
 
     apimod = type(os)("api")
 
     def pytest_xyz(arg):
-        "x"
+        """X"""
 
     def pytest_xyz_noarg():
-        "x"
+        """X"""
 
     apimod.pytest_xyz = pytest_xyz  # type: ignore
     apimod.pytest_xyz_noarg = pytest_xyz_noarg  # type: ignore

--- a/testing/test_reports.py
+++ b/testing/test_reports.py
@@ -9,8 +9,7 @@ from _pytest.reports import TestReport
 
 class TestReportSerialization:
     def test_xdist_longrepr_to_str_issue_241(self, testdir):
-        """
-        Regarding issue pytest-xdist#241
+        """Regarding issue pytest-xdist#241.
 
         This test came originally from test_remote.py in xdist (ca03269).
         """
@@ -133,9 +132,7 @@ class TestReportSerialization:
             assert rep_entries[i].lines == a_entries[i].lines
 
     def test_itemreport_outcomes(self, testdir):
-        """
-        This test came originally from test_remote.py in xdist (ca03269).
-        """
+        # This test came originally from test_remote.py in xdist (ca03269).
         reprec = testdir.inline_runsource(
             """
             import pytest

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -310,7 +310,7 @@ class BaseFunctionalTests:
         assert reps[5].failed
 
     def test_exact_teardown_issue1206(self, testdir) -> None:
-        """issue shadowing error with wrong number of arguments on teardown_method."""
+        """Issue shadowing error with wrong number of arguments on teardown_method."""
         rec = testdir.inline_runsource(
             """
             import pytest
@@ -742,7 +742,7 @@ def test_importorskip_dev_module(monkeypatch) -> None:
 
 
 def test_importorskip_module_level(testdir) -> None:
-    """importorskip must be able to skip entire modules when used at module level"""
+    """`importorskip` must be able to skip entire modules when used at module level."""
     testdir.makepyfile(
         """
         import pytest
@@ -757,7 +757,7 @@ def test_importorskip_module_level(testdir) -> None:
 
 
 def test_importorskip_custom_reason(testdir) -> None:
-    """make sure custom reasons are used"""
+    """Make sure custom reasons are used."""
     testdir.makepyfile(
         """
         import pytest
@@ -871,9 +871,8 @@ def test_makereport_getsource_dynamic_code(testdir, monkeypatch) -> None:
 
 
 def test_store_except_info_on_error() -> None:
-    """ Test that upon test failure, the exception info is stored on
-    sys.last_traceback and friends.
-    """
+    """Test that upon test failure, the exception info is stored on
+    sys.last_traceback and friends."""
     # Simulate item that might raise a specific exception, depending on `raise_error` class var
     class ItemMightRaise:
         nodeid = "item_that_raises"
@@ -934,9 +933,7 @@ def test_current_test_env_var(testdir, monkeypatch) -> None:
 
 
 class TestReportContents:
-    """
-    Test user-level API of ``TestReport`` objects.
-    """
+    """Test user-level API of ``TestReport`` objects."""
 
     def getrunner(self):
         return lambda item: runner.runtestprotocol(item, log=False)

--- a/testing/test_runner_xunit.py
+++ b/testing/test_runner_xunit.py
@@ -1,7 +1,4 @@
-"""
- test correct setup/teardowns at
- module, class, and instance level
-"""
+"""Test correct setup/teardowns at module, class, and instance level."""
 from typing import List
 
 import pytest
@@ -246,7 +243,7 @@ def test_setup_funcarg_setup_when_outer_scope_fails(testdir):
 def test_setup_teardown_function_level_with_optional_argument(
     testdir, monkeypatch, arg: str,
 ) -> None:
-    """parameter to setup/teardown xunit-style functions parameter is now optional (#1728)."""
+    """Parameter to setup/teardown xunit-style functions parameter is now optional (#1728)."""
     import sys
 
     trace_setups_teardowns = []  # type: List[str]

--- a/testing/test_setuponly.py
+++ b/testing/test_setuponly.py
@@ -254,7 +254,7 @@ def test_capturing(testdir):
 
 
 def test_show_fixtures_and_execute_test(testdir):
-    """ Verifies that setups are shown and tests are executed. """
+    """Verify that setups are shown and tests are executed."""
     p = testdir.makepyfile(
         """
         import pytest

--- a/testing/test_setupplan.py
+++ b/testing/test_setupplan.py
@@ -1,5 +1,5 @@
 def test_show_fixtures_and_test(testdir, dummy_yaml_custom_test):
-    """ Verifies that fixtures are not executed. """
+    """Verify that fixtures are not executed."""
     testdir.makepyfile(
         """
         import pytest
@@ -20,8 +20,7 @@ def test_show_fixtures_and_test(testdir, dummy_yaml_custom_test):
 
 
 def test_show_multi_test_fixture_setup_and_teardown_correctly_simple(testdir):
-    """
-    Verify that when a fixture lives for longer than a single test, --setup-plan
+    """Verify that when a fixture lives for longer than a single test, --setup-plan
     correctly displays the SETUP/TEARDOWN indicators the right number of times.
 
     As reported in https://github.com/pytest-dev/pytest/issues/2049
@@ -68,9 +67,7 @@ def test_show_multi_test_fixture_setup_and_teardown_correctly_simple(testdir):
 
 
 def test_show_multi_test_fixture_setup_and_teardown_same_as_setup_show(testdir):
-    """
-    Verify that SETUP/TEARDOWN messages match what comes out of --setup-show.
-    """
+    """Verify that SETUP/TEARDOWN messages match what comes out of --setup-show."""
     testdir.makepyfile(
         """
         import pytest

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -188,9 +188,7 @@ class TestXFail:
         assert callreport.wasxfail == "this is an xfail"
 
     def test_xfail_using_platform(self, testdir):
-        """
-        Verify that platform can be used with xfail statements.
-        """
+        """Verify that platform can be used with xfail statements."""
         item = testdir.getitem(
             """
             import pytest
@@ -476,9 +474,8 @@ class TestXFail:
         result.stdout.fnmatch_lines([matchline])
 
     def test_strict_sanity(self, testdir):
-        """sanity check for xfail(strict=True): a failing test should behave
-        exactly like a normal xfail.
-        """
+        """Sanity check for xfail(strict=True): a failing test should behave
+        exactly like a normal xfail."""
         p = testdir.makepyfile(
             """
             import pytest
@@ -1137,9 +1134,7 @@ def test_xfail_item(testdir):
 
 
 def test_module_level_skip_error(testdir):
-    """
-    Verify that using pytest.skip at module level causes a collection error
-    """
+    """Verify that using pytest.skip at module level causes a collection error."""
     testdir.makepyfile(
         """
         import pytest
@@ -1156,9 +1151,7 @@ def test_module_level_skip_error(testdir):
 
 
 def test_module_level_skip_with_allow_module_level(testdir):
-    """
-    Verify that using pytest.skip(allow_module_level=True) is allowed
-    """
+    """Verify that using pytest.skip(allow_module_level=True) is allowed."""
     testdir.makepyfile(
         """
         import pytest
@@ -1173,9 +1166,7 @@ def test_module_level_skip_with_allow_module_level(testdir):
 
 
 def test_invalid_skip_keyword_parameter(testdir):
-    """
-    Verify that using pytest.skip() with unknown parameter raises an error
-    """
+    """Verify that using pytest.skip() with unknown parameter raises an error."""
     testdir.makepyfile(
         """
         import pytest

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1,6 +1,4 @@
-"""
-terminal reporting of the full testing process.
-"""
+"""Terminal reporting of the full testing process."""
 import collections
 import os
 import sys
@@ -440,10 +438,8 @@ class TestCollectonly:
         )
 
     def test_collectonly_missing_path(self, testdir):
-        """this checks issue 115,
-            failure in parseargs will cause session
-            not to have the items attribute
-        """
+        """Issue 115: failure in parseargs will cause session not to
+        have the items attribute."""
         result = testdir.runpytest("--collect-only", "uhm_missing_path")
         assert result.ret == 4
         result.stderr.fnmatch_lines(["*ERROR: file not found*"])
@@ -531,7 +527,7 @@ class TestFixtureReporting:
         )
 
     def test_setup_teardown_output_and_test_failure(self, testdir):
-        """ Test for issue #442 """
+        """Test for issue #442."""
         testdir.makepyfile(
             """
             def setup_function(function):
@@ -1076,9 +1072,7 @@ def test_color_no(testdir):
 
 @pytest.mark.parametrize("verbose", [True, False])
 def test_color_yes_collection_on_non_atty(testdir, verbose):
-    """skip collect progress report when working on non-terminals.
-    #1397
-    """
+    """#1397: Skip collect progress report when working on non-terminals."""
     testdir.makepyfile(
         """
         import pytest
@@ -1208,9 +1202,8 @@ def test_traceconfig(testdir):
 
 
 class TestGenericReporting:
-    """ this test class can be subclassed with a different option
-        provider to run e.g. distributed tests.
-    """
+    """Test class which can be subclassed with a different option provider to
+    run e.g. distributed tests."""
 
     def test_collect_fail(self, testdir, option):
         testdir.makepyfile("import xyz\n")

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1196,9 +1196,7 @@ def test_pdb_teardown_called(testdir, monkeypatch) -> None:
 
 @pytest.mark.parametrize("mark", ["@unittest.skip", "@pytest.mark.skip"])
 def test_pdb_teardown_skipped(testdir, monkeypatch, mark: str) -> None:
-    """
-    With --pdb, setUp and tearDown should not be called for skipped tests.
-    """
+    """With --pdb, setUp and tearDown should not be called for skipped tests."""
     tracked = []  # type: List[str]
     monkeypatch.setattr(pytest, "test_pdb_teardown_skipped", tracked, raising=False)
 

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -13,9 +13,7 @@ WARNINGS_SUMMARY_HEADER = "warnings summary"
 
 @pytest.fixture
 def pyfile_with_warnings(testdir: Testdir, request: FixtureRequest) -> str:
-    """
-    Create a test file which calls a function in a module which generates warnings.
-    """
+    """Create a test file which calls a function in a module which generates warnings."""
     testdir.syspathinsert()
     test_name = request.function.__name__
     module_name = test_name.lstrip("test_") + "_module"
@@ -42,9 +40,7 @@ def pyfile_with_warnings(testdir: Testdir, request: FixtureRequest) -> str:
 
 @pytest.mark.filterwarnings("default")
 def test_normal_flow(testdir, pyfile_with_warnings):
-    """
-    Check that the warnings section is displayed.
-    """
+    """Check that the warnings section is displayed."""
     result = testdir.runpytest(pyfile_with_warnings)
     result.stdout.fnmatch_lines(
         [
@@ -180,9 +176,8 @@ def test_works_with_filterwarnings(testdir):
 
 @pytest.mark.parametrize("default_config", ["ini", "cmdline"])
 def test_filterwarnings_mark(testdir, default_config):
-    """
-    Test ``filterwarnings`` mark works and takes precedence over command line and ini options.
-    """
+    """Test ``filterwarnings`` mark works and takes precedence over command
+    line and ini options."""
     if default_config == "ini":
         testdir.makeini(
             """
@@ -305,9 +300,7 @@ def test_warning_captured_hook(testdir):
 
 @pytest.mark.filterwarnings("always")
 def test_collection_warnings(testdir):
-    """
-    Check that we also capture warnings issued during test collection (#3251).
-    """
+    """Check that we also capture warnings issued during test collection (#3251)."""
     testdir.makepyfile(
         """
         import warnings
@@ -387,7 +380,7 @@ def test_hide_pytest_internal_warnings(testdir, ignore_pytest_warnings):
 
 @pytest.mark.parametrize("ignore_on_cmdline", [True, False])
 def test_option_precedence_cmdline_over_ini(testdir, ignore_on_cmdline):
-    """filters defined in the command-line should take precedence over filters in ini files (#3946)."""
+    """Filters defined in the command-line should take precedence over filters in ini files (#3946)."""
     testdir.makeini(
         """
         [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -154,7 +154,17 @@ commands = python scripts/publish-gh-release-notes.py {posargs}
 
 [flake8]
 max-line-length = 120
-extend-ignore = E203
+extend-ignore =
+    ; whitespace before ':'
+    E203
+    ; Missing Docstrings
+    D100,D101,D102,D103,D104,D105,D106,D107
+    ; Whitespace Issues
+    D202,D203,D204,D205,D209,D213
+    ; Quotes Issues
+    D302
+    ; Docstring Content Issues
+    D400,D401,D401,D402,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414,D415,D416,D417
 
 [isort]
 ; This config mimics what reorder-python-imports does.


### PR DESCRIPTION
As discussed in #7471, we now have a preferred docstring style. While I was initially reluctant to add lints for the style we settled on, based on past experience, I tried pydocstyle again and it was quite useful, and I changed my mind. So this PR adds flake8-docstrings to our pre-commit setup.

The previous PR #7510 fixed docstring issues in `src/`. Since the lint works on the entire code, this PR also has a commit to fix issues in `testing/`.