### PR TITLE
tox: use pip legacy resolver for regen job

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,9 @@ commands =
 changedir = doc/en
 basepython = python3
 passenv = SETUPTOOLS_SCM_PRETEND_VERSION
+# TODO: When setuptools-scm 5.0.0 is released, use SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTEST
+# and remove the next line.
+install_command=python -m pip --use-deprecated=legacy-resolver install {opts} {packages}
 deps =
     dataclasses
     PyYAML


### PR DESCRIPTION
The env var effects all of the pip installs, including regendoc which
also uses setuptools-scm, so it gets the wrong version, and fails to
install with the new pip resolver:

    ERROR: Requested regendoc from https://files.pythonhosted.org/packages/a8/5d/206e4951420bf5bbe1475c66eb06ec40d9177035e223858fee890eed0188/regendoc-0.6.1.tar.gz#sha256=db1e8c9ae02c1af559eae105bfd77ba41ed07fc8ca7030ea59db5f3f161236a4 has different version in metadata: '6.2.0'