### PR TITLE
Support for ignoring directories with .pytestignore

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -224,6 +224,7 @@ Omer Hadari
 Ondřej Súkup
 Oscar Benjamin
 Patrick Hayes
+Paul Carlisle
 Pauli Virtanen
 Pavel Karateev
 Paweł Adamczak

--- a/changelog/7925.feature.rst
+++ b/changelog/7925.feature.rst
@@ -1,0 +1,1 @@
+Support for ignoring collection of directories containing a ``.pytestignore`` file.

--- a/doc/en/example/pythoncollection.rst
+++ b/doc/en/example/pythoncollection.rst
@@ -46,6 +46,36 @@ you will see that ``pytest`` only collects test-modules, which do not match the 
 The ``--ignore-glob`` option allows to ignore test file paths based on Unix shell-style wildcards.
 If you want to exclude test-modules that end with ``_01.py``, execute ``pytest`` with ``--ignore-glob='*_01.py'``.
 
+Another option for ignoring a directory is via the inclusion of a ``.pytestignore`` file.
+
+.. code-block:: text
+
+    tests/
+    |-- foo
+    |   |-- .pytestignore
+    |   |-- test_foo_01.py
+    |   |-- test_foo_02.py
+    |   '-- test_foo_03.py
+    '-- bar
+        |-- test_bar_01.py
+        |-- test_bar_02.py
+        '-- test_bar_03.py
+
+Because of its inclusion of a ``.pytestignore`` file, the ``foo`` directory will not be collected.
+
+.. code-block:: pytest
+
+    =========================== test session starts ============================
+    platform linux -- Python 3.x.y, pytest-5.x.y, py-1.x.y, pluggy-0.x.y
+    rootdir: $REGENDOC_TMPDIR, inifile:
+    collected 5 items
+
+    tests/bar/test_bar_01.py .                                           [ 33%]
+    tests/bar/test_bar_02.py .                                           [ 66%]
+    tests/bar/test_bar_03.py .                                           [100%]
+
+    ========================= 3 passed in 0.02 seconds =========================
+
 Deselect tests during test collection
 -------------------------------------
 

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -358,6 +358,13 @@ def _in_venv(path: py.path.local) -> bool:
     return any([fname.basename in activates for fname in bindir.listdir()])
 
 
+def contains_ignorefile(path: Path) -> bool:
+    try:
+        return path.is_dir() and path.joinpath(".pytestignore").exists()
+    except PermissionError:
+        return False
+
+
 def pytest_ignore_collect(path: py.path.local, config: Config) -> Optional[bool]:
     ignore_paths = config._getconftest_pathlist("collect_ignore", path=path.dirpath())
     ignore_paths = ignore_paths or []
@@ -365,7 +372,7 @@ def pytest_ignore_collect(path: py.path.local, config: Config) -> Optional[bool]
     if excludeopt:
         ignore_paths.extend([py.path.local(x) for x in excludeopt])
 
-    if py.path.local(path) in ignore_paths:
+    if py.path.local(path) in ignore_paths or contains_ignorefile(Path(path)):
         return True
 
     ignore_globs = config._getconftest_pathlist(

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -241,6 +241,19 @@ class TestCollectFS:
             items, reprec = testdir.inline_genitems()
             assert [x.name for x in items] == ["test_%s" % dirname]
 
+    def test_ignore_pytestignore_file(self, testdir):
+        tmpdir = testdir.tmpdir
+        tmpdir.ensure("sub1", "test_notfound.py")
+        tmpdir.ensure("sub1", ".pytestignore")
+        tmpdir.ensure("sub2", "test_found.py")
+        for x in Path(str(tmpdir)).rglob("test_*.py"):
+            x.write_text("def test_hello(): pass", "utf-8")
+
+        result = testdir.runpytest("--collect-only")
+        s = result.stdout.str()
+        assert "test_notfound" not in s
+        assert "test_found" in s
+
 
 class TestCollectPluginHookRelay:
     def test_pytest_collect_file(self, testdir):


### PR DESCRIPTION
The presence of this file in a directory would tell pytest to ignore its
collection.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
