### PR TITLE
unittest: fix quadratic behavior in collection of unittests using setUpClass/setup_method

### DIFF
--- a/bench/unit_test.py
+++ b/bench/unit_test.py
@@ -1,0 +1,13 @@
+from unittest import TestCase  # noqa: F401
+
+for i in range(15000):
+    exec(
+        f"""
+class Test{i}(TestCase):
+    @classmethod
+    def setUpClass(cls): pass
+    def test_1(self): pass
+    def test_2(self): pass
+    def test_3(self): pass
+"""
+    )

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -119,7 +119,12 @@ def _make_xunit_fixture(
     if setup is None and teardown is None:
         return None
 
-    @pytest.fixture(scope=scope, autouse=True)
+    @pytest.fixture(
+        scope=scope,
+        autouse=True,
+        # Use a unique name to speed up lookup.
+        name=f"unittest_{setup_name}_fixture_{obj.__qualname__}",
+    )
     def fixture(self, request: FixtureRequest) -> Generator[None, None, None]:
         if _is_skipped(self):
             reason = self.__unittest_skip_why__


### PR DESCRIPTION
This is similar to 50114d4731876dae; I missed that unittest does the same thing.