### PR TITLE
migrate node fs paths to pathlib primary and reorg ctors/from_parent

### DIFF
--- a/changelog/8037.deprecation.rst
+++ b/changelog/8037.deprecation.rst
@@ -1,0 +1,1 @@
+Deprecate implying node ctor arguments.

--- a/changelog/8037.feature.rst
+++ b/changelog/8037.feature.rst
@@ -1,0 +1,1 @@
+Introduce ``Node.fs_path`` as pathlib replacement for ``Node.fspath``

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -64,6 +64,12 @@ STRICT_OPTION = PytestDeprecationWarning(
 
 PRIVATE = PytestDeprecationWarning("A private pytest class or function was used.")
 
+NODE_IMPLIED_ARG = UnformattedWarning(
+    PytestDeprecationWarning,
+    "implying {type.__name__}.{arg} from parent.{arg} has been deprecated\n"
+    "please use the Node.from_parent to have them be implied by the superclass named ctors",
+)
+
 
 # You want to make some `__init__` or function "private".
 #

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -254,8 +254,9 @@ class DoctestItem(pytest.Item):
         parent: "Union[DoctestTextfile, DoctestModule]",
         runner: Optional["doctest.DocTestRunner"] = None,
         dtest: Optional["doctest.DocTest"] = None,
+        **kw: Any,
     ) -> None:
-        super().__init__(name, parent)
+        super().__init__(name=name, parent=parent, **kw)
         self.runner = runner
         self.dtest = dtest
         self.obj = None

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -662,7 +662,7 @@ class FixtureRequest:
                     "\n\nRequested here:\n{}:{}".format(
                         funcitem.nodeid,
                         fixturedef.argname,
-                        getlocation(fixturedef.func, funcitem.config.rootdir),
+                        getlocation(fixturedef.func, str(funcitem.config.rootpath)),
                         source_path_str,
                         source_lineno,
                     )

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -464,7 +464,12 @@ class Session(nodes.FSCollector):
 
     def __init__(self, config: Config) -> None:
         super().__init__(
-            config.rootdir, parent=None, config=config, session=self, nodeid=""
+            fs_path=config.rootpath,
+            name="",
+            parent=None,
+            config=config,
+            session=self,
+            nodeid="",
         )
         self.testsfailed = 0
         self.testscollected = 0
@@ -688,7 +693,7 @@ class Session(nodes.FSCollector):
                             if col:
                                 if isinstance(col[0], Package):
                                     pkg_roots[str(parent)] = col[0]
-                                node_cache1[Path(col[0].fspath)] = [col[0]]
+                                node_cache1[col[0].fs_path] = [col[0]]
 
             # If it's a directory argument, recurse and look for any Subpackages.
             # Let the Package collector deal with subnodes, don't collect here.
@@ -717,7 +722,7 @@ class Session(nodes.FSCollector):
                         continue
 
                     for x in self._collectfile(path):
-                        key2 = (type(x), Path(x.fspath))
+                        key2 = (type(x), x.fs_path)
                         if key2 in node_cache2:
                             yield node_cache2[key2]
                         else:
@@ -749,12 +754,12 @@ class Session(nodes.FSCollector):
                             continue
                         if not isinstance(node, nodes.Collector):
                             continue
-                        key = (type(node), node.nodeid)
-                        if key in matchnodes_cache:
-                            rep = matchnodes_cache[key]
+                        key_matchnodes = (type(node), node.nodeid)
+                        if key_matchnodes in matchnodes_cache:
+                            rep = matchnodes_cache[key_matchnodes]
                         else:
                             rep = collect_one_node(node)
-                            matchnodes_cache[key] = rep
+                            matchnodes_cache[key_matchnodes] = rep
                         if rep.passed:
                             submatchnodes = []
                             for r in rep.result:

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -568,10 +568,10 @@ class FSCollector(Collector):
     ):
         """The public constructor."""
         if fspath is not None:
-            assert fs_path is None
+            assert fs_path is None, "fs_path and fspath cannot both be passed at the same time"
             known_path = Path(fspath)
         else:
-            assert fs_path is not None
+            assert fs_path is not None, "fs_path or fspath must be given"
             known_path = fs_path
             fspath = py.path.local(known_path)
 

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -568,7 +568,9 @@ class FSCollector(Collector):
     ):
         """The public constructor."""
         if fspath is not None:
-            assert fs_path is None, "fs_path and fspath cannot both be passed at the same time"
+            assert (
+                fs_path is None
+            ), "fs_path and fspath cannot both be passed at the same time"
             known_path = Path(fspath)
         else:
             assert fs_path is not None, "fs_path or fspath must be given"

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -118,7 +118,6 @@ class Node(metaclass=NodeMeta):
     )
 
     name: str
-    parent: Optional["Node"]
     config: Config
     session: "Session"
     fs_path: Path

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -900,7 +900,7 @@ class Pytester:
         example_dir = self._request.config.getini("pytester_example_dir")
         if example_dir is None:
             raise ValueError("pytester_example_dir is unset, can't copy examples")
-        example_dir = Path(str(self._request.config.rootdir)) / example_dir
+        example_dir = self._request.config.rootpath / example_dir
 
         for extra_element in self._request.node.iter_markers("pytester_example_path"):
             assert extra_element.args

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -1346,13 +1346,9 @@ def test_fscollector_from_parent(pytester: Pytester, request: FixtureRequest) ->
     """
 
     class MyCollector(pytest.File):
-        def __init__(self, fspath, parent, x):
-            super().__init__(fspath, parent)
+        def __init__(self, *, x, **kw):
+            super().__init__(**kw)
             self.x = x
-
-        @classmethod
-        def from_parent(cls, parent, *, fspath, x):
-            return super().from_parent(parent=parent, fspath=fspath, x=x)
 
     collector = MyCollector.from_parent(
         parent=request.session, fspath=py.path.local(pytester.path) / "foo", x=10


### PR DESCRIPTION
@pytest-dev/core with this i'm starting my continuation of the removal of both, too smart ctors annd migrating fspath to a pathlib version

its going to be a draft for a while while i iterate and figure the exact details, please scrutinize meanwhile ^^