### PR TITLE
Fix a typo in documentation about tmpdir_factory

### DIFF
--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -615,7 +615,7 @@ tmpdir_factory
 
 :ref:`tmpdir and tmpdir_factory`
 
-``tmp_path_factory`` is an instance of :class:`~pytest.TempdirFactory`:
+``tmpdir_factory`` is an instance of :class:`~pytest.TempdirFactory`:
 
 .. autoclass:: pytest.TempdirFactory()
     :members:


### PR DESCRIPTION
The section refers to tmpdir_factory, but the sentence mentionned
tmp_path_factory.