### PR TITLE
python: small optimization in PyCollector.collect()

### DIFF
--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -843,15 +843,6 @@ class TestConftestCustomization:
         result = testdir.runpytest("--collect-only")
         result.stdout.fnmatch_lines(["*MyFunction*some*"])
 
-    def test_makeitem_non_underscore(self, testdir, monkeypatch):
-        modcol = testdir.getmodulecol("def _hello(): pass")
-        values = []
-        monkeypatch.setattr(
-            pytest.Module, "_makeitem", lambda self, name, obj: values.append(name)
-        )
-        values = modcol.collect()
-        assert "_hello" not in values
-
     def test_issue2369_collect_module_fileext(self, testdir):
         """Ensure we can collect files with weird file extensions as Python
         modules (#2369)"""


### PR DESCRIPTION
Inline `_makeitem()` so that `self.ihook` (which is moderately expensive) can be called only once.

Note: the removed test "test_makeitem_non_underscore" comes from an old behavior of skipping names that start with `_` which has since been generalized, making the test no longer relevant.