### PR TITLE
Prepare release 6.1.1

### DIFF
--- a/changelog/7807.bugfix.rst
+++ b/changelog/7807.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed regression in pytest 6.1.0 causing incorrect rootdir to be determined in some non-trivial cases where parent directories have config files as well.

--- a/changelog/7814.bugfix.rst
+++ b/changelog/7814.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed crash in header reporting when :confval:`testpaths` is used and contains absolute paths (regression in 6.1.0).

--- a/doc/en/announce/index.rst
+++ b/doc/en/announce/index.rst
@@ -6,6 +6,7 @@ Release announcements
    :maxdepth: 2
 
 
+   release-6.1.1
    release-6.1.0
    release-6.0.2
    release-6.0.1

--- a/doc/en/announce/release-6.1.1.rst
+++ b/doc/en/announce/release-6.1.1.rst
@@ -1,0 +1,18 @@
+pytest-6.1.1
+=======================================
+
+pytest 6.1.1 has just been released to PyPI.
+
+This is a bug-fix release, being a drop-in replacement. To upgrade::
+
+  pip install --upgrade pytest
+
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
+
+Thanks to all of the contributors to this release:
+
+* Ran Benita
+
+
+Happy testing,
+The pytest Development Team

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -28,6 +28,18 @@ with advance notice in the **Deprecations** section of releases.
 
 .. towncrier release notes start
 
+pytest 6.1.1 (2020-10-03)
+=========================
+
+Bug Fixes
+---------
+
+- `#7807 <https://github.com/pytest-dev/pytest/issues/7807>`_: Fixed regression in pytest 6.1.0 causing incorrect rootdir to be determined in some non-trivial cases where parent directories have config files as well.
+
+
+- `#7814 <https://github.com/pytest-dev/pytest/issues/7814>`_: Fixed crash in header reporting when :confval:`testpaths` is used and contains absolute paths (regression in 6.1.0).
+
+
 pytest 6.1.0 (2020-09-26)
 =========================
 

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -28,7 +28,7 @@ Install ``pytest``
 .. code-block:: bash
 
     $ pytest --version
-    pytest 6.1.0
+    pytest 6.1.1
 
 .. _`simpletest`:
 


### PR DESCRIPTION
Created automatically from https://github.com/pytest-dev/pytest/issues/7843#issuecomment-703150391.

Once all builds pass and it has been **approved** by one or more maintainers, the build
can be released by pushing a tag `6.1.1` to this repository.
