### PR TITLE
#7938 - [Plugin: Stepwise][Enhancements] Refactoring, smarter registration & --sw-skip functionality

### DIFF
--- a/changelog/7938.improvement.rst
+++ b/changelog/7938.improvement.rst
@@ -1,0 +1,1 @@
+Stepwise plugin improvements and a new ``--sw-skip`` shorthand argument is now available

--- a/changelog/7938.improvement.rst
+++ b/changelog/7938.improvement.rst
@@ -1,1 +1,1 @@
-Stepwise plugin improvements and a new ``--sw-skip`` shorthand argument is now available
+New ``--sw-skip`` argument which is a shorthand for ``--stepwise-skip``.

--- a/src/_pytest/stepwise.py
+++ b/src/_pytest/stepwise.py
@@ -78,12 +78,12 @@ class StepwisePlugin:
 
         # If the previously failed test was not found among the test items,
         # do not skip any tests.
-        if not failed_index:
+        if failed_index is None:
             self.report_status = "previously failed test not found, not skipping."
         else:
             self.report_status = f"skipping {failed_index} already passed items."
             deselected = items[:failed_index]
-            items[:] = items[failed_index:]
+            del items[:failed_index]
             config.hook.pytest_deselected(items=deselected)
 
     def pytest_runtest_logreport(self, report: TestReport) -> None:

--- a/src/_pytest/stepwise.py
+++ b/src/_pytest/stepwise.py
@@ -82,8 +82,9 @@ class StepwisePlugin:
             self.report_status = "previously failed test not found, not skipping."
         else:
             self.report_status = f"skipping {failed_index} already passed items."
+            deselected = items[:failed_index]
             items[:] = items[failed_index:]
-            config.hook.pytest_deselected(items=items[:failed_index])
+            config.hook.pytest_deselected(items=deselected)
 
     def pytest_runtest_logreport(self, report: TestReport) -> None:
         if report.failed:

--- a/src/_pytest/stepwise.py
+++ b/src/_pytest/stepwise.py
@@ -20,6 +20,7 @@ def pytest_addoption(parser: Parser) -> None:
     )
     group.addoption(
         "--stepwise-skip",
+        "--sw-skip",
         action="store_true",
         dest="stepwise_skip",
         help="ignore the first failing test but stop on the next failing test",

--- a/src/_pytest/stepwise.py
+++ b/src/_pytest/stepwise.py
@@ -56,7 +56,7 @@ class StepwisePlugin:
         self.session = session
 
     def pytest_collection_modifyitems(
-        self, session: Session, config: Config, items: List[nodes.Item]
+        self, config: Config, items: List[nodes.Item]
     ) -> None:
         if not self.lastfailed:
             self.report_status = "no previously failed tests, not skipping."

--- a/src/_pytest/stepwise.py
+++ b/src/_pytest/stepwise.py
@@ -15,6 +15,7 @@ def pytest_addoption(parser: Parser) -> None:
         "--sw",
         "--stepwise",
         action="store_true",
+        default=False,
         dest="stepwise",
         help="exit on test failure and continue from last failing test next time",
     )
@@ -22,6 +23,7 @@ def pytest_addoption(parser: Parser) -> None:
         "--stepwise-skip",
         "--sw-skip",
         action="store_true",
+        default=False,
         dest="stepwise_skip",
         help="ignore the first failing test but stop on the next failing test",
     )

--- a/src/_pytest/stepwise.py
+++ b/src/_pytest/stepwise.py
@@ -57,7 +57,7 @@ class StepwisePlugin:
         assert config.cache is not None
         self.cache: Cache = config.cache
         self.lastfailed: Optional[str] = self.cache.get(STEPWISE_CACHE_DIR, None)
-        self.skip: bool = config.option.stepwise_skip
+        self.skip: bool = config.getoption("stepwise_skip")
 
     def pytest_sessionstart(self, session: Session) -> None:
         self.session = session

--- a/testing/test_stepwise.py
+++ b/testing/test_stepwise.py
@@ -117,10 +117,10 @@ def test_fail_and_continue_with_stepwise(stepwise_testdir):
     assert "test_success_after_fail PASSED" in stdout
 
 
