### PR TITLE
Log level name coloring made configurable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -173,6 +173,7 @@ Kodi B. Arfer
 Kostis Anagnostopoulos
 Kristoffer Nordström
 Kyle Altendorf
+Laurent Rivière
 Lawrence Mitchell
 Lee Kamentsky
 Lev Maximov

--- a/changelog/8181.improvement.rst
+++ b/changelog/8181.improvement.rst
@@ -1,1 +1,1 @@
-New option `log_cli_level_color` (default to True) to allow disabling the coloring of log level name when color in terminal output is enabled.
+New option `log_cli_level_color` (default to yes) to allow disabling the coloring of log level name when color in terminal output is enabled.

--- a/changelog/8181.improvement.rst
+++ b/changelog/8181.improvement.rst
@@ -1,0 +1,1 @@
+New option `log_cli_level_color` (default to True) to allow disabling the coloring of log level name when color in terminal output is enabled.

--- a/doc/en/logging.rst
+++ b/doc/en/logging.rst
@@ -189,7 +189,8 @@ as the logging level num.
 Additionally, you can also specify ``--log-cli-format`` and
 ``--log-cli-date-format`` which mirror and default to ``--log-format`` and
 ``--log-date-format`` if not provided, but are applied only to the console
-logging handler.
+logging handler. There is also an option ``--log-cli-level-color`` to enable/disable
+log level name coloring when ``--color`` is enabled.
 
 All of the CLI log options can also be set in the configuration INI file. The
 option names are:
@@ -197,6 +198,7 @@ option names are:
 * ``log_cli_level``
 * ``log_cli_format``
 * ``log_cli_date_format``
+* ``log_cli_level_color``
 
 If you need to record the whole test suite logging calls to a file, you can pass
 ``--log-file=/path/to/log/file``. This log file is opened in write mode which

--- a/doc/en/reference.rst
+++ b/doc/en/reference.rst
@@ -1872,6 +1872,9 @@ All the command-line flags can be obtained by running ``pytest --help``::
                             log date format as used by the logging module.
       --log-cli-level=LOG_CLI_LEVEL
                             cli logging level.
+      --log-cli-level-color={yes,no}
+                            Whether log level name should be colored (only if --color
+                            is also enabled)
       --log-cli-format=LOG_CLI_FORMAT
                             log format as used by the logging module.
       --log-cli-date-format=LOG_CLI_DATE_FORMAT

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -257,6 +257,7 @@ def pytest_addoption(parser: Parser) -> None:
         "--log-cli-level-color",
         dest="log_cli_level_color",
         default=True,
+        type="bool",
         help="enable log level name coloring (color in terminal output must be enabled).",
     )
     add_option_ini(

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -254,6 +254,12 @@ def pytest_addoption(parser: Parser) -> None:
         help="log date format as used by the logging module.",
     )
     add_option_ini(
+        "--log-cli-level-color",
+        dest="log_cli_level_color",
+        default=True,
+        help="enable log level name coloring (color in terminal output must be enabled).",
+    )
+    add_option_ini(
         "--log-file",
         dest="log_file",
         default=None,
@@ -583,8 +589,12 @@ class LoggingPlugin:
     def _create_formatter(self, log_format, log_date_format, auto_indent):
         # Color option doesn't exist if terminal plugin is disabled.
         color = getattr(self._config.option, "color", "no")
-        if color != "no" and ColoredLevelFormatter.LEVELNAME_FMT_REGEX.search(
-            log_format
+        log_cli_level_color = get_option_ini(self._config, "log_cli_level_color")
+
+        if (
+            color != "no"
+            and log_cli_level_color
+            and ColoredLevelFormatter.LEVELNAME_FMT_REGEX.search(log_format)
         ):
             formatter: logging.Formatter = ColoredLevelFormatter(
                 create_terminal_writer(self._config), log_format, log_date_format

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -256,9 +256,9 @@ def pytest_addoption(parser: Parser) -> None:
     add_option_ini(
         "--log-cli-level-color",
         dest="log_cli_level_color",
-        default=True,
-        type="bool",
-        help="enable log level name coloring (color in terminal output must be enabled).",
+        default="yes",
+        choices=["yes", "no"],
+        help="Whether log level name should be colored (only if --color is also enabled).",
     )
     add_option_ini(
         "--log-file",
@@ -594,7 +594,7 @@ class LoggingPlugin:
 
         if (
             color != "no"
-            and log_cli_level_color
+            and log_cli_level_color != "no"
             and ColoredLevelFormatter.LEVELNAME_FMT_REGEX.search(log_format)
         ):
             formatter: logging.Formatter = ColoredLevelFormatter(

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1098,6 +1098,58 @@ def test_colored_captured_log(pytester: Pytester) -> None:
     )
 
 
+def test_cli_level_color_disabled(pytester: Pytester) -> None:
+    """Test that the log level names of captured log messages
+    are not colored if `--log-cli-level-color=no` is passed."""
+    pytester.makepyfile(
+        """
+        import logging
+
+        logger = logging.getLogger(__name__)
+
+        def test_foo():
+            logger.info('text going to logger from call')
+            assert False
+        """
+    )
+    result = pytester.runpytest(
+        "--log-level=INFO", "--color=yes", "--log-cli-level-color=no"
+    )
+    assert result.ret == 1
+    result.stdout.fnmatch_lines(
+        [
+            "*-- Captured log call --*",
+            "INFO    *text going to logger from call",
+        ]
+    )
+
+
+def test_cli_level_color_enabled(pytester: Pytester) -> None:
+    """Test that the log level names of captured log messages
+    are not colored if `--log-cli-level-color=no` is passed."""
+    pytester.makepyfile(
+        """
+        import logging
+
+        logger = logging.getLogger(__name__)
+
+        def test_foo():
+            logger.info('text going to logger from call')
+            assert False
+        """
+    )
+    result = pytester.runpytest(
+        "--log-level=INFO", "--color=yes", "--log-cli-level-color=yes"
+    )
+    assert result.ret == 1
+    result.stdout.fnmatch_lines(
+        [
+            "*-- Captured log call --*",
+            "\x1b[32mINFO    \x1b[0m*text going to logger from call",
+        ]
+    )
+
+
 def test_colored_ansi_esc_caplogtext(pytester: Pytester) -> None:
     """Make sure that caplog.text does not contain ANSI escape sequences."""
     pytester.makepyfile(


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
-->

Proposition to add an option to disable log level name coloring when color output is enabled. 

closes #8181