### PR TITLE
config/argparsing: use proper deprecations instead of ad-hoc DeprecationWarning

### DIFF
--- a/changelog/8315.deprecation.rst
+++ b/changelog/8315.deprecation.rst
@@ -1,0 +1,5 @@
+Several behaviors of :meth:`Parser.addoption <_pytest.config.argparsing.Parser.addoption>` are now
+scheduled for removal in pytest 7 (deprecated since pytest 2.4.0):
+
+- ``parser.addoption(..., help=".. %default ..")`` - use ``%(default)s`` instead.
+- ``parser.addoption(..., type="int/string/float/complex")`` - use ``type=int`` etc. instead.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -18,6 +18,19 @@ Deprecated Features
 Below is a complete list of all pytest features which are considered deprecated. Using those features will issue
 :class:`PytestWarning` or subclasses, which can be filtered using :ref:`standard warning filters <warnings>`.
 
+
+Backward compatibilities in ``Parser.addoption``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 2.4
+
+Several behaviors of :meth:`Parser.addoption <_pytest.config.argparsing.Parser.addoption>` are now
+scheduled for removal in pytest 7 (deprecated since pytest 2.4.0):
+
+- ``parser.addoption(..., help=".. %default ..")`` - use ``%(default)s`` instead.
+- ``parser.addoption(..., type="int/string/float/complex")`` - use ``type=int`` etc. instead.
+
+
 Raising ``unittest.SkipTest`` during collection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -18,6 +18,9 @@ from typing import Union
 import _pytest._io
 from _pytest.compat import final
 from _pytest.config.exceptions import UsageError
+from _pytest.deprecated import ARGUMENT_PERCENT_DEFAULT
+from _pytest.deprecated import ARGUMENT_TYPE_STR
+from _pytest.deprecated import ARGUMENT_TYPE_STR_CHOICE
 
 if TYPE_CHECKING:
     from typing import NoReturn
@@ -212,12 +215,7 @@ class Argument:
         self._short_opts: List[str] = []
         self._long_opts: List[str] = []
         if "%default" in (attrs.get("help") or ""):
-            warnings.warn(
-                'pytest now uses argparse. "%default" should be'
-                ' changed to "%(default)s" ',
-                DeprecationWarning,
-                stacklevel=3,
-            )
+            warnings.warn(ARGUMENT_PERCENT_DEFAULT, stacklevel=3)
         try:
             typ = attrs["type"]
         except KeyError:
@@ -227,11 +225,7 @@ class Argument:
             if isinstance(typ, str):
                 if typ == "choice":
                     warnings.warn(
-                        "`type` argument to addoption() is the string %r."
-                        " For choices this is optional and can be omitted, "
-                        " but when supplied should be a type (for example `str` or `int`)."
-                        " (options: %s)" % (typ, names),
-                        DeprecationWarning,
+                        ARGUMENT_TYPE_STR_CHOICE.format(typ=typ, names=names),
                         stacklevel=4,
                     )
                     # argparse expects a type here take it from
@@ -239,11 +233,7 @@ class Argument:
                     attrs["type"] = type(attrs["choices"][0])
                 else:
                     warnings.warn(
-                        "`type` argument to addoption() is the string %r, "
-                        " but when supplied should be a type (for example `str` or `int`)."
-                        " (options: %s)" % (typ, names),
-                        DeprecationWarning,
-                        stacklevel=4,
+                        ARGUMENT_TYPE_STR.format(typ=typ, names=names), stacklevel=4
                     )
                     attrs["type"] = Argument._typ_map[typ]
                 # Used in test_parseopt -> test_parse_defaultgetter.

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -69,6 +69,25 @@ UNITTEST_SKIP_DURING_COLLECTION = PytestDeprecationWarning(
     "Use pytest.skip() instead."
 )
 
+ARGUMENT_PERCENT_DEFAULT = PytestDeprecationWarning(
+    'pytest now uses argparse. "%default" should be changed to "%(default)s"',
+)
+
+ARGUMENT_TYPE_STR_CHOICE = UnformattedWarning(
+    PytestDeprecationWarning,
+    "`type` argument to addoption() is the string {typ!r}."
+    " For choices this is optional and can be omitted, "
+    " but when supplied should be a type (for example `str` or `int`)."
+    " (options: {names})",
+)
+
+ARGUMENT_TYPE_STR = UnformattedWarning(
+    PytestDeprecationWarning,
+    "`type` argument to addoption() is the string {typ!r}, "
+    " but when supplied should be a type (for example `str` or `int`)."
+    " (options: {names})",
+)
+
 
 # You want to make some `__init__` or function "private".
 #


### PR DESCRIPTION
Prepare for removing this in the next major pytest release.