### PR TITLE
Only define gethookproxy, isinitpath on Session

### DIFF
--- a/changelog/7591.bugfix.rst
+++ b/changelog/7591.bugfix.rst
@@ -1,0 +1,1 @@
+pylint shouldn't complain anymore about unimplemented abstract methods when inheriting from :ref:`File <non-python tests>`.

--- a/changelog/7648.deprecation.rst
+++ b/changelog/7648.deprecation.rst
@@ -1,0 +1,3 @@
+The ``gethookproxy()`` and ``isinitpath()`` methods of ``FSCollector`` and ``Package`` are deprecated;
+use ``self.session.gethookproxy()`` and ``self.session.isinitpath()`` instead.
+This should work on all pytest versions.

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -84,3 +84,8 @@ WARNING_CAPTURED_HOOK = PytestDeprecationWarning(
     "The pytest_warning_captured is deprecated and will be removed in a future release.\n"
     "Please use pytest_warning_recorded instead."
 )
+
+FSCOLLECTOR_GETHOOKPROXY_ISINITPATH = PytestDeprecationWarning(
+    "The gethookproxy() and isinitpath() methods of FSCollector and Package are deprecated; "
+    "use self.session.gethookproxy() and self.session.isinitpath() instead. "
+)

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -27,6 +27,7 @@ from _pytest.config import Config
 from _pytest.config import directory_arg
 from _pytest.config import ExitCode
 from _pytest.config import hookimpl
+from _pytest.config import PytestPluginManager
 from _pytest.config import UsageError
 from _pytest.config.argparsing import Parser
 from _pytest.fixtures import FixtureManager
@@ -389,6 +390,17 @@ def pytest_collection_modifyitems(items: List[nodes.Item], config: Config) -> No
         items[:] = remaining
 
 
+class FSHookProxy:
+    def __init__(self, pm: PytestPluginManager, remove_mods) -> None:
+        self.pm = pm
+        self.remove_mods = remove_mods
+
+    def __getattr__(self, name: str):
+        x = self.pm.subset_hook_caller(name, remove_plugins=self.remove_mods)
+        self.__dict__[name] = x
+        return x
+
+
 class NoMatch(Exception):
     """Matching cannot locate matching names."""
 
@@ -495,7 +507,20 @@ class Session(nodes.FSCollector):
         return path in self._initialpaths
 
     def gethookproxy(self, fspath: py.path.local):
