### PR TITLE
Update to deadsnakes/action@v2.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,7 +131,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Set up Python ${{ matrix.python }} (deadsnakes)
-      uses: deadsnakes/action@v1.0.0
+      uses: deadsnakes/action@v2.0.0
       if: matrix.python == '3.9-dev'
       with:
         python-version: ${{ matrix.python }}


### PR DESCRIPTION
should be a noop (despite the major version bump) -- I rewrote the action to be more stable and need fewer security updates
