### PR TITLE
Migrate test_error_diffs.py from testdir to pytester

### DIFF
--- a/testing/test_error_diffs.py
+++ b/testing/test_error_diffs.py
@@ -275,8 +275,8 @@ if sys.version_info[:2] >= (3, 7):
 
 
 @pytest.mark.parametrize("code, expected", TESTCASES)
-def test_error_diff(code, expected, pytester: Pytester) -> None:
-    expected = [line.lstrip() for line in expected.splitlines()]
+def test_error_diff(code: str, expected: str, pytester: Pytester) -> None:
+    expected = [line.lstrip() for line in expected.splitlines()]  # type: ignore
     p = pytester.makepyfile(code)
     result = pytester.runpytest(p, "-vv")
     result.stdout.fnmatch_lines(expected)

--- a/testing/test_error_diffs.py
+++ b/testing/test_error_diffs.py
@@ -276,8 +276,8 @@ if sys.version_info[:2] >= (3, 7):
 
 @pytest.mark.parametrize("code, expected", TESTCASES)
 def test_error_diff(code: str, expected: str, pytester: Pytester) -> None:
-    expected = [line.lstrip() for line in expected.splitlines()]  # type: ignore
+    expected_lines = [line.lstrip() for line in expected.splitlines()]
     p = pytester.makepyfile(code)
     result = pytester.runpytest(p, "-vv")
-    result.stdout.fnmatch_lines(expected)
+    result.stdout.fnmatch_lines(expected_lines)
     assert result.ret == 1

--- a/testing/test_error_diffs.py
+++ b/testing/test_error_diffs.py
@@ -7,6 +7,7 @@ See https://github.com/pytest-dev/pytest/issues/3333 for details.
 import sys
 
 import pytest
+from _pytest.pytester import Pytester
 
 
 TESTCASES = [
@@ -274,9 +275,9 @@ if sys.version_info[:2] >= (3, 7):
 
 
 @pytest.mark.parametrize("code, expected", TESTCASES)
-def test_error_diff(code, expected, testdir):
+def test_error_diff(code, expected, pytester: Pytester) -> None:
     expected = [line.lstrip() for line in expected.splitlines()]
-    p = testdir.makepyfile(code)
-    result = testdir.runpytest(p, "-vv")
+    p = pytester.makepyfile(code)
+    result = pytester.runpytest(p, "-vv")
     result.stdout.fnmatch_lines(expected)
     assert result.ret == 1


### PR DESCRIPTION
Partial fix for #7942

Converts test_error_diffs.py from testdir to pytester