### PR TITLE
Revert fspath deprecation

### DIFF
--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -33,15 +33,6 @@ In order to support the transition to :mod:`pathlib`, the following hooks now re
 The accompanying ``py.path.local`` based paths have been deprecated: plugins which manually invoke those hooks should only pass the new ``pathlib.Path`` arguments, and users should change their hook implementations to use the new ``pathlib.Path`` arguments.
 
 
-``Node.fspath`` in favor of ``pathlib`` and ``Node.path``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. deprecated:: 6.3
-
-As pytest tries to move off `py.path.local <https://py.readthedocs.io/en/latest/path.html>`__ we ported most of the node internals to :mod:`pathlib`.
-
-Pytest will provide compatibility for quite a while.
-
 Diamond inheritance between :class:`pytest.File` and :class:`pytest.Item`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -89,12 +89,6 @@ ARGUMENT_TYPE_STR = UnformattedWarning(
 )
 
 
-NODE_FSPATH = UnformattedWarning(
-    PytestDeprecationWarning,
-    "{type}.fspath is deprecated and will be replaced by {type}.path.\n"
-    "see https://docs.pytest.org/en/latest/deprecations.html#node-fspath-in-favor-of-pathlib-and-node-path",
-)
-
 HOOK_LEGACY_PATH_ARG = UnformattedWarning(
     PytestDeprecationWarning,
     "The ({pylib_path_arg}: py.path.local) argument is deprecated, please use ({pathlib_path_arg}: pathlib.Path)\n"

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -54,7 +54,6 @@ from _pytest.config import Config
 from _pytest.config.argparsing import Parser
 from _pytest.deprecated import check_ispytest
 from _pytest.deprecated import FILLFUNCARGS
-from _pytest.deprecated import NODE_FSPATH
 from _pytest.deprecated import YIELD_FIXTURE
 from _pytest.mark import Mark
 from _pytest.mark import ParameterSet
@@ -520,7 +519,6 @@ class FixtureRequest:
     @property
     def fspath(self) -> LEGACY_PATH:
         """(deprecated) The file system path of the test module which collected this test."""
-        warnings.warn(NODE_FSPATH.format(type=type(self).__name__), stacklevel=2)
         return legacy_path(self.path)
 
     @property

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -28,7 +28,6 @@ from _pytest.compat import legacy_path
 from _pytest.config import Config
 from _pytest.config import ConftestImportFailure
 from _pytest.deprecated import FSCOLLECTOR_GETHOOKPROXY_ISINITPATH
-from _pytest.deprecated import NODE_FSPATH
 from _pytest.mark.structures import Mark
 from _pytest.mark.structures import MarkDecorator
 from _pytest.mark.structures import NodeKeywords
@@ -226,12 +225,10 @@ class Node(metaclass=NodeMeta):
     @property
     def fspath(self) -> LEGACY_PATH:
         """(deprecated) returns a legacy_path copy of self.path"""
-        warnings.warn(NODE_FSPATH.format(type=type(self).__name__), stacklevel=2)
         return legacy_path(self.path)
 
     @fspath.setter
     def fspath(self, value: LEGACY_PATH) -> None:
-        warnings.warn(NODE_FSPATH.format(type=type(self).__name__), stacklevel=2)
         self.path = Path(value)
 
     @classmethod

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -967,8 +967,7 @@ class TestRequestBasic:
         (item,) = pytester.genitems([modcol])
         req = fixtures.FixtureRequest(item, _ispytest=True)
         assert req.path == modcol.path
-        with pytest.warns(pytest.PytestDeprecationWarning):
-            assert req.fspath == modcol.fspath
+        assert req.fspath == modcol.fspath
 
     def test_request_fixturenames(self, pytester: Pytester) -> None:
         pytester.makepyfile(

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -614,8 +614,7 @@ class TestSession:
         items2, hookrec = pytester.inline_genitems(item.nodeid)
         (item2,) = items2
         assert item2.name == item.name
-        with pytest.warns(DeprecationWarning):
-            assert item2.fspath == item.fspath
+        assert item2.fspath == item.fspath
         assert item2.path == item.path
 
     def test_find_byid_without_instance_parents(self, pytester: Pytester) -> None:


### PR DESCRIPTION
It is not clear yet how we should proceed with this deprecation
because `pytest.Item.reportinfo` is public API and returns a `py.path` object,
and also how plugins and our examples should handle that.

Reverting just the deprecation aspect of #8251 so we can get a 7.0.0 release out.

We will reintroduce the deprecation later once we have a clear path moving forward with replacing `reportinfo`.

Closes #8445
Closes #8821

