### PR TITLE
pathlib: fix symlinked directories not followed during collection

### DIFF
--- a/changelog/7981.bugfix.rst
+++ b/changelog/7981.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed symlinked directories not being followed during collection. Regressed in pytest 6.1.0.

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -558,7 +558,7 @@ def visit(
     entries = sorted(os.scandir(path), key=lambda entry: entry.name)
     yield from entries
     for entry in entries:
-        if entry.is_dir(follow_symlinks=False) and recurse(entry):
+        if entry.is_dir() and recurse(entry):
             yield from visit(entry.path, recurse)
 
 

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -9,6 +9,7 @@ from _pytest.config import ExitCode
 from _pytest.main import _in_venv
 from _pytest.main import Session
 from _pytest.pathlib import symlink_or_skip
+from _pytest.pytester import Pytester
 from _pytest.pytester import Testdir
 
 
@@ -1176,6 +1177,15 @@ def test_collect_symlink_out_of_tree(testdir):
         ]
     )
     assert result.ret == 0
+
+
+def test_collect_symlink_dir(pytester: Pytester) -> None:
+    """A symlinked directory is collected."""
+    dir = pytester.mkdir("dir")
+    dir.joinpath("test_it.py").write_text("def test_it(): pass", "utf-8")
+    pytester.path.joinpath("symlink_dir").symlink_to(dir)
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=2)
 
 
 def test_collectignore_via_conftest(testdir):


### PR DESCRIPTION
Fixes #7981.