### PR TITLE
doc: temporary workaround for pytest-pygments lexing error

### DIFF
--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -947,7 +947,7 @@ Example:
 
 Running this test will *skip* the invocation of ``data_set`` with value ``2``:
 
-.. code-block:: pytest
+.. code-block::
 
     $ pytest test_fixture_marks.py -v
     =========================== test session starts ============================


### PR DESCRIPTION
pytest-pygments doesn't yet recognize the skip reason in summary line added recently. Workaround it until we get to updating it.

Ref: https://github.com/asottile/pygments-pytest/issues/28