### PR TITLE
Increase truncation threshold with -v, disable with -vv

### DIFF
--- a/changelog/8403.improvement.rst
+++ b/changelog/8403.improvement.rst
@@ -1,0 +1,5 @@
+By default, pytest will truncate long strings in assert errors so they don't clutter the output too much,
+currently at ``240`` characters by default.
+
+However, in some cases the longer output helps, or is even crucial, to diagnose a failure. Using ``-v`` will
+now increase the truncation threshold to ``2400`` characters, and ``-vv`` or higher will disable truncation entirely.

--- a/doc/en/reference/plugin_list.rst
+++ b/doc/en/reference/plugin_list.rst
@@ -1,5 +1,7 @@
-Plugins List
-============
+.. _plugin-list:
+
+Plugin List
+===========
 
 PyPI projects that match "pytest-\*" are considered plugins and are listed
 automatically. Packages classified as inactive are excluded.

--- a/scripts/update-plugin-list.py
+++ b/scripts/update-plugin-list.py
@@ -6,8 +6,11 @@ import packaging.version
 import requests
 import tabulate
 
-FILE_HEAD = r"""Plugins List
-============
+FILE_HEAD = r"""\
+.. _plugin-list:
+
+Plugin List
+===========
 
 PyPI projects that match "pytest-\*" are considered plugins and are listed
 automatically. Packages classified as inactive are excluded.

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -153,6 +153,7 @@ def pytest_runtest_protocol(item: Item) -> Generator[None, None, None]:
 
     saved_assert_hooks = util._reprcompare, util._assertion_pass
     util._reprcompare = callbinrepr
+    util._config = item.config
 
     if ihook.pytest_assertion_pass.get_hookimpls():
 
@@ -164,6 +165,7 @@ def pytest_runtest_protocol(item: Item) -> Generator[None, None, None]:
     yield
 
     util._reprcompare, util._assertion_pass = saved_assert_hooks
+    util._config = None
 
 
 def pytest_sessionfinish(session: "Session") -> None:

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -27,6 +27,7 @@ from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import Union
 
+from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE
 from _pytest._io.saferepr import saferepr
 from _pytest._version import version
 from _pytest.assertion import util
@@ -427,7 +428,18 @@ def _saferepr(obj: object) -> str:
     sequences, especially '\n{' and '\n}' are likely to be present in
     JSON reprs.
     """
-    return saferepr(obj).replace("\n", "\\n")
+    maxsize = _get_maxsize_for_saferepr(util._config)
+    return saferepr(obj, maxsize=maxsize).replace("\n", "\\n")
+
+
+def _get_maxsize_for_saferepr(config: Optional[Config]) -> Optional[int]:
+    """Get `maxsize` configuration for saferepr based on the given config object."""
+    verbosity = config.getoption("verbose") if config is not None else 0
+    if verbosity >= 2:
+        return None
+    if verbosity >= 1:
+        return DEFAULT_REPR_MAX_SIZE * 10
+    return DEFAULT_REPR_MAX_SIZE
 
 
 def _format_assertmsg(obj: object) -> str:

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -15,6 +15,8 @@ from _pytest import outcomes
 from _pytest._io.saferepr import _pformat_dispatch
 from _pytest._io.saferepr import safeformat
 from _pytest._io.saferepr import saferepr
+from _pytest.config import Config
+
 
 # The _reprcompare attribute on the util module is used by the new assertion
 # interpretation code and assertion rewriter to detect this plugin was
@@ -25,6 +27,9 @@ _reprcompare: Optional[Callable[[str, object, object], Optional[str]]] = None
 # Works similarly as _reprcompare attribute. Is populated with the hook call
 # when pytest_runtest_setup is called.
 _assertion_pass: Optional[Callable[[int, str, str], None]] = None
+
+# Config object which is assigned during pytest_runtest_protocol.
+_config: Optional[Config] = None
 
 
 def format_explanation(explanation: str) -> str:

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -1,5 +1,6 @@
 import pytest
 from _pytest._io.saferepr import _pformat_dispatch
+from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE
 from _pytest._io.saferepr import saferepr
 
 
@@ -12,6 +13,13 @@ def test_maxsize():
     s = saferepr("x" * 50, maxsize=25)
     assert len(s) == 25
     expected = repr("x" * 10 + "..." + "x" * 10)
+    assert s == expected
+
+
+def test_no_maxsize():
+    text = "x" * DEFAULT_REPR_MAX_SIZE * 10
+    s = saferepr(text, maxsize=None)
+    expected = repr(text)
     assert s == expected
 
 


### PR DESCRIPTION
This helps with the problem described in #6682.

~~Decided to go with `-vvv` and `-vvvv` because I believe they are rarely used, so this should really affect users that want to disable truncation, but would like to hear opinions.~~

As discussed in #8403, changed the verbosity to 2400 for `-v`, and unlimited for `-vv` and up.

Fix #6682
Fix #8403 