### PR TITLE
Rewrite only modules part of the pytest plugin

### DIFF
--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -234,11 +234,10 @@ class AssertionRewritingHook(importlib.abc.MetaPathFinder, importlib.abc.Loader)
         try:
             return self._marked_for_rewrite_cache[name]
         except KeyError:
-            for marked in self._must_rewrite:
-                if name == marked or name.startswith(marked + "."):
-                    state.trace(f"matched marked file {name!r} (from {marked!r})")
-                    self._marked_for_rewrite_cache[name] = True
-                    return True
+            if name in self._must_rewrite:
+                state.trace(f"matched marked file {name!r}")
+                self._marked_for_rewrite_cache[name] = True
+                return True
 
             self._marked_for_rewrite_cache[name] = False
             return False

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -13,6 +13,7 @@ import types
 import warnings
 from functools import lru_cache
 from pathlib import Path
+from pathlib import PurePath
 from types import TracebackType
 from typing import Any
 from typing import Callable
@@ -61,9 +62,9 @@ from _pytest.warning_types import PytestConfigWarning
 
 if TYPE_CHECKING:
 
+    from .argparsing import Argument
     from _pytest._code.code import _TracebackStyle
     from _pytest.terminal import TerminalReporter
-    from .argparsing import Argument
 
 
 _PluggyPlugin = object
@@ -778,68 +779,26 @@ class Notset:
 notset = Notset()
 
 
-def _iter_rewritable_modules(package_files: Iterable[str]) -> Iterator[str]:
-    """Given an iterable of file names in a source distribution, return the "names" that should
-    be marked for assertion rewrite.
-
-    For example the package "pytest_mock/__init__.py" should be added as "pytest_mock" in
-    the assertion rewrite mechanism.
-
-    This function has to deal with dist-info based distributions and egg based distributions
-    (which are still very much in use for "editable" installs).
-
-    Here are the file names as seen in a dist-info based distribution:
-
-        pytest_mock/__init__.py
-        pytest_mock/_version.py
-        pytest_mock/plugin.py
-        pytest_mock.egg-info/PKG-INFO
-
-    Here are the file names as seen in an egg based distribution:
-
-        src/pytest_mock/__init__.py
-        src/pytest_mock/_version.py
-        src/pytest_mock/plugin.py
-        src/pytest_mock.egg-info/PKG-INFO
-        LICENSE
-        setup.py
-
-    We have to take in account those two distribution flavors in order to determine which
-    names should be considered for assertion rewriting.
-
-    More information:
-        https://github.com/pytest-dev/pytest-mock/issues/167
+def _iter_rewritable_modules(files: Sequence[PurePath]) -> Iterator[str]:
     """
-    package_files = list(package_files)
-    seen_some = False
-    for fn in package_files:
-        is_simple_module = "/" not in fn and fn.endswith(".py")
-        is_package = fn.count("/") == 1 and fn.endswith("__init__.py")
-        if is_simple_module:
-            module_name, _ = os.path.splitext(fn)
-            # we ignore "setup.py" at the root of the distribution
-            if module_name != "setup":
-                seen_some = True
-                yield module_name
-        elif is_package:
-            package_name = os.path.dirname(fn)
-            seen_some = True
-            yield package_name
-
-    if not seen_some:
-        # At this point we did not find any packages or modules suitable for assertion
-        # rewriting, so we try again by stripping the first path component (to account for
-        # "src" based source trees for example).
-        # This approach lets us have the common case continue to be fast, as egg-distributions
-        # are rarer.
-        new_package_files = []
-        for fn in package_files:
-            parts = fn.split("/")
-            new_fn = "/".join(parts[1:])
-            if new_fn:
-                new_package_files.append(new_fn)
-        if new_package_files:
-            yield from _iter_rewritable_modules(new_package_files)
+    Given a source distribution, return the "names" that should be
+    marked for assertion rewrite.
+    """
+    info_suffix = ".dist-info", ".egg-info"
+    info_at = next((f.parent for f in files if f.parent.suffix in info_suffix), None)
+    # imports are resolved from alongside the info folder
+    base = tuple() if info_at is None else info_at.parent.parts
+    for fn in files:
+        if fn.suffix != ".py":
+            continue
+        b_len = len(base)
+        parts = list(fn.parts[b_len:] if fn.parts[:b_len] == base else fn.parts)
+        parts[-1] = fn.stem
+        if parts[-1] == "__init__":
+            parts = parts[:-1]
+        if len(parts) == 1 and parts[0] == "setup":  # do not include setup.py at root
+            continue
+        yield ".".join(parts)
 
 
 def _args_converter(args: Iterable[str]) -> Tuple[str, ...]:
@@ -888,7 +847,8 @@ class Config:
         *,
         invocation_params: Optional[InvocationParams] = None,
     ) -> None:
-        from .argparsing import Parser, FILE_OR_DIR
+        from .argparsing import FILE_OR_DIR
+        from .argparsing import Parser
 
         if invocation_params is None:
             invocation_params = self.InvocationParams(
@@ -1154,16 +1114,10 @@ class Config:
         if os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
             # We don't autoload from setuptools entry points, no need to continue.
             return
-
-        package_files = (
-            str(file)
-            for dist in importlib_metadata.distributions()
-            if any(ep.group == "pytest11" for ep in dist.entry_points)
-            for file in dist.files or []
-        )
-
-        for name in _iter_rewritable_modules(package_files):
-            hook.mark_rewrite(name)
+        for dist in importlib_metadata.distributions():
+            if any(ep.group == "pytest11" for ep in dist.entry_points):
+                for name in _iter_rewritable_modules(dist.files or []):
+                    hook.mark_rewrite(name)
 
     def _validate_args(self, args: List[str], via: str) -> List[str]:
         """Validate known args."""
@@ -1273,8 +1227,9 @@ class Config:
             return
 
         # Imported lazily to improve start-up time.
+        from packaging.requirements import InvalidRequirement
+        from packaging.requirements import Requirement
         from packaging.version import Version
-        from packaging.requirements import InvalidRequirement, Requirement
 
         plugin_info = self.pluginmanager.list_plugin_distinfo()
         plugin_dist_info = {dist.project_name: dist.version for _, dist in plugin_info}

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -201,6 +201,7 @@ class TestImportHookInstallation:
             "mainwrapper.py": """\
             import pytest
             from _pytest.compat import importlib_metadata
+            from pathlib import PurePath
 
             class DummyEntryPoint(object):
                 name = 'spam'
@@ -213,7 +214,7 @@ class TestImportHookInstallation:
 
             class DummyDistInfo(object):
                 version = '1.0'
-                files = ('spamplugin.py', 'hampkg/__init__.py')
+                files = (PurePath('spamplugin.py'), PurePath('hampkg/__init__.py'))
                 entry_points = (DummyEntryPoint(),)
                 metadata = {'name': 'foo'}
 


### PR DESCRIPTION
The idea is to only rewrite packages that contain pytest plugins and not other packages in the same namespace. 

PS. The tests are failing but will fix it if we think this is a good direction to go in. 

Could fix https://github.com/pytest-dev/pytest/issues/2419