### PR TITLE
fix #8991 and enhance collection performance

### DIFF
--- a/changelog/9125.improvement.rst
+++ b/changelog/9125.improvement.rst
@@ -1,0 +1,1 @@
+Improve collection performance by caching the internal hook proxy objects.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -568,7 +568,7 @@ class Session(nodes.FSCollector):
         if proxy is not None:
             return proxy
 
-        my_conftestmodules = self._pm._getconftestmodules(
+        my_conftestmodules = pm._getconftestmodules(
             path,
             self.config.getoption("importmode"),
             rootpath=self.config.rootpath,


### PR DESCRIPTION
The commit introduces few performance improvements for `_pytest.main.Session.gethookproxy`.

As per #8991 it seems that caching `gethookproxy` can buy some collection time since almost same `fspath` will yield the same `proxy` however due to the fact that plugin manger updates `_conftest_plugins` as it collect; using `lru_cache` will regress some of the tests. 

The fix tries to implement a simple cache dict that is cleared every time the number of seen collected conftest plugin is changed. 

Below are results when tested against pandas test suite about 16% less collection time. 

```shell
hyperfine --warmup=1 --min-runs 4 'venv_vanilla/bin/pytest --collect-only -q pandas/pandas/tests -k test_nans_count' 'venv_pytest/bin/pytest --collect-only -q pandas/pandas/tests -k test_nans_count'
Benchmark #1: venv_vanilla/bin/pytest --collect-only -q pandas/pandas/tests -k test_nans_count
  Time (mean ± σ):     146.703 s ±  1.040 s    [User: 144.008 s, System: 2.980 s]
  Range (min … max):   145.604 s … 148.006 s    4 runs

Benchmark #2: venv_modifyied/bin/pytest --collect-only -q pandas/pandas/tests -k test_nans_count
  Time (mean ± σ):     126.830 s ±  3.221 s    [User: 124.087 s, System: 3.101 s]
  Range (min … max):   123.021 s … 130.446 s    4 runs

Summary
  'venv_modifyied/bin/pytest --collect-only -q pandas/pandas/tests -k test_nans_count' ran
    1.16 ± 0.03 times faster than 'venv_vanilla/bin/pytest --collect-only -q pandas/pandas/tests -k test_nans_count'
```

And below are line profiler comparison 

Before caching

```shell
Total time: 64.3543 s
File: pytest/src/_pytest/main.py
Function: gethookproxy at line 543

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   543                                               @profile
   544                                               def gethookproxy(self, fspath: "os.PathLike[str]"):
   545                                                   # Check if we have the common case of running
   546                                                   # hooks with all conftest.py files.
   547    205108     796878.0      3.9      1.2          pm = self.config.pluginmanager
   548    410216   13867279.0     33.8     21.5          my_conftestmodules = pm._getconftestmodules(
   549    205108   38889376.0    189.6     60.4              Path(fspath),
   550    205108    2686139.0     13.1      4.2              self.config.getoption("importmode"),
   551    205108    1025885.0      5.0      1.6              rootpath=self.config.rootpath,
   552                                                   )
   553    205108    1351659.0      6.6      2.1          remove_mods = pm._conftest_plugins.difference(my_conftestmodules)
   554    205108     659567.0      3.2      1.0          if remove_mods:
   555                                                       # One or more conftests are not in use at this fspath.
   556    205096    2566431.0     12.5      4.0              from .config.compat import PathAwareHookProxy
   557
   558    205096    1874691.0      9.1      2.9              proxy = PathAwareHookProxy(FSHookProxy(pm, remove_mods))
   559                                                   else:
   560                                                       # All plugins are active for this fspath.
   561        12         43.0      3.6      0.0              proxy = self.config.hook
   562    205108     636347.0      3.1      1.0          return proxy
```

After caching

```shell
Total time: 11.4839 s
File: /pytest/src/_pytest/main.py
Function: gethookproxy at line 547

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   547                                               @profile
   548                                               def gethookproxy(self, fspath: "os.PathLike[str]") -> PathAwareHookProxy:
   549                                                   # Check if we have the common case of running
   550                                                   # hooks with all conftest.py files.
   551
   552    205813     828010.0      4.0      7.2          len_conftest_plugins = len(self._pm._conftest_plugins)
   553
   554    205813     717134.0      3.5      6.2          if len_conftest_plugins != self._num_conftest_plugins_collected:
   555        23       1052.0     45.7      0.0              self._fspath_hookproxy_cache.clear()
   556        23         84.0      3.7      0.0              self._num_conftest_plugins_collected = len_conftest_plugins
   557
   558    205813    1338631.0      6.5     11.7          proxy: Optional[PathAwareHookProxy] = self._fspath_hookproxy_cache.get(fspath)
   559
   560    205813     674276.0      3.3      5.9          if proxy:
   561    203797     628775.0      3.1      5.5              return proxy
   562
   563      4032    6764603.0   1677.7     58.9          my_conftestmodules = self._pm._getconftestmodules(
   564      2016     421239.0    208.9      3.7              Path(fspath),
   565      2016      29414.0     14.6      0.3              self.config.getoption("importmode"),
   566      2016      11151.0      5.5      0.1              rootpath=self.config.rootpath,
   567                                                   )
   568      2016      20378.0     10.1      0.2          remove_mods = self._pm._conftest_plugins.difference(my_conftestmodules)
   569      2016       6940.0      3.4      0.1          if remove_mods:
   570                                                       # One or more conftests are not in use at this fspath.
   571      2010      22098.0     11.0      0.2              proxy = PathAwareHookProxy(FSHookProxy(self._pm, remove_mods))
   572                                                   else:
   573                                                       # All plugins are active for this fspath.
   574         6         20.0      3.3      0.0              proxy = self.config.hook
   575      2016      13761.0      6.8      0.1          self._fspath_hookproxy_cache[fspath] = proxy
   576      2016       6365.0      3.2      0.1          return proxy
```

Appreciate your thoughts and feedback