### PR TITLE
Fix cwd removal on Solaris

### DIFF
--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1388,6 +1388,9 @@ class TestEarlyRewriteBailout:
     @pytest.mark.skipif(
         sys.platform.startswith("win32"), reason="cannot remove cwd on Windows"
     )
+    @pytest.mark.skipif(
+        sys.platform.startswith("sunos5"), reason="cannot remove cwd on Solaris"
+    )
     def test_cwd_changed(self, pytester: Pytester, monkeypatch) -> None:
         # Setup conditions for py's fspath trying to import pathlib on py34
         # always (previously triggered via xdist only).


### PR DESCRIPTION
This is a simple fix for testing on Solaris, where (similarly to Windows) cwd cannot be removed.

- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
