### PR TITLE
mark/expression: allow backslash characters in identifiers

### DIFF
--- a/changelog/8983.bugfix.rst
+++ b/changelog/8983.bugfix.rst
@@ -1,0 +1,2 @@
+The test selection options ``pytest -k`` and ``pytest -m`` now support matching names containing backslash (`\\`) characters.
+Backslashes are treated literally, not as escape characters (the values being matched against are already escaped).

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -6,7 +6,7 @@ expression: expr? EOF
 expr:       and_expr ('or' and_expr)*
 and_expr:   not_expr ('and' not_expr)*
 not_expr:   'not' not_expr | '(' expr ')' | ident
-ident:      (\w|:|\+|-|\.|\[|\])+
+ident:      (\w|:|\+|-|\.|\[|\]|\\)+
 
 The semantics are:
 
@@ -88,7 +88,7 @@ class Scanner:
                 yield Token(TokenType.RPAREN, ")", pos)
                 pos += 1
             else:
-                match = re.match(r"(:?\w|:|\+|-|\.|\[|\])+", input[pos:])
+                match = re.match(r"(:?\w|:|\+|-|\.|\[|\]|\\)+", input[pos:])
                 if match:
                     value = match.group(0)
                     if value == "or":

--- a/testing/test_mark_expression.py
+++ b/testing/test_mark_expression.py
@@ -66,6 +66,20 @@ def test_syntax_oddeties(expr: str, expected: bool) -> None:
     assert evaluate(expr, matcher) is expected
 
 
+def test_backslash_not_treated_specially() -> None:
+    r"""When generating nodeids, if the source name contains special characters
+    like a newline, they are escaped into two characters like \n. Therefore, a
+    user will never need to insert a literal newline, only \n (two chars). So
+    mark expressions themselves do not support escaping, instead they treat
+    backslashes as regular identifier characters."""
+    matcher = {r"\nfoo\n"}.__contains__
+
+    assert evaluate(r"\nfoo\n", matcher)
+    assert not evaluate(r"foo", matcher)
+    with pytest.raises(ParseError):
+        evaluate("\nfoo\n", matcher)
+
+
 @pytest.mark.parametrize(
     ("expr", "column", "message"),
     (
@@ -129,6 +143,7 @@ def test_syntax_errors(expr: str, column: int, message: str) -> None:
         ":::",
         "a:::c",
         "a+-b",
+        r"\nhe\\l\lo\n\t\rbye",
         "אבגד",
         "aaאבגדcc",
         "a[bcd]",
@@ -156,7 +171,6 @@ def test_valid_idents(ident: str) -> None:
     "ident",
     (
         "/",
-        "\\",
         "^",
         "*",
         "=",


### PR DESCRIPTION
Fixes #8983. I see two options for how to treat backslashes (besides rejectign them), as escape characters or literal identifier characters. I went with the latter; please see the test docstring for the rationale.