### PR TITLE
Remove tmpdir from tests

### DIFF
--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -286,9 +286,7 @@ def test_deindent() -> None:
     assert lines == ["def f():", "    def g():", "        pass"]
 
 
-def test_source_of_class_at_eof_without_newline(
-    tmpdir, _sys_snapshot, tmp_path: Path
-) -> None:
+def test_source_of_class_at_eof_without_newline(_sys_snapshot, tmp_path: Path) -> None:
     # this test fails because the implicit inspect.getsource(A) below
     # does not return the "x = 1" last line.
     source = Source(

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -274,7 +274,7 @@ class TestFunction:
         pytester.makepyfile(
             """
             class A(object):
-                def __call__(self, tmpdir):
+                def __call__(self):
                     0/0
 
             test_a = A()

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -274,7 +274,7 @@ class TestFunction:
         pytester.makepyfile(
             """
             class A(object):
-                def __call__(self):
+                def __call__(self, tmp_path):
                     0/0
 
             test_a = A()

--- a/testing/python/integration.py
+++ b/testing/python/integration.py
@@ -234,7 +234,7 @@ class TestMockDecoration:
             @mock.patch("os.path.abspath")
             @mock.patch("os.path.normpath")
             @mock.patch("os.path.basename", new=mock_basename)
-            def test_someting(normpath, abspath):
+            def test_someting(normpath, abspath, tmp_path):
                 abspath.return_value = "this"
                 os.path.normpath(os.path.abspath("hello"))
                 normpath.assert_any_call("this")

--- a/testing/python/integration.py
+++ b/testing/python/integration.py
@@ -234,7 +234,7 @@ class TestMockDecoration:
             @mock.patch("os.path.abspath")
             @mock.patch("os.path.normpath")
             @mock.patch("os.path.basename", new=mock_basename)
-            def test_someting(normpath, abspath, tmpdir):
+            def test_someting(normpath, abspath):
                 abspath.return_value = "this"
                 os.path.normpath(os.path.abspath("hello"))
                 normpath.assert_any_call("this")

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -136,7 +136,7 @@ class TestCollectFS:
         ensure_file(tmp_path / ".whatever" / "test_notfound.py")
         ensure_file(tmp_path / ".bzr" / "test_notfound.py")
         ensure_file(tmp_path / "normal" / "test_found.py")
-        for x in Path(str(tmp_path)).rglob("test_*.py"):
+        for x in tmp_path.rglob("test_*.py"):
             x.write_text("def test_hello(): pass", "utf-8")
 
         result = pytester.runpytest("--collect-only")
@@ -632,8 +632,7 @@ class Test_getinitialnodes:
     def test_global_file(self, pytester: Pytester) -> None:
         tmp_path = pytester.path
         x = ensure_file(tmp_path / "x.py")
-        with tmp_path.cwd():
-            config = pytester.parseconfigure(x)
+        config = pytester.parseconfigure(x)
         col = pytester.getnode(config, x)
         assert isinstance(col, pytest.Module)
         assert col.name == "x.py"

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -127,16 +127,16 @@ class TestCollector:
 
 class TestCollectFS:
     def test_ignored_certain_directories(self, pytester: Pytester) -> None:
-        tmpdir = pytester.path
-        ensure_file(tmpdir / "build" / "test_notfound.py")
-        ensure_file(tmpdir / "dist" / "test_notfound.py")
-        ensure_file(tmpdir / "_darcs" / "test_notfound.py")
-        ensure_file(tmpdir / "CVS" / "test_notfound.py")
-        ensure_file(tmpdir / "{arch}" / "test_notfound.py")
-        ensure_file(tmpdir / ".whatever" / "test_notfound.py")
-        ensure_file(tmpdir / ".bzr" / "test_notfound.py")
-        ensure_file(tmpdir / "normal" / "test_found.py")
-        for x in Path(str(tmpdir)).rglob("test_*.py"):
+        tmp_path = pytester.path
+        ensure_file(tmp_path / "build" / "test_notfound.py")
+        ensure_file(tmp_path / "dist" / "test_notfound.py")
+        ensure_file(tmp_path / "_darcs" / "test_notfound.py")
+        ensure_file(tmp_path / "CVS" / "test_notfound.py")
+        ensure_file(tmp_path / "{arch}" / "test_notfound.py")
+        ensure_file(tmp_path / ".whatever" / "test_notfound.py")
+        ensure_file(tmp_path / ".bzr" / "test_notfound.py")
+        ensure_file(tmp_path / "normal" / "test_found.py")
+        for x in Path(str(tmp_path)).rglob("test_*.py"):
             x.write_text("def test_hello(): pass", "utf-8")
 
         result = pytester.runpytest("--collect-only")
@@ -226,10 +226,12 @@ class TestCollectFS:
             norecursedirs = mydir xyz*
         """
         )
-        tmpdir = pytester.path
-        ensure_file(tmpdir / "mydir" / "test_hello.py").write_text("def test_1(): pass")
-        ensure_file(tmpdir / "xyz123" / "test_2.py").write_text("def test_2(): 0/0")
-        ensure_file(tmpdir / "xy" / "test_ok.py").write_text("def test_3(): pass")
+        tmp_path = pytester.path
+        ensure_file(tmp_path / "mydir" / "test_hello.py").write_text(
+            "def test_1(): pass"
+        )
+        ensure_file(tmp_path / "xyz123" / "test_2.py").write_text("def test_2(): 0/0")
+        ensure_file(tmp_path / "xy" / "test_ok.py").write_text("def test_3(): pass")
         rec = pytester.inline_run()
         rec.assertoutcome(passed=1)
         rec = pytester.inline_run("xyz123/test_2.py")
@@ -242,10 +244,10 @@ class TestCollectFS:
             testpaths = gui uts
         """
         )
-        tmpdir = pytester.path
-        ensure_file(tmpdir / "env" / "test_1.py").write_text("def test_env(): pass")
-        ensure_file(tmpdir / "gui" / "test_2.py").write_text("def test_gui(): pass")
-        ensure_file(tmpdir / "uts" / "test_3.py").write_text("def test_uts(): pass")
+        tmp_path = pytester.path
+        ensure_file(tmp_path / "env" / "test_1.py").write_text("def test_env(): pass")
+        ensure_file(tmp_path / "gui" / "test_2.py").write_text("def test_gui(): pass")
+        ensure_file(tmp_path / "uts" / "test_3.py").write_text("def test_uts(): pass")
 
         # executing from rootdir only tests from `testpaths` directories
         # are collected
@@ -255,7 +257,7 @@ class TestCollectFS:
         # check that explicitly passing directories in the command-line
         # collects the tests
         for dirname in ("env", "gui", "uts"):
-            items, reprec = pytester.inline_genitems(tmpdir.joinpath(dirname))
+            items, reprec = pytester.inline_genitems(tmp_path.joinpath(dirname))
             assert [x.name for x in items] == ["test_%s" % dirname]
 
         # changing cwd to each subdirectory and running pytest without
@@ -628,9 +630,9 @@ class TestSession:
 
 class Test_getinitialnodes:
     def test_global_file(self, pytester: Pytester) -> None:
-        tmpdir = pytester.path
-        x = ensure_file(tmpdir / "x.py")
-        with tmpdir.cwd():
+        tmp_path = pytester.path
+        x = ensure_file(tmp_path / "x.py")
+        with tmp_path.cwd():
             config = pytester.parseconfigure(x)
         col = pytester.getnode(config, x)
         assert isinstance(col, pytest.Module)
@@ -645,8 +647,8 @@ class Test_getinitialnodes:
         The parent chain should match: Module<x.py> -> Package<subdir> -> Session.
             Session's parent should always be None.
         """
-        tmpdir = pytester.path
-        subdir = tmpdir.joinpath("subdir")
+        tmp_path = pytester.path
+        subdir = tmp_path.joinpath("subdir")
         x = ensure_file(subdir / "x.py")
         ensure_file(subdir / "__init__.py")
         with subdir.cwd():

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -44,15 +44,15 @@ class TestConftestValueAccessGlobal:
     def basedir(
         self, request, tmp_path_factory: TempPathFactory
     ) -> Generator[Path, None, None]:
-        tmpdir = tmp_path_factory.mktemp("basedir", numbered=True)
-        tmpdir.joinpath("adir/b").mkdir(parents=True)
-        tmpdir.joinpath("adir/conftest.py").write_text("a=1 ; Directory = 3")
-        tmpdir.joinpath("adir/b/conftest.py").write_text("b=2 ; a = 1.5")
+        tmp_path = tmp_path_factory.mktemp("basedir", numbered=True)
+        tmp_path.joinpath("adir/b").mkdir(parents=True)
+        tmp_path.joinpath("adir/conftest.py").write_text("a=1 ; Directory = 3")
+        tmp_path.joinpath("adir/b/conftest.py").write_text("b=2 ; a = 1.5")
         if request.param == "inpackage":
-            tmpdir.joinpath("adir/__init__.py").touch()
-            tmpdir.joinpath("adir/b/__init__.py").touch()
+            tmp_path.joinpath("adir/__init__.py").touch()
+            tmp_path.joinpath("adir/b/__init__.py").touch()
 
-        yield tmpdir
+        yield tmp_path
 
     def test_basic_init(self, basedir: Path) -> None:
         conftest = PytestPluginManager()


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Some more cleanup of `tmpdir` from the test suite

* Remove some unused 'tmpdir's
* Replace some 'tmpdirs' with 'tmp_path' in makepyfile calls
* Rename variables 'tmpdir'->'tmp_path'

    Rename this variables reflecting the migrations made e.g. with 3bcd316f0
    and ed658d682

Following this, the remaining usages (trying to ignore `from _pytest.tmpdir import ...`) look like:

```
$ git grep --word-regexp --perl-regexp --count '(?<!from _pytest\.)tmpdir' -- testing/
testing/example_scripts/tmpdir/tmpdir_fixture.py:3
testing/python/fixtures.py:9
testing/test_tmpdir.py:15
```

I think there are some more usages in `testing/python/fixtures.py` that could possibly be replace, but the others all look to be explicitly testing `tmpdir`