### PR TITLE
Some py.path.local -> pathlib.Path

### DIFF
--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -7,6 +7,7 @@ import traceback
 import types
 import warnings
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -525,7 +526,7 @@ class DoctestModule(pytest.Module):
 
         if self.fspath.basename == "conftest.py":
             module = self.config.pluginmanager._importconftest(
-                self.fspath, self.config.getoption("importmode")
+                Path(self.fspath), self.config.getoption("importmode")
             )
         else:
             try:

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -520,7 +520,7 @@ class FSCollector(Collector):
         """The public constructor."""
         return super().from_parent(parent=parent, fspath=fspath, **kw)
 
-    def gethookproxy(self, fspath: py.path.local):
+    def gethookproxy(self, fspath: "os.PathLike[str]"):
         warnings.warn(FSCOLLECTOR_GETHOOKPROXY_ISINITPATH, stacklevel=2)
         return self.session.gethookproxy(fspath)
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -653,7 +653,7 @@ class Package(Module):
             func = partial(_call_with_optional_argument, teardown_module, self.obj)
             self.addfinalizer(func)
 
-    def gethookproxy(self, fspath: py.path.local):
+    def gethookproxy(self, fspath: "os.PathLike[str]"):
         warnings.warn(FSCOLLECTOR_GETHOOKPROXY_ISINITPATH, stacklevel=2)
         return self.session.gethookproxy(fspath)
 

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -8,6 +8,7 @@ from _pytest.compat import getfuncargnames
 from _pytest.config import ExitCode
 from _pytest.fixtures import FixtureRequest
 from _pytest.pytester import get_public_names
+from _pytest.pytester import Pytester
 from _pytest.pytester import Testdir
 
 
@@ -1961,8 +1962,10 @@ class TestAutouseManagement:
         reprec = testdir.inline_run("-v", "-s")
         reprec.assertoutcome(passed=4)
 
