### PR TITLE
Improve summary stats when using '--collect-only'

### DIFF
--- a/changelog/7701.improvement.rst
+++ b/changelog/7701.improvement.rst
@@ -1,0 +1,1 @@
+Improved reporting when using ``--collected-only``. It will now show the number of collected tests in the summary stats. 

--- a/changelog/7701.improvement.rst
+++ b/changelog/7701.improvement.rst
@@ -1,1 +1,1 @@
-Improved reporting when using ``--collected-only``. It will now show the number of collected tests in the summary stats. 
+Improved reporting when using ``--collected-only``. It will now show the number of collected tests in the summary stats.

--- a/doc/en/example/nonpython.rst
+++ b/doc/en/example/nonpython.rst
@@ -102,4 +102,4 @@ interesting to just look at the collection tree:
         <YamlItem hello>
         <YamlItem ok>
 
-    ========================== 2/2 tests found (0 deselected) in 0.12s ===========================
+    ========================== 2/2 tests found in 0.12s ===========================

--- a/doc/en/example/nonpython.rst
+++ b/doc/en/example/nonpython.rst
@@ -102,4 +102,4 @@ interesting to just look at the collection tree:
         <YamlItem hello>
         <YamlItem ok>
 
-    ========================== no tests ran in 0.12s ===========================
+    ========================== 2/2 tests found (0 deselected) in 0.12s ===========================

--- a/doc/en/example/nonpython.rst
+++ b/doc/en/example/nonpython.rst
@@ -102,4 +102,4 @@ interesting to just look at the collection tree:
         <YamlItem hello>
         <YamlItem ok>
 
-    ========================== 2/2 tests found in 0.12s ===========================
+    ========================== 2 tests found in 0.12s ===========================

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -175,7 +175,7 @@ objects, they are still using the default pytest representation:
       <Function test_timedistance_v3[forward]>
       <Function test_timedistance_v3[backward]>
 
-    ========================== no tests ran in 0.12s ===========================
+    ========================== 8/8 tests found (0 deselected) in 0.12s ===========================
 
 In ``test_timedistance_v3``, we used ``pytest.param`` to specify the test IDs
 together with the actual data, instead of listing them separately.
@@ -252,7 +252,7 @@ If you just collect tests you'll also nicely see 'advanced' and 'basic' as varia
           <Function test_demo1[advanced]>
           <Function test_demo2[advanced]>
 
-    ========================== no tests ran in 0.12s ===========================
+    ========================== 4/4 tests found (0 deselected) in 0.12s ===========================
 
 Note that we told ``metafunc.parametrize()`` that your scenario values
 should be considered class-scoped.  With pytest-2.3 this leads to a
@@ -328,7 +328,7 @@ Let's first see how it looks like at collection time:
       <Function test_db_initialized[d1]>
       <Function test_db_initialized[d2]>
 
-    ========================== no tests ran in 0.12s ===========================
+    ========================== 2/2 tests found (0 deselected) in 0.12s ===========================
 
 And then when we run the test:
 

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -175,7 +175,7 @@ objects, they are still using the default pytest representation:
       <Function test_timedistance_v3[forward]>
       <Function test_timedistance_v3[backward]>
 
-    ========================== 8/8 tests found (0 deselected) in 0.12s ===========================
+    ========================== 8/8 tests found in 0.12s ===========================
 
 In ``test_timedistance_v3``, we used ``pytest.param`` to specify the test IDs
 together with the actual data, instead of listing them separately.
@@ -252,7 +252,7 @@ If you just collect tests you'll also nicely see 'advanced' and 'basic' as varia
           <Function test_demo1[advanced]>
           <Function test_demo2[advanced]>
 
-    ========================== 4/4 tests found (0 deselected) in 0.12s ===========================
+    ========================== 4/4 tests found in 0.12s ===========================
 
 Note that we told ``metafunc.parametrize()`` that your scenario values
 should be considered class-scoped.  With pytest-2.3 this leads to a
@@ -328,7 +328,7 @@ Let's first see how it looks like at collection time:
       <Function test_db_initialized[d1]>
       <Function test_db_initialized[d2]>
 
-    ========================== 2/2 tests found (0 deselected) in 0.12s ===========================
+    ========================== 2/2 tests found in 0.12s ===========================
 
 And then when we run the test:
 

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -175,7 +175,7 @@ objects, they are still using the default pytest representation:
       <Function test_timedistance_v3[forward]>
       <Function test_timedistance_v3[backward]>
 
