### PR TITLE
Fix "external plugins" link

### DIFF
--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -74,7 +74,7 @@ Features
 
 - Python 3.6+ and PyPy 3
 
-- Rich plugin architecture, with over 315+ `external plugins <http://plugincompat.herokuapp.com>`_ and thriving community
+- Rich plugin architecture, with over 315+ `external plugins <https://docs.pytest.org/en/latest/reference/plugin_list.html>`_ and thriving community
 
 
 Documentation


### PR DESCRIPTION
The "external plugins" link was pointing to a deprecated Heroku app. This PR uses the correct plugin link to save the reader an extra click.