### PR TITLE
Fix `--debug` and setting of `PYTEST_CURRENT_TEST` in non-UTF8 locales

### DIFF
--- a/changelog/7781.bugfix.rst
+++ b/changelog/7781.bugfix.rst
@@ -1,0 +1,1 @@
+Fix writing non-encodable text to log file when using ``--debug``.

--- a/changelog/7786.bugfix.rst
+++ b/changelog/7786.bugfix.rst
@@ -1,0 +1,1 @@
+Fix setting of ``PYTEST_CURRENT_TEST`` when the current locale cannot encode the test name.

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -100,7 +100,7 @@ def pytest_cmdline_parse():
     config = outcome.get_result()  # type: Config
     if config.option.debug:
         path = os.path.abspath("pytestdebug.log")
-        debugfile = open(path, "w")
+        debugfile = open(path, "w", encoding="UTF-8")
         debugfile.write(
             "versions pytest-%s, py-%s, "
             "python-%s\ncwd=%s\nargs=%s\n\n"

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -189,7 +189,13 @@ def _update_current_test_var(
         value = "{} ({})".format(item.nodeid, when)
         # don't allow null bytes on environment variables (see #2644, #2957)
         value = value.replace("\x00", "(null)")
-        os.environ[var_name] = value
+        # if we are running with a locale that cannot encode the test name
+        # and we're on a system where os.environb is supported, explicitly
+        # encode using UTF-8 (otherwise we get an EncodeError)
+        if os.supports_bytes_environ:
+            os.environb[var_name.encode()] = value.encode()
+        else:
+            os.environ[var_name] = value
     else:
         os.environ.pop(var_name)
 

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -108,6 +108,21 @@ def test_debug(testdir):
     assert "pytest_sessionstart" in p.read()
 
 
+def test_debug_with_non_ascii_test_name(testdir, monkeypatch):
+    testdir.makepyfile(
+        """\
+        def test4_чћшђ_čćšđ():
+            pass
+        """
+    )
+    # force ASCII default io encoding (PYTHONIOENCODING didn't seem to work?)
+    monkeypatch.setenv("LANG", "C")
+    result = testdir.runpytest_subprocess("--debug")
+    assert result.ret == ExitCode.OK
+    log_contents = testdir.tmpdir.join("pytestdebug.log").read_binary()
+    assert b"pytest_sessionstart" in log_contents
+
+
 def test_PYTEST_DEBUG(testdir, monkeypatch):
     monkeypatch.setenv("PYTEST_DEBUG", "1")
     result = testdir.runpytest_subprocess()


### PR DESCRIPTION
Resolves #7781 
Resolves #7786