### PR TITLE
'prerelease' input is not required in prepare-release-pr workflow

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -13,7 +13,7 @@ on:
         default: 'no'
       prerelease:
         description: 'Prerelease (ex: rc1). Leave empty if not a pre-release.'
-        required: true
+        required: false
         default: ''
 
 # Set permissions at the job level.


### PR DESCRIPTION
The default is the correct value when generating a normal release.
