### PR TITLE
Improve `iterparentnodeids` to consume `/` parts until the first `::`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -235,6 +235,7 @@ Omar Kohl
 Omer Hadari
 Ondřej Súkup
 Oscar Benjamin
+Parth Patel
 Patrick Hayes
 Pauli Virtanen
 Pavel Karateev

--- a/changelog/8509.bugfix.rst
+++ b/changelog/8509.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed issue where `TestCase.setUpClass` is not called when a test method has `/` in its name in versions of `pytest >=6.2.0`.

--- a/changelog/8509.bugfix.rst
+++ b/changelog/8509.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed issue where `TestCase.setUpClass` is not called when a test method has `/` in its name in versions of `pytest >=6.2.0`.

--- a/changelog/8509.improvement.rst
+++ b/changelog/8509.improvement.rst
@@ -1,0 +1,3 @@
+Fixed issue where `TestCase.setUpClass` is not called when a test method has `/` in its name in versions of `pytest >=6.2.0`.
+
+Paths only consider `/` parts of a patch until the first `::` in `iterparentnodeids`. Then `::` parts of a path are considered. Test cases for this were updated to reflect this change.

--- a/changelog/8509.improvement.rst
+++ b/changelog/8509.improvement.rst
@@ -1,3 +1,5 @@
-Fixed issue where `TestCase.setUpClass` is not called when a test method has `/` in its name in versions of `pytest >=6.2.0`.
+Fixed issue where `TestCase.setUpClass` is not called when a test has `/` in its name since pytest 6.2.0.
 
-Paths only consider `/` parts of a patch until the first `::` in `iterparentnodeids`. Then `::` parts of a path are considered. Test cases for this were updated to reflect this change.
+This refers to the path part in pytest node IDs, e.g. `TestClass::test_it` in the node ID `tests/test_file.py::TestClass::test_it`.
+
+Now, instead of assuming that the test name does not contain ``/``, it is assumed that test path does not contain ``::``. We plan to hopefully make both of these work in the future.

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -77,7 +77,16 @@ def iterparentnodeids(nodeid: str) -> Iterator[str]:
             break
         else:
             if at:
-                yield nodeid[:at]
+                if sep == SEP:
+                    colons_after_at = nodeid.find("::", at)
+                    colons_before_at = nodeid.find("::", pos, at)
+                    if colons_after_at > -1 or colons_before_at == -1:
+                        yield nodeid[:at]
+                    else:
+                        sep = "::"
+                        continue
+                else:
+                    yield nodeid[:at]
             pos = at + len(sep)
 
 

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -62,32 +62,33 @@ def iterparentnodeids(nodeid: str) -> Iterator[str]:
         "testing/code/test_excinfo.py::TestFormattedExcinfo"
         "testing/code/test_excinfo.py::TestFormattedExcinfo::test_repr_source"
 
-    Note that :: parts are only considered at the last / component.
+    Note that / components are only considered until the first ::.
     """
     pos = 0
-    sep = SEP
+    first_colons: Optional[int] = nodeid.find("::")
+    if first_colons == -1:
+        first_colons = None
+    # The root Session node - always present.
     yield ""
+    # Eagerly consume SEP parts until first colons.
     while True:
-        at = nodeid.find(sep, pos)
-        if at == -1 and sep == SEP:
-            sep = "::"
-        elif at == -1:
-            if nodeid:
-                yield nodeid
+        at = nodeid.find(SEP, pos, first_colons)
+        if at == -1:
             break
-        else:
-            if at:
-                if sep == SEP:
-                    colons_after_at = nodeid.find("::", at)
-                    colons_before_at = nodeid.find("::", pos, at)
-                    if colons_after_at > -1 or colons_before_at == -1:
-                        yield nodeid[:at]
-                    else:
-                        sep = "::"
-                        continue
-                else:
-                    yield nodeid[:at]
-            pos = at + len(sep)
+        if at > 0:
+            yield nodeid[:at]
+        pos = at + len(SEP)
+    # Eagerly consume :: parts.
+    while True:
+        at = nodeid.find("::", pos)
+        if at == -1:
+            break
+        if at > 0:
+            yield nodeid[:at]
+        pos = at + len("::")
+    # The node ID itself.
+    if nodeid:
+        yield nodeid
 
 
 def _imply_path(

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -23,10 +23,13 @@ from _pytest.warning_types import PytestWarning
         ("a/b/c::D/d::e", ["", "a", "a/b", "a/b/c::D", "a/b/c::D/d", "a/b/c::D/d::e"]),
         # : alone is not a separator.
         ("a/b::D:e:f::g", ["", "a", "a/b", "a/b::D:e:f", "a/b::D:e:f::g"]),
+        # / not considered if a part of a test name
+        ("a/b::c/d::e[/test]", ["", "a", "a/b::c", "a/b::c/d", "a/b::c/d::e[/test]"]),
     ),
 )
 def test_iterparentnodeids(nodeid: str, expected: List[str]) -> None:
     result = list(nodes.iterparentnodeids(nodeid))
+    print("RESULT", result)
     assert result == expected
 
 

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -18,13 +18,13 @@ from _pytest.warning_types import PytestWarning
         ("a/b/c", ["", "a", "a/b", "a/b/c"]),
         ("a/bbb/c::D", ["", "a", "a/bbb", "a/bbb/c", "a/bbb/c::D"]),
         ("a/b/c::D::eee", ["", "a", "a/b", "a/b/c", "a/b/c::D", "a/b/c::D::eee"]),
-        # :: considered only at the last component.
         ("::xx", ["", "::xx"]),
-        ("a/b/c::D/d::e", ["", "a", "a/b", "a/b/c::D", "a/b/c::D/d", "a/b/c::D/d::e"]),
+        # / only considered until first ::
+        ("a/b/c::D/d::e", ["", "a", "a/b", "a/b/c", "a/b/c::D/d", "a/b/c::D/d::e"]),
         # : alone is not a separator.
         ("a/b::D:e:f::g", ["", "a", "a/b", "a/b::D:e:f", "a/b::D:e:f::g"]),
         # / not considered if a part of a test name
-        ("a/b::c/d::e[/test]", ["", "a", "a/b::c", "a/b::c/d", "a/b::c/d::e[/test]"]),
+        ("a/b::c/d::e[/test]", ["", "a", "a/b", "a/b::c/d", "a/b::c/d::e[/test]"]),
     ),
 )
 def test_iterparentnodeids(nodeid: str, expected: List[str]) -> None:

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -29,7 +29,6 @@ from _pytest.warning_types import PytestWarning
 )
 def test_iterparentnodeids(nodeid: str, expected: List[str]) -> None:
     result = list(nodes.iterparentnodeids(nodeid))
-    print("RESULT", result)
     assert result == expected
 
 


### PR DESCRIPTION
Fix for issue #8509 and improve `iterparentnodeids`to consume `/` parts until the first `::`