### PR TITLE
Use tox to execute release script

### DIFF
--- a/scripts/release-on-comment.py
+++ b/scripts/release-on-comment.py
@@ -2,8 +2,8 @@
 This script is part of the pytest release process which is triggered by comments
 in issues.
 
-This script is started by the `release-on-comment.yml` workflow, which is triggered by two comment
-related events:
+This script is started by the `release-on-comment.yml` workflow, which always executes on
+`master` and is triggered by two comment related events:
 
 * https://help.github.com/en/actions/reference/events-that-trigger-workflows#issue-comment-event-issue_comment
 * https://help.github.com/en/actions/reference/events-that-trigger-workflows#issues-event-issues
@@ -30,7 +30,7 @@ import argparse
 import json
 import os
 import re
-import sys
+import traceback
 from pathlib import Path
 from subprocess import CalledProcessError
 from subprocess import check_call
@@ -94,7 +94,6 @@ def print_and_exit(msg) -> None:
 
 
 def trigger_release(payload_path: Path, token: str) -> None:
-    error_contents = ""  # to be used to store error output in case any command fails
     payload, base_branch, is_major = validate_and_get_issue_comment_payload(
         payload_path
     )
@@ -119,6 +118,7 @@ def trigger_release(payload_path: Path, token: str) -> None:
         issue.create_comment(str(e))
         print_and_exit(f"{Fore.RED}{e}")
 
+    error_contents = ""
     try:
         print(f"Version: {Fore.CYAN}{version}")
 
@@ -146,11 +146,12 @@ def trigger_release(payload_path: Path, token: str) -> None:
 
         print(f"Branch {Fore.CYAN}{release_branch}{Fore.RESET} created.")
 
+        # important to use tox here because we have changed branches, so dependencies
+        # might have changed as well
+        cmdline = ["tox", "-e", "release", "--", version, "--skip-check-links"]
+        print("Running", " ".join(cmdline))
         run(
-            [sys.executable, "scripts/release.py", version, "--skip-check-links"],
-            text=True,
-            check=True,
-            capture_output=True,
+            cmdline, text=True, check=True, capture_output=True,
         )
 
         oauth_url = f"https://{token}:x-oauth-basic@github.com/{SLUG}.git"
@@ -178,43 +179,31 @@ def trigger_release(payload_path: Path, token: str) -> None:
         )
         print(f"Notified in original comment {Fore.CYAN}{comment.url}{Fore.RESET}.")
 
-        print(f"{Fore.GREEN}Success.")
     except CalledProcessError as e:
-        error_contents = e.output
-    except Exception as e:
-        error_contents = str(e)
-        link = f"https://github.com/{SLUG}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
-        issue.create_comment(
-            dedent(
-                f"""
-            Sorry, the request to prepare release `{version}` from {base_branch} failed with:
-
-            ```
-            {e}
-            ```
-
-            See: {link}.
-            """
-            )
-        )
-        print_and_exit(f"{Fore.RED}{e}")
+        error_contents = f"CalledProcessError\noutput:\n{e.output}\nstderr:\n{e.stderr}"
+    except Exception:
+        error_contents = f"Exception:\n{traceback.format_exc()}"
 
     if error_contents:
         link = f"https://github.com/{SLUG}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
-        issue.create_comment(
-            dedent(
-                f"""
-                Sorry, the request to prepare release `{version}` from {base_branch} failed with:
-
-                ```
-                {error_contents}
-                ```
-
-                See: {link}.
-                """
-            )
+        msg = ERROR_COMMENT.format(
+            version=version, base_branch=base_branch, contents=error_contents, link=link
         )
+        issue.create_comment(msg)
         print_and_exit(f"{Fore.RED}{error_contents}")
+    else:
+        print(f"{Fore.GREEN}Success.")
+
+
+ERROR_COMMENT = """\
+The request to prepare release `{version}` from {base_branch} failed with:
+
+```
+{contents}
+```
+
+See: {link}.
+"""
 
 
 def find_next_version(base_branch: str, is_major: bool) -> str:


### PR DESCRIPTION
The release-on-comment script is always executed on *master*, so we should
execute the `release.py` script using tox to ensure we create the
right environment.

Also fixed errors in the error handling code.