### PR TITLE
tweak documentation of report's sections attribute

### DIFF
--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -281,10 +281,10 @@ class TestReport(BaseReport):
         #: defined properties of the test.
         self.user_properties = list(user_properties or [])
 
-        #: List of pairs ``(str, str)`` of extra information which needs to
-        #: marshallable. Used by pytest to add captured text
-        #: from ``stdout`` and ``stderr``, but may be used by other plugins
-        #: to add arbitrary information to reports.
+        #: Tuples of str ``(heading, content)`` with extra information
+        #: for the test report. Used by pytest to add text captured
+        #: from ``stdout``, ``stderr``, and intercepted logging events. May
+        #: be used by other plugins to add arbitrary information to reports.
         self.sections = list(sections)
 
         #: Time it took to run just the test.
@@ -381,11 +381,10 @@ class CollectReport(BaseReport):
         #: The collected items and collection nodes.
         self.result = result or []
 
-        #: List of pairs ``(str, str)`` of extra information which needs to
-        #: marshallable.
-        # Used by pytest to add captured text : from ``stdout`` and ``stderr``,
-        # but may be used by other plugins : to add arbitrary information to
-        # reports.
+        #: Tuples of str ``(heading, content)`` with extra information
+        #: for the test report. Used by pytest to add text captured
+        #: from ``stdout``, ``stderr``, and intercepted logging events. May
+        #: be used by other plugins to add arbitrary information to reports.
         self.sections = list(sections)
 
         self.__dict__.update(extra)


### PR DESCRIPTION
fix some formatting in the TestReport / CollectReport, and reword the description about the 'sections' attribute

this is what it looks like currently: https://docs.pytest.org/en/stable/reference.html#pytest.reports.TestReport.sections

The CollectReport one maybe didn't render at all due to bunk formatting (?)

- "which needs to marshallable" does not make a lot of sense (presumably means json serializable?) but is unnecessary anyway since the type is already annotated as `List[Tuple[str, str]]` which will be marshallable.  Also I think I just now got the joke of why [marshmallow](https://marshmallow.readthedocs.io/en/stable/) project is named so...  😄 
- `(str, str)` just duplicated the existing type annotation so I changed it to `(heading, content)` to better indicate how each string in the pair is actually used
- also mentioned that the sections is now also used for caplog 