### PR TITLE
Some py.path -> pathlib conversions

### DIFF
--- a/extra/get_issues.py
+++ b/extra/get_issues.py
@@ -1,6 +1,6 @@
 import json
+from pathlib import Path
 
-import py
 import requests
 
 issues_url = "https://api.github.com/repos/pytest-dev/pytest/issues"
@@ -31,12 +31,12 @@ def get_issues():
 
 
 def main(args):
-    cachefile = py.path.local(args.cache)
+    cachefile = Path(args.cache)
     if not cachefile.exists() or args.refresh:
         issues = get_issues()
-        cachefile.write(json.dumps(issues))
+        cachefile.write_text(json.dumps(issues), "utf-8")
     else:
-        issues = json.loads(cachefile.read())
+        issues = json.loads(cachefile.read_text("utf-8"))
 
     open_issues = [x for x in issues if x["state"] == "open"]
 

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -18,7 +18,6 @@ from typing import TypeVar
 from typing import Union
 
 import attr
-import py
 
 from _pytest._io.saferepr import saferepr
 from _pytest.outcomes import fail
@@ -104,13 +103,18 @@ def is_async_function(func: object) -> bool:
     )
 
 
-def getlocation(function, curdir=None) -> str:
+def getlocation(function, curdir: Optional[str] = None) -> str:
+    from _pytest.pathlib import Path
+
     function = get_real_func(function)
-    fn = py.path.local(inspect.getfile(function))
+    fn = Path(inspect.getfile(function))
     lineno = function.__code__.co_firstlineno
     if curdir is not None:
