### PR TITLE
Fix plugin-list label in the docs

### DIFF
--- a/doc/en/reference/plugin_list.rst
+++ b/doc/en/reference/plugin_list.rst
@@ -1,4 +1,4 @@
-\
+
 .. _plugin-list:
 
 Plugin List

--- a/scripts/update-plugin-list.py
+++ b/scripts/update-plugin-list.py
@@ -6,7 +6,7 @@ import packaging.version
 import requests
 import tabulate
 
-FILE_HEAD = r"""\
+FILE_HEAD = r"""
 .. _plugin-list:
 
 Plugin List


### PR DESCRIPTION
Last time I "fixed" this, I left a `\` at the start of the string to avoid an initial newline, but didn't realize it was a raw string.

This should fix it now for good (the extra newline at the start doesn't really hurt).