### PR TITLE
#7942 test_session.py migrate from testdir to Pytester

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -261,6 +261,7 @@ Ryan Wooden
 Samuel Dion-Girardeau
 Samuel Searles-Bryant
 Samuele Pedroni
+Sanket Duthade
 Sankt Petersbug
 Segev Finer
 Serhii Mozghovyi

--- a/testing/test_session.py
+++ b/testing/test_session.py
@@ -1,10 +1,12 @@
 import pytest
 from _pytest.config import ExitCode
+from _pytest.monkeypatch import MonkeyPatch
+from _pytest.pytester import Pytester
 
 
 class SessionTests:
-    def test_basic_testitem_events(self, testdir):
-        tfile = testdir.makepyfile(
+    def test_basic_testitem_events(self, pytester: Pytester) -> None:
+        tfile = pytester.makepyfile(
             """
             def test_one():
                 pass
@@ -17,7 +19,7 @@ class SessionTests:
                     pass
         """
         )
-        reprec = testdir.inline_run(tfile)
+        reprec = pytester.inline_run(tfile)
         passed, skipped, failed = reprec.listoutcomes()
         assert len(skipped) == 0
         assert len(passed) == 1
@@ -35,8 +37,8 @@ class SessionTests:
         # assert len(colreports) == 4
         # assert colreports[1].report.failed
 
-    def test_nested_import_error(self, testdir):
-        tfile = testdir.makepyfile(
+    def test_nested_import_error(self, pytester: Pytester) -> None:
+        tfile = pytester.makepyfile(
             """
             import import_fails
             def test_this():
@@ -47,14 +49,14 @@ class SessionTests:
             a = 1
         """,
         )
-        reprec = testdir.inline_run(tfile)
+        reprec = pytester.inline_run(tfile)
         values = reprec.getfailedcollections()
         assert len(values) == 1
         out = str(values[0].longrepr)
         assert out.find("does_not_work") != -1
 
-    def test_raises_output(self, testdir):
-        reprec = testdir.inline_runsource(
+    def test_raises_output(self, pytester: Pytester) -> None:
+        reprec = pytester.inline_runsource(
             """
             import pytest
             def test_raises_doesnt():
@@ -63,18 +65,18 @@ class SessionTests:
         )
         passed, skipped, failed = reprec.listoutcomes()
         assert len(failed) == 1
-        out = failed[0].longrepr.reprcrash.message
+        out = failed[0].longrepr.reprcrash.message  # type: ignore[union-attr]
         assert "DID NOT RAISE" in out
 
-    def test_syntax_error_module(self, testdir):
-        reprec = testdir.inline_runsource("this is really not python")
+    def test_syntax_error_module(self, pytester: Pytester) -> None:
+        reprec = pytester.inline_runsource("this is really not python")
         values = reprec.getfailedcollections()
         assert len(values) == 1
         out = str(values[0].longrepr)
         assert out.find("not python") != -1
 
-    def test_exit_first_problem(self, testdir):
-        reprec = testdir.inline_runsource(
+    def test_exit_first_problem(self, pytester: Pytester) -> None:
+        reprec = pytester.inline_runsource(
             """
             def test_one(): assert 0
             def test_two(): assert 0
@@ -85,8 +87,8 @@ class SessionTests:
         assert failed == 1
         assert passed == skipped == 0
 
-    def test_maxfail(self, testdir):
-        reprec = testdir.inline_runsource(
+    def test_maxfail(self, pytester: Pytester) -> None:
+        reprec = pytester.inline_runsource(
             """
             def test_one(): assert 0
             def test_two(): assert 0
@@ -98,8 +100,8 @@ class SessionTests:
         assert failed == 2
         assert passed == skipped == 0
 
-    def test_broken_repr(self, testdir):
-        p = testdir.makepyfile(
+    def test_broken_repr(self, pytester: Pytester) -> None:
+        p = pytester.makepyfile(
             """
             import pytest
 
@@ -124,14 +126,14 @@ class SessionTests:
 
         """
         )
-        reprec = testdir.inline_run(p)
+        reprec = pytester.inline_run(p)
         passed, skipped, failed = reprec.listoutcomes()
         assert (len(passed), len(skipped), len(failed)) == (1, 0, 1)
-        out = failed[0].longrepr.reprcrash.message
+        out = failed[0].longrepr.reprcrash.message  # type: ignore[union-attr]
         assert out.find("<[reprexc() raised in repr()] BrokenRepr1") != -1
 
-    def test_broken_repr_with_showlocals_verbose(self, testdir):
-        p = testdir.makepyfile(
+    def test_broken_repr_with_showlocals_verbose(self, pytester: Pytester) -> None:
+        p = pytester.makepyfile(
             """
             class ObjWithErrorInRepr:
                 def __repr__(self):
@@ -142,10 +144,10 @@ class SessionTests:
                 assert x == "value"
         """
         )
-        reprec = testdir.inline_run("--showlocals", "-vv", p)
+        reprec = pytester.inline_run("--showlocals", "-vv", p)
         passed, skipped, failed = reprec.listoutcomes()
         assert (len(passed), len(skipped), len(failed)) == (0, 0, 1)
-        entries = failed[0].longrepr.reprtraceback.reprentries
+        entries = failed[0].longrepr.reprtraceback.reprentries  # type: ignore[union-attr]
         assert len(entries) == 1
         repr_locals = entries[0].reprlocals
         assert repr_locals.lines
@@ -154,8 +156,8 @@ class SessionTests:
             "x          = <[NotImplementedError() raised in repr()] ObjWithErrorInRepr"
         )
 
-    def test_skip_file_by_conftest(self, testdir):
-        testdir.makepyfile(
+    def test_skip_file_by_conftest(self, pytester: Pytester) -> None:
+        pytester.makepyfile(
             conftest="""
             import pytest
             def pytest_collect_file():
@@ -166,7 +168,7 @@ class SessionTests:
         """,
         )
         try:
-            reprec = testdir.inline_run(testdir.tmpdir)
+            reprec = pytester.inline_run(pytester.path)
         except pytest.skip.Exception:  # pragma: no cover
             pytest.fail("wrong skipped caught")
         reports = reprec.getreports("pytest_collectreport")
@@ -175,8 +177,8 @@ class SessionTests:
 
 
 class TestNewSession(SessionTests):
-    def test_order_of_execution(self, testdir):
-        reprec = testdir.inline_runsource(
+    def test_order_of_execution(self, pytester: Pytester) -> None:
+        reprec = pytester.inline_runsource(
             """
             values = []
             def test_1():
@@ -201,8 +203,8 @@ class TestNewSession(SessionTests):
         assert failed == skipped == 0
         assert passed == 7
 
-    def test_collect_only_with_various_situations(self, testdir):
-        p = testdir.makepyfile(
+    def test_collect_only_with_various_situations(self, pytester: Pytester) -> None:
+        p = pytester.makepyfile(
             test_one="""
                 def test_one():
                     raise ValueError()
@@ -217,7 +219,7 @@ class TestNewSession(SessionTests):
             test_three="xxxdsadsadsadsa",
             __init__="",
         )
-        reprec = testdir.inline_run("--collect-only", p.dirpath())
+        reprec = pytester.inline_run("--collect-only", p.parent)
 
         itemstarted = reprec.getcalls("pytest_itemcollected")
         assert len(itemstarted) == 3
@@ -229,66 +231,66 @@ class TestNewSession(SessionTests):
         colfail = [x for x in finished if x.failed]
         assert len(colfail) == 1
 
-    def test_minus_x_import_error(self, testdir):
-        testdir.makepyfile(__init__="")
-        testdir.makepyfile(test_one="xxxx", test_two="yyyy")
-        reprec = testdir.inline_run("-x", testdir.tmpdir)
+    def test_minus_x_import_error(self, pytester: Pytester) -> None:
+        pytester.makepyfile(__init__="")
+        pytester.makepyfile(test_one="xxxx", test_two="yyyy")
+        reprec = pytester.inline_run("-x", pytester.path)
         finished = reprec.getreports("pytest_collectreport")
         colfail = [x for x in finished if x.failed]
         assert len(colfail) == 1
 
-    def test_minus_x_overridden_by_maxfail(self, testdir):
-        testdir.makepyfile(__init__="")
-        testdir.makepyfile(test_one="xxxx", test_two="yyyy", test_third="zzz")
-        reprec = testdir.inline_run("-x", "--maxfail=2", testdir.tmpdir)
+    def test_minus_x_overridden_by_maxfail(self, pytester: Pytester) -> None:
+        pytester.makepyfile(__init__="")
+        pytester.makepyfile(test_one="xxxx", test_two="yyyy", test_third="zzz")
+        reprec = pytester.inline_run("-x", "--maxfail=2", pytester.path)
         finished = reprec.getreports("pytest_collectreport")
         colfail = [x for x in finished if x.failed]
         assert len(colfail) == 2
 
 
-def test_plugin_specify(testdir):
+def test_plugin_specify(pytester: Pytester) -> None:
     with pytest.raises(ImportError):
-        testdir.parseconfig("-p", "nqweotexistent")
+        pytester.parseconfig("-p", "nqweotexistent")
     # pytest.raises(ImportError,
     #    "config.do_configure(config)"
     # )
 
 
-def test_plugin_already_exists(testdir):
-    config = testdir.parseconfig("-p", "terminal")
+def test_plugin_already_exists(pytester: Pytester) -> None:
+    config = pytester.parseconfig("-p", "terminal")
     assert config.option.plugins == ["terminal"]
     config._do_configure()
     config._ensure_unconfigure()
 
 
-def test_exclude(testdir):
-    hellodir = testdir.mkdir("hello")
-    hellodir.join("test_hello.py").write("x y syntaxerror")
-    hello2dir = testdir.mkdir("hello2")
-    hello2dir.join("test_hello2.py").write("x y syntaxerror")
-    testdir.makepyfile(test_ok="def test_pass(): pass")
-    result = testdir.runpytest("--ignore=hello", "--ignore=hello2")
+def test_exclude(pytester: Pytester) -> None:
+    hellodir = pytester.mkdir("hello")
+    hellodir.joinpath("test_hello.py").write_text("x y syntaxerror")
+    hello2dir = pytester.mkdir("hello2")
+    hello2dir.joinpath("test_hello2.py").write_text("x y syntaxerror")
+    pytester.makepyfile(test_ok="def test_pass(): pass")
+    result = pytester.runpytest("--ignore=hello", "--ignore=hello2")
     assert result.ret == 0
     result.stdout.fnmatch_lines(["*1 passed*"])
 
 
-def test_exclude_glob(testdir):
-    hellodir = testdir.mkdir("hello")
-    hellodir.join("test_hello.py").write("x y syntaxerror")
-    hello2dir = testdir.mkdir("hello2")
-    hello2dir.join("test_hello2.py").write("x y syntaxerror")
-    hello3dir = testdir.mkdir("hallo3")
-    hello3dir.join("test_hello3.py").write("x y syntaxerror")
-    subdir = testdir.mkdir("sub")
-    subdir.join("test_hello4.py").write("x y syntaxerror")
-    testdir.makepyfile(test_ok="def test_pass(): pass")
-    result = testdir.runpytest("--ignore-glob=*h[ea]llo*")
+def test_exclude_glob(pytester: Pytester) -> None:
+    hellodir = pytester.mkdir("hello")
+    hellodir.joinpath("test_hello.py").write_text("x y syntaxerror")
+    hello2dir = pytester.mkdir("hello2")
+    hello2dir.joinpath("test_hello2.py").write_text("x y syntaxerror")
+    hello3dir = pytester.mkdir("hallo3")
+    hello3dir.joinpath("test_hello3.py").write_text("x y syntaxerror")
+    subdir = pytester.mkdir("sub")
+    subdir.joinpath("test_hello4.py").write_text("x y syntaxerror")
+    pytester.makepyfile(test_ok="def test_pass(): pass")
+    result = pytester.runpytest("--ignore-glob=*h[ea]llo*")
     assert result.ret == 0
     result.stdout.fnmatch_lines(["*1 passed*"])
 
 
-def test_deselect(testdir):
-    testdir.makepyfile(
+def test_deselect(pytester: Pytester) -> None:
+    pytester.makepyfile(
         test_a="""
         import pytest
 
@@ -303,7 +305,7 @@ def test_deselect(testdir):
             def test_c2(self): pass
     """
     )
-    result = testdir.runpytest(
+    result = pytester.runpytest(
         "-v",
         "--deselect=test_a.py::test_a2[1]",
         "--deselect=test_a.py::test_a2[2]",
@@ -315,8 +317,8 @@ def test_deselect(testdir):
         assert not line.startswith(("test_a.py::test_a2[1]", "test_a.py::test_a2[2]"))
 
 
-def test_sessionfinish_with_start(testdir):
-    testdir.makeconftest(
+def test_sessionfinish_with_start(pytester: Pytester) -> None:
+    pytester.makeconftest(
         """
         import os
         values = []
@@ -329,18 +331,20 @@ def test_sessionfinish_with_start(testdir):
 
     """
     )
-    res = testdir.runpytest("--collect-only")
+    res = pytester.runpytest("--collect-only")
     assert res.ret == ExitCode.NO_TESTS_COLLECTED
 
 
 @pytest.mark.parametrize("path", ["root", "{relative}/root", "{environment}/root"])
-def test_rootdir_option_arg(testdir, monkeypatch, path):
-    monkeypatch.setenv("PY_ROOTDIR_PATH", str(testdir.tmpdir))
-    path = path.format(relative=str(testdir.tmpdir), environment="$PY_ROOTDIR_PATH")
+def test_rootdir_option_arg(
+    pytester: Pytester, monkeypatch: MonkeyPatch, path: str
+) -> None:
+    monkeypatch.setenv("PY_ROOTDIR_PATH", str(pytester.path))
+    path = path.format(relative=str(pytester.path), environment="$PY_ROOTDIR_PATH")
 
-    rootdir = testdir.mkdir("root")
-    rootdir.mkdir("tests")
-    testdir.makepyfile(
+    rootdir = pytester.path / "root" / "tests"
+    rootdir.mkdir(parents=True)
+    pytester.makepyfile(
         """
         import os
         def test_one():
@@ -348,18 +352,18 @@ def test_rootdir_option_arg(testdir, monkeypatch, path):
     """
     )
 
-    result = testdir.runpytest(f"--rootdir={path}")
+    result = pytester.runpytest(f"--rootdir={path}")
     result.stdout.fnmatch_lines(
         [
-            f"*rootdir: {testdir.tmpdir}/root",
+            f"*rootdir: {pytester.path}/root",
             "root/test_rootdir_option_arg.py *",
             "*1 passed*",
         ]
     )
 
 
-def test_rootdir_wrong_option_arg(testdir):
-    result = testdir.runpytest("--rootdir=wrong_dir")
+def test_rootdir_wrong_option_arg(pytester: Pytester) -> None:
+    result = pytester.runpytest("--rootdir=wrong_dir")
     result.stderr.fnmatch_lines(
         ["*Directory *wrong_dir* not found. Check your '--rootdir' option.*"]
     )


### PR DESCRIPTION
Partial fix for #7942

This PR does the following things:
1. Migrates ```test_session.py``` from ```testdir``` to ```Pytester```.
2. Adds name to ```AUTHORS```.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
