### PR TITLE
Make code.FormattedExcinfo.get_source more defensive

### DIFF
--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -721,11 +721,11 @@ class FormattedExcinfo:
     ) -> List[str]:
         """Return formatted and marked up source lines."""
         lines = []
-        if source is None or line_index >= len(source.lines):
+        if source is not None and line_index < 0:
+            line_index += len(source.lines)
+        if source is None or line_index >= len(source.lines) or line_index < 0:
             source = Source("???")
             line_index = 0
-        if line_index < 0:
-            line_index += len(source)
         space_prefix = "    "
         if short:
             lines.append(space_prefix + source.lines[line_index].strip())

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -1397,6 +1397,29 @@ def test_cwd_deleted(pytester: Pytester) -> None:
     result.stderr.no_fnmatch_line("*INTERNALERROR*")
 
 
+def test_regression_nagative_line_index(pytester: Pytester) -> None:
+    """
+    With Python 3.10 alphas, there was an INTERNALERROR reported in
+    https://github.com/pytest-dev/pytest/pull/8227
+    This test ensures it does not regress.
+    """
+    pytester.makepyfile(
+        """
+        import ast
+        import pytest
+
+
+        def test_literal_eval():
+            with pytest.raises(ValueError, match="^$"):
+                ast.literal_eval("pytest")
+    """
+    )
+    result = pytester.runpytest()
+    result.stdout.fnmatch_lines(["* 1 failed in *"])
+    result.stdout.no_fnmatch_line("*INTERNALERROR*")
+    result.stderr.no_fnmatch_line("*INTERNALERROR*")
+
+
 @pytest.mark.usefixtures("limited_recursion_depth")
 def test_exception_repr_extraction_error_on_recursion():
     """


### PR DESCRIPTION
I am trying to investigate a bug in Setuptools, and I ran into this internal error in pytest:

```
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/_code/code.py", line 798, in repr_traceback_entry
INTERNALERROR>     s = self.get_source(source, line_index, excinfo, short=short)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/_code/code.py", line 727, in get_source
INTERNALERROR>     lines.append(space_prefix + source.lines[line_index].strip())
INTERNALERROR> IndexError: list index out of range
```

<details>

<summary>Full traceback...</summary>

```
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/main.py", line 269, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/main.py", line 323, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/manager.py", line 84, in <lambda>
INTERNALERROR>     self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/main.py", line 348, in pytest_runtestloop
INTERNALERROR>     item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/manager.py", line 84, in <lambda>
INTERNALERROR>     self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/runner.py", line 109, in pytest_runtest_protocol
INTERNALERROR>     runtestprotocol(item, nextitem=nextitem)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/runner.py", line 126, in runtestprotocol
INTERNALERROR>     reports.append(call_and_report(item, "call", log))
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/runner.py", line 217, in call_and_report
INTERNALERROR>     report: TestReport = hook.pytest_runtest_makereport(item=item, call=call)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/manager.py", line 84, in <lambda>
INTERNALERROR>     self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/callers.py", line 203, in _multicall
INTERNALERROR>     gen.send(outcome)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/skipping.py", line 272, in pytest_runtest_makereport
INTERNALERROR>     rep = outcome.get_result()
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/runner.py", line 337, in pytest_runtest_makereport
INTERNALERROR>     return TestReport.from_item_and_call(item, call)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/reports.py", line 322, in from_item_and_call
INTERNALERROR>     longrepr = item.repr_failure(excinfo)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/python.py", line 1677, in repr_failure
INTERNALERROR>     return self._repr_failure_py(excinfo, style=style)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/nodes.py", line 398, in _repr_failure_py
INTERNALERROR>     return excinfo.getrepr(
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/_code/code.py", line 648, in getrepr
INTERNALERROR>     return fmt.repr_excinfo(self)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/_code/code.py", line 905, in repr_excinfo
INTERNALERROR>     reprtraceback = self.repr_traceback(excinfo_)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/_code/code.py", line 846, in repr_traceback
INTERNALERROR>     reprentry = self.repr_traceback_entry(entry, einfo)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/_code/code.py", line 798, in repr_traceback_entry
INTERNALERROR>     s = self.get_source(source, line_index, excinfo, short=short)
INTERNALERROR>   File "/home/pviktori/dev/setuptools/.tox/py310/lib/python3.10/site-packages/_pytest/_code/code.py", line 727, in get_source
INTERNALERROR>     lines.append(space_prefix + source.lines[line_index].strip())
INTERNALERROR> IndexError: list index out of range
```

</details>

When line_index was a large negative number, get_source failed on `source.lines[line_index]`.
I don't (yet) understand the underlying error (Setuptools does some creative backwards-compatibility stunts with the import machinery), but the pytest code looks like it wants to be defensive here. Possibly, using the same dummy Source as with a large positive line_index is correct.

Sorry for not including tests; I don't know how to test it properly. This is more of a bug report with attached code than a proper pull request :)
It seems related to https://github.com/pytest-dev/pytest/issues/752 (but the pylib link there is dead).

