### PR TITLE
Logging docs: fix reference to pytest.LogCaptureFixture.

### DIFF
--- a/doc/en/how-to/logging.rst
+++ b/doc/en/how-to/logging.rst
@@ -167,7 +167,7 @@ the records for the ``setup`` and ``call`` stages during teardown like so:
 
 
 
-The full API is available at :class:`_pytest.logging.LogCaptureFixture`.
+The full API is available at :class:`pytest.LogCaptureFixture`.
 
 
 .. _live_logs:


### PR DESCRIPTION
Small PR to fix reference to `LogCaptureFixture` from https://docs.pytest.org/en/stable/logging.html#caplog-fixture
