### PR TITLE
Fix small typo in pluggy writing hook functions docs

### DIFF
--- a/doc/en/how-to/writing_hook_functions.rst
+++ b/doc/en/how-to/writing_hook_functions.rst
@@ -261,9 +261,9 @@ and use pytest_addoption as follows:
 
    def pytest_addhooks(pluginmanager):
        """ This example assumes the hooks are grouped in the 'hooks' module. """
-       from . import hook
+       from . import hooks
 
-       pluginmanager.add_hookspecs(hook)
+       pluginmanager.add_hookspecs(hooks)
 
 
    def pytest_addoption(parser, pluginmanager):


### PR DESCRIPTION
slightly incorrect import in the example of writing & registering user define hooks.
