### PR TITLE
Return value of a function in a raises context manager

### DIFF
--- a/doc/en/assert.rst
+++ b/doc/en/assert.rst
@@ -123,6 +123,20 @@ The regexp parameter of the ``match`` method is matched with the ``re.search``
 function, so in the above example ``match='123'`` would have worked as
 well.
 
+Also it useful to actually check return value from tested function, when no exception was raised.
+
+.. code-block:: python
+
+    def return_value():
+        return "No exception was raised, but there is a return value."
+
+
+    def test_my_exception():
+        with pytest.raises(RuntimeError) as excinfo:
+            excinfo.return_value = return_value()
+
+When no exception was raised, you'll see info about returned value.
+
 There's an alternate form of the ``pytest.raises`` function where you pass
 a function that will be executed with the given ``*args`` and ``**kwargs`` and
 assert that the given exception is raised:

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -446,6 +446,7 @@ class ExceptionInfo(Generic[_E]):
     _excinfo = attr.ib(type=Optional[Tuple[Type["_E"], "_E", TracebackType]])
     _striptext = attr.ib(type=str, default="")
     _traceback = attr.ib(type=Optional[Traceback], default=None)
+    return_value = attr.ib(type=Optional[Any], default=None)
 
     @classmethod
     def from_exc_info(


### PR DESCRIPTION
Hi everyone! I've made some improvement into raises context manager. There were a couple of times in practices when no exception was raised, but tested function return some value. So, there was no useful output and it takes quite a time to find what actually happened in tested code. I decided to fix by allowing to print an extended info about return value of a tested function or code block.

If you generally like my idea and a draft implementation let me know. I'll write some test then and will prepare more accurately the PR. 

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
