### PR TITLE
Make pygments part of 'testing' extras

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ testing =
     hypothesis>=3.56
     mock
     nose
+    pygments>=2.7.2
     requests
     xmlschema
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,6 @@ deps =
     numpy: numpy>=1.19.4
     pexpect: pexpect>=4.8.0
     pluggymain: pluggy @ git+https://github.com/pytest-dev/pluggy.git
-    pygments>=2.7.2
     unittestextras: twisted
     unittestextras: asynctest
     xdist: pytest-xdist>=2.1.0


### PR DESCRIPTION
Tests in test_terminalwriter depend on pygments being installed to work, so it should be installed with the `testing` extras.

