### PR TITLE
Allow 'unknown config key' warnings to be filtered out

### DIFF
--- a/changelog/7620.bugfix.rst
+++ b/changelog/7620.bugfix.rst
@@ -1,1 +1,3 @@
 It is now possible to silence :class:`pytest.PytestConfigWarning` messages about unknown configuration keys by using :confval:`filterwarnings`.
+
+Also, multiple keys are combined in a single warning, instead of showing a separate warning per key.

--- a/changelog/7620.bugfix.rst
+++ b/changelog/7620.bugfix.rst
@@ -1,0 +1,1 @@
+It is now possible to silence :class:`pytest.PytestConfigWarning` messages about unknown configuration keys by using :confval:`filterwarnings`.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1154,8 +1154,12 @@ class Config:
                 )
 
     def _validate_config_keys(self) -> None:
-        for key in sorted(self._get_unknown_ini_keys()):
-            self._warn_or_fail_if_strict("Unknown config ini key: {}\n".format(key))
+        keys = sorted(self._get_unknown_ini_keys())
+        if keys:
+            noun = "key" if len(keys) == 1 else "keys"
+            self._warn_or_fail_if_strict(
+                "Unknown config {}: {}".format(noun, ", ".join(keys))
+            )
 
     def _validate_plugins(self) -> None:
         required_plugins = sorted(self.getini("required_plugins"))

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -183,10 +183,9 @@ class TestParseIni:
                 ["unknown_ini", "another_unknown_ini"],
                 [
                     "=*= warnings summary =*=",
-                    "*PytestConfigWarning:*Unknown config ini key: another_unknown_ini",
-                    "*PytestConfigWarning:*Unknown config ini key: unknown_ini",
+                    "*PytestConfigWarning:*Unknown config keys: another_unknown_ini, unknown_ini",
                 ],
-                "Unknown config ini key: another_unknown_ini",
+                "Unknown config keys: another_unknown_ini, unknown_ini",
             ),
             (
                 """
@@ -197,9 +196,9 @@ class TestParseIni:
                 ["unknown_ini"],
                 [
                     "=*= warnings summary =*=",
-                    "*PytestConfigWarning:*Unknown config ini key: unknown_ini",
+                    "*PytestConfigWarning:*Unknown config key: unknown_ini",
                 ],
-                "Unknown config ini key: unknown_ini",
+                "Unknown config key: unknown_ini",
             ),
             (
                 """
@@ -260,7 +259,7 @@ class TestParseIni:
             """
             [pytest]
             filterwarnings =
-                ignore:Unknown config ini key:pytest.PytestConfigWarning
+                ignore:Unknown config key:pytest.PytestConfigWarning
             foobar=1
         """
         )


### PR DESCRIPTION
Delay issuing unknown config key warnings until collection is done, which allows users to filter it out using `filterwarnings`.

It also combines all missing keys into a single warning, instead of issuing a separate warning, but I'm not sure that's a good idea or not (this is a separate commit so it is easy to take it out).

Fix #7620