### PR TITLE
Don't use NotImplementedError in `@overload`s

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -27,3 +27,4 @@ exclude_lines =
     ^\s*assert False(,|$)
 
     ^\s*if TYPE_CHECKING:
+    ^\s*@overload( |$)

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -334,11 +334,11 @@ class Traceback(List[TracebackEntry]):
 
     @overload
     def __getitem__(self, key: int) -> TracebackEntry:
-        raise NotImplementedError()
+        ...
 
     @overload  # noqa: F811
     def __getitem__(self, key: slice) -> "Traceback":  # noqa: F811
-        raise NotImplementedError()
+        ...
 
     def __getitem__(  # noqa: F811
         self, key: Union[int, slice]

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -44,11 +44,11 @@ class Source:
 
     @overload
     def __getitem__(self, key: int) -> str:
-        raise NotImplementedError()
+        ...
 
     @overload  # noqa: F811
     def __getitem__(self, key: slice) -> "Source":  # noqa: F811
-        raise NotImplementedError()
+        ...
 
     def __getitem__(self, key: Union[int, slice]) -> Union[str, "Source"]:  # noqa: F811
         if isinstance(key, int):

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -378,13 +378,13 @@ else:
         def __get__(
             self, instance: None, owner: Optional["Type[_S]"] = ...
         ) -> "cached_property[_S, _T]":
-            raise NotImplementedError()
+            ...
 
         @overload  # noqa: F811
         def __get__(  # noqa: F811
             self, instance: _S, owner: Optional["Type[_S]"] = ...
         ) -> _T:
-            raise NotImplementedError()
+            ...
 
         def __get__(self, instance, owner=None):  # noqa: F811
             if instance is None:

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1230,7 +1230,7 @@ def fixture(
     ] = ...,
     name: Optional[str] = ...
 ) -> _FixtureFunction:
-    raise NotImplementedError()
+    ...
 
 
 @overload  # noqa: F811
@@ -1248,7 +1248,7 @@ def fixture(  # noqa: F811
     ] = ...,
     name: Optional[str] = None
 ) -> FixtureFunctionMarker:
