### PR TITLE
Add links to some CHANGELOG entries

### DIFF
--- a/changelog/7425.feature.rst
+++ b/changelog/7425.feature.rst
@@ -2,4 +2,4 @@ New :fixture:`pytester` fixture, which is identical to :fixture:`testdir` but it
 
 This is part of the movement to use :class:`pathlib.Path` objects internally, in order to remove the dependency to ``py`` in the future.
 
-Internally, the old :class:`Testdir` is now a thin wrapper around :class:`Pytester`, preserving the old interface.
+Internally, the old :class:`Testdir <_pytest.pytester.Testdir>` is now a thin wrapper around :class:`Pytester <_pytest.pytester.Pytester>`, preserving the old interface.

--- a/changelog/7527.improvement.rst
+++ b/changelog/7527.improvement.rst
@@ -1,1 +1,1 @@
-When a comparison between `namedtuple` instances of the same type fails, pytest now shows the differing field names (possibly nested) instead of their indexes.
+When a comparison between :func:`namedtuple <collections.namedtuple>` instances of the same type fails, pytest now shows the differing field names (possibly nested) instead of their indexes.

--- a/changelog/7710.improvement.rst
+++ b/changelog/7710.improvement.rst
@@ -1,3 +1,4 @@
-Use strict equality comparison for nonnumeric types in ``approx`` instead of
-raising ``TypeError``.
+Use strict equality comparison for non-numeric types in :func:`pytest.approx` instead of
+raising :class:`TypeError`.
+
 This was the undocumented behavior before 3.7, but is now officially a supported feature.

--- a/changelog/7911.bugfix.rst
+++ b/changelog/7911.bugfix.rst
@@ -1,1 +1,1 @@
-Directories created by `tmpdir` are now considered stale after 3 days without modification (previous value was 3 hours) to avoid deleting directories still in use in long running test suites.
+Directories created by by :fixture:`tmp_path` and :fixture:`tmpdir` are now considered stale after 3 days without modification (previous value was 3 hours) to avoid deleting directories still in use in long running test suites.

--- a/changelog/7913.bugfix.rst
+++ b/changelog/7913.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed a crash or hang in ``pytester.spawn`` when the ``readline`` module is involved.
+Fixed a crash or hang in :meth:`pytester.spawn <_pytest.pytester.Pytester.spawn>` when the :mod:`readline` module is involved.

--- a/changelog/8023.improvement.rst
+++ b/changelog/8023.improvement.rst
@@ -1,1 +1,1 @@
-Added ``'node_modules'`` to default value for ``norecursedirs``.
+Added ``'node_modules'`` to default value for :confval:`norecursedirs`.

--- a/changelog/8032.improvement.rst
+++ b/changelog/8032.improvement.rst
@@ -1,1 +1,1 @@
-`doClassCleanups` (introduced in `unittest` in Python and 3.8) is now called.
+:meth:`doClassCleanups <unittest.TestCase.doClassCleanups>` (introduced in :mod:`unittest` in Python and 3.8) is now called appropriately.


### PR DESCRIPTION
While adding links to https://github.com/pytest-dev/pytest/pull/8052, noticed
a few more missing.