### PR TITLE
Add pythonenv* to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ issue/
 env/
 .env/
 .venv/
-pythonenv*
+/pythonenv*/
 3rdparty/
 .tox
 .cache

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ issue/
 env/
 .env/
 .venv/
+pythonenv*
 3rdparty/
 .tox
 .cache


### PR DESCRIPTION
GitHub Codespaces automatically create a pythonenv folder. For example: `pythonenv3.8/` which containts a virtual environment. This should not be commited by default.