### PR TITLE
config: start migrating Config.{rootdir,inifile} from py.path.local to pathlib

### DIFF
--- a/changelog/7685.improvement.rst
+++ b/changelog/7685.improvement.rst
@@ -1,0 +1,3 @@
+Added two new attributes :attr:`rootpath <_pytest.config.Config.rootpath>` and :attr:`inipath <_pytest.config.Config.inipath>` to :class:`Config <_pytest.config.Config>`.
+These attributes are :class:`pathlib.Path` versions of the existing :attr:`rootdir <_pytest.config.Config.rootdir>` and :attr:`inifile <_pytest.config.Config.inifile>` attributes,
+and should be preferred over them when possible.

--- a/doc/en/customize.rst
+++ b/doc/en/customize.rst
@@ -180,10 +180,15 @@ are never merged - the first match wins.
 The internal :class:`Config <_pytest.config.Config>` object (accessible via hooks or through the :fixture:`pytestconfig` fixture)
 will subsequently carry these attributes:
 
-- ``config.rootdir``: the determined root directory, guaranteed to exist.
+- :attr:`config.rootpath <_pytest.config.Config.rootpath>`: the determined root directory, guaranteed to exist.
 
-- ``config.inifile``: the determined ``configfile``, may be ``None`` (it is named ``inifile``
-  for historical reasons).
+- :attr:`config.inipath <_pytest.config.Config.inipath>`: the determined ``configfile``, may be ``None``
+  (it is named ``inipath`` for historical reasons).
+
+.. versionadded:: 6.1
+    The ``config.rootpath`` and ``config.inipath`` properties. They are :class:`pathlib.Path`
+    versions of the older ``config.rootdir`` and ``config.inifile``, which have type
+    ``py.path.local``, and still exist for backward compatibility.
 
 The ``rootdir`` is used as a reference directory for constructing test
 addresses ("nodeids") and can be used also by plugins for storing

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -78,7 +78,7 @@ class Cache:
 
     @staticmethod
     def cache_dir_from_config(config: Config) -> Path:
-        return resolve_from_str(config.getini("cache_dir"), config.rootdir)
+        return resolve_from_str(config.getini("cache_dir"), config.rootpath)
 
     def warn(self, fmt: str, **args: object) -> None:
         import warnings
@@ -264,7 +264,7 @@ class LFPlugin:
 
     def get_last_failed_paths(self) -> Set[Path]:
         """Return a set with all Paths()s of the previously failed nodeids."""
-        rootpath = Path(str(self.config.rootdir))
+        rootpath = self.config.rootpath
         result = {rootpath / nodeid.split("::")[0] for nodeid in self.lastfailed}
         return {x for x in result if x.exists()}
 
@@ -495,7 +495,7 @@ def pytest_report_header(config: Config) -> Optional[str]:
         # starting with .., ../.. if sensible
 
         try:
-            displaypath = cachedir.relative_to(str(config.rootdir))
+            displaypath = cachedir.relative_to(config.rootpath)
         except ValueError:
             displaypath = cachedir
         return "cachedir: {}".format(displaypath)

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -820,13 +820,13 @@ class Config:
     :param PytestPluginManager pluginmanager:
 
     :param InvocationParams invocation_params:
-        Object containing the parameters regarding the ``pytest.main``
+        Object containing parameters regarding the :func:`pytest.main`
         invocation.
     """
 
     @attr.s(frozen=True)
     class InvocationParams:
-        """Holds parameters passed during ``pytest.main()``
+        """Holds parameters passed during :func:`pytest.main`.
 
         The object attributes are read-only.
 
@@ -841,11 +841,20 @@ class Config:
         """
 
         args = attr.ib(type=Tuple[str, ...], converter=_args_converter)
-        """Tuple of command-line arguments as passed to ``pytest.main()``."""
+        """The command-line arguments as passed to :func:`pytest.main`.
+
+        :type: Tuple[str, ...]
+        """
         plugins = attr.ib(type=Optional[Sequence[Union[str, _PluggyPlugin]]])
-        """List of extra plugins, might be `None`."""
+        """Extra plugins, might be `None`.
+
+        :type: Optional[Sequence[Union[str, plugin]]]
+        """
         dir = attr.ib(type=Path)
