### PR TITLE
Use correct input arg type for _bestrelpath

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -138,6 +138,7 @@ Grigorii Eremeev (budulianin)
 Guido Wesdorp
 Guoqiang Zhang
 Harald Armin Massa
+Harshna
 Henk-Jaap Wagenaar
 Holger Kohr
 Hugo van Kemenade

--- a/changelog/8990.bugfix.rst
+++ b/changelog/8990.bugfix.rst
@@ -1,1 +1,1 @@
-TerminalReporter's ``_locationline()`` will now pass the correct type of input arg to  ``_pytest.pathlib.bestrelpath``. Previously it was passing in ``str`` which raised an exception.
+Fix `pytest -vv` crashing with an internal exception `AttributeError: 'str' object has no attribute 'relative_to'` in some cases.

--- a/changelog/8990.bugfix.rst
+++ b/changelog/8990.bugfix.rst
@@ -1,0 +1,1 @@
+TerminalReporter's ``_locationline()`` will now pass the correct type of input arg to  ``_pytest.pathlib.bestrelpath``. Previously it was passing in ``str`` which raised an exception.

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -685,6 +685,8 @@ def bestrelpath(directory: Path, dest: Path) -> str:
 
     If no such path can be determined, returns dest.
     """
+    assert isinstance(directory, Path)
+    assert isinstance(dest, Path)
     if dest == directory:
         return os.curdir
     # Find the longest common directory.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -880,8 +880,7 @@ class TerminalReporter:
             if self.verbosity >= 2 and nodeid.split("::")[0] != fspath.replace(
                 "\\", nodes.SEP
             ):
-                fs_path = Path(fspath)
-                res += " <- " + bestrelpath(self.startpath, fs_path)
+                res += " <- " + bestrelpath(self.startpath, Path(fspath))
         else:
             res = "[location]"
         return res + " "

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -865,7 +865,7 @@ class TerminalReporter:
     def _locationline(
         self, nodeid: str, fspath: str, lineno: Optional[int], domain: str
     ) -> str:
-        def mkrel(nodeid) -> str:
+        def mkrel(nodeid: str) -> str:
             line = self.config.cwd_relative_nodeid(nodeid)
             if domain and line.endswith(domain):
                 line = line[: -len(domain)]

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -862,8 +862,10 @@ class TerminalReporter:
                     yellow=True,
                 )
 
-    def _locationline(self, nodeid, fspath, lineno, domain):
-        def mkrel(nodeid):
+    def _locationline(
+        self, nodeid: str, fspath: str, lineno: Optional[int], domain: str
+    ) -> str:
+        def mkrel(nodeid) -> str:
             line = self.config.cwd_relative_nodeid(nodeid)
             if domain and line.endswith(domain):
                 line = line[: -len(domain)]
@@ -873,13 +875,13 @@ class TerminalReporter:
             return line
 
         # collect_fspath comes from testid which has a "/"-normalized path.
-
         if fspath:
             res = mkrel(nodeid)
             if self.verbosity >= 2 and nodeid.split("::")[0] != fspath.replace(
                 "\\", nodes.SEP
             ):
-                res += " <- " + bestrelpath(self.startpath, fspath)
+                fs_path = Path(fspath)
+                res += " <- " + bestrelpath(self.startpath, fs_path)
         else:
             res = "[location]"
         return res + " "

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1165,3 +1165,16 @@ def test_log_file_cli_subdirectories_are_successfully_created(
     result = pytester.runpytest("--log-file=foo/bar/logf.log")
     assert "logf.log" in os.listdir(expected)
     assert result.ret == ExitCode.OK
+
+
+def test_locationline_returns_best_relative_location(pytester: Pytester) -> None:
+    item = pytester.getitem("def test_func(): pass")
+    item.config.option.verbose = 2
+
+    tr = TerminalReporter(item.config)
+    fspath = f"{pytester.path}/unique/path"
+    nodeid = "nodeid::test"
+    result = tr._locationline(nodeid, fspath, 1, "domain")
+
+    expected_result = f"{nodeid} <- unique/path "
+    assert result == expected_result

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1165,18 +1165,3 @@ def test_log_file_cli_subdirectories_are_successfully_created(
     result = pytester.runpytest("--log-file=foo/bar/logf.log")
     assert "logf.log" in os.listdir(expected)
     assert result.ret == ExitCode.OK
-
-
-def test_locationline_returns_best_relative_location(pytester: Pytester) -> None:
-    item = pytester.getitem("def test_func(): pass")
-    item.config.option.verbose = 2
-
-    tr = TerminalReporter(item.config)
-    path_to_test = os.path.join("unique", "path")
-    fspath = os.path.join(pytester.path, path_to_test)
-    nodeid = "nodeid::test"
-
-    result = tr._locationline(nodeid, fspath, 1, "domain")
-
-    expected_result = f"{nodeid} <- {path_to_test} "
-    assert result == expected_result

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1172,9 +1172,11 @@ def test_locationline_returns_best_relative_location(pytester: Pytester) -> None
     item.config.option.verbose = 2
 
     tr = TerminalReporter(item.config)
-    fspath = f"{pytester.path}/unique/path"
+    path_to_test = os.path.join("unique", "path")
+    fspath = os.path.join(pytester.path, path_to_test)
     nodeid = "nodeid::test"
+
     result = tr._locationline(nodeid, fspath, 1, "domain")
 
-    expected_result = f"{nodeid} <- unique/path "
+    expected_result = f"{nodeid} <- {path_to_test} "
     assert result == expected_result


### PR DESCRIPTION
Closes #8990 

* Correct input arg type passed to `_pytest.pathlib.bestrelpath` (expects a `Path` object).
* Associated test.
* Type annotations added.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
