### PR TITLE
logging: Make it possible to add cli colors to custom log levels 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -305,6 +305,7 @@ Tanvi Mehta
 Tarcisio Fischer
 Tareq Alayan
 Ted Xiao
+Terje Runde
 Thomas Grainger
 Thomas Hisch
 Tim Hoffmann

--- a/changelog/8803.improvement.rst
+++ b/changelog/8803.improvement.rst
@@ -1,7 +1,9 @@
-Make it possible to add colors to custom log levels on cli log.
+It is now possible to add colors to custom log levels on cli log.
 
 By using :func:`add_color_level <_pytest.logging.add_color_level` from a ``pytest_configure`` hook, colors can be added::
 
     logging_plugin = config.pluginmanager.get_plugin('logging-plugin')
     logging_plugin.log_cli_handler.formatter.add_color_level(logging.INFO, 'cyan')
     logging_plugin.log_cli_handler.formatter.add_color_level(logging.SPAM, 'blue')
+    
+    See :ref:`log_colors` for more information.

--- a/changelog/8803.improvement.rst
+++ b/changelog/8803.improvement.rst
@@ -1,0 +1,8 @@
+Make it possible to add colors to custom log levels on cli log.
+
+By using :func:`add_color_level <_pytest.logging.add_color_level` from a ``pytest_configure`` hook, colors can be added::
+
+    logging_plugin = config.pluginmanager.get_plugin('logging-plugin')
+    logging_plugin.log_cli_handler.formatter.add_color_level(logging.INFO, 'cyan')
+    logging_plugin.log_cli_handler.formatter.add_color_level(logging.SPAM, 'blue')
+

--- a/changelog/8803.improvement.rst
+++ b/changelog/8803.improvement.rst
@@ -5,4 +5,3 @@ By using :func:`add_color_level <_pytest.logging.add_color_level` from a ``pytes
     logging_plugin = config.pluginmanager.get_plugin('logging-plugin')
     logging_plugin.log_cli_handler.formatter.add_color_level(logging.INFO, 'cyan')
     logging_plugin.log_cli_handler.formatter.add_color_level(logging.SPAM, 'blue')
-

--- a/changelog/8803.improvement.rst
+++ b/changelog/8803.improvement.rst
@@ -5,5 +5,5 @@ By using :func:`add_color_level <_pytest.logging.add_color_level` from a ``pytes
     logging_plugin = config.pluginmanager.get_plugin('logging-plugin')
     logging_plugin.log_cli_handler.formatter.add_color_level(logging.INFO, 'cyan')
     logging_plugin.log_cli_handler.formatter.add_color_level(logging.SPAM, 'blue')
-    
+
     See :ref:`log_colors` for more information.

--- a/doc/en/how-to/logging.rst
+++ b/doc/en/how-to/logging.rst
@@ -242,7 +242,7 @@ through ``add_color_level()``. Example:
 .. warning::
 
     This feature and its API are considered **experimental** and might change
-    between releases without a deprecation notice.   
+    between releases without a deprecation notice.
 .. _log_release_notes:
 
 Release notes

--- a/doc/en/how-to/logging.rst
+++ b/doc/en/how-to/logging.rst
@@ -219,9 +219,14 @@ option names are:
 You can call ``set_log_path()`` to customize the log_file path dynamically. This functionality
 is considered **experimental**.
 
+.. _log_colors:
+
+Customizing Colors
+^^^^^^^^^^^^^^^^^^
+
 Log levels are colored if colored terminal output is enabled. Changing
 from default colors or putting color on custom log levels is supported
-**experimentally** through ``add_color_level()``. Example:
+through ``add_color_level()``. Example:
 
 .. code-block:: python
 
@@ -234,7 +239,10 @@ from default colors or putting color on custom log levels is supported
 
         # Add color to a custom log level (a custom log level `SPAM` is already set up)
         logging_plugin.log_cli_handler.formatter.add_color_level(logging.SPAM, "blue")
+.. warning::
 
+    This feature and its API are considered **experimental** and might change
+    between releases without a deprecation notice.   
 .. _log_release_notes:
 
 Release notes

--- a/doc/en/how-to/logging.rst
+++ b/doc/en/how-to/logging.rst
@@ -227,13 +227,13 @@ from default colors or putting color on custom log levels is supported
 
     @pytest.hookimpl
     def pytest_configure(config):
-        logging_plugin = config.pluginmanager.get_plugin('logging-plugin')
+        logging_plugin = config.pluginmanager.get_plugin("logging-plugin")
 
         # Change color on existing log level
-        logging_plugin.log_cli_handler.formatter.add_color_level(logging.INFO, 'cyan')
+        logging_plugin.log_cli_handler.formatter.add_color_level(logging.INFO, "cyan")
 
         # Add color to a custom log level (a custom log level `SPAM` is already set up)
-        logging_plugin.log_cli_handler.formatter.add_color_level(logging.SPAM, 'blue')
+        logging_plugin.log_cli_handler.formatter.add_color_level(logging.SPAM, "blue")
 
 .. _log_release_notes:
 

--- a/doc/en/how-to/logging.rst
+++ b/doc/en/how-to/logging.rst
@@ -219,6 +219,22 @@ option names are:
 You can call ``set_log_path()`` to customize the log_file path dynamically. This functionality
 is considered **experimental**.
 
