### PR TITLE
Allow ovewriting a parametrized fixture while reusing the parent fixture's value

### DIFF
--- a/changelog/1953.bugfix.rst
+++ b/changelog/1953.bugfix.rst
@@ -1,0 +1,20 @@
+Fix error when overwriting a parametrized fixture, while also reusing the super fixture value.
+
+.. code-block:: python
+
+    # conftest.py
+    import pytest
+
+
+    @pytest.fixture(params=[1, 2])
+    def foo(request):
+        return request.param
+
+
+    # test_foo.py
+    import pytest
+
+
+    @pytest.fixture
+    def foo(foo):
+        return foo * 2

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1533,15 +1533,8 @@ class FixtureManager:
         """Generate new tests based on parametrized fixtures used by the given metafunc"""
 
         def get_parametrize_mark_argnames(mark: Mark) -> Sequence[str]:
-            if "argnames" in mark.kwargs:
-                argnames = mark.kwargs[
-                    "argnames"
-                ]  # type: Union[str, Tuple[str, ...], List[str]]
-            else:
-                argnames = mark.args[0]
-            if not isinstance(argnames, (tuple, list)):
-                argnames = [x.strip() for x in argnames.split(",") if x.strip()]
-            return argnames
+            args, _ = ParameterSet._parse_parametrize_args(*mark.args, **mark.kwargs)
+            return args
 
         for argname in metafunc.fixturenames:
             # Get the FixtureDefs for the argname.


### PR DESCRIPTION
Fix #1953
