### PR TITLE
Fix failing staticmethod tests if they are inherited

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,6 +29,7 @@ Andy Freeland
 Anthon van der Neut
 Anthony Shaw
 Anthony Sottile
+Anton Grinevich
 Anton Lodder
 Antony Lee
 Arel Cordero

--- a/changelog/8061.bugfix.rst
+++ b/changelog/8061.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed failing staticmethod test cases if they are inherited from a parent test class.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -162,7 +162,7 @@ def getfuncargnames(
     # it's passed as an unbound method or function, remove the first
     # parameter name.
     if is_method or (
-        cls and not isinstance(cls.__dict__.get(name, None), staticmethod)
+        cls and not isinstance(inspect.getattr_static(cls, name), staticmethod)
     ):
         arg_names = arg_names[1:]
     # Remove any names that will be replaced with mocks.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -162,7 +162,12 @@ def getfuncargnames(
     # it's passed as an unbound method or function, remove the first
     # parameter name.
     if is_method or (
-        cls and not isinstance(inspect.getattr_static(cls, name), staticmethod)
+        # Not using `getattr` because we don't want to resolve the staticmethod.
+        # Not using `cls.__dict__` because we want to check the entire MRO.
+        cls
+        and not isinstance(
+            inspect.getattr_static(cls, name, default=None), staticmethod
+        )
     ):
         arg_names = arg_names[1:]
     # Remove any names that will be replaced with mocks.

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -59,6 +59,20 @@ def test_getfuncargnames_staticmethod():
     assert getfuncargnames(A.static, cls=A) == ("arg1", "arg2")
 
 
+def test_getfuncargnames_staticmethod_inherited() -> None:
+    """Test getfuncargnames for inherited staticmethods (#8061)"""
+
+    class A:
+        @staticmethod
+        def static(arg1, arg2, x=1):
+            raise NotImplementedError()
+
+    class B(A):
+        pass
+
+    assert getfuncargnames(B.static, cls=B) == ("arg1", "arg2")
+
+
 def test_getfuncargnames_partial():
     """Check getfuncargnames for methods defined with functools.partial (#5701)"""
     import functools


### PR DESCRIPTION
Fixes #8061 

[inspect.getattr_static()](https://docs.python.org/3/library/inspect.html#inspect.getattr_static) (since python 3.2) seem to work better than `cls.__dict__.get()` here (if i don't miss anything). 
 
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
