### PR TITLE
Allow Class.from_parent to forward custom parameters to the constructor

### DIFF
--- a/changelog/8367.bugfix.rst
+++ b/changelog/8367.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``Class.from_parent`` so it forwards extra keyword arguments to the constructor.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -763,9 +763,9 @@ class Class(PyCollector):
     """Collector for test methods."""
 
     @classmethod
-    def from_parent(cls, parent, *, name, obj=None):
+    def from_parent(cls, parent, *, name, obj=None, **kw):
         """The public constructor."""
-        return super().from_parent(name=name, parent=parent)
+        return super().from_parent(name=name, parent=parent, **kw)
 
     def collect(self) -> Iterable[Union[nodes.Item, nodes.Collector]]:
         if not safe_getattr(self.obj, "__test__", True):

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -1372,9 +1372,7 @@ def test_class_from_parent(pytester: Pytester, request: FixtureRequest) -> None:
         def from_parent(cls, parent, *, name, x):
             return super().from_parent(parent=parent, name=name, x=x)
 
-    collector = MyCollector.from_parent(
-        parent=request.session, name="foo", x=10
-    )
+    collector = MyCollector.from_parent(parent=request.session, name="foo", x=10)
     assert collector.x == 10
 
 

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -1360,6 +1360,24 @@ def test_fscollector_from_parent(pytester: Pytester, request: FixtureRequest) ->
     assert collector.x == 10
 
 
+def test_class_from_parent(pytester: Pytester, request: FixtureRequest) -> None:
+    """Ensure Class.from_parent can forward custom arguments to the constructor."""
+
+    class MyCollector(pytest.Class):
+        def __init__(self, name, parent, x):
+            super().__init__(name, parent)
+            self.x = x
+
+        @classmethod
+        def from_parent(cls, parent, *, name, x):
+            return super().from_parent(parent=parent, name=name, x=x)
+
+    collector = MyCollector.from_parent(
+        parent=request.session, name="foo", x=10
+    )
+    assert collector.x == 10
+
+
 class TestImportModeImportlib:
     def test_collect_duplicate_names(self, pytester: Pytester) -> None:
         """--import-mode=importlib can import modules with same names that are not in packages."""


### PR DESCRIPTION
Similarly to #7143, at work we have a project with a custom pytest.Class
subclass, adding an additional argument to the constructor.

All from_parent implementations in pytest accept and forward *kw, except
Class (before this change) and DoctestItem - since I'm not familiar with
doctest support, I've left the latter as-is.

cc @bytinbit @MatthiasGabriel 