### PR TITLE
ci: Mark Python 3.10 as experimental

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    continue-on-error: "${{ matrix.experimental == true }}"
 
     strategy:
       fail-fast: false
@@ -73,6 +74,7 @@ jobs:
             python: "3.10-dev"
             os: windows-latest
             tox_env: "py310-xdist"
+            experimental: true
 
           - name: "ubuntu-py36"
             python: "3.6"
@@ -103,6 +105,7 @@ jobs:
             python: "3.10-dev"
             os: ubuntu-latest
             tox_env: "py310-xdist"
+            experimental: true
           - name: "ubuntu-pypy3"
             python: "pypy-3.7"
             os: ubuntu-latest


### PR DESCRIPTION
It currently breaks all builds and even after #8540 it looks like tests
still fail because of https://github.com/benjaminp/six/issues/341

As a hotfix, mark it as experimental until everything is fixed, so that
our CI isn't all red.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
