### PR TITLE
capture: fix disabled()/global_and_fixture_disabled() enabling capturing when it was disabled

### DIFF
--- a/changelog/7148.bugfix.rst
+++ b/changelog/7148.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``--log-cli`` potentially causing unrelated ``print`` output to be swallowed.

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -17,6 +17,7 @@ from _pytest.capture import CaptureManager
 from _pytest.capture import CaptureResult
 from _pytest.capture import MultiCapture
 from _pytest.config import ExitCode
+from _pytest.pytester import Testdir
 
 # note: py.io capture tests where copied from
 # pylib 1.4.20.dev2 (rev 13d9af95547e)
@@ -639,6 +640,34 @@ class TestCaptureFixture:
             assert "test_normal executed" in result.stdout.str()
         else:
             result.stdout.no_fnmatch_line("*test_normal executed*")
+
+    def test_disabled_capture_fixture_twice(self, testdir: Testdir) -> None:
+        """Test that an inner disabled() exit doesn't undo an outer disabled().
+
+        Issue #7148.
+        """
+        testdir.makepyfile(
+            """
+            def test_disabled(capfd):
+                print('captured before')
+                with capfd.disabled():
+                    print('while capture is disabled 1')
+                    with capfd.disabled():
+                        print('while capture is disabled 2')
+                    print('while capture is disabled 1 after')
+                print('captured after')
+                assert capfd.readouterr() == ('captured before\\ncaptured after\\n', '')
+        """
+        )
+        result = testdir.runpytest_subprocess()
+        result.stdout.fnmatch_lines(
+            [
+                "*while capture is disabled 1",
+                "*while capture is disabled 2",
+                "*while capture is disabled 1 after",
+            ],
+            consecutive=True,
+        )
 
     @pytest.mark.parametrize("fixture", ["capsys", "capfd"])
     def test_fixture_use_by_other_fixtures(self, testdir, fixture):


### PR DESCRIPTION
The `CaptureManager.global_and_fixture_disabled()` context manager (and `CaptureFixture.disabled()` which calls it) did `suspend(); ...; resume()` but if the capturing was already suspended, the `resume()` would resume it when it shouldn't.

This caused caused some messages to be swallowed when `--log-cli` is used because it uses `global_and_fixture_disabled` when capturing is not necessarily resumed.