### PR TITLE
[6.0.x] logging: fix handler level restored incorrectly if caplog.set_level is called more than once

### DIFF
--- a/changelog/7672.bugfix.rst
+++ b/changelog/7672.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed log-capturing level restored incorrectly if ``caplog.set_level`` is called more than once.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -437,7 +437,8 @@ class LogCaptureFixture:
         # save the original log-level to restore it during teardown
         self._initial_logger_levels.setdefault(logger, logger_obj.level)
         logger_obj.setLevel(level)
-        self._initial_handler_level = self.handler.level
+        if self._initial_handler_level is None:
+            self._initial_handler_level = self.handler.level
         self.handler.setLevel(level)
 
     @contextmanager

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -65,6 +65,7 @@ def test_change_level_undos_handler_level(testdir: Testdir) -> None:
 
         def test1(caplog):
             assert caplog.handler.level == 0
+            caplog.set_level(9999)
             caplog.set_level(41)
             assert caplog.handler.level == 41
 


### PR DESCRIPTION
Backport of #7673