### PR TITLE
py36+: remove TYPE_CHECKING from _pytest.compat

### DIFF
--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -17,9 +17,9 @@
 # The short X.Y version.
 import os
 import sys
+from typing import TYPE_CHECKING
 
 from _pytest import __version__ as version
-from _pytest.compat import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import sphinx.application

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -21,6 +21,7 @@ from typing import Pattern
 from typing import Sequence
 from typing import Set
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
 from weakref import ref
@@ -40,7 +41,6 @@ from _pytest._io.saferepr import saferepr
 from _pytest.compat import final
 from _pytest.compat import get_real_func
 from _pytest.compat import overload
-from _pytest.compat import TYPE_CHECKING
 from _pytest.pathlib import Path
 
 if TYPE_CHECKING:

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -4,12 +4,12 @@ from typing import Any
 from typing import Generator
 from typing import List
 from typing import Optional
+from typing import TYPE_CHECKING
 
 from _pytest.assertion import rewrite
 from _pytest.assertion import truncate
 from _pytest.assertion import util
 from _pytest.assertion.rewrite import assertstate_key
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.config import hookimpl
 from _pytest.config.argparsing import Parser

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -22,6 +22,7 @@ from typing import Optional
 from typing import Sequence
 from typing import Set
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 
 import py
@@ -33,7 +34,6 @@ from _pytest.assertion.util import (  # noqa: F401
     format_explanation as _format_explanation,
 )
 from _pytest.compat import fspath
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.main import Session
 from _pytest.pathlib import fnmatch_ex

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -14,11 +14,11 @@ from typing import Iterator
 from typing import Optional
 from typing import TextIO
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 
 import pytest
 from _pytest.compat import final
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.config.argparsing import Parser
 from _pytest.fixtures import SubRequest

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -14,6 +14,7 @@ from typing import Generic
 from typing import Optional
 from typing import overload as overload
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
 
@@ -21,12 +22,6 @@ import attr
 
 from _pytest.outcomes import fail
 from _pytest.outcomes import TEST_OUTCOME
-
-if sys.version_info < (3, 5, 2):
-    TYPE_CHECKING = False  # type: bool
-else:
-    from typing import TYPE_CHECKING
-
 
 if TYPE_CHECKING:
     from typing import NoReturn

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -26,6 +26,7 @@ from typing import Sequence
 from typing import Set
 from typing import TextIO
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 
 import attr
@@ -45,7 +46,6 @@ from _pytest._code import filter_traceback
 from _pytest._io import TerminalWriter
 from _pytest.compat import final
 from _pytest.compat import importlib_metadata
-from _pytest.compat import TYPE_CHECKING
 from _pytest.outcomes import fail
 from _pytest.outcomes import Skipped
 from _pytest.pathlib import bestrelpath

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -11,13 +11,13 @@ from typing import Mapping
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 
 import py
 
 import _pytest._io
 from _pytest.compat import final
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config.exceptions import UsageError
 
 if TYPE_CHECKING:

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -5,12 +5,12 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 
 import iniconfig
 
 from .exceptions import UsageError
-from _pytest.compat import TYPE_CHECKING
 from _pytest.outcomes import fail
 from _pytest.pathlib import absolutepath
 from _pytest.pathlib import commonpath

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -9,11 +9,11 @@ from typing import Generator
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 
 from _pytest import outcomes
 from _pytest._code import ExceptionInfo
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.config import ConftestImportFailure
 from _pytest.config import hookimpl

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -17,6 +17,7 @@ from typing import Optional
 from typing import Pattern
 from typing import Sequence
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 
 import py.path
@@ -28,7 +29,6 @@ from _pytest._code.code import ReprFileLocation
 from _pytest._code.code import TerminalRepr
 from _pytest._io import TerminalWriter
 from _pytest.compat import safe_getattr
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.config.argparsing import Parser
 from _pytest.fixtures import FixtureRequest

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -19,6 +19,7 @@ from typing import Optional
 from typing import Sequence
 from typing import Set
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
 
@@ -43,7 +44,6 @@ from _pytest.compat import NOTSET
 from _pytest.compat import order_preserving_dict
 from _pytest.compat import overload
 from _pytest.compat import safe_getattr
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import _PluggyPlugin
 from _pytest.config import Config
 from _pytest.config.argparsing import Parser

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -7,12 +7,12 @@ from typing import Mapping
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 
 import py.path
 from pluggy import HookspecMarker
 
