### PR TITLE
nose: fix class- and module-level fixture behavior

### DIFF
--- a/changelog/9272.bugfix.rst
+++ b/changelog/9272.bugfix.rst
@@ -1,0 +1,2 @@
+The nose compatibility module-level fixtures `setup()` and `teardown()` are now only called once per module, instead of for each test function.
+They are now called even if object-level `setup`/`teardown` is defined.

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -165,28 +165,36 @@ def test_module_level_setup(pytester: Pytester) -> None:
         items = {}
 
         def setup():
-            items[1]=1
+            items.setdefault("setup", []).append("up")
 
         def teardown():
-            del items[1]
+            items.setdefault("setup", []).append("down")
 
         def setup2():
-            items[2] = 2
+            items.setdefault("setup2", []).append("up")
 
         def teardown2():
-            del items[2]
+            items.setdefault("setup2", []).append("down")
 
         def test_setup_module_setup():
-            assert items[1] == 1
+            assert items["setup"] == ["up"]
+
+        def test_setup_module_setup_again():
+            assert items["setup"] == ["up"]
 
         @with_setup(setup2, teardown2)
         def test_local_setup():
-            assert items[2] == 2
-            assert 1 not in items
+            assert items["setup"] == ["up"]
+            assert items["setup2"] == ["up"]
+
+        @with_setup(setup2, teardown2)
+        def test_local_setup_again():
+            assert items["setup"] == ["up"]
+            assert items["setup2"] == ["up", "down", "up"]
     """
     )
     result = pytester.runpytest("-p", "nose")
-    result.stdout.fnmatch_lines(["*2 passed*"])
+    result.stdout.fnmatch_lines(["*4 passed*"])
 
 
 def test_nose_style_setup_teardown(pytester: Pytester) -> None:


### PR DESCRIPTION
Fixes #9272.

Fixing the issue directly in the plugin is somewhat hard, so do it in core, by moving the aliasing directly to the pytest xunit fixture support. Since the plugin is going to be deprecated, I figure it's OK to cheat a bit.