### PR TITLE
Update talks/trainings page

### DIFF
--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -1,5 +1,12 @@
 :orphan:
 
+.. sidebar:: Next Open Trainings
+
+   - `pytest: Test Driven Development (nicht nur) für Python <https://workshoptage.ch/workshops/2020/pytest-test-driven-development-nicht-nur-fuer-python/>`_ (German) at the `CH Open Workshoptage <https://workshoptage.ch/>`_, September 8 2020, HSLU Campus Rotkreuz (ZG), Switzerland.
+   - `Professional testing with Python <https://www.python-academy.com/courses/specialtopics/python_course_testing.html>`_, via Python Academy, February 1-3 2021, Leipzig (Germany) and remote.
+
+   Also see `previous talks and blogposts <talks.html>`_.
+
 .. _features:
 
 pytest: helps you write better programs

--- a/doc/en/talks.rst
+++ b/doc/en/talks.rst
@@ -4,10 +4,8 @@ Talks and Tutorials
 
 .. sidebar:: Next Open Trainings
 
-   - `Free 1h webinar: "pytest: Test Driven Development für Python" <https://mylearning.ch/kurse/online-kurse/tech-webinar/>`_ (German), online, August 18 2020.
    - `"pytest: Test Driven Development (nicht nur) für Python" <https://workshoptage.ch/workshops/2020/pytest-test-driven-development-nicht-nur-fuer-python/>`_ (German) at the `CH Open Workshoptage <https://workshoptage.ch/>`_, September 8 2020, HSLU Campus Rotkreuz (ZG), Switzerland.
-
-.. _`funcargs`: funcargs.html
+   - `Professional testing with Python <https://www.python-academy.com/courses/specialtopics/python_course_testing.html>`_, via Python Academy, February 1-3 2021, Leipzig (Germany) and remote.
 
 Books
 ---------------------------------------------
@@ -20,6 +18,16 @@ Books
 
 Talks and blog postings
 ---------------------------------------------
+
+- Webinar: `pytest: Test Driven Development für Python (German) <https://bruhin.software/ins-pytest/>`_, Florian Bruhin, via mylearning.ch, 2020
+
+- Webinar: `Simplify Your Tests with Fixtures <https://blog.jetbrains.com/pycharm/2020/08/webinar-recording-simplify-your-tests-with-fixtures-with-oliver-bestwalter/>`_, Oliver Bestwalter, via JetBrains, 2020
+
+- Training: `Introduction to pytest - simple, rapid and fun testing with Python <https://www.youtube.com/watch?v=CMuSn9cofbI>`_, Florian Bruhin, PyConDE 2019
+
+- Abridged metaprogramming classics - this episode: pytest, Oliver Bestwalter, PyConDE 2019 (`repository <https://github.com/obestwalter/abridged-meta-programming-classics>`__, `recording <https://www.youtube.com/watch?v=zHpeMTJsBRk&feature=youtu.be>`__)
+
+- Testing PySide/PyQt code easily using the pytest framework, Florian Bruhin, Qt World Summit 2019 (`slides <https://bruhin.software/talks/qtws19.pdf>`__, `recording <https://www.youtube.com/watch?v=zdsBS5BXGqQ>`__)
 
 - `pytest: recommendations, basic packages for testing in Python and Django, Andreu Vallbona, PyBCN June 2019 <https://www.slideshare.net/AndreuVallbonaPlazas/pybcn-pytest-recomendaciones-paquetes-bsicos-para-testing-en-python-y-django>`_.
 
@@ -51,8 +59,6 @@ Talks and blog postings
 
 - `pytest: helps you write better Django apps, Andreas Pelme, DjangoCon
   Europe 2014 <https://www.youtube.com/watch?v=aaArYVh6XSM>`_.
-
-- :ref:`fixtures`
 
 - `Testing Django Applications with pytest, Andreas Pelme, EuroPython
   2013 <https://www.youtube.com/watch?v=aUf8Fkb7TaY>`_.

--- a/doc/en/talks.rst
+++ b/doc/en/talks.rst
@@ -2,11 +2,6 @@
 Talks and Tutorials
 ==========================
 
-.. sidebar:: Next Open Trainings
-
-   - `"pytest: Test Driven Development (nicht nur) für Python" <https://workshoptage.ch/workshops/2020/pytest-test-driven-development-nicht-nur-fuer-python/>`_ (German) at the `CH Open Workshoptage <https://workshoptage.ch/>`_, September 8 2020, HSLU Campus Rotkreuz (ZG), Switzerland.
-   - `Professional testing with Python <https://www.python-academy.com/courses/specialtopics/python_course_testing.html>`_, via Python Academy, February 1-3 2021, Leipzig (Germany) and remote.
-
 Books
 ---------------------------------------------
 


### PR DESCRIPTION
- Remove past webinar
- Add new open training
- Add some talks/webinars by Oliver Bestwalter and by me - I'm sure there have been more talks than those, but I don't have the time to go through years of conferences, so I just added the ones I remember
- Remove some stale link targets

Also, what do you think about moving the "Next Open Trainings" sidebar from the talks page to the main page? Right now it's quite hard to find the talks/tutorials page (and the training announcement) because it's also not part of the sidebar menu yet (I think it was with the old theme?).

IMHO it'd be nice to show it on the main page instead (since it's often only around for a couple of weeks/months anyways) to give those trainings a bit more visiblity - but since I'm probably the main person benefiting from that kind of thing that's not a decision I want to take alone. What do others think?