### PR TITLE
Backport training update

### DIFF
--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -2,7 +2,7 @@
 
 .. sidebar:: Next Open Trainings
 
-   - `Professional testing with Python <https://www.python-academy.com/courses/specialtopics/python_course_testing.html>`_, via Python Academy, February 1-3 2021, remote and Leipzig (Germany). **Early-bird discount available until January 15th**.
+   - `Professionelles Testen für Python mit pytest <https://www.enterpy.de/lecture_compact1.php?id=12713>`_ (German), part of the enterPy conference, April 22nd (sold out) and May 20th, remote.
 
    Also see `previous talks and blogposts <talks.html>`_.
 


### PR DESCRIPTION
Next I plan to:

- Set the `6.2.x` branch as an active version on RTD (like `4.6.x` already is)
- Set the `6.2.x` version as default instead of `stable`
- Make a reminder to revert back to `stable` once we have a new release out

I don't see a way to tell RTD to use the latest `6.*.*` branch, but that's as close as we can get.

Does that seem right?