### PR TITLE
#7124: Fix `--doctest-modules` crashing when `__main__.py` is present

### DIFF
--- a/changelog/7124.bugfix.rst
+++ b/changelog/7124.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue where ``__main__.py`` would raise an ``ImportError`` when ``--doctest-modules`` was provided.

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -125,7 +125,9 @@ def pytest_collect_file(
 ) -> Optional[Union["DoctestModule", "DoctestTextfile"]]:
     config = parent.config
     if fspath.suffix == ".py":
-        if config.option.doctestmodules and not _is_setup_py(fspath):
+        if config.option.doctestmodules and not any(
+            (_is_setup_py(fspath), _is_main_py(fspath))
+        ):
             mod: DoctestModule = DoctestModule.from_parent(parent, path=fspath)
             return mod
     elif _is_doctest(config, fspath, parent):
@@ -146,6 +148,10 @@ def _is_doctest(config: Config, path: Path, parent: Collector) -> bool:
         return True
     globs = config.getoption("doctestglob") or ["test*.txt"]
     return any(fnmatch_ex(glob, path) for glob in globs)
+
+
+def _is_main_py(path: Path) -> bool:
+    return path.name == "__main__.py"
 
 
 class ReprFailDoctest(TerminalRepr):

--- a/testing/example_scripts/doctest/main_py/__main__.py
+++ b/testing/example_scripts/doctest/main_py/__main__.py
@@ -1,0 +1,2 @@
+def test_this_is_ignored():
+    assert True

--- a/testing/example_scripts/doctest/main_py/test_normal_module.py
+++ b/testing/example_scripts/doctest/main_py/test_normal_module.py
@@ -1,0 +1,6 @@
+def test_doc():
+    """
+    >>> 10 > 5
+    True
+    """
+    assert False

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -813,7 +813,7 @@ class TestDoctests:
         result.stdout.fnmatch_lines(["*collected 0 items*"])
 
     def test_main_py_does_not_cause_import_errors(self, pytester: Pytester):
-        p = pytester.copy_example("doctest//main_py")
+        p = pytester.copy_example("doctest/main_py")
         result = pytester.runpytest(p, "--doctest-modules")
         result.stdout.fnmatch_lines(["*collected 2 items*", "*1 failed, 1 passed*"])
 


### PR DESCRIPTION
Hi, hope you are all doing well.  Been a bit busy as of lately but I am hoping to start contributing again, here is an issue outlined in:

#7124

whereby when ``--doctest-modules`` was being passed, `ImportError` on `__main__.py` was raised, causing a crash.  I have added a special case for `__main__.py` here, similarly to `setup.py`, would welcome any feed back on this approach or if you can guide me to another one if this is incorrect.

 - adds `__main__.py` specific checks for the `doctest` plugin `collect_item` hook implementation
 - unit / integration tests