### PR TITLE
Improved docs for `pytester.copy_example`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -224,6 +224,7 @@ Michael Goerz
 Michael Krebs
 Michael Seifert
 Michal Wajszczuk
+Michał Zięba
 Mihai Capotă
 Mike Hoyle (hoylemd)
 Mike Lundy

--- a/changelog/4320.doc.rst
+++ b/changelog/4320.doc.rst
@@ -1,0 +1,1 @@
+Improved docs for `pytester.copy_example`.

--- a/doc/en/how-to/writing_plugins.rst
+++ b/doc/en/how-to/writing_plugins.rst
@@ -416,7 +416,12 @@ return a result object, with which we can assert the tests' outcomes.
         result.assert_outcomes(passed=4)
 
 
-Additionally it is possible to copy examples for an example folder before running pytest on it.
+Additionally it is possible to copy examples to the ``pytester``'s isolated environment
+before running pytest on it. This way we can abstract the tested logic to separate files,
+which is especially useful for longer tests and/or longer ``conftest.py`` files.
+
+Note that for ``pytester.copy_example`` to work we need to set `pytester_example_dir`
+in our ``pytest.ini`` to tell pytest where to look for example files.
 
 .. code-block:: ini
 


### PR DESCRIPTION
Improved docs for `pytester.copy_example` to provide better context on the usual usage observed in the `pytest` repo. I considered updating the code to reflect that, but I think a simple snippet like that does its job. I'm open to any suggestions though!

I'm not sure whether the change is significant enough to require a changelog entry – I'll remove it if deemed unnecessary.

Closes #4320.