-    raise NotImplementedError()
+    ...
 
 
 def fixture(  # noqa: F811

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -501,13 +501,13 @@ class Session(nodes.FSCollector):
     def perform_collect(
         self, args: Optional[Sequence[str]] = ..., genitems: "Literal[True]" = ...
     ) -> Sequence[nodes.Item]:
-        raise NotImplementedError()
+        ...
 
     @overload  # noqa: F811
     def perform_collect(  # noqa: F811
         self, args: Optional[Sequence[str]] = ..., genitems: bool = ...
     ) -> Sequence[Union[nodes.Item, nodes.Collector]]:
-        raise NotImplementedError()
+        ...
 
     def perform_collect(  # noqa: F811
         self, args: Optional[Sequence[str]] = None, genitems: bool = True
@@ -528,13 +528,13 @@ class Session(nodes.FSCollector):
     def _perform_collect(
         self, args: Optional[Sequence[str]], genitems: "Literal[True]"
     ) -> List[nodes.Item]:
-        raise NotImplementedError()
+        ...
 
     @overload  # noqa: F811
     def _perform_collect(  # noqa: F811
         self, args: Optional[Sequence[str]], genitems: bool
     ) -> Union[List[Union[nodes.Item]], List[Union[nodes.Item, nodes.Collector]]]:
-        raise NotImplementedError()
+        ...
 
     def _perform_collect(  # noqa: F811
         self, args: Optional[Sequence[str]], genitems: bool

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -327,13 +327,13 @@ class MarkDecorator:
     # the first match so it works out even if we break the rules.
     @overload
     def __call__(self, arg: _Markable) -> _Markable:  # type: ignore[misc]
-        raise NotImplementedError()
+        pass
 
     @overload  # noqa: F811
     def __call__(  # noqa: F811
         self, *args: object, **kwargs: object
     ) -> "MarkDecorator":
-        raise NotImplementedError()
+        pass
 
     def __call__(self, *args: object, **kwargs: object):  # noqa: F811
         """Call the MarkDecorator."""
@@ -388,11 +388,11 @@ if TYPE_CHECKING:
     class _SkipMarkDecorator(MarkDecorator):
         @overload  # type: ignore[override,misc]
         def __call__(self, arg: _Markable) -> _Markable:
-            raise NotImplementedError()
+            ...
 
         @overload  # noqa: F811
         def __call__(self, reason: str = ...) -> "MarkDecorator":  # noqa: F811
-            raise NotImplementedError()
+            ...
 
     class _SkipifMarkDecorator(MarkDecorator):
         def __call__(  # type: ignore[override]
@@ -401,12 +401,12 @@ if TYPE_CHECKING:
             *conditions: Union[str, bool],
             reason: str = ...
         ) -> MarkDecorator:
-            raise NotImplementedError()
+            ...
 
     class _XfailMarkDecorator(MarkDecorator):
         @overload  # type: ignore[override,misc]
         def __call__(self, arg: _Markable) -> _Markable:
-            raise NotImplementedError()
+            ...
 
         @overload  # noqa: F811
         def __call__(  # noqa: F811
@@ -420,7 +420,7 @@ if TYPE_CHECKING:
             ] = ...,
             strict: bool = ...
         ) -> MarkDecorator:
-            raise NotImplementedError()
+            ...
 
     class _ParametrizeMarkDecorator(MarkDecorator):
         def __call__(  # type: ignore[override]
@@ -437,19 +437,19 @@ if TYPE_CHECKING:
             ] = ...,
             scope: Optional[_Scope] = ...
         ) -> MarkDecorator:
-            raise NotImplementedError()
+            ...
 
     class _UsefixturesMarkDecorator(MarkDecorator):
         def __call__(  # type: ignore[override]
             self, *fixtures: str
         ) -> MarkDecorator:
-            raise NotImplementedError()
+            ...
 
     class _FilterwarningsMarkDecorator(MarkDecorator):
         def __call__(  # type: ignore[override]
             self, *filters: str
         ) -> MarkDecorator:
-            raise NotImplementedError()
+            ...
 
 
 class MarkGenerator:

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -152,13 +152,13 @@ class MonkeyPatch:
     def setattr(
         self, target: str, name: object, value: Notset = ..., raising: bool = ...,
     ) -> None:
-        raise NotImplementedError()
+        ...
 
     @overload  # noqa: F811
     def setattr(  # noqa: F811
         self, target: object, name: str, value: object, raising: bool = ...,
     ) -> None:
-        raise NotImplementedError()
+        ...
 
     def setattr(  # noqa: F811
         self,

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -311,11 +311,11 @@ class Node(metaclass=NodeMeta):
 
     @overload
     def get_closest_marker(self, name: str) -> Optional[Mark]:
-        raise NotImplementedError()
+        ...
 
     @overload  # noqa: F811
     def get_closest_marker(self, name: str, default: Mark) -> Mark:  # noqa: F811
-        raise NotImplementedError()
+        ...
 
     def get_closest_marker(  # noqa: F811
         self, name: str, default: Optional[Mark] = None

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -201,7 +201,7 @@ class ParsedCall:
     if TYPE_CHECKING:
         # The class has undetermined attributes, this tells mypy about it.
         def __getattr__(self, key: str):
-            raise NotImplementedError()
+            ...
 
 
 class HookRecorder:
@@ -274,13 +274,13 @@ class HookRecorder:
     def getreports(
         self, names: "Literal['pytest_collectreport']",
     ) -> Sequence[CollectReport]:
-        raise NotImplementedError()
+        ...
 
     @overload  # noqa: F811
     def getreports(  # noqa: F811
         self, names: "Literal['pytest_runtest_logreport']",
     ) -> Sequence[TestReport]:
-        raise NotImplementedError()
+        ...
 
     @overload  # noqa: F811
     def getreports(  # noqa: F811
@@ -290,7 +290,7 @@ class HookRecorder:
             "pytest_runtest_logreport",
         ),
     ) -> Sequence[Union[CollectReport, TestReport]]:
-        raise NotImplementedError()
+        ...
 
     def getreports(  # noqa: F811
         self,
@@ -337,13 +337,13 @@ class HookRecorder:
     def getfailures(
         self, names: "Literal['pytest_collectreport']",
     ) -> Sequence[CollectReport]:
-        raise NotImplementedError()
+        ...
 
     @overload  # noqa: F811
     def getfailures(  # noqa: F811
         self, names: "Literal['pytest_runtest_logreport']",
     ) -> Sequence[TestReport]:
-        raise NotImplementedError()
+        ...
 
     @overload  # noqa: F811
     def getfailures(  # noqa: F811
@@ -353,7 +353,7 @@ class HookRecorder:
             "pytest_runtest_logreport",
         ),
     ) -> Sequence[Union[CollectReport, TestReport]]:
-        raise NotImplementedError()
+        ...
 
     def getfailures(  # noqa: F811
         self,

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -529,7 +529,7 @@ def raises(
     *,
     match: "Optional[Union[str, Pattern[str]]]" = ...
 ) -> "RaisesContext[_E]":
-    ...  # pragma: no cover
+    ...
 
 
 @overload  # noqa: F811
@@ -539,7 +539,7 @@ def raises(  # noqa: F811
     *args: Any,
     **kwargs: Any
 ) -> _pytest._code.ExceptionInfo[_E]:
-    ...  # pragma: no cover
+    ...
 
 
 def raises(  # noqa: F811

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -42,14 +42,14 @@ def recwarn() -> Generator["WarningsRecorder", None, None]:
 def deprecated_call(
     *, match: Optional[Union[str, "Pattern[str]"]] = ...
 ) -> "WarningsRecorder":
-    raise NotImplementedError()
+    ...
 
 
 @overload  # noqa: F811
 def deprecated_call(  # noqa: F811
     func: Callable[..., T], *args: Any, **kwargs: Any
 ) -> T:
-    raise NotImplementedError()
+    ...
 
 
 def deprecated_call(  # noqa: F811
@@ -89,7 +89,7 @@ def warns(
     *,
     match: "Optional[Union[str, Pattern[str]]]" = ...
 ) -> "WarningsChecker":
-    raise NotImplementedError()
+    ...
 
 
 @overload  # noqa: F811
@@ -99,7 +99,7 @@ def warns(  # noqa: F811
     *args: Any,
     **kwargs: Any
 ) -> T:
-    raise NotImplementedError()
+    ...
 
 
 def warns(  # noqa: F811

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -71,7 +71,7 @@ class BaseReport:
     if TYPE_CHECKING:
         # Can have arbitrary fields given to __init__().
         def __getattr__(self, key: str) -> Any:
-            raise NotImplementedError()
+            ...
 
     def toterminal(self, out: TerminalWriter) -> None:
         if hasattr(self, "node"):


### PR DESCRIPTION
We used it as a shortcut for avoiding coverage, but pylint has a special interpretation of it as an abstract method which we don't want.

Refs #7591 (fixes the `get_closest_marker` case but not the others).