### PR TITLE
[RFC] python: remove the `Instance` collector node

### DIFF
--- a/changelog/9277.breaking.rst
+++ b/changelog/9277.breaking.rst
@@ -1,0 +1,3 @@
+The ``pytest.Instance`` collector type has been removed.
+Importing ``pytest.Instance`` or ``_pytest.python.Instance`` returns a dummy type and emits a deprecation warning.
+See :ref:`instance-collector-deprecation` for details.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -18,6 +18,25 @@ Deprecated Features
 Below is a complete list of all pytest features which are considered deprecated. Using those features will issue
 :class:`PytestWarning` or subclasses, which can be filtered using :ref:`standard warning filters <warnings>`.
 
+.. _instance-collector-deprecation:
+
+The ``pytest.Instance`` collector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionremoved:: 7.0
+
+The ``pytest.Instance`` collector type has been removed.
+
+Previously, Python test methods were collected as :class:`~pytest.Class` -> ``Instance`` -> :class:`~pytest.Function`.
+Now :class:`~pytest.Class` collects the test methods directly.
+
+Most plugins which reference ``Instance`` do so in order to ignore or skip it,
+using a check such as ``if isinstance(node, Instance): return``.
+Such plugins should simply remove consideration of ``Instance`` on pytest>=7.
+However, to keep such uses working, a dummy type has been instanted in ``pytest.Instance`` and ``_pytest.python.Instance``,
+and importing it emits a deprecation warning. This will be removed in pytest 8.
+
+
 .. _node-ctor-fspath-deprecation:
 
 ``fspath`` argument for Node constructors replaced with ``pathlib.Path``

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -119,6 +119,11 @@ KEYWORD_MSG_ARG = UnformattedWarning(
     "pytest.{func}(msg=...) is now deprecated, use pytest.{func}(reason=...) instead",
 )
 
+INSTANCE_COLLECTOR = PytestDeprecationWarning(
+    "The pytest.Instance collector type is deprecated and is no longer used. "
+    "See https://docs.pytest.org/en/latest/deprecations.html#the-pytest-instance-collector",
+)
+
 # You want to make some `__init__` or function "private".
 #
 #   def my_private_function(some, args):

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -450,10 +450,6 @@ def pytest_unconfigure(config: Config) -> None:
 def mangle_test_address(address: str) -> List[str]:
     path, possible_open_bracket, params = address.partition("[")
     names = path.split("::")
-    try:
-        names.remove("()")
-    except ValueError:
-        pass
     # Convert file path to dotted path.
     names[0] = names[0].replace(nodes.SEP, ".")
     names[0] = re.sub(r"\.py$", "", names[0])

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -781,9 +781,6 @@ class Session(nodes.FSCollector):
                                     submatchnodes.append(r)
                             if submatchnodes:
                                 work.append((submatchnodes, matchnames[1:]))
-                            # XXX Accept IDs that don't have "()" for class instances.
-                            elif len(rep.result) == 1 and rep.result[0].name == "()":
-                                work.append((rep.result, matchnames))
                         else:
                             # Report collection failures here to avoid failing to run some test
                             # specified in the command line because the module could not be

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -158,7 +158,7 @@ class KeywordMatcher:
         import pytest
 
         for node in item.listchain():
-            if not isinstance(node, (pytest.Instance, pytest.Session)):
+            if not isinstance(node, pytest.Session):
                 mapped_names.add(node.name)
 
         # Add the names added as extra keywords to current or parent items.

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -225,9 +225,7 @@ class Node(metaclass=NodeMeta):
         else:
             if not self.parent:
                 raise TypeError("nodeid or parent must be provided")
-            self._nodeid = self.parent.nodeid
-            if self.name != "()":
-                self._nodeid += "::" + self.name
+            self._nodeid = self.parent.nodeid + "::" + self.name
 
         #: A place where plugins can store information on the node for their
         #: own use.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -58,6 +58,7 @@ from _pytest.config import hookimpl
 from _pytest.config.argparsing import Parser
 from _pytest.deprecated import check_ispytest
 from _pytest.deprecated import FSCOLLECTOR_GETHOOKPROXY_ISINITPATH
+from _pytest.deprecated import INSTANCE_COLLECTOR
 from _pytest.fixtures import FuncFixtureInfo
 from _pytest.main import Session
 from _pytest.mark import MARK_GEN
