### PR TITLE
Add type annotations to the description instead of signature

### DIFF
--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -35,6 +35,7 @@ release = ".".join(version.split(".")[:2])
 # sys.path.insert(0, os.path.abspath('.'))
 
 autodoc_member_order = "bysource"
+autodoc_typehints = "description"
 todo_include_todos = 1
 
 # -- General configuration -----------------------------------------------------


### PR DESCRIPTION
This configures Sphinx autodoc to include the type annotations
along with the description of the function/method, instead of including
it into the signature.

Fix #8405