-from _pytest.compat import TYPE_CHECKING
 from _pytest.deprecated import WARNING_CAPTURED_HOOK
 
 if TYPE_CHECKING:

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -14,6 +14,7 @@ from typing import Optional
 from typing import Sequence
 from typing import Set
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 
 import attr
@@ -23,7 +24,6 @@ import _pytest._code
 from _pytest import nodes
 from _pytest.compat import final
 from _pytest.compat import overload
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.config import directory_arg
 from _pytest.config import ExitCode

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -4,6 +4,7 @@ import warnings
 from typing import AbstractSet
 from typing import List
 from typing import Optional
+from typing import TYPE_CHECKING
 from typing import Union
 
 import attr
@@ -17,7 +18,6 @@ from .structures import MARK_GEN
 from .structures import MarkDecorator
 from .structures import MarkGenerator
 from .structures import ParameterSet
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.config import ExitCode
 from _pytest.config import hookimpl

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -23,10 +23,9 @@ from typing import Iterator
 from typing import Mapping
 from typing import Optional
 from typing import Sequence
+from typing import TYPE_CHECKING
 
 import attr
-
-from _pytest.compat import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import NoReturn

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -13,6 +13,7 @@ from typing import Optional
 from typing import Sequence
 from typing import Set
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
 
@@ -24,7 +25,6 @@ from ..compat import final
 from ..compat import NOTSET
 from ..compat import NotSetType
 from ..compat import overload
-from ..compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.outcomes import fail
 from _pytest.warning_types import PytestUnknownMarkWarning

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -10,6 +10,7 @@ from typing import List
 from typing import Optional
 from typing import Set
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
 
@@ -21,7 +22,6 @@ from _pytest._code.code import ExceptionInfo
 from _pytest._code.code import TerminalRepr
 from _pytest.compat import cached_property
 from _pytest.compat import overload
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.config import ConftestImportFailure
 from _pytest.deprecated import FSCOLLECTOR_GETHOOKPROXY_ISINITPATH

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -18,6 +18,7 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 from weakref import WeakKeyDictionary
 
@@ -30,7 +31,6 @@ from _pytest._code import Source
 from _pytest.capture import _get_multicapture
 from _pytest.compat import final
 from _pytest.compat import overload
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import _PluggyPlugin
 from _pytest.config import Config
 from _pytest.config import ExitCode

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -23,6 +23,7 @@ from typing import Mapping
 from typing import Optional
 from typing import Set
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 
 import py
@@ -49,7 +50,6 @@ from _pytest.compat import REGEX_TYPE
 from _pytest.compat import safe_getattr
 from _pytest.compat import safe_isclass
 from _pytest.compat import STRING_TYPES
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.config import ExitCode
 from _pytest.config import hookimpl

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -13,6 +13,7 @@ from typing import Generic
 from typing import Optional
 from typing import Pattern
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
 
@@ -20,7 +21,6 @@ import _pytest._code
 from _pytest.compat import final
 from _pytest.compat import overload
 from _pytest.compat import STRING_TYPES
-from _pytest.compat import TYPE_CHECKING
 from _pytest.outcomes import fail
 
 if TYPE_CHECKING:

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -10,12 +10,12 @@ from typing import List
 from typing import Optional
 from typing import Pattern
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
 
 from _pytest.compat import final
 from _pytest.compat import overload
-from _pytest.compat import TYPE_CHECKING
 from _pytest.fixtures import fixture
 from _pytest.outcomes import fail
 

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -8,6 +8,7 @@ from typing import Iterator
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
 
@@ -27,7 +28,6 @@ from _pytest._code.code import ReprTraceback
 from _pytest._code.code import TerminalRepr
 from _pytest._io import TerminalWriter
 from _pytest.compat import final
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.nodes import Collector
 from _pytest.nodes import Item

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -9,6 +9,7 @@ from typing import Generic
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
 
@@ -23,7 +24,6 @@ from _pytest._code.code import ExceptionChainRepr
 from _pytest._code.code import ExceptionInfo
 from _pytest._code.code import TerminalRepr
 from _pytest.compat import final
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config.argparsing import Parser
 from _pytest.nodes import Collector
 from _pytest.nodes import Item

--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -6,10 +6,10 @@ import traceback
 from typing import Generator
 from typing import Optional
 from typing import Tuple
