### PR TITLE
Fix towncrier output

### DIFF
--- a/changelog/9040.trivial.rst
+++ b/changelog/9040.trivial.rst
@@ -1,0 +1,1 @@
+Enable compatibility with ``pluggy 1.0`` or later.

--- a/changelog/_template.rst
+++ b/changelog/_template.rst
@@ -1,3 +1,6 @@
+
+{{ top_underline * ((top_line)|length)}}
+
 {% for section in sections %}
 {% set underline = "-" %}
 {% if section %}


### PR DESCRIPTION
Add top line to towncrier template

Looks correct now:

```rst
.. towncrier release notes start

pytest 7.0.0 (2021-08-27)
=========================


Breaking Changes
----------------

- `#8246 <https://github.com/pytest-dev/pytest/issues/8246>`_: ``--version`` now writes version information to ``stdout`` rather than ``stderr``.
[...]
```
    
Fixes #8817, supersedes #9045 and also includes the changelog commit cherry-picked from there.

See https://github.com/twisted/towncrier/issues/346 and https://github.com/twisted/towncrier/issues/340.