### PR TITLE
Adjust enum reprs conditional from Python 3.10 to 3.11

### DIFF
--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -448,7 +448,7 @@ class TestMetafunc:
         enum = pytest.importorskip("enum")
         e = enum.Enum("Foo", "one, two")
         result = idmaker(("a", "b"), [pytest.param(e.one, e.two)])
-        if sys.version_info[:2] >= (3, 10):
+        if sys.version_info[:2] >= (3, 11):
             assert result == ["one-two"]
         else:
             assert result == ["Foo.one-Foo.two"]

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -744,7 +744,7 @@ def test_run_result_repr() -> None:
 
     # known exit code
     r = pytester_mod.RunResult(1, outlines, errlines, duration=0.5)
-    if sys.version_info[:2] >= (3, 10):
+    if sys.version_info[:2] >= (3, 11):
         assert repr(r) == (
             "<RunResult ret=TESTS_FAILED len(stdout.lines)=3"
             " len(stderr.lines)=4 duration=0.50s>"


### PR DESCRIPTION
I don't think a changelog fragment is necessary: It changes tests only, no chnagelog fragment was even in the original commit that introduced the condiitonal.