-        """Directory from which ``pytest.main()`` was invoked."""
+        """The directory from which :func:`pytest.main` was invoked.
+
+        :type: pathlib.Path
+        """
 
     def __init__(
         self,
@@ -867,6 +876,10 @@ class Config:
         """
 
         self.invocation_params = invocation_params
+        """The parameters with which pytest was invoked.
+
+        :type: InvocationParams
+        """
 
         _a = FILE_OR_DIR
         self._parser = Parser(
@@ -876,7 +889,7 @@ class Config:
         self.pluginmanager = pluginmanager
         """The plugin manager handles plugin registration and hook invocation.
 
-        :type: PytestPluginManager.
+        :type: PytestPluginManager
         """
 
         self.trace = self.pluginmanager.trace.root.get("config")
@@ -901,7 +914,12 @@ class Config:
 
     @property
     def invocation_dir(self) -> py.path.local:
-        """Backward compatibility."""
+        """The directory from which pytest was invoked.
+
+        Prefer to use :attr:`invocation_params.dir <InvocationParams.dir>`.
+
+        :type: py.path.local
+        """
         return py.path.local(str(self.invocation_params.dir))
 
     def add_cleanup(self, func: Callable[[], None]) -> None:

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -916,11 +916,52 @@ class Config:
     def invocation_dir(self) -> py.path.local:
         """The directory from which pytest was invoked.
 
-        Prefer to use :attr:`invocation_params.dir <InvocationParams.dir>`.
+        Prefer to use :attr:`invocation_params.dir <InvocationParams.dir>`,
+        which is a :class:`pathlib.Path`.
 
         :type: py.path.local
         """
         return py.path.local(str(self.invocation_params.dir))
+
+    @property
+    def rootpath(self) -> Path:
+        """The path to the :ref:`rootdir <rootdir>`.
+
+        :type: pathlib.Path
+
+        .. versionadded:: 6.1
+        """
+        return self._rootpath
+
+    @property
+    def rootdir(self) -> py.path.local:
+        """The path to the :ref:`rootdir <rootdir>`.
+
+        Prefer to use :attr:`rootpath`, which is a :class:`pathlib.Path`.
+
+        :type: py.path.local
+        """
+        return py.path.local(str(self.rootpath))
+
+    @property
+    def inipath(self) -> Optional[Path]:
+        """The path to the :ref:`configfile <configfiles>`.
+
+        :type: Optional[pathlib.Path]
+
+        .. versionadded:: 6.1
+        """
+        return self._inipath
+
+    @property
+    def inifile(self) -> Optional[py.path.local]:
+        """The path to the :ref:`configfile <configfiles>`.
+
+        Prefer to use :attr:`inipath`, which is a :class:`pathlib.Path`.
+
+        :type: Optional[py.path.local]
+        """
+        return py.path.local(str(self.inipath)) if self.inipath else None
 
     def add_cleanup(self, func: Callable[[], None]) -> None:
         """Add a function to be called when the config object gets out of
@@ -1032,8 +1073,8 @@ class Config:
             rootdir_cmd_arg=ns.rootdir or None,
             config=self,
         )
-        self.rootdir = py.path.local(str(rootpath))
-        self.inifile = py.path.local(str(inipath)) if inipath else None
+        self._rootpath = rootpath
+        self._inipath = inipath
         self.inicfg = inicfg
         self._parser.extra_info["rootdir"] = self.rootdir
         self._parser.extra_info["inifile"] = self.inifile

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -603,7 +603,7 @@ class LoggingPlugin:
         fpath = Path(fname)
 
         if not fpath.is_absolute():
-            fpath = Path(str(self._config.rootdir), fpath)
+            fpath = self._config.rootpath / fpath
 
         if not fpath.parent.exists():
             fpath.parent.mkdir(exist_ok=True, parents=True)

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -33,6 +33,7 @@ from _pytest.config.argparsing import Parser
 from _pytest.fixtures import FixtureManager
 from _pytest.outcomes import exit
 from _pytest.pathlib import absolutepath
+from _pytest.pathlib import bestrelpath
 from _pytest.pathlib import Path
 from _pytest.pathlib import visit
 from _pytest.reports import CollectReport
@@ -425,11 +426,11 @@ class Failed(Exception):
 
 
 @attr.s
-class _bestrelpath_cache(Dict[py.path.local, str]):
-    path = attr.ib(type=py.path.local)
+class _bestrelpath_cache(Dict[Path, str]):
+    path = attr.ib(type=Path)
 
-    def __missing__(self, path: py.path.local) -> str:
-        r = self.path.bestrelpath(path)  # type: str
+    def __missing__(self, path: Path) -> str:
+        r = bestrelpath(self.path, path)
         self[path] = r
         return r
 
@@ -444,8 +445,8 @@ class Session(nodes.FSCollector):
     exitstatus = None  # type: Union[int, ExitCode]
 
     def __init__(self, config: Config) -> None:
-        nodes.FSCollector.__init__(
-            self, config.rootdir, parent=None, config=config, session=self, nodeid=""
+        super().__init__(
+            config.rootdir, parent=None, config=config, session=self, nodeid=""
         )
         self.testsfailed = 0
         self.testscollected = 0
@@ -456,8 +457,8 @@ class Session(nodes.FSCollector):
         self._initialpaths = frozenset()  # type: FrozenSet[py.path.local]
 
         self._bestrelpathcache = _bestrelpath_cache(
-            config.rootdir
-        )  # type: Dict[py.path.local, str]
+            config.rootpath
+        )  # type: Dict[Path, str]
 
         self.config.pluginmanager.register(self, name="session")
 
