### PR TITLE
Add missing import into example script in documentation

### DIFF
--- a/doc/en/skipping.rst
+++ b/doc/en/skipping.rst
@@ -405,6 +405,7 @@ test instances when using parametrize:
 
 .. code-block:: python
 
+    import sys
     import pytest
 
 


### PR DESCRIPTION
Very small fix.