### PR TITLE
runner: refactor SetupState

### DIFF
--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -372,6 +372,7 @@ def _fill_fixtures_impl(function: "Function") -> None:
         fi = fm.getfixtureinfo(function.parent, function.obj, None)
         function._fixtureinfo = fi
         request = function._request = FixtureRequest(function, _ispytest=True)
+        fm.session._setupstate.prepare(function)
         request._fillfixtures()
         # Prune out funcargs for jstests.
         newfuncargs = {}

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -544,8 +544,8 @@ class FixtureRequest:
         self._addfinalizer(finalizer, scope=self.scope)
 
     def _addfinalizer(self, finalizer: Callable[[], object], scope) -> None:
-        item = self._getscopeitem(scope)
-        item.addfinalizer(finalizer)
+        node = self._getscopeitem(scope)
+        node.addfinalizer(finalizer)
 
     def applymarker(self, marker: Union[str, MarkDecorator]) -> None:
         """Apply a marker to a single test function invocation.

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -438,9 +438,6 @@ class SetupState:
 
     def _pop_and_teardown(self) -> None:
         colitem = self.stack.pop()
-        self._teardown_with_finalization(colitem)
-
-    def _callfinalizers(self, colitem: Node) -> None:
         finalizers = self._finalizers.pop(colitem, None)
         exc = None
         while finalizers:
@@ -454,9 +451,6 @@ class SetupState:
                     exc = e
         if exc:
             raise exc
-
-    def _teardown_with_finalization(self, colitem: Node) -> None:
-        self._callfinalizers(colitem)
         colitem.teardown()
         for colitem in self._finalizers:
             assert colitem in self.stack

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -422,7 +422,7 @@ class SetupState:
         needed_collectors = colitem.listchain()
         for col in needed_collectors[len(self.stack) :]:
             assert col not in self.stack
-            self.stack[col] = []
+            self.stack[col] = [col.teardown]
             try:
                 col.setup()
             except TEST_OUTCOME as e:
@@ -443,7 +443,6 @@ class SetupState:
             if list(self.stack.keys()) == needed_collectors[: len(self.stack)]:
                 break
             colitem, finalizers = self.stack.popitem()
-            finalizers.insert(0, colitem.teardown)
             while finalizers:
                 fin = finalizers.pop()
                 try:

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -434,8 +434,8 @@ class SetupState:
         """Attach a finalizer to the given colitem."""
         assert colitem and not isinstance(colitem, tuple)
         assert callable(finalizer)
-        # assert colitem in self.stack  # some unit tests don't setup stack :/
-        self._finalizers.setdefault(colitem, []).append(finalizer)
+        assert colitem in self.stack, (colitem, self.stack)
+        self._finalizers[colitem].append(finalizer)
 
     def teardown_exact(self, nextitem: Optional[Item]) -> None:
         needed_collectors = nextitem and nextitem.listchain() or []

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -443,29 +443,20 @@ class SetupState:
         while self.stack:
             if self.stack == needed_collectors[: len(self.stack)]:
                 break
-            try:
-                colitem = self.stack.pop()
-                finalizers = self._finalizers.pop(colitem)
-                finalizers.insert(0, colitem.teardown)
-                inner_exc = None
-                while finalizers:
-                    fin = finalizers.pop()
-                    try:
-                        fin()
-                    except TEST_OUTCOME as e:
-                        # XXX Only first exception will be seen by user,
-                        #     ideally all should be reported.
-                        if inner_exc is None:
-                            inner_exc = e
-                for colitem in self._finalizers:
-                    assert colitem in self.stack
-                if inner_exc:
-                    raise inner_exc
-            except TEST_OUTCOME as e:
-                # XXX Only first exception will be seen by user,
-                #     ideally all should be reported.
-                if exc is None:
-                    exc = e
+            colitem = self.stack.pop()
+            finalizers = self._finalizers.pop(colitem)
+            finalizers.insert(0, colitem.teardown)
+            while finalizers:
+                fin = finalizers.pop()
+                try:
+                    fin()
+                except TEST_OUTCOME as e:
+                    # XXX Only first exception will be seen by user,
+                    #     ideally all should be reported.
+                    if exc is None:
+                        exc = e
+            for colitem in self._finalizers:
+                assert colitem in self.stack
         if exc:
             raise exc
         if nextitem is None:

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -403,22 +403,22 @@ def pytest_make_collect_report(collector: Collector) -> CollectReport:
 class SetupState:
     """Shared state for setting up/tearing down test items or collectors."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.stack: List[Node] = []
         self._finalizers: Dict[Node, List[Callable[[], object]]] = {}
 
