### PR TITLE
scripts: Don't capture output in prepare-release-pr.py

### DIFF
--- a/scripts/prepare-release-pr.py
+++ b/scripts/prepare-release-pr.py
@@ -66,22 +66,16 @@ def prepare_release_pr(
 
     run(
         ["git", "config", "user.name", "pytest bot"],
-        text=True,
         check=True,
-        capture_output=True,
     )
     run(
         ["git", "config", "user.email", "pytestbot@gmail.com"],
-        text=True,
         check=True,
-        capture_output=True,
     )
 
     run(
         ["git", "checkout", "-b", release_branch, f"origin/{base_branch}"],
-        text=True,
         check=True,
-        capture_output=True,
     )
 
     print(f"Branch {Fore.CYAN}{release_branch}{Fore.RESET} created.")
@@ -92,17 +86,13 @@ def prepare_release_pr(
     print("Running", " ".join(cmdline))
     run(
         cmdline,
-        text=True,
         check=True,
-        capture_output=True,
     )
 
     oauth_url = f"https://{token}:x-oauth-basic@github.com/{SLUG}.git"
     run(
         ["git", "push", oauth_url, f"HEAD:{release_branch}", "--force"],
-        text=True,
         check=True,
-        capture_output=True,
     )
     print(f"Branch {Fore.CYAN}{release_branch}{Fore.RESET} pushed.")
 


### PR DESCRIPTION
We don't need to access the output in the script, and if we capture it,
we don't get any output on CI, so no way to see why a release failed.

Failing release here: https://github.com/pytest-dev/pytest/runs/2931408672?check_suite_focus=true#step:6:35

I deleted the 7.0.x maint branch I had created again, so we don't need to backport this (it's only been around for a couple of minutes). Will recreate once it's in.