### PR TITLE
Show fullname on direct Node construction warning

### DIFF
--- a/changelog/8994.improvement.rst
+++ b/changelog/8994.improvement.rst
@@ -1,0 +1,2 @@
+Included the module of the class in the error message about direct
+node construction (without using ``from_parent``).

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -123,7 +123,7 @@ class NodeMeta(type):
             "See "
             "https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent"
             " for more details."
-        ).format(name=self.__name__)
+        ).format(name=f"{self.__module__}.{self.__name__}")
         fail(msg, pytrace=False)
 
     def _create(self, *k, **kw):

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -6,6 +6,7 @@ from typing import Type
 import pytest
 from _pytest import nodes
 from _pytest.compat import legacy_path
+from _pytest.outcomes import OutcomeException
 from _pytest.pytester import Pytester
 from _pytest.warning_types import PytestWarning
 
@@ -38,6 +39,19 @@ def test_node_from_parent_disallowed_arguments() -> None:
         nodes.Node.from_parent(None, session=None)  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="config is"):
         nodes.Node.from_parent(None, config=None)  # type: ignore[arg-type]
+
+
+def test_node_direct_construction_deprecated() -> None:
+    with pytest.raises(
+        OutcomeException,
+        match=(
+            "Direct construction of _pytest.nodes.Node has been deprecated, please "
+            "use _pytest.nodes.Node.from_parent.\nSee "
+            "https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent"
+            " for more details."
+        ),
+    ):
+        nodes.Node(None, session=None)  # type: ignore[arg-type]
 
 
 def test_subclassing_both_item_and_collector_deprecated(


### PR DESCRIPTION
This commit add the fullname on the Node construction warning.
Also add a test for this case.

closes #8994 
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