-    def addfinalizer(self, finalizer: Callable[[], object], colitem) -> None:
+    def addfinalizer(self, finalizer: Callable[[], object], colitem: Node) -> None:
         """Attach a finalizer to the given colitem."""
         assert colitem and not isinstance(colitem, tuple)
         assert callable(finalizer)
         # assert colitem in self.stack  # some unit tests don't setup stack :/
         self._finalizers.setdefault(colitem, []).append(finalizer)
 
-    def _pop_and_teardown(self):
+    def _pop_and_teardown(self) -> None:
         colitem = self.stack.pop()
         self._teardown_with_finalization(colitem)
 
-    def _callfinalizers(self, colitem) -> None:
+    def _callfinalizers(self, colitem: Node) -> None:
         finalizers = self._finalizers.pop(colitem, None)
         exc = None
         while finalizers:
@@ -433,7 +433,7 @@ class SetupState:
         if exc:
             raise exc
 
-    def _teardown_with_finalization(self, colitem) -> None:
+    def _teardown_with_finalization(self, colitem: Node) -> None:
         self._callfinalizers(colitem)
         colitem.teardown()
         for colitem in self._finalizers:
@@ -446,11 +446,11 @@ class SetupState:
             self._teardown_with_finalization(key)
         assert not self._finalizers
 
-    def teardown_exact(self, item, nextitem) -> None:
+    def teardown_exact(self, item: Item, nextitem: Optional[Item]) -> None:
         needed_collectors = nextitem and nextitem.listchain() or []
         self._teardown_towards(needed_collectors)
 
-    def _teardown_towards(self, needed_collectors) -> None:
+    def _teardown_towards(self, needed_collectors: List[Node]) -> None:
         exc = None
         while self.stack:
             if self.stack == needed_collectors[: len(self.stack)]:
@@ -465,7 +465,7 @@ class SetupState:
         if exc:
             raise exc
 
-    def prepare(self, colitem) -> None:
+    def prepare(self, colitem: Item) -> None:
         """Setup objects along the collector chain to the test-method."""
 
         # Check if the last collection node has raised an error.

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -422,8 +422,10 @@ class SetupState:
 
         needed_collectors = colitem.listchain()
         for col in needed_collectors[len(self.stack) :]:
+            assert col not in self.stack
+            assert col not in self._finalizers
             self.stack.append(col)
-            self._finalizers.setdefault(col, [])
+            self._finalizers[col] = []
             try:
                 col.setup()
             except TEST_OUTCOME as e:

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -423,6 +423,7 @@ class SetupState:
         needed_collectors = colitem.listchain()
         for col in needed_collectors[len(self.stack) :]:
             self.stack.append(col)
+            self._finalizers.setdefault(col, [])
             try:
                 col.setup()
             except TEST_OUTCOME as e:
@@ -444,7 +445,7 @@ class SetupState:
                 break
             try:
                 colitem = self.stack.pop()
-                finalizers = self._finalizers.pop(colitem, None)
+                finalizers = self._finalizers.pop(colitem)
                 inner_exc = None
                 while finalizers:
                     fin = finalizers.pop()

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -480,8 +480,6 @@ class SetupState:
     def teardown_all(self) -> None:
         while self.stack:
             self._pop_and_teardown()
-        for key in list(self._finalizers):
-            self._teardown_with_finalization(key)
         assert not self._finalizers
 
 

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -463,9 +463,6 @@ class SetupState:
 
     def teardown_exact(self, item: Item, nextitem: Optional[Item]) -> None:
         needed_collectors = nextitem and nextitem.listchain() or []
-        self._teardown_towards(needed_collectors)
-
-    def _teardown_towards(self, needed_collectors: List[Node]) -> None:
         exc = None
         while self.stack:
             if self.stack == needed_collectors[: len(self.stack)]:

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -446,6 +446,7 @@ class SetupState:
             try:
                 colitem = self.stack.pop()
                 finalizers = self._finalizers.pop(colitem)
+                finalizers.insert(0, colitem.teardown)
                 inner_exc = None
                 while finalizers:
                     fin = finalizers.pop()
@@ -456,11 +457,10 @@ class SetupState:
                         #     ideally all should be reported.
                         if inner_exc is None:
                             inner_exc = e
-                if inner_exc:
-                    raise inner_exc
-                colitem.teardown()
                 for colitem in self._finalizers:
                     assert colitem in self.stack
