### PR TITLE
Fix docs URL in unregistered marks warning message

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -163,6 +163,7 @@ Jordan Speicher
 Joseph Hunkeler
 Josh Karpel
 Joshua Bronson
+Julien de la Bruère-Terreault
 Jurko Gospodnetić
 Justyna Janczyszyn
 Justice Ndou

--- a/changelog/8787.bugfix.rst
+++ b/changelog/8787.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed URL of documentation link in message of warning issued on unregisterd marks.
+Fixed URL of documentation link in message of warning issued on unregistered marks.

--- a/changelog/8787.bugfix.rst
+++ b/changelog/8787.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed URL of documentation link in message of warning issued on unregisterd marks.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -530,7 +530,7 @@ class MarkGenerator:
                 warnings.warn(
                     "Unknown pytest.mark.%s - is this a typo?  You can register "
                     "custom marks to avoid this warning - for details, see "
-                    "https://docs.pytest.org/en/latest/how-to/mark.html" % name,
+                    "https://docs.pytest.org/en/stable/how-to/mark.html" % name,
                     PytestUnknownMarkWarning,
                     2,
                 )

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -530,7 +530,7 @@ class MarkGenerator:
                 warnings.warn(
                     "Unknown pytest.mark.%s - is this a typo?  You can register "
                     "custom marks to avoid this warning - for details, see "
-                    "https://docs.pytest.org/en/stable/mark.html" % name,
+                    "https://docs.pytest.org/en/latest/how-to/mark.html" % name,
                     PytestUnknownMarkWarning,
                     2,
                 )


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
Fixes #8787

Fix URL of documentation link in message of warning issued on unregisterd marks from https://docs.pytest.org/en/latest/mark.html (broken link) to https://docs.pytest.org/en/latest/how-to/mark.html.