### PR TITLE
terminal: when the skip/xfail is empty, don't show it as "()"

### DIFF
--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -554,7 +554,7 @@ class TerminalReporter:
                     )
                     reason = _get_raw_skip_reason(rep)
                     reason_ = _format_trimmed(" ({})", reason, available_width)
-                    if reason_ is not None:
+                    if reason and reason_ is not None:
                         self._tw.write(reason_)
                 if self._show_progress_info:
                     self._write_progress_information_filling_space()

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -362,6 +362,10 @@ class TestTerminal:
             @pytest.mark.xfail(reason="789")
             def test_3():
                 assert False
+
+            @pytest.mark.xfail(reason="")
+            def test_4():
+                assert False
         """
         )
         result = pytester.runpytest("-v")
@@ -370,6 +374,7 @@ class TestTerminal:
                 "test_verbose_skip_reason.py::test_1 SKIPPED (123) *",
                 "test_verbose_skip_reason.py::test_2 XPASS (456) *",
                 "test_verbose_skip_reason.py::test_3 XFAIL (789) *",
+                "test_verbose_skip_reason.py::test_4 XFAIL  *",
             ]
         )
 


### PR DESCRIPTION
Avoid showing the `()` in a line like

    x.py::test_4 XPASS ()   [100%]

which looks funny.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