+from typing import TYPE_CHECKING
 
 import attr
 
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.config import hookimpl
 from _pytest.config.argparsing import Parser

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -20,6 +20,7 @@ from typing import Sequence
 from typing import Set
 from typing import TextIO
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 
 import attr
@@ -34,7 +35,6 @@ from _pytest._code.code import ExceptionRepr
 from _pytest._io.wcwidth import wcswidth
 from _pytest.compat import final
 from _pytest.compat import order_preserving_dict
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import _PluggyPlugin
 from _pytest.config import Config
 from _pytest.config import ExitCode

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -9,13 +9,13 @@ from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 
 import _pytest._code
 import pytest
 from _pytest.compat import getimfunc
 from _pytest.compat import is_async_function
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import hookimpl
 from _pytest.fixtures import FixtureRequest
 from _pytest.nodes import Collector

--- a/src/_pytest/warning_types.py
+++ b/src/_pytest/warning_types.py
@@ -1,11 +1,11 @@
 from typing import Any
 from typing import Generic
+from typing import TYPE_CHECKING
 from typing import TypeVar
 
 import attr
 
 from _pytest.compat import final
-from _pytest.compat import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Type  # noqa: F401 (used in type string)

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -3,9 +3,9 @@ import warnings
 from contextlib import contextmanager
 from typing import Generator
 from typing import Optional
+from typing import TYPE_CHECKING
 
 import pytest
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import apply_warning_filters
 from _pytest.config import Config
 from _pytest.config import parse_warning_filter

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -7,6 +7,7 @@ import textwrap
 from typing import Any
 from typing import Dict
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 
 import py
@@ -17,7 +18,6 @@ from _pytest._code.code import ExceptionChainRepr
 from _pytest._code.code import ExceptionInfo
 from _pytest._code.code import FormattedExcinfo
 from _pytest._io import TerminalWriter
-from _pytest.compat import TYPE_CHECKING
 from _pytest.pytester import LineMatcher
 
 try:

--- a/testing/test_compat.py
+++ b/testing/test_compat.py
@@ -2,6 +2,7 @@ import enum
 import sys
 from functools import partial
 from functools import wraps
+from typing import TYPE_CHECKING
 from typing import Union
 
 import pytest
@@ -12,7 +13,6 @@ from _pytest.compat import get_real_func
 from _pytest.compat import is_generator
 from _pytest.compat import safe_getattr
 from _pytest.compat import safe_isclass
-from _pytest.compat import TYPE_CHECKING
 from _pytest.outcomes import OutcomeException
 
 if TYPE_CHECKING:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -6,6 +6,7 @@ from typing import Dict
 from typing import List
 from typing import Sequence
 from typing import Tuple
+from typing import TYPE_CHECKING
 
 import attr
 import py.path
@@ -13,7 +14,6 @@ import py.path
 import _pytest._code
 import pytest
 from _pytest.compat import importlib_metadata
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import _get_plugin_specs_as_list
 from _pytest.config import _iter_rewritable_modules
 from _pytest.config import _strtobool

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -4,13 +4,13 @@ from datetime import datetime
 from typing import cast
 from typing import List
 from typing import Tuple
+from typing import TYPE_CHECKING
 from xml.dom import minidom
 
 import py
 import xmlschema
 
 import pytest
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import Config
 from _pytest.junitxml import bin_xml_escape
 from _pytest.junitxml import LogXML

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -4,11 +4,11 @@ import sys
 import textwrap
 from typing import Dict
 from typing import Generator
+from typing import TYPE_CHECKING
 
 import py
 
 import pytest
-from _pytest.compat import TYPE_CHECKING
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pytester import Testdir
 

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -5,6 +5,7 @@ import types
 from typing import Dict
 from typing import List
 from typing import Tuple
+from typing import TYPE_CHECKING
 
 import py
 
@@ -13,7 +14,6 @@ import pytest
 from _pytest import outcomes
 from _pytest import reports
 from _pytest import runner
-from _pytest.compat import TYPE_CHECKING
 from _pytest.config import ExitCode
 from _pytest.outcomes import OutcomeException
 


### PR DESCRIPTION
automated with:

```bash
git grep -l 'from .* import TYPE_CHECKING' |
    xargs reorder-python-imports \
        --application-directories .:src \
        --remove-import 'from _pytest.compat import TYPE_CHECKING' \
        --add-import 'from typing import TYPE_CHECKING'
```

See #7808