### PR TITLE
doc/reference: include PluginManager in PytestPluginManager and remove it

### DIFF
--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -872,12 +872,6 @@ Parser
 .. autoclass:: _pytest.config.argparsing.Parser()
     :members:
 
-PluginManager
-~~~~~~~~~~~~~
-
-.. autoclass:: pluggy.PluginManager()
-    :members:
-
 
 PytestPluginManager
 ~~~~~~~~~~~~~~~~~~~
@@ -885,6 +879,7 @@ PytestPluginManager
 .. autoclass:: _pytest.config.PytestPluginManager()
     :members:
     :undoc-members:
+    :inherited-members:
     :show-inheritance:
 
 Session


### PR DESCRIPTION
Before, `PluginManager` was a copy of the pluggy doc, and `PytestPluginManager` was documented separately.

pytest users only really need to know about `PytestPluginManager`, so instead of splitting, have the `PytestPluginManager` documentation include all of `PluginManager` members and remove `PluginManager` from the reference (it is still shown as the base class).