### PR TITLE
doc: Update trainings

### DIFF
--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -2,9 +2,8 @@
 
 .. sidebar:: Next Open Trainings
 
-   - `Introduction to pytest <https://ep2021.europython.eu/talks/7S5Cnc6-introduction-to-pytest/>`_, part of `Europython 2021 <https://ep2021.europython.eu/>`_, July 27th, remote.
    - `pytest: Professionelles Testen (nicht nur) für Python <https://workshoptage.ch/workshops/2021/pytest-test-driven-development-nicht-nur-fuer-python-2/>`_ (German), part of `CH-Open Workshoptage <https://workshoptage.ch/>`_, September 9th, ETH Zurich, Switzerland.
-   - `Professional Testing with Python <https://www.python-academy.com/courses/specialtopics/python_course_testing.html>`_, via `Python Academy <https://www.python-academy.com/>`_, Q4/2021 (TBD, 3 days), Leipzig (Germany) and remote.
+   - `Professional Testing with Python <https://www.python-academy.com/courses/specialtopics/python_course_testing.html>`_, via `Python Academy <https://www.python-academy.com/>`_, February 1st to 3rd, 2022, Leipzig (Germany) and remote.
 
    Also see `previous talks and blogposts <talks.html>`_.
 


### PR DESCRIPTION
Europython is done (went quite well!), and the date for the Python Academy one is known now (though we ended up going for Q1/2022 instead).