### PR TITLE
Add myself to tidelift

### DIFF
--- a/TIDELIFT.rst
+++ b/TIDELIFT.rst
@@ -25,6 +25,7 @@ The current list of contributors receiving funding are:
 
 * `@asottile`_
 * `@nicoddemus`_
+* `@The-Compiler`_
 
 Contributors interested in receiving a part of the funds just need to submit a PR adding their
 name to the list. Contributors that want to stop receiving the funds should also submit a PR
@@ -56,3 +57,4 @@ funds. Just drop a line to one of the `@pytest-dev/tidelift-admins`_ or use the 
 
 .. _`@asottile`: https://github.com/asottile
 .. _`@nicoddemus`: https://github.com/nicoddemus
+.. _`@The-Compiler`: https://github.com/The-Compiler


### PR DESCRIPTION
Given that I'm ramping up my contributions to pytest and plugins again recently, I'd like to request being added to Tidelift.

I'm "tidelift.com@the-compiler.org" over there (though I'm not sure what state my account is in exactly, after logging in I was first asked for an organization name :confused:).

cc @pytest-dev/tidelift-admins