### PR TITLE
use callable(obj) in istestfunction

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -384,10 +384,7 @@ class PyCollector(PyobjMixin, nodes.Collector):
             if isinstance(obj, staticmethod):
                 # staticmethods need to be unwrapped.
                 obj = safe_getattr(obj, "__func__", False)
-            return (
-                safe_getattr(obj, "__call__", False)
-                and fixtures.getfixturemarker(obj) is None
-            )
+            return callable(obj) and fixtures.getfixturemarker(obj) is None
         else:
             return False
 


### PR DESCRIPTION
change istestfunction to use `callable(obj)`. closes #7378