### PR TITLE
[6.2] Remove duplicate '>=' in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ python_requires = >=3.6
 package_dir =
     =src
 setup_requires =
-    setuptools>=>=42.0
+    setuptools>=42.0
     setuptools-scm>=3.4
 zip_safe = no
 


### PR DESCRIPTION
This is a backport from main. Fedora's tooling is confused by the typo:

```
Handling setuptools>=>=42.0 from get_requires_for_build_wheel
...
ValueError: Unknown character in version: >=42.0.
```