### PR TITLE
Fix Python 3.10 test issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,14 @@ filterwarnings = [
     "default:invalid escape sequence:DeprecationWarning",
     # ignore use of unregistered marks, because we use many to test the implementation
     "ignore::_pytest.warning_types.PytestUnknownMarkWarning",
+    # https://github.com/benjaminp/six/issues/341
+    "ignore:_SixMetaPathImporter\\.exec_module\\(\\) not found; falling back to load_module\\(\\):ImportWarning",
+    # https://github.com/benjaminp/six/pull/352
+    "ignore:_SixMetaPathImporter\\.find_spec\\(\\) not found; falling back to find_module\\(\\):ImportWarning",
+    # https://github.com/pypa/setuptools/pull/2517
+    "ignore:VendorImporter\\.find_spec\\(\\) not found; falling back to find_module\\(\\):ImportWarning",
+    # https://github.com/pytest-dev/execnet/pull/127
+    "ignore:isSet\\(\\) is deprecated, use is_set\\(\\) instead:DeprecationWarning",
 ]
 pytester_example_dir = "testing/example_scripts"
 markers = [

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1173,7 +1173,7 @@ def test_usage_error_code(pytester: Pytester) -> None:
     assert result.ret == ExitCode.USAGE_ERROR
 
 
-@pytest.mark.filterwarnings("default")
+@pytest.mark.filterwarnings("default::pytest.PytestUnhandledCoroutineWarning")
 def test_warn_on_async_function(pytester: Pytester) -> None:
     # In the below we .close() the coroutine only to avoid
     # "RuntimeWarning: coroutine 'test_2' was never awaited"
@@ -1206,7 +1206,7 @@ def test_warn_on_async_function(pytester: Pytester) -> None:
     )
 
 
