### PR TITLE
better handle errors raised while applying filterwarnings (#7864)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,6 +51,7 @@ Cal Leeming
 Carl Friedrich Bolz
 Carlos Jenkins
 Ceridwen
+Charles Aracil
 Charles Cloud
 Charles Machalow
 Charnjit SiNGH (CCSJ)

--- a/changelog/7864.improvement.rst
+++ b/changelog/7864.improvement.rst
@@ -1,0 +1,1 @@
+Better handle errors raised while applying filterwarnings.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1569,7 +1569,14 @@ def parse_warning_filter(
         parts.append("")
     action_, message, category_, module, lineno_ = [s.strip() for s in parts]
     action: str = warnings._getaction(action_)  # type: ignore[attr-defined]
-    category: Type[Warning] = warnings._getcategory(category_)  # type: ignore[attr-defined]
+    try:
+        category: Type[Warning] = warnings._getcategory(category_)  # type: ignore[attr-defined] # noqa: E501
+    except Exception as e:
+        raise Exception(
+            "Error while processing warning rules. Please make sure importing "
+            "the warning classes defined in filterwarning doesn't trigger an "
+            "exception."
+        ) from e
     if message and escape:
         message = re.escape(message)
     if module and escape:


### PR DESCRIPTION
closes #7864

Add a more explicit error when raising exception while trying to import filterwarnings.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
