### PR TITLE
Start simplifying collection code in Session

### DIFF
--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -32,6 +32,7 @@ from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.config.argparsing import Parser
 from _pytest.fixtures import FixtureRequest
+from _pytest.nodes import Collector
 from _pytest.outcomes import OutcomeException
 from _pytest.pathlib import import_path
 from _pytest.python_api import approx
@@ -118,7 +119,7 @@ def pytest_unconfigure() -> None:
 
 
 def pytest_collect_file(
-    path: py.path.local, parent
+    path: py.path.local, parent: Collector,
 ) -> Optional[Union["DoctestModule", "DoctestTextfile"]]:
     config = parent.config
     if path.ext == ".py":

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -274,10 +274,12 @@ def pytest_ignore_collect(path: py.path.local, config: "Config") -> Optional[boo
     """
 
 
-def pytest_collect_file(path: py.path.local, parent) -> "Optional[Collector]":
-    """Return collection Node or None for the given path.
+def pytest_collect_file(
+    path: py.path.local, parent: "Collector"
+) -> "Optional[Collector]":
+    """Create a Collector for the given path, or None if not relevant.
 
-    Any new node needs to have the specified ``parent`` as a parent.
+    The new node needs to have the specified ``parent`` as a parent.
 
     :param py.path.local path: The path to collect.
     """

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -709,52 +709,51 @@ class Session(nodes.FSCollector):
     ) -> Sequence[Union[nodes.Item, nodes.Collector]]:
         self.trace("matchnodes", matching, names)
         self.trace.root.indent += 1
-        nodes = self._matchnodes(matching, names)
-        num = len(nodes)
-        self.trace("matchnodes finished -> ", num, "nodes")
-        self.trace.root.indent -= 1
-        if num == 0:
-            raise NoMatch(matching, names[:1])
-        return nodes
 
-    def _matchnodes(
-        self, matching: Sequence[Union[nodes.Item, nodes.Collector]], names: List[str],
-    ) -> Sequence[Union[nodes.Item, nodes.Collector]]:
         if not matching or not names:
-            return matching
-        name = names[0]
-        assert name
-        nextnames = names[1:]
-        resultnodes = []  # type: List[Union[nodes.Item, nodes.Collector]]
-        for node in matching:
-            if isinstance(node, nodes.Item):
-                if not names:
-                    resultnodes.append(node)
-                continue
-            assert isinstance(node, nodes.Collector)
-            key = (type(node), node.nodeid)
-            if key in self._collection_node_cache3:
-                rep = self._collection_node_cache3[key]
-            else:
-                rep = collect_one_node(node)
-                self._collection_node_cache3[key] = rep
-            if rep.passed:
-                has_matched = False
-                for x in rep.result:
-                    # TODO: Remove parametrized workaround once collection structure contains parametrization.
-                    if x.name == name or x.name.split("[")[0] == name:
+            result = matching
+        else:
+            name = names[0]
+            assert name
+            nextnames = names[1:]
+            resultnodes = []  # type: List[Union[nodes.Item, nodes.Collector]]
+            for node in matching:
+                if isinstance(node, nodes.Item):
+                    if not names:
+                        resultnodes.append(node)
+                    continue
+                assert isinstance(node, nodes.Collector)
+                key = (type(node), node.nodeid)
+                if key in self._collection_node_cache3:
+                    rep = self._collection_node_cache3[key]
+                else:
+                    rep = collect_one_node(node)
+                    self._collection_node_cache3[key] = rep
+                if rep.passed:
+                    has_matched = False
+                    for x in rep.result:
+                        # TODO: Remove parametrized workaround once collection structure contains parametrization.
+                        if x.name == name or x.name.split("[")[0] == name:
+                            resultnodes.extend(self.matchnodes([x], nextnames))
+                            has_matched = True
+                    # XXX Accept IDs that don't have "()" for class instances.
+                    if not has_matched and len(rep.result) == 1 and x.name == "()":
+                        nextnames.insert(0, name)
                         resultnodes.extend(self.matchnodes([x], nextnames))
