### PR TITLE
Put smoke test deps in requirements.txt for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/testing/plugins_integration"
+  schedule:
+    interval: monthly
+    time: "03:00"
+  open-pull-requests-limit: 10
+  allow:
+  - dependency-type: direct
+  - dependency-type: indirect

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: pip
   directory: "/testing/plugins_integration"
   schedule:
-    interval: monthly
+    interval: weekly
     time: "03:00"
   open-pull-requests-limit: 10
   allow:

--- a/testing/plugins_integration/requirements.txt
+++ b/testing/plugins_integration/requirements.txt
@@ -1,0 +1,15 @@
+anyio[curio,trio]==2.0.0
+django==3.1.1
+pytest-asyncio==0.14.0
+pytest-bdd==4.0.1
+pytest-cov==2.10.1
+pytest-django==3.10.0
+pytest-flakes==4.0.2
+pytest-html==2.1.1
+pytest-mock==3.3.1
+pytest-rerunfailures==9.1.1
+pytest-sugar==0.9.4
+pytest-trio==0.6.0
+pytest-twisted==1.13.2
+twisted==20.3.0
+pytest-xvfb==2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -119,22 +119,7 @@ pip_pre=true
 download=true
 install_command=python -m pip --use-feature=2020-resolver install {opts} {packages}
 changedir = testing/plugins_integration
-deps =
-    anyio[curio,trio]
-    django
-    pytest-asyncio
-    pytest-bdd
-    pytest-cov
-    pytest-django
-    pytest-flakes
-    pytest-html
-    pytest-mock
-    pytest-rerunfailures
-    pytest-sugar
-    pytest-trio
-    pytest-twisted
-    twisted
-    pytest-xvfb
+deps = -rtesting/plugins_integration/requirements.txt
 setenv =
     PYTHONPATH=.
     # due to pytest-rerunfailures requiring 6.2+; can be removed after 6.2.0


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
Here's an idea.

This moves the smoke test deps from https://github.com/pytest-dev/pytest/pull/7721 into a `requirements.txt` so they can pinned.

Then, https://dependabot.com can be added to monitor this new `requirements.txt` and send a new PR when there's a new plugin release. Add `/testing/plugins_integration` as the Directory:

<img src="https://user-images.githubusercontent.com/1324225/94373087-a46ff200-010b-11eb-883c-ab2720cc007c.png" width=50%>

That means we get a trigger when new plugins are released, which increases confidence that current master works with each plugin.

For example, see https://github.com/hugovk/pytest/pull/6 and https://github.com/hugovk/pytest/pull/7 on a similar branch on my fork.

Upsides:
* Triggers a build on plugin releases
* Always smoke test latest plugin version (as before)

Downsides:
* More PRs.
  * If they're too frequent, the update schedule could be changed from live to daily, weekly or monthly. 
  * It's also possible to set them to merge automatically once status checks pass.

I've left anyio at the non-latest version, to allow a test bump from 2.0.0 to 2.0.2.
