### PR TITLE
Remove a redundant paragraph

### DIFF
--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -228,12 +228,6 @@ At a basic level, test functions request fixtures by declaring them as
 arguments, as in the ``test_my_fruit_in_basket(my_fruit, fruit_basket):`` in the
 previous example.
 
-At a basic level, pytest depends on a test to tell it what fixtures it needs, so
-we have to build that information into the test itself. We have to make the test
-"**request**" the fixtures it depends on, and to do this, we have to
-list those fixtures as parameters in the test function's "signature" (which is
-the ``def test_something(blah, stuff, more):`` line).
-
 When pytest goes to run a test, it looks at the parameters in that test
 function's signature, and then searches for fixtures that have the same names as
 those parameters. Once pytest finds them, it runs those fixtures, captures what


### PR DESCRIPTION
doc This paragraph looks like it is a more verbose version of the sentence right above it.  Removing it doesn't reduce the amount of information here but does make the section flow a little better.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
-->
