### PR TITLE
pytester: some improvements and encoding fix to subprocess luanching

### DIFF
--- a/changelog/7623.bugfix.rst
+++ b/changelog/7623.bugfix.rst
@@ -1,0 +1,7 @@
+The :class:`_pytest.pytester.Testdir` functions
+:func:`_pytest.pytester.Testdir.runpytest_subprocess()`,
+:func:`_pytest.pytester.Testdir.runpython()` and
+:func:`_pytest.pytester.Testdir.runpython_c()`
+now launch Python with a UTF-8 IO encoding. Previously, if the subprocess
+emitted non-UTF-8 bytes and the host's IO encoding was not UTF-8, the function
+would raise a ``UnicodeDecodeError``.

--- a/changelog/7627.feature.rst
+++ b/changelog/7627.feature.rst
@@ -1,0 +1,3 @@
+The :func:`_pytest.pytester.Testdir.run()` function has new optional arguments:
+``encoding`` and ``errors`` to control how the ``stdout`` and ``stderr`` output of the launched process is decoded,
+and ``env`` to control the environment of the process.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1218,7 +1218,10 @@ class Testdir:
 
         You probably want to use :py:meth:`run` instead.
         """
-        env = os.environ.copy()
+        if kw.get("env") is not None:
+            env = kw["env"].copy()
+        else:
+            env = os.environ.copy()
         env["PYTHONPATH"] = os.pathsep.join(
             filter(None, [os.getcwd(), env.get("PYTHONPATH", "")])
         )

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1245,7 +1245,13 @@ class Testdir:
         return popen
 
     def run(
-        self, *cmdargs, timeout: Optional[float] = None, stdin=CLOSE_STDIN
+        self,
+        *cmdargs,
+        timeout: Optional[float] = None,
+        stdin=CLOSE_STDIN,
+        encoding: str = "utf-8",
+        errors: str = "strict",
+        env=None
     ) -> RunResult:
         """Run a command with arguments.
 
@@ -1261,6 +1267,13 @@ class Testdir:
             the pipe, otherwise it is passed through to ``popen``.
             Defaults to ``CLOSE_STDIN``, which translates to using a pipe
             (``subprocess.PIPE``) that gets closed.
+        :param encoding:
+            The encoding used to decode the stdout and stderr of the process.
+        :param errors:
+            The error handler to use when decoding the stdout and stderr of the process.
+        :param env:
+            The enviornment variables for the process.
+            The default is to inherit the environment of the current process.
         """
         __tracebackhide__ = True
 
@@ -1282,6 +1295,7 @@ class Testdir:
                 stdout=stdout,
                 stderr=stderr,
                 close_fds=(sys.platform != "win32"),
+                env=env,
             )
             if isinstance(stdin, bytes):
                 popen.stdin.close()
@@ -1299,8 +1313,8 @@ class Testdir:
 
             duration = timing.perf_counter() - start
 
-        with open(stdout_path, encoding="utf8") as stdout_text, open(
-            stderr_path, encoding="utf8"
+        with open(stdout_path, encoding=encoding, errors=errors) as stdout_text, open(
+            stderr_path, encoding=encoding, errors=errors
         ) as stderr_text:
             out = stdout_text.read().splitlines()
             err = stderr_text.read().splitlines()

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1345,14 +1345,26 @@ class Testdir:
 
         :rtype: RunResult
         """
-        return self.run(sys.executable, script)
+        # Use a consistent encoding, isolated from the host system.
+        encoding = "utf-8"
+        env = {
+            **os.environ.copy(),
+            "PYTHONIOENCODING": encoding,
+        }
+        return self.run(sys.executable, script, encoding=encoding, env=env)
 
-    def runpython_c(self, command):
+    def runpython_c(self, command) -> RunResult:
         """Run python -c "command".
 
         :rtype: RunResult
         """
-        return self.run(sys.executable, "-c", command)
+        # Use a consistent encoding, isolated from the host system.
+        encoding = "utf-8"
+        env = {
+            **os.environ.copy(),
+            "PYTHONIOENCODING": encoding,
+        }
+        return self.run(sys.executable, "-c", command, encoding=encoding, env=env)
 
     def runpytest_subprocess(self, *args, timeout: Optional[float] = None) -> RunResult:
         """Run pytest as a subprocess with given arguments.
@@ -1378,7 +1390,13 @@ class Testdir:
         if plugins:
             args = ("-p", plugins[0]) + args
         args = self._getpytestargs() + args
-        return self.run(*args, timeout=timeout)
+        # Use a consistent encoding, isolated from the host system.
+        encoding = "utf-8"
+        env = {
+            **os.environ.copy(),
+            "PYTHONIOENCODING": encoding,
+        }
+        return self.run(*args, timeout=timeout, encoding=encoding, env=env)
 
     def spawn_pytest(
         self, string: str, expect_timeout: float = 10.0


### PR DESCRIPTION
The first commit is a little cleanup.

The second and third commits add some features to `Testdir.run` that are needed for the next commit but are good to have anyway.

The last commit fixes #7623. I haven't actually tested it, because getting a non UTF-8 encoding (or a subset of it) on a modern Linux is almost impossible. But I think it should work. Pasting its commit message here:

To ensure that pytester subprocess tests are not affected by host system IO encoding (as do the inprocess tests, thanks to pytest's capturing), force its stdout/stderr to a known good encoding (UTF-8).

The alternative to this approach is, instead of trying to force the subprocess's encoding, try to adapt to it during decoding. Practically, it would mean trying to decode with `locale.getpreferredencoding()` or such. I opted against it in order to promote consistency across machines, and for consistency with inprocess tests, even though it makes the tests less realistic on the host machine.