### PR TITLE
Make min duration configurable for slowest tests

### DIFF
--- a/changelog/7667.feature.rst
+++ b/changelog/7667.feature.rst
@@ -1,0 +1,1 @@
+Make min duration configurable for slowest tests.

--- a/changelog/7667.feature.rst
+++ b/changelog/7667.feature.rst
@@ -1,1 +1,1 @@
-Make min duration configurable for slowest tests.
+New `--durations-min` command-line flag controls the minimal duration for inclusion in the slowest list of tests shown by `--durations`. Previously this was hard-coded to `0.005s`.

--- a/changelog/7667.feature.rst
+++ b/changelog/7667.feature.rst
@@ -1,1 +1,1 @@
-New `--durations-min` command-line flag controls the minimal duration for inclusion in the slowest list of tests shown by `--durations`. Previously this was hard-coded to `0.005s`.
+New ``--durations-min`` command-line flag controls the minimal duration for inclusion in the slowest list of tests shown by ``--durations``. Previously this was hard-coded to ``0.005s``.

--- a/doc/en/usage.rst
+++ b/doc/en/usage.rst
@@ -426,14 +426,15 @@ Pytest supports the use of ``breakpoint()`` with the following behaviours:
 Profiling test execution duration
 -------------------------------------
 
+.. versionchanged:: 6.0
 
-To get a list of the slowest 10 test durations:
+To get a list of the slowest 10 test durations over 1.0s long:
 
 .. code-block:: bash
 
-    pytest --durations=10
+    pytest --durations=10 --durations-min=1.0
 
-By default, pytest will not show test durations that are too small (<0.01s) unless ``-vv`` is passed on the command-line.
+By default, pytest will not show test durations that are too small (<0.005s) unless ``-vv`` is passed on the command-line.
 
 
 .. _faulthandler:

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -52,10 +52,19 @@ def pytest_addoption(parser: Parser) -> None:
         metavar="N",
         help="show N slowest setup/test durations (N=0 for all).",
     )
+    group.addoption(
+        "--durations-min",
+        action="store",
+        type=float,
+        default=0.005,
+        metavar="N",
+        help="Minimal duration in seconds for inclusion in slowest list. Default 0.005",
+    )
 
 
 def pytest_terminal_summary(terminalreporter: "TerminalReporter") -> None:
     durations = terminalreporter.config.option.durations
+    durations_min = terminalreporter.config.option.durations_min
     verbose = terminalreporter.config.getvalue("verbose")
     if durations is None:
         return
@@ -76,11 +85,11 @@ def pytest_terminal_summary(terminalreporter: "TerminalReporter") -> None:
         dlist = dlist[:durations]
 
     for i, rep in enumerate(dlist):
-        if verbose < 2 and rep.duration < 0.005:
+        if verbose < 2 and rep.duration < durations_min:
             tr.write_line("")
             tr.write_line(
-                "(%s durations < 0.005s hidden.  Use -vv to show these durations.)"
-                % (len(dlist) - i)
+                "(%s durations < %gs hidden.  Use -vv to show these durations.)"
+                % (len(dlist) - i, durations_min)
             )
             break
         tr.write_line("{:02.2f}s {:<8} {}".format(rep.duration, rep.when, rep.nodeid))


### PR DESCRIPTION
Enables users to use custom values for the threshold used to determine slow tests.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
