### PR TITLE
main: fix only one doctest collected on pytest --doctest-modules __init__.py

### DIFF
--- a/changelog/8016.bugfix.rst
+++ b/changelog/8016.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed only one doctest being collected when using ``pytest --doctest-modules path/to/an/__init__.py``.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -765,12 +765,14 @@ class Session(nodes.FSCollector):
                     self._notfound.append((report_arg, col))
                     continue
 
-                # If __init__.py was the only file requested, then the matched node will be
-                # the corresponding Package, and the first yielded item will be the __init__
-                # Module itself, so just use that. If this special case isn't taken, then all
-                # the files in the package will be yielded.
-                if argpath.basename == "__init__.py":
-                    assert isinstance(matching[0], nodes.Collector)
+                # If __init__.py was the only file requested, then the matched
+                # node will be the corresponding Package (by default), and the
+                # first yielded item will be the __init__ Module itself, so
+                # just use that. If this special case isn't taken, then all the
+                # files in the package will be yielded.
+                if argpath.basename == "__init__.py" and isinstance(
+                    matching[0], Package
+                ):
                     try:
                         yield next(iter(matching[0].collect()))
                     except StopIteration:

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -68,9 +68,13 @@ class TestDoctests:
             assert isinstance(items[0].parent, DoctestModule)
             assert items[0].parent is items[1].parent
 
-    def test_collect_module_two_doctest_no_modulelevel(self, pytester: Pytester):
+    @pytest.mark.parametrize("filename", ["__init__", "whatever"])
+    def test_collect_module_two_doctest_no_modulelevel(
+        self, pytester: Pytester, filename: str,
+    ) -> None:
         path = pytester.makepyfile(
-            whatever="""
+            **{
+                filename: """
             '# Empty'
             def my_func():
                 ">>> magic = 42 "
@@ -84,7 +88,8 @@ class TestDoctests:
                 # This is another function
                 >>> import os # this one does have a doctest
                 '''
-        """
+            """,
+            },
         )
         for p in (path, pytester.path):
             items, reprec = pytester.inline_genitems(p, "--doctest-modules")


### PR DESCRIPTION
Fixes #8016. Closes #8015.

When `--doctest-modules` is used, an `__init__.py` file is not a `Package` but a `DoctestModule`, but some collection code assumed that `__init__.py` implies a `Package`. That code caused only a single test to be collected in the scenario in the subject.

Tighten up this check to explicitly check for `Package`. There are better solutions, but for another time.

Report & test by @gatesn.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
