### PR TITLE
expose `warnings=` to pytester `assert_outcomes()`

### DIFF
--- a/changelog/8953.feature.rst
+++ b/changelog/8953.feature.rst
@@ -1,0 +1,2 @@
+:class:`RunResult <_pytest.pytester.RunResult>` method :meth:`assert_outcomes <_pytest.pytester.RunResult.assert_outcomes>` now accepts a
+``warnings`` argument to assert the total number of warnings captured.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -588,6 +588,7 @@ class RunResult:
         errors: int = 0,
         xpassed: int = 0,
         xfailed: int = 0,
+        warnings: int = 0,
     ) -> None:
         """Assert that the specified outcomes appear with the respective
         numbers (0 means it didn't occur) in the text output from a test run."""
@@ -603,6 +604,7 @@ class RunResult:
             errors=errors,
             xpassed=xpassed,
             xfailed=xfailed,
+            warnings=warnings,
         )
 
 

--- a/src/_pytest/pytester_assertions.py
+++ b/src/_pytest/pytester_assertions.py
@@ -42,6 +42,7 @@ def assert_outcomes(
     errors: int = 0,
     xpassed: int = 0,
     xfailed: int = 0,
+    warnings: int = 0,
 ) -> None:
     """Assert that the specified outcomes appear with the respective
     numbers (0 means it didn't occur) in the text output from a test run."""
@@ -54,6 +55,7 @@ def assert_outcomes(
         "errors": outcomes.get("errors", 0),
         "xpassed": outcomes.get("xpassed", 0),
         "xfailed": outcomes.get("xfailed", 0),
+        "warnings": outcomes.get("warnings", 0),
     }
     expected = {
         "passed": passed,
@@ -62,5 +64,6 @@ def assert_outcomes(
         "errors": errors,
         "xpassed": xpassed,
         "xfailed": xfailed,
+        "warnings": warnings,
     }
     assert obtained == expected

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -335,7 +335,7 @@ def test_SkipTest_during_collection(pytester: Pytester) -> None:
         """
     )
     result = pytester.runpytest(p)
-    result.assert_outcomes(skipped=1)
+    result.assert_outcomes(skipped=1, warnings=1)
 
 
 def test_SkipTest_in_test(pytester: Pytester) -> None:

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -849,12 +849,15 @@ def test_testdir_makefile_ext_empty_string_makes_file(testdir) -> None:
     assert "test_testdir_makefile" in str(p1)
 
 
+@pytest.mark.filterwarnings("default")
 def test_pytester_assert_outcomes_warnings(pytester: Pytester) -> None:
-    p = pytester.makepyfile(
+    pytester.makepyfile(
         """
+        import warnings
+
         def test_with_warning():
-            pass
+            warnings.warn(UserWarning("some custom warning"))
         """
     )
-    result = pytester.runpytest(p, "--strict")
+    result = pytester.runpytest()
     result.assert_outcomes(passed=1, warnings=1)

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -847,3 +847,14 @@ def test_testdir_makefile_ext_empty_string_makes_file(testdir) -> None:
     """For backwards compat #8192"""
     p1 = testdir.makefile("", "")
     assert "test_testdir_makefile" in str(p1)
+
+
+def test_pytester_assert_outcomes_warnings(pytester: Pytester) -> None:
+    p = pytester.makepyfile(
+        """
+        def test_with_warning():
+            pass
+        """
+    )
+    result = pytester.runpytest(p, "--strict")
+    result.assert_outcomes(passed=1, warnings=1)


### PR DESCRIPTION
Evening all, while investigating some other areas I noticed `pytester` cannot actually assert outcomes on `warnings=` so I've decided to bolt that on, I'm not sure if there is a good reason why this wasen't already a feature, maybe because of shadowing the builtin `warnings` module with it's naming or so? or it might create a bit of unpredictability in our tests?

Might have some test fallout, will have a look as soon as

edit: Actually there might be a very good use-case why this is **NOT** the default..

edit2: Reopening as it _might_ be an ok feature?

closes #8953 