### PR TITLE
Expand command line argument examples with validation examples

### DIFF
--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -151,7 +151,10 @@ We could add simple validation for the input by listing the choices:
 
     def pytest_addoption(parser):
         parser.addoption(
-            "--cmdopt", action="store", default="type1", help="my option: type1 or type2",
+            "--cmdopt",
+            action="store",
+            default="type1",
+            help="my option: type1 or type2",
             choices=("type1", "type2"),
         )
 
@@ -183,9 +186,13 @@ If you need to provide more detailed error messages, you can use the
 
         return value
 
+
     def pytest_addoption(parser):
         parser.addoption(
-            "--cmdopt", action="store", default="type1", help="my option: type1 or type2",
+            "--cmdopt",
+            action="store",
+            default="type1",
+            help="my option: type1 or type2",
             type=type_checker,
         )
 


### PR DESCRIPTION
This shows how to pass more detailed error messages back to the user when
they've provided an incorrect value for a custom command line option.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
