### PR TITLE
python: fix empty parametrize() leading to "NotSetType.token" id

### DIFF
--- a/changelog/7686.bugfix.rst
+++ b/changelog/7686.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed `NotSetType.token` being used as the parameter ID when the parametrization list is empty.
+Regressed in pytest 6.0.0.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1293,6 +1293,9 @@ def _idval(
         return str(val)
     elif isinstance(val, REGEX_TYPE):
         return ascii_escaped(val.pattern)
+    elif val is NOTSET:
+        # Fallback to default. Note that NOTSET is an enum.Enum.
+        pass
     elif isinstance(val, enum.Enum):
         return str(val)
     elif isinstance(getattr(val, "__name__", None), str):

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -21,6 +21,7 @@ from _pytest import fixtures
 from _pytest import python
 from _pytest.compat import _format_args
 from _pytest.compat import getfuncargnames
+from _pytest.compat import NOTSET
 from _pytest.outcomes import fail
 from _pytest.pytester import Testdir
 from _pytest.python import _idval
@@ -358,6 +359,14 @@ class TestMetafunc:
         values = [(TestClass, "TestClass"), (test_function, "test_function")]
         for val, expected in values:
             assert _idval(val, "a", 6, None, nodeid=None, config=None) == expected
+
+    def test_notset_idval(self) -> None:
+        """Test that a NOTSET value (used by an empty parameterset) generates
+        a proper ID.
+
+        Regression test for #7686.
+        """
+        assert _idval(NOTSET, "a", 0, None, nodeid=None, config=None) == "a0"
 
     def test_idmaker_autoname(self) -> None:
         """#250"""


### PR DESCRIPTION
Fixes #7686.

In ff8b7884e8f1019f60f270eab2c4909ff557dd4e `NOTSET` was changed to a singleton enum, which ended up unexpectedly triggering a code path in ID generation which checks for `isinstance(Enum)`.

Add an explicit case for it, which is not too bad anyway.