-    ========================== 8/8 tests found in 0.12s ===========================
+    ========================== 8 tests found in 0.12s ===========================
 
 In ``test_timedistance_v3``, we used ``pytest.param`` to specify the test IDs
 together with the actual data, instead of listing them separately.
@@ -252,7 +252,7 @@ If you just collect tests you'll also nicely see 'advanced' and 'basic' as varia
           <Function test_demo1[advanced]>
           <Function test_demo2[advanced]>
 
-    ========================== 4/4 tests found in 0.12s ===========================
+    ========================== 4 tests found in 0.12s ===========================
 
 Note that we told ``metafunc.parametrize()`` that your scenario values
 should be considered class-scoped.  With pytest-2.3 this leads to a

--- a/doc/en/example/pythoncollection.rst
+++ b/doc/en/example/pythoncollection.rst
@@ -220,7 +220,7 @@ You can always peek at the collection tree without running tests like this:
           <Function test_method>
           <Function test_anothermethod>
 
-    ========================== 3/3 tests found (0 deselected) in 0.12s ===========================
+    ========================== 3/3 tests found in 0.12s ===========================
 
 .. _customizing-test-collection:
 

--- a/doc/en/example/pythoncollection.rst
+++ b/doc/en/example/pythoncollection.rst
@@ -157,7 +157,7 @@ The test collection would look like this:
           <Function simple_check>
           <Function complex_check>
 
-    ========================== 2/2 tests found (0 deselected) in 0.12s ===========================
+    ========================== 2/2 tests found in 0.12s ===========================
 
 You can check for multiple glob patterns by adding a space between the patterns:
 
@@ -282,7 +282,7 @@ leave out the ``setup.py`` file:
     <Module 'pkg/module_py2.py'>
       <Function 'test_only_on_python2'>
 
-    ====== 1/1 tests found (0 deselected) in 0.04 seconds ======
+    ====== 1/1 tests found in 0.04 seconds ======
 
 If you run with a Python 3 interpreter both the one test and the ``setup.py``
 file will be left out:
@@ -296,7 +296,7 @@ file will be left out:
     rootdir: $REGENDOC_TMPDIR, configfile: pytest.ini
     collected 0 items
 
-    ========================== 0/0 tests found (0 deselected) in 0.12s ===========================
+    ========================== no tests found in 0.12s ===========================
 
 It's also possible to ignore files based on Unix shell-style wildcards by adding
 patterns to :globalvar:`collect_ignore_glob`.

--- a/doc/en/example/pythoncollection.rst
+++ b/doc/en/example/pythoncollection.rst
@@ -157,7 +157,7 @@ The test collection would look like this:
           <Function simple_check>
           <Function complex_check>
 
-    ========================== no tests ran in 0.12s ===========================
+    ========================== 2/2 tests found (0 deselected) in 0.12s ===========================
 
 You can check for multiple glob patterns by adding a space between the patterns:
 
@@ -220,7 +220,7 @@ You can always peek at the collection tree without running tests like this:
           <Function test_method>
           <Function test_anothermethod>
 
-    ========================== no tests ran in 0.12s ===========================
+    ========================== 3/3 tests found (0 deselected) in 0.12s ===========================
 
 .. _customizing-test-collection:
 
@@ -282,7 +282,7 @@ leave out the ``setup.py`` file:
     <Module 'pkg/module_py2.py'>
       <Function 'test_only_on_python2'>
 
-    ====== no tests ran in 0.04 seconds ======
+    ====== 1/1 tests found (0 deselected) in 0.04 seconds ======
 
 If you run with a Python 3 interpreter both the one test and the ``setup.py``
 file will be left out:
@@ -296,7 +296,7 @@ file will be left out:
     rootdir: $REGENDOC_TMPDIR, configfile: pytest.ini
     collected 0 items
 
-    ========================== no tests ran in 0.12s ===========================
+    ========================== 0/0 tests found (0 deselected) in 0.12s ===========================
 
 It's also possible to ignore files based on Unix shell-style wildcards by adding
 patterns to :globalvar:`collect_ignore_glob`.

