### PR TITLE
rewrite: fixup end_lineno, end_col_offset of rewritten asserts

### DIFF
--- a/changelog/9163.bugfix.rst
+++ b/changelog/9163.bugfix.rst
@@ -1,0 +1,1 @@
+The end line number and end column offset are now properly set for rewritten assert statements.

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -111,6 +111,28 @@ class TestAssertionRewrite:
             assert imp.col_offset == 0
         assert isinstance(m.body[3], ast.Expr)
 
+    def test_location_is_set(self) -> None:
+        s = textwrap.dedent(
+            """
+
+        assert False, (
+
+            "Ouch"
+          )
+
+        """
+        )
+        m = rewrite(s)
+        for node in m.body:
+            if isinstance(node, ast.Import):
+                continue
+            for n in [node, *ast.iter_child_nodes(node)]:
+                assert n.lineno == 3
+                assert n.col_offset == 0
+                if sys.version_info >= (3, 8):
+                    assert n.end_lineno == 6
+                    assert n.end_col_offset == 3
+
     def test_dont_rewrite(self) -> None:
         s = """'PYTEST_DONT_REWRITE'\nassert 14"""
         m = rewrite(s)


### PR DESCRIPTION
These are new additions in Python 3.8:
https://docs.python.org/3/whatsnew/3.8.html#ast
I'm not sure what's using them but we should set them anyway.