-        relfn = fn.relto(curdir)
-        if relfn:
+        try:
+            relfn = fn.relative_to(curdir)
+        except ValueError:
+            pass
+        else:
             return "%s:%d" % (relfn, lineno + 1)
     return "%s:%d" % (fn, lineno + 1)
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -123,7 +123,7 @@ def filter_traceback_for_conftest_import_failure(
 
 
 def main(
-    args: Optional[List[str]] = None,
+    args: Optional[Union[List[str], py.path.local]] = None,
     plugins: Optional[Sequence[Union[str, _PluggyPlugin]]] = None,
 ) -> Union[int, ExitCode]:
     """Perform an in-process test run.
@@ -1308,7 +1308,7 @@ class Config:
         values = []  # type: List[py.path.local]
         for relroot in relroots:
             if not isinstance(relroot, py.path.local):
-                relroot = relroot.replace("/", py.path.local.sep)
+                relroot = relroot.replace("/", os.sep)
                 relroot = modpath.join(relroot, abs=True)
             values.append(relroot)
         return values

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1006,12 +1006,15 @@ class Config:
         ns, unknown_args = self._parser.parse_known_and_unknown_args(
             args, namespace=copy.copy(self.option)
         )
-        self.rootdir, self.inifile, self.inicfg = determine_setup(
+        rootpath, inipath, inicfg = determine_setup(
             ns.inifilename,
             ns.file_or_dir + unknown_args,
             rootdir_cmd_arg=ns.rootdir or None,
             config=self,
         )
+        self.rootdir = py.path.local(str(rootpath))
+        self.inifile = py.path.local(str(inipath)) if inipath else None
+        self.inicfg = inicfg
         self._parser.extra_info["rootdir"] = self.rootdir
         self._parser.extra_info["inifile"] = self.inifile
         self._parser.addini("addopts", "extra command line options", "args")

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+import os
 import sys
 import warnings
 from collections import defaultdict
@@ -1515,8 +1516,8 @@ class FixtureManager:
             # by their test id).
             if p.basename.startswith("conftest.py"):
                 nodeid = p.dirpath().relto(self.config.rootdir)
-                if p.sep != nodes.SEP:
-                    nodeid = nodeid.replace(p.sep, nodes.SEP)
+                if os.sep != nodes.SEP:
+                    nodeid = nodeid.replace(os.sep, nodes.SEP)
 
         self.parsefactories(plugin, nodeid)
 

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -571,6 +571,15 @@ def visit(
             yield from visit(entry.path, recurse)
 
 
+def absolutepath(path: Union[Path, str]) -> Path:
+    """Convert a path to an absolute path using os.path.abspath.
+
+    Prefer this over Path.resolve() (see #6523).
+    Prefer this over Path.absolute() (not public, doesn't normalize).
+    """
+    return Path(os.path.abspath(str(path)))
+
+
 def commonpath(path1: Path, path2: Path) -> Optional[Path]:
     """Return the common part shared with the other path, or None if there is
     no common part."""

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -569,3 +569,35 @@ def visit(
     for entry in entries:
         if entry.is_dir(follow_symlinks=False) and recurse(entry):
             yield from visit(entry.path, recurse)
+
+
+def commonpath(path1: Path, path2: Path) -> Optional[Path]:
+    """Return the common part shared with the other path, or None if there is
+    no common part."""
+    try:
+        return Path(os.path.commonpath((str(path1), str(path2))))
+    except ValueError:
+        return None
+
+
+def bestrelpath(directory: Path, dest: Path) -> str:
+    """Return a string which is a relative path from directory to dest such
+    that directory/bestrelpath == dest.
+
+    If no such path can be determined, returns dest.
+    """
+    if dest == directory:
+        return os.curdir
+    # Find the longest common directory.
+    base = commonpath(directory, dest)
+    # Can be the case on Windows.
+    if not base:
+        return str(dest)
+    reldirectory = directory.relative_to(base)
+    reldest = dest.relative_to(base)
+    return os.path.join(
+        # Back from directory to base.
+        *([os.pardir] * len(reldirectory.parts)),
+        # Forward from base to dest.
+        *reldest.parts,
+    )

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1339,7 +1339,7 @@ def _show_fixtures_per_test(config: Config, session: Session) -> None:
     verbose = config.getvalue("verbose")
 
     def get_best_relpath(func):
-        loc = getlocation(func, curdir)
+        loc = getlocation(func, str(curdir))
         return curdir.bestrelpath(py.path.local(loc))
 
     def write_fixture(fixture_def: fixtures.FixtureDef[object]) -> None:
@@ -1404,7 +1404,7 @@ def _showfixtures_main(config: Config, session: Session) -> None:
         if not fixturedefs:
             continue
         for fixturedef in fixturedefs:
-            loc = getlocation(fixturedef.func, curdir)
+            loc = getlocation(fixturedef.func, str(curdir))
             if (fixturedef.argname, loc) in seen:
                 continue
             seen.add((fixturedef.argname, loc))
@@ -1434,7 +1434,7 @@ def _showfixtures_main(config: Config, session: Session) -> None:
         if verbose > 0:
             tw.write(" -- %s" % bestrel, yellow=True)
         tw.write("\n")
-        loc = getlocation(fixturedef.func, curdir)
+        loc = getlocation(fixturedef.func, str(curdir))
         doc = inspect.getdoc(fixturedef.func)
         if doc:
             write_docstring(tw, doc)

--- a/src/_pytest/resultlog.py
+++ b/src/_pytest/resultlog.py
@@ -3,8 +3,6 @@ import os
 from typing import IO
 from typing import Union
 
-import py
-
 from _pytest._code.code import ExceptionRepr
 from _pytest.config import Config
 from _pytest.config.argparsing import Parser
@@ -106,5 +104,5 @@ class ResultLog:
         if excrepr.reprcrash is not None:
             path = excrepr.reprcrash.path
         else:
-            path = "cwd:%s" % py.path.local()
+            path = "cwd:%s" % os.getcwd()
         self.write_log_entry(path, "!", str(excrepr))

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -586,7 +586,7 @@ class TestInvocationVariants:
         ):
             pytest.main("-h")  # type: ignore[arg-type]
 
-    def test_invoke_with_path(self, tmpdir, capsys):
+    def test_invoke_with_path(self, tmpdir: py.path.local, capsys) -> None:
         retcode = pytest.main(tmpdir)
         assert retcode == ExitCode.NO_TESTS_COLLECTED
         out, err = capsys.readouterr()

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -6,6 +6,8 @@ from textwrap import dedent
 import py
 
 import pytest
+from _pytest.pathlib import bestrelpath
+from _pytest.pathlib import commonpath
 from _pytest.pathlib import ensure_deletable
 from _pytest.pathlib import fnmatch_ex
 from _pytest.pathlib import get_extended_length_path_str
@@ -381,3 +383,21 @@ def test_suppress_error_removing_lock(tmp_path):
     # check now that we can remove the lock file in normal circumstances
     assert ensure_deletable(path, consider_lock_dead_if_created_before=mtime + 30)
     assert not lock.is_file()
+
+
+def test_bestrelpath() -> None:
+    curdir = Path("/foo/bar/baz/path")
+    assert bestrelpath(curdir, curdir) == "."
+    assert bestrelpath(curdir, curdir / "hello" / "world") == "hello" + os.sep + "world"
+    assert bestrelpath(curdir, curdir.parent / "sister") == ".." + os.sep + "sister"
+    assert bestrelpath(curdir, curdir.parent) == ".."
+    assert bestrelpath(curdir, Path("hello")) == "hello"
+
+
+def test_commonpath() -> None:
+    path = Path("/foo/bar/baz/path")
+    subpath = path / "sampledir"
+    assert commonpath(path, subpath) == path
+    assert commonpath(subpath, path) == path
+    assert commonpath(Path(str(path) + "suffix"), path) == path.parent
+    assert commonpath(path, path.parent.parent) == path.parent.parent


### PR DESCRIPTION
The first commit adds analogues of `py.path.local`'s `bestrelpath` and `common` functions to `_pytest.pathlib`.

The second commit converts `_pytest.config.findpaths` to use pathlib.

The third commit coverts some random places to pathlib.