### PR TITLE
Stop importing `pytest` to avoid upcoming import cycles

### DIFF
--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -17,12 +17,14 @@ from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import Union
 
-import pytest
 from _pytest.compat import final
 from _pytest.config import Config
+from _pytest.config import hookimpl
 from _pytest.config.argparsing import Parser
+from _pytest.fixtures import fixture
 from _pytest.fixtures import SubRequest
 from _pytest.nodes import Collector
+from _pytest.nodes import File
 from _pytest.nodes import Item
 
 if TYPE_CHECKING:
@@ -145,7 +147,7 @@ def _py36_windowsconsoleio_workaround(stream: TextIO) -> None:
     sys.stderr = _reopen_stdio(sys.stderr, "wb")
 
 
-@pytest.hookimpl(hookwrapper=True)
+@hookimpl(hookwrapper=True)
 def pytest_load_initial_conftests(early_config: Config):
     ns = early_config.known_args_namespace
     if ns.capture == "fd":
@@ -784,9 +786,9 @@ class CaptureManager:
 
     # Hooks
 
-    @pytest.hookimpl(hookwrapper=True)
+    @hookimpl(hookwrapper=True)
     def pytest_make_collect_report(self, collector: Collector):
-        if isinstance(collector, pytest.File):
+        if isinstance(collector, File):
             self.resume_global_capture()
             outcome = yield
             self.suspend_global_capture()
@@ -799,26 +801,26 @@ class CaptureManager:
         else:
             yield
 
-    @pytest.hookimpl(hookwrapper=True)
+    @hookimpl(hookwrapper=True)
     def pytest_runtest_setup(self, item: Item) -> Generator[None, None, None]:
         with self.item_capture("setup", item):
             yield
 
-    @pytest.hookimpl(hookwrapper=True)
+    @hookimpl(hookwrapper=True)
     def pytest_runtest_call(self, item: Item) -> Generator[None, None, None]:
         with self.item_capture("call", item):
             yield
 
-    @pytest.hookimpl(hookwrapper=True)
+    @hookimpl(hookwrapper=True)
     def pytest_runtest_teardown(self, item: Item) -> Generator[None, None, None]:
         with self.item_capture("teardown", item):
             yield
 
-    @pytest.hookimpl(tryfirst=True)
+    @hookimpl(tryfirst=True)
     def pytest_keyboard_interrupt(self) -> None:
         self.stop_global_capturing()
 
-    @pytest.hookimpl(tryfirst=True)
+    @hookimpl(tryfirst=True)
     def pytest_internalerror(self) -> None:
         self.stop_global_capturing()
 
@@ -893,7 +895,7 @@ class CaptureFixture(Generic[AnyStr]):
 # The fixtures.
 
 
-@pytest.fixture
+@fixture
 def capsys(request: SubRequest) -> Generator[CaptureFixture[str], None, None]:
     """Enable text capturing of writes to ``sys.stdout`` and ``sys.stderr``.
 
@@ -910,7 +912,7 @@ def capsys(request: SubRequest) -> Generator[CaptureFixture[str], None, None]:
     capman.unset_fixture()
 
 
-@pytest.fixture
+@fixture
 def capsysbinary(request: SubRequest) -> Generator[CaptureFixture[bytes], None, None]:
     """Enable bytes capturing of writes to ``sys.stdout`` and ``sys.stderr``.
 