@@ -868,12 +869,22 @@ class Class(PyCollector):
         self.obj.__pytest_setup_method = xunit_setup_method_fixture
 
 
-# Instance used to be a node type between Class and Function.  It has been
-# removed in pytest 7.0. Some plugins exist which reference `pytest.Instance`
-# only to ignore it; this dummy class keeps them working. This could probably
-# be removed at some point.
-class Instance:
+class InstanceDummy:
+    """Instance used to be a node type between Class and Function. It has been
+    removed in pytest 7.0. Some plugins exist which reference `pytest.Instance`
+    only to ignore it; this dummy class keeps them working. This will be removed
+    in pytest 8."""
+
     pass
+
+
+# Note: module __getattr__ only works on Python>=3.7. Unfortunately
+# we can't provide this deprecation warning on Python 3.6.
+def __getattr__(name: str) -> object:
+    if name == "Instance":
+        warnings.warn(INSTANCE_COLLECTOR, 2)
+        return InstanceDummy
+    raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
 def hasinit(obj: object) -> bool:

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -756,9 +756,6 @@ class TerminalReporter:
                     rep.toterminal(self._tw)
 
     def _printcollecteditems(self, items: Sequence[Item]) -> None:
-        # To print out items and their parent collectors
-        # we take care to leave out Instances aka ()
-        # because later versions are going to get rid of them anyway.
         if self.config.option.verbose < 0:
             if self.config.option.verbose < -1:
                 counts = Counter(item.nodeid.split("::", 1)[0] for item in items)
@@ -778,8 +775,6 @@ class TerminalReporter:
                 stack.pop()
             for col in needed_collectors[len(stack) :]:
                 stack.append(col)
-                if col.name == "()":  # Skip Instances.
-                    continue
                 indent = (len(stack) - 1) * "  "
                 self._tw.line(f"{indent}{col}")
                 if self.config.option.verbose >= 1:

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -48,7 +48,6 @@ from _pytest.pytester import RecordedHookCall
 from _pytest.pytester import RunResult
 from _pytest.python import Class
 from _pytest.python import Function
-from _pytest.python import Instance
 from _pytest.python import Metafunc
 from _pytest.python import Module
 from _pytest.python import Package
@@ -76,6 +75,7 @@ from _pytest.warning_types import PytestUnraisableExceptionWarning
 from _pytest.warning_types import PytestWarning
 
 set_trace = __pytestPDB.set_trace
+
 
 __all__ = [
     "__version__",
@@ -106,7 +106,6 @@ __all__ = [
     "HookRecorder",
     "hookspec",
     "importorskip",
-    "Instance",
     "Item",
     "LineMatcher",
     "LogCaptureFixture",
@@ -153,3 +152,12 @@ __all__ = [
     "xfail",
     "yield_fixture",
 ]
+
+
+def __getattr__(name: str) -> object:
+    if name == "Instance":
+        # The import emits a deprecation warning.
+        from _pytest.python import Instance
+
+        return Instance
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/pytest/collect.py
+++ b/src/pytest/collect.py
@@ -11,7 +11,6 @@ COLLECT_FAKEMODULE_ATTRIBUTES = [
     "Collector",
     "Module",
     "Function",
-    "Instance",
     "Session",
     "Item",
     "Class",

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -286,3 +286,21 @@ def test_node_ctor_fspath_argument_is_deprecated(pytester: Pytester) -> None:
             parent=mod.parent,
             fspath=legacy_path("bla"),
         )
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 7),
+    reason="This deprecation can only be emitted on python>=3.7",
+)
+def test_importing_instance_is_deprecated(pytester: Pytester) -> None:
+    with pytest.warns(
+        pytest.PytestDeprecationWarning,
+        match=re.escape("The pytest.Instance collector type is deprecated"),
+    ):
+        pytest.Instance
+
+    with pytest.warns(
+        pytest.PytestDeprecationWarning,
+        match=re.escape("The pytest.Instance collector type is deprecated"),
+    ):
+        from _pytest.python import Instance  # noqa: F401

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -12,7 +12,7 @@ from _pytest.monkeypatch import MonkeyPatch
 from _pytest.nodes import Collector
 from _pytest.pytester import Pytester
 from _pytest.python import Class
-from _pytest.python import Instance
+from _pytest.python import Function
 
 
 class TestModule:
