### PR TITLE
permit node to warn with any warning type, not just PytestWarning

### DIFF
--- a/changelog/7615.improvement.rst
+++ b/changelog/7615.improvement.rst
@@ -1,1 +1,1 @@
-`node.warn` now permits any subclass of Warning, not just PytestWarnings
+:meth:`Node.warn <_pytest.nodes.Node.warn>` now permits any subclass of :class:`Warning`, not just :class:`PytestWarning <pytest.PytestWarning>`.

--- a/changelog/7615.improvement.rst
+++ b/changelog/7615.improvement.rst
@@ -1,0 +1,1 @@
+`node.warn` now permits any subclass of Warning, not just PytestWarnings

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -213,6 +213,10 @@ class Node(metaclass=NodeMeta):
 
             node.warn(PytestWarning("some message"))
             node.warn(UserWarning("some message"))
+
+        .. versionchanged:: 6.2
+            Any subclass of :class:`Warning` is now accepted, rather than only
+            :class:`PytestWarning <pytest.PytestWarning>` subclasses.
         """
         # enforce type checks here to avoid getting a generic type error later otherwise.
         if not isinstance(warning, Warning):

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -34,7 +34,6 @@ from _pytest.store import Store
 if TYPE_CHECKING:
     # Imported here due to circular import.
     from _pytest.main import Session
-    from _pytest.warning_types import PytestWarning
     from _pytest._code.code import _TracebackStyle
 
 
@@ -198,27 +197,27 @@ class Node(metaclass=NodeMeta):
     def __repr__(self) -> str:
         return "<{} {}>".format(self.__class__.__name__, getattr(self, "name", None))
 
-    def warn(self, warning: "PytestWarning") -> None:
+    def warn(self, warning: Warning) -> None:
         """Issue a warning for this Node.
 
         Warnings will be displayed after the test session, unless explicitly suppressed.
 
         :param Warning warning:
-            The warning instance to issue. Must be a subclass of PytestWarning.
+            The warning instance to issue.
 
-        :raises ValueError: If ``warning`` instance is not a subclass of PytestWarning.
+        :raises ValueError: If ``warning`` instance is not a subclass of Warning.
 
         Example usage:
 
         .. code-block:: python
 
             node.warn(PytestWarning("some message"))
+            node.warn(UserWarning("some message"))
         """
-        from _pytest.warning_types import PytestWarning
-
-        if not isinstance(warning, PytestWarning):
+        # enforce type checks here to avoid getting a generic type error later otherwise.
+        if not isinstance(warning, Warning):
             raise ValueError(
-                "warning must be an instance of PytestWarning or subclass, got {!r}".format(
+                "warning must be an instance of Warning or subclass, got {!r}".format(
                     warning
                 )
             )


### PR DESCRIPTION
Hi all, as per #7615 This pr enabled the item `node.warn` to handle any subclass of Warning rather than be explicitly locked to instances / subclass of PytestWarning.  I am not entirely sure on the 'use-case' for this but I'm just working on contributions and came across the issue.  Normally I wouldn't be a fan of isinstance checking and raising a ValueError under such scenario(s) but I kept the same internals as previously here because otherwise a generic TypeError is raised which offers little benefit to the  caller.

Thanks!