### PR TITLE
mark/structures: fix NodeKeywords.{__iter__,__len__} given duplicates

### DIFF
--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -579,14 +579,17 @@ class NodeKeywords(MutableMapping[str, Any]):
         raise ValueError("cannot delete key in keywords dict")
 
     def __iter__(self) -> Iterator[str]:
+        # Doesn't need to be fast.
         yield from self._markers
         if self.parent is not None:
-            yield from self.parent.keywords
+            for keyword in self.parent.keywords:
+                # self._marks and self.parent.keywords can have duplicates.
+                if keyword not in self._markers:
+                    yield keyword
 
     def __len__(self) -> int:
-        return len(self._markers) + (
-            len(self.parent.keywords) if self.parent is not None else 0
-        )
+        # Doesn't need to be fast.
+        return sum(1 for keyword in self)
 
     def __repr__(self) -> str:
         return f"<NodeKeywords for node {self.node}>"


### PR DESCRIPTION
Regressed in c4b9b14a4 -- the `set` stuff had a reason which I had missed.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
