### PR TITLE
doc: Update open trainings

### DIFF
--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -2,7 +2,7 @@
 
 .. sidebar:: Next Open Trainings
 
-   - `Professionelles Testen für Python mit pytest <https://www.enterpy.de/lecture_compact1.php?id=12713>`_ (German), part of the enterPy conference, April 22nd, remote.
+   - `Professionelles Testen für Python mit pytest <https://www.enterpy.de/lecture_compact1.php?id=12713>`_ (German), part of the enterPy conference, April 22nd (sold out) and May 20th, remote.
 
    Also see `previous talks and blogposts <talks.html>`_.
 


### PR DESCRIPTION
The training is sold out with 10 people (yay!), so there's a second date for it now.

Is there a better way we can keep pytest.org up to date with those changes? From what I understand, it only gets updated when we make a new release from `main`, which hasn't happened this year so far? It's kinda troublesome we still advertise a training from February (with "Early-bird discount available until January 15th.") there... 

I struggle to think of a better solution though... Can we (and do we want to) reconfgure RTD so it shows "latest" by default instead, or would that be too confusing if we had breaking changes?