### PR TITLE
[RFC] structured NamedTuples for code locations

### DIFF
--- a/changelog/8056.misc.rst
+++ b/changelog/8056.misc.rst
@@ -1,0 +1,1 @@
+``Item.location`` and ``TestReport.location`` now return an ``ItemLocation`` NamedTuple instead of a plain tuple, giving named access to ``path``, ``lineindex``, and ``testname``. A similar ``CodeLocation`` NamedTuple is used internally for fixture locations. Both types are tuple subclasses, so existing code that indexes or unpacks them is unaffected.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -888,6 +888,12 @@ Item
     :members:
     :show-inheritance:
 
+ItemLocation
+~~~~~~~~~~~~
+
+.. autoclass:: pytest.ItemLocation
+    :members:
+
 File
 ~~~~
 

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import sys
 from typing import Any
 from typing import Final
+from typing import NamedTuple
 from typing import NoReturn
 from typing import TYPE_CHECKING
 
@@ -72,18 +73,54 @@ def signature(obj: Callable[..., Any]) -> Signature:
     return inspect.signature(obj)
 
 
-def getlocation(function, curdir: str | os.PathLike[str] | None = None) -> str:
+class CodeLocation(NamedTuple):
+    """A source code location: file path and line number.
+
+    Converts to a ``path:lineno`` string representation.
+    """
+
+    path: Path
+    lineno: int
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.lineno}"
+
+
+def getlocation(
+    function,
+    relative_to: Path | None,
+    *,
+    allow_escape: bool = False,
+) -> CodeLocation:
+    """Return the source location (file path, line number) of *function*.
+
+    :param function:
+        The function (or wrapped function) to locate.
+    :param relative_to:
+        If given, the returned path is made relative to this directory.
+    :param allow_escape:
+        When *True* the relative path may contain ``..`` components
+        (i.e. the function is allowed to live outside *relative_to*).
+        When *False* (the default), only strict sub-paths are
+        relativised; everything else keeps its absolute path.
+    """
     function = get_real_func(function)
     fn = Path(inspect.getfile(function))
     lineno = function.__code__.co_firstlineno
-    if curdir is not None:
+
+    if relative_to is not None:
+        from .pathlib import bestrelpath
+
         try:
-            relfn = fn.relative_to(curdir)
+            if allow_escape:
+                relfn = Path(bestrelpath(relative_to, fn))
+            else:
+                relfn = fn.relative_to(relative_to)
         except ValueError:
             pass
         else:
-            return f"{relfn}:{lineno + 1}"
-    return f"{fn}:{lineno + 1}"
+            return CodeLocation(relfn, lineno + 1)
+    return CodeLocation(fn, lineno + 1)
 
 
 def num_mock_patch_args(function) -> int:

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -122,8 +122,6 @@ class ItemLocation(NamedTuple):
 def getlocation(
     function,
     relative_to: Path | None,
-    *,
-    allow_escape: bool = False,
 ) -> CodeLocation:
     """Return the source location (file path, line number) of *function*.
 
@@ -131,24 +129,16 @@ def getlocation(
         The function (or wrapped function) to locate.
     :param relative_to:
         If given, the returned path is made relative to this directory.
-    :param allow_escape:
-        When *True* the relative path may contain ``..`` components
-        (i.e. the function is allowed to live outside *relative_to*).
-        When *False* (the default), only strict sub-paths are
-        relativised; everything else keeps its absolute path.
+        Only strict sub-paths are relativised; everything else keeps
+        its absolute path.
     """
     function = get_real_func(function)
     fn = Path(inspect.getfile(function))
     lineindex = function.__code__.co_firstlineno - 1
 
     if relative_to is not None:
-        from .pathlib import bestrelpath
-
         try:
-            if allow_escape:
-                relfn = Path(bestrelpath(relative_to, fn))
-            else:
-                relfn = fn.relative_to(relative_to)
+            relfn = fn.relative_to(relative_to)
         except ValueError:
             pass
         else:

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -77,13 +77,46 @@ class CodeLocation(NamedTuple):
     """A source code location: file path and line number.
 
     Converts to a ``path:lineno`` string representation.
+
+    The stored ``lineindex`` is 0-based; use the ``lineno`` property
+    for the conventional 1-based line number.
     """
 
     path: Path