-@pytest.mark.parametrize("sw_option", ["--stepwise-skip", "--sw-skip"])
-def test_run_with_skip_option(stepwise_testdir, sw_option):
+@pytest.mark.parametrize("stepwise_skip", ["--stepwise-skip", "--sw-skip"])
+def test_run_with_skip_option(stepwise_testdir, stepwise_skip):
     result = stepwise_testdir.runpytest(
-        "-v", "--strict-markers", "--stepwise", f"{sw_option}", "--fail", "--fail-last",
+        "-v", "--strict-markers", "--stepwise", stepwise_skip, "--fail", "--fail-last",
     )
     assert _strip_resource_warnings(result.stderr.lines) == []
 

--- a/testing/test_stepwise.py
+++ b/testing/test_stepwise.py
@@ -117,14 +117,10 @@ def test_fail_and_continue_with_stepwise(stepwise_testdir):
     assert "test_success_after_fail PASSED" in stdout
 
 
-def test_run_with_skip_option(stepwise_testdir):
+@pytest.mark.parametrize("sw_option", ("--stepwise-skip", "--sw-skip"))
+def test_run_with_skip_option(stepwise_testdir, sw_option):
     result = stepwise_testdir.runpytest(
-        "-v",
-        "--strict-markers",
-        "--stepwise",
-        "--stepwise-skip",
-        "--fail",
-        "--fail-last",
+        "-v", "--strict-markers", "--stepwise", f"{sw_option}", "--fail", "--fail-last",
     )
     assert _strip_resource_warnings(result.stderr.lines) == []
 

--- a/testing/test_stepwise.py
+++ b/testing/test_stepwise.py
@@ -117,7 +117,7 @@ def test_fail_and_continue_with_stepwise(stepwise_testdir):
     assert "test_success_after_fail PASSED" in stdout
 
 
-@pytest.mark.parametrize("sw_option", ("--stepwise-skip", "--sw-skip"))
+@pytest.mark.parametrize("sw_option", ["--stepwise-skip", "--sw-skip"])
 def test_run_with_skip_option(stepwise_testdir, sw_option):
     result = stepwise_testdir.runpytest(
         "-v", "--strict-markers", "--stepwise", f"{sw_option}", "--fail", "--fail-last",

--- a/testing/test_stepwise.py
+++ b/testing/test_stepwise.py
@@ -93,6 +93,23 @@ def test_run_without_stepwise(stepwise_testdir):
     result.stdout.fnmatch_lines(["*test_success_after_fail PASSED*"])
 
 
+def test_stepwise_output_summary(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        @pytest.mark.parametrize("expected", [True, True, True, True, False])
+        def test_data(expected):
+            assert expected
+        """
+    )
+    result = testdir.runpytest("-v", "--stepwise")
+    result.stdout.fnmatch_lines(["stepwise: no previously failed tests, not skipping."])
+    result = testdir.runpytest("-v", "--stepwise")
+    result.stdout.fnmatch_lines(
+        ["stepwise: skipping 4 already passed items.", "*1 failed, 4 deselected*"]
+    )
+
+
 def test_fail_and_continue_with_stepwise(stepwise_testdir):
     # Run the tests with a failing second test.
     result = stepwise_testdir.runpytest(


### PR DESCRIPTION
Hi team, hope you are all keeping well.  While trying to advance my knowledge of the project I have been understanding plugins a little bit.  Here is a small PR to tidy up some of the stepwise plugin code for consistency.  Some of the most important changes are:

 - Stop registering the plugin if stepwise itself is not active (rather than these constant is_active checks inside hooks).
 - Adding a --sw-skip shorthand option to mirror that of --sw itself
 - Added a pytest_sessionfinish hook to stepwise (this is because --cache-clear was always outputting the [] now, I wanted to keep --cache-clear accurate in such circumstances and claim the cache is 'empty' ? However (imo) this should be handled in pytest_unconfigure and when --sw is not present, stepwise is always writing the [] upfront.  - need advice here 

I moved some strings out into more constants/globals - curious on your thoughts on that & secondly I think we are permitted f string use now (that 3.5+ is no longer officially supported? - I think that is the case anyway).

closes #7938

As always - thanks for all the great contributions to this open source project everyone! I appreciate your own time to review this and welcome any feedback.