--- a/doc/en/example/pythoncollection.rst
+++ b/doc/en/example/pythoncollection.rst
@@ -157,7 +157,7 @@ The test collection would look like this:
           <Function simple_check>
           <Function complex_check>
 
-    ========================== 2/2 tests found in 0.12s ===========================
+    ========================== 2 tests found in 0.12s ===========================
 
 You can check for multiple glob patterns by adding a space between the patterns:
 
@@ -220,7 +220,7 @@ You can always peek at the collection tree without running tests like this:
           <Function test_method>
           <Function test_anothermethod>
 
-    ========================== 3/3 tests found in 0.12s ===========================
+    ========================== 3 tests found in 0.12s ===========================
 
 .. _customizing-test-collection:
 
@@ -282,7 +282,7 @@ leave out the ``setup.py`` file:
     <Module 'pkg/module_py2.py'>
       <Function 'test_only_on_python2'>
 
-    ====== 1/1 tests found in 0.04 seconds ======
+    ====== 1 tests found in 0.04 seconds ======
 
 If you run with a Python 3 interpreter both the one test and the ``setup.py``
 file will be left out:

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -919,7 +919,7 @@ Running the above tests results in the following test IDs being used:
      <Function test_ehlo[mail.python.org]>
      <Function test_noop[mail.python.org]>
 
-   ========================== no tests ran in 0.12s ===========================
+   ========================== 10/10 tests found (0 deselected) in 0.12s ===========================
 
 .. _`fixture-parametrize-marks`:
 

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -919,7 +919,7 @@ Running the above tests results in the following test IDs being used:
      <Function test_ehlo[mail.python.org]>
      <Function test_noop[mail.python.org]>
 
-   ========================== 10/10 tests found (0 deselected) in 0.12s ===========================
+   ========================== 10/10 tests found in 0.12s ===========================
 
 .. _`fixture-parametrize-marks`:
 

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -919,7 +919,7 @@ Running the above tests results in the following test IDs being used:
      <Function test_ehlo[mail.python.org]>
      <Function test_noop[mail.python.org]>
 
-   ========================== 10/10 tests found in 0.12s ===========================
+   ========================== 10 tests found in 0.12s ===========================
 
 .. _`fixture-parametrize-marks`:
 

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1190,7 +1190,7 @@ class TerminalReporter:
             if parts[-1][0] != "no tests ran":
                 parts.append(("no tests ran", {_color_for_type_default: True}))
 
-            # Prepend total number of collected items with "--collect-only".
+            # Prepend total number of selected items with "--collect-only".
             color = _color_for_type.get("selected", _color_for_type_default)
             markup = {color: True, "bold": color == main_color}
             parts.insert(0, ("%d %s" % _make_plural(selected, "selected"), markup))

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1182,18 +1182,18 @@ class TerminalReporter:
                 if key in ["deselected"]:
                     selected -= count
 
-        if not parts:
+        if not parts and not self.config.getoption("collectonly"):
             parts = [("no tests ran", {_color_for_type_default: True})]
 
         if self.config.getoption("collectonly"):
-            # Always display "no tests ran" message with "--collect-only".
-            if parts[-1][0] != "no tests ran":
-                parts.append(("no tests ran", {_color_for_type_default: True}))
-
-            # Prepend total number of selected items with "--collect-only".
-            color = _color_for_type.get("selected", _color_for_type_default)
-            markup = {color: True, "bold": color == main_color}
-            parts.insert(0, ("%d %s" % _make_plural(selected, "selected"), markup))
+            co_output = "%i/%i tests found (%i deselected)"
+            deselected = self._numcollected - selected
+            parts = [
+                (
+                    co_output % (selected, self._numcollected, deselected),
+                    {main_color: True},
+                )
+            ]
 
         return parts, main_color
 

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1190,16 +1190,16 @@ class TerminalReporter:
             parts = [("no tests ran", {_color_for_type_default: True})]
 
         if self.config.getoption("collectonly"):
-            co_output = "%i/%i tests found"
-            deselected = self._numcollected - selected
 
-            # It seems unecessary to add this if no tests were deselected.
-            if deselected > 0:
-                co_output += " (%i deselected)" % (deselected)
+            if self._numcollected == selected:
+                co_output = "%d %s found" % _make_plural(self._numcollected, "test")
+            else:
+                deselected = self._numcollected - selected
+                co_output = f"{selected}/{self._numcollected} tests found ({deselected} deselected)"
 
