### PR TITLE
testing: fix flaky test when executed slowly

### DIFF
--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -899,7 +899,7 @@ def test_collection_collect_only_live_logging(testdir, verbose):
         expected_lines.extend(
             [
                 "*test_collection_collect_only_live_logging.py::test_simple*",
-                "no tests ran in [0-1].[0-9][0-9]s",
+                "no tests ran in [0-9].[0-9][0-9]s",
             ]
         )
     elif verbose == "-qq":


### PR DESCRIPTION
The 0-1 was a bit too optimistic: CI got "no tests ran in 3.98s".

https://github.com/pytest-dev/pytest/runs/1017890126