### PR TITLE
testing: don't ignore "Module already imported so cannot be rewritten" warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ filterwarnings = [
     # produced by older pyparsing<=2.2.0.
     "default:Using or importing the ABCs:DeprecationWarning:pyparsing.*",
     "default:the imp module is deprecated in favour of importlib:DeprecationWarning:nose.*",
-    "ignore:Module already imported so cannot be rewritten:pytest.PytestWarning",
     # produced by python3.6/site.py itself (3.6.7 on Travis, could not trigger it with 3.6.8)."
     "ignore:.*U.*mode is deprecated:DeprecationWarning:(?!(pytest|_pytest))",
     # produced by pytest-xdist


### PR DESCRIPTION
The test suite passes without it being ignored. The absence of this warning cost me some head-scratching time, so enable it again.