-            parts = [(co_output % (selected, self._numcollected), {main_color: True},)]
+            parts = [(co_output, {main_color: True})]
 
-            # Sticking with "0/0 tests found (0 deselected)" would e confusing.
+            # Sticking with "0/0 tests found (0 deselected)" would be confusing.
             if self._numcollected == 0:
                 parts = [("no tests found", {_color_for_type_default: True})]
 

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1179,20 +1179,21 @@ class TerminalReporter:
                 markup = {color: True, "bold": color == main_color}
                 parts.append(("%d %s" % _make_plural(count, key), markup))
 
-                if key in ["error", "skipped", "deselected"]:
+                if key in ["deselected"]:
                     selected -= count
 
         if not parts:
             parts = [("no tests ran", {_color_for_type_default: True})]
 
         if self.config.getoption("collectonly"):
+            # Always display "no tests ran" message with "--collect-only".
+            if parts[-1][0] != "no tests ran":
+                parts.append(("no tests ran", {_color_for_type_default: True}))
+
             # Prepend total number of collected items with "--collect-only".
             color = _color_for_type.get("selected", _color_for_type_default)
             markup = {color: True, "bold": color == main_color}
             parts.insert(0, ("%d %s" % _make_plural(selected, "selected"), markup))
-
-            # Always display "no tests ran" message with "--collect-only".
-            parts.append(("no tests ran", {_color_for_type_default: True}))
 
         return parts, main_color
 

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1187,19 +1187,18 @@ class TerminalReporter:
         if self.config.getoption("collectonly"):
             return self._build_collect_only_summary_stats_line()
         else:
-            return self._build_normal_only_summary_stats_line()
+            return self._build_normal_summary_stats_line()
 
     def _get_reports_to_display(self, key: str) -> List[Any]:
         """Get test/collection reports for the given status key, such as `passed` or `error`."""
         reports = self.stats.get(key, [])
         return [x for x in reports if getattr(x, "count_towards_summary", True)]
 
-    def _build_normal_only_summary_stats_line(
+    def _build_normal_summary_stats_line(
         self,
     ) -> Tuple[List[Tuple[str, Dict[str, bool]]], str]:
         main_color, known_types = self._get_main_color()
         parts = []
-        errors = 0
 
         for key in known_types:
             reports = self._get_reports_to_display(key)
@@ -1208,9 +1207,6 @@ class TerminalReporter:
                 color = _color_for_type.get(key, _color_for_type_default)
                 markup = {color: True, "bold": color == main_color}
                 parts.append(("%d %s" % _make_plural(count, key), markup))
-
-                if key == "error":
-                    errors += count
 
         if not parts:
             parts = [("no tests ran", {_color_for_type_default: True})]
@@ -1224,22 +1220,24 @@ class TerminalReporter:
         errors = len(self._get_reports_to_display("error"))
 
         if self._numcollected == 0:
-            parts = [("no tests found", {"yellow": True})]
+            parts = [("no tests collected", {"yellow": True})]
             main_color = "yellow"
 
         elif deselected == 0:
             main_color = "green"
-            collected_output = "%d %s found" % _make_plural(self._numcollected, "test")
+            collected_output = "%d %s collected" % _make_plural(
+                self._numcollected, "test"
+            )
             parts = [(collected_output, {main_color: True})]
         else:
             all_tests_were_deselected = self._numcollected == deselected
             if all_tests_were_deselected:
                 main_color = "yellow"
-                collected_output = f"no tests found ({deselected} deselected)"
+                collected_output = f"no tests collected ({deselected} deselected)"
             else:
                 main_color = "green"
                 selected = self._numcollected - deselected
-                collected_output = f"{selected}/{self._numcollected} tests found ({deselected} deselected)"
+                collected_output = f"{selected}/{self._numcollected} tests collected ({deselected} deselected)"
 
             parts = [(collected_output, {main_color: True})]
 

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1166,8 +1166,9 @@ class TerminalReporter:
 
     def build_summary_stats_line(self) -> Tuple[List[Tuple[str, Dict[str, bool]]], str]:
         main_color, known_types = self._get_main_color()
-
         parts = []
+        selected = self._numcollected
+
         for key in known_types:
             reports = self.stats.get(key, None)
             if reports:
@@ -1178,8 +1179,20 @@ class TerminalReporter:
                 markup = {color: True, "bold": color == main_color}
                 parts.append(("%d %s" % _make_plural(count, key), markup))
 
+                if key in ["error", "skipped", "deselected"]:
+                    selected -= count
+
         if not parts:
             parts = [("no tests ran", {_color_for_type_default: True})]
+
+        if self.config.getoption("collectonly"):
+            # Prepend total number of collected items with "--collect-only".
+            color = _color_for_type.get("selected", _color_for_type_default)
+            markup = {color: True, "bold": color == main_color}
+            parts.insert(0, ("%d %s" % _make_plural(selected, "selected"), markup))
+
+            # Always display "no tests ran" message with "--collect-only".
+            parts.append(("no tests ran", {_color_for_type_default: True}))
 
         return parts, main_color
 

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -889,7 +889,7 @@ def test_collection_collect_only_live_logging(testdir, verbose):
             [
                 "*collected 1 item*",
                 "*<Module test_collection_collect_only_live_logging.py>*",
-                "*1 test found*",
+                "*1 test collected*",
             ]
         )
     elif verbose == "-q":