-    lineno: int
+    lineindex: int
+
+    @property
+    def lineno(self) -> int:
+        """1-based line number for display."""
+        return self.lineindex + 1
 
     def __str__(self) -> str:
         return f"{self.path}:{self.lineno}"
+
+
+class ItemLocation(NamedTuple):
+    """Location of a test item: relative path, line index, and test name.
+
+    Returned by :attr:`Item.location <pytest.Item.location>` and stored
+    on :class:`TestReport <pytest.TestReport>`.
+
+    The stored ``lineindex`` is 0-based (matching ``reportinfo()``);
+    use the ``lineno`` property for the conventional 1-based number.
+    """
+
+    path: str
+    lineindex: int | None
+    testname: str
+
+    @property
+    def lineno(self) -> int | None:
+        """1-based line number for display, or *None*."""
+        return self.lineindex + 1 if self.lineindex is not None else None
+
+    def __str__(self) -> str:
+        if self.lineno is not None:
+            return f"{self.path}:{self.lineno}"
+        return self.path
 
 
 def getlocation(
@@ -106,7 +139,7 @@ def getlocation(
     """
     function = get_real_func(function)
     fn = Path(inspect.getfile(function))
-    lineno = function.__code__.co_firstlineno
+    lineindex = function.__code__.co_firstlineno - 1
 
     if relative_to is not None:
         from .pathlib import bestrelpath
@@ -119,8 +152,8 @@ def getlocation(
         except ValueError:
             pass
         else:
-            return CodeLocation(relfn, lineno + 1)
-    return CodeLocation(fn, lineno + 1)
+            return CodeLocation(relfn, lineindex)
+    return CodeLocation(fn, lineindex)
 
 
 def num_mock_patch_args(function) -> int:

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -40,6 +40,7 @@ from _pytest._code.code import ExceptionInfoFormatter
 from _pytest._code.code import TerminalRepr
 from _pytest._io import TerminalWriter
 from _pytest.compat import assert_never
+from _pytest.compat import CodeLocation
 from _pytest.compat import deprecated
 from _pytest.compat import get_real_func
 from _pytest.compat import getfuncargnames
@@ -750,7 +751,9 @@ class FixtureRequest(abc.ABC):
                 source_path_str = str(source_path.relative_to(funcitem.config.rootpath))
             except ValueError:
                 source_path_str = str(source_path)
-            location = getlocation(fixturedef.func, funcitem.config.rootpath)
+            location = getlocation(
+                fixturedef.func, relative_to=funcitem.config.rootpath
+            )
             msg = (
                 "The requested fixture has no parameter defined for test:\n"
                 f"    {funcitem.nodeid}\n\n"
@@ -1373,7 +1376,7 @@ class FixtureFunctionMarker:
 
         name = self.name or function.__name__
         if name == "request":
-            location = getlocation(function)
+            location = getlocation(function, relative_to=None)
             fail(
                 f"'request' is a reserved word for fixtures, use another name:\n  {location}",
                 pytrace=False,
@@ -2178,13 +2181,13 @@ def show_fixtures_per_test(config: Config) -> int | ExitCode:
 _PYTEST_DIR = Path(_pytest.__file__).parent
 
 
-def _pretty_fixture_path(invocation_dir: Path, func) -> str:
-    loc = Path(getlocation(func, invocation_dir))
+def _pretty_fixture_path(invocation_dir: Path, func: object) -> str:
+    location = getlocation(func, relative_to=invocation_dir, allow_escape=False)
     prefix = Path("...", "_pytest")
     try:
-        return str(prefix / loc.relative_to(_PYTEST_DIR))
+        return f"{prefix / location.path.relative_to(_PYTEST_DIR)}:{location.lineno}"
     except ValueError:
-        return bestrelpath(invocation_dir, loc)
+        return str(location)
 
 
 def _get_fixtures_per_test(test: nodes.Item) -> Iterator[FixtureDef[object]]:
@@ -2225,10 +2228,6 @@ def _show_fixtures_per_test(config: Config, session: Session) -> None:
     tw = _pytest.config.create_terminal_writer(config)
     verbose = config.get_verbosity()
 
-    def get_best_relpath(func) -> str:
-        loc = getlocation(func, invocation_dir)
-        return bestrelpath(invocation_dir, Path(loc))
-
     def write_fixture(fixture_def: FixtureDef[object]) -> None:
         argname = fixture_def.argname
         if verbose <= 0 and argname.startswith("_"):
@@ -2257,7 +2256,8 @@ def _show_fixtures_per_test(config: Config, session: Session) -> None:
         tw.line()
         tw.sep("-", f"fixtures used by {item.name}")
         # TODO: Fix this type ignore.
-        tw.sep("-", f"({get_best_relpath(item.function)})")  # type: ignore[attr-defined]
+        loc = getlocation(item.function, relative_to=invocation_dir)  # type: ignore[attr-defined]
+        tw.sep("-", f"({loc})")
 
         for fixturedef in fixturedefs:
             write_fixture(fixturedef)
@@ -2283,14 +2283,14 @@ def _showfixtures_main(config: Config, session: Session) -> None:
     fm = session._fixturemanager
 
     available = []
-    seen: set[tuple[str, str]] = set()
+    seen: set[tuple[str, CodeLocation]] = set()
 
     for argname, fixturedefs in fm._arg2fixturedefs.items():
         assert fixturedefs is not None
         if not fixturedefs:
             continue
         for fixturedef in fixturedefs:
-            loc = getlocation(fixturedef.func, invocation_dir)
+            loc = getlocation(fixturedef.func, relative_to=invocation_dir)
             if (fixturedef.argname, loc) in seen:
                 continue
             seen.add((fixturedef.argname, loc))

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -2255,9 +2255,7 @@ def _show_fixtures_per_test(config: Config, session: Session) -> None:
 
         tw.line()
         tw.sep("-", f"fixtures used by {item.name}")
-        # TODO: Fix this type ignore.
-        loc = getlocation(item.function, relative_to=invocation_dir)  # type: ignore[attr-defined]
-        tw.sep("-", f"({loc})")
+        tw.sep("-", f"({item.location})")
 
         for fixturedef in fixturedefs:
             write_fixture(fixturedef)

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -2182,7 +2182,7 @@ _PYTEST_DIR = Path(_pytest.__file__).parent
 
 
 def _pretty_fixture_path(invocation_dir: Path, func: object) -> str:
-    location = getlocation(func, relative_to=invocation_dir, allow_escape=False)
+    location = getlocation(func, relative_to=invocation_dir)
     prefix = Path("...", "_pytest")
     try:
         return f"{prefix / location.path.relative_to(_PYTEST_DIR)}:{location.lineno}"

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -754,7 +754,7 @@ class Item(Node, abc.ABC):
     @cached_property
     def location(self) -> ItemLocation:
         """
-        Returns an :class:`ItemLocation` of ``(path, lineindex, testname)``
+        Returns an :class:`ItemLocation <pytest.ItemLocation>` of ``(path, lineindex, testname)``
         for this item where ``path`` is relative to ``config.rootpath``
         and ``lineindex`` is a 0-based line number.
         """

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -27,6 +27,7 @@ from _pytest._code.code import ExceptionInfo
 from _pytest._code.code import TerminalRepr
 from _pytest._code.code import Traceback
 from _pytest._code.code import TracebackStyle
+from _pytest.compat import ItemLocation
 from _pytest.compat import LEGACY_PATH
 from _pytest.compat import signature
 from _pytest.config import Config
@@ -751,14 +752,14 @@ class Item(Node, abc.ABC):
         return self.path, None, ""
 
     @cached_property
-    def location(self) -> tuple[str, int | None, str]:
+    def location(self) -> ItemLocation:
         """
-        Returns a tuple of ``(relfspath, lineno, testname)`` for this item
-        where ``relfspath`` is file path relative to ``config.rootpath``
-        and lineno is a 0-based line number.
+        Returns an :class:`ItemLocation` of ``(path, lineindex, testname)``
+        for this item where ``path`` is relative to ``config.rootpath``
+        and ``lineindex`` is a 0-based line number.
         """
         location = self.reportinfo()
         path = absolutepath(location[0])
         relfspath = self.session._node_location_to_relpath(path)
         assert type(location[2]) is str
-        return (relfspath, location[1], location[2])
+        return ItemLocation(relfspath, location[1], location[2])

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -338,7 +338,7 @@ class TestReport(BaseReport):
         #: Normalized collection nodeid.
         self.nodeid = nodeid
 
-        #: An :class:`ItemLocation` (filesystempath, lineindex, domaininfo)
+        #: An :class:`ItemLocation <pytest.ItemLocation>` (filesystempath, lineindex, domaininfo)
         #: indicating the actual location of a test item - it might be
         #: different from the collected one e.g. if a method is inherited
         #: from a different module.

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -29,6 +29,7 @@ from _pytest._code.code import ReprLocals
 from _pytest._code.code import ReprTraceback
 from _pytest._code.code import TerminalRepr
 from _pytest._io import TerminalWriter
+from _pytest.compat import ItemLocation
 from _pytest.config import Config
 from _pytest.nodes import Collector
 from _pytest.nodes import Item
@@ -60,7 +61,7 @@ def getworkerinfoline(node):
 
 class BaseReport:
     when: str | None
-    location: tuple[str, int | None, str] | None
+    location: ItemLocation | None
     longrepr: (
         None | ExceptionInfo[BaseException] | tuple[str, int, str] | str | TerminalRepr
     )
@@ -318,7 +319,7 @@ class TestReport(BaseReport):
     def __init__(
         self,
         nodeid: str,
-        location: tuple[str, int | None, str],
+        location: ItemLocation | tuple[str, int | None, str],
         keywords: Mapping[str, Any],
         outcome: Literal["passed", "failed", "skipped"],
         longrepr: None
@@ -337,12 +338,19 @@ class TestReport(BaseReport):
         #: Normalized collection nodeid.
         self.nodeid = nodeid
 
-        #: A (filesystempath, lineno, domaininfo) tuple indicating the
-        #: actual location of a test item - it might be different from the
-        #: collected one e.g. if a method is inherited from a different module.
+        #: An :class:`ItemLocation` (filesystempath, lineindex, domaininfo)
+        #: indicating the actual location of a test item - it might be
+        #: different from the collected one e.g. if a method is inherited
+        #: from a different module.
         #: The filesystempath may be relative to ``config.rootdir``.
-        #: The line number is 0-based.
-        self.location: tuple[str, int | None, str] = location
+        #: The line number (``lineindex``) is 0-based.
+        self.location: ItemLocation = (
+            location
+            if isinstance(location, ItemLocation)
+            else ItemLocation(*location)
+            if len(location) == 3
+            else location
+        )
 
         #: A name -> value dictionary containing all keywords and
         #: markers associated with a test invocation.
@@ -498,8 +506,8 @@ class CollectReport(BaseReport):
     @property
     def location(  # type:ignore[override]
         self,
-    ) -> tuple[str, int | None, str] | None:
-        return (self.fspath, None, self.fspath)
+    ) -> ItemLocation | None:
+        return ItemLocation(self.fspath, None, self.fspath)
 
     def __repr__(self) -> str:
         return f"<CollectReport {self.nodeid!r} lenresult={len(self.result)} outcome={self.outcome!r}>"
@@ -690,5 +698,8 @@ def _report_kwargs_from_json(reportdict: dict[str, Any]) -> dict[str, Any]:
         for section in reportdict["longrepr"]["sections"]:
             exception_info.addsection(*section)
         reportdict["longrepr"] = exception_info
+
+    if "location" in reportdict and reportdict["location"] is not None:
+        reportdict["location"] = ItemLocation(*reportdict["location"])
 
     return reportdict

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -616,6 +616,8 @@ def _report_to_json(report: BaseReport) -> dict[str, Any]:
             d[name] = os.fspath(d[name])
         elif name == "result":
             d[name] = None  # for now
+    if "location" in d and isinstance(d["location"], ItemLocation):
+        d["location"] = tuple(d["location"])
     return d
 
 

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -114,9 +114,13 @@ def pytest_sessionfinish(session: Session) -> None:
 
 def pytest_runtest_protocol(item: Item, nextitem: Item | None) -> bool:
     ihook = item.ihook
-    ihook.pytest_runtest_logstart(nodeid=item.nodeid, location=item.location)
+    # Plain tuple for backward compat: pytest-xdist (<= 3.x) sends location
+    # over execnet which cannot serialize NamedTuple subclasses.
+    # TODO: pass ItemLocation directly once xdist handles it (#8056).
+    location = tuple(item.location)
+    ihook.pytest_runtest_logstart(nodeid=item.nodeid, location=location)
     runtestprotocol(item, nextitem=nextitem)
-    ihook.pytest_runtest_logfinish(nodeid=item.nodeid, location=item.location)
+    ihook.pytest_runtest_logfinish(nodeid=item.nodeid, location=location)
     return True
 
 

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -11,6 +11,7 @@ from _pytest.approx import approx
 from _pytest.assertion import register_assert_rewrite
 from _pytest.cacheprovider import Cache
 from _pytest.capture import CaptureFixture
+from _pytest.compat import ItemLocation
 from _pytest.config import cmdline
 from _pytest.config import Config
 from _pytest.config import console_main
@@ -119,6 +120,7 @@ __all__ = [
     "Function",
     "HookRecorder",
     "Item",
+    "ItemLocation",
     "LineMatcher",
     "LogCaptureFixture",
     "Mark",

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -3850,7 +3850,7 @@ class TestShowFixtures:
             """
             *tmp_path -- *
             *fixtures defined from*
-            *arg1 -- test_show_fixtures_testmodule.py:6*
+            *arg1 -- test_show_fixtures_testmodule.py:5*
             *hello world*
         """
         )
@@ -3910,10 +3910,10 @@ class TestShowFixtures:
             textwrap.dedent(
                 """\
                 * fixtures defined from test_show_fixtures_trimmed_doc *
-                arg2 -- test_show_fixtures_trimmed_doc.py:10
+                arg1 -- test_show_fixtures_trimmed_doc.py:2
                     line1
                     line2
-                arg1 -- test_show_fixtures_trimmed_doc.py:3
+                arg2 -- test_show_fixtures_trimmed_doc.py:9
                     line1
                     line2
                 """
@@ -3939,7 +3939,7 @@ class TestShowFixtures:
             textwrap.dedent(
                 """\
                 * fixtures defined from test_show_fixtures_indented_doc *
-                fixture1 -- test_show_fixtures_indented_doc.py:3
+                fixture1 -- test_show_fixtures_indented_doc.py:2
                     line1
                         indented line
                 """
@@ -3967,7 +3967,7 @@ class TestShowFixtures:
             textwrap.dedent(
                 """\
                 * fixtures defined from test_show_fixtures_indented_doc_first_line_unindented *
-                fixture1 -- test_show_fixtures_indented_doc_first_line_unindented.py:3
+                fixture1 -- test_show_fixtures_indented_doc_first_line_unindented.py:2
                     line1
                     line2
                         indented line
@@ -3995,7 +3995,7 @@ class TestShowFixtures:
             textwrap.dedent(
                 """\
                 * fixtures defined from test_show_fixtures_indented_in_class *
-                fixture1 -- test_show_fixtures_indented_in_class.py:4
+                fixture1 -- test_show_fixtures_indented_in_class.py:3
                     line1
                     line2
                         indented line
@@ -4035,11 +4035,11 @@ class TestShowFixtures:
         result.stdout.fnmatch_lines(
             """
             * fixtures defined from test_a *
-            fix_a -- test_a.py:4
+            fix_a -- test_a.py:3
                 Fixture A
 
             * fixtures defined from test_b *
-            fix_b -- test_b.py:4
+            fix_b -- test_b.py:3
                 Fixture B
         """
         )
@@ -4075,11 +4075,11 @@ class TestShowFixtures:
         result.stdout.fnmatch_lines(
             """
             * fixtures defined from conftest *
-            arg1 -- conftest.py:3
+            arg1 -- conftest.py:2
                 Hello World in conftest.py
 
             * fixtures defined from test_show_fixtures_with_same_name *
-            arg1 -- test_show_fixtures_with_same_name.py:3
+            arg1 -- test_show_fixtures_with_same_name.py:2
                 Hi from test module
         """
         )
@@ -4247,7 +4247,7 @@ class TestParameterizedSubRequest:
                 "The requested fixture has no parameter defined for test:",
                 "    test_call_from_fixture.py::test_foo",
                 "Requested fixture 'fix_with_param' defined in:",
-                "test_call_from_fixture.py:4",
+                "test_call_from_fixture.py:3",
                 "Requested here:",
                 "test_call_from_fixture.py:9",
                 "*1 error in*",
@@ -4273,7 +4273,7 @@ class TestParameterizedSubRequest:
                 "The requested fixture has no parameter defined for test:",
                 "    test_call_from_test.py::test_foo",
                 "Requested fixture 'fix_with_param' defined in:",
-                "test_call_from_test.py:4",
+                "test_call_from_test.py:3",
                 "Requested here:",
                 "test_call_from_test.py:8",
                 "*1 failed*",
@@ -4304,7 +4304,7 @@ class TestParameterizedSubRequest:
                 "    test_external_fixture.py::test_foo",
                 "",
                 "Requested fixture 'fix_with_param' defined in:",
-                "conftest.py:4",
+                "conftest.py:3",
                 "Requested here:",
                 "test_external_fixture.py:2",
                 "*1 failed*",
@@ -4350,7 +4350,7 @@ class TestParameterizedSubRequest:
                 "    test_foos.py::test_foo",
                 "",
                 "Requested fixture 'fix_with_param' defined in:",
-                f"{fixfile}:4",
+                f"{fixfile}:3",
                 "Requested here:",
                 "test_foos.py:4",
                 "*1 failed*",
@@ -4367,7 +4367,7 @@ class TestParameterizedSubRequest:
                 "    test_foos.py::test_foo",
                 "",
                 "Requested fixture 'fix_with_param' defined in:",
-                f"{fixfile}:4",
+                f"{fixfile}:3",
                 "Requested here:",
                 f"{testfile}:4",
                 "*1 failed*",
@@ -5021,7 +5021,7 @@ def test_fixture_named_request(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(
         [
             "*'request' is a reserved word for fixtures, use another name:",
-            "  *test_fixture_named_request.py:8",
+            "  *test_fixture_named_request.py:7",
         ]
     )
 

--- a/testing/python/show_fixtures_per_test.py
+++ b/testing/python/show_fixtures_per_test.py
@@ -30,8 +30,8 @@ def test_fixtures_in_module(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(
         [
             "*fixtures used by test_arg1*",
-            "*(test_fixtures_in_module.py:9)*",
-            "arg1 -- test_fixtures_in_module.py:6",
+            "*(test_fixtures_in_module.py:8)*",
+            "arg1 -- test_fixtures_in_module.py:5",
             "    arg1 docstring",
         ]
     )
@@ -69,16 +69,16 @@ def test_fixtures_in_conftest(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(
         [
             "*fixtures used by test_arg2*",
-            "*(test_fixtures_in_conftest.py:2)*",
-            "arg2 -- conftest.py:6",
+            "*(test_fixtures_in_conftest.py:1)*",
+            "arg2 -- conftest.py:5",
             "    arg2 docstring",
             "*fixtures used by test_arg3*",
-            "*(test_fixtures_in_conftest.py:4)*",
-            "arg1 -- conftest.py:3",
+            "*(test_fixtures_in_conftest.py:3)*",
+            "arg1 -- conftest.py:2",
             "    arg1 docstring",
-            "arg2 -- conftest.py:6",
+            "arg2 -- conftest.py:5",
             "    arg2 docstring",
-            "arg3 -- conftest.py:9",
+            "arg3 -- conftest.py:8",
             "    arg3",
         ]
     )
@@ -112,10 +112,10 @@ def test_should_show_fixtures_used_by_test(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(
         [
             "*fixtures used by test_args*",
-            "*(test_should_show_fixtures_used_by_test.py:6)*",
-            "arg1 -- test_should_show_fixtures_used_by_test.py:3",
+            "*(test_should_show_fixtures_used_by_test.py:5)*",
+            "arg1 -- test_should_show_fixtures_used_by_test.py:2",
             "    arg1 from testmodule",
-            "arg2 -- conftest.py:6",
+            "arg2 -- conftest.py:5",
             "    arg2 from conftest",
         ]
     )
@@ -149,12 +149,12 @@ def test_verbose_include_private_fixtures_and_loc(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(
         [
             "*fixtures used by test_args*",
-            "*(test_verbose_include_private_fixtures_and_loc.py:6)*",
-            "_arg1 -- conftest.py:3",
+            "*(test_verbose_include_private_fixtures_and_loc.py:5)*",
+            "_arg1 -- conftest.py:2",
             "    _arg1 from conftest",
-            "arg2 -- conftest.py:6",
+            "arg2 -- conftest.py:5",
             "    arg2 from conftest",
-            "arg3 -- test_verbose_include_private_fixtures_and_loc.py:3",
+            "arg3 -- test_verbose_include_private_fixtures_and_loc.py:2",
             "    arg3 from testmodule",
         ]
     )
@@ -209,8 +209,8 @@ def test_multiline_docstring_in_module(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(
         [
             "*fixtures used by test_arg1*",
-            "*(test_multiline_docstring_in_module.py:13)*",
-            "arg1 -- test_multiline_docstring_in_module.py:3",
+            "*(test_multiline_docstring_in_module.py:12)*",
+            "arg1 -- test_multiline_docstring_in_module.py:2",
             "    Docstring content that spans across multiple lines,",
             "    through second line,",
             "    and through third line.",
@@ -243,8 +243,8 @@ def test_verbose_include_multiline_docstring(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(
         [
             "*fixtures used by test_arg1*",
-            "*(test_verbose_include_multiline_docstring.py:13)*",
-            "arg1 -- test_verbose_include_multiline_docstring.py:3",
+            "*(test_verbose_include_multiline_docstring.py:12)*",
+            "arg1 -- test_verbose_include_multiline_docstring.py:2",
             "    Docstring content that spans across multiple lines,",
             "    through second line,",
             "    and through third line.",
@@ -309,20 +309,20 @@ def test_should_show_parametrized_fixtures_used_by_test(pytester: Pytester) -> N
     result.stdout.fnmatch_lines(
         [
             "*fixtures used by test_directly_parametrized_fixture*",
-            "*(test_should_show_parametrized_fixtures_used_by_test.py:14)*",
-            "directly -- test_should_show_parametrized_fixtures_used_by_test.py:4",
+            "*(test_should_show_parametrized_fixtures_used_by_test.py:13)*",
+            "directly -- test_should_show_parametrized_fixtures_used_by_test.py:3",
             "    parametrized fixture",
             "*fixtures used by test_directly_parametrized_fixture*",
-            "*(test_should_show_parametrized_fixtures_used_by_test.py:14)*",
-            "directly -- test_should_show_parametrized_fixtures_used_by_test.py:4",
+            "*(test_should_show_parametrized_fixtures_used_by_test.py:13)*",
+            "directly -- test_should_show_parametrized_fixtures_used_by_test.py:3",
             "    parametrized fixture",
             "*fixtures used by test_indirectly_parametrized_fixture*",
-            "*(test_should_show_parametrized_fixtures_used_by_test.py:17)*",
-            "indirectly -- test_should_show_parametrized_fixtures_used_by_test.py:9",
+            "*(test_should_show_parametrized_fixtures_used_by_test.py:16)*",
+            "indirectly -- test_should_show_parametrized_fixtures_used_by_test.py:8",
             "    indirectly parametrized fixture",
             "*fixtures used by test_indirectly_parametrized_fixture*",
-            "*(test_should_show_parametrized_fixtures_used_by_test.py:17)*",
-            "indirectly -- test_should_show_parametrized_fixtures_used_by_test.py:9",
+            "*(test_should_show_parametrized_fixtures_used_by_test.py:16)*",
+            "indirectly -- test_should_show_parametrized_fixtures_used_by_test.py:8",
             "    indirectly parametrized fixture",
         ]
     )

--- a/testing/test_compat.py
+++ b/testing/test_compat.py
@@ -11,6 +11,7 @@ import warnings
 from _pytest.compat import assert_never
 from _pytest.compat import deprecated
 from _pytest.compat import get_real_func
+from _pytest.compat import ItemLocation
 from _pytest.compat import safe_getattr
 from _pytest.compat import safe_isclass
 from _pytest.outcomes import OutcomeException
@@ -190,6 +191,20 @@ def test_assert_never_literal() -> None:
         pass
     else:
         assert_never(x)
+
+
+def test_itemlocation_str_no_lineno() -> None:
+    """ItemLocation.__str__ with lineindex=None omits the line number."""
+    loc = ItemLocation("tests/foo.py", None, "test_bar")
+    assert str(loc) == "tests/foo.py"
+    assert loc.lineno is None
+
+
+def test_itemlocation_str_with_lineno() -> None:
+    """ItemLocation.__str__ with a lineindex includes 1-based lineno."""
+    loc = ItemLocation("tests/foo.py", 9, "test_bar")
+    assert str(loc) == "tests/foo.py:10"
+    assert loc.lineno == 10
 
 
 def test_deprecated() -> None:

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -12,6 +12,7 @@ from xml.dom import minidom
 
 import xmlschema
 
+from _pytest.compat import ItemLocation
 from _pytest.config import Config
 from _pytest.junitxml import bin_xml_escape
 from _pytest.junitxml import LogXML
@@ -1249,7 +1250,7 @@ def test_unicode_issue368(pytester: Pytester) -> None:
         longrepr = ustr
         sections: list[tuple[str, str]] = []
         nodeid = "something"
-        location = "tests/filename.py", 42, "TestClass.method"
+        location = ItemLocation("tests/filename.py", 42, "TestClass.method")
         when = "teardown"
 
     test_report = cast(TestReport, Report())
@@ -1598,7 +1599,7 @@ def test_url_property(pytester: Pytester) -> None:
         longrepr = "FooBarBaz"
         sections: list[tuple[str, str]] = []
         nodeid = "something"
-        location = "tests/filename.py", 42, "TestClass.method"
+        location = ItemLocation("tests/filename.py", 42, "TestClass.method")
         url = test_url
 
     test_report = cast(TestReport, Report())

--- a/testing/typing_checks.py
+++ b/testing/typing_checks.py
@@ -12,6 +12,7 @@ from typing import Literal
 
 from typing_extensions import assert_type
 
+from _pytest.compat import ItemLocation
 import pytest
 from pytest import MonkeyPatch
 from pytest import ScopeName
@@ -58,7 +59,7 @@ def check_raises_is_a_context_manager(val: bool) -> None:
 # Issue #12941.
 def check_testreport_attributes(report: TestReport) -> None:
     assert_type(report.when, Literal["setup", "call", "teardown"])
-    assert_type(report.location, tuple[str, int | None, str])
+    assert_type(report.location, ItemLocation)
 
 
 # Issue #14234.


### PR DESCRIPTION
Introduces `CodeLocation` and `ItemLocation` NamedTuples to replace the unstructured strings and bare tuples currently used for code locations. Both types store a 0-based `lineindex` field and expose a 1-based `.lineno` property, making the convention explicit rather than something each call site has to remember.

### `CodeLocation` (replaces `str` from `getlocation()`)

Two fields: `path: Path`, `lineindex: int`. Used for fixture locations in error messages and `--fixtures` / `--fixtures-per-test` output. `__str__` produces `path:lineno` (1-based).

`getlocation()` previously stored `co_firstlineno + 1` — an off-by-one since `co_firstlineno` is already 1-based. Now stores `co_firstlineno - 1` (0-based) and lets the `.lineno` property add +1 back correctly.

### `ItemLocation` (replaces `tuple[str, int | None, str]` from `Item.location`)

Three fields: `path: str`, `lineindex: int | None`, `testname: str`. Returned by `Item.location`, stored on `TestReport`. Tuple subclass — all existing indexing, unpacking, and equality comparisons continue to work unchanged.

### Other changes

- `write_item` in `fixtures.py` now uses `item.location` instead of `getlocation(item.function, ...)`, removing the `item.function` assumption that fails for `DoctestItem` and custom `Item` subclasses.
- `BaseReport.location` / `TestReport.location` typed as `ItemLocation`. `TestReport.__init__` coerces plain tuples for backwards compatibility.
- `_report_kwargs_from_json` reconstructs `ItemLocation` after JSON round-trip.
- Hook signatures, `reportinfo()` contract, and JSON wire format are all unchanged.