+                if inner_exc:
+                    raise inner_exc
             except TEST_OUTCOME as e:
                 # XXX Only first exception will be seen by user,
                 #     ideally all should be reported.

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -856,7 +856,7 @@ class TestRequestBasic:
         teardownlist = parent.obj.teardownlist
         ss = item.session._setupstate
         assert not teardownlist
-        ss.teardown_exact(item, None)
+        ss.teardown_exact(None)
         print(ss.stack)
         assert teardownlist == [1]
 

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -130,7 +130,8 @@ class TestFillFixtures:
         pytester.copy_example()
         item = pytester.getitem(Path("test_funcarg_basic.py"))
         assert isinstance(item, Function)
-        item._request._fillfixtures()
+        # Execute's item's setup, which fills fixtures.
+        item.session._setupstate.prepare(item)
         del item.funcargs["request"]
         assert len(get_public_names(item.funcargs)) == 2
         assert item.funcargs["some"] == "test_func"
@@ -809,17 +810,24 @@ class TestRequestBasic:
         item = pytester.getitem(
             """
             import pytest
-            values = [2]
+
             @pytest.fixture
-            def something(request): return 1
+            def something(request):
+                return 1
+
+            values = [2]
             @pytest.fixture
             def other(request):
                 return values.pop()
+
             def test_func(something): pass
         """
         )
         assert isinstance(item, Function)
         req = item._request
+
+        # Execute item's setup.
+        item.session._setupstate.prepare(item)
 
         with pytest.raises(pytest.FixtureLookupError):
             req.getfixturevalue("notexists")
@@ -831,7 +839,6 @@ class TestRequestBasic:
         assert val2 == 2
         val2 = req.getfixturevalue("other")  # see about caching
         assert val2 == 2
-        item._request._fillfixtures()
         assert item.funcargs["something"] == 1
         assert len(get_public_names(item.funcargs)) == 2
         assert "request" in item.funcargs

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -64,11 +64,12 @@ class TestSetupState:
 
         item = pytester.getitem("def test_func(): pass")
         ss = runner.SetupState()
+        ss.prepare(item)
         ss.addfinalizer(fin1, item)
         ss.addfinalizer(fin2, item)
         ss.addfinalizer(fin3, item)
         with pytest.raises(Exception) as err:
-            ss._callfinalizers(item)
+            ss.teardown_exact(item, None)
         assert err.value.args == ("oops",)
         assert r == ["fin3", "fin1"]
 
@@ -83,10 +84,11 @@ class TestSetupState:
 
         item = pytester.getitem("def test_func(): pass")
         ss = runner.SetupState()
+        ss.prepare(item)
         ss.addfinalizer(fin1, item)
         ss.addfinalizer(fin2, item)
         with pytest.raises(Exception) as err:
-            ss._callfinalizers(item)
+            ss.teardown_exact(item, None)
         assert err.value.args == ("oops2",)
 
     def test_teardown_multiple_scopes_one_fails(self, pytester: Pytester) -> None:

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -104,13 +104,14 @@ class TestSetupState:
             module_teardown.append("fin_module")
 
         item = pytester.getitem("def test_func(): pass")
+        mod = item.listchain()[-2]
         ss = item.session._setupstate
-        ss.addfinalizer(fin_module, item.listchain()[-2])
-        ss.addfinalizer(fin_func, item)
         ss.prepare(item)
+        ss.addfinalizer(fin_module, mod)
+        ss.addfinalizer(fin_func, item)
         with pytest.raises(Exception, match="oops1"):
             ss.teardown_exact(None)
-        assert module_teardown
+        assert module_teardown == ["fin_module"]
 
 
 class BaseFunctionalTests:

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -34,9 +34,10 @@ class TestSetupState:
     def test_teardown_exact_stack_empty(self, pytester: Pytester) -> None:
         item = pytester.getitem("def test_func(): pass")
         ss = runner.SetupState()
