### PR TITLE
Replace hardcoded links to Python bugs with extlinks

### DIFF
--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -1397,7 +1397,7 @@ Bug Fixes
 - :issue:`5914`: pytester: fix :py:func:`~_pytest.pytester.LineMatcher.no_fnmatch_line` when used after positive matching.
 
 
-- :issue:`6082`: Fix line detection for doctest samples inside :py:class:`python:property` docstrings, as a workaround to `bpo-17446 <https://bugs.python.org/issue17446>`__.
+- :issue:`6082`: Fix line detection for doctest samples inside :py:class:`python:property` docstrings, as a workaround to :bpo:`17446`.
 
 
 - :issue:`6254`: Fix compatibility with pytest-parallel (regression in pytest 5.3.0).

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -162,7 +162,7 @@ linkcheck_workers = 5
 
 _repo = "https://github.com/pytest-dev/pytest"
 extlinks = {
-    "bpo": ("https://bugs.python.org/issue%s", "bpo-%s"),
+    "bpo": ("https://bugs.python.org/issue%s", "bpo-"),
     "pypi": ("https://pypi.org/project/%s/", ""),
     "issue": (f"{_repo}/issues/%s", "issue #"),
 }

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -162,6 +162,7 @@ linkcheck_workers = 5
 
 _repo = "https://github.com/pytest-dev/pytest"
 extlinks = {
+    "bpo": ("https://bugs.python.org/issue%s", "bpo-%s"),
     "pypi": ("https://pypi.org/project/%s/", ""),
     "issue": (f"{_repo}/issues/%s", "issue #"),
 }


### PR DESCRIPTION
This PR replaces referencing Python bugs via hardcoded URLs to https://bugs.python.org/ by using `sphinx.ext.extlinks` plugin.

Old usage example:
```
`bpo-123 <https://bugs.python.org/issue123>`__
```
New usage replacement:
```
:bpo:`123`
```
This PR partially addresses #9081.

Note that ATM there is only one reference to BPO in the docs. Introducing a new extlink just for one URL thus may be a complete overkill! Maybe it's wise to close this PR w/o merging.