### PR TITLE
doc: Remove unused imports in examples

### DIFF
--- a/doc/en/tmpdir.rst
+++ b/doc/en/tmpdir.rst
@@ -20,7 +20,6 @@ created in the `base temporary directory`_.
 .. code-block:: python
 
     # content of test_tmp_path.py
-    import os
 
     CONTENT = "content"
 
@@ -97,7 +96,6 @@ and more.  Here is an example test usage:
 .. code-block:: python
 
     # content of test_tmpdir.py
-    import os
 
 
     def test_create_file(tmpdir):

--- a/doc/en/tmpdir.rst
+++ b/doc/en/tmpdir.rst
@@ -20,7 +20,6 @@ created in the `base temporary directory`_.
 .. code-block:: python
 
     # content of test_tmp_path.py
-
     CONTENT = "content"
 
 

--- a/doc/en/tmpdir.rst
+++ b/doc/en/tmpdir.rst
@@ -95,8 +95,6 @@ and more.  Here is an example test usage:
 .. code-block:: python
 
     # content of test_tmpdir.py
-
-
     def test_create_file(tmpdir):
         p = tmpdir.mkdir("sub").join("hello.txt")
         p.write("content")


### PR DESCRIPTION
The "os" imports in the `tmp_path` and `tmpdir` fixture examples are
unused and thus have been removed to prevent confusion.
