### PR TITLE
Approx decimal sequence mapping

### DIFF
--- a/changelog/8421.feature.rst
+++ b/changelog/8421.feature.rst
@@ -1,0 +1,1 @@
+:func:`pytest.approx` now works on :class:`~decimal.Decimal` within mappings/dicts and sequences/lists.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -72,6 +72,8 @@ class ApproxBase:
         return not (actual == self)
 
     def _approx_scalar(self, x) -> "ApproxScalar":
+        if isinstance(x, Decimal):
+            return ApproxDecimal(x, rel=self.rel, abs=self.abs, nan_ok=self.nan_ok)
         return ApproxScalar(x, rel=self.rel, abs=self.abs, nan_ok=self.nan_ok)
 
     def _yield_comparisons(self, actual):

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -313,7 +313,6 @@ class TestApprox:
         assert approx(expected, rel=5e-7, abs=0) == actual
         assert approx(expected, rel=5e-8, abs=0) != actual
 
-    @pytest.mark.xfail
     def test_list_decimal(self):
         actual = [Decimal("1.000001"), Decimal("2.000001")]
         expected = [Decimal("1"), Decimal("2")]
@@ -353,7 +352,6 @@ class TestApprox:
         assert approx(expected, rel=5e-7, abs=0) == actual
         assert approx(expected, rel=5e-8, abs=0) != actual
 
-    @pytest.mark.xfail
     def test_dict_decimal(self):
         actual = {"a": Decimal("1.000001"), "b": Decimal("2.000001")}
         # Dictionaries became ordered in python3.6, so switch up the order here

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -313,6 +313,13 @@ class TestApprox:
         assert approx(expected, rel=5e-7, abs=0) == actual
         assert approx(expected, rel=5e-8, abs=0) != actual
 
+    @pytest.mark.xfail
+    def test_list_decimal(self):
+        actual = [Decimal("1.000001"), Decimal("2.000001")]
+        expected = [Decimal("1"), Decimal("2")]
+
+        assert actual == approx(expected)
+
     def test_list_wrong_len(self):
         assert [1, 2] != approx([1])
         assert [1, 2] != approx([1, 2, 3])
@@ -345,6 +352,15 @@ class TestApprox:
         assert actual != approx(expected, rel=5e-8, abs=0)
         assert approx(expected, rel=5e-7, abs=0) == actual
         assert approx(expected, rel=5e-8, abs=0) != actual
+
+    @pytest.mark.xfail
+    def test_dict_decimal(self):
+        actual = {"a": Decimal("1.000001"), "b": Decimal("2.000001")}
+        # Dictionaries became ordered in python3.6, so switch up the order here
+        # to make sure it doesn't matter.
+        expected = {"b": Decimal("2"), "a": Decimal("1")}
+
+        assert actual == approx(expected)
 
     def test_dict_wrong_len(self):
         assert {"a": 1, "b": 2} != approx({"a": 1})


### PR DESCRIPTION
closes #8421 

The tests are pretty bare, I could add assertions with eg. Decimal `rel`, and assertions failing because the values are not close enough. I don't know how relevant these assertions would be :O I will gladly add them if you think it's necessary :)

I'm not all that proud of the "fix" either. It's not clear to me where to best do the check against Decimal :\

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
