### PR TITLE
Compare also paths on Windows when considering ImportPathMismatchError

### DIFF
--- a/changelog/7678.bugfix.rst
+++ b/changelog/7678.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed bug where ``ImportPathMismatchError`` would be raised for files compiled in
+the host and loaded later from an UNC mounted path (Windows).


### PR DESCRIPTION
On Windows, os.path.samefile returns false for paths mounted in UNC paths which
point to the same location.

I couldn't reproduce the actual case reported, but looking at the code it seems
this commit should fix the issue.

Fix #7678
Fix #8076
