### PR TITLE
setup.cfg: fix setuptools dash-separator warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,12 +77,12 @@ _pytest = py.typed
 pytest = py.typed
 
 [build_sphinx]
-source-dir = doc/en/
-build-dir = doc/build
+source_dir = doc/en/
+build_dir = doc/build
 all_files = 1
 
 [upload_sphinx]
-upload-dir = doc/en/build/html
+upload_dir = doc/en/build/html
 
 [check-manifest]
 ignore =


### PR DESCRIPTION
Warnings like this:

```
python3.9/site-packages/setuptools/dist.py:634: UserWarning: Usage of dash-separated 'upload-dir' will not be supported in future versions. Please use the underscore name 'upload_dir' instead
```