### PR TITLE
Prefix contextmanagers with module name in doc examples

### DIFF
--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -597,6 +597,7 @@ def raises(
     Use ``pytest.raises`` as a context manager, which will capture the exception of the given
     type::
 
+        >>> import pytest
         >>> with pytest.raises(ZeroDivisionError):
         ...    1/0
 

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -597,7 +597,7 @@ def raises(
     Use ``pytest.raises`` as a context manager, which will capture the exception of the given
     type::
 
-        >>> with raises(ZeroDivisionError):
+        >>> with pytest.raises(ZeroDivisionError):
         ...    1/0
 
     If the code block does not raise the expected exception (``ZeroDivisionError`` in the example
@@ -606,16 +606,16 @@ def raises(
     You can also use the keyword argument ``match`` to assert that the
     exception matches a text or regex::
 
-        >>> with raises(ValueError, match='must be 0 or None'):
+        >>> with pytest.raises(ValueError, match='must be 0 or None'):
         ...     raise ValueError("value must be 0 or None")
 
-        >>> with raises(ValueError, match=r'must be \d+$'):
+        >>> with pytest.raises(ValueError, match=r'must be \d+$'):
         ...     raise ValueError("value must be 42")
 
     The context manager produces an :class:`ExceptionInfo` object which can be used to inspect the
     details of the captured exception::
 
-        >>> with raises(ValueError) as exc_info:
+        >>> with pytest.raises(ValueError) as exc_info:
         ...     raise ValueError("value must be 42")
         >>> assert exc_info.type is ValueError
         >>> assert exc_info.value.args[0] == "value must be 42"
@@ -629,7 +629,7 @@ def raises(
        not be executed. For example::
 
            >>> value = 15
-           >>> with raises(ValueError) as exc_info:
+           >>> with pytest.raises(ValueError) as exc_info:
            ...     if value > 10:
            ...         raise ValueError("value must be <= 10")
            ...     assert exc_info.type is ValueError  # this will not execute
@@ -637,7 +637,7 @@ def raises(
        Instead, the following approach must be taken (note the difference in
        scope)::
 
-           >>> with raises(ValueError) as exc_info:
+           >>> with pytest.raises(ValueError) as exc_info:
            ...     if value > 10:
            ...         raise ValueError("value must be <= 10")
            ...

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -60,7 +60,7 @@ def deprecated_call(
         ...     warnings.warn('use v3 of this api', DeprecationWarning)
         ...     return 200
 
-        >>> with deprecated_call():
+        >>> with pytest.deprecated_call():
         ...    assert api_call_v2() == 200
 
     It can also be used by passing a function and ``*args`` and ``**kwargs``,
@@ -116,19 +116,19 @@ def warns(
     This function can be used as a context manager, or any of the other ways
     ``pytest.raises`` can be used::
 
-        >>> with warns(RuntimeWarning):
+        >>> with pytest.warns(RuntimeWarning):
         ...    warnings.warn("my warning", RuntimeWarning)
 
     In the context manager form you may use the keyword argument ``match`` to assert
     that the warning matches a text or regex::
 
-        >>> with warns(UserWarning, match='must be 0 or None'):
+        >>> with pytest.warns(UserWarning, match='must be 0 or None'):
         ...     warnings.warn("value must be 0 or None", UserWarning)
 
-        >>> with warns(UserWarning, match=r'must be \d+$'):
+        >>> with pytest.warns(UserWarning, match=r'must be \d+$'):
         ...     warnings.warn("value must be 42", UserWarning)
 
-        >>> with warns(UserWarning, match=r'must be \d+$'):
+        >>> with pytest.warns(UserWarning, match=r'must be \d+$'):
         ...     warnings.warn("this is not here", UserWarning)
         Traceback (most recent call last):
           ...

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -60,6 +60,7 @@ def deprecated_call(
         ...     warnings.warn('use v3 of this api', DeprecationWarning)
         ...     return 200
 
+        >>> import pytest
         >>> with pytest.deprecated_call():
         ...    assert api_call_v2() == 200
 
@@ -116,6 +117,7 @@ def warns(
     This function can be used as a context manager, or any of the other ways
     ``pytest.raises`` can be used::
 
+        >>> import pytest
         >>> with pytest.warns(RuntimeWarning):
         ...    warnings.warn("my warning", RuntimeWarning)
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -214,8 +214,3 @@ def mock_timing(monkeypatch: MonkeyPatch):
     result = MockTiming()
     result.patch()
     return result
-
-
-@pytest.fixture(autouse=True)
-def add_pytest_to_doctest_namespace(doctest_namespace):
-    doctest_namespace["pytest"] = pytest

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -214,3 +214,8 @@ def mock_timing(monkeypatch: MonkeyPatch):
     result = MockTiming()
     result.patch()
     return result
+
+
+@pytest.fixture(autouse=True)
+def add_pytest_to_doctest_namespace(doctest_namespace):
+    doctest_namespace["pytest"] = pytest


### PR DESCRIPTION
AFAIK it's good practice to only `import pytest` and not individual functions (`from pytest import raises`).

Therefore code examples should have the context managers prefixed with the module name.