### PR TITLE
Fix pytest + plugin + __init__.py as argument = error

### DIFF
--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -660,6 +660,8 @@ class Session(nodes.FSCollector):
                 assert isinstance(m[0], nodes.Collector)
                 try:
                     yield next(iter(m[0].collect()))
+                except NotImplementedError:
+                    yield m[0]
                 except StopIteration:
                     # The package collects nothing with only an __init__.py
                     # file in it, which gets ignored by the default


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

fixes #7763 

When `__init__.py` is in the list of files given as argument, and a plugin produces a test item for it (like flakes, black, ...) than the script tries to call the `collect` method on the item, which is not implemented in case of flakes and black (and maybe others).
This pr deals with the raised error.

also see
- pytest-flakes https://github.com/asmeurer/pytest-flakes/pull/38
- pytest-black https://github.com/shopkeep/pytest-black/pull/47