### PR TITLE
Use collections.Counter instead of a dict - Closes #7868

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -275,6 +275,7 @@ Sven-Hendrik Haase
 Sylvain Marié
 Tadek Teleżyński
 Takafumi Arakaki
+Tanvi Mehta
 Tarcisio Fischer
 Tareq Alayan
 Ted Xiao

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -920,7 +920,9 @@ class TerminalReporter:
                 if len(locations) < 10:
                     return "\n".join(map(str, locations))
 
-                counts_by_filename = Counter(str(loc).split("::", 1)[0] for loc in locations)
+                counts_by_filename = Counter(
+                    str(loc).split("::", 1)[0] for loc in locations
+                )
                 return "\n".join(
                     "{}: {} warning{}".format(k, v, "s" if v > 1 else "")
                     for k, v in counts_by_filename.items()

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -8,6 +8,7 @@ import inspect
 import platform
 import sys
 import warnings
+from collections import Counter
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -754,10 +755,7 @@ class TerminalReporter:
         # because later versions are going to get rid of them anyway.
         if self.config.option.verbose < 0:
             if self.config.option.verbose < -1:
-                counts: Dict[str, int] = {}
-                for item in items:
-                    name = item.nodeid.split("::", 1)[0]
-                    counts[name] = counts.get(name, 0) + 1
+                counts = Counter(item.nodeid.split("::", 1)[0] for item in items)
                 for name, count in sorted(counts.items()):
                     self._tw.line("%s: %d" % (name, count))
             else:
@@ -922,10 +920,7 @@ class TerminalReporter:
                 if len(locations) < 10:
                     return "\n".join(map(str, locations))
 
-                counts_by_filename: Dict[str, int] = {}
-                for loc in locations:
-                    key = str(loc).split("::", 1)[0]
-                    counts_by_filename[key] = counts_by_filename.get(key, 0) + 1
+                counts_by_filename = Counter(str(loc).split("::", 1)[0] for loc in locations)
                 return "\n".join(
                     "{}: {} warning{}".format(k, v, "s" if v > 1 else "")
                     for k, v in counts_by_filename.items()


### PR DESCRIPTION
Use `collections.Counter` instead of a `dict` in `terminal.py` Closes #7868

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