@@ -897,7 +897,7 @@ def test_collection_collect_only_live_logging(testdir, verbose):
         expected_lines.extend(
             [
                 "*test_collection_collect_only_live_logging.py::test_simple*",
-                "1 test found in [0-9].[0-9][0-9]s",
+                "1 test collected in [0-9].[0-9][0-9]s",
             ]
         )
     elif verbose == "-qq":

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -889,7 +889,7 @@ def test_collection_collect_only_live_logging(testdir, verbose):
             [
                 "*collected 1 item*",
                 "*<Module test_collection_collect_only_live_logging.py>*",
-                "*1 selected, no tests ran*",
+                "*1/1 tests found (0 deselected)*",
             ]
         )
     elif verbose == "-q":
@@ -897,7 +897,7 @@ def test_collection_collect_only_live_logging(testdir, verbose):
         expected_lines.extend(
             [
                 "*test_collection_collect_only_live_logging.py::test_simple*",
-                "1 selected, no tests ran in [0-9].[0-9][0-9]s",
+                "1/1 tests found (0 deselected) in [0-9].[0-9][0-9]s",
             ]
         )
     elif verbose == "-qq":

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -889,7 +889,7 @@ def test_collection_collect_only_live_logging(testdir, verbose):
             [
                 "*collected 1 item*",
                 "*<Module test_collection_collect_only_live_logging.py>*",
-                "*1/1 tests found*",
+                "*1 test found*",
             ]
         )
     elif verbose == "-q":
@@ -897,7 +897,7 @@ def test_collection_collect_only_live_logging(testdir, verbose):
         expected_lines.extend(
             [
                 "*test_collection_collect_only_live_logging.py::test_simple*",
-                "1/1 tests found in [0-9].[0-9][0-9]s",
+                "1 test found in [0-9].[0-9][0-9]s",
             ]
         )
     elif verbose == "-qq":

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -889,7 +889,7 @@ def test_collection_collect_only_live_logging(testdir, verbose):
             [
                 "*collected 1 item*",
                 "*<Module test_collection_collect_only_live_logging.py>*",
-                "*no tests ran*",
+                "*1 selected, no tests ran*",
             ]
         )
     elif verbose == "-q":
@@ -897,7 +897,7 @@ def test_collection_collect_only_live_logging(testdir, verbose):
         expected_lines.extend(
             [
                 "*test_collection_collect_only_live_logging.py::test_simple*",
-                "no tests ran in [0-9].[0-9][0-9]s",
+                "1 selected, no tests ran in [0-9].[0-9][0-9]s",
             ]
         )
     elif verbose == "-qq":

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -889,7 +889,7 @@ def test_collection_collect_only_live_logging(testdir, verbose):
             [
                 "*collected 1 item*",
                 "*<Module test_collection_collect_only_live_logging.py>*",
-                "*1/1 tests found (0 deselected)*",
+                "*1/1 tests found*",
             ]
         )
     elif verbose == "-q":
