### PR TITLE
argparsing: support parser.addini(type="paths") which returns pathlib.Paths

### DIFF
--- a/changelog/7259.feature.rst
+++ b/changelog/7259.feature.rst
@@ -1,2 +1,7 @@
 Added :meth:`cache.mkdir() <pytest.Cache.mkdir>`, which is similar to the existing :meth:`cache.makedir() <pytest.Cache.makedir>`,
 but returns a :class:`pathlib.Path` instead of a legacy ``py.path.local``.
+
+Added a ``paths`` type to :meth:`parser.addini() <_pytest.config.argparsing.Parser.addini>`,
+as in ``parser.addini("mypaths", "my paths", type="paths")``,
+which is similar to the existing ``pathlist``,
+but returns a list of :class:`pathlib.Path` instead of legacy ``py.path.local``.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1427,6 +1427,12 @@ class Config:
             dp = self.inipath.parent
             input_values = shlex.split(value) if isinstance(value, str) else value
             return [legacy_path(str(dp / x)) for x in input_values]
+        elif type == "paths":
+            # TODO: This assert is probably not valid in all cases.
+            assert self.inipath is not None
+            dp = self.inipath.parent
+            input_values = shlex.split(value) if isinstance(value, str) else value
+            return [dp / x for x in input_values]
         elif type == "args":
             return shlex.split(value) if isinstance(value, str) else value
         elif type == "linelist":

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -163,22 +163,35 @@ class Parser:
         name: str,
         help: str,
         type: Optional[
-            "Literal['string', 'pathlist', 'args', 'linelist', 'bool']"
+            "Literal['string', 'paths', 'pathlist', 'args', 'linelist', 'bool']"
         ] = None,
         default=None,
     ) -> None:
         """Register an ini-file option.
 
-        :name: Name of the ini-variable.
-        :type: Type of the variable, can be ``string``, ``pathlist``, ``args``,
-               ``linelist`` or ``bool``.  Defaults to ``string`` if ``None`` or
-               not passed.
-        :default: Default value if no ini-file option exists but is queried.
+        :name:
+            Name of the ini-variable.
+        :type:
+            Type of the variable. Can be:
+
+                * ``string``: a string
+                * ``bool``: a boolean
+                * ``args``: a list of strings, separated as in a shell
+                * ``linelist``: a list of strings, separated by line breaks
+                * ``paths``: a list of :class:`pathlib.Path`, separated as in a shell
+                * ``pathlist``: a list of ``py.path``, separated as in a shell
+
+            .. versionadded:: 6.3
+                The ``paths`` variable type.
+
+            Defaults to ``string`` if ``None`` or not passed.
+        :default:
+            Default value if no ini-file option exists but is queried.
 
         The value of ini-variables can be retrieved via a call to
         :py:func:`config.getini(name) <_pytest.config.Config.getini>`.
         """
-        assert type in (None, "string", "pathlist", "args", "linelist", "bool")
+        assert type in (None, "string", "paths", "pathlist", "args", "linelist", "bool")
         self._inidict[name] = (help, type, default)
         self._ininames.append(name)
 


### PR DESCRIPTION
Part of issue #7259, specifically https://github.com/pytest-dev/pytest/issues/7259#issuecomment-826610939.