### PR TITLE
typeshed `os.PathLike` is now `@runtime_checkable`, remove mypy ignore

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -305,9 +305,7 @@ def _prepareconfig(
 ) -> "Config":
     if args is None:
         args = sys.argv[1:]
-    # TODO: Remove type-ignore after next mypy release.
-    # https://github.com/python/typeshed/commit/076983eec45e739c68551cb6119fd7d85fd4afa9
-    elif isinstance(args, os.PathLike):  # type: ignore[misc]
+    elif isinstance(args, os.PathLike):
         args = [os.fspath(args)]
     elif not isinstance(args, list):
         msg = "`args` parameter expected to be a list of strings, got: {!r} (type: {})"


### PR DESCRIPTION
`os.PathLike` is now `@runtime_checkable` in typeshed, so it is my understanding we no longer need to suppress `os.PathLike` isinstance checks.

https://github.com/python/typeshed/blob/e1b9ab33727ddbb2bab21c0a1c161d9a0b2c7c2f/stdlib/os/__init__.pyi#L311-L313

```py
@runtime_checkable
class PathLike(Protocol[_AnyStr_co]):
    def __fspath__(self) -> _AnyStr_co: ...
```