### PR TITLE
[6.1.x] findpaths: fix regression causing incorrect rootdir to be determined

### DIFF
--- a/changelog/7807.bugfix.rst
+++ b/changelog/7807.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed regression in pytest 6.1.0 causing incorrect rootdir to be determined in some non-trivial cases where parent directories have config files as well.

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -1,4 +1,3 @@
-import itertools
 import os
 from typing import Dict
 from typing import Iterable
@@ -100,7 +99,7 @@ def locate_config(
         args = [Path.cwd()]
     for arg in args:
         argpath = absolutepath(arg)
-        for base in itertools.chain((argpath,), reversed(argpath.parents)):
+        for base in (argpath, *argpath.parents):
             for config_name in config_names:
                 p = base / config_name
                 if p.is_file():
@@ -184,9 +183,7 @@ def determine_setup(
         ancestor = get_common_ancestor(dirs)
         rootdir, inipath, inicfg = locate_config([ancestor])
         if rootdir is None and rootdir_cmd_arg is None:
-            for possible_rootdir in itertools.chain(
-                (ancestor,), reversed(ancestor.parents)
-            ):
+            for possible_rootdir in (ancestor, *ancestor.parents):
                 if (possible_rootdir / "setup.py").is_file():
                     rootdir = possible_rootdir
                     break

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1375,6 +1375,21 @@ class TestRootdir:
         assert rootpath == tmp_path
         assert inipath is None
 
+    def test_with_config_also_in_parent_directory(
+        self, tmp_path: Path, monkeypatch: MonkeyPatch
+    ) -> None:
+        """Regression test for #7807."""
+        (tmp_path / "setup.cfg").write_text("[tool:pytest]\n", "utf-8")
+        (tmp_path / "myproject").mkdir()
+        (tmp_path / "myproject" / "setup.cfg").write_text("[tool:pytest]\n", "utf-8")
+        (tmp_path / "myproject" / "tests").mkdir()
+        monkeypatch.chdir(tmp_path / "myproject")
+
+        rootpath, inipath, _ = determine_setup(None, ["tests/"])
+
+        assert rootpath == tmp_path / "myproject"
+        assert inipath == tmp_path / "myproject" / "setup.cfg"
+
 
 class TestOverrideIniArgs:
     @pytest.mark.parametrize("name", "setup.cfg tox.ini pytest.ini".split())


### PR DESCRIPTION
Backport #7813.