### PR TITLE
mark: expose Mark, MarkDecorator, MarkGenerator under pytest for typing purposes

### DIFF
--- a/changelog/7469.deprecation.rst
+++ b/changelog/7469.deprecation.rst
@@ -2,5 +2,6 @@ Directly constructing the following classes is now deprecated:
 
 - ``_pytest.mark.structures.Mark``
 - ``_pytest.mark.structures.MarkDecorator``
+- ``_pytest.mark.structures.MarkGenerator``
 
 These have always been considered private, but now issue a deprecation warning, which may become a hard error in pytest 7.0.0.

--- a/changelog/7469.deprecation.rst
+++ b/changelog/7469.deprecation.rst
@@ -1,0 +1,5 @@
+Directly constructing the following classes is now deprecated:
+
+- ``_pytest.mark.structures.Mark``
+
+These have always been considered private, but now issue a deprecation warning, which may become a hard error in pytest 7.0.0.

--- a/changelog/7469.deprecation.rst
+++ b/changelog/7469.deprecation.rst
@@ -1,5 +1,6 @@
 Directly constructing the following classes is now deprecated:
 
 - ``_pytest.mark.structures.Mark``
+- ``_pytest.mark.structures.MarkDecorator``
 
 These have always been considered private, but now issue a deprecation warning, which may become a hard error in pytest 7.0.0.

--- a/changelog/7469.feature.rst
+++ b/changelog/7469.feature.rst
@@ -4,6 +4,7 @@ The newly-exported types are:
 
 - ``pytest.Mark`` for :class:`marks <pytest.Mark>`.
 - ``pytest.MarkDecorator`` for :class:`mark decorators <pytest.MarkDecorator>`.
+- ``pytest.MarkGenerator`` for the :class:`pytest.mark <pytest.MarkGenerator>` singleton.
 
 Constructing them directly is not supported; they are only meant for use in type annotations.
 Doing so will emit a deprecation warning, and may become a hard-error in pytest 7.0.

--- a/changelog/7469.feature.rst
+++ b/changelog/7469.feature.rst
@@ -1,0 +1,10 @@
+The types of objects used in pytest's API are now exported so they may be used in type annotations.
+
+The newly-exported types are:
+
+- ``pytest.Mark`` for :class:`marks <pytest.Mark>`.
+
+Constructing them directly is not supported; they are only meant for use in type annotations.
+Doing so will emit a deprecation warning, and may become a hard-error in pytest 7.0.
+
+Subclassing them is also not supported. This is not currently enforced at runtime, but is detected by type-checkers such as mypy.

--- a/changelog/7469.feature.rst
+++ b/changelog/7469.feature.rst
@@ -3,6 +3,7 @@ The types of objects used in pytest's API are now exported so they may be used i
 The newly-exported types are:
 
 - ``pytest.Mark`` for :class:`marks <pytest.Mark>`.
+- ``pytest.MarkDecorator`` for :class:`mark decorators <pytest.MarkDecorator>`.
 
 Constructing them directly is not supported; they are only meant for use in type annotations.
 Doing so will emit a deprecation warning, and may become a hard-error in pytest 7.0.

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -849,7 +849,7 @@ Item
 MarkDecorator
 ~~~~~~~~~~~~~
 
-.. autoclass:: _pytest.mark.MarkDecorator
+.. autoclass:: pytest.MarkDecorator()
     :members:
 
 

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -239,7 +239,7 @@ For example:
     def test_function():
         ...
 
-Will create and attach a :class:`Mark <_pytest.mark.structures.Mark>` object to the collected
+Will create and attach a :class:`Mark <pytest.Mark>` object to the collected
 :class:`Item <pytest.Item>`, which can then be accessed by fixtures or hooks with
 :meth:`Node.iter_markers <_pytest.nodes.Node.iter_markers>`. The ``mark`` object will have the following attributes:
 
@@ -863,7 +863,7 @@ MarkGenerator
 Mark
 ~~~~
 
-.. autoclass:: _pytest.mark.structures.Mark
+.. autoclass:: pytest.Mark()
     :members:
 
 

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -856,7 +856,7 @@ MarkDecorator
 MarkGenerator
 ~~~~~~~~~~~~~
 
