### PR TITLE
Merge pull request #7687 from bluetech/idval-notset

### DIFF
--- a/changelog/7686.bugfix.rst
+++ b/changelog/7686.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed `NotSetType.token` being used as the parameter ID when the parametrization list is empty.
+Regressed in pytest 6.0.0.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1254,6 +1254,9 @@ def _idval(
         return str(val)
     elif isinstance(val, REGEX_TYPE):
         return ascii_escaped(val.pattern)
+    elif val is NOTSET:
+        # Fallback to default. Note that NOTSET is an enum.Enum.
+        pass
     elif isinstance(val, enum.Enum):
         return str(val)
     elif isinstance(getattr(val, "__name__", None), str):

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -19,6 +19,7 @@ from hypothesis import strategies
 import pytest
 from _pytest import fixtures
 from _pytest import python
+from _pytest.compat import NOTSET
 from _pytest.outcomes import fail
 from _pytest.pytester import Testdir
 from _pytest.python import _idval
@@ -362,6 +363,14 @@ class TestMetafunc:
         values = [(TestClass, "TestClass"), (test_function, "test_function")]
         for val, expected in values:
             assert _idval(val, "a", 6, None, nodeid=None, config=None) == expected
+
+    def test_notset_idval(self) -> None:
+        """Test that a NOTSET value (used by an empty parameterset) generates
+        a proper ID.
+
+        Regression test for #7686.
+        """
+        assert _idval(NOTSET, "a", 0, None, nodeid=None, config=None) == "a0"
 
     def test_idmaker_autoname(self) -> None:
         """#250"""


### PR DESCRIPTION
python: fix empty parametrize() leading to "NotSetType.token" id

