### PR TITLE
Revert "doc: temporary workaround for pytest-pygments lexing error"

### DIFF
--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -1975,7 +1975,7 @@ Example:
 
 Running this test will *skip* the invocation of ``data_set`` with value ``2``:
 
-.. code-block::
+.. code-block:: pytest
 
     $ pytest test_fixture_marks.py -v
     =========================== test session starts ============================

--- a/doc/en/requirements.txt
+++ b/doc/en/requirements.txt
@@ -1,5 +1,5 @@
 pallets-sphinx-themes
-pygments-pytest>=1.1.0
+pygments-pytest>=2.2.0
 sphinx-removed-in>=0.2.0
 sphinx>=3.1,<4
 sphinxcontrib-trio


### PR DESCRIPTION
Reverts #8129.

@asottile added support in pytest-pygments 2.2.0.

Tested with `tox -e regen && tox -e docs`.