### PR TITLE
Use the CodeCov GitHub Action instead of the Bash Uploader

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,7 +169,7 @@ jobs:
       if: matrix.use_coverage && github.repository == 'pytest-dev/pytest'
       uses: codecov/codecov-action@v2
       with:
-        files: ./.coverage
+        files: ./.coverage,./coverage.xml
         fail_ci_if_error: true
         env_vars: OS,PYTHON
         name: ${{ matrix.name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,14 +167,12 @@ jobs:
 
     - name: Upload coverage
       if: matrix.use_coverage && github.repository == 'pytest-dev/pytest'
-      env:
-        CODECOV_NAME: ${{ matrix.name }}
       uses: codecov/codecov-action@v2
       with:
         files: ./coverage1.xml
         fail_ci_if_error: true
         env_vars: OS,PYTHON
-        name: pytest-codecov
+        name: ${{ matrix.name }}
         verbose: true
 
   linting:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,7 +169,7 @@ jobs:
       if: matrix.use_coverage && github.repository == 'pytest-dev/pytest'
       uses: codecov/codecov-action@v2
       with:
-        files: ./coverage.xml
+        files: ./.coverage
         fail_ci_if_error: true
         env_vars: OS,PYTHON
         name: ${{ matrix.name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,7 +169,13 @@ jobs:
       if: matrix.use_coverage && github.repository == 'pytest-dev/pytest'
       env:
         CODECOV_NAME: ${{ matrix.name }}
-      run: bash scripts/upload-coverage.sh -F GHA,${{ runner.os }}
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./coverage1.xml
+        fail_ci_if_error: true
+        env_vars: OS,PYTHON
+        name: pytest-codecov
+        verbose: true
 
   linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,7 +169,7 @@ jobs:
       if: matrix.use_coverage && github.repository == 'pytest-dev/pytest'
       uses: codecov/codecov-action@v2
       with:
-        files: ./coverage1.xml
+        files: ./coverage.xml
         fail_ci_if_error: true
         env_vars: OS,PYTHON
         name: ${{ matrix.name }}


### PR DESCRIPTION
Closes #9202 

Using the new GitHub Action for CodeCov to upload the code coverage report instead of the bash uploader.

https://github.com/marketplace/actions/codecov