### PR TITLE
Fix value in error message about negative relative tolerance

### DIFF
--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -317,7 +317,7 @@ class ApproxScalar(ApproxBase):
 
         if relative_tolerance < 0:
             raise ValueError(
-                f"relative tolerance can't be negative: {absolute_tolerance}"
+                f"relative tolerance can't be negative: {relative_tolerance}"
             )
         if math.isnan(relative_tolerance):
             raise ValueError("relative tolerance can't be NaN.")

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -143,9 +143,9 @@ class TestApprox:
 
     def test_negative_tolerance_message(self):
         # Error message for negative tolerance should include the value.
-        with pytest.raises(ValueError, match='-3'):
+        with pytest.raises(ValueError, match="-3"):
             0 == approx(1, abs=-3)
-        with pytest.raises(ValueError, match='-3'):
+        with pytest.raises(ValueError, match="-3"):
             0 == approx(1, rel=-3)
 
     def test_inf_tolerance(self):

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -141,6 +141,13 @@ class TestApprox:
         with pytest.raises(ValueError):
             1.1 == approx(1, rel, abs)
 
+    def test_negative_tolerance_message(self):
+        # Error message for negative tolerance should include the value.
+        with pytest.raises(ValueError, match='-3'):
+            0 == approx(1, abs=-3)
+        with pytest.raises(ValueError, match='-3'):
+            0 == approx(1, rel=-3)
+
     def test_inf_tolerance(self):
         # Everything should be equal if the tolerance is infinite.
         large_diffs = [(1, 1000), (1e-50, 1e50), (-1.0, -1e300), (0.0, 10)]


### PR DESCRIPTION
Hello!
A static code analyzer informed us that the wrong variable is used for the "relative tolerance can't be negative" error message in `pytest.approx`.
I don't know how to best write a test for this, since error messages usually aren't covered by tests.

A reproducer:
```
from pytest import approx
0 == approx(1, rel=-3)
```
gives:
```
ValueError: relative tolerance can't be negative: 1e-12
```
but should give:
```
ValueError: relative tolerance can't be negative: -3
```

(There's also no documentation; I don't think this is docs-worthy.)
