### PR TITLE
Docs: monkeypatch.setenv does not accept bool

### DIFF
--- a/doc/en/builtin.rst
+++ b/doc/en/builtin.rst
@@ -132,7 +132,7 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
             monkeypatch.delattr(obj, name, raising=True)
             monkeypatch.setitem(mapping, name, value)
             monkeypatch.delitem(obj, name, raising=True)
-            monkeypatch.setenv(name, value, prepend=False)
+            monkeypatch.setenv(name, value, prepend=None)
             monkeypatch.delenv(name, raising=True)
             monkeypatch.syspath_prepend(path)
             monkeypatch.chdir(path)

--- a/doc/en/how-to/monkeypatch.rst
+++ b/doc/en/how-to/monkeypatch.rst
@@ -21,7 +21,7 @@ functionality in tests:
     monkeypatch.delattr(obj, name, raising=True)
     monkeypatch.setitem(mapping, name, value)
     monkeypatch.delitem(obj, name, raising=True)
-    monkeypatch.setenv(name, value, prepend=False)
+    monkeypatch.setenv(name, value, prepend=None)
     monkeypatch.delenv(name, raising=True)
     monkeypatch.syspath_prepend(path)
     monkeypatch.chdir(path)

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -36,7 +36,7 @@ def monkeypatch() -> Generator["MonkeyPatch", None, None]:
         monkeypatch.delattr(obj, name, raising=True)
         monkeypatch.setitem(mapping, name, value)
         monkeypatch.delitem(obj, name, raising=True)
-        monkeypatch.setenv(name, value, prepend=os.pathsep)
+        monkeypatch.setenv(name, value, prepend=None)
         monkeypatch.delenv(name, raising=True)
         monkeypatch.syspath_prepend(path)
         monkeypatch.chdir(path)

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -36,7 +36,7 @@ def monkeypatch() -> Generator["MonkeyPatch", None, None]:
         monkeypatch.delattr(obj, name, raising=True)
         monkeypatch.setitem(mapping, name, value)
         monkeypatch.delitem(obj, name, raising=True)
-        monkeypatch.setenv(name, value, prepend=False)
+        monkeypatch.setenv(name, value, prepend=os.pathsep)
         monkeypatch.delenv(name, raising=True)
         monkeypatch.syspath_prepend(path)
         monkeypatch.chdir(path)


### PR DESCRIPTION
The [`monkeypatch` docs](https://docs.pytest.org/en/6.2.x/reference.html?highlight=monkeypatch#pytest.monkeypatch.monkeypatch) show an example of passing `prepend=False` to `monkeypatch.setenv`. However, the [`monkeypatch.setenv` docs](https://docs.pytest.org/en/6.2.x/reference.html?highlight=monkeypatch#pytest.MonkeyPatch.setenv) clearly state that `prepend` is of type `str` or `None`. This PR fixes the `monkeypatch` docs.