### PR TITLE
doc: Add note about training early bird discount

### DIFF
--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -2,7 +2,7 @@
 
 .. sidebar:: Next Open Trainings
 
-   - `Professional testing with Python <https://www.python-academy.com/courses/specialtopics/python_course_testing.html>`_, via Python Academy, February 1-3 2021, Leipzig (Germany) and remote.
+   - `Professional testing with Python <https://www.python-academy.com/courses/specialtopics/python_course_testing.html>`_, via Python Academy, February 1-3 2021, remote and Leipzig (Germany). **Early-bird discount available until January 15th**.
 
    Also see `previous talks and blogposts <talks.html>`_.
 


### PR DESCRIPTION
Together with Python Academy I've just extended the early bird deadline in a last effort to get another couple of sign-ups - only one sign-up so far unfortunately...

Should be trivial to review at least :slightly_smiling_face: 

Preview: https://pytest--8225.org.readthedocs.build/en/8225/