### PR TITLE
py36+: use new NamedTuple syntax

### DIFF
--- a/changelog/7808.breaking.rst
+++ b/changelog/7808.breaking.rst
@@ -1,1 +1,1 @@
-pytest now supports python3.6+ only.
+pytest now supports python3.6.1+ only.

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     atomicwrites>=1.0;sys_platform=="win32"
     colorama;sys_platform=="win32"
     importlib-metadata>=0.12;python_version<"3.8"
-python_requires = >=3.6
+python_requires = >=3.6.1
 package_dir =
     =src
 setup_requires =

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -74,16 +74,11 @@ def get_empty_parameterset_mark(
     return mark
 
 
-class ParameterSet(
-    NamedTuple(
-        "ParameterSet",
-        [
-            ("values", Sequence[Union[object, NotSetType]]),
-            ("marks", Collection[Union["MarkDecorator", "Mark"]]),
-            ("id", Optional[str]),
-        ],
-    )
-):
+class ParameterSet(NamedTuple):
+    values: Sequence[Union[object, NotSetType]]
+    marks: Collection[Union["MarkDecorator", "Mark"]]
+    id: Optional[str]
+
     @classmethod
     def param(
         cls,


### PR DESCRIPTION
See #7808

this one is slightly controversial, though I expect almost zero usage of 3.6.0