### PR TITLE
tox: remove checkqa-mypy environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
     hooks:
     -   id: python-use-type-annotations
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790  # NOTE: keep this in sync with setup.cfg.
+    rev: v0.790
     hooks:
     -   id: mypy
         files: ^(src/|testing/)

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,8 +62,6 @@ console_scripts =
     py.test=pytest:console_main
 
 [options.extras_require]
-checkqa-mypy =
-    mypy==0.790
 testing =
     argcomplete
     hypothesis>=3.56

--- a/tox.ini
+++ b/tox.ini
@@ -59,19 +59,6 @@ basepython = python3
 deps = pre-commit>=1.11.0
 commands = pre-commit run --all-files --show-diff-on-failure {posargs:}
 
-[testenv:mypy]
-extras = checkqa-mypy, testing
-commands = mypy {posargs:src testing}
-
-[testenv:mypy-diff]
-extras = checkqa-mypy, testing
-deps =
-    lxml
-    diff-cover
-commands =
-  -mypy --cobertura-xml-report {envtmpdir} {posargs:src testing}
-  diff-cover --fail-under=100 --compare-branch={env:DIFF_BRANCH:origin/{env:GITHUB_BASE_REF:master}} {envtmpdir}/cobertura.xml
-
 [testenv:docs]
 basepython = python3
 usedevelop = True


### PR DESCRIPTION
We run mypy through pre-commit, and we don't keep duplicate targets in tox for all of the other linters. Since this adds some (small) maintenance overhead, remove it.