### PR TITLE
Add pyupgrade-docs to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,11 @@ repos:
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==20.8b1]
+-   repo: https://github.com/verhovsky/pyupgrade-docs
+    rev: v0.2.5
+    hooks:
+    -   id: pyupgrade-docs
+        args: [--py36-plus]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:

--- a/doc/en/assert.rst
+++ b/doc/en/assert.rst
@@ -240,10 +240,7 @@ file which provides an alternative explanation for ``Foo`` objects:
 
    def pytest_assertrepr_compare(op, left, right):
        if isinstance(left, Foo) and isinstance(right, Foo) and op == "==":
-           return [
-               "Comparing Foo instances:",
-               "   vals: {} != {}".format(left.val, right.val),
-           ]
+           return ["Comparing Foo instances:", f"   vals: {left.val} != {right.val}"]
 
 now, given this test module:
 

--- a/doc/en/doctest.rst
+++ b/doc/en/doctest.rst
@@ -126,7 +126,9 @@ pytest also introduces new options:
 
 * ``NUMBER``: when enabled, floating-point numbers only need to match as far as
   the precision you have written in the expected doctest output. For example,
-  the following output would only need to match to 2 decimal places::
+  the following output would only need to match to 2 decimal places:
+
+  .. code-block:: pycon
 
       >>> math.pi
       3.14

--- a/doc/en/example/markers.rst
+++ b/doc/en/example/markers.rst
@@ -375,7 +375,7 @@ specifies via named environments:
         envnames = [mark.args[0] for mark in item.iter_markers(name="env")]
         if envnames:
             if item.config.getoption("-E") not in envnames:
-                pytest.skip("test requires env in {!r}".format(envnames))
+                pytest.skip(f"test requires env in {envnames!r}")
 
 A test file using this local plugin:
 
@@ -530,7 +530,7 @@ test function.  From a conftest file we can read it like this:
 
     def pytest_runtest_setup(item):
         for mark in item.iter_markers(name="glob"):
-            print("glob args={} kwargs={}".format(mark.args, mark.kwargs))
+            print(f"glob args={mark.args} kwargs={mark.kwargs}")
             sys.stdout.flush()
 
 Let's run this without capturing output and see what we get:
@@ -569,7 +569,7 @@ for your particular platform, you could use the following plugin:
         supported_platforms = ALL.intersection(mark.name for mark in item.iter_markers())
         plat = sys.platform
         if supported_platforms and plat not in supported_platforms:
-            pytest.skip("cannot run on platform {}".format(plat))
+            pytest.skip(f"cannot run on platform {plat}")
 
 then tests will be skipped if they were specified for a different platform.
 Let's do a little test file to show how this looks like:

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -288,7 +288,7 @@ Example:
     def checkconfig(x):
         __tracebackhide__ = True
         if not hasattr(x, "config"):
-            pytest.fail("not configured: {}".format(x))
+            pytest.fail(f"not configured: {x}")
 
 
     def test_something():
@@ -332,7 +332,7 @@ this to make sure unexpected exception types aren't hidden:
     def checkconfig(x):
         __tracebackhide__ = operator.methodcaller("errisinstance", ConfigException)
         if not hasattr(x, "config"):
-            raise ConfigException("not configured: {}".format(x))
+            raise ConfigException(f"not configured: {x}")
 
 
     def test_something():
@@ -557,7 +557,7 @@ an ``incremental`` marker which is to be used on classes:
                 test_name = _test_failed_incremental[cls_name].get(parametrize_index, None)
                 # if name found, test has failed for the combination of class name & test name
                 if test_name is not None:
-                    pytest.xfail("previous test failed ({})".format(test_name))
+                    pytest.xfail(f"previous test failed ({test_name})")
 
 
 These two hook implementations work together to abort incremental-marked

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -1681,7 +1681,7 @@ read an optional server URL from the test module which uses our fixture:
         server = getattr(request.module, "smtpserver", "smtp.gmail.com")
         smtp_connection = smtplib.SMTP(server, 587, timeout=5)
         yield smtp_connection
