### PR TITLE
Remove Travis references

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,9 +20,6 @@
     :target: https://codecov.io/gh/pytest-dev/pytest
     :alt: Code coverage Status
 
-.. image:: https://travis-ci.org/pytest-dev/pytest.svg?branch=master
-    :target: https://travis-ci.org/pytest-dev/pytest
-
 .. image:: https://github.com/pytest-dev/pytest/workflows/main/badge.svg
     :target: https://github.com/pytest-dev/pytest/actions?query=workflow%3Amain
 

--- a/scripts/append_codecov_token.py
+++ b/scripts/append_codecov_token.py
@@ -1,8 +1,8 @@
 """
 Appends the codecov token to the 'codecov.yml' file at the root of the repository.
 
-This is done by CI during PRs and builds on the pytest-dev repository so we can upload coverage, at least
-until codecov grows some native integration like it has with Travis and AppVeyor.
+This is done by CI during PRs and builds on the pytest-dev repository so we can
+upload coverage, at least until codecov grows some native integration with GitHub Actions.
 
 See discussion in https://github.com/pytest-dev/pytest/pull/6441 for more information.
 """

--- a/scripts/publish-gh-release-notes.py
+++ b/scripts/publish-gh-release-notes.py
@@ -1,7 +1,7 @@
 """
 Script used to publish GitHub release notes extracted from CHANGELOG.rst.
 
-This script is meant to be executed after a successful deployment in Travis.
+This script is meant to be executed after a successful deployment in GitHub actions.
 
 Uses the following environment variables:
 
@@ -12,11 +12,8 @@ Uses the following environment variables:
 
     https://github.com/settings/tokens
 
-  It should be encrypted using:
-
-    $travis encrypt GH_RELEASE_NOTES_TOKEN=<token> -r pytest-dev/pytest
-
-  And the contents pasted in the ``deploy.env.secure`` section in the ``travis.yml`` file.
+  This token should be set in a secret in the repository, which is exposed as an
+  environment variable in the main.yml workflow file.
 
 The script also requires ``pandoc`` to be previously installed in the system.
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 isolated_build = True
 minversion = 3.20.0
 distshare = {homedir}/.tox/distshare
-# make sure to update environment list in travis.yml and appveyor.yml
 envlist =
     linting
     py36
@@ -23,7 +22,7 @@ commands =
     doctesting: {env:_PYTEST_TOX_COVERAGE_RUN:} pytest --doctest-modules --pyargs _pytest
     coverage: coverage combine
     coverage: coverage report -m
-passenv = USER USERNAME COVERAGE_* TRAVIS PYTEST_ADDOPTS TERM
+passenv = USER USERNAME COVERAGE_* PYTEST_ADDOPTS TERM
 setenv =
     _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_POSARGS_DOCTESTING:} {env:_PYTEST_TOX_POSARGS_LSOF:} {env:_PYTEST_TOX_POSARGS_XDIST:}
 


### PR DESCRIPTION
Since we stopped testing Python 3.5, we no longer use Travis.
