### PR TITLE
py36+ tests are definition ordered [v2]

### DIFF
--- a/changelog/5196.feature.rst
+++ b/changelog/5196.feature.rst
@@ -1,0 +1,3 @@
+Tests are now ordered by definition order in more cases.
+
+In a class hierarchy, tests from base classes are now consistently ordered before tests defined on thier subclasses (reverse MRO order).

--- a/changelog/5196.feature.rst
+++ b/changelog/5196.feature.rst
@@ -1,3 +1,3 @@
 Tests are now ordered by definition order in more cases.
 
-In a class hierarchy, tests from base classes are now consistently ordered before tests defined on thier subclasses (reverse MRO order).
+In a class hierarchy, tests from base classes are now consistently ordered before tests defined on their subclasses (reverse MRO order).


### PR DESCRIPTION
Fixes #5196. Closes #7848.

This PR updates @asottile's PR #7848 to also ensure that tests from base classes are ordered before tests defined in the subclasses.

Besides pytest's tests, I also tested it on two projects (using Python 3.9.7):

- pytest: the collection tree is the same. Collection time goes from 5.81s to 3.51s.

- pandas: the collection tree is almost the same, except 2 test classes where tests from base classes are now ordered before the subclasses (for reference, these are `TestDataFrame(Generic)`, `TestCategoricalIndex(Base)`). I think this behavior change is good. Collection time goes from 65.89s to 45.80s.

The main speedup comes from avoiding `inspect.getsource()` calls on test class objects, used previously to manually sort by definition order. The function is slow, and I suspect (didn't verify) that it got much slower in Python 3.9 due to some correctness fixes ([details here](696136b993e11b37c4f34d729a0375e5ad544ade)).