### PR TITLE
Removes 2 empty lines from example code

### DIFF
--- a/doc/en/assert.rst
+++ b/doc/en/assert.rst
@@ -175,8 +175,6 @@ when it encounters comparisons.  For example:
 .. code-block:: python
 
     # content of test_assert2.py
-
-
     def test_set_comparison():
         set1 = set("1308")
         set2 = set("8035")


### PR DESCRIPTION
head-fork: maskypy40/pytest
compare: patch-1

base-fork: pytest-dev/pytest
base: master

Removes 2 empty, redundant lines in the code-block of test_asser2.py in assert.rst. 