### PR TITLE
Fix an issue with importlib spec_from_file_location

### DIFF
--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -497,6 +497,16 @@ def import_path(
             if spec is not None:
                 break
         else:
+            if (3, 8) <= sys.version_info[:2] < (3, 10) and not path.is_absolute():
+                # module.__spec__.__file__ is supposed to be absolute in py3.8+
+                # importlib.util.spec_from_file_location does this automatically from
+                # 3.10+
+                # This was backported to 3.8 and 3.9, but then reverted in 3.8.11 and
+                # 3.9.6
+                # See https://twistedmatrix.com/trac/ticket/10230
+                # and https://bugs.python.org/issue44070
+                path = path.resolve()
+
             spec = importlib.util.spec_from_file_location(module_name, str(path))
 
         if spec is None:


### PR DESCRIPTION
As explained in issue #8918, in https://bugs.python.org/issue44070, spec_from_file_location() has changed its behaviour so that the responsibility of passing absolute paths is on the caller between 3.8 and 3.10.

Since the code already uses Path, I choose to use resolve to get the full path in place of the suggested solution.

closes #8918

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
