### PR TITLE
Make the test class instance behaviour clearer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -62,6 +62,7 @@ Charles Machalow
 Charnjit SiNGH (CCSJ)
 Chris Lamb
 Chris NeJame
+Chris Rose
 Christian Boelsen
 Christian Fetzer
 Christian Neumüller

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -169,40 +169,34 @@ This is outlined below:
 
     # content of test_class_demo.py
     class TestClassDemoInstance:
+        value = 0
+
         def test_one(self):
-            assert 0
+            self.value = 1
+            assert self.value == 1
 
         def test_two(self):
-            assert 0
+            assert self.value == 1
 
 
 .. code-block:: pytest
 
     $ pytest -k TestClassDemoInstance -q
-    FF                                                                   [100%]
+    .F                                                                   [100%]
     ================================= FAILURES =================================
-    ______________________ TestClassDemoInstance.test_one ______________________
-
-    self = <test_class_demo.TestClassDemoInstance object at 0xdeadbeef>
-
-        def test_one(self):
-    >       assert 0
-    E       assert 0
-
-    test_class_demo.py:3: AssertionError
     ______________________ TestClassDemoInstance.test_two ______________________
 
     self = <test_class_demo.TestClassDemoInstance object at 0xdeadbeef>
 
         def test_two(self):
-    >       assert 0
-    E       assert 0
+    >       assert self.value == 1
+    E       assert 0 == 1
+    E        +  where 0 = <test_class_demo.TestClassDemoInstance object at 0xdeadbeef>.value
 
-    test_class_demo.py:6: AssertionError
+    test_class_demo.py:9: AssertionError
     ========================= short test summary info ==========================
-    FAILED test_class_demo.py::TestClassDemoInstance::test_one - assert 0
-    FAILED test_class_demo.py::TestClassDemoInstance::test_two - assert 0
-    2 failed in 0.12s
+    FAILED test_class_demo.py::TestClassDemoInstance::test_two - assert 0 == 1
+    1 failed, 1 passed in 0.04s
 
 Note that attributes added at class level are *class attributes*, so they will be shared between tests.
 


### PR DESCRIPTION
In the "Getting Started" doc, the test class instance example for
instance sharing doesn't actually demonstrate anything about the
reinstantiation of the class. This change shows clearly how the instance
data isn't retained between test runs.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
