### PR TITLE
fixes #8133: migrate to setuptools_scm 6.x 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -222,7 +222,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --upgrade wheel setuptools tox
+        pip install --upgrade wheel setuptools setuptools_scm[toml]>=6 tox
 
     - name: Build package
       run: |

--- a/changelog/8133.trivial.rst
+++ b/changelog/8133.trivial.rst
@@ -1,0 +1,1 @@
+Migrate to setuptools_scm 6.x to use SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTEST for more robust release tooling.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
   # sync with setup.py until we discard non-pep-517/518
-  "setuptools>=42.0",
-  "setuptools-scm[toml]>=3.4",
+  "setuptools>=45.0",
+  "setuptools-scm[toml]>=6.2.3",
   "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -63,7 +63,7 @@ def regen(version):
     print(f"{Fore.CYAN}[generate.regen] {Fore.RESET}Updating docs")
     check_call(
         ["tox", "-e", "regen"],
-        env={**os.environ, "SETUPTOOLS_SCM_PRETEND_VERSION": version},
+        env={**os.environ, "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTEST": version},
     )
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,8 +55,8 @@ python_requires = >=3.6
 package_dir =
     =src
 setup_requires =
-    setuptools>=42.0
-    setuptools-scm>=3.4
+    setuptools
+    setuptools-scm>=6.0
 zip_safe = no
 
 [options.entry_points]

--- a/tox.ini
+++ b/tox.ini
@@ -17,13 +17,15 @@ envlist =
     docs
     docs-checklinks
 
+
+
 [testenv]
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest {posargs:{env:_PYTEST_TOX_DEFAULT_POSARGS:}}
     doctesting: {env:_PYTEST_TOX_COVERAGE_RUN:} pytest --doctest-modules --pyargs _pytest
     coverage: coverage combine
     coverage: coverage report -m
-passenv = USER USERNAME COVERAGE_* PYTEST_ADDOPTS TERM
+passenv = USER USERNAME COVERAGE_* PYTEST_ADDOPTS TERM SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTEST
 setenv =
     _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_POSARGS_DOCTESTING:} {env:_PYTEST_TOX_POSARGS_LSOF:} {env:_PYTEST_TOX_POSARGS_XDIST:}
 
@@ -83,10 +85,7 @@ commands =
 [testenv:regen]
 changedir = doc/en
 basepython = python3
-passenv = SETUPTOOLS_SCM_PRETEND_VERSION
-# TODO: When setuptools-scm 5.0.0 is released, use SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTEST
-# and remove the next line.
-install_command=python -m pip --use-deprecated=legacy-resolver install {opts} {packages}
+passenv = SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTEST
 deps =
     dataclasses
     PyYAML
@@ -112,8 +111,6 @@ changedir = testing/plugins_integration
 deps = -rtesting/plugins_integration/requirements.txt
 setenv =
     PYTHONPATH=.
-    # due to pytest-rerunfailures requiring 6.2+; can be removed after 6.2.0
-    SETUPTOOLS_SCM_PRETEND_VERSION=6.2.0a1
 commands =
     pip check
     pytest bdd_wallet.py
@@ -179,6 +176,7 @@ extend-ignore =
     D302
     ; Docstring Content Issues
     D400,D401,D401,D402,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414,D415,D416,D417
+
 
 [isort]
 ; This config mimics what reorder-python-imports does.


### PR DESCRIPTION
and use SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTEST

fixes #8133 
