### PR TITLE
Fix typo in fixture.rst

### DIFF
--- a/doc/en/reference/fixtures.rst
+++ b/doc/en/reference/fixtures.rst
@@ -410,7 +410,7 @@ example, consider this file:
 
 .. literalinclude:: /example/fixtures/test_fixtures_order_autouse_multiple_scopes.py
 
-Even though nothing in ``TestClassWithC1Request`` is requesting ``c1``, it still
+Even though nothing in ``TestClassWithoutC1Request`` is requesting ``c1``, it still
 is executed for the tests inside it anyway:
 
 .. image:: /example/fixtures/test_fixtures_order_autouse_multiple_scopes.svg


### PR DESCRIPTION
Example referenced the wrong function name

cherry pick of #8746 which targetted the wrong branch