### PR TITLE
tox: remove requires: pip>=20.3.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ envlist =
     py37-freeze
     docs
     docs-checklinks
-requires = pip >= 20.3.1
 
 [testenv]
 commands =


### PR DESCRIPTION
Causes some [trouble in CI](https://github.com/pytest-dev/pytest/issues/8101#issuecomment-743780316) and not really needed as old pip should still work.