-                        has_matched = True
-                # XXX Accept IDs that don't have "()" for class instances.
-                if not has_matched and len(rep.result) == 1 and x.name == "()":
-                    nextnames.insert(0, name)
-                    resultnodes.extend(self.matchnodes([x], nextnames))
-            else:
-                # Report collection failures here to avoid failing to run some test
-                # specified in the command line because the module could not be
-                # imported (#134).
-                node.ihook.pytest_collectreport(report=rep)
-        return resultnodes
+                else:
+                    # Report collection failures here to avoid failing to run some test
+                    # specified in the command line because the module could not be
+                    # imported (#134).
+                    node.ihook.pytest_collectreport(report=rep)
+            result = resultnodes
+
+        self.trace("matchnodes finished -> ", len(result), "nodes")
+        self.trace.root.indent -= 1
+
+        if not result:
+            raise NoMatch(matching, names[:1])
+        else:
+            return result
 
     def genitems(
         self, node: Union[nodes.Item, nodes.Collector]

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -656,7 +656,7 @@ class Session(nodes.FSCollector):
         self._collection_pkg_roots.clear()
 
     def _collect(
-        self, argpath: py.path.local, names: List[str]
+        self, argpath: py.path.local, names: Sequence[str]
     ) -> Iterator[Union[nodes.Item, nodes.Collector]]:
         from _pytest.python import Package
 
@@ -741,7 +741,9 @@ class Session(nodes.FSCollector):
             yield from m
 
     def matchnodes(
-        self, matching: Sequence[Union[nodes.Item, nodes.Collector]], names: List[str],
+        self,
+        matching: Sequence[Union[nodes.Item, nodes.Collector]],
+        names: Sequence[str],
     ) -> Sequence[Union[nodes.Item, nodes.Collector]]:
         self.trace("matchnodes", matching, names)
         self.trace.root.indent += 1
@@ -751,7 +753,6 @@ class Session(nodes.FSCollector):
         else:
             name = names[0]
             assert name
-            nextnames = names[1:]
             resultnodes = []  # type: List[Union[nodes.Item, nodes.Collector]]
             for node in matching:
                 if isinstance(node, nodes.Item):
@@ -770,12 +771,11 @@ class Session(nodes.FSCollector):
                     for x in rep.result:
                         # TODO: Remove parametrized workaround once collection structure contains parametrization.
                         if x.name == name or x.name.split("[")[0] == name:
-                            resultnodes.extend(self.matchnodes([x], nextnames))
+                            resultnodes.extend(self.matchnodes([x], names[1:]))
                             has_matched = True
                     # XXX Accept IDs that don't have "()" for class instances.
                     if not has_matched and len(rep.result) == 1 and x.name == "()":
-                        nextnames.insert(0, name)
-                        resultnodes.extend(self.matchnodes([x], nextnames))
+                        resultnodes.extend(self.matchnodes([x], names))
                 else:
                     # Report collection failures here to avoid failing to run some test
                     # specified in the command line because the module could not be

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -764,15 +764,16 @@ class Session(nodes.FSCollector):
                 rep = collect_one_node(node)
                 self._collection_node_cache3[key] = rep
             if rep.passed:
-                has_matched = False
+                submatching = []
                 for x in rep.result:
                     # TODO: Remove parametrized workaround once collection structure contains parametrization.
                     if x.name == names[0] or x.name.split("[")[0] == names[0]:
-                        result.extend(self.matchnodes([x], names[1:]))
-                        has_matched = True
+                        submatching.append(x)
+                if submatching:
+                    result.extend(self.matchnodes(submatching, names[1:]))
                 # XXX Accept IDs that don't have "()" for class instances.
-                if not has_matched and len(rep.result) == 1 and x.name == "()":
-                    result.extend(self.matchnodes([x], names))
+                elif len(rep.result) == 1 and rep.result[0].name == "()":
+                    result.extend(self.matchnodes(rep.result, names))
             else:
                 # Report collection failures here to avoid failing to run some test
                 # specified in the command line because the module could not be

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -756,8 +756,6 @@ class Session(nodes.FSCollector):
             resultnodes = []  # type: List[Union[nodes.Item, nodes.Collector]]
             for node in matching:
                 if isinstance(node, nodes.Item):
-                    if not names:
-                        resultnodes.append(node)
                     continue
                 assert isinstance(node, nodes.Collector)
                 key = (type(node), node.nodeid)

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -597,10 +597,11 @@ class Session(nodes.FSCollector):
 
         self._notfound = []  # type: List[Tuple[str, NoMatch]]
         self._initial_parts = []  # type: List[Tuple[py.path.local, List[str]]]
-        self.items = items = []  # type: List[nodes.Item]
+        self.items = []  # type: List[nodes.Item]
 
         hook = self.config.hook
 
+        items = self.items  # type: Sequence[Union[nodes.Item, nodes.Collector]]
         try:
             initialpaths = []  # type: List[py.path.local]
             for arg in args:
@@ -620,9 +621,7 @@ class Session(nodes.FSCollector):
                     errors.append("not found: {}\n{}".format(arg, line))
                 raise UsageError(*errors)
             if not genitems:
-                # Type ignored because genitems=False is only used by tests. We don't
-                # want to change the type of `session.items` for this case.
-                items = rep.result  # type: ignore[assignment]
+                items = rep.result
             else:
                 if rep.passed:
                     for node in rep.result:

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -707,8 +707,53 @@ class Session(nodes.FSCollector):
                     col = collect_root._collectfile(argpath, handle_dupes=False)
                     if col:
                         self._collection_node_cache1[argpath] = col
-                m = self.matchnodes(col, names)
-                if not m:
+
+                matching = []
+                work = [
+                    (col, names)
+                ]  # type: List[Tuple[Sequence[Union[nodes.Item, nodes.Collector]], Sequence[str]]]
+                while work:
+                    self.trace("matchnodes", col, names)
+                    self.trace.root.indent += 1
+
+                    matchnodes, matchnames = work.pop()
+                    for node in matchnodes:
+                        if not matchnames:
+                            matching.append(node)
+                            continue
+                        if not isinstance(node, nodes.Collector):
+                            continue
+                        key = (type(node), node.nodeid)
+                        if key in self._collection_matchnodes_cache:
+                            rep = self._collection_matchnodes_cache[key]
+                        else:
+                            rep = collect_one_node(node)
+                            self._collection_matchnodes_cache[key] = rep
+                        if rep.passed:
+                            submatchnodes = []
+                            for r in rep.result:
+                                # TODO: Remove parametrized workaround once collection structure contains
+                                # parametrization.
+                                if (
+                                    r.name == matchnames[0]
+                                    or r.name.split("[")[0] == matchnames[0]
+                                ):
+                                    submatchnodes.append(r)
+                            if submatchnodes:
+                                work.append((submatchnodes, matchnames[1:]))
+                            # XXX Accept IDs that don't have "()" for class instances.
+                            elif len(rep.result) == 1 and rep.result[0].name == "()":
+                                work.append((rep.result, matchnames))
+                        else:
+                            # Report collection failures here to avoid failing to run some test
+                            # specified in the command line because the module could not be
+                            # imported (#134).
+                            node.ihook.pytest_collectreport(report=rep)
+
+                    self.trace("matchnodes finished -> ", len(matching), "nodes")
+                    self.trace.root.indent -= 1
+
+                if not matching:
                     report_arg = "::".join((str(argpath), *names))
                     self._notfound.append((report_arg, col))
                     continue
@@ -718,67 +763,23 @@ class Session(nodes.FSCollector):
                 # Module itself, so just use that. If this special case isn't taken, then all
                 # the files in the package will be yielded.
                 if argpath.basename == "__init__.py":
-                    assert isinstance(m[0], nodes.Collector)
+                    assert isinstance(matching[0], nodes.Collector)
                     try:
-                        yield next(iter(m[0].collect()))
+                        yield next(iter(matching[0].collect()))
                     except StopIteration:
                         # The package collects nothing with only an __init__.py
                         # file in it, which gets ignored by the default
                         # "python_files" option.
                         pass
                     continue
-                yield from m
+
+                yield from matching
 
             self.trace.root.indent -= 1
         self._collection_node_cache1.clear()
         self._collection_node_cache2.clear()
         self._collection_matchnodes_cache.clear()
         self._collection_pkg_roots.clear()
-
-    def matchnodes(
-        self,
-        matching: Sequence[Union[nodes.Item, nodes.Collector]],
-        names: Sequence[str],
-    ) -> Sequence[Union[nodes.Item, nodes.Collector]]:
-        result = []
-        work = [(matching, names)]
-        while work:
-            self.trace("matchnodes", matching, names)
-            self.trace.root.indent += 1
-
-            matching, names = work.pop()
-            for node in matching:
-                if not names:
-                    result.append(node)
-                    continue
-                if not isinstance(node, nodes.Collector):
-                    continue
-                key = (type(node), node.nodeid)
-                if key in self._collection_matchnodes_cache:
-                    rep = self._collection_matchnodes_cache[key]
-                else:
-                    rep = collect_one_node(node)
-                    self._collection_matchnodes_cache[key] = rep
-                if rep.passed:
-                    submatching = []
-                    for x in rep.result:
-                        # TODO: Remove parametrized workaround once collection structure contains parametrization.
-                        if x.name == names[0] or x.name.split("[")[0] == names[0]:
-                            submatching.append(x)
-                    if submatching:
-                        work.append((submatching, names[1:]))
-                    # XXX Accept IDs that don't have "()" for class instances.
-                    elif len(rep.result) == 1 and rep.result[0].name == "()":
-                        work.append((rep.result, names))
-                else:
-                    # Report collection failures here to avoid failing to run some test
-                    # specified in the command line because the module could not be
-                    # imported (#134).
-                    node.ihook.pytest_collectreport(report=rep)
-
-            self.trace("matchnodes finished -> ", len(result), "nodes")
-            self.trace.root.indent -= 1
-        return result
 
     def genitems(
         self, node: Union[nodes.Item, nodes.Collector]

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -511,9 +511,8 @@ class Session(nodes.FSCollector):
         if ihook.pytest_ignore_collect(path=path, config=self.config):
             return False
         norecursepatterns = self.config.getini("norecursedirs")
-        for pat in norecursepatterns:
-            if path.check(fnmatch=pat):
-                return False
+        if any(path.check(fnmatch=pat) for pat in norecursepatterns):
+            return False
         return True
 
     def _collectfile(
@@ -650,13 +649,12 @@ class Session(nodes.FSCollector):
 
                     if parent.isdir():
                         pkginit = parent.join("__init__.py")
-                        if pkginit.isfile():
-                            if pkginit not in node_cache1:
-                                col = self._collectfile(pkginit, handle_dupes=False)
-                                if col:
-                                    if isinstance(col[0], Package):
-                                        pkg_roots[str(parent)] = col[0]
-                                    node_cache1[col[0].fspath] = [col[0]]
+                        if pkginit.isfile() and pkginit not in node_cache1:
+                            col = self._collectfile(pkginit, handle_dupes=False)
+                            if col:
+                                if isinstance(col[0], Package):
+                                    pkg_roots[str(parent)] = col[0]
+                                node_cache1[col[0].fspath] = [col[0]]
 
             # If it's a directory argument, recurse and look for any Subpackages.
             # Let the Package collector deal with subnodes, don't collect here.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -748,7 +748,7 @@ class Session(nodes.FSCollector):
         self.trace("matchnodes", matching, names)
         self.trace.root.indent += 1
 
-        if not matching or not names:
+        if not names:
             result = matching
         else:
             name = names[0]

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -724,6 +724,8 @@ class Session(nodes.FSCollector):
                 if col:
                     self._collection_node_cache1[argpath] = col
             m = self.matchnodes(col, names)
+            if not m:
+                raise NoMatch(col)
             # If __init__.py was the only file requested, then the matched node will be
             # the corresponding Package, and the first yielded item will be the __init__
             # Module itself, so just use that. If this special case isn't taken, then all
@@ -780,10 +782,7 @@ class Session(nodes.FSCollector):
         self.trace("matchnodes finished -> ", len(result), "nodes")
         self.trace.root.indent -= 1
 
-        if not result:
-            raise NoMatch(matching, names[:1])
-        else:
-            return result
+        return result
 
     def genitems(
         self, node: Union[nodes.Item, nodes.Collector]

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -634,6 +634,43 @@ class Package(Module):
         warnings.warn(FSCOLLECTOR_GETHOOKPROXY_ISINITPATH, stacklevel=2)
         return self.session.isinitpath(path)
 
+    def _recurse(self, direntry: "os.DirEntry[str]") -> bool:
+        if direntry.name == "__pycache__":
+            return False
+        path = py.path.local(direntry.path)
+        ihook = self.session.gethookproxy(path.dirpath())
+        if ihook.pytest_ignore_collect(path=path, config=self.config):
+            return False
+        norecursepatterns = self.config.getini("norecursedirs")
+        for pat in norecursepatterns:
+            if path.check(fnmatch=pat):
+                return False
+        return True
+
+    def _collectfile(
+        self, path: py.path.local, handle_dupes: bool = True
+    ) -> typing.Sequence[nodes.Collector]:
+        assert (
+            path.isfile()
+        ), "{!r} is not a file (isdir={!r}, exists={!r}, islink={!r})".format(
+            path, path.isdir(), path.exists(), path.islink()
+        )
+        ihook = self.session.gethookproxy(path)
+        if not self.session.isinitpath(path):
+            if ihook.pytest_ignore_collect(path=path, config=self.config):
+                return ()
+
+        if handle_dupes:
+            keepduplicates = self.config.getoption("keepduplicates")
+            if not keepduplicates:
+                duplicate_paths = self.config.pluginmanager._duplicatepaths
+                if path in duplicate_paths:
+                    return ()
+                else:
+                    duplicate_paths.add(path)
+
+        return ihook.pytest_collect_file(path=path, parent=self)  # type: ignore[no-any-return]
+
     def collect(self) -> Iterable[Union[nodes.Item, nodes.Collector]]:
         this_path = self.fspath.dirpath()
         init_module = this_path.join("__init__.py")

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -184,7 +184,9 @@ def pytest_pyfunc_call(pyfuncitem: "Function") -> Optional[object]:
     return True
 
 
-def pytest_collect_file(path: py.path.local, parent) -> Optional["Module"]:
+def pytest_collect_file(
+    path: py.path.local, parent: nodes.Collector
+) -> Optional["Module"]:
     ext = path.ext
     if ext == ".py":
         if not parent.session.isinitpath(path):

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -644,9 +644,8 @@ class Package(Module):
         if ihook.pytest_ignore_collect(path=path, config=self.config):
             return False
         norecursepatterns = self.config.getini("norecursedirs")
-        for pat in norecursepatterns:
-            if path.check(fnmatch=pat):
-                return False
+        if any(path.check(fnmatch=pat) for pat in norecursepatterns):
+            return False
         return True
 
     def _collectfile(


### PR DESCRIPTION
Collection starts in `Session.perform_collect()`. I am trying to understand what it does, but it's very complex (in the cyclomatic complexity sense) and hard to follow. This PR starts to try and reveal the inner beauty of the code :)

The PR is split into commits, each doing one refactoring. Most of them are straightforward (except for `Revert "Move common code between Session and Package to FSCollector"` perhaps) and should be easier to follow than reading the full diff.

The end result is that most of the logic is localized in the `Session.collect()` instead of being spread around many places. The next step would be to figure out what all of the caches and special cases do, and either simplify and document them, or (I suspect) plain remove them if they're not serving a purpose.