### PR TITLE
Revert "Adjust enum reprs for Python 3.10"

### DIFF
--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -448,10 +448,7 @@ class TestMetafunc:
         enum = pytest.importorskip("enum")
         e = enum.Enum("Foo", "one, two")
         result = idmaker(("a", "b"), [pytest.param(e.one, e.two)])
-        if sys.version_info[:2] >= (3, 10):
-            assert result == ["one-two"]
-        else:
-            assert result == ["Foo.one-Foo.two"]
+        assert result == ["Foo.one-Foo.two"]
 
     def test_idmaker_idfn(self) -> None:
         """#351"""

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -744,16 +744,10 @@ def test_run_result_repr() -> None:
 
     # known exit code
     r = pytester_mod.RunResult(1, outlines, errlines, duration=0.5)
-    if sys.version_info[:2] >= (3, 10):
-        assert repr(r) == (
-            "<RunResult ret=TESTS_FAILED len(stdout.lines)=3"
-            " len(stderr.lines)=4 duration=0.50s>"
-        )
-    else:
-        assert repr(r) == (
-            "<RunResult ret=ExitCode.TESTS_FAILED len(stdout.lines)=3"
-            " len(stderr.lines)=4 duration=0.50s>"
-        )
+    assert (
+        repr(r) == "<RunResult ret=ExitCode.TESTS_FAILED len(stdout.lines)=3"
+        " len(stderr.lines)=4 duration=0.50s>"
+    )
 
     # unknown exit code: just the number
     r = pytester_mod.RunResult(99, outlines, errlines, duration=0.5)


### PR DESCRIPTION
I don't think a changelog fragment is necessary: It changes tests only, no chnagelog fragment was even in the original commit that introduced the conditional.

Alternative to https://github.com/pytest-dev/pytest/pull/8895