@@ -585,7 +585,7 @@ class TestFunction:
                     pass
         """
         )
-        colitems = modcol.collect()[0].collect()[0].collect()
+        colitems = modcol.collect()[0].collect()
         assert colitems[0].name == "test1[a-c]"
         assert colitems[1].name == "test1[b-c]"
         assert colitems[2].name == "test2[a-c]"
@@ -1183,19 +1183,26 @@ class TestReportInfo:
         modcol = pytester.getmodulecol(
             """
             # lineno 0
-            class TestClass(object):
+            class TestClass:
                 def __getattr__(self, name):
                     return "this is not an int"
 
+                def __class_getattr__(cls, name):
+                    return "this is not an int"
+
                 def intest_foo(self):
+                    pass
+
+                def test_bar(self):
                     pass
         """
         )
         classcol = pytester.collect_by_name(modcol, "TestClass")
         assert isinstance(classcol, Class)
-        instance = list(classcol.collect())[0]
-        assert isinstance(instance, Instance)
-        path, lineno, msg = instance.reportinfo()
+        path, lineno, msg = classcol.reportinfo()
+        func = list(classcol.collect())[0]
+        assert isinstance(func, Function)
+        path, lineno, msg = func.reportinfo()
 
 
 def test_customized_python_discovery(pytester: Pytester) -> None:

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -979,7 +979,7 @@ class TestLastFailed:
                 "",
                 "<Module pkg1/test_1.py>",
                 "  <Class TestFoo>",
-                "      <Function test_fail>",
+                "    <Function test_fail>",
                 "  <Function test_other>",
                 "",
                 "*= 2/3 tests collected (1 deselected) in *",

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -74,9 +74,7 @@ class TestCollector:
         )
         cls = pytester.collect_by_name(modcol, "TestClass")
         assert isinstance(cls, pytest.Class)
-        instance = pytester.collect_by_name(cls, "()")
-        assert isinstance(instance, pytest.Instance)
-        fn = pytester.collect_by_name(instance, "test_foo")
+        fn = pytester.collect_by_name(cls, "test_foo")
         assert isinstance(fn, pytest.Function)
 
         module_parent = fn.getparent(pytest.Module)

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -936,7 +936,7 @@ class TestPython:
 def test_mangle_test_address() -> None:
     from _pytest.junitxml import mangle_test_address
 
-    address = "::".join(["a/my.py.thing.py", "Class", "()", "method", "[a-1-::]"])
+    address = "::".join(["a/my.py.thing.py", "Class", "method", "[a-1-::]"])
     newnames = mangle_test_address(address)
     assert newnames == ["a.my.py.thing", "Class", "method", "[a-1-::]"]
 

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -272,8 +272,10 @@ def test_nose_setup_ordering(pytester: Pytester) -> None:
         class TestClass(object):
             def setup(self):
                 assert visited
+                self.visited_cls = True
             def test_first(self):
-                pass
+                assert visited
+                assert self.visited_cls
         """
     )
     result = pytester.runpytest()

--- a/testing/test_session.py
+++ b/testing/test_session.py
@@ -227,7 +227,7 @@ class TestNewSession(SessionTests):
         started = reprec.getcalls("pytest_collectstart")
         finished = reprec.getreports("pytest_collectreport")
         assert len(started) == len(finished)
-        assert len(started) == 8
+        assert len(started) == 6
         colfail = [x for x in finished if x.failed]
         assert len(colfail) == 1
 


### PR DESCRIPTION
### What is `Instance`?

Given a test file like this:

```py
class TestIt:
    def test_it(): pass
```

the collection tree is

```
<Module test_file.py>
  <Class TestIt>
    <Instance ()>
      <Function test_it>
```

- The `obj` of the `Module` is the `test_file.py` module object
- The `obj` of the `Class` is the class type `TestIt`.
- The `obj` of the `Instance` is an *instance* of `TestIt` i.e. `TestIt()`. An instance is created when the `Instance` does its `collect()`, to pick up fixtures, and is (mutably) refreshed by each child `Function` setup phase, which each want a fresh instance.
- The `obj` of the `Function` is the bound method `test_it`.

So the main thing encapsulated by `Instance` is the instantiation of test classes. It provides the property that for a given `Function` item `func`, `getattr(func.parent, func.originalname)` gives either a standalone function when not in a class, or a bound method when in a class. That is, directly callable without arguments.

### What is proposed

I propose removing `Instance`, instead have `Class` directly collect `Function`s and act as their parent.

### Why?