-    def test_class_function_parametrization_finalization(self, testdir):
-        p = testdir.makeconftest(
+    def test_class_function_parametrization_finalization(
+        self, pytester: Pytester
+    ) -> None:
+        p = pytester.makeconftest(
             """
             import pytest
             import pprint
@@ -1984,7 +1987,7 @@ class TestAutouseManagement:
                 request.addfinalizer(fin)
         """
         )
-        testdir.makepyfile(
+        pytester.makepyfile(
             """
             import pytest
 
@@ -1996,8 +1999,7 @@ class TestAutouseManagement:
                     pass
         """
         )
-        confcut = f"--confcutdir={testdir.tmpdir}"
-        reprec = testdir.inline_run("-v", "-s", confcut)
+        reprec = pytester.inline_run("-v", "-s", "--confcutdir", pytester.path)
         reprec.assertoutcome(passed=8)
         config = reprec.getcalls("pytest_unconfigure")[0].config
         values = config.pluginmanager._getconftestmodules(p, importmode="prepend")[

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -364,7 +364,9 @@ class TestCustomConftests:
     def test_collectignore_exclude_on_option(self, pytester: Pytester) -> None:
         pytester.makeconftest(
             """
-            collect_ignore = ['hello', 'test_world.py']
+            import py
+            from pathlib import Path
+            collect_ignore = [py.path.local('hello'), 'test_world.py', Path('bye')]
             def pytest_addoption(parser):
                 parser.addoption("--XX", action="store_true", default=False)
             def pytest_configure(config):

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -574,16 +574,16 @@ class TestConfigAPI:
             config.getvalue("x")
         assert config.getoption("x", 1) == 1
 
-    def test_getconftest_pathlist(self, pytester: Pytester, tmpdir) -> None:
-        somepath = tmpdir.join("x", "y", "z")
-        p = tmpdir.join("conftest.py")
-        p.write("pathlist = ['.', %r]" % str(somepath))
+    def test_getconftest_pathlist(self, pytester: Pytester, tmp_path: Path) -> None:
+        somepath = tmp_path.joinpath("x", "y", "z")
+        p = tmp_path.joinpath("conftest.py")
+        p.write_text(f"pathlist = ['.', {str(somepath)!r}]")
         config = pytester.parseconfigure(p)
-        assert config._getconftest_pathlist("notexist", path=tmpdir) is None
-        pl = config._getconftest_pathlist("pathlist", path=tmpdir) or []
+        assert config._getconftest_pathlist("notexist", path=tmp_path) is None
+        pl = config._getconftest_pathlist("pathlist", path=tmp_path) or []
         print(pl)
         assert len(pl) == 2
-        assert pl[0] == tmpdir
+        assert pl[0] == tmp_path
         assert pl[1] == somepath
 
     @pytest.mark.parametrize("maybe_type", ["not passed", "None", '"string"'])
@@ -1935,10 +1935,10 @@ class TestPytestPluginsVariable:
         assert msg not in res.stdout.str()
 
 
-def test_conftest_import_error_repr(tmpdir: py.path.local) -> None:
+def test_conftest_import_error_repr(tmp_path: Path) -> None:
     """`ConftestImportFailure` should use a short error message and readable
     path to the failed conftest.py file."""
-    path = tmpdir.join("foo/conftest.py")
+    path = tmp_path.joinpath("foo/conftest.py")
     with pytest.raises(
         ConftestImportFailure,
         match=re.escape(f"RuntimeError: some error (from {path})"),

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -4,6 +4,7 @@ import textwrap
 from pathlib import Path
 from typing import cast
 from typing import Dict
+from typing import Generator
 from typing import List
 from typing import Optional
 
@@ -15,7 +16,7 @@ from _pytest.config import PytestPluginManager
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pathlib import symlink_or_skip
 from _pytest.pytester import Pytester
-from _pytest.pytester import Testdir
+from _pytest.tmpdir import TempPathFactory
 
 
 def ConftestWithSetinitial(path) -> PytestPluginManager:
@@ -25,12 +26,12 @@ def ConftestWithSetinitial(path) -> PytestPluginManager:
 
 
 def conftest_setinitial(
-    conftest: PytestPluginManager, args, confcutdir: Optional[py.path.local] = None
+    conftest: PytestPluginManager, args, confcutdir: Optional["os.PathLike[str]"] = None
 ) -> None:
     class Namespace:
         def __init__(self) -> None:
             self.file_or_dir = args
-            self.confcutdir = str(confcutdir)
+            self.confcutdir = os.fspath(confcutdir) if confcutdir is not None else None
             self.noconftest = False
             self.pyargs = False
             self.importmode = "prepend"
@@ -42,54 +43,58 @@ def conftest_setinitial(
 @pytest.mark.usefixtures("_sys_snapshot")
 class TestConftestValueAccessGlobal:
     @pytest.fixture(scope="module", params=["global", "inpackage"])
-    def basedir(self, request, tmpdir_factory):
-        tmpdir = tmpdir_factory.mktemp("basedir", numbered=True)
-        tmpdir.ensure("adir/conftest.py").write("a=1 ; Directory = 3")
-        tmpdir.ensure("adir/b/conftest.py").write("b=2 ; a = 1.5")
+    def basedir(
+        self, request, tmp_path_factory: TempPathFactory
+    ) -> Generator[Path, None, None]:
+        tmpdir = tmp_path_factory.mktemp("basedir", numbered=True)
+        tmpdir.joinpath("adir/b").mkdir(parents=True)
+        tmpdir.joinpath("adir/conftest.py").write_text("a=1 ; Directory = 3")
+        tmpdir.joinpath("adir/b/conftest.py").write_text("b=2 ; a = 1.5")
         if request.param == "inpackage":
-            tmpdir.ensure("adir/__init__.py")
-            tmpdir.ensure("adir/b/__init__.py")
+            tmpdir.joinpath("adir/__init__.py").touch()
+            tmpdir.joinpath("adir/b/__init__.py").touch()
 
         yield tmpdir
 
-    def test_basic_init(self, basedir):
+    def test_basic_init(self, basedir: Path) -> None:
         conftest = PytestPluginManager()
-        p = basedir.join("adir")
+        p = basedir / "adir"
         assert conftest._rget_with_confmod("a", p, importmode="prepend")[1] == 1
 
-    def test_immediate_initialiation_and_incremental_are_the_same(self, basedir):
+    def test_immediate_initialiation_and_incremental_are_the_same(
+        self, basedir: Path
+    ) -> None:
         conftest = PytestPluginManager()
         assert not len(conftest._dirpath2confmods)
         conftest._getconftestmodules(basedir, importmode="prepend")
         snap1 = len(conftest._dirpath2confmods)
         assert snap1 == 1
-        conftest._getconftestmodules(basedir.join("adir"), importmode="prepend")
+        conftest._getconftestmodules(basedir / "adir", importmode="prepend")
         assert len(conftest._dirpath2confmods) == snap1 + 1
-        conftest._getconftestmodules(basedir.join("b"), importmode="prepend")
+        conftest._getconftestmodules(basedir / "b", importmode="prepend")
         assert len(conftest._dirpath2confmods) == snap1 + 2
 
-    def test_value_access_not_existing(self, basedir):
+    def test_value_access_not_existing(self, basedir: Path) -> None:
         conftest = ConftestWithSetinitial(basedir)
         with pytest.raises(KeyError):
             conftest._rget_with_confmod("a", basedir, importmode="prepend")
 
-    def test_value_access_by_path(self, basedir):
+    def test_value_access_by_path(self, basedir: Path) -> None:
         conftest = ConftestWithSetinitial(basedir)
-        adir = basedir.join("adir")
+        adir = basedir / "adir"
         assert conftest._rget_with_confmod("a", adir, importmode="prepend")[1] == 1
         assert (
-            conftest._rget_with_confmod("a", adir.join("b"), importmode="prepend")[1]
-            == 1.5
+            conftest._rget_with_confmod("a", adir / "b", importmode="prepend")[1] == 1.5
         )
 
-    def test_value_access_with_confmod(self, basedir):
-        startdir = basedir.join("adir", "b")
-        startdir.ensure("xx", dir=True)
+    def test_value_access_with_confmod(self, basedir: Path) -> None:
+        startdir = basedir / "adir" / "b"
+        startdir.joinpath("xx").mkdir()
         conftest = ConftestWithSetinitial(startdir)
         mod, value = conftest._rget_with_confmod("a", startdir, importmode="prepend")
         assert value == 1.5
         path = py.path.local(mod.__file__)
-        assert path.dirpath() == basedir.join("adir", "b")
+        assert path.dirpath() == basedir / "adir" / "b"
         assert path.purebasename.startswith("conftest")
 
 
@@ -102,12 +107,12 @@ def test_conftest_in_nonpkg_with_init(tmp_path: Path, _sys_snapshot) -> None:
     ConftestWithSetinitial(tmp_path.joinpath("adir-1.0", "b"))
 
 
-def test_doubledash_considered(testdir: Testdir) -> None:
-    conf = testdir.mkdir("--option")
-    conf.join("conftest.py").ensure()
+def test_doubledash_considered(pytester: Pytester) -> None:
+    conf = pytester.mkdir("--option")
+    conf.joinpath("conftest.py").touch()
     conftest = PytestPluginManager()
-    conftest_setinitial(conftest, [conf.basename, conf.basename])
-    values = conftest._getconftestmodules(py.path.local(conf), importmode="prepend")
+    conftest_setinitial(conftest, [conf.name, conf.name])
+    values = conftest._getconftestmodules(conf, importmode="prepend")
     assert len(values) == 1
 
 
@@ -127,15 +132,18 @@ def test_conftest_global_import(pytester: Pytester) -> None:
     pytester.makeconftest("x=3")
     p = pytester.makepyfile(
         """
-        import py, pytest
+        from pathlib import Path
+        import pytest
         from _pytest.config import PytestPluginManager
         conf = PytestPluginManager()
-        mod = conf._importconftest(py.path.local("conftest.py"), importmode="prepend")
+        mod = conf._importconftest(Path("conftest.py"), importmode="prepend")
         assert mod.x == 3
         import conftest
         assert conftest is mod, (conftest, mod)
-        subconf = py.path.local().ensure("sub", "conftest.py")
-        subconf.write("y=4")
+        sub = Path("sub")
+        sub.mkdir()
+        subconf = sub / "conftest.py"
+        subconf.write_text("y=4")
         mod2 = conf._importconftest(subconf, importmode="prepend")
         assert mod != mod2
         assert mod2.y == 4
@@ -147,19 +155,19 @@ def test_conftest_global_import(pytester: Pytester) -> None:
     assert res.ret == 0
 
 
-def test_conftestcutdir(testdir: Testdir) -> None:
-    conf = testdir.makeconftest("")
-    p = testdir.mkdir("x")
+def test_conftestcutdir(pytester: Pytester) -> None:
+    conf = pytester.makeconftest("")
+    p = pytester.mkdir("x")
     conftest = PytestPluginManager()
-    conftest_setinitial(conftest, [testdir.tmpdir], confcutdir=p)
+    conftest_setinitial(conftest, [pytester.path], confcutdir=p)
     values = conftest._getconftestmodules(p, importmode="prepend")
     assert len(values) == 0
-    values = conftest._getconftestmodules(conf.dirpath(), importmode="prepend")
+    values = conftest._getconftestmodules(conf.parent, importmode="prepend")
     assert len(values) == 0
     assert Path(conf) not in conftest._conftestpath2mod
     # but we can still import a conftest directly
     conftest._importconftest(conf, importmode="prepend")
-    values = conftest._getconftestmodules(conf.dirpath(), importmode="prepend")
+    values = conftest._getconftestmodules(conf.parent, importmode="prepend")
     assert values[0].__file__.startswith(str(conf))
     # and all sub paths get updated properly
     values = conftest._getconftestmodules(p, importmode="prepend")
@@ -170,10 +178,8 @@ def test_conftestcutdir(testdir: Testdir) -> None:
 def test_conftestcutdir_inplace_considered(pytester: Pytester) -> None:
     conf = pytester.makeconftest("")
     conftest = PytestPluginManager()
-    conftest_setinitial(conftest, [conf.parent], confcutdir=py.path.local(conf.parent))
-    values = conftest._getconftestmodules(
-        py.path.local(conf.parent), importmode="prepend"
-    )
+    conftest_setinitial(conftest, [conf.parent], confcutdir=conf.parent)
+    values = conftest._getconftestmodules(conf.parent, importmode="prepend")
     assert len(values) == 1
     assert values[0].__file__.startswith(str(conf))
 
@@ -184,7 +190,7 @@ def test_setinitial_conftest_subdirs(pytester: Pytester, name: str) -> None:
     subconftest = sub.joinpath("conftest.py")
     subconftest.touch()
     conftest = PytestPluginManager()
-    conftest_setinitial(conftest, [sub.parent], confcutdir=py.path.local(pytester.path))
+    conftest_setinitial(conftest, [sub.parent], confcutdir=pytester.path)
     key = subconftest.resolve()
     if name not in ("whatever", ".dotdir"):
         assert key in conftest._conftestpath2mod
@@ -337,22 +343,19 @@ def test_conftest_existing_junitxml(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(["*--xyz*"])
 
 
-def test_conftest_import_order(testdir: Testdir, monkeypatch: MonkeyPatch) -> None:
-    ct1 = testdir.makeconftest("")
-    sub = testdir.mkdir("sub")
-    ct2 = sub.join("conftest.py")
-    ct2.write("")
+def test_conftest_import_order(pytester: Pytester, monkeypatch: MonkeyPatch) -> None:
+    ct1 = pytester.makeconftest("")
+    sub = pytester.mkdir("sub")
+    ct2 = sub / "conftest.py"
+    ct2.write_text("")
 
     def impct(p, importmode):
         return p
 
     conftest = PytestPluginManager()
-    conftest._confcutdir = testdir.tmpdir
+    conftest._confcutdir = pytester.path
     monkeypatch.setattr(conftest, "_importconftest", impct)
-    mods = cast(
-        List[py.path.local],
-        conftest._getconftestmodules(py.path.local(sub), importmode="prepend"),
-    )
+    mods = cast(List[Path], conftest._getconftestmodules(sub, importmode="prepend"))
     expected = [ct1, ct2]
     assert mods == expected
 


### PR DESCRIPTION
- Some conftest related functions
- `Config._confcutdir`
- Allow arbitrary `os.PathLike[str]` in `gethookproxy`.