### PR TITLE
Add small section on migrating from nose to pytest.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -200,6 +200,7 @@ Matthias Hafner
 Maxim Filipenko
 Maximilian Cosmo Sitter
 mbyt
+Mickey Pashov
 Michael Aquilina
 Michael Birtwell
 Michael Droettboom

--- a/doc/en/nose.rst
+++ b/doc/en/nose.rst
@@ -68,4 +68,13 @@ Unsupported idioms / known issues
   fundamentally incompatible with pytest because they don't support fixtures
   properly since collection and test execution are separated.
 
+Migrating from Nose to Pytest
+------------------------------
+
+`nose2pytest <https://github.com/pytest-dev/nose2pytest>`_ is a Python script
+and py.test plugin to help convert Nose-based tests into py.test-based tests.
+Specifically, the script transforms nose.tools.assert_* function calls into
+raw assert statements, while preserving format of original arguments
+as much as possible.
+
 .. _nose: https://nose.readthedocs.io/en/latest/


### PR DESCRIPTION
This change was initiated after a discussion found [here](https://github.com/pytest-dev/pytest/discussions/8024#discussioncomment-127351).

The section currently features the `nose2pytest` tool with plans to expand
on some of the common gotchas when performing such migrations.

Questions for reviewers:
- Should I update the the CHANGELOG - I think it's not necessary.
- Should I add myself to AUTHORS - the change seems pretty small so I'll leave it for now.
