### PR TITLE
Fix some typos, remove redundant words and escapes

### DIFF
--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -5097,7 +5097,7 @@ Improved Documentation
 
 - In one of the simple examples, use ``pytest_collection_modifyitems()`` to skip
   tests based on a command-line option, allowing its sharing while preventing a
-  user error when acessing ``pytest.config`` before the argument parsing.
+  user error when accessing ``pytest.config`` before the argument parsing.
   (`#2653 <https://github.com/pytest-dev/pytest/issues/2653>`_)
 
 
@@ -5509,7 +5509,7 @@ Changes
   Thanks `@ojii`_ for the PR.
 
 * Replace minor/patch level version numbers in the documentation with placeholders.
-  This significantly reduces change-noise as different contributors regnerate
+  This significantly reduces change-noise as different contributors regenerate
   the documentation on different platforms.
   Thanks `@RonnyPfannschmidt`_ for the PR.
 

--- a/scripts/release-on-comment.py
+++ b/scripts/release-on-comment.py
@@ -82,7 +82,7 @@ def validate_and_get_issue_comment_payload(
 ) -> Tuple[str, str, bool]:
     payload = json.loads(issue_payload_path.read_text(encoding="UTF-8"))
     body = get_comment_data(payload)["body"]
-    m = re.match(r"@pytestbot please prepare (major )?release from ([\w\-_\.]+)", body)
+    m = re.match(r"@pytestbot please prepare (major )?release from ([-_.\w]+)", body)
     if m:
         is_major, base_branch = m.group(1) is not None, m.group(2)
     else:

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -363,7 +363,7 @@ class FDCaptureBinary:
         except OSError:
             # FD capturing is conceptually simple -- create a temporary file,
             # redirect the FD to it, redirect back when done. But when the
-            # target FD is invalid it throws a wrench into this loveley scheme.
+            # target FD is invalid it throws a wrench into this lovely scheme.
             #
             # Tests themselves shouldn't care if the FD is valid, FD capturing
             # should work regardless of external circumstances. So falling back

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -268,7 +268,7 @@ class DoctestItem(pytest.Item):
         runner: "doctest.DocTestRunner",
         dtest: "doctest.DocTest",
     ):
-        # incompatible signature due to to imposed limits on sublcass
+        # incompatible signature due to imposed limits on subclass
         """The public named constructor."""
         return super().from_parent(name=name, parent=parent, runner=runner, dtest=dtest)
 

--- a/src/_pytest/store.py
+++ b/src/_pytest/store.py
@@ -25,7 +25,7 @@ class StoreKey(Generic[T]):
 
 
 class Store:
-    """Store is a type-safe heterogenous mutable mapping that
+    """Store is a type-safe heterogeneous mutable mapping that
     allows keys and value types to be defined separately from
     where it (the Store) is created.
 

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -235,7 +235,7 @@ def test_log_cli_default_level(pytester: Pytester) -> None:
         ]
     )
     result.stdout.no_fnmatch_line("*INFO message won't be shown*")
-    # make sure that that we get a '0' exit code for the testsuite
+    # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0
 
 
@@ -528,7 +528,7 @@ def test_log_cli_level(pytester: Pytester) -> None:
     )
     result.stdout.no_fnmatch_line("*This log message won't be shown*")
 
-    # make sure that that we get a '0' exit code for the testsuite
+    # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0
 
     result = pytester.runpytest("-s", "--log-level=INFO")
@@ -542,7 +542,7 @@ def test_log_cli_level(pytester: Pytester) -> None:
     )
     result.stdout.no_fnmatch_line("*This log message won't be shown*")
 
-    # make sure that that we get a '0' exit code for the testsuite
+    # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0
 
 
@@ -578,7 +578,7 @@ def test_log_cli_ini_level(pytester: Pytester) -> None:
     )
     result.stdout.no_fnmatch_line("*This log message won't be shown*")
 
-    # make sure that that we get a '0' exit code for the testsuite
+    # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0
 
 
@@ -653,7 +653,7 @@ def test_log_file_cli(pytester: Pytester) -> None:
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(["test_log_file_cli.py PASSED"])
 
-    # make sure that that we get a '0' exit code for the testsuite
+    # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0
     assert os.path.isfile(log_file)
     with open(log_file) as rfh:
@@ -684,7 +684,7 @@ def test_log_file_cli_level(pytester: Pytester) -> None:
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(["test_log_file_cli_level.py PASSED"])
 
-    # make sure that that we get a '0' exit code for the testsuite
+    # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0
     assert os.path.isfile(log_file)
     with open(log_file) as rfh:
@@ -735,7 +735,7 @@ def test_log_file_ini(pytester: Pytester) -> None:
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(["test_log_file_ini.py PASSED"])
 
-    # make sure that that we get a '0' exit code for the testsuite
+    # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0
     assert os.path.isfile(log_file)
     with open(log_file) as rfh:
@@ -774,7 +774,7 @@ def test_log_file_ini_level(pytester: Pytester) -> None:
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(["test_log_file_ini_level.py PASSED"])
 
-    # make sure that that we get a '0' exit code for the testsuite
+    # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0
     assert os.path.isfile(log_file)
     with open(log_file) as rfh:
@@ -808,7 +808,7 @@ def test_log_file_unicode(pytester: Pytester) -> None:
 
     result = pytester.runpytest()
 
-    # make sure that that we get a '0' exit code for the testsuite
+    # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0
     assert os.path.isfile(log_file)
     with open(log_file, encoding="utf-8") as rfh:

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -692,9 +692,8 @@ class TestMetafunc:
         """
         #714
         Test parametrization with 'indirect' parameter applied on
-        particular arguments. As y is is direct, its value should
-        be used directly rather than being passed to the fixture
-        y.
+        particular arguments. As y is direct, its value should
+        be used directly rather than being passed to the fixture y.
 
         :param pytester: the instance of Pytester class, a temporary
         test directory.


### PR DESCRIPTION
Fix some typos, remove redundant words.
Remove redundant escapes from a regex.