### PR TITLE
[6.1.x] terminal: fix crash in header reporting when absolute testpaths is used

### DIFF
--- a/changelog/7814.bugfix.rst
+++ b/changelog/7814.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed crash in header reporting when :confval:`testpaths` is used and contains absolute paths (regression in 6.1.0).

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -718,10 +718,10 @@ class TerminalReporter:
         if config.inipath:
             line += ", configfile: " + bestrelpath(config.rootpath, config.inipath)
 
-        testpaths = config.getini("testpaths")
+        testpaths = config.getini("testpaths")  # type: List[str]
         if testpaths and config.args == testpaths:
-            rel_paths = [bestrelpath(config.rootpath, x) for x in testpaths]
-            line += ", testpaths: {}".format(", ".join(rel_paths))
+            line += ", testpaths: {}".format(", ".join(testpaths))
+
         result = [line]
 
         plugininfo = config.pluginmanager.list_plugin_distinfo()

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -18,6 +18,7 @@ import pytest
 from _pytest._io.wcwidth import wcswidth
 from _pytest.config import Config
 from _pytest.config import ExitCode
+from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pathlib import Path
 from _pytest.pytester import Testdir
 from _pytest.reports import BaseReport
@@ -748,6 +749,29 @@ class TestTerminalFunctional:
         # with testpaths option, passing directory in command-line: do not show testpaths then
         result = testdir.runpytest("tests")
         result.stdout.fnmatch_lines(["rootdir: *test_header0, configfile: tox.ini"])
+
+    def test_header_absolute_testpath(
+        self, testdir: Testdir, monkeypatch: MonkeyPatch
+    ) -> None:
+        """Regresstion test for #7814."""
+        tests = testdir.tmpdir.join("tests")
+        tests.ensure_dir()
+        testdir.makepyprojecttoml(
+            """
+            [tool.pytest.ini_options]
+            testpaths = ['{}']
+        """.format(
+                tests
+            )
+        )
+        result = testdir.runpytest()
+        result.stdout.fnmatch_lines(
+            [
+                "rootdir: *absolute_testpath0, configfile: pyproject.toml, testpaths: {}".format(
+                    tests
+                )
+            ]
+        )
 
     def test_no_header(self, testdir):
         testdir.tmpdir.join("tests").ensure_dir()


### PR DESCRIPTION
Backport of commit 61f80a783a38441040c5999a4033af8004ee4c6b from #7817.