### PR TITLE
python_api: handle array-like args in approx()

### DIFF
--- a/changelog/8132.bugfix.rst
+++ b/changelog/8132.bugfix.rst
@@ -1,0 +1,10 @@
+Fixed regression in ``approx``: in 6.2.0 ``approx`` no longer raises
+``TypeError`` when dealing with non-numeric types, falling back to normal comparison.
+Before 6.2.0, array types like tf.DeviceArray fell through to the scalar case,
+and happened to compare correctly to a scalar if they had only one element.
+After 6.2.0, these types began failing, because they inherited neither from
+standard Python number hierarchy nor from ``numpy.ndarray``.
+
+``approx`` now converts arguments to ``numpy.ndarray`` if they expose the array
+protocol and are not scalars. This treats array-like objects like numpy arrays,
+regardless of size.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -543,26 +543,18 @@ def approx(expected, rel=None, abs=None, nan_ok: bool = False) -> ApproxBase:
 
 
 def _is_numpy_array(obj: object) -> bool:
-    """Return true if the given object is implicitly convertible to numpy array.
-
-    A special effort is made to avoid importing numpy unless it's really necessary.
     """
-    import sys
-
-    np: Any = sys.modules.get("numpy")
-    if np is not None:
-        # avoid infinite recursion on numpy scalars, which have __array__
-        if np.isscalar(obj):
-            return False
-        elif isinstance(obj, np.ndarray):
-            return True
-        elif hasattr(obj, "__array__") or hasattr("obj", "__array_interface__"):
-            return True
-    return False
+    Return true if the given object is implicitly convertible to ndarray,
+    and numpy is already imported.
+    """
+    return _as_numpy_array(obj) is not None
 
 
 def _as_numpy_array(obj: object) -> Optional["ndarray"]:
-    """Return an ndarray if obj is implicitly convertible, and numpy is already imported."""
+    """
+    Return an ndarray if the given object is implicitly convertible to ndarray,
+    and numpy is already imported, otherwise None.
+    """
     import sys
 
     np: Any = sys.modules.get("numpy")

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -447,6 +447,36 @@ class TestApprox:
         assert a12 != approx(a21)
         assert a21 != approx(a12)
 
+    def test_numpy_array_protocol(self):
+        """
+        array-like objects such as tensorflow's DeviceArray are handled like ndarray.
+        See issue #8132
+        """
+        np = pytest.importorskip("numpy")
+
+        class DeviceArray:
+            def __init__(self, value, size):
+                self.value = value
+                self.size = size
+
+            def __array__(self):
+                return self.value * np.ones(self.size)
+
+        class DeviceScalar:
+            def __init__(self, value):
+                self.value = value
+
+            def __array__(self):
+                return np.array(self.value)
+
+        expected = 1
+        actual = 1 + 1e-6
+        assert approx(expected) == DeviceArray(actual, size=1)
+        assert approx(expected) == DeviceArray(actual, size=2)
+        assert approx(expected) == DeviceScalar(actual)
+        assert approx(DeviceScalar(expected)) == actual
+        assert approx(DeviceScalar(expected)) == DeviceScalar(actual)
+
     def test_doctests(self, mocked_doctest_runner) -> None:
         import doctest
 


### PR DESCRIPTION
This treats objects that expose an ndarray via the `__array__` interface the
same as direct subclasses of ndarray. Fixes #8132.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
