### PR TITLE
infrastructure: Stricter tox dependensies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,7 +165,10 @@ jobs:
       with:
         path: ~/.cache/pre-commit
         key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - run: pip install tox
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
     - run: tox -e linting
 
   deploy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
   # sync with setup.py until we discard non-pep-517/518
-  "setuptools>=42.0",
-  "setuptools-scm[toml]>=3.4",
+  "setuptools>=50.3.2",
+  "setuptools-scm[toml]>=4.1.2",
   "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
   # sync with setup.py until we discard non-pep-517/518
-  "setuptools>=50.3.2",
-  "setuptools-scm[toml]>=4.1.2",
+  "setuptools>=42.0",
+  "setuptools-scm[toml]>=3.4",
   "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     attrs>=19.2.0
     iniconfig
     packaging
-    pluggy>=0.12,<=1.0
+    pluggy>=0.12,<1.0.0a1
     py>=1.8.2
     toml
     atomicwrites>=1.0;sys_platform=="win32"
@@ -52,8 +52,8 @@ python_requires = >=3.6
 package_dir =
     =src
 setup_requires =
-    setuptools>=50.3.2
-    setuptools-scm
+    setuptools>=>=42.0
+    setuptools-scm>=3.4
 zip_safe = no
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     attrs>=19.2.0
     iniconfig
     packaging
-    pluggy>=0.12,<1.0
+    pluggy>=0.12,<=1.0
     py>=1.8.2
     toml
     atomicwrites>=1.0;sys_platform=="win32"

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ python_requires = >=3.6
 package_dir =
     =src
 setup_requires =
-    setuptools>=40.0
+    setuptools>=50.3.2
     setuptools-scm
 zip_safe = no
 

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ deps =
     unittestextras: twisted
     unittestextras: asynctest
     xdist: pytest-xdist>=2.1.0
+    xdist: -e .
     {env:_PYTEST_TOX_EXTRA_DEP:}
 
 [testenv:linting]
@@ -142,7 +143,7 @@ passenv = *
 deps =
     colorama
     github3.py
-    pre-commit>=1.11.0
+    pre-commit>=2.9.3
     wheel
     towncrier
 commands = python scripts/release.py {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-minversion = 3.5.3
+minversion = 3.20.0
 distshare = {homedir}/.tox/distshare
 # make sure to update environment list in travis.yml and appveyor.yml
 envlist =
@@ -16,6 +16,7 @@ envlist =
     py37-freeze
     docs
     docs-checklinks
+requires = pip >= 20.3.1
 
 [testenv]
 commands =
@@ -44,19 +45,19 @@ setenv =
 extras = testing
 deps =
     doctesting: PyYAML
-    numpy: numpy
-    pexpect: pexpect
-    pluggymaster: git+https://github.com/pytest-dev/pluggy.git@master
-    pygments
+    numpy: numpy>=1.19.4
+    pexpect: pexpect>=4.8.0
+    pluggymaster: git+https://github.com/pytest-dev/pluggy.git@0.13.1
+    pygments>=2.7.2
     unittestextras: twisted
     unittestextras: asynctest
-    xdist: pytest-xdist>=1.13
+    xdist: pytest-xdist>=2.1.0
     {env:_PYTEST_TOX_EXTRA_DEP:}
 
 [testenv:linting]
 skip_install = True
 basepython = python3
-deps = pre-commit>=1.11.0
+deps = pre-commit>=2.9.3
 commands = pre-commit run --all-files --show-diff-on-failure {posargs:}
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ deps =
     doctesting: PyYAML
     numpy: numpy>=1.19.4
     pexpect: pexpect>=4.8.0
-    pluggymaster: git+https://github.com/pytest-dev/pluggy.git@0.13.1
+    pluggymaster: git+https://github.com/pytest-dev/pluggy.git@master
     pygments>=2.7.2
     unittestextras: twisted
     unittestextras: asynctest


### PR DESCRIPTION
Proposal for #8117 

@bluetech - I pinned the min versions for some of the packages to the current latest in `tox.ini` (so pip will resolve them sooner). Builds are running faster now ([ubuntu-py37-pluggy](https://github.com/pytest-dev/pytest/runs/1532409214?check_suite_focus=true) ~2min).

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
