### PR TITLE
rename master to main in PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ If this change fixes an issue, please:
 
 Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:
 
-- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.
+- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.
 
   Write sentences in the **past or present tense**, examples:
 


### PR DESCRIPTION
Setting the pull requests template to link to main rather than master.  Had a look at: https://github.com/pytest-dev/pytest/pull/8462 which appears to omit this file.  @RonnyPfannschmidt would you prefer I target this to the `fixup` branch instead of pytest `main` directly?