@@ -927,7 +929,7 @@ def capsysbinary(request: SubRequest) -> Generator[CaptureFixture[bytes], None, 
     capman.unset_fixture()
 
 
-@pytest.fixture
+@fixture
 def capfd(request: SubRequest) -> Generator[CaptureFixture[str], None, None]:
     """Enable text capturing of writes to file descriptors ``1`` and ``2``.
 
@@ -944,7 +946,7 @@ def capfd(request: SubRequest) -> Generator[CaptureFixture[str], None, None]:
     capman.unset_fixture()
 
 
-@pytest.fixture
+@fixture
 def capfdbinary(request: SubRequest) -> Generator[CaptureFixture[bytes], None, None]:
     """Enable bytes capturing of writes to file descriptors ``1`` and ``2``.
 

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -15,9 +15,9 @@ from typing import Tuple
 from typing import TypeVar
 from typing import Union
 
-import pytest
 from _pytest.compat import final
 from _pytest.fixtures import fixture
+from _pytest.warning_types import PytestWarning
 
 RE_IMPORT_ERROR_NAME = re.compile(r"^No module named (.*)$")
 
@@ -271,7 +271,7 @@ class MonkeyPatch:
         """
         if not isinstance(value, str):
             warnings.warn(  # type: ignore[unreachable]
-                pytest.PytestWarning(
+                PytestWarning(
                     "Value of environment variable {name} type should be str, but got "
                     "{value!r} (type: {type}); converted to str implicitly".format(
                         name=name, value=value, type=type(value).__name__

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -29,7 +29,7 @@ import attr
 import pluggy
 import py
 
-import pytest
+import _pytest._version
 from _pytest import nodes
 from _pytest import timing
 from _pytest._code import ExceptionInfo
@@ -39,6 +39,7 @@ from _pytest.compat import final
 from _pytest.config import _PluggyPlugin
 from _pytest.config import Config
 from _pytest.config import ExitCode
+from _pytest.config import hookimpl
 from _pytest.config.argparsing import Parser
 from _pytest.nodes import Item
 from _pytest.nodes import Node
@@ -259,7 +260,7 @@ def getreportopt(config: Config) -> str:
     return reportopts
 
 
-@pytest.hookimpl(trylast=True)  # after _pytest.runner
+@hookimpl(trylast=True)  # after _pytest.runner
 def pytest_report_teststatus(report: BaseReport) -> Tuple[str, str, str]:
     letter = "F"
     if report.passed:
@@ -628,7 +629,7 @@ class TerminalReporter:
             self._add_stats("error", [report])
         elif report.skipped:
             self._add_stats("skipped", [report])
-        items = [x for x in report.result if isinstance(x, pytest.Item)]
+        items = [x for x in report.result if isinstance(x, Item)]
         self._numcollected += len(items)
         if self.isatty:
             self.report_collect()
@@ -673,7 +674,7 @@ class TerminalReporter:
         else:
             self.write_line(line)
 
-    @pytest.hookimpl(trylast=True)
+    @hookimpl(trylast=True)
     def pytest_sessionstart(self, session: "Session") -> None:
         self._session = session
         self._sessionstarttime = timing.time()
@@ -688,7 +689,7 @@ class TerminalReporter:
                 verinfo = ".".join(map(str, pypy_version_info[:3]))
                 msg += "[pypy-{}-{}]".format(verinfo, pypy_version_info[3])
             msg += ", pytest-{}, py-{}, pluggy-{}".format(
-                pytest.__version__, py.__version__, pluggy.__version__
+                _pytest._version.version, py.__version__, pluggy.__version__
             )
             if (
                 self.verbosity > 0
@@ -783,7 +784,7 @@ class TerminalReporter:
                         for line in doc.splitlines():
                             self._tw.line("{}{}".format(indent + "  ", line))
 
-    @pytest.hookimpl(hookwrapper=True)
+    @hookimpl(hookwrapper=True)
     def pytest_sessionfinish(
         self, session: "Session", exitstatus: Union[int, ExitCode]
     ):
@@ -810,7 +811,7 @@ class TerminalReporter:
             self.write_sep("!", str(session.shouldstop), red=True)
         self.summary_stats()
 
-    @pytest.hookimpl(hookwrapper=True)
+    @hookimpl(hookwrapper=True)
     def pytest_terminal_summary(self) -> Generator[None, None, None]:
         self.summary_errors()
         self.summary_failures()

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -8,13 +8,13 @@ from typing import Optional
 import attr
 import py
 
-import pytest
 from .pathlib import ensure_reset_dir
 from .pathlib import LOCK_TIMEOUT
 from .pathlib import make_numbered_dir
 from .pathlib import make_numbered_dir_with_cleanup
 from _pytest.compat import final
 from _pytest.config import Config
+from _pytest.fixtures import fixture
 from _pytest.fixtures import FixtureRequest
 from _pytest.monkeypatch import MonkeyPatch
 
@@ -146,14 +146,14 @@ def pytest_configure(config: Config) -> None:
     mp.setattr(config, "_tmpdirhandler", t, raising=False)
 
 
-@pytest.fixture(scope="session")
+@fixture(scope="session")
 def tmpdir_factory(request: FixtureRequest) -> TempdirFactory:
     """Return a :class:`_pytest.tmpdir.TempdirFactory` instance for the test session."""
     # Set dynamically by pytest_configure() above.
     return request.config._tmpdirhandler  # type: ignore
 
 
-@pytest.fixture(scope="session")
+@fixture(scope="session")
 def tmp_path_factory(request: FixtureRequest) -> TempPathFactory:
     """Return a :class:`_pytest.tmpdir.TempPathFactory` instance for the test session."""
     # Set dynamically by pytest_configure() above.
@@ -168,7 +168,7 @@ def _mk_tmp(request: FixtureRequest, factory: TempPathFactory) -> Path:
     return factory.mktemp(name, numbered=True)
 
 
-@pytest.fixture
+@fixture
 def tmpdir(tmp_path: Path) -> py.path.local:
     """Return a temporary directory path object which is unique to each test
     function invocation, created as a sub directory of the base temporary
@@ -181,7 +181,7 @@ def tmpdir(tmp_path: Path) -> py.path.local:
     return py.path.local(tmp_path)
 
 
-@pytest.fixture
+@fixture
 def tmp_path(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> Path:
     """Return a temporary directory path object which is unique to each test
     function invocation, created as a sub directory of the base temporary


### PR DESCRIPTION
Don't import `pytest` from within some `_pytest` modules since an upcoming commit will import from them into `pytest`.

It would have been nice not to have to do it, so that internal plugins look more like external plugins, but with the existing layout this seems unavoidable.