### PR TITLE
Document that Parser.addini() can take, and defaults to, 'string'

### DIFF
--- a/changelog/7872.doc.rst
+++ b/changelog/7872.doc.rst
@@ -1,0 +1,1 @@
+``_pytest.config.argparsing.Parser.addini()`` accepts explicit ``None`` and ``"string"``.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1402,7 +1402,7 @@ class Config:
         elif type == "bool":
             return _strtobool(str(value).strip())
         else:
-            assert type is None
+            assert type in [None, "string"]
             return value
 
     def _getconftest_pathlist(

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -160,20 +160,23 @@ class Parser:
         self,
         name: str,
         help: str,
-        type: Optional["Literal['pathlist', 'args', 'linelist', 'bool']"] = None,
+        type: Optional[
+            "Literal['string', 'pathlist', 'args', 'linelist', 'bool']"
+        ] = None,
         default=None,
     ) -> None:
         """Register an ini-file option.
 
         :name: Name of the ini-variable.
-        :type: Type of the variable, can be ``pathlist``, ``args``, ``linelist``
-               or ``bool``.
+        :type: Type of the variable, can be ``string``, ``pathlist``, ``args``,
+               ``linelist`` or ``bool``.  Defaults to ``string`` if ``None`` or
+               not passed.
         :default: Default value if no ini-file option exists but is queried.
 
         The value of ini-variables can be retrieved via a call to
         :py:func:`config.getini(name) <_pytest.config.Config.getini>`.
         """
-        assert type in (None, "pathlist", "args", "linelist", "bool")
+        assert type in (None, "string", "pathlist", "args", "linelist", "bool")
         self._inidict[name] = (help, type, default)
         self._ininames.append(name)
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -570,11 +570,17 @@ class TestConfigAPI:
         assert pl[0] == tmpdir
         assert pl[1] == somepath
 
-    def test_addini(self, testdir):
+    @pytest.mark.parametrize("maybe_type", ["not passed", "None", '"string"'])
+    def test_addini(self, testdir, maybe_type):
+        if maybe_type == "not passed":
+            type_string = ""
+        else:
+            type_string = f", {maybe_type}"
+
         testdir.makeconftest(
-            """
+            f"""
             def pytest_addoption(parser):
-                parser.addini("myname", "my new ini value")
+                parser.addini("myname", "my new ini value"{type_string})
         """
         )
         testdir.makeini(


### PR DESCRIPTION
- [X] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
