### PR TITLE
Use public API for adding config cleanup

### DIFF
--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -88,7 +88,7 @@ def pytest_configure(config: Config) -> None:
             pytestPDB._config,
         ) = pytestPDB._saved.pop()
 
-    config._cleanup.append(fin)
+    config.add_cleanup(fin)
 
 
 class pytestPDB:

--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -49,7 +49,7 @@ def pytest_configure(config: Config) -> None:
         import pytest
 
         old = pytest.xfail
-        config._cleanup.append(lambda: setattr(pytest, "xfail", old))
+        config.add_cleanup(lambda: setattr(pytest, "xfail", old))
 
         def nop(*args, **kwargs):
             pass

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -199,11 +199,11 @@ def pytest_configure(config: Config) -> None:
     to the tmp_path_factory session fixture.
     """
     mp = MonkeyPatch()
-    tmppath_handler = TempPathFactory.from_config(config, _ispytest=True)
-    t = TempdirFactory(tmppath_handler, _ispytest=True)
-    config._cleanup.append(mp.undo)
-    mp.setattr(config, "_tmp_path_factory", tmppath_handler, raising=False)
-    mp.setattr(config, "_tmpdirhandler", t, raising=False)
+    config.add_cleanup(mp.undo)
+    _tmp_path_factory = TempPathFactory.from_config(config, _ispytest=True)
+    _tmpdirhandler = TempdirFactory(_tmp_path_factory, _ispytest=True)
+    mp.setattr(config, "_tmp_path_factory", _tmp_path_factory, raising=False)
+    mp.setattr(config, "_tmpdirhandler", _tmpdirhandler, raising=False)
 
 
 @fixture(scope="session")

--- a/testing/test_debugging.py
+++ b/testing/test_debugging.py
@@ -934,7 +934,7 @@ class TestDebuggingBreakpoints:
             from _pytest.debugging import pytestPDB
 
             def pytest_configure(config):
-                config._cleanup.append(check_restored)
+                config.add_cleanup(check_restored)
 
             def check_restored():
                 assert sys.breakpointhook == sys.__breakpointhook__
@@ -983,7 +983,7 @@ class TestDebuggingBreakpoints:
             os.environ['PYTHONBREAKPOINT'] = '_pytest._CustomDebugger.set_trace'
 
             def pytest_configure(config):
-                config._cleanup.append(check_restored)
+                config.add_cleanup(check_restored)
 
             def check_restored():
                 assert sys.breakpointhook == sys.__breakpointhook__


### PR DESCRIPTION
No need to spuriously access the private internals of Config.