### PR TITLE
[BLOCKED] --import-mode=importlib: use sys.path relative path if present (wait for #7870)

### DIFF
--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -468,6 +468,9 @@ def import_path(
     if mode is ImportMode.importlib:
         module_name = path.stem
 
+        # If the module exists under a location in sys.path, just import it using that module name.
+        # This is as close to a "normal import" as possible - no need to modify sys.path and the
+        # module will have __package__ set correctly (so relative imports also work).
         resolved_name = resolve_sys_path_module_name(path)
         if resolved_name is not None:
             return importlib.import_module(resolved_name)


### PR DESCRIPTION
This PR is inspired by https://github.com/pytest-dev/pytest/issues/5147#issuecomment-607075562 to use `sys.path` to discover package paths when attempting to import test modules in `importlib` mode.

This helps weird edge-case papercuts such as:
- relative imports in test files, which currently doesn't work with `importlib` mode (see https://github.com/pytest-dev/pytest/issues/7245#issuecomment-686398389)
- implicit namespace packages where the child package name clashes with a builtin module, which I have issues with on _all_ modes (not just importlib).

This patch only takes effect if the file being tested is in the user's sys.path. I think that usually this is only the case if the containing package was installed with `setup.py develop`.

I'm happy to write docs, changelog entry etc., but first wanted to collect feedback on this approach before doing so.


--- 

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.