### PR TITLE
Custom multiple marker execution order

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -269,6 +269,7 @@ Sankt Petersbug
 Segev Finer
 Serhii Mozghovyi
 Seth Junot
+Shubham Adep
 Simon Gomizelj
 Simon Kerr
 Skylar Downes

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -247,6 +247,17 @@ Will create and attach a :class:`Mark <_pytest.mark.structures.Mark>` object to 
 
     mark.args == (10, "slow")
     mark.kwargs == {"method": "thread"}
+    
+Example for using multiple custom markers:
+
+.. code-block:: python
+    
+    @pytest.mark.timeout(10, "slow", method="thread")
+    @pytest.mark.slow
+    def test_function():
+        ...
+ 
+Will order execution of markers from inside - out. The above example will execute @pytest.mark.slow before @pytest.mark.timeout(10, "slow", method="thread"). 
 
 
 .. _`fixtures-api`:

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -257,7 +257,7 @@ Example for using multiple custom markers:
     def test_function():
         ...
 
-When :meth:`Node.iter_markers <_pytest.nodes.Node.iter_markers>` is used with multiple markers, the marker closest to the function will be iterated over first. The above example will result in ``@pytest.mark.slow`` followed by ``@pytest.mark.timeout(...)``.
+When :meth:`Node.iter_markers <_pytest.nodes.Node.iter_markers>` or :meth:`Node.iter_markers <_pytest.nodes.Node.iter_markers_with_node>` is used with multiple markers, the marker closest to the function will be iterated over first. The above example will result in ``@pytest.mark.slow`` followed by ``@pytest.mark.timeout(...)``.
 
 .. _`fixtures-api`:
 

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -251,13 +251,12 @@ Will create and attach a :class:`Mark <_pytest.mark.structures.Mark>` object to 
 Example for using multiple custom markers:
 
 .. code-block:: python
-
     @pytest.mark.timeout(10, "slow", method="thread")
     @pytest.mark.slow
     def test_function():
         ...
 
-Will order execution of markers from inside - out. The above example will execute @pytest.mark.slow before @pytest.mark.timeout(10, "slow", method="thread"). 
+Will order execution of markers from inside - out. The above example will execute @pytest.mark.slow before @pytest.mark.timeout(10, "slow", method="thread").
 
 .. _`fixtures-api`:
 

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -251,6 +251,7 @@ Will create and attach a :class:`Mark <_pytest.mark.structures.Mark>` object to 
 Example for using multiple custom markers:
 
 .. code-block:: python
+
     @pytest.mark.timeout(10, "slow", method="thread")
     @pytest.mark.slow
     def test_function():

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -247,18 +247,17 @@ Will create and attach a :class:`Mark <_pytest.mark.structures.Mark>` object to 
 
     mark.args == (10, "slow")
     mark.kwargs == {"method": "thread"}
-    
+
 Example for using multiple custom markers:
 
 .. code-block:: python
-    
+
     @pytest.mark.timeout(10, "slow", method="thread")
     @pytest.mark.slow
     def test_function():
         ...
- 
-Will order execution of markers from inside - out. The above example will execute @pytest.mark.slow before @pytest.mark.timeout(10, "slow", method="thread"). 
 
+Will order execution of markers from inside - out. The above example will execute @pytest.mark.slow before @pytest.mark.timeout(10, "slow", method="thread"). 
 
 .. _`fixtures-api`:
 


### PR DESCRIPTION
 [Issue](https://github.com/pytest-dev/pytest/issues/8020) stated that ordering of multiple custom markers is from inside - out. Following are the changes in this PR:

1. Added explanation to use multiple custom markers.
2. Added python code samples for the same in the documentation. 

Please let me know for further changes / concerns.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
