### PR TITLE
doc: patch Sphinx to detect our `@final` for marking classes as `final`

### DIFF
--- a/changelog/7780.doc.rst
+++ b/changelog/7780.doc.rst
@@ -1,0 +1,1 @@
+Classes which should not be inherited from are now marked ``final class`` in the API reference.

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -15,8 +15,10 @@
 #
 # The full version, including alpha/beta/rc tags.
 # The short X.Y version.
+import ast
 import os
 import sys
+from typing import List
 from typing import TYPE_CHECKING
 
 from _pytest import __version__ as version
@@ -398,3 +400,22 @@ def setup(app: "sphinx.application.Sphinx") -> None:
     )
 
     configure_logging(app)
+
+    # Make Sphinx mark classes with "final" when decorated with @final.
+    # We need this because we import final from pytest._compat, not from
+    # typing (for Python < 3.8 compat), so Sphinx doesn't detect it.
+    # To keep things simple we accept any `@final` decorator.
+    # Ref: https://github.com/pytest-dev/pytest/pull/7780
+    import sphinx.pycode.ast
+    import sphinx.pycode.parser
+
+    original_is_final = sphinx.pycode.parser.VariableCommentPicker.is_final
+
+    def patched_is_final(self, decorators: List[ast.expr]) -> bool:
+        if original_is_final(self, decorators):
+            return True
+        return any(
+            sphinx.pycode.ast.unparse(decorator) == "final" for decorator in decorators
+        )
+
+    sphinx.pycode.parser.VariableCommentPicker.is_final = patched_is_final


### PR DESCRIPTION
Continuation to #7780, makes the `final class` also show up in the API Reference.

Thanks to @domdfcoding for code & assistance.

Compared to @domdfcoding's code, I made it less accurate (just accepts any `@final` as an indicator, disregarding where it's imported from), but simpler and hopefully more robust against changes in Sphinx. Since it's only scoped to pytest it shouldn't be a problem.

We also have a similar issue with `@overload`, but that should take care of itself after #7811 is merged (as confirmed by the RTD build of that PR).