-        print("finalizing {} ({})".format(smtp_connection, server))
+        print(f"finalizing {smtp_connection} ({server})")
         smtp_connection.close()
 
 We use the ``request.module`` attribute to optionally obtain an
@@ -1843,7 +1843,7 @@ through the special :py:class:`request <FixtureRequest>` object:
     def smtp_connection(request):
         smtp_connection = smtplib.SMTP(request.param, 587, timeout=5)
         yield smtp_connection
-        print("finalizing {}".format(smtp_connection))
+        print(f"finalizing {smtp_connection}")
         smtp_connection.close()
 
 The main change is the declaration of ``params`` with
@@ -2146,7 +2146,7 @@ to show the setup/teardown flow:
 
 
     def test_2(otherarg, modarg):
-        print("  RUN test2 with otherarg {} and modarg {}".format(otherarg, modarg))
+        print(f"  RUN test2 with otherarg {otherarg} and modarg {modarg}")
 
 
 Let's run the tests in verbose mode and with looking at the print-output:

--- a/doc/en/logging.rst
+++ b/doc/en/logging.rst
@@ -164,9 +164,7 @@ the records for the ``setup`` and ``call`` stages during teardown like so:
                 x.message for x in caplog.get_records(when) if x.levelno == logging.WARNING
             ]
             if messages:
-                pytest.fail(
-                    "warning messages encountered during testing: {}".format(messages)
-                )
+                pytest.fail(f"warning messages encountered during testing: {messages}")
 
 
 

--- a/doc/en/usage.rst
+++ b/doc/en/usage.rst
@@ -371,7 +371,9 @@ Note that on any failure the exception information is stored on
 ``sys.last_value``, ``sys.last_type`` and ``sys.last_traceback``. In
 interactive use, this allows one to drop into postmortem debugging with
 any debug tool. One can also manually access the exception information,
-for example::
+for example:
+
+.. code-block:: pycon
 
     >>> import sys
     >>> sys.last_traceback.tb_lineno

--- a/doc/en/warnings.rst
+++ b/doc/en/warnings.rst
@@ -279,16 +279,21 @@ which works in a similar manner to :ref:`raises <assertraises>`:
             warnings.warn("my warning", UserWarning)
 
 The test will fail if the warning in question is not raised. The keyword
-argument ``match`` to assert that the exception matches a text or regex::
+argument ``match`` to assert that the exception matches a text or regex:
 
-    >>> with warns(UserWarning, match='must be 0 or None'):
+.. code-block:: pycon
+
+    >>> with warns(UserWarning, match="must be 0 or None"):
     ...     warnings.warn("value must be 0 or None", UserWarning)
+    ...
 
-    >>> with warns(UserWarning, match=r'must be \d+$'):
+    >>> with warns(UserWarning, match=r"must be \d+$"):
     ...     warnings.warn("value must be 42", UserWarning)
+    ...
 
-    >>> with warns(UserWarning, match=r'must be \d+$'):
+    >>> with warns(UserWarning, match=r"must be \d+$"):
     ...     warnings.warn("this is not here", UserWarning)
+    ...
     Traceback (most recent call last):
       ...
     Failed: DID NOT WARN. No warnings of type ...UserWarning... was emitted...

--- a/doc/en/writing_plugins.rst
+++ b/doc/en/writing_plugins.rst
@@ -369,7 +369,7 @@ string value of ``Hello World!`` if we do not supply a value or ``Hello
         def _hello(name=None):
             if not name:
                 name = request.config.getoption("name")
-            return "Hello {name}!".format(name=name)
+            return f"Hello {name}!"
 
         return _hello
 


### PR DESCRIPTION
a follow up to #5705

since pytest supports only Python 3.6+, we can use f-strings in the documentation