### PR TITLE
Elide pytest-internal paths for --fixtures

### DIFF
--- a/changelog/8822.improvement.rst
+++ b/changelog/8822.improvement.rst
@@ -1,0 +1,1 @@
+When showing fixture paths in `--fixtures` or `--fixtures-by-test`, fixtures coming from pytest itself now display an elided path, rather than the full path to the file in the `site-packages` directory.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1569,7 +1569,7 @@ def _showfixtures_main(config: Config, session: Session) -> None:
         if doc:
             write_docstring(tw, doc.split("\n\n")[0] if verbose <= 0 else doc)
         else:
-            tw.line(f"    no docstring available", red=True)
+            tw.line("    no docstring available", red=True)
         tw.line()
 
 

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -3346,9 +3346,9 @@ class TestShowFixtures:
         result = pytester.runpytest("--fixtures")
         result.stdout.fnmatch_lines(
             [
-                "tmp_path_factory [[]session scope[]] -- *tmpdir.py*",
+                "tmp_path_factory [[]session scope[]] -- .../_pytest/tmpdir.py:*",
                 "*for the test session*",
-                "tmp_path -- *",
+                "tmp_path -- .../_pytest/tmpdir.py:*",
                 "*temporary directory*",
             ]
         )
@@ -3357,9 +3357,9 @@ class TestShowFixtures:
         result = pytester.runpytest("--fixtures", "-v")
         result.stdout.fnmatch_lines(
             [
-                "tmp_path_factory [[]session scope[]] -- *tmpdir.py*",
+                "tmp_path_factory [[]session scope[]] -- .../_pytest/tmpdir.py:*",
                 "*for the test session*",
-                "tmp_path -- *tmpdir.py*",
+                "tmp_path -- .../_pytest/tmpdir.py:*",
                 "*temporary directory*",
             ]
         )


### PR DESCRIPTION
Before this PR:

```
caplog -- .tox/py39-pyqt515/lib/python3.9/site-packages/_pytest/logging.py:476
    Access and control log capturing
```

with it:

```
caplog -- .../_pytest/logging.py:491
    Access and control log capturing.
```

Note that we still display the full path for fixtures from plugins, though. I think a fix for that would be a bit more involved, and probably not something for 7.0.

Fixes #8822