### PR TITLE
Refactor internal scope handling by introducing Scope enum

### DIFF
--- a/changelog/8913.trivial.rst
+++ b/changelog/8913.trivial.rst
@@ -1,0 +1,1 @@
+The private ``CallSpec2._arg2scopenum`` attribute has been removed after an internal refactoring.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -400,7 +400,7 @@ def store_mark(obj, mark: Mark) -> None:
 # Typing for builtin pytest marks. This is cheating; it gives builtin marks
 # special privilege, and breaks modularity. But practicality beats purity...
 if TYPE_CHECKING:
-    from _pytest.fixtures import _Scope
+    from _pytest.scope import _ScopeName
 
     class _SkipMarkDecorator(MarkDecorator):
         @overload  # type: ignore[override,misc]
@@ -450,7 +450,7 @@ if TYPE_CHECKING:
                     Callable[[Any], Optional[object]],
                 ]
             ] = ...,
-            scope: Optional[_Scope] = ...,
+            scope: Optional[_ScopeName] = ...,
         ) -> MarkDecorator:
             ...
 

--- a/src/_pytest/scope.py
+++ b/src/_pytest/scope.py
@@ -1,0 +1,89 @@
+"""
+Scope definition and related utilities.
+
+Those are defined here, instead of in the 'fixtures' module because
+their use is spread across many other pytest modules, and centralizing it in 'fixtures'
+would cause circular references.
+
+Also this makes the module light to import, as it should.
+"""
+from enum import Enum
+from functools import total_ordering
+from typing import Optional
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing_extensions import Literal
+
+    _ScopeName = Literal["session", "package", "module", "class", "function"]
+
+
+@total_ordering
+class Scope(Enum):
+    """
+    Represents one of the possible fixture scopes in pytest.
+
+    Scopes are ordered from lower to higher, that is:
+
+              ->>> higher ->>>
+
+    Function < Class < Module < Package < Session
+
+              <<<- lower  <<<-
+    """
+
+    # Scopes need to be listed from lower to higher.
+    Function: "_ScopeName" = "function"
+    Class: "_ScopeName" = "class"
+    Module: "_ScopeName" = "module"
+    Package: "_ScopeName" = "package"
+    Session: "_ScopeName" = "session"
+
+    def next_lower(self) -> "Scope":
+        """Return the next lower scope."""
+        index = _SCOPE_INDICES[self]
+        if index == 0:
+            raise ValueError(f"{self} is the lower-most scope")
+        return _ALL_SCOPES[index - 1]
+
+    def next_higher(self) -> "Scope":
+        """Return the next higher scope."""
+        index = _SCOPE_INDICES[self]
+        if index == len(_SCOPE_INDICES) - 1:
+            raise ValueError(f"{self} is the upper-most scope")
+        return _ALL_SCOPES[index + 1]
+
+    def __lt__(self, other: "Scope") -> bool:
+        self_index = _SCOPE_INDICES[self]
+        other_index = _SCOPE_INDICES[other]
+        return self_index < other_index
+
+    @classmethod
+    def from_user(
+        cls, scope_name: "_ScopeName", descr: str, where: Optional[str] = None
+    ) -> "Scope":
+        """
+        Given a scope name from the user, return the equivalent Scope enum. Should be used
+        whenever we want to convert a user provided scope name to its enum object.
+
+        If the scope name is invalid, construct a user friendly message and call pytest.fail.
+        """
+        from _pytest.outcomes import fail
+
+        try:
+            return Scope(scope_name)
+        except ValueError:
+            fail(
+                "{} {}got an unexpected scope value '{}'".format(
+                    descr, f"from {where} " if where else "", scope_name
+                ),
+                pytrace=False,
+            )
+
+
+_ALL_SCOPES = list(Scope)
+_SCOPE_INDICES = {scope: index for index, scope in enumerate(_ALL_SCOPES)}
+
+
+# Ordered list of scopes which can contain many tests (in practice all except Function).
+HIGH_SCOPES = [x for x in Scope if x is not Scope.Function]

--- a/src/_pytest/setuponly.py
+++ b/src/_pytest/setuponly.py
@@ -9,6 +9,7 @@ from _pytest.config import ExitCode
 from _pytest.config.argparsing import Parser
 from _pytest.fixtures import FixtureDef
 from _pytest.fixtures import SubRequest
+from _pytest.scope import Scope
 
 
 def pytest_addoption(parser: Parser) -> None:
