### PR TITLE
tests: Use less conflicting name for directory

### DIFF
--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -88,7 +88,7 @@ def test__check_initialpaths_for_relpath() -> None:
 
     assert nodes._check_initialpaths_for_relpath(session, sub) == "file"
 
-    outside = Path("/outside")
+    outside = Path("/outside-this-does-not-exist")
     assert nodes._check_initialpaths_for_relpath(session, outside) is None
 
 


### PR DESCRIPTION
Otherwise, if e.g. /outside is used for a Docker container, the test will fail:

```
>       assert nodes._check_initialpaths_for_relpath(session, outside) is None
E       AssertionError: assert '' is None
```