While the callable property is nice, it's seems not so important, but has a cost -- almost no-one is interested in `Instance`, its purpose is not obvious, and everywhere tries to hide its existence:

- `pytest --collectonly` hides it from the collection tree displayed to the user, with a rationale "because later versions are going to get rid of them anyway".
- It is not reflected in the nodeid `::` hierarchy.
- Hidden in junitxml output.
- Needs to be ignored by various plugins (see below)
- While it's public, it's completely undocumented.
- The mutability aspect where child `Function`s each modify the `Instance` to have a new instance is not very nice.

Overall I think it's more intuitive to have the `Class` -> `Function` hierarchy without `Instance` in the middle.

### What happens without it?

With `Class` as the direct parent, `getattr(func.parent, func.originalname)` can now return either a standalone function (or staticmethod or classmethod) which can be called directly, or an unbound method which can't be called directly (requires `self`). So now `Function._getobj` checks if `parent` is a `Class`, then it creates a newinstance and calls `getattr` on that. So basically `Function._getobj` "inlines" what was previously done by `Instance`.

### Backward compat

`Instance` is public as `pytest.Instance`, but is undocumented. I think pytest 7.0 is a good time to remove it, if we decide to.

The `instance` property was previously defined on `PyobjMixin`, I've moved it to `Function` and re-implemented to obtain the instance from `obj` instead of from the collection hierarchy.

I made an audit of a corpus of 680 plugins for the string `Instance`, below are my findings. Of course it doesn't account for any breakage that might occur without `Instance` being explicitly referenced.

"dummy" here means just a `class Instance: pass` to keep most cases below working.

---

:heavy_check_mark: 

https://github.com/LaserPhaser/pytest-collect-formatter/blob/3ba6d95e60690db0125b30872fe1247091625b58/pytest_collect_formatter/plugin.py#L18-L23

References `"Instance"` (string) to ignore it, won't be affected.

---

:white_check_mark: 

https://github.com/astraw38/pytest-docgen/blob/ce2a8e25d88336957f33cfed461bb0433ed23366/src/pytest_docgen/pytest_docgen.py#L504-L507

References to ignore it. Will be affected if outright removed, OK with dummy.

---

:white_check_mark: 

https://github.com/goodboy/pytest-interactive/blob/59d2819d7df6bbf1b4f3abdd4554719f56e7e07f/interactive/plugin.py#L107-L109

References to ignore it, OK with dummy.

---

:heavy_check_mark: 

https://github.com/nyantec/pytest-menu/blob/5298f27619a2b7d5fb246e65d1ecf5288a85f2f5/menu/plugin.py#L68

Comment reference to ignore it, won't be affected.

---

:x: 

https://github.com/megachweng/pytest-wetest/blob/32a6bea1b546f68f10b25d8e620c766d46a986d6/pytest_wetest.py#L266-L268

Seems like a legitimate use, will be affected.

---

:white_check_mark: 

https://github.com/asteriogonzalez/pytest-study/blob/d50cd560efaaf0b544657c63f2413b0c0c80db4e/pytest_study.py#L64-L65

References to ignore it, OK with dummy.

---

:x: 

https://github.com/OriMenashe/pytest-scenario/blob/cd04c76eb0731cee8fdb250893636e9f68ab5467/pytest_scenario/plugin.py#L222-L227

References as the parent of class-based `Function`s, will be affected, will need a version check to adapt to the new hierarchy, or be written in a more robust way.

---

:white_check_mark: 

https://github.com/megachweng/pytest-informative-node/blob/6ee9a82ec5e2652b3119840d1ebec4d41e8a318d/pytest_informative_node.py#L105-L106

References just to traverse hierarchy, OK with dummy.

---

:heavy_check_mark: 

https://github.com/theY4Kman/pytest-camel-collect/blob/a6897abf3a92f976da03e407dfad1b1a0916da15/pytest_camel_collect/plugin.py#L113-L122

References as string, won't be affected.

---

:white_check_mark: 

https://github.com/reportportal/agent-python-pytest/blob/ba6dde3dfe7af9df8e322efd4a9bdf665b7f774e/pytest_reportportal/service.py#L582-L592

References just to traverse hierarchy, OK with dummy.

---

:white_check_mark: 

https://github.com/timpaquatte/pytest-mutagen/blob/b4cc63c320641ffd64dfcb343458ac02f3ccd48d/src/pytest_mutagen/mutation_session.py#L89-L98

Seems like it tries to ignore it, OK with dummy.