### PR TITLE
Doc: Move the module declaration to index.rst

### DIFF
--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -11,6 +11,7 @@
 pytest: helps you write better programs
 =======================================
 
+.. module:: pytest
 
 The ``pytest`` framework makes it easy to write small tests, yet
 scales to support complex functional testing for applications and libraries.

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -3,8 +3,6 @@
 API Reference
 =============
 
-.. module:: pytest
-
 This page contains the full reference to pytest's API.
 
 .. contents::


### PR DESCRIPTION
When the declaration stays in reference.rst, it creates duplicated
"pytest" symbols such as `pytest.pytest.mark.filterwarnings`.

Resolves https://github.com/pytest-dev/pytest/pull/8220#issuecomment-767363725
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
