### PR TITLE
Fix test collection for windowspaths >260 chars

### DIFF
--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -38,6 +38,7 @@ from _pytest.fixtures import FixtureManager
 from _pytest.outcomes import exit
 from _pytest.pathlib import absolutepath
 from _pytest.pathlib import bestrelpath
+from _pytest.pathlib import ensure_extended_length_path
 from _pytest.pathlib import fnmatch_ex
 from _pytest.pathlib import visit
 from _pytest.reports import CollectReport
@@ -716,6 +717,7 @@ class Session(nodes.FSCollector):
             # Let the Package collector deal with subnodes, don't collect here.
             if argpath.is_dir():
                 assert not names, f"invalid arg {(argpath, names)!r}"
+                argpath = ensure_extended_length_path(Path(argpath))
 
                 seen_dirs: Set[Path] = set()
                 for direntry in visit(str(argpath), self._recurse):


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Closes #8999 

It would be nice to add a test that tests collection in a folder with long paths, I'm not sure what the best for this would be. I could create a test based on the referenced issue similar to this one?
https://github.com/pytest-dev/pytest/blob/2439729413e701a19398316711ec5d795ae2ec63/testing/test_collection.py#L127
