### PR TITLE
alter the PyObjMixin to carry over typing information from Node

### DIFF
--- a/changelog/8248.trivial.rst
+++ b/changelog/8248.trivial.rst
@@ -1,0 +1,1 @@
+Internal Restructure: let python.PyObjMixing inherit from nodes.Node to carry over typing information.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -23,7 +23,6 @@ from typing import Optional
 from typing import Sequence
 from typing import Set
 from typing import Tuple
-from typing import Type
 from typing import TYPE_CHECKING
 from typing import Union
 
@@ -255,20 +254,13 @@ def pytest_pycollect_makeitem(collector: "PyCollector", name: str, obj: object):
             return res
 
 
-class PyobjMixin:
+class PyobjMixin(nodes.Node):
+    """this mix-in inherits from Node to carry over the typing information
+
+    as its intended to always mix in before a node
+    its position in the mro is unaffected"""
+
     _ALLOW_MARKERS = True
-
-    # Function and attributes that the mixin needs (for type-checking only).
-    if TYPE_CHECKING:
-        name: str = ""
-        parent: Optional[nodes.Node] = None
-        own_markers: List[Mark] = []
-
-        def getparent(self, cls: Type[nodes._NodeType]) -> Optional[nodes._NodeType]:
-            ...
-
-        def listchain(self) -> List[nodes.Node]:
-            ...
 
     @property
     def module(self):


### PR DESCRIPTION
as PyObjMixin is always supposed to be mixed in the mro
before nodes.Node the behavior doesn't change,
but all the typing information carry over to help mypy.

extracted from #8037

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
