### PR TITLE
adding contact and badge for pytest-dev discord server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,11 @@
     :target: https://pytest.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
+.. image:: https://img.shields.io/badge/Discord-pytest--dev-blue
+    :target: https://discord.com/invite/pytest-dev
+    :alt: Discord
+
+
 The ``pytest`` framework makes it easy to write small tests, yet
 scales to support complex functional testing for applications and libraries.
 

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,10 @@
     :target: https://discord.com/invite/pytest-dev
     :alt: Discord
 
+.. image:: https://img.shields.io/badge/Libera%20chat-%23pytest-orange
+    :target: https://web.libera.chat/#pytest
+    :alt: Libera chat
+
 
 The ``pytest`` framework makes it easy to write small tests, yet
 scales to support complex functional testing for applications and libraries.

--- a/doc/en/contact.rst
+++ b/doc/en/contact.rst
@@ -8,6 +8,8 @@ Contact channels
 - `pytest issue tracker`_ to report bugs or suggest features (for version
   2.0 and above).
 - `pytest discussions`_ at github for general questions.
+- `pytest discord server <https://discord.com/invite/pytest-dev>`_
+  for pytest development visibility and general assistance.
 - `pytest on stackoverflow.com <http://stackoverflow.com/search?q=pytest>`_
   to post precise questions with the tag ``pytest``.  New Questions will usually
   be seen by pytest users or developers and answered quickly.


### PR DESCRIPTION
Short and sweet; adds a discord badge into the readme and updates the contacts docs to reference the **pytest-dev** discord server.

(Not sure on what is best for the text on these; so feel free to recommend any changes :) was a best guess!)

edit: It is possible to make a more 'interactive' discord badge; stating how many users online etc but it might require some admin permissions on the discord server itself - if anyone wants to pursue that