### PR TITLE
Stop using exception.message

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@ Andrea Cimatoribus
 Andreas Motl
 Andreas Zeidler
 Andrew Shapton
+Andrey Bienkowski
 Andrey Paramonov
 Andrzej Klajnert
 Andrzej Ostrowski

--- a/testing/test_mark_expression.py
+++ b/testing/test_mark_expression.py
@@ -118,7 +118,7 @@ def test_syntax_errors(expr: str, column: int, message: str) -> None:
     with pytest.raises(ParseError) as excinfo:
         evaluate(expr, lambda ident: True)
     assert excinfo.value.column == column
-    assert excinfo.value.message == message
+    assert str(excinfo.value) == message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1713825#c0

> In PEP 352, exception.message was deprecated (now, you can get the string from of an exception by simply doing str(exception). As of Python 3.0, exception.message was dropped, and attempting to access it causes an error.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
