### PR TITLE
Add pytest.version_tuple

### DIFF
--- a/changelog/8761.feature.rst
+++ b/changelog/8761.feature.rst
@@ -1,0 +1,1 @@
+New :ref:`version-tuple` attribute, which makes it simpler for users to do something depending on the pytest version (such as declaring hooks which are introduced in later versions).

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -226,6 +226,37 @@ Marks a test function as *expected to fail*.
           a new release of a library fixes a known bug).
 
 
+pytest.__version__
+~~~~~~~~~~~~~~~~~~
+
+The current pytest version, as a string::
+
+    >>> import pytest
+    >>> pytest.__version__
+    '7.0.0'
+
+
+.. _`version-tuple`:
+
+pytest.version_tuple
+~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 7.0
+
+The current pytest version, as a tuple::
+
+    >>> import pytest
+    >>> pytest.version_tuple
+    (7, 0, 0)
+
+For pre-releases, the last component will be a string with the prerelease version::
+
+    >>> import pytest
+    >>> pytest.version_tuple
+    (7, 0, '0rc1')
+
+
+
 Custom marks
 ~~~~~~~~~~~~
 

--- a/src/_pytest/__init__.py
+++ b/src/_pytest/__init__.py
@@ -1,8 +1,9 @@
-__all__ = ["__version__"]
+__all__ = ["__version__", "version_tuple"]
 
 try:
-    from ._version import version as __version__
-except ImportError:
+    from ._version import version as __version__, version_tuple
+except ImportError:  # pragma: no cover
     # broken installation, we don't even try
     # unknown only works because we do poor mans version compare
     __version__ = "unknown"
+    version_tuple = (0, 0, "unknown")  # type:ignore[assignment]

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -2,6 +2,7 @@
 """pytest: unit and functional testing with Python."""
 from . import collect
 from _pytest import __version__
+from _pytest import version_tuple
 from _pytest._code import ExceptionInfo
 from _pytest.assertion import register_assert_rewrite
 from _pytest.cacheprovider import Cache
@@ -130,6 +131,7 @@ __all__ = [
     "Session",
     "set_trace",
     "skip",
+    "version_tuple",
     "TempPathFactory",
     "Testdir",
     "TempdirFactory",

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -19,6 +19,12 @@ def test_version_less_verbose(pytester: Pytester, pytestconfig, monkeypatch) -> 
     result.stderr.fnmatch_lines([f"pytest {pytest.__version__}"])
 
 
+def test_versions():
+    """Regression check for the public version attributes in pytest."""
+    assert isinstance(pytest.__version__, str)
+    assert isinstance(pytest.version_tuple, tuple)
+
+
 def test_help(pytester: Pytester) -> None:
     result = pytester.runpytest("--help")
     assert result.ret == 0


### PR DESCRIPTION
This adds `pytest.version_tuple`, which makes it simpler for users to do something depending on the pytest version, such as declaring hooks which are introduced in later versions.

This feature was added originally in https://github.com/pypa/setuptools_scm/pull/475.

Followup to https://github.com/pytest-dev/pytest/pull/7605.
