### PR TITLE
Revert "legacypath: only add `testdir` and `tmpdir` fixtures if corresponding plugins are registered"

### DIFF
--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -638,7 +638,7 @@ tmpdir
 
 :ref:`tmpdir and tmpdir_factory`
 
-.. autofunction:: _pytest.legacypath.LegacyTmpdirPlugin.tmpdir()
+.. autofunction:: _pytest.legacypath.tmpdir()
     :no-auto-options:
 
 


### PR DESCRIPTION
This reverts commit e6eac28f0eefd6eca641111f14a565f9ea15da1b.

This approach doesn't work when pytester is loaded thru a conftest `pytest_plugins`.

Fixes #9280.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
