### PR TITLE
terminal: fix crash in header reporting when absolute testpaths is used

### DIFF
--- a/changelog/7814.bugfix.rst
+++ b/changelog/7814.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed crash in header reporting when :confval:`testpaths` is used and contains absolute paths (regression in 6.1.0).

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -581,7 +581,10 @@ def absolutepath(path: Union[Path, str]) -> Path:
 
 def commonpath(path1: Path, path2: Path) -> Optional[Path]:
     """Return the common part shared with the other path, or None if there is
-    no common part."""
+    no common part.
+
+    If one path is relative and one is absolute, returns None.
+    """
     try:
         return Path(os.path.commonpath((str(path1), str(path2))))
     except ValueError:
@@ -592,13 +595,17 @@ def bestrelpath(directory: Path, dest: Path) -> str:
     """Return a string which is a relative path from directory to dest such
     that directory/bestrelpath == dest.
 
+    The paths must be either both absolute or both relative.
+
     If no such path can be determined, returns dest.
     """
     if dest == directory:
         return os.curdir
     # Find the longest common directory.
     base = commonpath(directory, dest)
-    # Can be the case on Windows.
+    # Can be the case on Windows for two absolute paths on different drives.
+    # Can be the case for two relative paths without common prefix.
+    # Can be the case for a relative path and an absolute path.
     if not base:
         return str(dest)
     reldirectory = directory.relative_to(base)

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -719,7 +719,7 @@ class TerminalReporter:
             line += ", configfile: " + bestrelpath(config.rootpath, config.inipath)
 
         testpaths = config.getini("testpaths")  # type: List[str]
-        if testpaths and config.args == testpaths:
+        if config.invocation_params.dir == config.rootpath and config.args == testpaths:
             line += ", testpaths: {}".format(", ".join(testpaths))
 
         result = [line]

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -718,10 +718,10 @@ class TerminalReporter:
         if config.inipath:
             line += ", configfile: " + bestrelpath(config.rootpath, config.inipath)
 
-        testpaths = config.getini("testpaths")
+        testpaths = config.getini("testpaths")  # type: List[str]
         if testpaths and config.args == testpaths:
-            rel_paths = [bestrelpath(config.rootpath, x) for x in testpaths]
-            line += ", testpaths: {}".format(", ".join(rel_paths))
+            line += ", testpaths: {}".format(", ".join(testpaths))
+
         result = [line]
 
         plugininfo = config.pluginmanager.list_plugin_distinfo()

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -18,6 +18,7 @@ import pytest
 from _pytest._io.wcwidth import wcswidth
 from _pytest.config import Config
 from _pytest.config import ExitCode
+from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pathlib import Path
 from _pytest.pytester import Testdir
 from _pytest.reports import BaseReport
@@ -748,6 +749,29 @@ class TestTerminalFunctional:
         # with testpaths option, passing directory in command-line: do not show testpaths then
         result = testdir.runpytest("tests")
         result.stdout.fnmatch_lines(["rootdir: *test_header0, configfile: tox.ini"])
+
+    def test_header_absolute_testpath(
+        self, testdir: Testdir, monkeypatch: MonkeyPatch
+    ) -> None:
+        """Regresstion test for #7814."""
+        tests = testdir.tmpdir.join("tests")
+        tests.ensure_dir()
+        testdir.makepyprojecttoml(
+            """
+            [tool.pytest.ini_options]
+            testpaths = ['{}']
+        """.format(
+                tests
+            )
+        )
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines(
+            [
+                "rootdir: *absolute_testpath0, configfile: pyproject.toml, testpaths: {}".format(
+                    tests
+                )
+            ]
+        )
 
     def test_no_header(self, testdir):
         testdir.tmpdir.join("tests").ensure_dir()


### PR DESCRIPTION
Regressed in 6.1.0 in 62e249a.

The `x` is an `str` but is expected to be a `pathlib.Path`. Not caught by mypy because `config.getini()` returns `Any`.

Fix by just removing the `bestrelpath` call:

- testpaths are always relative to the rootdir, it thus would be very unusual to specify an absolute path there.

- The code was wrong even before the regression: `py.path.local`'s `bestrelpath` function expects a `py.path.local`, not an `str`. But it had some weird `try ... except AttributeError` fallback which just returns the argument, i.e. it was a no-op. So there is no behavior change.

- It seems reasonable to me to just print the full path if that's what the ini specifies.

The two other commits are related improvements.