### PR TITLE
Pin towncrier to 19.9.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,8 @@ basepython = python3
 usedevelop = True
 deps =
     -r{toxinidir}/doc/en/requirements.txt
-    towncrier
+    # https://github.com/twisted/towncrier/issues/340
+    towncrier<21.3.0
 commands =
     python scripts/towncrier-draft-to-file.py
     # the '-t changelog_towncrier_draft' tags makes sphinx include the draft
@@ -138,7 +139,8 @@ deps =
     github3.py
     pre-commit>=2.9.3
     wheel
-    towncrier
+    # https://github.com/twisted/towncrier/issues/340
+    towncrier<21.3.0
 commands = python scripts/release.py {posargs}
 
 [testenv:prepare-release-pr]


### PR DESCRIPTION
See https://github.com/twisted/towncrier/issues/346
Closes #8817, supersedes #9045 and #9046.

@nicoddemus Any particular reason you pinned to 18.6 in #9045? I think 19.9 is the newest non-affected version.