### PR TITLE
address #8361 - introduce hook caller wrappers that enable backward compat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,7 +89,7 @@ repos:
         types: [python]
     -   id: py-path-deprecated
         name: py.path usage is deprecated
+        exclude: docs|src/_pytest/deprecated.py|testing/deprecated_test.py
         language: pygrep
         entry: \bpy\.path\.local
-        exclude: docs
         types: [python]

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -19,6 +19,20 @@ Below is a complete list of all pytest features which are considered deprecated.
 :class:`PytestWarning` or subclasses, which can be filtered using :ref:`standard warning filters <warnings>`.
 
 
+``py.path.local`` arguments for hooks replaced with ``pathlib.Path``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In order to support the transition oto pathlib, the following hooks added additional arugments:
+
+*  ``pytest_ignore_collect(fspath: pathlib.Path)``
+*  ``pytest_collect_file(fspath: pathlib.Path)``
+*  ``pytest_pycollect_makemodule(fspath: pathlib.Path)``
+*  ``pytest_report_header(startpath: pathlib.Path)``
+*  ``pytest_report_collectionfinish(startpath: pathlib.Path)``
+
+The accompanying ``py.path.local`` based paths have been deprecated.
+
+
 ``Node.fspath`` in favor of ``pathlib`` and ``Node.path``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -22,15 +22,15 @@ Below is a complete list of all pytest features which are considered deprecated.
 ``py.path.local`` arguments for hooks replaced with ``pathlib.Path``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In order to support the transition oto pathlib, the following hooks added additional arugments:
+In order to support the transition to :mod:`pathlib`, the following hooks now receive additional arguments:
 
-*  ``pytest_ignore_collect(fspath: pathlib.Path)``
-*  ``pytest_collect_file(fspath: pathlib.Path)``
-*  ``pytest_pycollect_makemodule(fspath: pathlib.Path)``
-*  ``pytest_report_header(startpath: pathlib.Path)``
-*  ``pytest_report_collectionfinish(startpath: pathlib.Path)``
+*  :func:`pytest_ignore_collect(fspath: pathlib.Path) <_pytest.hookspec.pytest_ignore_collect>`
+*  :func:`pytest_collect_file(fspath: pathlib.Path) <_pytest.hookspec.pytest_collect_file>`
+*  :func:`pytest_pycollect_makemodule(fspath: pathlib.Path) <_pytest.hookspec.pytest_pycollect_makemodule>`
+*  :func:`pytest_report_header(startpath: pathlib.Path) <_pytest.hookspec.pytest_report_header>`
+*  :func:`pytest_report_collectionfinish(startpath: pathlib.Path) <_pytest.hookspec.pytest_report_collectionfinish>`
 
