### PR TITLE
issue a warning when Item and Collector are used in diamond inheritance

### DIFF
--- a/changelog/8447.deprecation.rst
+++ b/changelog/8447.deprecation.rst
@@ -1,0 +1,4 @@
+Warn when inheritance is used to bring Collectors into Items,
+it was never sanely supported and triggers hard to debug errors.
+
+Instead of inheritance composition should be used.

--- a/changelog/8447.deprecation.rst
+++ b/changelog/8447.deprecation.rst
@@ -1,4 +1,4 @@
-Warn when inheritance is used to bring Collectors into Items,
-it was never sanely supported and triggers hard to debug errors.
+Defining a custom pytest node type which is both an item and a collector now issues a warning.
+It was never sanely supported and triggers hard to debug errors.
 
-Instead of inheritance composition should be used.
+Instead, a separate collector node should be used, which collects the item. See :ref:`nonpython` for an example.

--- a/changelog/8447.deprecation.rst
+++ b/changelog/8447.deprecation.rst
@@ -1,4 +1,4 @@
 Defining a custom pytest node type which is both an item and a collector now issues a warning.
 It was never sanely supported and triggers hard to debug errors.
 
-Instead, a separate collector node should be used, which collects the item. See :ref:`nonpython` for an example.
+Instead, a separate collector node should be used, which collects the item. See :ref:`non-python tests` for an example.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -42,6 +42,20 @@ As pytest tries to move off `py.path.local <https://py.readthedocs.io/en/latest/
 
 Pytest will provide compatibility for quite a while.
 
+Diamond inheritance between :class:`pytest.File` and :class:`pytest.Item`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 6.3
+
+Inheriting from both Item and file at once has never been supported officially,
+however some plugins providing linting/code analysis have been using this as a hack.
+
+This practice is now officially deprecated and a common way to fix this is `example pr fixing inheritance`_.
+
+
+
+.. _example pr fixing inheritance: https://github.com/asmeurer/pytest-flakes/pull/40/files
+
 
 Backward compatibilities in ``Parser.addoption``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -484,7 +484,7 @@ class Session(nodes.FSCollector):
 
     @classmethod
     def from_config(cls, config: Config) -> "Session":
-        session: Session = cls._create(config)
+        session: Session = cls._create(config=config)
         return session
 
     def __repr__(self) -> str:

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -34,6 +34,7 @@ from _pytest.outcomes import fail
 from _pytest.pathlib import absolutepath
 from _pytest.pathlib import commonpath
 from _pytest.store import Store
+from _pytest.warning_types import PytestWarning
 
 if TYPE_CHECKING:
     # Imported here due to circular import.
@@ -609,6 +610,19 @@ class Item(Node):
     """
 
     nextitem = None
+
+    def __init_subclass__(cls):
+        problems = ", ".join(
+            base.__name__ for base in cls.__bases__ if issubclass(base, Collector)
+        )
+        if problems:
+            warnings.warn(
+                f"{cls.__name__} is a Item subclass and should not be a collector.\n"
+                f"however its bases {problems} are collectors\n"
+                "please split the collection and the items into 2 node types\n"
+                "TODO: doc link",
+                PytestWarning,
+            )
 
     def __init__(
         self,

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -653,7 +653,8 @@ class Item(Node):
                 f"{cls.__name__} is an Item subclass and should not be a collector, "
                 f"however its bases {problems} are collectors.\n"
                 "Please split the Collectors and the Item into separate node types.\n"
-                "TODO: doc link",
+                "Pytest Doc example: https://docs.pytest.org/en/latest/example/nonpython.html\n"
+                "example pull request on a plugin: https://github.com/asmeurer/pytest-flakes/pull/40/",
                 PytestWarning,
             )
 

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -132,8 +132,14 @@ class NodeMeta(type):
             return super().__call__(*k, **kw)
         except TypeError:
             sig = signature(cast(Type[Node], self).__init__)
-            sig.replace()
             known_kw = {k: v for k, v in kw.items() if k in sig.parameters}
+            from .warning_types import PytestDeprecationWarning
+
+            warnings.warn(
+                PytestDeprecationWarning(
+                    f"{self} is not using a cooperative constructor and only takes {set(known_kw)}"
+                )
+            )
 
             return super().__call__(*k, **known_kw)
 

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -131,7 +131,7 @@ class NodeMeta(type):
         try:
             return super().__call__(*k, **kw)
         except TypeError:
-            sig = signature(cast(Type[Node], self).__init__)
+            sig = signature(getattr(self, "__init__"))
             known_kw = {k: v for k, v in kw.items() if k in sig.parameters}
             from .warning_types import PytestDeprecationWarning
 

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -566,7 +566,6 @@ class FSCollector(Collector):
                 assert path is None
                 path = path_or_parent
 
-        assert parent is not None
         path, fspath = _imply_path(path, fspath=fspath)
         if name is None:
             name = path.name
@@ -580,7 +579,9 @@ class FSCollector(Collector):
                 name = name.replace(os.sep, SEP)
         self.path = path
 
-        session = session or parent.session
+        if session is None:
+            assert parent is not None
+            session = parent.session
 
         if nodeid is None:
             try:

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -611,15 +611,15 @@ class Item(Node):
 
     nextitem = None
 
-    def __init_subclass__(cls):
+    def __init_subclass__(cls) -> None:
         problems = ", ".join(
             base.__name__ for base in cls.__bases__ if issubclass(base, Collector)
         )
         if problems:
             warnings.warn(
-                f"{cls.__name__} is a Item subclass and should not be a collector.\n"
-                f"however its bases {problems} are collectors\n"
-                "please split the collection and the items into 2 node types\n"
+                f"{cls.__name__} is an Item subclass and should not be a collector, "
+                f"however its bases {problems} are collectors.\n"
+                "Please split the Collectors and the Item into separate node types.\n"
                 "TODO: doc link",
                 PytestWarning,
             )

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -5,6 +5,7 @@ from typing import Type
 
 import pytest
 from _pytest import nodes
+from _pytest.compat import legacy_path
 from _pytest.pytester import Pytester
 from _pytest.warning_types import PytestWarning
 
@@ -39,8 +40,14 @@ def test_node_from_parent_disallowed_arguments() -> None:
         nodes.Node.from_parent(None, config=None)  # type: ignore[arg-type]
 
 
-def test_subclassing_both_item_and_collector_warns(request, tmp_path: Path) -> None:
-    from _pytest.compat import legacy_path
+def test_subclassing_both_item_and_collector_deprecated(
+    request, tmp_path: Path
+) -> None:
+    """
+    Verifies we warn on diamond inheritance
+    as well as correctly managing legacy inheritance ctors with missing args
+    as found in plugins
+    """
 
     with pytest.warns(
         PytestWarning,

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -46,7 +46,7 @@ def test_subclassing_both_item_and_collector_warns(request, tmp_path: Path) -> N
         PytestWarning,
         match=(
             "(?m)SoWrong is an Item subclass and should not be a collector, however its bases File are collectors.\n"
-            "Please split the Collectors and the Item into separate node types.\nTODO:.*"
+            "Please split the Collectors and the Item into separate node types.\n.*"
         ),
     ):
 

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -55,7 +55,12 @@ def test_subclassing_both_item_and_collector_warns(request, tmp_path: Path) -> N
                 """Legacy ctor with legacy call # don't wana see"""
                 super().__init__(fspath, parent)
 
-    SoWrong.from_parent(request.session, fspath=legacy_path(tmp_path / "broken.txt"))
+    with pytest.warns(
+        PytestWarning, match=".*SoWrong.* not using a cooperative constructor.*"
+    ):
+        SoWrong.from_parent(
+            request.session, fspath=legacy_path(tmp_path / "broken.txt")
+        )
 
 
 @pytest.mark.parametrize(

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -39,7 +39,7 @@ def test_node_from_parent_disallowed_arguments() -> None:
         nodes.Node.from_parent(None, config=None)  # type: ignore[arg-type]
 
 
-def test_subclassing_node_with_item_warns() -> None:
+def test_subclassing_both_item_and_collector_warns() -> None:
 
     with pytest.warns(
         PytestWarning, match="SoWrong is a Item subclass and should not be a collector"

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -39,6 +39,16 @@ def test_node_from_parent_disallowed_arguments() -> None:
         nodes.Node.from_parent(None, config=None)  # type: ignore[arg-type]
 
 
+def test_subclassing_node_with_item_warns() -> None:
+
+    with pytest.warns(
+        PytestWarning, match="SoWrong is a Item subclass and should not be a collector"
+    ):
+
+        class SoWrong(nodes.Item, nodes.File):
+            pass
+
+
 @pytest.mark.parametrize(
     "warn_type, msg", [(DeprecationWarning, "deprecated"), (PytestWarning, "pytest")]
 )


### PR DESCRIPTION
resolves #8435

- [x] include doc example from https://github.com/asmeurer/pytest-flakes/pull/40/files
- [x] document the problem in more detail
- [x] consider the addition of a `FileItem` with unique test ids
- [x] return ctor backward compat