### PR TITLE
terminal: fix "(<Skipped instance>)" skip reason in test status line

### DIFF
--- a/changelog/8152.bugfix.rst
+++ b/changelog/8152.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed "(<Skipped instance>)" being shown as a skip reason in the verbose test summary line when the reason is empty.

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -38,7 +38,7 @@ class OutcomeException(BaseException):
         self.pytrace = pytrace
 
     def __repr__(self) -> str:
-        if self.msg:
+        if self.msg is not None:
             return self.msg
         return f"<{self.__class__.__name__} instance>"
 

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1403,4 +1403,6 @@ def _get_raw_skip_reason(report: TestReport) -> str:
         _, _, reason = report.longrepr
         if reason.startswith("Skipped: "):
             reason = reason[len("Skipped: ") :]
+        elif reason == "Skipped":
+            reason = ""
         return reason

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -366,6 +366,26 @@ class TestTerminal:
             @pytest.mark.xfail(reason="")
             def test_4():
                 assert False
+
+            @pytest.mark.skip
+            def test_5():
+                pass
+
+            @pytest.mark.xfail
+            def test_6():
+                pass
+
+            def test_7():
+                pytest.skip()
+
+            def test_8():
+                pytest.skip("888 is great")
+
+            def test_9():
+                pytest.xfail()
+
+            def test_10():
+                pytest.xfail("It's 🕙 o'clock")
         """
         )
         result = pytester.runpytest("-v")
@@ -375,6 +395,12 @@ class TestTerminal:
                 "test_verbose_skip_reason.py::test_2 XPASS (456) *",
                 "test_verbose_skip_reason.py::test_3 XFAIL (789) *",
                 "test_verbose_skip_reason.py::test_4 XFAIL  *",
+                "test_verbose_skip_reason.py::test_5 SKIPPED (unconditional skip) *",
+                "test_verbose_skip_reason.py::test_6 XPASS  *",
+                "test_verbose_skip_reason.py::test_7 SKIPPED  *",
+                "test_verbose_skip_reason.py::test_8 SKIPPED (888 is great) *",
+                "test_verbose_skip_reason.py::test_9 XFAIL  *",
+                "test_verbose_skip_reason.py::test_10 XFAIL (It's 🕙 o'clock) *",
             ]
         )
 


### PR DESCRIPTION
Noticed this issue in the new 6.2 feature. The following test when run with `pytest -v`

```py
import pytest

def test_it():
    pytest.skip()
```

would show

```
x.py::test_it SKIPPED (<Skipped instance>)                [100%]
```