### PR TITLE
DOC: Update multiple references to testdir to pytester

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -324,20 +324,20 @@ Here is a simple overview, with pytest-specific bits:
 Writing Tests
 ~~~~~~~~~~~~~
 
-Writing tests for plugins or for pytest itself is often done using the `testdir fixture <https://docs.pytest.org/en/stable/reference.html#testdir>`_, as a "black-box" test.
+Writing tests for plugins or for pytest itself is often done using the `pytester fixture <https://docs.pytest.org/en/stable/reference.html#pytester>`_, as a "black-box" test.
 
 For example, to ensure a simple test passes you can write:
 
 .. code-block:: python
 
-    def test_true_assertion(testdir):
-        testdir.makepyfile(
+    def test_true_assertion(pytester):
+        pytester.makepyfile(
             """
             def test_foo():
                 assert True
         """
         )
-        result = testdir.runpytest()
+        result = pytester.runpytest()
         result.assert_outcomes(failed=0, passed=1)
 
 
@@ -346,14 +346,14 @@ Alternatively, it is possible to make checks based on the actual output of the t
 
 .. code-block:: python
 
-    def test_true_assertion(testdir):
-        testdir.makepyfile(
+    def test_true_assertion(pytester):
+        pytester.makepyfile(
             """
             def test_foo():
                 assert False
         """
         )
-        result = testdir.runpytest()
+        result = pytester.runpytest()
         result.stdout.fnmatch_lines(["*assert False*", "*1 failed*"])
 
 When choosing a file where to write a new test, take a look at the existing files and see if there's

--- a/doc/en/writing_plugins.rst
+++ b/doc/en/writing_plugins.rst
@@ -337,7 +337,7 @@ testing directory:
 Alternatively you can invoke pytest with the ``-p pytester`` command line
 option.
 
-This will allow you to use the :py:class:`testdir <_pytest.pytester.Testdir>`
+This will allow you to use the :py:class:`pytester <_pytest.pytester.Pytester>`
 fixture for testing your plugin code.
 
 Let's demonstrate what you can do with the plugin with an example. Imagine we
@@ -374,17 +374,17 @@ string value of ``Hello World!`` if we do not supply a value or ``Hello
         return _hello
 
 
-Now the ``testdir`` fixture provides a convenient API for creating temporary
+Now the ``pytester`` fixture provides a convenient API for creating temporary
 ``conftest.py`` files and test files. It also allows us to run the tests and
 return a result object, with which we can assert the tests' outcomes.
 
 .. code-block:: python
 
-    def test_hello(testdir):
+    def test_hello(pytester):
         """Make sure that our plugin works."""
 
         # create a temporary conftest.py file
-        testdir.makeconftest(
+        pytester.makeconftest(
             """
             import pytest
 
@@ -399,7 +399,7 @@ return a result object, with which we can assert the tests' outcomes.
         )
 
         # create a temporary pytest test file
-        testdir.makepyfile(
+        pytester.makepyfile(
             """
             def test_hello_default(hello):
                 assert hello() == "Hello World!"
@@ -410,7 +410,7 @@ return a result object, with which we can assert the tests' outcomes.
         )
 
         # run all tests with pytest
-        result = testdir.runpytest()
+        result = pytester.runpytest()
 
         # check that all 4 tests passed
         result.assert_outcomes(passed=4)
@@ -430,9 +430,9 @@ Additionally it is possible to copy examples for an example folder before runnin
     # content of test_example.py
 
 
-    def test_plugin(testdir):
-        testdir.copy_example("test_example.py")
-        testdir.runpytest("-k", "test_example")
+    def test_plugin(pytester):
+        pytester.copy_example("test_example.py")
+        pytester.runpytest("-k", "test_example")
 
 
     def test_example():


### PR DESCRIPTION
In https://docs.pytest.org/en/stable/reference.html#testdir, it is
suggested:

> New code should avoid using testdir in favor of pytester.

Multiple spots in the documents still use testdir and they can be quite
confusing (especially the plugin writing guide).

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
