### PR TITLE
code: remove unneeded comparison eval wrapper

### DIFF
--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -422,19 +422,10 @@ class Traceback(List[TracebackEntry]):
                 f = entry.frame
                 loc = f.f_locals
                 for otherloc in values:
-                    if f.eval(
-                        co_equal,
-                        __recursioncache_locals_1=loc,
-                        __recursioncache_locals_2=otherloc,
-                    ):
+                    if otherloc == loc:
                         return i
             values.append(entry.frame.f_locals)
         return None
-
-
-co_equal = compile(
-    "__recursioncache_locals_1 == __recursioncache_locals_2", "?", "eval"
-)
 
 
 E = TypeVar("E", bound=BaseException, covariant=True)


### PR DESCRIPTION
Given a `RecursionError` traceback, the `Traceback.recursionindex()`
method returns the index of the frame which started the recursion
(repeated set of frames). To do so it attempts to check whether two
frames are equivalent. Just checking the function/line is not enough
because the recursion variable(s) might differ (e.g. imagine the numeric
value in a recursive factorial implementation). So it also compares the
`f_locals` (local variables) of each frame for equivalence.

For some reason, the locals comparison is wrapped in an `eval` whose
purpose is to evaluate the comparison in one of the compared frame's
context (locals + globals in scope). However, I can not think of any way
in which the global scope could affect the evaluation. It would have an
affect when the locals are bound but that's already done. So this seems
unnecessary - remove it.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