-The accompanying ``py.path.local`` based paths have been deprecated.
+The accompanying ``py.path.local`` based paths have been deprecated: plugins which manually invoke those hooks should only pass the new ``pathlib.Path`` arguments, and users should change their hook implementations to use the new ``pathlib.Path`` arguments.
 
 
 ``Node.fspath`` in favor of ``pathlib`` and ``Node.path``

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -917,8 +917,10 @@ class Config:
         :type: PytestPluginManager
         """
 
+        from .compat import PathAwareHookProxy
+
         self.trace = self.pluginmanager.trace.root.get("config")
-        self.hook = self.pluginmanager.hook
+        self.hook = PathAwareHookProxy(self.pluginmanager.hook)
         self._inicache: Dict[str, Any] = {}
         self._override_ini: Sequence[str] = ()
         self._opt2dest: Dict[str, str] = {}

--- a/src/_pytest/config/compat.py
+++ b/src/_pytest/config/compat.py
@@ -1,0 +1,41 @@
+from typing import TYPE_CHECKING
+
+from _pytest.nodes import _imply_path
+
+if TYPE_CHECKING:
+    from ..compat import LEGACY_PATH
+
+
+import functools
+
+# hookname: (Path, LEGACY_PATH)
+imply_paths_hooks = {
+    "pytest_ignore_collect": ("fspath", "path"),
+    "pytest_collect_file": ("fspath", "path"),
+    "pytest_pycollect_makemodule": ("fspath", "path"),
+    "pytest_report_header": ("startpath", "startdir"),
+    "pytest_report_collectionfinish": ("startpath", "startdir"),
+}
+
+
+class PathAwareHookProxy:
+    def __init__(self, hook_caller):
+        self.__hook_caller = hook_caller
+
+    def __getattr__(self, key):
+        if key not in imply_paths_hooks:
+            return getattr(self.__hook_caller, key)
+        else:
+            hook = getattr(self.__hook_caller, key)
+            path_var, fspath_var = imply_paths_hooks[key]
+
+            @functools.wraps(hook)
+            def fixed_hook(**kw):
+                path_value = kw.pop(path_var, None)
+                fspath_value: "LEGACY_PATH" = kw.pop(fspath_var, None)
+                path_value, fspath_value = _imply_path(path_value, fspath_value)
+                kw[path_var] = path_value
+                kw[fspath_var] = fspath_value
+                return hook(**kw)
+
+            return fixed_hook

--- a/src/_pytest/config/compat.py
+++ b/src/_pytest/config/compat.py
@@ -1,8 +1,9 @@
-import functools
+import warnings
 from pathlib import Path
 from typing import Optional
 
 from ..compat import LEGACY_PATH
+from ..deprecated import HOOK_LEGACY_PATH_ARG
 from _pytest.nodes import _imply_path
 
 # hookname: (Path, LEGACY_PATH)
@@ -19,6 +20,9 @@ class PathAwareHookProxy:
     def __init__(self, hook_caller):
         self.__hook_caller = hook_caller
 
+    def __dir__(self):
+        return dir(self.__hook_caller)
+
     def __getattr__(self, key):
         if key not in imply_paths_hooks:
             return getattr(self.__hook_caller, key)
@@ -26,13 +30,19 @@ class PathAwareHookProxy:
             hook = getattr(self.__hook_caller, key)
             path_var, fspath_var = imply_paths_hooks[key]
 
-            @functools.wraps(hook)
             def fixed_hook(**kw):
                 path_value: Optional[Path] = kw.pop(path_var, None)
                 fspath_value: Optional[LEGACY_PATH] = kw.pop(fspath_var, None)
+                if fspath_value is not None:
+                    warnings.warn(
+                        HOOK_LEGACY_PATH_ARG.format(
+                            pylib_path_arg=fspath_var, pathlib_path_arg=path_var
+                        )
+                    )
                 path_value, fspath_value = _imply_path(path_value, fspath_value)
                 kw[path_var] = path_value
                 kw[fspath_var] = fspath_value
                 return hook(**kw)
 
+            fixed_hook.__name__ = key
             return fixed_hook

--- a/src/_pytest/config/compat.py
+++ b/src/_pytest/config/compat.py
@@ -1,12 +1,9 @@
-from typing import TYPE_CHECKING
-
-from _pytest.nodes import _imply_path
-
-if TYPE_CHECKING:
-    from ..compat import LEGACY_PATH
-
-
 import functools
+from pathlib import Path
+from typing import Optional
+
+from ..compat import LEGACY_PATH
+from _pytest.nodes import _imply_path
 
 # hookname: (Path, LEGACY_PATH)
 imply_paths_hooks = {
@@ -31,8 +28,8 @@ class PathAwareHookProxy:
 
             @functools.wraps(hook)
             def fixed_hook(**kw):
-                path_value = kw.pop(path_var, None)
-                fspath_value: "LEGACY_PATH" = kw.pop(fspath_var, None)
+                path_value: Optional[Path] = kw.pop(path_var, None)
+                fspath_value: Optional[LEGACY_PATH] = kw.pop(fspath_var, None)
                 path_value, fspath_value = _imply_path(path_value, fspath_value)
                 kw[path_var] = path_value
                 kw[fspath_var] = fspath_value

--- a/src/_pytest/config/compat.py
+++ b/src/_pytest/config/compat.py
@@ -49,7 +49,8 @@ class PathAwareHookProxy:
                     warnings.warn(
                         HOOK_LEGACY_PATH_ARG.format(
                             pylib_path_arg=fspath_var, pathlib_path_arg=path_var
-                        )
+                        ),
+                        stacklevel=2,
                     )
                 path_value, fspath_value = _imply_path(path_value, fspath_value)
                 kw[path_var] = path_value

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -95,6 +95,10 @@ NODE_FSPATH = UnformattedWarning(
     "see https://docs.pytest.org/en/latest/deprecations.html#node-fspath-in-favor-of-pathlib-and-node-path",
 )
 
+HOOK_LEGACY_PATH_ARG = UnformattedWarning(
+    PytestDeprecationWarning,
+    "{pylib_path_arg} : py.path.local is deprecated, please use {pathlib_path_arg} : pathlib.Path",
+)
 # You want to make some `__init__` or function "private".
 #
 #   def my_private_function(some, args):

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -97,7 +97,9 @@ NODE_FSPATH = UnformattedWarning(
 
 HOOK_LEGACY_PATH_ARG = UnformattedWarning(
     PytestDeprecationWarning,
-    "{pylib_path_arg} : py.path.local is deprecated, please use {pathlib_path_arg} : pathlib.Path",
+    "The ({pylib_path_arg}: py.path.local) argument is deprecated, please use ({pathlib_path_arg}: pathlib.Path)\n"
+    "see https://docs.pytest.org/en/latest/deprecations.html"
+    "#py-path-local-arguments-for-hooks-replaced-with-pathlib-path",
 )
 # You want to make some `__init__` or function "private".
 #

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -551,7 +551,9 @@ class Session(nodes.FSCollector):
         remove_mods = pm._conftest_plugins.difference(my_conftestmodules)
         if remove_mods:
             # One or more conftests are not in use at this fspath.
-            proxy = FSHookProxy(pm, remove_mods)
+            from .config.compat import PathAwareHookProxy
+
+            proxy = PathAwareHookProxy(FSHookProxy(pm, remove_mods))
         else:
             # All plugins are active for this fspath.
             proxy = self.config.hook

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -563,9 +563,8 @@ class Session(nodes.FSCollector):
         if direntry.name == "__pycache__":
             return False
         fspath = Path(direntry.path)
-        path = legacy_path(fspath)
         ihook = self.gethookproxy(fspath.parent)
-        if ihook.pytest_ignore_collect(fspath=fspath, path=path, config=self.config):
+        if ihook.pytest_ignore_collect(fspath=fspath, config=self.config):
             return False
         norecursepatterns = self.config.getini("norecursedirs")
         if any(fnmatch_ex(pat, fspath) for pat in norecursepatterns):
@@ -575,7 +574,6 @@ class Session(nodes.FSCollector):
     def _collectfile(
         self, fspath: Path, handle_dupes: bool = True
     ) -> Sequence[nodes.Collector]:
-        path = legacy_path(fspath)
         assert (
             fspath.is_file()
         ), "{!r} is not a file (isdir={!r}, exists={!r}, islink={!r})".format(
@@ -583,9 +581,7 @@ class Session(nodes.FSCollector):
         )
         ihook = self.gethookproxy(fspath)
         if not self.isinitpath(fspath):
-            if ihook.pytest_ignore_collect(
-                fspath=fspath, path=path, config=self.config
-            ):
+            if ihook.pytest_ignore_collect(fspath=fspath, config=self.config):
                 return ()
 
         if handle_dupes:
@@ -597,7 +593,7 @@ class Session(nodes.FSCollector):
                 else:
                     duplicate_paths.add(fspath)
 
-        return ihook.pytest_collect_file(fspath=fspath, path=path, parent=self)  # type: ignore[no-any-return]
+        return ihook.pytest_collect_file(fspath=fspath, parent=self)  # type: ignore[no-any-return]
 
     @overload
     def perform_collect(

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -716,7 +716,7 @@ class TerminalReporter:
                 msg += " -- " + str(sys.executable)
             self.write_line(msg)
             lines = self.config.hook.pytest_report_header(
-                config=self.config, startpath=self.startpath, startdir=self.startdir
+                config=self.config, startpath=self.startpath
             )
             self._write_report_lines_from_hooks(lines)
 
@@ -753,7 +753,6 @@ class TerminalReporter:
         lines = self.config.hook.pytest_report_collectionfinish(
             config=self.config,
             startpath=self.startpath,
-            startdir=self.startdir,
             items=session.items,
         )
         self._write_report_lines_from_hooks(lines)

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -160,20 +160,22 @@ def test_raising_unittest_skiptest_during_collection_is_deprecated(
 def test_hookproxy_warnings_for_fspath(pytestconfig, tmp_path, request):
     path = legacy_path(tmp_path)
 
-    with pytest.warns(
-        PytestDeprecationWarning,
-        match="path : py.path.local is deprecated, please use fspath : pathlib.Path",
-    ):
+    PATH_WARN_MATCH = r".*path: py\.path\.local\) argument is deprecated, please use \(fspath: pathlib\.Path.*"
+
+    with pytest.warns(PytestDeprecationWarning, match=PATH_WARN_MATCH) as r:
         pytestconfig.hook.pytest_ignore_collect(
             config=pytestconfig, path=path, fspath=tmp_path
         )
-    with pytest.warns(
-        PytestDeprecationWarning,
-        match="path : py.path.local is deprecated, please use fspath : pathlib.Path",
-    ):
+    (record,) = r
+    assert record.filename == __file__
+    assert record.lineno == 166
+
+    with pytest.warns(PytestDeprecationWarning, match=PATH_WARN_MATCH) as r:
         request.node.ihook.pytest_ignore_collect(
             config=pytestconfig, path=path, fspath=tmp_path
         )
-
+    (record,) = r
+    assert record.filename == __file__
+    assert record.lineno == 174
     pytestconfig.hook.pytest_ignore_collect(config=pytestconfig, fspath=tmp_path)
     request.node.ihook.pytest_ignore_collect(config=pytestconfig, fspath=tmp_path)

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -4,7 +4,9 @@ from unittest import mock
 
 import pytest
 from _pytest import deprecated
+from _pytest.compat import legacy_path
 from _pytest.pytester import Pytester
+from pytest import PytestDeprecationWarning
 
 
 @pytest.mark.parametrize("attribute", pytest.collect.__all__)  # type: ignore
@@ -153,3 +155,22 @@ def test_raising_unittest_skiptest_during_collection_is_deprecated(
             "*PytestDeprecationWarning: Raising unittest.SkipTest*",
         ]
     )
+
+
+def test_hookproxy_warnings_for_fspath(pytestconfig, tmp_path, request):
+    path = legacy_path(tmp_path)
+
+    with pytest.warns(
+        PytestDeprecationWarning,
+        match="path : py.path.local is deprecated, please use fspath : pathlib.Path",
+    ):
+        pytestconfig.hook.pytest_ignore_collect(
+            config=pytestconfig, path=path, fspath=tmp_path
+        )
+    with pytest.warns(
+        PytestDeprecationWarning,
+        match="path : py.path.local is deprecated, please use fspath : pathlib.Path",
+    ):
+        request.node.ihook.pytest_ignore_collect(
+            config=pytestconfig, path=path, fspath=tmp_path
+        )

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -174,3 +174,6 @@ def test_hookproxy_warnings_for_fspath(pytestconfig, tmp_path, request):
         request.node.ihook.pytest_ignore_collect(
             config=pytestconfig, path=path, fspath=tmp_path
         )
+
+    pytestconfig.hook.pytest_ignore_collect(config=pytestconfig, fspath=tmp_path)
+    request.node.ihook.pytest_ignore_collect(config=pytestconfig, fspath=tmp_path)


### PR DESCRIPTION
- [x] unittests
- [ ] tests or receivers with legacy args + deprecation
- [x] remove legacy path parameters from internal calls
- [x] add warning for hook invocations on missing prams and suggested drops


fixes #8361 

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
