### PR TITLE
Add alias clarification to deprecation warning

### DIFF
--- a/changelog/7815.doc.rst
+++ b/changelog/7815.doc.rst
@@ -1,0 +1,1 @@
+Added alias clarification on the deprecation warning for `_fillfuncargs` function.

--- a/changelog/7815.doc.rst
+++ b/changelog/7815.doc.rst
@@ -1,1 +1,1 @@
-Added alias clarification on the deprecation warning for `_fillfuncargs` function.
+Improve deprecation warning message for ``pytest._fillfuncargs()``.

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -21,7 +21,7 @@ DEPRECATED_EXTERNAL_PLUGINS = {
 
 
 FILLFUNCARGS = PytestDeprecationWarning(
-    "The `_fillfuncargs` function is deprecated, use "
+    "The `_fillfuncargs` function (public alias of _pytest.fixtures.fillfixtures function) is deprecated, use "
     "function._request._fillfixtures() instead if you cannot avoid reaching into internals."
 )
 

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -21,8 +21,8 @@ DEPRECATED_EXTERNAL_PLUGINS = {
 
 
 FILLFUNCARGS = PytestDeprecationWarning(
-    "The `_fillfuncargs` function (public alias of _pytest.fixtures.fillfixtures function) is deprecated, use "
-    "function._request._fillfixtures() instead if you cannot avoid reaching into internals."
+    "pytest._fillfuncargs() is deprecated, use "
+    "_pytest.fixtures.fillfixtures() instead if you cannot avoid reaching into internals."
 )
 
 PYTEST_COLLECT_MODULE = UnformattedWarning(

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -20,9 +20,10 @@ DEPRECATED_EXTERNAL_PLUGINS = {
 }
 
 
-FILLFUNCARGS = PytestDeprecationWarning(
-    "pytest._fillfuncargs() is deprecated, use "
-    "_pytest.fixtures.fillfixtures() instead if you cannot avoid reaching into internals."
+FILLFUNCARGS = UnformattedWarning(
+    PytestDeprecationWarning,
+    "{name} is deprecated, use "
+    "function._request._fillfixtures() instead if you cannot avoid reaching into internals.",
 )
 
 PYTEST_COLLECT_MODULE = UnformattedWarning(

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -339,9 +339,14 @@ def reorder_items_atscope(
     return items_done
 
 
-def fillfixtures(function: "Function") -> None:
-    """Fill missing funcargs for a test function."""
+def _fillfuncargs(function: "Function") -> None:
+    """Fill missing fixtures for a test function (deprecated)."""
     warnings.warn(FILLFUNCARGS, stacklevel=2)
+    fillfixtures(function)
+
+
+def fillfixtures(function: "Function") -> None:
+    """Fill missing fixtures for a test function."""
     try:
         request = function._request
     except AttributeError:

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -340,13 +340,21 @@ def reorder_items_atscope(
 
 
 def _fillfuncargs(function: "Function") -> None:
-    """Fill missing fixtures for a test function (deprecated)."""
-    warnings.warn(FILLFUNCARGS, stacklevel=2)
-    fillfixtures(function)
+    """Fill missing fixtures for a test function, old public API (deprecated)."""
+    warnings.warn(FILLFUNCARGS.format(name="pytest._fillfuncargs()"), stacklevel=2)
+    _fill_fixtures_impl(function)
 
 
 def fillfixtures(function: "Function") -> None:
-    """Fill missing fixtures for a test function."""
+    """Fill missing fixtures for a test function (deprecated)."""
+    warnings.warn(
+        FILLFUNCARGS.format(name="_pytest.fixtures.fillfixtures()"), stacklevel=2
+    )
+    _fill_fixtures_impl(function)
+
+
+def _fill_fixtures_impl(function: "Function") -> None:
+    """Internal implementation to fill fixtures on the given function object."""
     try:
         request = function._request
     except AttributeError:

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -11,7 +11,7 @@ from _pytest.config import hookspec
 from _pytest.config import main
 from _pytest.config import UsageError
 from _pytest.debugging import pytestPDB as __pytestPDB
-from _pytest.fixtures import fillfixtures as _fillfuncargs
+from _pytest.fixtures import _fillfuncargs
 from _pytest.fixtures import fixture
 from _pytest.fixtures import FixtureLookupError
 from _pytest.fixtures import yield_fixture

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -26,7 +26,8 @@ def test_external_plugins_integrated(testdir, plugin):
 def test_fillfuncargs_is_deprecated() -> None:
     with pytest.warns(
         pytest.PytestDeprecationWarning,
-        match="The `_fillfuncargs` function is deprecated",
+        match="The `_fillfuncargs` function (public alias of _pytest.fixtures.fillfixtures function) is deprecated, use "
+              "function._request._fillfixtures() instead if you cannot avoid reaching into internals.",
     ):
         pytest._fillfuncargs(mock.Mock())
 

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -29,10 +29,23 @@ def test_fillfuncargs_is_deprecated() -> None:
         pytest.PytestDeprecationWarning,
         match=re.escape(
             "pytest._fillfuncargs() is deprecated, use "
-            "_pytest.fixtures.fillfixtures() instead if you cannot avoid reaching into internals."
+            "function._request._fillfixtures() instead if you cannot avoid reaching into internals."
         ),
     ):
         pytest._fillfuncargs(mock.Mock())
+
+
+def test_fillfixtures_is_deprecated() -> None:
+    import _pytest.fixtures
+
+    with pytest.warns(
+        pytest.PytestDeprecationWarning,
+        match=re.escape(
+            "_pytest.fixtures.fillfixtures() is deprecated, use "
+            "function._request._fillfixtures() instead if you cannot avoid reaching into internals."
+        ),
+    ):
+        _pytest.fixtures.fillfixtures(mock.Mock())
 
 
 def test_minus_k_dash_is_deprecated(testdir) -> None:

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -1,3 +1,4 @@
+import re
 import warnings
 from unittest import mock
 
@@ -26,8 +27,10 @@ def test_external_plugins_integrated(testdir, plugin):
 def test_fillfuncargs_is_deprecated() -> None:
     with pytest.warns(
         pytest.PytestDeprecationWarning,
-        match="The `_fillfuncargs` function (public alias of _pytest.fixtures.fillfixtures function) is deprecated, use "
-              "function._request._fillfixtures() instead if you cannot avoid reaching into internals.",
+        match=re.escape(
+            "pytest._fillfuncargs() is deprecated, use "
+            "_pytest.fixtures.fillfixtures() instead if you cannot avoid reaching into internals."
+        ),
     ):
         pytest._fillfuncargs(mock.Mock())
 

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -87,7 +87,7 @@ def test_getfuncargnames_staticmethod_partial():
 class TestFillFixtures:
     def test_fillfuncargs_exposed(self):
         # used by oejskit, kept for compatibility
-        assert pytest._fillfuncargs == fixtures.fillfixtures
+        assert pytest._fillfuncargs == fixtures._fillfuncargs
 
     def test_funcarg_lookupfails(self, testdir):
         testdir.copy_example()


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
@Zac-HD Yes, this is related to the issue #7815. I could come up with a better format for the warning if it is needed.