### PR TITLE
implementing a qual_name property for nodes

### DIFF
--- a/changelog/7365.feature.rst
+++ b/changelog/7365.feature.rst
@@ -1,1 +1,1 @@
-Instances of :class:`Node <_pytest.nodes.Node>` now expose a `qual_name` property
+Instances of :class:`Node <_pytest.nodes.Node>` now store their fully dotted path via a `qual_name` property.

--- a/changelog/7365.feature.rst
+++ b/changelog/7365.feature.rst
@@ -1,0 +1,1 @@
+Instances of :class:`Node <_pytest.nodes.Node>` now expose a `qual_name` property

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -172,6 +172,10 @@ class Node(metaclass=NodeMeta):
         # own use. Currently only intended for internal plugins.
         self._store = Store()
 
+    @property
+    def qual_name(self) -> str:
+        return "::".join(node.name for node in self.listchain())
+
     @classmethod
     def from_parent(cls, parent: "Node", **kw):
         """Public constructor for Nodes.

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -174,7 +174,7 @@ class Node(metaclass=NodeMeta):
 
     @property
     def qual_name(self) -> str:
-        return "::".join([x for x in self.listnames() if x != "()"])
+        return ".".join(x for x in self.listnames() if x != "()")
 
     @classmethod
     def from_parent(cls, parent: "Node", **kw):

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -174,7 +174,7 @@ class Node(metaclass=NodeMeta):
 
     @property
     def qual_name(self) -> str:
-        return "::".join(node.name for node in self.listchain())
+        return "::".join([x for x in self.listnames() if x != "()"])
 
     @classmethod
     def from_parent(cls, parent: "Node", **kw):

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -99,7 +99,7 @@ def test_node_qual_name_package_func(pytester: Pytester) -> None:
     pkg.joinpath("test_mod.py").write_text(
         """
 def test_it(request):
-    assert request.node.qual_name == 'test_node_qual_name_package_func0/mypkg::test_mod.py::test_it'"""
+    assert request.node.qual_name == 'test_node_qual_name_package_func0.mypkg.test_mod.py.test_it'"""
     )
     result = pytester.runpytest()
     assert result.ret == ExitCode.OK
@@ -109,7 +109,7 @@ def test_node_qual_name_module_func(pytester: Pytester) -> None:
     pytester.makepyfile(
         """
         def test_qual_name(request):
-            expected = 'test_node_qual_name_module_func0/test_node_qual_name_module_func.py::test_qual_name'
+            expected = 'test_node_qual_name_module_func0.test_node_qual_name_module_func.py.test_qual_name'
             assert request.node.qual_name == expected
         """
     )
@@ -122,7 +122,7 @@ def test_node_qual_name_class_func(pytester: Pytester) -> None:
         """
         class TestQual:
             def test_clazz(self, request):
-                expected = 'test_node_qual_name_class_func0/test_node_qual_name_class_func.py::TestQual::test_clazz'
+                expected = 'test_node_qual_name_class_func0.test_node_qual_name_class_func.py.TestQual.test_clazz'
                 assert request.node.qual_name == expected
         """
     )

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -99,7 +99,7 @@ def test_node_qual_name_package_func(pytester: Pytester) -> None:
     pkg.joinpath("test_mod.py").write_text(
         """
 def test_it(request):
-    assert request.node.qual_name == 'test_node_qual_name_package_func0::mypkg::test_mod.py::test_it'"""
+    assert request.node.qual_name == 'test_node_qual_name_package_func0/mypkg::test_mod.py::test_it'"""
     )
     result = pytester.runpytest()
     assert result.ret == ExitCode.OK
@@ -109,7 +109,7 @@ def test_node_qual_name_module_func(pytester: Pytester) -> None:
     pytester.makepyfile(
         """
         def test_qual_name(request):
-            expected = 'test_node_qual_name_module_func0::test_node_qual_name_module_func.py::test_qual_name'
+            expected = 'test_node_qual_name_module_func0/test_node_qual_name_module_func.py::test_qual_name'
             assert request.node.qual_name == expected
         """
     )
@@ -117,14 +117,12 @@ def test_node_qual_name_module_func(pytester: Pytester) -> None:
     assert result.ret == ExitCode.OK
 
 
-@pytest.mark.xfail()
 def test_node_qual_name_class_func(pytester: Pytester) -> None:
-    # TODO fix the ::():: for inside classes here returned by listchain() ?
     pytester.makepyfile(
         """
         class TestQual:
             def test_clazz(self, request):
-                expected = 'test_node_qual_name_class_func0::test_node_qual_name_class_func.py::TestQual::test_clazz'
+                expected = 'test_node_qual_name_class_func0/test_node_qual_name_class_func.py::TestQual::test_clazz'
                 assert request.node.qual_name == expected
         """
     )


### PR DESCRIPTION
initial attempt at adding a `qual_name` property to instances of `Node`.  This still needs some work and advice, namely these:

1. should this be '::' joining, or '.' ?
2. `listchain()` seems to be returning an `()` for functions inside classes, not sure (yet) if that is a bug or intentional behaviour and how to address that.

Still some work to do here, but would appreciate someone with more indepth node/collection to give their thoughts.

For some reason:

`<class 'test_node_qual_name_class_func.TestQual'>` has a `name` attr of `()`, not sure why that is?

closes #7365 