### PR TITLE
Use Ubuntu 20.04, lualatex for readthedocs builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,7 @@ python:
         path: .
 
 build:
+  os: ubuntu-20.04
   apt_packages:
     - inkscape
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,6 @@
 version: 2
 
 python:
-   version: 3.7
    install:
       - requirements: doc/en/requirements.txt
       - method: pip
@@ -9,6 +8,8 @@ python:
 
 build:
   os: ubuntu-20.04
+  tools:
+    python: "3.9"
   apt_packages:
     - inkscape
 

--- a/changelog/9242.doc.rst
+++ b/changelog/9242.doc.rst
@@ -1,0 +1,1 @@
+Upgrade readthedocs configuration to use a [newer Ubuntu version](https://blog.readthedocs.com/new-build-specification/) with better unicode support for PDF docs.

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -43,7 +43,8 @@ todo_include_todos = 1
 latex_engine = "lualatex"
 
 latex_elements = {
-    'preamble': dedent("""
+    "preamble": dedent(
+        r"""
         \directlua{
             luaotfload.add_fallback("fallbacks", {
                 "Noto Serif CJK SC:style=Regular;",
@@ -52,7 +53,8 @@ latex_elements = {
         }
 
         \setmainfont{FreeSerif}[RawFeature={fallback=fallbacks}]
-    """)
+        """
+    )
 }
 
 # -- General configuration -----------------------------------------------------

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -19,6 +19,7 @@ import ast
 import os
 import shutil
 import sys
+from textwrap import dedent
 from typing import List
 from typing import TYPE_CHECKING
 
@@ -39,9 +40,20 @@ autodoc_member_order = "bysource"
 autodoc_typehints = "description"
 todo_include_todos = 1
 
-# Use a different latex engine due to possible Unicode characters in the documentation:
-# https://docs.readthedocs.io/en/stable/guides/pdf-non-ascii-languages.html
-latex_engine = "xelatex"
+latex_engine = "lualatex"
+
+latex_elements = {
+    'preamble': dedent("""
+        \directlua{
+            luaotfload.add_fallback("fallbacks", {
+                "Noto Serif CJK SC:style=Regular;",
+                "Symbola:Style=Regular;"
+            })
+        }
+
+        \setmainfont{FreeSerif}[RawFeature={fallback=fallbacks}]
+    """)
+}
 
 # -- General configuration -----------------------------------------------------
 


### PR DESCRIPTION
Read the Docs recently [added support for Ubuntu 20.04][2004]. This has
a newer version of TeX Live with better Unicode support. Specifically,
it is now possible to configure a list of fallback fonts to try for
characters missing from the current font, instead of displaying question
marks.

In the existing PDF docs, you can see some missing Unicode characters in
the descriptions for the pytest-addons-test and pytest-hammertime
plugins, which contain placeholder question marks.

Sadly, to get colour unicode support in PDFs, we will need to wait for
even newer software from Read the Docs, e.g., the `LuaHBTeX, Version
1.12.0 (TeX Live 2020/Debian)` of Ubuntu 20.10, to which one can add
`"Noto Color Emoji:mode=harf;",` to the fallback list.

[2004]: https://blog.readthedocs.com/new-build-specification/

- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
