### PR TITLE
Remove upper pinning on tomli

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     packaging
     pluggy>=0.12,<1.0.0a1
     py>=1.8.2
-    tomli>=1.0.0,<2.0.0
+    tomli>=1.0.0
     atomicwrites>=1.0;sys_platform=="win32"
     colorama;sys_platform=="win32"
     importlib-metadata>=0.12;python_version<"3.8"


### PR DESCRIPTION
the best practice is to only `<` when you know something is broken, and even then prefer `!=` assuming it will be fixed upstream for maximum compatibility