@@ -64,7 +65,9 @@ def _show_fixture_action(fixturedef: FixtureDef[object], msg: str) -> None:
 
     tw = config.get_terminal_writer()
     tw.line()
-    tw.write(" " * 2 * fixturedef.scopenum)
+    # Use smaller indentation the higher the scope: Session = 0, Package = 1, etc.
+    scope_indent = list(reversed(Scope)).index(fixturedef._scope)
+    tw.write(" " * 2 * scope_indent)
     tw.write(
         "{step} {scope} {fixture}".format(
             step=msg.ljust(8),  # align the output to TEARDOWN

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -29,12 +29,11 @@ from _pytest.python import Class
 from _pytest.python import Function
 from _pytest.python import PyCollector
 from _pytest.runner import CallInfo
+from _pytest.scope import Scope
 
 if TYPE_CHECKING:
     import unittest
     import twisted.trial.unittest
-
-    from _pytest.fixtures import _Scope
 
     _SysExcInfoType = Union[
         Tuple[Type[BaseException], BaseException, types.TracebackType],
@@ -102,7 +101,7 @@ class UnitTestCase(Class):
             "setUpClass",
             "tearDownClass",
             "doClassCleanups",
-            scope="class",
+            scope=Scope.Class,
             pass_self=False,
         )
         if class_fixture:
@@ -113,7 +112,7 @@ class UnitTestCase(Class):
             "setup_method",
             "teardown_method",
             None,
-            scope="function",
+            scope=Scope.Function,
             pass_self=True,
         )
         if method_fixture:
@@ -125,7 +124,7 @@ def _make_xunit_fixture(
     setup_name: str,
     teardown_name: str,
     cleanup_name: Optional[str],
-    scope: "_Scope",
+    scope: Scope,
     pass_self: bool,
 ):
     setup = getattr(obj, setup_name, None)
@@ -141,7 +140,7 @@ def _make_xunit_fixture(
             pass
 
     @pytest.fixture(
-        scope=scope,
+        scope=scope.value,
         autouse=True,
         # Use a unique name to speed up lookup.
         name=f"_unittest_{setup_name}_fixture_{obj.__qualname__}",

--- a/testing/test_scope.py
+++ b/testing/test_scope.py
@@ -1,0 +1,39 @@
+import re
+
+import pytest
+from _pytest.scope import Scope
+
+
+def test_ordering() -> None:
+    assert Scope.Session > Scope.Package
+    assert Scope.Package > Scope.Module
+    assert Scope.Module > Scope.Class
+    assert Scope.Class > Scope.Function
+
+
+def test_next_lower() -> None:
+    assert Scope.Session.next_lower() is Scope.Package
+    assert Scope.Package.next_lower() is Scope.Module
+    assert Scope.Module.next_lower() is Scope.Class
+    assert Scope.Class.next_lower() is Scope.Function
+
+    with pytest.raises(ValueError, match="Function is the lower-most scope"):
+        Scope.Function.next_lower()
+
+
+def test_next_higher() -> None:
+    assert Scope.Function.next_higher() is Scope.Class
+    assert Scope.Class.next_higher() is Scope.Module
+    assert Scope.Module.next_higher() is Scope.Package
+    assert Scope.Package.next_higher() is Scope.Session
+
+    with pytest.raises(ValueError, match="Session is the upper-most scope"):
+        Scope.Session.next_higher()
+
+
+def test_from_user() -> None:
+    assert Scope.from_user("module", "for parametrize", "some::id") is Scope.Module
+
+    expected_msg = "for parametrize from some::id got an unexpected scope value 'foo'"
+    with pytest.raises(pytest.fail.Exception, match=re.escape(expected_msg)):
+        Scope.from_user("foo", "for parametrize", "some::id")  # type:ignore[arg-type]


### PR DESCRIPTION
This replaces the internal use of string literals and "scopenum"
to a proper Scope enum, which also centralizes indexes, getting
higher scopes, get next scope in the order, etc. Another benefit
is that it helps the type checker by introducing a proper type,
and improve readability (IMHO).

This is _mostly_ an internal change, however due to historical
reasons, the API of the following _internal_ objects has
changed slightly:

* `CallSpec2`: `_arg2scopenum` renamed to `_arg2scope` for consistency.
* `FixtureRequest`:
  Previously contained a `scope: str` attribute.
  Changed attribute to `_scope: Scope`, with a backward compatible read-only property `scope -> str`.
  This one might cause some confusion, because the internal attribute has a different type
  than the public property of the same name.
* `SubRequest.__init__` parameter changed from `_Scope` to `Scope`.
