### PR TITLE
add feature to omit collection of private names when running with -k option

### DIFF
--- a/changelog/7539.feature.rst
+++ b/changelog/7539.feature.rst
@@ -1,0 +1,2 @@
+add feature to ignore private names(characterised with names starting with '_') from being collected when running pytest
+with ``-k`` option.

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -172,6 +172,9 @@ class KeywordMatcher:
         # Add the markers to the keywords as we no longer handle them correctly.
         mapped_names.update(mark.name for mark in item.iter_markers())
 
+        # Remove names that are private(characterised by starting with '_')
+        mapped_names = set(filter(lambda name: not name.startswith("_"), mapped_names))
+
         return cls(mapped_names)
 
     def __call__(self, subname: str) -> bool:

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -689,6 +689,32 @@ class TestTerminalFunctional:
         )
         assert result.ret == 0
 
+    def test_keyword_with_private_node(self, pytester: Pytester) -> None:
+        testpath = pytester.makepyfile(
+            """
+                def test_foo_one():
+                    pass
+                def test_foo_two():
+                    pass
+                def test_foo_three():
+                    pass
+                def test_bar_one():
+                    pass
+                def test_bar_two():
+                    pass
+                def _test_bar_three():
+                    pass
+           """
+        )
+        result = pytester.runpytest("-k", "bar", testpath)
+        result.stdout.fnmatch_lines(
+            [
+                "collected 5 items / 3 deselected / 2 selected",
+                "*test_keyword_with_private_node.py ..*",
+            ]
+        )
+        assert result.ret == 0
+
     def test_deselected_with_hookwrapper(self, pytester: Pytester) -> None:
         pytester.makeconftest(
             """


### PR DESCRIPTION
Fixes #7539

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
