### PR TITLE
Fixed an issue where `getpass.getuser()` contained illegal characters for file directories

### DIFF
--- a/changelog/8317.bugfix.rst
+++ b/changelog/8317.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed an issue where illegal directory characters derived from ``getpass.getuser()` raised an ``OSError``.
+Fixed an issue where illegal directory characters derived from ``getpass.getuser()`` raised an ``OSError``.

--- a/changelog/8317.bugfix.rst
+++ b/changelog/8317.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue where illegal directory characters derived from ``getpass.getuser()` raised an ``OSError``.

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -115,7 +115,14 @@ class TempPathFactory:
             # use a sub-directory in the temproot to speed-up
             # make_numbered_dir() call
             rootdir = temproot.joinpath(f"pytest-of-{user}")
-            rootdir.mkdir(exist_ok=True)
+            try:
+                rootdir.mkdir(exist_ok=True)
+            except OSError:
+                # Due to the weird and wonderful challenges of cross-platform compliant
+                # directory names, try to use whatever getuser() has provided and failing
+                # that, default back to unknown and try that.
+                rootdir = temproot.joinpath("pytest-of-unknown")
+                rootdir.mkdir(exist_ok=True)
             basetemp = make_numbered_dir_with_cleanup(
                 prefix="pytest-", root=rootdir, keep=3, lock_timeout=LOCK_TIMEOUT
             )

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -118,9 +118,7 @@ class TempPathFactory:
             try:
                 rootdir.mkdir(exist_ok=True)
             except OSError:
-                # Due to the weird and wonderful challenges of cross-platform compliant
-                # directory names, try to use whatever getuser() has provided and failing
-                # that, default back to unknown and try that.
+                # getuser() likely returned illegal characters for the platform, use unknown back off mechanism
                 rootdir = temproot.joinpath("pytest-of-unknown")
                 rootdir.mkdir(exist_ok=True)
             basetemp = make_numbered_dir_with_cleanup(

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -452,7 +452,7 @@ def test_tmp_path_factory_handles_invalid_dir_characters(
     tmp_path_factory: TempPathFactory, monkeypatch: MonkeyPatch
 ) -> None:
     monkeypatch.setattr("getpass.getuser", lambda: "os/<:*?;>agnostic")
-    # force the cached _basetemp to be None
+    # _basetemp / _given_basetemp are cached / set in parallel runs, patch them
     monkeypatch.setattr(tmp_path_factory, "_basetemp", None)
     monkeypatch.setattr(tmp_path_factory, "_given_basetemp", None)
     p = tmp_path_factory.getbasetemp()

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -448,30 +448,11 @@ def test_basetemp_with_read_only_files(pytester: Pytester) -> None:
     assert result.ret == 0
 
 
-@pytest.mark.usefixtures("invalid_get_user")
-def test_tmpdir_factory_handles_invalid_dir_characters(
-    tmpdir_factory: TempdirFactory,
-) -> None:
-    assert "pytest-of-unknown" in str(tmpdir_factory.mktemp("test"))
-
-
-@pytest.mark.usefixtures("invalid_get_user")
 def test_tmp_path_factory_handles_invalid_dir_characters(
-    tmp_path_factory: TempPathFactory,
+    tmp_path_factory: TempPathFactory, monkeypatch: MonkeyPatch
 ) -> None:
-    assert "pytest-of-unknown" in str(tmp_path_factory.mktemp("test"))
-
-
-@pytest.mark.usefixtures("invalid_get_user")
-def test_tmpdir_handles_invalid_dir_characters(tmpdir) -> None:
-    assert "pytest-of-unknown" in str(tmpdir)
-
-
-@pytest.mark.usefixtures("invalid_get_user")
-def test_pytester_handles_invalid_dir_characters(pytester: Pytester) -> None:
-    assert "pytest-of-unknown" in str(pytester)
-
-
-@pytest.fixture
-def invalid_get_user(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setattr("getpass.getuser", lambda: "os/agnostic")
+    monkeypatch.setattr("getpass.getuser", lambda: "os/<:*?;>agnostic")
+    # force the cached _basetemp to be None
+    monkeypatch.setattr(tmp_path_factory, "_basetemp", None)
+    p = tmp_path_factory.getbasetemp()
+    assert "pytest-of-unknown" in str(p)

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -454,5 +454,6 @@ def test_tmp_path_factory_handles_invalid_dir_characters(
     monkeypatch.setattr("getpass.getuser", lambda: "os/<:*?;>agnostic")
     # force the cached _basetemp to be None
     monkeypatch.setattr(tmp_path_factory, "_basetemp", None)
+    monkeypatch.setattr(tmp_path_factory, "_given_basetemp", None)
     p = tmp_path_factory.getbasetemp()
     assert "pytest-of-unknown" in str(p)

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -11,6 +11,7 @@ import attr
 import pytest
 from _pytest import pathlib
 from _pytest.config import Config
+from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pathlib import cleanup_numbered_dir
 from _pytest.pathlib import create_cleanup_lock
 from _pytest.pathlib import make_numbered_dir
@@ -445,3 +446,32 @@ def test_basetemp_with_read_only_files(pytester: Pytester) -> None:
     # running a second time and ensure we don't crash
     result = pytester.runpytest("--basetemp=tmp")
     assert result.ret == 0
+
+
+@pytest.mark.usefixtures("invalid_get_user")
+def test_tmpdir_factory_handles_invalid_dir_characters(
+    tmpdir_factory: TempdirFactory,
+) -> None:
+    assert "pytest-of-unknown" in str(tmpdir_factory.mktemp("test"))
+
+
+@pytest.mark.usefixtures("invalid_get_user")
+def test_tmp_path_factory_handles_invalid_dir_characters(
+    tmp_path_factory: TempPathFactory,
+) -> None:
+    assert "pytest-of-unknown" in str(tmp_path_factory.mktemp("test"))
+
+
+@pytest.mark.usefixtures("invalid_get_user")
+def test_tmpdir_handles_invalid_dir_characters(tmpdir) -> None:
+    assert "pytest-of-unknown" in str(tmpdir)
+
+
+@pytest.mark.usefixtures("invalid_get_user")
+def test_pytester_handles_invalid_dir_characters(pytester: Pytester) -> None:
+    assert "pytest-of-unknown" in str(pytester)
+
+
+@pytest.fixture
+def invalid_get_user(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr("getpass.getuser", lambda: "os/agnostic")


### PR DESCRIPTION
closes #8317.  It is possible that `getpass.getuser()` can be illegal characters not appropriate for a directory name (platform dependent etc).  This PR addresses that by attempting it normally and backing off to use the default `-of-unknown` when it occurs.  This is consistent when `getuser()` is not Truthy.

Appreciate the feed back, thanks again.