### PR TITLE
assertion/rewrite: write pyc's according to PEP-552 on Python>=3.7

### DIFF
--- a/changelog/8014.trivial.rst
+++ b/changelog/8014.trivial.rst
@@ -1,0 +1,2 @@
+`.pyc` files created by pytest's assertion rewriting now conform to the newer PEP-552 format on Python>=3.7.
+(These files are internal and only interpreted by pytest itself.)


### PR DESCRIPTION
Python 3.7 changed the pyc format by adding a flags word: https://www.python.org/dev/peps/pep-0552/. Even though it is not necessary for us to match it, it is nice to be able to read pyc files we emit with standard tools for debugging the rewriter.

Update our custom pyc files to use that format. We write flags==0 meaning we still use the mtime+size format rather than the newer hash format.