-        ss.teardown_exact(item, None)
-        ss.teardown_exact(item, None)
-        ss.teardown_exact(item, None)
+        ss.prepare(item)
+        ss.teardown_exact(None)
+        ss.teardown_exact(None)
+        ss.teardown_exact(None)
 
     def test_setup_fails_and_failure_is_cached(self, pytester: Pytester) -> None:
         item = pytester.getitem(
@@ -69,7 +70,7 @@ class TestSetupState:
         ss.addfinalizer(fin2, item)
         ss.addfinalizer(fin3, item)
         with pytest.raises(Exception) as err:
-            ss.teardown_exact(item, None)
+            ss.teardown_exact(None)
         assert err.value.args == ("oops",)
         assert r == ["fin3", "fin1"]
 
@@ -88,7 +89,7 @@ class TestSetupState:
         ss.addfinalizer(fin1, item)
         ss.addfinalizer(fin2, item)
         with pytest.raises(Exception) as err:
-            ss.teardown_exact(item, None)
+            ss.teardown_exact(None)
         assert err.value.args == ("oops2",)
 
     def test_teardown_multiple_scopes_one_fails(self, pytester: Pytester) -> None:
@@ -106,7 +107,7 @@ class TestSetupState:
         ss.addfinalizer(fin_func, item)
         ss.prepare(item)
         with pytest.raises(Exception, match="oops1"):
-            ss.teardown_exact(item, None)
+            ss.teardown_exact(None)
         assert module_teardown
 
 

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -26,7 +26,7 @@ class TestSetupState:
         ss = item.session._setupstate
         values = [1]
         ss.prepare(item)
-        ss.addfinalizer(values.pop, colitem=item)
+        ss.addfinalizer(values.pop, item)
         assert values
         ss.teardown_exact(None)
         assert not values

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -28,7 +28,7 @@ class TestSetupState:
         ss.prepare(item)
         ss.addfinalizer(values.pop, colitem=item)
         assert values
-        ss._pop_and_teardown()
+        ss.teardown_exact(None)
         assert not values
 
     def test_teardown_exact_stack_empty(self, pytester: Pytester) -> None:

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -22,8 +22,8 @@ from _pytest.pytester import Pytester
 
 class TestSetupState:
     def test_setup(self, pytester: Pytester) -> None:
-        ss = runner.SetupState()
         item = pytester.getitem("def test_func(): pass")
+        ss = item.session._setupstate
         values = [1]
         ss.prepare(item)
         ss.addfinalizer(values.pop, colitem=item)
@@ -33,7 +33,7 @@ class TestSetupState:
 
     def test_teardown_exact_stack_empty(self, pytester: Pytester) -> None:
         item = pytester.getitem("def test_func(): pass")
-        ss = runner.SetupState()
+        ss = item.session._setupstate
         ss.prepare(item)
         ss.teardown_exact(None)
         ss.teardown_exact(None)
@@ -47,9 +47,11 @@ class TestSetupState:
             def test_func(): pass
         """
         )
-        ss = runner.SetupState()
-        pytest.raises(ValueError, lambda: ss.prepare(item))
-        pytest.raises(ValueError, lambda: ss.prepare(item))
+        ss = item.session._setupstate
+        with pytest.raises(ValueError):
+            ss.prepare(item)
+        with pytest.raises(ValueError):
+            ss.prepare(item)
 
     def test_teardown_multiple_one_fails(self, pytester: Pytester) -> None:
         r = []
@@ -64,7 +66,7 @@ class TestSetupState:
             r.append("fin3")
 
         item = pytester.getitem("def test_func(): pass")
-        ss = runner.SetupState()
+        ss = item.session._setupstate
         ss.prepare(item)
         ss.addfinalizer(fin1, item)
         ss.addfinalizer(fin2, item)
@@ -84,7 +86,7 @@ class TestSetupState:
             raise Exception("oops2")
 
         item = pytester.getitem("def test_func(): pass")
-        ss = runner.SetupState()
+        ss = item.session._setupstate
         ss.prepare(item)
         ss.addfinalizer(fin1, item)
         ss.addfinalizer(fin2, item)
@@ -102,7 +104,7 @@ class TestSetupState:
             module_teardown.append("fin_module")
 
         item = pytester.getitem("def test_func(): pass")
-        ss = runner.SetupState()
+        ss = item.session._setupstate
         ss.addfinalizer(fin_module, item.listchain()[-2])
         ss.addfinalizer(fin_func, item)
         ss.prepare(item)


### PR DESCRIPTION
This PR refactors `SetupState` which handles the setting up and tearing down of nodes as they are executed. I believe it makes the code simpler and easier to understand, and also stricter. I also added a docstring trying to explain how it works a bit.

You can read the commits, if you want to see the progression and justification for each step, or just read the PR diff for the final result (though maybe use patience diff, the github diff somewhat botches it).

Because this makes things stricter, in particular the requirements that finalizers be added only once a node is present in the stack, this may introduce some regressions in plugins which do tricky stuff, or even user code (though in this case I don't think so). Of course I am ready to handle them on a case by case basis if they occur.