### PR TITLE
Add str() support to LineMatcher

### DIFF
--- a/changelog/1265.improvement.rst
+++ b/changelog/1265.improvement.rst
@@ -1,0 +1,1 @@
+Added __str__ method to LineMatcher class.

--- a/changelog/1265.improvement.rst
+++ b/changelog/1265.improvement.rst
@@ -1,1 +1,1 @@
-Added __str__ method to LineMatcher class.
+Added an ``__str__`` implementation to the :class:`~pytest.pytester.LineMatcher` class which is returned from ``pytester.run_pytest().stdout`` and similar. It returns the entire output, like the existing ``str()`` method.

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -527,6 +527,7 @@ To use it, include in your topmost ``conftest.py`` file:
 
 .. autoclass:: LineMatcher()
     :members:
+    :special-members: __str__
 
 .. autoclass:: HookRecorder()
     :members:

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1708,7 +1708,11 @@ class LineMatcher:
         self._log_output: List[str] = []
 
     def __str__(self) -> str:
-        """Return the entire original text."""
+        """Return the entire original text.
+        
+        .. versionadded:: 6.2
+            You can use :method:`str` in older versions.
+        """
         return "\n".join(self.lines)
 
     def _getlines(self, lines2: Union[str, Sequence[str], Source]) -> Sequence[str]:

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1707,6 +1707,10 @@ class LineMatcher:
         self.lines = lines
         self._log_output: List[str] = []
 
+    def __str__(self) -> str:
+        """Return the entire original text."""
+        return "\n".join(self.lines)
+
     def _getlines(self, lines2: Union[str, Sequence[str], Source]) -> Sequence[str]:
         if isinstance(lines2, str):
             lines2 = Source(lines2)
@@ -1908,4 +1912,4 @@ class LineMatcher:
 
     def str(self) -> str:
         """Return the entire original text."""
-        return "\n".join(self.lines)
+        return self.__str__()

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1709,7 +1709,6 @@ class LineMatcher:
 
     def __str__(self) -> str:
         """Return the entire original text.
-        
         .. versionadded:: 6.2
             You can use :method:`str` in older versions.
         """

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -512,7 +512,7 @@ class RunResult:
         self.stdout = LineMatcher(outlines)
         """:class:`LineMatcher` of stdout.
 
-        Use e.g. :func:`stdout.str() <LineMatcher.str()>` to reconstruct stdout, or the commonly used
+        Use e.g. :func:`str(stdout) <LineMatcher.__str__()>` to reconstruct stdout, or the commonly used
         :func:`stdout.fnmatch_lines() <LineMatcher.fnmatch_lines()>` method.
         """
         self.stderr = LineMatcher(errlines)
@@ -1709,8 +1709,9 @@ class LineMatcher:
 
     def __str__(self) -> str:
         """Return the entire original text.
+
         .. versionadded:: 6.2
-            You can use :method:`str` in older versions.
+            You can use :meth:`str` in older versions.
         """
         return "\n".join(self.lines)
 

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1912,4 +1912,4 @@ class LineMatcher:
 
     def str(self) -> str:
         """Return the entire original text."""
-        return self.__str__()
+        return str(self)

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -610,6 +610,11 @@ def test_linematcher_no_matching_after_match() -> None:
     assert str(e.value).splitlines() == ["fnmatch: '*'", "   with: '1'"]
 
 
+def test_linematcher_string_api() -> None:
+    lm = LineMatcher(["foo", "bar"])
+    assert str(lm) == "foo\nbar"
+
+
 def test_pytester_addopts_before_testdir(request, monkeypatch) -> None:
     orig = os.environ.get("PYTEST_ADDOPTS", None)
     monkeypatch.setenv("PYTEST_ADDOPTS", "--orig-unused")


### PR DESCRIPTION
Added `__str__` method to LineMatcher class.

The `LineMatcher` class is used in the `RunResult` class, which has the `stdout` attribute, which is an instance of `LineMatcher`. `result.stdout.str()` is used 66 times in the codebase. The use of the `str()` function is mentioned [here](https://github.com/pytest-dev/pytest/blob/8ea8cdb36d031206742e609975ba0393533db92c/src/_pytest/pytester.py#L512-L517) as well. If I should make any other changes. Since `.str()` is used throughout the codebase, changing everything to `str(matcher)` seems pointless.

If you think a test should be added, let me now, however it is implicitly tested in the `Pytester` tests.

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. 

Closes #1265 