### PR TITLE
Add missing space in '--version' help message

### DIFF
--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -51,7 +51,7 @@ def pytest_addoption(parser: Parser) -> None:
         action="count",
         default=0,
         dest="version",
-        help="display pytest version and information about plugins."
+        help="display pytest version and information about plugins. "
         "When given twice, also display information about plugins.",
     )
     group._addoption(

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -28,6 +28,9 @@ def test_help(pytester: Pytester) -> None:
                                 For example: -m 'mark1 and not mark2'.
         reporting:
           --durations=N *
+          -V, --version         display pytest version and information about plugins.
+                                When given twice, also display information about
+                                plugins.
         *setup.cfg*
         *minversion*
         *to see*markers*pytest --markers*


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Previously:

```
  -V, --version         display pytest version and information about plugins.When given twice, also
                        display information about plugins.
```