### PR TITLE
DOC: Mark pytest module

### DIFF
--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -3,6 +3,8 @@
 API Reference
 =============
 
+.. module:: pytest
+
 This page contains the full reference to pytest's API.
 
 .. contents::


### PR DESCRIPTION
Pytest document currently does not index the top-level package name
`pytest`, which causes some trouble when building documentation that
cross-refers to the pytest package via ``:mod:`pytest` ``.

Reference: https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#role-py-mod

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