+Log levels are colored if colored terminal output is enabled. Changing
+from default colors or putting color on custom log levels is supported
+**experimentally** through ``add_color_level()``. Example:
+
+.. code-block:: python
+
+    @pytest.hookimpl
+    def pytest_configure(config):
+        logging_plugin = config.pluginmanager.get_plugin('logging-plugin')
+
+        # Change color on existing log level
+        logging_plugin.log_cli_handler.formatter.add_color_level(logging.INFO, 'cyan')
+
+        # Add color to a custom log level (a custom log level `SPAM` is already set up)
+        logging_plugin.log_cli_handler.formatter.add_color_level(logging.SPAM, 'blue')
+
 .. _log_release_notes:
 
 Release notes

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -70,7 +70,7 @@ class ColoredLevelFormatter(logging.Formatter):
         for level, color_opts in self.LOGLEVEL_COLOROPTS.items():
             self.add_color_level(level, *color_opts)
 
-    def add_color_level(self, level, *color_opts):
+    def add_color_level(self, level: int, *color_opts: AbstractSet[str]):
         """Add or update color opts for a log level.
 
         .. warning::

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -70,8 +70,15 @@ class ColoredLevelFormatter(logging.Formatter):
         for level, color_opts in self.LOGLEVEL_COLOROPTS.items():
             self.add_color_level(level, *color_opts)
 
-    def add_color_level(self, level: int, *color_opts: AbstractSet[str]):
+    def add_color_level(self, level: int, *color_opts: str):
         """Add or update color opts for a log level.
+
+        :param level:
+            Log level to apply a style to, e.g. ``logging.INFO``.
+        :param color_opts:
+            ANSI escape sequence color options. Capitalized colors indicates
+            background color, i.e. ``'green', 'Yellow', 'bold'`` will give bold
+            green text on yellow background.
 
         .. warning::
             This is an experimental API.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -71,7 +71,11 @@ class ColoredLevelFormatter(logging.Formatter):
             self.add_color_level(level, *color_opts)
 
     def add_color_level(self, level, *color_opts):
-        """Add or update color opts for a log level."""
+        """Add or update color opts for a log level.
+
+        .. warning::
+            This is an experimental API.
+        """
 
         assert self._fmt is not None
         levelname_fmt_match = self.LEVELNAME_FMT_REGEX.search(self._fmt)

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -79,9 +79,7 @@ class ColoredLevelFormatter(logging.Formatter):
             return
         levelname_fmt = levelname_fmt_match.group()
 
-        formatted_levelname = levelname_fmt % {
-            "levelname": logging.getLevelName(level)
-        }
+        formatted_levelname = levelname_fmt % {"levelname": logging.getLevelName(level)}
 
         # add ANSI escape sequences around the formatted levelname
         color_kwargs = {name: True for name in color_opts}

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -70,7 +70,7 @@ class ColoredLevelFormatter(logging.Formatter):
         for level, color_opts in self.LOGLEVEL_COLOROPTS.items():
             self.add_color_level(level, *color_opts)
 
-    def add_color_level(self, level: int, *color_opts: str):
+    def add_color_level(self, level: int, *color_opts: str) -> None:
         """Add or update color opts for a log level.
 
         :param level:

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -63,8 +63,15 @@ class ColoredLevelFormatter(logging.Formatter):
 
     def __init__(self, terminalwriter: TerminalWriter, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        self._terminalwriter = terminalwriter
         self._original_fmt = self._style._fmt
         self._level_to_fmt_mapping: Dict[int, str] = {}
+
+        for level, color_opts in self.LOGLEVEL_COLOROPTS.items():
+            self.add_color_level(level, *color_opts)
+
+    def add_color_level(self, level, *color_opts):
+        """Add or update color opts for a log level."""
 
         assert self._fmt is not None
         levelname_fmt_match = self.LEVELNAME_FMT_REGEX.search(self._fmt)
@@ -72,19 +79,18 @@ class ColoredLevelFormatter(logging.Formatter):
             return
         levelname_fmt = levelname_fmt_match.group()
 
-        for level, color_opts in self.LOGLEVEL_COLOROPTS.items():
-            formatted_levelname = levelname_fmt % {
-                "levelname": logging.getLevelName(level)
-            }
+        formatted_levelname = levelname_fmt % {
+            "levelname": logging.getLevelName(level)
+        }
 
-            # add ANSI escape sequences around the formatted levelname
-            color_kwargs = {name: True for name in color_opts}
-            colorized_formatted_levelname = terminalwriter.markup(
-                formatted_levelname, **color_kwargs
-            )
-            self._level_to_fmt_mapping[level] = self.LEVELNAME_FMT_REGEX.sub(
-                colorized_formatted_levelname, self._fmt
-            )
+        # add ANSI escape sequences around the formatted levelname
+        color_kwargs = {name: True for name in color_opts}
+        colorized_formatted_levelname = self._terminalwriter.markup(
+            formatted_levelname, **color_kwargs
+        )
+        self._level_to_fmt_mapping[level] = self.LEVELNAME_FMT_REGEX.sub(
+            colorized_formatted_levelname, self._fmt
+        )
 
     def format(self, record: logging.LogRecord) -> str:
         fmt = self._level_to_fmt_mapping.get(record.levelno, self._original_fmt)


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
This PR adds the possibility to color custom log levels on the CLI:
![pride](https://user-images.githubusercontent.com/459297/123624692-2910ad80-d80f-11eb-8f28-382575c9e275.png)

Not sure how this can be unit tested or where to add documentation. Please comment.

Closes #8803.