### PR TITLE
closes #8394 Generated fixture names for unittest/xunit/nose should start with underscore

### DIFF
--- a/changelog/8394.bugfix.rst
+++ b/changelog/8394.bugfix.rst
@@ -1,0 +1,1 @@
+Use private names for internal fixtures that handle classic setup/teardown so that they don't show up with the default ``--fixtures`` invocation (but they still show up with ``--fixtures -v``).

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -528,7 +528,7 @@ class Module(nodes.File, PyCollector):
             autouse=True,
             scope="module",
             # Use a unique name to speed up lookup.
-            name=f"xunit_setup_module_fixture_{self.obj.__name__}",
+            name=f"_xunit_setup_module_fixture_{self.obj.__name__}",
         )
         def xunit_setup_module_fixture(request) -> Generator[None, None, None]:
             if setup_module is not None:
@@ -557,7 +557,7 @@ class Module(nodes.File, PyCollector):
             autouse=True,
             scope="function",
             # Use a unique name to speed up lookup.
-            name=f"xunit_setup_function_fixture_{self.obj.__name__}",
+            name=f"_xunit_setup_function_fixture_{self.obj.__name__}",
         )
         def xunit_setup_function_fixture(request) -> Generator[None, None, None]:
             if request.instance is not None:
@@ -809,7 +809,7 @@ class Class(PyCollector):
             autouse=True,
             scope="class",
             # Use a unique name to speed up lookup.
-            name=f"xunit_setup_class_fixture_{self.obj.__qualname__}",
+            name=f"_xunit_setup_class_fixture_{self.obj.__qualname__}",
         )
         def xunit_setup_class_fixture(cls) -> Generator[None, None, None]:
             if setup_class is not None:
@@ -838,7 +838,7 @@ class Class(PyCollector):
             autouse=True,
             scope="function",
             # Use a unique name to speed up lookup.