@@ -897,7 +897,7 @@ def test_collection_collect_only_live_logging(testdir, verbose):
         expected_lines.extend(
             [
                 "*test_collection_collect_only_live_logging.py::test_simple*",
-                "1/1 tests found (0 deselected) in [0-9].[0-9][0-9]s",
+                "1/1 tests found in [0-9].[0-9][0-9]s",
             ]
         )
     elif verbose == "-qq":

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1417,7 +1417,7 @@ class TestMetafuncFunctional:
                 '    @pytest.mark.parametrise("x", range(2))',
                 "E   Failed: Unknown 'parametrise' mark, did you mean 'parametrize'?",
                 "*! Interrupted: 1 error during collection !*",
-                "*= 1 error in *",
+                "*= no tests found, 1 error in *",
             ]
         )
 

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1417,7 +1417,7 @@ class TestMetafuncFunctional:
                 '    @pytest.mark.parametrise("x", range(2))',
                 "E   Failed: Unknown 'parametrise' mark, did you mean 'parametrize'?",
                 "*! Interrupted: 1 error during collection !*",
-                "*= 0 selected, 1 error, no tests ran in *",
+                "*= 0/0 tests found (0 deselected) in *",
             ]
         )
 

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1417,7 +1417,7 @@ class TestMetafuncFunctional:
                 '    @pytest.mark.parametrise("x", range(2))',
                 "E   Failed: Unknown 'parametrise' mark, did you mean 'parametrize'?",
                 "*! Interrupted: 1 error during collection !*",
-                "*= no tests found, 1 error in *",
+                "*= no tests collected, 1 error in *",
             ]
         )
 

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1417,7 +1417,7 @@ class TestMetafuncFunctional:
                 '    @pytest.mark.parametrise("x", range(2))',
                 "E   Failed: Unknown 'parametrise' mark, did you mean 'parametrize'?",
                 "*! Interrupted: 1 error during collection !*",
-                "*= 0/0 tests found (0 deselected) in *",
+                "*= 1 error in *",
             ]
         )
 

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1417,7 +1417,7 @@ class TestMetafuncFunctional:
                 '    @pytest.mark.parametrise("x", range(2))',
                 "E   Failed: Unknown 'parametrise' mark, did you mean 'parametrize'?",
                 "*! Interrupted: 1 error during collection !*",
-                "*= 1 error in *",
+                "*= 0 selected, 1 error, no tests ran in *",
             ]
         )
 

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -908,7 +908,7 @@ class TestLastFailed:
                 "",
                 "<Module pkg1/test_1.py>",
                 "  <Function test_fail>",
-                "*= 1 deselected in *",
+                "*= 1 selected, 1 deselected, no tests ran in *",
             ],
         )
 
@@ -941,7 +941,7 @@ class TestLastFailed:
                 "      <Function test_fail>",
                 "  <Function test_other>",
                 "",
-                "*= 1 deselected in *",
+                "*= 2 selected, 1 deselected, no tests ran in *",
             ],
             consecutive=True,
         )
@@ -976,7 +976,7 @@ class TestLastFailed:
                 "<Module pkg1/test_1.py>",
                 "  <Function test_pass>",
                 "",
-                "*= no tests ran in*",
+                "*= 1 selected, no tests ran in*",
             ],
             consecutive=True,
         )

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -976,7 +976,7 @@ class TestLastFailed:
                 "<Module pkg1/test_1.py>",
                 "  <Function test_pass>",
                 "",
-                "*= 1/1 tests found in*",
+                "*= 1 test found in*",
             ],
             consecutive=True,
         )

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -976,7 +976,7 @@ class TestLastFailed:
                 "<Module pkg1/test_1.py>",
                 "  <Function test_pass>",
                 "",
-                "*= 1/1 tests found (0 deselected) in*",
+                "*= 1/1 tests found in*",
             ],
             consecutive=True,
         )

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -908,7 +908,7 @@ class TestLastFailed:
                 "",
                 "<Module pkg1/test_1.py>",
                 "  <Function test_fail>",
-                "*= 1 selected, 1 deselected, no tests ran in *",
+                "*= 1/2 tests found (1 deselected) in *",
             ],
         )
 
@@ -941,7 +941,7 @@ class TestLastFailed:
                 "      <Function test_fail>",
                 "  <Function test_other>",
                 "",
-                "*= 2 selected, 1 deselected, no tests ran in *",
+                "*= 2/3 tests found (1 deselected) in *",
             ],
             consecutive=True,
         )
