### PR TITLE
Replace term 'triple' with 'tuple' in hookspec docstrings

### DIFF
--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -446,7 +446,7 @@ def pytest_runtest_logstart(
     See :func:`pytest_runtest_protocol` for a description of the runtest protocol.
 
     :param str nodeid: Full node ID of the item.
-    :param location: A triple of ``(filename, lineno, testname)``.
+    :param location: A tuple of ``(filename, lineno, testname)``.
     """
 
 
@@ -458,7 +458,7 @@ def pytest_runtest_logfinish(
     See :func:`pytest_runtest_protocol` for a description of the runtest protocol.
 
     :param str nodeid: Full node ID of the item.
-    :param location: A triple of ``(filename, lineno, testname)``.
+    :param location: A tuple of ``(filename, lineno, testname)``.
     """
 
 


### PR DESCRIPTION
Hey, very minor adjustment - was reading through hookspecs to build my understanding and noticed the `triple` term used in place of `tuple`, thought I should make that technically correct.

Thanks - have a wonderful weekend 👍 