-            name=f"xunit_setup_method_fixture_{self.obj.__qualname__}",
+            name=f"_xunit_setup_method_fixture_{self.obj.__qualname__}",
         )
         def xunit_setup_method_fixture(self, request) -> Generator[None, None, None]:
             method = request.function

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -144,7 +144,7 @@ def _make_xunit_fixture(
         scope=scope,
         autouse=True,
         # Use a unique name to speed up lookup.
-        name=f"unittest_{setup_name}_fixture_{obj.__qualname__}",
+        name=f"_unittest_{setup_name}_fixture_{obj.__qualname__}",
     )
     def fixture(self, request: FixtureRequest) -> Generator[None, None, None]:
         if _is_skipped(self):

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -211,6 +211,96 @@ def test_nose_style_setup_teardown(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(["*2 passed*"])
 
 
+def test_fixtures_nose_setup_module_issue8394(pytester: Pytester) -> None:
+    pytester.makepyfile(
+        """
+        def setup_module():
+            pass
+
+        def teardown_module():
+            pass
+
+        def test_world():
+            pass
+        """        
+    )
+    result = pytester.runpytest("--fixtures")
+    assert result.ret == 0
+    result.stdout.no_fnmatch_line("*no docstring available*")
+
+    result = pytester.runpytest("--fixtures", "-v")
+    assert result.ret == 0
+    result.stdout.fnmatch_lines(["*no docstring available*"])
+
+
+def test_fixtures_nose_setup_method_issue8394(pytester: Pytester) -> None:
+    pytester.makepyfile(
+        """
+        class Test(object):
+            def setup_method(self, meth): 
+                pass
+
+            def teardown_method(self, meth):
+                pass
+
+            def test_method_1(self): pass
+        """        
+    )
+    
+    result = pytester.runpytest("--fixtures")
+    assert result.ret == 0
+    result.stdout.no_fnmatch_line("*no docstring available*")
+
+    result = pytester.runpytest("--fixtures", "-v")
+    assert result.ret == 0
+    result.stdout.fnmatch_lines(["*no docstring available*"])
+
+
+def test_fixtures_nose_setup_class_issue8394(pytester: Pytester) -> None:
+    pytester.makepyfile(
+        """
+        class Test(object):
+            def setup_class(cls): 
+                pass
+
+            def teardown_class(cls):
+                pass
+
+            def test_method_1(self): pass
+        """        
+    )
+    
+    result = pytester.runpytest("--fixtures")
+    assert result.ret == 0
+    result.stdout.no_fnmatch_line("*no docstring available*")
+
+    result = pytester.runpytest("--fixtures", "-v")
+    assert result.ret == 0
+    result.stdout.fnmatch_lines(["*no docstring available*"])
+
+
+def test_fixtures_nose_setup_function_issue8394(pytester: Pytester) -> None:
+    pytester.makepyfile(
+        """
+        def setup_function(func):
+            pass
+
+        def teardown_function(func):
+            pass
+
+        def test_world():
+            pass
+        """        
+    )
+    result = pytester.runpytest("--fixtures")
+    assert result.ret == 0
+    result.stdout.no_fnmatch_line("*no docstring available*")
+
+    result = pytester.runpytest("--fixtures", "-v")
+    assert result.ret == 0
+    result.stdout.fnmatch_lines(["*no docstring available*"])
+
+
 def test_nose_setup_ordering(pytester: Pytester) -> None:
     pytester.makepyfile(
         """

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -243,7 +243,7 @@ def test_fixtures_nose_setup_issue8394(pytester: Pytester) -> None:
                 pass
 
             def test_method(self): pass
-        """        
+        """
     )
     regex = "*no docstring available*"
     result = pytester.runpytest("--fixtures")

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -245,14 +245,14 @@ def test_fixtures_nose_setup_issue8394(pytester: Pytester) -> None:
             def test_method(self): pass
         """
     )
-    regex = "*no docstring available*"
+    match = "*no docstring available*"
     result = pytester.runpytest("--fixtures")
     assert result.ret == 0
-    result.stdout.no_fnmatch_line(regex)
+    result.stdout.no_fnmatch_line(match)
 
     result = pytester.runpytest("--fixtures", "-v")
     assert result.ret == 0
-    result.stdout.fnmatch_lines([regex, regex, regex, regex])
+    result.stdout.fnmatch_lines([match, match, match, match])
 
 
 def test_nose_setup_ordering(pytester: Pytester) -> None:

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -222,7 +222,7 @@ def test_fixtures_nose_setup_module_issue8394(pytester: Pytester) -> None:
 
         def test_world():
             pass
-        """        
+        """
     )
     result = pytester.runpytest("--fixtures")
     assert result.ret == 0
@@ -237,16 +237,16 @@ def test_fixtures_nose_setup_method_issue8394(pytester: Pytester) -> None:
     pytester.makepyfile(
         """
         class Test(object):
-            def setup_method(self, meth): 
+            def setup_method(self, meth):
                 pass
 
             def teardown_method(self, meth):
                 pass
 
             def test_method_1(self): pass
-        """        
+        """
     )
-    
+
     result = pytester.runpytest("--fixtures")
     assert result.ret == 0
     result.stdout.no_fnmatch_line("*no docstring available*")
@@ -260,16 +260,16 @@ def test_fixtures_nose_setup_class_issue8394(pytester: Pytester) -> None:
     pytester.makepyfile(
         """
         class Test(object):
-            def setup_class(cls): 
+            def setup_class(cls):
                 pass
 
             def teardown_class(cls):
                 pass
 
             def test_method_1(self): pass
-        """        
+        """
     )
-    
+
     result = pytester.runpytest("--fixtures")
     assert result.ret == 0
     result.stdout.no_fnmatch_line("*no docstring available*")
@@ -290,7 +290,7 @@ def test_fixtures_nose_setup_function_issue8394(pytester: Pytester) -> None:
 
         def test_world():
             pass
