### PR TITLE
Add types-atomicwrites to mypy's pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,7 @@ repos:
           - attrs>=19.2.0
           - packaging
           - tomli
+          - types-atomicwrites
           - types-pkg_resources
 -   repo: local
     hooks:


### PR DESCRIPTION
This is a Windows only dependency, so the problem only shows up when trying to commit on Windows.
