### PR TITLE
ci: Persist git credentials for prepare-release-pr

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -30,7 +30,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@v2


### PR DESCRIPTION
See #8599, follow-up to #8681

The token is needed so we can use `git push`.