### PR TITLE
Fix typo in fixture.rst

### DIFF
--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -1454,7 +1454,7 @@ example, consider this file:
 
 .. literalinclude:: example/fixtures/test_fixtures_order_autouse_multiple_scopes.py
 
-Even though nothing in ``TestClassWithC1Request`` is requesting ``c1``, it still
+Even though nothing in ``TestClassWithoutC1Request`` is requesting ``c1``, it still
 is executed for the tests inside it anyway:
 
 .. image:: example/fixtures/test_fixtures_order_autouse_multiple_scopes.svg


### PR DESCRIPTION
Example referenced the wrong function name

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
