### PR TITLE
pre-commit: install typed dependencies in the mypy target

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,9 @@ repos:
         args: []
         additional_dependencies:
           - iniconfig>=1.1.0
+          - py>=1.8.2
+          - attrs>=19.2.0
+          - packaging
 -   repo: local
     hooks:
     -   id: rst


### PR DESCRIPTION
Otherwise, mypy doesn't know about them and their types are considered `Any`.