### PR TITLE
Fix syntax typo in writing_hook_functions.rst

### DIFF
--- a/doc/en/how-to/writing_hook_functions.rst
+++ b/doc/en/how-to/writing_hook_functions.rst
@@ -328,8 +328,8 @@ top level of your plugin:
 
 .. code-block:: python
 
-    been_there_key: pytest.StashKey[bool]()
-    done_that_key: pytest.StashKey[str]()
+    been_there_key = pytest.StashKey[bool]()
+    done_that_key = pytest.StashKey[str]()
 
 then use the keys to stash your data at some point:
 


### PR DESCRIPTION
Just noticed it, can be confusing.