### PR TITLE
implement a --suppress-logger option to logging to suppress logging for one or multiple loggers

### DIFF
--- a/changelog/7431.feature.rst
+++ b/changelog/7431.feature.rst
@@ -1,0 +1,1 @@
+``--suppress-logger`` CLI option added to suppress output from individual loggers

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -583,11 +583,10 @@ class LoggingPlugin:
         )
         self.log_cli_handler.setFormatter(log_cli_formatter)
         if config.option.suppress_logger:
-            self._suppress_loggers(config)
+            self._suppress_loggers()
 
-    @staticmethod
-    def _suppress_loggers(config: Config) -> None:
-        logger_names = set(config.option.suppress_logger)
+    def _suppress_loggers(self) -> None:
+        logger_names = set(self._config.option.suppress_logger)
         for name in logger_names:
             # disable propagation for the given logger preventing of event passing to ancestor handlers
             # adding a NullHandler to prevent logging.LastResort handler from logging warnings to stderr

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -285,7 +285,7 @@ def pytest_addoption(parser: Parser) -> None:
         action="append",
         default=[],
         dest="suppress_logger",
-        help="Suppress logging output for the logger, this can be provided multiple times to suppress many loggers",
+        help="Suppress loggers by name",
     )
 
 

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -280,12 +280,12 @@ def pytest_addoption(parser: Parser) -> None:
         default=None,
         help="Auto-indent multiline messages passed to the logging module. Accepts true|on, false|off or an integer.",
     )
-    add_option_ini(
-        "--log-disable",
+    group.addoption(
+        "--suppress-logger",
         action="append",
         default=[],
-        dest="log_disable",
-        help="Disable propagation of these loggers"
+        dest="suppress_logger",
+        help="Suppress logging output for the logger, this can be provided multiple times to suppress many loggers",
     )
 
 
@@ -582,14 +582,14 @@ class LoggingPlugin:
             get_option_ini(config, "log_auto_indent"),
         )
         self.log_cli_handler.setFormatter(log_cli_formatter)
-        if config.option.log_disable:
-            self._disable_log_propagation(config)
+        if config.option.suppress_logger:
+            self._suppress_loggers(config)
 
     @staticmethod
-    def _disable_log_propagation(config: Config) -> None:
-        logger_names = set(config.option.log_disable)
+    def _suppress_loggers(config: Config) -> None:
+        logger_names = set(config.option.suppress_logger)
         for name in logger_names:
-            # disable propagation for the given logger to preventing of event passing to ancestor handlers
+            # disable propagation for the given logger preventing of event passing to ancestor handlers
             # adding a NullHandler to prevent logging.LastResort handler from logging warnings to stderr
             logger = logging.getLogger(name)
             logger.addHandler(logging.NullHandler())

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1159,25 +1159,22 @@ def test_suppress_loggers(testdir):
         """
         import logging
         import os
-        disable_log = logging.getLogger('disable')
-        second_log = logging.getLogger('second')
+        suppressed_log = logging.getLogger('suppressed')
+        other_log = logging.getLogger('other')
         normal_log = logging.getLogger('normal')
         def test_logger_propagation(caplog):
-            caplog.set_level(logging.DEBUG)
-            disable_log.warning("no log; no stderr")
-            second_log.info("no log")
-            normal_log.debug("Unsuppressed!")
-            print(os.linesep)
-            print(caplog.records)
+            with caplog.at_level(logging.DEBUG):
+                suppressed_log.warning("no log; no stderr")
+                other_log.info("no log")
+                normal_log.debug("Unsuppressed!")
+                print(os.linesep)
+                assert caplog.record_tuples == [('normal', 10, 'Unsuppressed!')]
          """
     )
     result = testdir.runpytest(
-        "--suppress-logger=disable", "--suppress-logger=second", "-s"
+        "--suppress-logger=suppressed", "--suppress-logger=other", "-s"
     )
     assert result.ret == ExitCode.OK
-    result.stdout.no_fnmatch_line("*[<LogRecord: disable*")
-    result.stdout.no_fnmatch_line("*[<LogRecord: second*")
-    result.stdout.fnmatch_lines(["*[<LogRecord: normal*"])
     assert len(result.stderr.lines) == 0
 
 


### PR DESCRIPTION
Hi everyone, I've been away for a while but I'm hoping to get some contributions going again.  Not entirely sure where to go with this one, but I thought I'd make a start on it.  I'm not entirely sure on the best way to test this, caplog came to mind as a useful tool.

This PR attempts to add a --suppress-logger=foo --suppress-logger=bar capabilities to the core logging plugin to allow the user to control what  can sometimes be considered 'bloating' output from various loggers.

Thanks for your time as always and I look forward to any discussions / direction and feedback.

closes #7431 