### PR TITLE
Allow contibuting additional global variables for skipif/xfail

### DIFF
--- a/changelog/7695.feature.rst
+++ b/changelog/7695.feature.rst
@@ -1,0 +1,19 @@
+A new hook was added, `pytest_markeval_namespace` which should return a dictionary.
+This dictionary will be used to augment the "global" variables available to evaluate skipif/xfail/xpass markers.
+
+Pseudo example
+
+``conftest.py``:
+
+.. code-block:: python
+
+   def pytest_markeval_namespace():
+       return {"color": "red"}
+
+``test_func.py``:
+
+.. code-block:: python
+
+   @pytest.mark.skipif("color == 'blue'", reason="Color is not red")
+   def test_func():
+       assert False

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -809,6 +809,25 @@ def pytest_warning_recorded(
 
 
 # -------------------------------------------------------------------------
+# Hooks for influencing skipping
+# -------------------------------------------------------------------------
+def pytest_markeval_namespace(config: "Config") -> Dict[str, Any]:
+    """Called when constructing the globals dictionary used for
+    evaluating string conditions in xfail/skipif markers.
+
+    This is useful when the condition for a marker requires
+    objects that are expensive or impossible to obtain during
+    collection time, which is required by normal boolean
+    conditions.
+
+    .. versionadded:: 6.2
+
+    :param _pytest.config.Config config: The pytest config object.
+    :returns: A dictionary of additional globals to add.
+    """
+
+
+# -------------------------------------------------------------------------
 # error handling and internal debugging hooks
 # -------------------------------------------------------------------------
 

--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -3,6 +3,7 @@ import os
 import platform
 import sys
 import traceback
+from collections.abc import Mapping
 from typing import Generator
 from typing import Optional
 from typing import Tuple
@@ -98,6 +99,16 @@ def evaluate_condition(item: Item, mark: Mark, condition: object) -> Tuple[bool,
             "platform": platform,
             "config": item.config,
         }
+        for dictionary in reversed(
+            item.ihook.pytest_markeval_namespace(config=item.config)
+        ):
+            if not isinstance(dictionary, Mapping):
+                raise ValueError(
+                    "pytest_markeval_namespace() needs to return a dict, got {!r}".format(
+                        dictionary
+                    )
+                )
+            globals_.update(dictionary)
         if hasattr(item, "obj"):
             globals_.update(item.obj.__globals__)  # type: ignore[attr-defined]
         try:


### PR DESCRIPTION
- [ ] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
