### PR TITLE
Remove "upload_sphinx" section from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,9 +82,6 @@ source_dir = doc/en/
 build_dir = doc/build
 all_files = 1
 
-[upload_sphinx]
-upload_dir = doc/en/build/html
-
 [check-manifest]
 ignore =
     src/_pytest/_version.py


### PR DESCRIPTION
The `Sphinx-PyPI-upload` tool the section corresponds to hasn't been updated since 2009, and the new (c. 2018) PyPI doesn't support documentation uploads anyway.

Therefore I think the section is redundant and safe to remove.
