### PR TITLE
terminal: fix crash in header reporting when testpaths is used without cli arguments

### DIFF
--- a/changelog/7814.bugfix.rst
+++ b/changelog/7814.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed crash in header reporting when :confval:`testpaths` is used without CLI arguments (regression in 6.1.0).

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -718,9 +718,11 @@ class TerminalReporter:
         if config.inipath:
             line += ", configfile: " + bestrelpath(config.rootpath, config.inipath)
 
-        testpaths = config.getini("testpaths")
+        testpaths = config.getini("testpaths")  # type: List[str]
         if testpaths and config.args == testpaths:
-            rel_paths = [bestrelpath(config.rootpath, x) for x in testpaths]
+            rel_paths = [
+                bestrelpath(config.rootpath, Path(absolutepath(x))) for x in testpaths
+            ]
             line += ", testpaths: {}".format(", ".join(rel_paths))
         result = [line]
 

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -18,6 +18,7 @@ import pytest
 from _pytest._io.wcwidth import wcswidth
 from _pytest.config import Config
 from _pytest.config import ExitCode
+from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pathlib import Path
 from _pytest.pytester import Testdir
 from _pytest.reports import BaseReport
@@ -748,6 +749,24 @@ class TestTerminalFunctional:
         # with testpaths option, passing directory in command-line: do not show testpaths then
         result = testdir.runpytest("tests")
         result.stdout.fnmatch_lines(["rootdir: *test_header0, configfile: tox.ini"])
+
+    def test_header_testpaths_are_relative(
+        self, testdir: Testdir, monkeypatch: MonkeyPatch
+    ) -> None:
+        """Regresstion test for #7814."""
+        testdir.tmpdir.join("tests").ensure_dir()
+        testdir.makeini(
+            """
+            [pytest]
+            testpaths = {}/tests
+        """.format(
+                testdir.tmpdir
+            )
+        )
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines(
+            ["rootdir: *are_relative0, configfile: tox.ini, testpaths: tests"]
+        )
 
     def test_no_header(self, testdir):
         testdir.tmpdir.join("tests").ensure_dir()


### PR DESCRIPTION
Fixes #7814.

Regressed in 6.1.0 in 62e249a1f934d1073c9a0167077e133c5e0f6270. The `x` is an `str` but is expected to be a `pathlib.Path`. Not caught by mypy because `config.getini()` returns `Any`.

The code was actually wrong before, even `py.path.local`'s `bestrelpath` function expects a `py.path.local`, not an `str`. But it had some weird `try ... except AttributeError` fallback which just returns the argument, i.e. it was a no-op.