### PR TITLE
doc: Point out two-argument form of monkeypatch.setattr

### DIFF
--- a/doc/en/monkeypatch.rst
+++ b/doc/en/monkeypatch.rst
@@ -16,6 +16,7 @@ functionality in tests:
 .. code-block:: python
 
     monkeypatch.setattr(obj, name, value, raising=True)
+    monkeypatch.setattr("somemodule.obj.name", value, raising=True)
     monkeypatch.delattr(obj, name, raising=True)
     monkeypatch.setitem(mapping, name, value)
     monkeypatch.delitem(obj, name, raising=True)


### PR DESCRIPTION
See the "for convenience" part here: https://docs.pytest.org/en/stable/reference.html#pytest.MonkeyPatch.setattr

Prompted by https://stackoverflow.com/questions/44660196/attributeerror-while-using-monkeypatch-of-pytest/44666743?noredirect=1#comment116593794_44666743