### PR TITLE
fix mock_timing fixture name (typo) in timing.py

### DIFF
--- a/src/_pytest/timing.py
+++ b/src/_pytest/timing.py
@@ -3,7 +3,7 @@
 We intentionally grab some "time" functions internally to avoid tests mocking "time" to affect
 pytest runtime information (issue #185).
 
-Fixture "mock_timinig" also interacts with this module for pytest's own tests.
+Fixture "mock_timing" also interacts with this module for pytest's own tests.
 """
 from time import perf_counter
 from time import sleep


### PR DESCRIPTION
Digging through the repo, apologies for nit picking :) came across a small typo for the fixture that resides in `testing/conftest.py` and corrected it.