-        """        
+        """
     )
     result = pytester.runpytest("--fixtures")
     assert result.ret == 0

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -211,7 +211,7 @@ def test_nose_style_setup_teardown(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(["*2 passed*"])
 
 
-def test_fixtures_nose_setup_module_issue8394(pytester: Pytester) -> None:
+def test_fixtures_nose_setup_issue8394(pytester: Pytester) -> None:
     pytester.makepyfile(
         """
         def setup_module():
@@ -220,68 +220,6 @@ def test_fixtures_nose_setup_module_issue8394(pytester: Pytester) -> None:
         def teardown_module():
             pass
 
-        def test_world():
-            pass
-        """
-    )
-    result = pytester.runpytest("--fixtures")
-    assert result.ret == 0
-    result.stdout.no_fnmatch_line("*no docstring available*")
-
-    result = pytester.runpytest("--fixtures", "-v")
-    assert result.ret == 0
-    result.stdout.fnmatch_lines(["*no docstring available*"])
-
-
-def test_fixtures_nose_setup_method_issue8394(pytester: Pytester) -> None:
-    pytester.makepyfile(
-        """
-        class Test(object):
-            def setup_method(self, meth):
-                pass
-
-            def teardown_method(self, meth):
-                pass
-
-            def test_method_1(self): pass
-        """
-    )
-
-    result = pytester.runpytest("--fixtures")
-    assert result.ret == 0
-    result.stdout.no_fnmatch_line("*no docstring available*")
-
-    result = pytester.runpytest("--fixtures", "-v")
-    assert result.ret == 0
-    result.stdout.fnmatch_lines(["*no docstring available*"])
-
-
-def test_fixtures_nose_setup_class_issue8394(pytester: Pytester) -> None:
-    pytester.makepyfile(
-        """
-        class Test(object):
-            def setup_class(cls):
-                pass
-
-            def teardown_class(cls):
-                pass
-
-            def test_method_1(self): pass
-        """
-    )
-
-    result = pytester.runpytest("--fixtures")
-    assert result.ret == 0
-    result.stdout.no_fnmatch_line("*no docstring available*")
-
-    result = pytester.runpytest("--fixtures", "-v")
-    assert result.ret == 0
-    result.stdout.fnmatch_lines(["*no docstring available*"])
-
-
-def test_fixtures_nose_setup_function_issue8394(pytester: Pytester) -> None:
-    pytester.makepyfile(
-        """
         def setup_function(func):
             pass
 
@@ -290,15 +228,31 @@ def test_fixtures_nose_setup_function_issue8394(pytester: Pytester) -> None:
 
         def test_world():
             pass
-        """
+
+        class Test(object):
+            def setup_class(cls):
+                pass
+
+            def teardown_class(cls):
+                pass
+
+            def setup_method(self, meth):
+                pass
+
+            def teardown_method(self, meth):
+                pass
+
+            def test_method(self): pass
+        """        
     )
+    regex = "*no docstring available*"
     result = pytester.runpytest("--fixtures")
     assert result.ret == 0
-    result.stdout.no_fnmatch_line("*no docstring available*")
+    result.stdout.no_fnmatch_line(regex)
 
     result = pytester.runpytest("--fixtures", "-v")
     assert result.ret == 0
-    result.stdout.fnmatch_lines(["*no docstring available*"])
+    result.stdout.fnmatch_lines([regex, regex, regex, regex])
 
 
 def test_nose_setup_ordering(pytester: Pytester) -> None:

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -303,7 +303,7 @@ def test_setup_setUpClass(pytester: Pytester) -> None:
 
 
 def test_fixtures_setup_setUpClass_issue8394(pytester: Pytester) -> None:
-    testpath = pytester.makepyfile(
+    pytester.makepyfile(
         """
         import unittest
         class MyTestCase(unittest.TestCase):
@@ -327,7 +327,7 @@ def test_fixtures_setup_setUpClass_issue8394(pytester: Pytester) -> None:
 
 
 def test_setup_class(pytester: Pytester) -> None:
-    pytester.makepyfile(
+    testpath = pytester.makepyfile(
         """
         import unittest
         import pytest

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -327,7 +327,7 @@ def test_fixtures_setup_setUpClass_issue8394(pytester: Pytester) -> None:
 
 
 def test_setup_class(pytester: Pytester) -> None:
-    testpath = pytester.makepyfile(
+    pytester.makepyfile(
         """
         import unittest
         import pytest
@@ -347,30 +347,6 @@ def test_setup_class(pytester: Pytester) -> None:
     )
     reprec = pytester.inline_run(testpath)
     reprec.assertoutcome(passed=3)
-
-
-def test_fixtures_setup(pytester: Pytester) -> None:
-    testpath = pytester.makepyfile(
-        """
-        import unittest
-        class MyTestCase(unittest.TestCase):
-            def setup_method(self, method):
-                pass
-            def test_func1(self):
-                pass
-            def teardown_method(self, method):
-                assert 0, "42"
-    """
-    )
-    result = pytester.runpytest("--fixtures")
-    assert result.ret == 0
-    result.stdout.no_fnmatch_line("*no docstring available*")
-
-    result = pytester.runpytest("--fixtures", "-v")
-    assert result.ret == 0
-    result.stdout.fnmatch_lines(
-        ["*no docstring available*", "*no docstring available*"]
-    )
 
 
 @pytest.mark.parametrize("type", ["Error", "Failure"])

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -301,6 +301,29 @@ def test_setup_setUpClass(pytester: Pytester) -> None:
     reprec = pytester.inline_run(testpath)
     reprec.assertoutcome(passed=3)
 
+def test_fixtures_setup_setUpClass_issue8394(pytester: Pytester) -> None:
+    testpath = pytester.makepyfile(
+        """
+        import unittest
+        class MyTestCase(unittest.TestCase):
+            @classmethod
+            def setUpClass(cls):
+                pass
+            def test_func1(self):
+                pass
+            @classmethod
+            def tearDownClass(cls):
+                pass
+    """
+    )
+    result = pytester.runpytest("--fixtures")
+    assert result.ret == 0
+    result.stdout.no_fnmatch_line("*no docstring available*")
+
+    result = pytester.runpytest("--fixtures", "-v")
+    assert result.ret == 0
+    result.stdout.fnmatch_lines(["*no docstring available*"])
+
 
 def test_setup_class(pytester: Pytester) -> None:
     testpath = pytester.makepyfile(
@@ -323,6 +346,28 @@ def test_setup_class(pytester: Pytester) -> None:
     )
     reprec = pytester.inline_run(testpath)
     reprec.assertoutcome(passed=3)
+
+
+def test_fixtures_setup(pytester: Pytester) -> None:
+    testpath = pytester.makepyfile(
+        """
+        import unittest
+        class MyTestCase(unittest.TestCase):
+            def setup_method(self, method):
+                pass
+            def test_func1(self):
+                pass
+            def teardown_method(self, method):
+                assert 0, "42"
+    """
+    )
+    result = pytester.runpytest("--fixtures")
+    assert result.ret == 0
+    result.stdout.no_fnmatch_line("*no docstring available*")
+
+    result = pytester.runpytest("--fixtures", "-v")
+    assert result.ret == 0
+    result.stdout.fnmatch_lines(["*no docstring available*", "*no docstring available*"])
 
 
 @pytest.mark.parametrize("type", ["Error", "Failure"])

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -301,6 +301,7 @@ def test_setup_setUpClass(pytester: Pytester) -> None:
     reprec = pytester.inline_run(testpath)
     reprec.assertoutcome(passed=3)
 
+
 def test_fixtures_setup_setUpClass_issue8394(pytester: Pytester) -> None:
     testpath = pytester.makepyfile(
         """
@@ -367,7 +368,9 @@ def test_fixtures_setup(pytester: Pytester) -> None:
 
     result = pytester.runpytest("--fixtures", "-v")
     assert result.ret == 0
-    result.stdout.fnmatch_lines(["*no docstring available*", "*no docstring available*"])
+    result.stdout.fnmatch_lines(
+        ["*no docstring available*", "*no docstring available*"]
+    )
 
 
 @pytest.mark.parametrize("type", ["Error", "Failure"])


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
### Problem
The problem was that the fixtures generated for unittest/xunit/nose were no longer starting with an underscore, and were always listed with `--fixtures`. This broke a unit-test that checked that all the fixtures we wrote have a docstring (because the auto-genned fixtures do not). See #8394 .

### Solution
- Followed the approach suggested by @nicoddemus in #8394 of just adding an underscore to the name templates where I found them: one for unittest and four for xunit/nose.

- I wrote a bunch of tests for each case separately and committed the (failing) tests first, followed by the commit that fixes them.
