### PR TITLE
Use duck-typing to check for non-numeric types in approx()

### DIFF
--- a/changelog/8132.bugfix.rst
+++ b/changelog/8132.bugfix.rst
@@ -1,0 +1,6 @@
+Fixed regression in ``approx``: in 6.2.0 ``approx`` no longer raises
+``TypeError`` when dealing with non-numeric types, falling back to normal comparison,
+however the check was done using ``isinstance`` which left out types which implemented
+the necessary methods for ``approx`` to work, such as tensorflow's ``DeviceArray``.
+
+The code has been changed to check for the necessary methods to accommodate those cases.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -241,12 +241,17 @@ class ApproxScalar(ApproxBase):
         if actual == self.expected:
             return True
 
-        # If either type is non-numeric, fall back to strict equality.
-        # NB: we need Complex, rather than just Number, to ensure that __abs__,
-        # __sub__, and __float__ are defined.
+        # Check types are non-numeric using duck-typing; if they are not numeric types,
+        # we consider them unequal because the short-circuit above failed.
+        required_attrs = [
+            "__abs__",
+            "__float__",
+            "__rsub__",
+            "__sub__",
+        ]
         if not (
-            isinstance(self.expected, (Complex, Decimal))
-            and isinstance(actual, (Complex, Decimal))
+            all(hasattr(self.expected, attr) for attr in required_attrs)
+            and all(hasattr(actual, attr) for attr in required_attrs)
         ):
             return False
 


### PR DESCRIPTION
Fix #8132