-@pytest.mark.filterwarnings("default")
+@pytest.mark.filterwarnings("default::pytest.PytestUnhandledCoroutineWarning")
 def test_warn_on_async_gen_function(pytester: Pytester) -> None:
     pytester.makepyfile(
         test_async="""

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -1237,7 +1237,7 @@ def test_unorderable_types(pytester: Pytester) -> None:
     assert result.ret == ExitCode.NO_TESTS_COLLECTED
 
 
-@pytest.mark.filterwarnings("default")
+@pytest.mark.filterwarnings("default::pytest.PytestCollectionWarning")
 def test_dont_collect_non_function_callable(pytester: Pytester) -> None:
     """Test for issue https://github.com/pytest-dev/pytest/issues/331
 

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -448,7 +448,10 @@ class TestMetafunc:
         enum = pytest.importorskip("enum")
         e = enum.Enum("Foo", "one, two")
         result = idmaker(("a", "b"), [pytest.param(e.one, e.two)])
-        assert result == ["Foo.one-Foo.two"]
+        if sys.version_info[:2] >= (3, 10):
+            assert result == ["one-two"]
+        else:
+            assert result == ["Foo.one-Foo.two"]
 
     def test_idmaker_idfn(self) -> None:
         """#351"""

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -1225,7 +1225,7 @@ def test_collect_symlink_dir(pytester: Pytester) -> None:
     """A symlinked directory is collected."""
     dir = pytester.mkdir("dir")
     dir.joinpath("test_it.py").write_text("def test_it(): pass", "utf-8")
-    pytester.path.joinpath("symlink_dir").symlink_to(dir)
+    symlink_or_skip(pytester.path.joinpath("symlink_dir"), dir)
     result = pytester.runpytest()
     result.assert_outcomes(passed=2)
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -290,7 +290,7 @@ class TestParseIni:
         result = pytester.runpytest()
         result.stdout.no_fnmatch_line("*PytestConfigWarning*")
 
-    @pytest.mark.filterwarnings("default")
+    @pytest.mark.filterwarnings("default::pytest.PytestConfigWarning")
     def test_disable_warnings_plugin_disables_config_warnings(
         self, pytester: Pytester
     ) -> None:

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -744,10 +744,16 @@ def test_run_result_repr() -> None:
 
     # known exit code
     r = pytester_mod.RunResult(1, outlines, errlines, duration=0.5)
-    assert (
-        repr(r) == "<RunResult ret=ExitCode.TESTS_FAILED len(stdout.lines)=3"
-        " len(stderr.lines)=4 duration=0.50s>"
-    )
+    if sys.version_info[:2] >= (3, 10):
+        assert repr(r) == (
+            "<RunResult ret=TESTS_FAILED len(stdout.lines)=3"
+            " len(stderr.lines)=4 duration=0.50s>"
+        )
+    else:
+        assert repr(r) == (
+            "<RunResult ret=ExitCode.TESTS_FAILED len(stdout.lines)=3"
+            " len(stderr.lines)=4 duration=0.50s>"
+        )
 
     # unknown exit code: just the number
     r = pytester_mod.RunResult(99, outlines, errlines, duration=0.5)

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -1143,21 +1143,34 @@ def test_errors_in_xfail_skip_expressions(pytester: Pytester) -> None:
     pypy_version_info = getattr(sys, "pypy_version_info", None)
     if pypy_version_info is not None and pypy_version_info < (6,):
         markline = markline[5:]
+    elif sys.version_info[:2] >= (3, 10):
+        markline = markline[11:]
     elif sys.version_info >= (3, 8) or hasattr(sys, "pypy_version_info"):
         markline = markline[4:]
-    result.stdout.fnmatch_lines(
-        [
+
+    if sys.version_info[:2] >= (3, 10):
+        expected = [
             "*ERROR*test_nameerror*",
-            "*evaluating*skipif*condition*",
             "*asd*",
-            "*ERROR*test_syntax*",
-            "*evaluating*xfail*condition*",
-            "    syntax error",
-            markline,
-            "SyntaxError: invalid syntax",
-            "*1 pass*2 errors*",
+            "",
+            "During handling of the above exception, another exception occurred:",
         ]
-    )
+    else:
+        expected = [
+            "*ERROR*test_nameerror*",
+        ]
+
+    expected += [
+        "*evaluating*skipif*condition*",
+        "*asd*",
+        "*ERROR*test_syntax*",
+        "*evaluating*xfail*condition*",
+        "    syntax error",
+        markline,
+        "SyntaxError: invalid syntax",
+        "*1 pass*2 errors*",
+    ]
+    result.stdout.fnmatch_lines(expected)
 
 
 def test_xfail_skipif_with_globals(pytester: Pytester) -> None:

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1618,7 +1618,7 @@ def test_terminal_summary(pytester: Pytester) -> None:
     )
 
 
-@pytest.mark.filterwarnings("default")
+@pytest.mark.filterwarnings("default::UserWarning")
 def test_terminal_summary_warnings_are_displayed(pytester: Pytester) -> None:
     """Test that warnings emitted during pytest_terminal_summary are displayed.
     (#1305).
@@ -1655,7 +1655,7 @@ def test_terminal_summary_warnings_are_displayed(pytester: Pytester) -> None:
     assert stdout.count("=== warnings summary ") == 2
 
 
-@pytest.mark.filterwarnings("default")
+@pytest.mark.filterwarnings("default::UserWarning")
 def test_terminal_summary_warnings_header_once(pytester: Pytester) -> None:
     pytester.makepyfile(
         """

--- a/testing/test_threadexception.py
+++ b/testing/test_threadexception.py
@@ -8,7 +8,7 @@ if sys.version_info < (3, 8):
     pytest.skip("threadexception plugin needs Python>=3.8", allow_module_level=True)
 
 
-@pytest.mark.filterwarnings("default")
+@pytest.mark.filterwarnings("default::pytest.PytestUnhandledThreadExceptionWarning")
 def test_unhandled_thread_exception(pytester: Pytester) -> None:
     pytester.makepyfile(
         test_it="""
@@ -42,7 +42,7 @@ def test_unhandled_thread_exception(pytester: Pytester) -> None:
     )
 
 
-@pytest.mark.filterwarnings("default")
+@pytest.mark.filterwarnings("default::pytest.PytestUnhandledThreadExceptionWarning")
 def test_unhandled_thread_exception_in_setup(pytester: Pytester) -> None:
     pytester.makepyfile(
         test_it="""
@@ -78,7 +78,7 @@ def test_unhandled_thread_exception_in_setup(pytester: Pytester) -> None:
     )
 
 
-@pytest.mark.filterwarnings("default")
+@pytest.mark.filterwarnings("default::pytest.PytestUnhandledThreadExceptionWarning")
 def test_unhandled_thread_exception_in_teardown(pytester: Pytester) -> None:
     pytester.makepyfile(
         test_it="""

--- a/testing/test_unraisableexception.py
+++ b/testing/test_unraisableexception.py
@@ -8,7 +8,7 @@ if sys.version_info < (3, 8):
     pytest.skip("unraisableexception plugin needs Python>=3.8", allow_module_level=True)
 
 
-@pytest.mark.filterwarnings("default")
+@pytest.mark.filterwarnings("default::pytest.PytestUnraisableExceptionWarning")
 def test_unraisable(pytester: Pytester) -> None:
     pytester.makepyfile(
         test_it="""
@@ -40,7 +40,7 @@ def test_unraisable(pytester: Pytester) -> None:
     )
 
 
-@pytest.mark.filterwarnings("default")
+@pytest.mark.filterwarnings("default::pytest.PytestUnraisableExceptionWarning")
 def test_unraisable_in_setup(pytester: Pytester) -> None:
     pytester.makepyfile(
         test_it="""
@@ -76,7 +76,7 @@ def test_unraisable_in_setup(pytester: Pytester) -> None:
     )
 
 
-@pytest.mark.filterwarnings("default")
+@pytest.mark.filterwarnings("default::pytest.PytestUnraisableExceptionWarning")
 def test_unraisable_in_teardown(pytester: Pytester) -> None:
     pytester.makepyfile(
         test_it="""

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -38,7 +38,7 @@ def pyfile_with_warnings(pytester: Pytester, request: FixtureRequest) -> str:
     return str(test_file)
 
 
-@pytest.mark.filterwarnings("default")
+@pytest.mark.filterwarnings("default::UserWarning", "default::RuntimeWarning")
 def test_normal_flow(pytester: Pytester, pyfile_with_warnings) -> None:
     """Check that the warnings section is displayed."""
     result = pytester.runpytest(pyfile_with_warnings)
@@ -55,7 +55,7 @@ def test_normal_flow(pytester: Pytester, pyfile_with_warnings) -> None:
     )
 
 
-@pytest.mark.filterwarnings("always")
+@pytest.mark.filterwarnings("always::UserWarning")
 def test_setup_teardown_warnings(pytester: Pytester) -> None:
     pytester.makepyfile(
         """
@@ -123,7 +123,7 @@ def test_ignore(pytester: Pytester, pyfile_with_warnings, method) -> None:
     assert WARNINGS_SUMMARY_HEADER not in result.stdout.str()
 
 
-@pytest.mark.filterwarnings("always")
+@pytest.mark.filterwarnings("always::UserWarning")
 def test_unicode(pytester: Pytester) -> None:
     pytester.makepyfile(
         """
@@ -182,7 +182,7 @@ def test_filterwarnings_mark(pytester: Pytester, default_config) -> None:
         pytester.makeini(
             """
             [pytest]
-            filterwarnings = always
+            filterwarnings = always::RuntimeWarning
         """
         )
     pytester.makepyfile(
@@ -202,7 +202,9 @@ def test_filterwarnings_mark(pytester: Pytester, default_config) -> None:
             warnings.warn(RuntimeWarning())
     """
     )
-    result = pytester.runpytest("-W always" if default_config == "cmdline" else "")
+    result = pytester.runpytest(
+        "-W always::RuntimeWarning" if default_config == "cmdline" else ""
+    )
     result.stdout.fnmatch_lines(["*= 1 failed, 2 passed, 1 warning in *"])
 
 
@@ -217,7 +219,7 @@ def test_non_string_warning_argument(pytester: Pytester) -> None:
             warnings.warn(UserWarning(1, 'foo'))
         """
     )
-    result = pytester.runpytest("-W", "always")
+    result = pytester.runpytest("-W", "always::UserWarning")
     result.stdout.fnmatch_lines(["*= 1 passed, 1 warning in *"])
 
 
@@ -236,7 +238,7 @@ def test_filterwarnings_mark_registration(pytester: Pytester) -> None:
     assert result.ret == 0
 
 
-@pytest.mark.filterwarnings("always")
+@pytest.mark.filterwarnings("always::UserWarning")
 def test_warning_captured_hook(pytester: Pytester) -> None:
     pytester.makeconftest(
         """
@@ -297,7 +299,7 @@ def test_warning_captured_hook(pytester: Pytester) -> None:
             assert collected_result[3] is None, str(collected)
 
 
-@pytest.mark.filterwarnings("always")
+@pytest.mark.filterwarnings("always::UserWarning")
 def test_collection_warnings(pytester: Pytester) -> None:
     """Check that we also capture warnings issued during test collection (#3251)."""
     pytester.makepyfile(
@@ -321,7 +323,7 @@ def test_collection_warnings(pytester: Pytester) -> None:
     )
 
 
-@pytest.mark.filterwarnings("always")
+@pytest.mark.filterwarnings("always::UserWarning")
 def test_mark_regex_escape(pytester: Pytester) -> None:
     """@pytest.mark.filterwarnings should not try to escape regex characters (#3936)"""
     pytester.makepyfile(
@@ -337,7 +339,7 @@ def test_mark_regex_escape(pytester: Pytester) -> None:
     assert WARNINGS_SUMMARY_HEADER not in result.stdout.str()
 
 
-@pytest.mark.filterwarnings("default")
+@pytest.mark.filterwarnings("default::pytest.PytestWarning")
 @pytest.mark.parametrize("ignore_pytest_warnings", ["no", "ini", "cmdline"])
 def test_hide_pytest_internal_warnings(
     pytester: Pytester, ignore_pytest_warnings
@@ -387,7 +389,7 @@ def test_option_precedence_cmdline_over_ini(
     pytester.makeini(
         """
         [pytest]
-        filterwarnings = error
+        filterwarnings = error::UserWarning
     """
     )
     pytester.makepyfile(
@@ -581,8 +583,7 @@ def test_warnings_checker_twice() -> None:
         warnings.warn("Message B", UserWarning)
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestExperimentalApiWarning")
-@pytest.mark.filterwarnings("always")
+@pytest.mark.filterwarnings("always::UserWarning")
 def test_group_warnings_by_message(pytester: Pytester) -> None:
     pytester.copy_example("warnings/test_group_warnings_by_message.py")
     result = pytester.runpytest()
@@ -613,8 +614,7 @@ def test_group_warnings_by_message(pytester: Pytester) -> None:
     )
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestExperimentalApiWarning")
-@pytest.mark.filterwarnings("always")
+@pytest.mark.filterwarnings("always::UserWarning")
 def test_group_warnings_by_message_summary(pytester: Pytester) -> None:
     pytester.copy_example("warnings/test_group_warnings_by_message_summary")
     pytester.syspathinsert()


### PR DESCRIPTION
Potential alternative to #8553. Fixes the Python 3.10 tests for me, without #8540. See #8546, though I wouldn't close it yet, as we might want to change the enum reprs instead?