### PR TITLE
Update pastebin URL from bpaste to bpa.st

### DIFF
--- a/changelog/9131.bugfix.rst
+++ b/changelog/9131.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the URL used by ``--pastebin`` to use `bpa.st <http://bpa.st>`__.

--- a/src/_pytest/pastebin.py
+++ b/src/_pytest/pastebin.py
@@ -77,7 +77,7 @@ def create_new_paste(contents: Union[str, bytes]) -> str:
     from urllib.parse import urlencode
 
     params = {"code": contents, "lexer": "text", "expiry": "1week"}
-    url = "https://bpaste.net"
+    url = "https://bpa.st"
     try:
         response: str = (
             urlopen(url, data=urlencode(params).encode("ascii")).read().decode("utf-8")

--- a/testing/test_pastebin.py
+++ b/testing/test_pastebin.py
@@ -161,12 +161,12 @@ class TestPaste:
 
     def test_create_new_paste(self, pastebin, mocked_urlopen) -> None:
         result = pastebin.create_new_paste(b"full-paste-contents")
-        assert result == "https://bpaste.net/show/3c0c6750bd"
+        assert result == "https://bpa.st/show/3c0c6750bd"
         assert len(mocked_urlopen) == 1
         url, data = mocked_urlopen[0]
         assert type(data) is bytes
         lexer = "text"
-        assert url == "https://bpaste.net"
+        assert url == "https://bpa.st"
         assert "lexer=%s" % lexer in data.decode()
         assert "code=full-paste-contents" in data.decode()
         assert "expiry=1week" in data.decode()


### PR DESCRIPTION
This fixes an issue that I am seeing when adding `--pastebin=failed` to pytest that results in a `bad response: HTTP Error 405: Not Allowed` error. Small repro below:

My environment:
* python 3.9.5 and also tried 3.6.10
* pytest 6.2.5
* Ubuntu 20.04.2 LTS and 18.04.5 LTS

test_fail.py:
```python
import pytest
def test_fail():
    assert False
```

cmd: `pytest --pastebin=failed --no-header test_fail.py`
output: 
```
================================= test session starts =================================
collected 1 item

test_fail.py F                                                                  [100%]

====================================== FAILURES =======================================
______________________________________ test_fail ______________________________________
tmpdir = local('/tmp/pytest-of-jerasley/pytest-13/test_fail0')

    def test_fail(tmpdir):
>       assert False
E       assert False

test_fail.py:4: AssertionError
======================== Sending information to Paste Service =========================
test_fail.py:4: AssertionError --> bad response: HTTP Error 405: Not Allowed
=============================== short test summary info ===============================
FAILED test_fail.py::test_fail - assert False
================================== 1 failed in 0.61s ==================================
```

It appears the bpaste URL has changed and is redirected to bpa.st. The redirect I think is causing issues with urllib. After updating the pastebin URL to https://bpa.st the results are the following:

```
================================= test session starts =================================
collected 1 item

test_fail.py F                                                                  [100%]

====================================== FAILURES =======================================
______________________________________ test_fail ______________________________________
tmpdir = local('/tmp/pytest-of-jerasley/pytest-14/test_fail0')

    def test_fail(tmpdir):
>       assert False
E       assert False

test_fail.py:4: AssertionError
======================== Sending information to Paste Service =========================
test_fail.py:4: AssertionError --> https://bpa.st/show/QEGQ
=============================== short test summary info ===============================
FAILED test_fail.py::test_fail - assert False
```