### PR TITLE
Failing doctest collection

### DIFF
--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -70,7 +70,7 @@ class TestDoctests:
 
     def test_collect_module_two_doctest_no_modulelevel(self, pytester: Pytester):
         path = pytester.makepyfile(
-            whatever="""
+            __init__="""
             '# Empty'
             def my_func():
                 ">>> magic = 42 "


### PR DESCRIPTION
When the module is an __init__.py the doctest collection only picks up 1 doctest.