### PR TITLE
 monkeypatch.syspath_prepend: Skip fixup_namespace_packages if pkg_resources not imported

### DIFF
--- a/changelog/8503.trivial.rst
+++ b/changelog/8503.trivial.rst
@@ -1,0 +1,4 @@
+:meth:`pytest.MonkeyPatch.syspath_prepend` no longer fails when
+``setuptools`` is not installed.
+It now only calls :func:`pkg_resources.fixup_namespace_packages` if
+``pkg_resources`` was previously imported, because it is not needed otherwise.

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -312,14 +312,17 @@ class MonkeyPatch:
 
     def syspath_prepend(self, path) -> None:
         """Prepend ``path`` to ``sys.path`` list of import locations."""
-        from pkg_resources import fixup_namespace_packages
 
         if self._savesyspath is None:
             self._savesyspath = sys.path[:]
         sys.path.insert(0, str(path))
 
         # https://github.com/pypa/setuptools/blob/d8b901bc/docs/pkg_resources.txt#L162-L171
-        fixup_namespace_packages(str(path))
+        # this is only needed when pkg_resources was already loaded by the namespace package
+        if "pkg_resources" in sys.modules:
+            from pkg_resources import fixup_namespace_packages
+
+            fixup_namespace_packages(str(path))
 
         # A call to syspathinsert() usually means that the caller wants to
         # import some dynamically created files, thus with python3 we


### PR DESCRIPTION
This is just a draft PR. Do we want this? Or should we handle missing `pkg_resources` from `monkeypatch.syspath_prepend()` instead?