-        return super()._gethookproxy(fspath)
+        # Check if we have the common case of running
+        # hooks with all conftest.py files.
+        pm = self.config.pluginmanager
+        my_conftestmodules = pm._getconftestmodules(
+            fspath, self.config.getoption("importmode")
+        )
+        remove_mods = pm._conftest_plugins.difference(my_conftestmodules)
+        if remove_mods:
+            # One or more conftests are not in use at this fspath.
+            proxy = FSHookProxy(pm, remove_mods)
+        else:
+            # All plugins are active for this fspath.
+            proxy = self.config.hook
+        return proxy
 
     @overload
     def perform_collect(

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -25,7 +25,7 @@ from _pytest.compat import overload
 from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.config import ConftestImportFailure
-from _pytest.config import PytestPluginManager
+from _pytest.deprecated import FSCOLLECTOR_GETHOOKPROXY_ISINITPATH
 from _pytest.deprecated import NODE_USE_FROM_PARENT
 from _pytest.fixtures import FixtureDef
 from _pytest.fixtures import FixtureLookupError
@@ -495,17 +495,6 @@ def _check_initialpaths_for_relpath(session, fspath):
             return fspath.relto(initial_path)
 
 
-class FSHookProxy:
-    def __init__(self, pm: PytestPluginManager, remove_mods) -> None:
-        self.pm = pm
-        self.remove_mods = remove_mods
-
-    def __getattr__(self, name: str):
-        x = self.pm.subset_hook_caller(name, remove_plugins=self.remove_mods)
-        self.__dict__[name] = x
-        return x
-
-
 class FSCollector(Collector):
     def __init__(
         self,
@@ -542,41 +531,27 @@ class FSCollector(Collector):
         """The public constructor."""
         return super().from_parent(parent=parent, fspath=fspath, **kw)
 
-    def _gethookproxy(self, fspath: py.path.local):
-        # Check if we have the common case of running
-        # hooks with all conftest.py files.
-        pm = self.config.pluginmanager
-        my_conftestmodules = pm._getconftestmodules(
-            fspath, self.config.getoption("importmode")
-        )
-        remove_mods = pm._conftest_plugins.difference(my_conftestmodules)
-        if remove_mods:
-            # One or more conftests are not in use at this fspath.
-            proxy = FSHookProxy(pm, remove_mods)
-        else:
-            # All plugins are active for this fspath.
-            proxy = self.config.hook
-        return proxy
-
     def gethookproxy(self, fspath: py.path.local):
-        raise NotImplementedError()
+        warnings.warn(FSCOLLECTOR_GETHOOKPROXY_ISINITPATH, stacklevel=2)
+        return self.session.gethookproxy(fspath)
+
+    def isinitpath(self, path: py.path.local) -> bool:
+        warnings.warn(FSCOLLECTOR_GETHOOKPROXY_ISINITPATH, stacklevel=2)
+        return self.session.isinitpath(path)
 
     def _recurse(self, direntry: "os.DirEntry[str]") -> bool:
         if direntry.name == "__pycache__":
             return False
         path = py.path.local(direntry.path)
-        ihook = self._gethookproxy(path.dirpath())
+        ihook = self.session.gethookproxy(path.dirpath())
         if ihook.pytest_ignore_collect(path=path, config=self.config):
             return False
         for pat in self._norecursepatterns:
             if path.check(fnmatch=pat):
                 return False
-        ihook = self._gethookproxy(path)
+        ihook = self.session.gethookproxy(path)
         ihook.pytest_collect_directory(path=path, parent=self)
         return True
-
-    def isinitpath(self, path: py.path.local) -> bool:
-        raise NotImplementedError()
 
     def _collectfile(
         self, path: py.path.local, handle_dupes: bool = True
@@ -586,8 +561,8 @@ class FSCollector(Collector):
         ), "{!r} is not a file (isdir={!r}, exists={!r}, islink={!r})".format(
             path, path.isdir(), path.exists(), path.islink()
         )
-        ihook = self.gethookproxy(path)
-        if not self.isinitpath(path):
+        ihook = self.session.gethookproxy(path)
+        if not self.session.isinitpath(path):
             if ihook.pytest_ignore_collect(path=path, config=self.config):
                 return ()
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -52,6 +52,7 @@ from _pytest.config import Config
 from _pytest.config import ExitCode
 from _pytest.config import hookimpl
 from _pytest.config.argparsing import Parser
+from _pytest.deprecated import FSCOLLECTOR_GETHOOKPROXY_ISINITPATH
 from _pytest.deprecated import FUNCARGNAMES
 from _pytest.fixtures import FuncFixtureInfo
 from _pytest.main import Session
@@ -627,10 +628,12 @@ class Package(Module):
             self.addfinalizer(func)
 
     def gethookproxy(self, fspath: py.path.local):
-        return super()._gethookproxy(fspath)
+        warnings.warn(FSCOLLECTOR_GETHOOKPROXY_ISINITPATH, stacklevel=2)
+        return self.session.gethookproxy(fspath)
 
     def isinitpath(self, path: py.path.local) -> bool:
-        return path in self.session._initialpaths
+        warnings.warn(FSCOLLECTOR_GETHOOKPROXY_ISINITPATH, stacklevel=2)
+        return self.session.isinitpath(path)
 
     def collect(self) -> Iterable[Union[nodes.Item, nodes.Collector]]:
         this_path = self.fspath.dirpath()


### PR DESCRIPTION
This fixes #7591 where pylint complains about missing implementations of abstract methods in subclasses of `File` which only override `collect()` (as they should).

It is also cleaner and makes sense, these methods really don't need to be overridden.

The previous methods defined directly on `FSCollector` and `Package` are deprecated, to be removed in pytest 7.

See commits e2934c3f8c03c83469f4c6670c207773a6e02df4 and f10ab021e21a44e2f0fa2be66660c4a6d4b7a61a for reference.