### PR TITLE
Refactor change in PR#7687

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1311,6 +1311,10 @@ def _idval(
     nodeid: Optional[str],
     config: Optional[Config],
 ) -> str:
+    if val is NOTSET:
+        # Fallback to default. Note that NOTSET is an enum.Enum.
+        return str(argname) + str(idx)
+
     if idfn:
         try:
             generated_id = idfn(val)
@@ -1334,15 +1338,13 @@ def _idval(
         return str(val)
     elif isinstance(val, REGEX_TYPE):
         return ascii_escaped(val.pattern)
-    elif val is NOTSET:
-        # Fallback to default. Note that NOTSET is an enum.Enum.
-        pass
     elif isinstance(val, enum.Enum):
         return str(val)
     elif isinstance(getattr(val, "__name__", None), str):
         # Name of a class, function, module, etc.
         name: str = getattr(val, "__name__")
         return name
+
     return str(argname) + str(idx)
 
 


### PR DESCRIPTION
In https://github.com/pytest-dev/pytest/pull/7687 a bugfix was added
after NOTSET was changed to a singleton enum, which ended up breaking
ID generation when it checked for isinstance(Enum).

That change, however, did not update the code path in the same ID
generation when used as an idfn function.

This adjusts the logic to handle both cases.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
