### PR TITLE
Fix faulthandler for Twisted Logger when used with "--capture=no"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,6 +21,7 @@ Anders Hovmöller
 Andras Mitzki
 Andras Tim
 Andrea Cimatoribus
+Andreas Motl
 Andreas Zeidler
 Andrey Paramonov
 Andrzej Klajnert

--- a/changelog/8249.bugfix.rst
+++ b/changelog/8249.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the ``faulthandler`` plugin for occasions when running with ``twisted.logger`` and using ``pytest --capture=no``.

--- a/src/_pytest/faulthandler.py
+++ b/src/_pytest/faulthandler.py
@@ -69,7 +69,12 @@ class FaultHandlerHooks:
     @staticmethod
     def _get_stderr_fileno():
         try:
-            return sys.stderr.fileno()
+            fileno = sys.stderr.fileno()
+            # The Twisted Logger will return an invalid file descriptor since it is not backed
+            # by an FD. So, let's also forward this to the same code path as with pytest-xdist.
+            if fileno == -1:
+                raise AttributeError()
+            return fileno
         except (AttributeError, io.UnsupportedOperation):
             # pytest-xdist monkeypatches sys.stderr with an object that is not an actual file.
             # https://docs.python.org/3/library/faulthandler.html#issue-with-file-descriptors


### PR DESCRIPTION
Hi again,

this patch resolves #8249.

The background on this is that the Twisted Logger will return an invalid file descriptor since it is not backed by an FD. It will make `pytest` croak and hang when invoked through `pytest --capture=no` on teardown.

The solution is to also forward this to the same code path as with `pytest-xdist`, where the code already has special handling for.

Hereby, I humbly ask for further guidance in order to bring in this patch. Please let me know
- if you prefer this mitigation to be handled differently.
- if you think the respective test case should be adjusted.

With kind regards,
Andreas.
