### PR TITLE
Prepare release 6.2.4

### DIFF
--- a/changelog/8539.bugfix.rst
+++ b/changelog/8539.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed assertion rewriting on Python 3.10.

--- a/doc/en/announce/index.rst
+++ b/doc/en/announce/index.rst
@@ -6,6 +6,7 @@ Release announcements
    :maxdepth: 2
 
 
+   release-6.2.4
    release-6.2.3
    release-6.2.2
    release-6.2.1

--- a/doc/en/announce/release-6.2.4.rst
+++ b/doc/en/announce/release-6.2.4.rst
@@ -1,0 +1,22 @@
+pytest-6.2.4
+=======================================
+
+pytest 6.2.4 has just been released to PyPI.
+
+This is a bug-fix release, being a drop-in replacement. To upgrade::
+
+  pip install --upgrade pytest
+
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
+
+Thanks to all of the contributors to this release:
+
+* Anthony Sottile
+* Bruno Oliveira
+* Christian Maurer
+* Florian Bruhin
+* Ran Benita
+
+
+Happy testing,
+The pytest Development Team

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -28,6 +28,15 @@ with advance notice in the **Deprecations** section of releases.
 
 .. towncrier release notes start
 
+pytest 6.2.4 (2021-05-04)
+=========================
+
+Bug Fixes
+---------
+
+- `#8539 <https://github.com/pytest-dev/pytest/issues/8539>`_: Fixed assertion rewriting on Python 3.10.
+
+
 pytest 6.2.3 (2021-04-03)
 =========================
 

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -28,7 +28,7 @@ Install ``pytest``
 .. code-block:: bash
 
     $ pytest --version
-    pytest 6.2.3
+    pytest 6.2.4
 
 .. _`simpletest`:
 


### PR DESCRIPTION
Created automatically from https://github.com/pytest-dev/pytest/issues/8631.

Once all builds pass and it has been **approved** by one or more maintainers, the build
can be released by pushing a tag `6.2.4` to this repository.

Closes #8631.