@@ -475,7 +476,7 @@ class Session(nodes.FSCollector):
             self.testscollected,
         )
 
-    def _node_location_to_relpath(self, node_path: py.path.local) -> str:
+    def _node_location_to_relpath(self, node_path: Path) -> str:
         # bestrelpath is a quite slow function.
         return self._bestrelpathcache[node_path]
 
@@ -599,7 +600,9 @@ class Session(nodes.FSCollector):
             initialpaths = []  # type: List[py.path.local]
             for arg in args:
                 fspath, parts = resolve_collection_argument(
-                    self.config.invocation_dir, arg, as_pypath=self.config.option.pyargs
+                    self.config.invocation_params.dir,
+                    arg,
+                    as_pypath=self.config.option.pyargs,
                 )
                 self._initial_parts.append((fspath, parts))
                 initialpaths.append(fspath)
@@ -817,7 +820,7 @@ def search_pypath(module_name: str) -> str:
 
 
 def resolve_collection_argument(
-    invocation_dir: py.path.local, arg: str, *, as_pypath: bool = False
+    invocation_path: Path, arg: str, *, as_pypath: bool = False
 ) -> Tuple[py.path.local, List[str]]:
     """Parse path arguments optionally containing selection parts and return (fspath, names).
 
@@ -844,7 +847,7 @@ def resolve_collection_argument(
     strpath, *parts = str(arg).split("::")
     if as_pypath:
         strpath = search_pypath(strpath)
-    fspath = Path(str(invocation_dir), strpath)
+    fspath = invocation_path / strpath
     fspath = absolutepath(fspath)
     if not fspath.exists():
         msg = (

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -31,6 +31,7 @@ from _pytest.mark.structures import Mark
 from _pytest.mark.structures import MarkDecorator
 from _pytest.mark.structures import NodeKeywords
 from _pytest.outcomes import fail
+from _pytest.pathlib import absolutepath
 from _pytest.pathlib import Path
 from _pytest.store import Store
 
@@ -401,7 +402,7 @@ class Node(metaclass=NodeMeta):
         # It will be better to just always display paths relative to invocation_dir, but
         # this requires a lot of plumbing (#6428).
         try:
-            abspath = Path(os.getcwd()) != Path(str(self.config.invocation_dir))
+            abspath = Path(os.getcwd()) != self.config.invocation_params.dir
         except OSError:
             abspath = True
 
@@ -597,10 +598,7 @@ class Item(Node):
     @cached_property
     def location(self) -> Tuple[str, Optional[int], str]:
         location = self.reportinfo()
-        if isinstance(location[0], py.path.local):
-            fspath = location[0]
-        else:
-            fspath = py.path.local(location[0])
+        fspath = absolutepath(str(location[0]))
         relfspath = self.session._node_location_to_relpath(fspath)
         assert type(location[2]) is str
         return (relfspath, location[1], location[2])

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -366,8 +366,7 @@ def make_numbered_dir_with_cleanup(
     raise e
 
 
-def resolve_from_str(input: str, root: py.path.local) -> Path:
-    rootpath = Path(root)
+def resolve_from_str(input: str, rootpath: Path) -> Path:
     input = expanduser(input)
     input = expandvars(input)
     if isabs(input):

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -18,6 +18,7 @@ import pytest
 from _pytest._io.wcwidth import wcswidth
 from _pytest.config import Config
 from _pytest.config import ExitCode
+from _pytest.pathlib import Path
 from _pytest.pytester import Testdir
 from _pytest.reports import BaseReport
 from _pytest.reports import CollectReport
@@ -2085,7 +2086,7 @@ def test_skip_reasons_folding() -> None:
     ev3.longrepr = longrepr
     ev3.skipped = True
 
-    values = _folded_skips(py.path.local(), [ev1, ev2, ev3])
+    values = _folded_skips(Path.cwd(), [ev1, ev2, ev3])
     assert len(values) == 1
     num, fspath, lineno_, reason = values[0]
     assert num == 3


### PR DESCRIPTION
The first commit is a small doc improvement to make the Config info in the API reference more complete.

The second commit adds two new attributes to Config, `rootpath` and `inipath`, which are the `Path` equivalents of `rootdir` and `inifile`, and moves `rootdir` and `inifile` to properties. For now the new attributes are not documented, and the documentation still refers to the old attributes. I can change this if it seems like a good idea.

The third commit converts some code internally from the old attributes to the new. There is always a chance of some subtle change in behavior here; I tried to be careful but we'll have to live and see...