### PR TITLE
Add pytest.version_tuple()

### DIFF
--- a/src/_pytest/__init__.py
+++ b/src/_pytest/__init__.py
@@ -1,8 +1,47 @@
 __all__ = ["__version__"]
 
+import re
+from typing import Tuple
+
 try:
     from ._version import version as __version__
 except ImportError:
     # broken installation, we don't even try
     # unknown only works because we do poor mans version compare
     __version__ = "unknown"
+
+
+def version_tuple() -> Tuple[int, int, int, str, str]:
+    """
+    Return a tuple containing the components of this pytest version:
+     (*major*, *minor*, *patch*, *release candidate*, *dev hash*).
+
+    Useful for plugins to handle multiple pytest versions when there are incompatibilities
+    at the plugin level, without parsing the version manually.
+    """
+    return parse_version(__version__)
+
+
+_VERSION_RE = re.compile(
+    r"""
+    (?P<major>\d+)
+    \.
+    (?P<minor>\d+)
+    \.
+    (?P<patch>\d+)
+    (?P<rc>rc\d+)?
+    (\.(?P<dev>.*))?
+    """,
+    re.VERBOSE,
+)
+
+
+def parse_version(version: str) -> Tuple[int, int, int, str, str]:
+    m = _VERSION_RE.match(version)
+    assert m is not None, "internal error parsing version {}".format(version)
+    major = int(m.group("major"))
+    minor = int(m.group("minor"))
+    patch = int(m.group("patch"))
+    rc = m.group("rc") or ""
+    dev = m.group("dev") or ""
+    return major, minor, patch, rc, dev

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -2,6 +2,7 @@
 """pytest: unit and functional testing with Python."""
 from . import collect
 from _pytest import __version__
+from _pytest import version_tuple
 from _pytest.assertion import register_assert_rewrite
 from _pytest.config import cmdline
 from _pytest.config import console_main
@@ -50,6 +51,7 @@ set_trace = __pytestPDB.set_trace
 
 __all__ = [
     "__version__",
+    "version_tuple",
     "_fillfuncargs",
     "approx",
     "Class",

--- a/testing/test_meta.py
+++ b/testing/test_meta.py
@@ -33,3 +33,21 @@ def test_no_warnings(module: str) -> None:
         "-c", "__import__({!r})".format(module),
     ))
     # fmt: on
+
+
+def test_version_tuple():
+    fields = pytest.__version__.split(".")
+    assert pytest.version_tuple()[:2] == (int(fields[0]), int(fields[1]))
+
+
+@pytest.mark.parametrize(
+    "v, expected",
+    [
+        ("6.0.0", (6, 0, 0, "", "")),
+        ("6.0.0rc1", (6, 0, 0, "rc1", "")),
+        ("6.23.1.dev39+ga", (6, 23, 1, "", "dev39+ga")),
+        ("6.23.1rc2.dev39+ga", (6, 23, 1, "rc2", "dev39+ga")),
+    ],
+)
+def test_passe_version_tuple(v, expected):
+    assert _pytest.parse_version(v) == expected


### PR DESCRIPTION
Often plugins need to identify the current pytest version in order to
handle some incompatibility or support newer features without breaking
the plugin to users of older pytest versions.

Currently plugin authors are required to either:

1. Parse the version themselves:

   https://github.com/pytest-dev/pytest-timeout/blob/f9ab1213c5242c0ba081ba50ec970859d22e8ff4/pytest_timeout.py#L389-L394

2. Or use feature checking:

   https://github.com/pytest-dev/pytest-xdist/blob/c6255faad4bde9385f5e5880f488b02206b1f073/src/xdist/remote.py#L104-L105

3. Or use brittle try/except semantics:

   https://github.com/pytest-dev/pytest-subtests/blob/96fc692a151f0709bf8ee209f8ce5d37b035f076/pytest_subtests.py#L178-L185

All the above solutions have problems:

1. Parsing using a library or by hand might break depending on the version scheme used by pytest. An example of that was `pytest-timeout`, which used `distutils.StrictVersion` to check for a feature, and that broke when we released `6.0.0rc1`.
2. Feature checking works, but doesn't make it explicit which pytest versions are being handled, which might leave the code obsolete when support for old pytest versions is dropped and that code is no longer required (as opposed to explicit version checking, which is often easy to find).
3. Same problem as 2, but even worse because the expected exception might have other cause. In the `subtests` example above, `TypeError` might be raised for other reasons, making that code break with a confusing error message.

So this introduces a public API to get the version information from pytest, `pytest.version_tuple()`.

It returns `(major, minor, patch, release candidate, dev)`, which allow plugin developers and users to safely check version similar to how it is done with `sys.version_info`.

Decided to name it `version_tuple()` instead of `version_info` (for parity with `sys.version_info`) because `sys.version_info` is a tuple, while I wanted to make it a function to avoid executing that code during import (module-level `__getattr__` would be a good fit for that, but alas Python 3.8+ only).

Missing:

- [ ] Docs
- [ ] Changelog
