### PR TITLE
Avoid `@lru_cache` on methods

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -533,12 +533,19 @@ class PytestPluginManager(PluginManager):
         else:
             directory = path
 
+        # Optimization: avoid repeated searches in the same directory.
+        # Assumes always called with same importmode and rootpath.
+        existing_clist = self._dirpath2confmods.get(directory)
+        if existing_clist:
+            return existing_clist
+
         # XXX these days we may rather want to use config.rootpath
         # and allow users to opt into looking into the rootdir parent
         # directories instead of requiring to specify confcutdir.
         clist = []
+        confcutdir_parents = self._confcutdir.parents if self._confcutdir else []
         for parent in reversed((directory, *directory.parents)):
-            if self._confcutdir and parent in self._confcutdir.parents:
+            if parent in confcutdir_parents:
                 continue
             conftestpath = parent / "conftest.py"
             if conftestpath.is_file():

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -522,7 +522,6 @@ class PytestPluginManager(PluginManager):
                 if x.is_dir():
                     self._getconftestmodules(x, importmode, rootpath)
 
-    @lru_cache(maxsize=128)
     def _getconftestmodules(
         self, path: Path, importmode: Union[str, ImportMode], rootpath: Path
     ) -> List[types.ModuleType]:


### PR DESCRIPTION
The problem with `@lru_cache` on methods is that it also captures `self` and leaks it until the entry is evicted (if ever).

I was able to restore the caching in both cases (one straightforward case in the first commit, the other in the second commit).