### PR TITLE
Fix cyclic links in goodpractices.rst

### DIFF
--- a/doc/en/explanation/goodpractices.rst
+++ b/doc/en/explanation/goodpractices.rst
@@ -240,7 +240,7 @@ tox
 ------
 
 Once you are done with your work and want to make sure that your actual
-package passes all tests you may want to look into `tox`_, the
+package passes all tests you may want to look into `tox <https://tox.readthedocs.io/>`_, the
 virtualenv test automation tool and its `pytest support
 <https://tox.readthedocs.io/en/latest/example/pytest.html>`_.
 tox helps you to setup virtualenv environments with pre-defined


### PR DESCRIPTION
It makes more sense to not link to the section itself, which causes a confusing cycle.