### PR TITLE
Prepare release 6.0.2

### DIFF
--- a/changelog/7148.bugfix.rst
+++ b/changelog/7148.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed ``--log-cli`` potentially causing unrelated ``print`` output to be swallowed.

--- a/changelog/7672.bugfix.rst
+++ b/changelog/7672.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed log-capturing level restored incorrectly if ``caplog.set_level`` is called more than once.

--- a/changelog/7686.bugfix.rst
+++ b/changelog/7686.bugfix.rst
@@ -1,2 +1,0 @@
-Fixed `NotSetType.token` being used as the parameter ID when the parametrization list is empty.
-Regressed in pytest 6.0.0.

--- a/changelog/7707.bugfix.rst
+++ b/changelog/7707.bugfix.rst
@@ -1,1 +1,0 @@
-Fix internal error when handling some exceptions that contain multiple lines or the style uses multiple lines (``--tb=line`` for example).

--- a/doc/en/announce/index.rst
+++ b/doc/en/announce/index.rst
@@ -6,6 +6,7 @@ Release announcements
    :maxdepth: 2
 
 
+   release-6.0.2
    release-6.0.1
    release-6.0.0
    release-6.0.0rc1

--- a/doc/en/announce/release-6.0.2.rst
+++ b/doc/en/announce/release-6.0.2.rst
@@ -1,0 +1,19 @@
+pytest-6.0.2
+=======================================
+
+pytest 6.0.2 has just been released to PyPI.
+
+This is a bug-fix release, being a drop-in replacement. To upgrade::
+
+  pip install --upgrade pytest
+
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
+
+Thanks to all of the contributors to this release:
+
+* Bruno Oliveira
+* Ran Benita
+
+
+Happy testing,
+The pytest Development Team

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -28,6 +28,25 @@ with advance notice in the **Deprecations** section of releases.
 
 .. towncrier release notes start
 
+pytest 6.0.2 (2020-09-04)
+=========================
+
+Bug Fixes
+---------
+
+- `#7148 <https://github.com/pytest-dev/pytest/issues/7148>`_: Fixed ``--log-cli`` potentially causing unrelated ``print`` output to be swallowed.
+
+
+- `#7672 <https://github.com/pytest-dev/pytest/issues/7672>`_: Fixed log-capturing level restored incorrectly if ``caplog.set_level`` is called more than once.
+
+
+- `#7686 <https://github.com/pytest-dev/pytest/issues/7686>`_: Fixed `NotSetType.token` being used as the parameter ID when the parametrization list is empty.
+  Regressed in pytest 6.0.0.
+
+
+- `#7707 <https://github.com/pytest-dev/pytest/issues/7707>`_: Fix internal error when handling some exceptions that contain multiple lines or the style uses multiple lines (``--tb=line`` for example).
+
+
 pytest 6.0.1 (2020-07-30)
 =========================
 

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -28,7 +28,7 @@ Install ``pytest``
 .. code-block:: bash
 
     $ pytest --version
-    pytest 6.0.1
+    pytest 6.0.2
 
 .. _`simpletest`:
 


### PR DESCRIPTION
Created automatically from https://github.com/pytest-dev/pytest/issues/7718#issuecomment-687405508.

Once all builds pass and it has been **approved** by one or more maintainers, the build
can be released by pushing a tag `6.0.2` to this repository.
