### PR TITLE
[6.0.x] Properly remove log_print

### DIFF
--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -212,9 +212,9 @@ Breaking Changes
 
 
 - `#7224 <https://github.com/pytest-dev/pytest/issues/7224>`_: The `item.catch_log_handler` and `item.catch_log_handlers` attributes, set by the
-  logging plugin and never meant to be public , are no longer available.
+  logging plugin and never meant to be public, are no longer available.
 
-  The deprecated ``--no-print-logs`` option is removed. Use ``--show-capture`` instead.
+  The deprecated ``--no-print-logs`` option and ``log_print`` ini option are removed. Use ``--show-capture`` instead.
 
 
 - `#7226 <https://github.com/pytest-dev/pytest/issues/7226>`_: Removed the unused ``args`` parameter from ``pytest.Function.__init__``.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -51,9 +51,10 @@ a public API and may break in the future.
 .. versionremoved:: 6.0
 
 
-Option ``--no-print-logs`` is removed. If you used ``--no-print-logs``, please use ``--show-capture`` instead.
+The ``--no-print-logs`` option and ``log_print`` ini setting are removed. If
+you used them, please use ``--show-capture`` instead.
 
-``--show-capture`` command-line option was added in ``pytest 3.5.0`` and allows to specify how to
+A ``--show-capture`` command-line option was added in ``pytest 3.5.0`` which allows to specify how to
 display captured output when tests fail: ``no``, ``stdout``, ``stderr``, ``log`` or ``all`` (the default).
 
 

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -1466,20 +1466,6 @@ passed multiple times. The expected format is ``name=value``. For example::
     For more information, see :ref:`logging`.
 
 
-.. confval:: log_print
-
-
-
-    If set to ``False``, will disable displaying captured logging messages for failed tests.
-
-    .. code-block:: ini
-
-        [pytest]
-        log_print = False
-
-    For more information, see :ref:`logging`.
-
-
 .. confval:: markers
 
     When the ``--strict-markers`` or ``--strict`` command-line arguments are used,


### PR DESCRIPTION
Backport of #7614.