### PR TITLE
Drop readline workaround introduced in #1281

### DIFF
--- a/changelog/8733.breaking.rst
+++ b/changelog/8733.breaking.rst
@@ -1,0 +1,5 @@
+Drop a workaround for `pyreadline <https://github.com/pyreadline/pyreadline>`__ that made it work with ``--pdb``.
+
+The workaround was introduced in `#1281 <https://github.com/pytest-dev/pytest/pull/1281>`__ in 2015, however since then
+`pyreadline seems to have gone unmaintained <https://github.com/pyreadline/pyreadline/issues/58>`__, is `generating
+warnings <https://github.com/pytest-dev/pytest/issues/8847>`__, and will stop working on Python 3.10.

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -68,30 +68,6 @@ def _colorama_workaround() -> None:
             pass
 
 
-def _readline_workaround() -> None:
-    """Ensure readline is imported so that it attaches to the correct stdio
-    handles on Windows.
-
-    Pdb uses readline support where available--when not running from the Python
-    prompt, the readline module is not imported until running the pdb REPL.  If
-    running pytest with the --pdb option this means the readline module is not
-    imported until after I/O capture has been started.
-
-    This is a problem for pyreadline, which is often used to implement readline
-    support on Windows, as it does not attach to the correct handles for stdout
-    and/or stdin if they have been redirected by the FDCapture mechanism.  This
-    workaround ensures that readline is imported before I/O capture is setup so
-    that it can attach to the actual stdin/out for the console.
-
-    See https://github.com/pytest-dev/pytest/pull/1281.
-    """
-    if sys.platform.startswith("win32"):
-        try:
-            import readline  # noqa: F401
-        except ImportError:
-            pass
-
-
 def _py36_windowsconsoleio_workaround(stream: TextIO) -> None:
     """Workaround for Windows Unicode console handling on Python>=3.6.
 
@@ -154,7 +130,6 @@ def pytest_load_initial_conftests(early_config: Config):
     if ns.capture == "fd":
         _py36_windowsconsoleio_workaround(sys.stdout)
     _colorama_workaround()
-    _readline_workaround()
     pluginmanager = early_config.pluginmanager
     capman = CaptureManager(ns.capture)
     pluginmanager.register(capman, "capturemanager")


### PR DESCRIPTION
Fix #8733
Closes #8847

* Also add types-atomicwrites as extras to mypy pre-commit hook (Windows)