### PR TITLE
Remove note on conftest.py files as part of pytest_cmdline_main hookspec

### DIFF
--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -176,9 +176,6 @@ def pytest_cmdline_main(config: "Config") -> Optional[Union["ExitCode", int]]:
     """Called for performing the main command line action. The default
     implementation will invoke the configure hooks and runtest_mainloop.
 
-    .. note::
-        This hook will not be called for ``conftest.py`` files, only for setuptools plugins.
-
     Stops at first non-None result, see :ref:`firstresult`.
 
     :param _pytest.config.Config config: The pytest config object.


### PR DESCRIPTION
Hi all, In reference to (closes #8287) I had a look into the pluggy machinery with regards to both root and sub `conftest.py` files, using the following setup:

```python
def test_cmdline_main(pytester: Pytester) -> None:
    pytester.makeconftest(
        """
        def pytest_cmdline_main(config) -> None:
            print("I AM IN A ROOT CONFTEST!")
        """
    )
    sub = pytester.mkdir("testing")
    sub.joinpath("conftest.py").write_text(
        textwrap.dedent(
            """\
            def pytest_cmdline_main(config) -> None:
                print("I AM IN A SUB CONFTEST!")
            """
        ))
    sub.joinpath("test_foobar.py").write_text(
        textwrap.dedent(
            """
            def test_something():
                assert True
                """
        )
    )
    result = pytester.runpytest("-v", "-s")
    result.stdout.fnmatch_lines(["I AM IN A SUB CONFTEST!", "I AM IN A ROOT CONFTEST!"])
```

As a result at first inspection, both plugins in the aforementioned `conftest.py` files are registered as hook implementations during executions of pluggys `_multicall` invocation, outlined here:

```console
[plugin=<module 'conftest' from 'C:\\Users\\Sy\\AppData\\Local\\Temp\\pytest-of-Sy\\pytest-12\\test_cmdline_main0\\conftest.py'>, 
plugin=<module 'conftest' from 'C:\\Users\\Sy\\AppData\\Local\\Temp\\pytest-of-Sy\\pytest-12\\test_cmdline_main0\\testing\\conftest.py'>>, ...]
```

At a glance this looks like this hook does infact support `conftest.py` files, so I have removed the note from the docs, there is a chance I am just wrong here, or this is actually a bug rather than a documentation discrepency.  Thanks!

I also notice 2 more references around a similar area in: 

`pytest_load_initial_conftests` & `pytest_cmdline_preparse` respectively.  I am unsure if they are similar here, if so please let me know and I can test/address thoses re: docs

P.s I assume removing the docstring here auto feeds through to documentation generation, would appreciate any guidance on that also, I checked with `tox -e docs` and inspected the `_build/_modules/_pytest/hookspec.html`