### PR TITLE
Prepare release 6.1.2

### DIFF
--- a/changelog/7758.bugfix.rst
+++ b/changelog/7758.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed an issue where some files in packages are getting lost from ``--lf`` even though they contain tests that failed. Regressed in pytest 5.4.0.

--- a/changelog/7815.doc.rst
+++ b/changelog/7815.doc.rst
@@ -1,1 +1,0 @@
-Improve deprecation warning message for ``pytest._fillfuncargs()``.

--- a/changelog/7911.bugfix.rst
+++ b/changelog/7911.bugfix.rst
@@ -1,1 +1,0 @@
-Directories created by `tmpdir` are now considered stale after 3 days without modification (previous value was 3 hours) to avoid deleting directories still in use in long running test suites.

--- a/doc/en/announce/index.rst
+++ b/doc/en/announce/index.rst
@@ -6,6 +6,7 @@ Release announcements
    :maxdepth: 2
 
 
+   release-6.1.2
    release-6.1.1
    release-6.1.0
    release-6.0.2

--- a/doc/en/announce/release-6.1.2.rst
+++ b/doc/en/announce/release-6.1.2.rst
@@ -1,0 +1,22 @@
+pytest-6.1.2
+=======================================
+
+pytest 6.1.2 has just been released to PyPI.
+
+This is a bug-fix release, being a drop-in replacement. To upgrade::
+
+  pip install --upgrade pytest
+
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
+
+Thanks to all of the contributors to this release:
+
+* Bruno Oliveira
+* Manuel Mariñez
+* Ran Benita
+* Vasilis Gerakaris
+* William Jamir Silva
+
+
+Happy testing,
+The pytest Development Team

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -28,6 +28,25 @@ with advance notice in the **Deprecations** section of releases.
 
 .. towncrier release notes start
 
+pytest 6.1.2 (2020-10-28)
+=========================
+
+Bug Fixes
+---------
+
+- `#7758 <https://github.com/pytest-dev/pytest/issues/7758>`_: Fixed an issue where some files in packages are getting lost from ``--lf`` even though they contain tests that failed. Regressed in pytest 5.4.0.
+
+
+- `#7911 <https://github.com/pytest-dev/pytest/issues/7911>`_: Directories created by `tmpdir` are now considered stale after 3 days without modification (previous value was 3 hours) to avoid deleting directories still in use in long running test suites.
+
+
+
+Improved Documentation
+----------------------
+
+- `#7815 <https://github.com/pytest-dev/pytest/issues/7815>`_: Improve deprecation warning message for ``pytest._fillfuncargs()``.
+
+
 pytest 6.1.1 (2020-10-03)
 =========================
 

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -28,7 +28,7 @@ Install ``pytest``
 .. code-block:: bash
 
     $ pytest --version
-    pytest 6.1.1
+    pytest 6.1.2
 
 .. _`simpletest`:
 


### PR DESCRIPTION
Created automatically from https://github.com/pytest-dev/pytest/issues/7957.

Once all builds pass and it has been **approved** by one or more maintainers, the build
can be released by pushing a tag `6.1.2` to this repository.

Closes #7957.