@@ -976,7 +976,7 @@ class TestLastFailed:
                 "<Module pkg1/test_1.py>",
                 "  <Function test_pass>",
                 "",
-                "*= 1 selected, no tests ran in*",
+                "*= 1/1 tests found (0 deselected) in*",
             ],
             consecutive=True,
         )

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -908,7 +908,7 @@ class TestLastFailed:
                 "",
                 "<Module pkg1/test_1.py>",
                 "  <Function test_fail>",
-                "*= 1/2 tests found (1 deselected) in *",
+                "*= 1/2 tests collected (1 deselected) in *",
             ],
         )
 
@@ -941,7 +941,7 @@ class TestLastFailed:
                 "      <Function test_fail>",
                 "  <Function test_other>",
                 "",
-                "*= 2/3 tests found (1 deselected) in *",
+                "*= 2/3 tests collected (1 deselected) in *",
             ],
             consecutive=True,
         )
@@ -976,7 +976,7 @@ class TestLastFailed:
                 "<Module pkg1/test_1.py>",
                 "  <Function test_pass>",
                 "",
-                "*= 1 test found in*",
+                "*= 1 test collected in*",
             ],
             consecutive=True,
         )

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -458,6 +458,51 @@ class TestCollectonly:
         result = testdir.runpytest("--collect-only", "-qq")
         result.stdout.fnmatch_lines(["*test_fun.py: 1*"])
 
+    def test_collect_only_summary_status(self, testdir):
+        """Custom status depending on test selection using -k or -m. #7701."""
+        testdir.makepyfile(
+            test_collect_foo="""
+            def test_foo(): pass
+            """,
+            test_collect_bar="""
+            def test_foobar(): pass
+            def test_bar(): pass
+            """,
+        )
+        result = testdir.runpytest("--collect-only")
+        result.stdout.fnmatch_lines("*== 3 tests found in * ==*")
+
+        result = testdir.runpytest("--collect-only", "test_collect_foo.py")
+        result.stdout.fnmatch_lines("*== 1 test found in * ==*")
+
+        result = testdir.runpytest("--collect-only", "test_collect_foo.py")
+        result.stdout.fnmatch_lines("*== 1 test found in * ==*")
+
+        result = testdir.runpytest("--collect-only", "-k", "foo")
+        result.stdout.fnmatch_lines("*== 2/3 tests matched (1 deselected) in * ==*")
+
+        result = testdir.runpytest("--collect-only", "-k", "test_bar")
+        result.stdout.fnmatch_lines("*== 1/3 tests matched (2 deselected) in * ==*")
+
+        result = testdir.runpytest("--collect-only", "-k", "invalid")
+        result.stdout.fnmatch_lines("*== no tests matched (3 deselected) in * ==*")
+
+        testdir.mkdir("no_tests_here")
+        result = testdir.runpytest("--collect-only", "no_tests_here")
+        result.stdout.fnmatch_lines("*== no tests found in * ==*")
+
+        testdir.makepyfile(
+            test_contains_error="""
+            raise RuntimeError
+            """,
+        )
+        result = testdir.runpytest("--collect-only")
+        result.stdout.fnmatch_lines("*== 3 tests found, 1 error in * ==*")
+        result = testdir.runpytest("--collect-only", "-k", "foo")
+        result.stdout.fnmatch_lines(
+            "*== 2/3 tests matched (1 deselected), 1 error in * ==*"
+        )
+
 
 class TestFixtureReporting:
     def test_setup_fixture_error(self, testdir):

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -470,23 +470,23 @@ class TestCollectonly:
             """,
         )
         result = testdir.runpytest("--collect-only")
-        result.stdout.fnmatch_lines("*== 3 tests found in * ==*")
+        result.stdout.fnmatch_lines("*== 3 tests collected in * ==*")
 
         result = testdir.runpytest("--collect-only", "test_collect_foo.py")
-        result.stdout.fnmatch_lines("*== 1 test found in * ==*")
+        result.stdout.fnmatch_lines("*== 1 test collected in * ==*")
 
         result = testdir.runpytest("--collect-only", "-k", "foo")
-        result.stdout.fnmatch_lines("*== 2/3 tests found (1 deselected) in * ==*")
+        result.stdout.fnmatch_lines("*== 2/3 tests collected (1 deselected) in * ==*")
 
         result = testdir.runpytest("--collect-only", "-k", "test_bar")
-        result.stdout.fnmatch_lines("*== 1/3 tests found (2 deselected) in * ==*")
+        result.stdout.fnmatch_lines("*== 1/3 tests collected (2 deselected) in * ==*")
 
         result = testdir.runpytest("--collect-only", "-k", "invalid")
-        result.stdout.fnmatch_lines("*== no tests found (3 deselected) in * ==*")
+        result.stdout.fnmatch_lines("*== no tests collected (3 deselected) in * ==*")
 
         testdir.mkdir("no_tests_here")
         result = testdir.runpytest("--collect-only", "no_tests_here")
-        result.stdout.fnmatch_lines("*== no tests found in * ==*")
+        result.stdout.fnmatch_lines("*== no tests collected in * ==*")
 
         testdir.makepyfile(
             test_contains_error="""