-.. autoclass:: _pytest.mark.MarkGenerator
+.. autoclass:: pytest.MarkGenerator()
     :members:
 
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -551,7 +551,7 @@ class FixtureRequest:
         on all function invocations.
 
         :param marker:
-            A :py:class:`_pytest.mark.MarkDecorator` object created by a call
+            A :class:`pytest.MarkDecorator` object created by a call
             to ``pytest.mark.NAME(...)``.
         """
         self.node.add_marker(marker)

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -488,9 +488,6 @@ class MarkGenerator:
     applies a 'slowtest' :class:`Mark` on ``test_function``.
     """
 
-    _config: Optional[Config] = None
-    _markers: Set[str] = set()
-
     # See TYPE_CHECKING above.
     if TYPE_CHECKING:
         skip: _SkipMarkDecorator
@@ -500,7 +497,13 @@ class MarkGenerator:
         usefixtures: _UsefixturesMarkDecorator
         filterwarnings: _FilterwarningsMarkDecorator
 
+    def __init__(self, *, _ispytest: bool = False) -> None:
+        check_ispytest(_ispytest)
+        self._config: Optional[Config] = None
+        self._markers: Set[str] = set()
+
     def __getattr__(self, name: str) -> MarkDecorator:
+        """Generate a new :class:`MarkDecorator` with the given name."""
         if name[0] == "_":
             raise AttributeError("Marker name must NOT start with underscore")
 
@@ -541,7 +544,7 @@ class MarkGenerator:
         return MarkDecorator(Mark(name, (), {}, _ispytest=True), _ispytest=True)
 
 
-MARK_GEN = MarkGenerator()
+MARK_GEN = MarkGenerator(_ispytest=True)
 
 
 @final

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -24,6 +24,7 @@ from _pytest.main import Session
 from _pytest.mark import Mark
 from _pytest.mark import MARK_GEN as mark
 from _pytest.mark import MarkDecorator
+from _pytest.mark import MarkGenerator
 from _pytest.mark import param
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.nodes import Collector
@@ -93,6 +94,7 @@ __all__ = [
     "mark",
     "Mark",
     "MarkDecorator",
+    "MarkGenerator",
     "Module",
     "MonkeyPatch",
     "Package",

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -21,6 +21,7 @@ from _pytest.fixtures import yield_fixture
 from _pytest.freeze_support import freeze_includes
 from _pytest.logging import LogCaptureFixture
 from _pytest.main import Session
+from _pytest.mark import Mark
 from _pytest.mark import MARK_GEN as mark
 from _pytest.mark import param
 from _pytest.monkeypatch import MonkeyPatch
@@ -89,6 +90,7 @@ __all__ = [
     "LogCaptureFixture",
     "main",
     "mark",
+    "Mark",
     "Module",
     "MonkeyPatch",
     "Package",

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -23,6 +23,7 @@ from _pytest.logging import LogCaptureFixture
 from _pytest.main import Session
 from _pytest.mark import Mark
 from _pytest.mark import MARK_GEN as mark
+from _pytest.mark import MarkDecorator
 from _pytest.mark import param
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.nodes import Collector
@@ -91,6 +92,7 @@ __all__ = [
     "main",
     "mark",
     "Mark",
+    "MarkDecorator",
     "Module",
     "MonkeyPatch",
     "Package",

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -21,7 +21,7 @@ class TestMark:
         assert attr in module.__all__  # type: ignore
 
     def test_pytest_mark_notcallable(self) -> None:
-        mark = MarkGenerator()
+        mark = MarkGenerator(_ispytest=True)
         with pytest.raises(TypeError):
             mark()  # type: ignore[operator]
 
@@ -40,7 +40,7 @@ class TestMark:
         assert pytest.mark.foo.with_args(SomeClass) is not SomeClass  # type: ignore[comparison-overlap]
 
     def test_pytest_mark_name_starts_with_underscore(self) -> None:
-        mark = MarkGenerator()
+        mark = MarkGenerator(_ispytest=True)
         with pytest.raises(AttributeError):
             mark._some_name
 


### PR DESCRIPTION
This is part of #7469, please see details there. Similar to previous PR #8017 that went in 6.1; haven't seen any complaints about it yet.