@@ -494,10 +494,10 @@ class TestCollectonly:
             """,
         )
         result = testdir.runpytest("--collect-only")
-        result.stdout.fnmatch_lines("*== 3 tests found, 1 error in * ==*")
+        result.stdout.fnmatch_lines("*== 3 tests collected, 1 error in * ==*")
         result = testdir.runpytest("--collect-only", "-k", "foo")
         result.stdout.fnmatch_lines(
-            "*== 2/3 tests found (1 deselected), 1 error in * ==*"
+            "*== 2/3 tests collected (1 deselected), 1 error in * ==*"
         )
 
 

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -479,13 +479,13 @@ class TestCollectonly:
         result.stdout.fnmatch_lines("*== 1 test found in * ==*")
 
         result = testdir.runpytest("--collect-only", "-k", "foo")
-        result.stdout.fnmatch_lines("*== 2/3 tests matched (1 deselected) in * ==*")
+        result.stdout.fnmatch_lines("*== 2/3 tests found (1 deselected) in * ==*")
 
         result = testdir.runpytest("--collect-only", "-k", "test_bar")
-        result.stdout.fnmatch_lines("*== 1/3 tests matched (2 deselected) in * ==*")
+        result.stdout.fnmatch_lines("*== 1/3 tests found (2 deselected) in * ==*")
 
         result = testdir.runpytest("--collect-only", "-k", "invalid")
-        result.stdout.fnmatch_lines("*== no tests matched (3 deselected) in * ==*")
+        result.stdout.fnmatch_lines("*== no tests found (3 deselected) in * ==*")
 
         testdir.mkdir("no_tests_here")
         result = testdir.runpytest("--collect-only", "no_tests_here")
@@ -500,7 +500,7 @@ class TestCollectonly:
         result.stdout.fnmatch_lines("*== 3 tests found, 1 error in * ==*")
         result = testdir.runpytest("--collect-only", "-k", "foo")
         result.stdout.fnmatch_lines(
-            "*== 2/3 tests matched (1 deselected), 1 error in * ==*"
+            "*== 2/3 tests found (1 deselected), 1 error in * ==*"
         )
 
 

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -475,9 +475,6 @@ class TestCollectonly:
         result = testdir.runpytest("--collect-only", "test_collect_foo.py")
         result.stdout.fnmatch_lines("*== 1 test found in * ==*")
 
-        result = testdir.runpytest("--collect-only", "test_collect_foo.py")
-        result.stdout.fnmatch_lines("*== 1 test found in * ==*")
-
         result = testdir.runpytest("--collect-only", "-k", "foo")
         result.stdout.fnmatch_lines("*== 2/3 tests found (1 deselected) in * ==*")
 


### PR DESCRIPTION
Hey,

This PR intends to improve on the output of the summary stats line when using the `--collection-only`. I wrote it a bit "hackishly" because I was discovering the codebase so any feedback on improving the code, or the behavior, would be greatly appreciated. I also took the liberty of updating the existing tests to match this new behavior.

I tried to make the behavior similar to what was requested in #7701 and it results in something similar to:

```
==== 114 selected, 2891 deselected, no tests ran in 1.50s ====
```

Additionally, I noticed that in the examples found in the documentation, it only displays contexts where only "no tests ran in (...)s" happens...would it make sense to add more examples of different outputs?

Closes #7701.

Let me know how you feel about this.

Thanks!

<!--
- [ ] Include documentation when adding new features.
-->
