### PR TITLE
Reemit deprecation warnings from `pytest.warns`

### DIFF
--- a/changelog/9288.improvement.rst
+++ b/changelog/9288.improvement.rst
@@ -1,0 +1,1 @@
+``pytest.warns`` no longer suppresses warnings derived from ``DeprecationWarning`` and ``PendingDeprecationWarning`` by default.

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -292,6 +292,15 @@ class WarningsChecker(WarningsRecorder):
 
         # only check if we're not currently handling an exception
         if exc_type is None and exc_val is None and exc_tb is None:
+            for w in self:
+                reemit = {DeprecationWarning, PendingDeprecationWarning}
+                if self.expected_warning is not None:
+                    reemit -= set(self.expected_warning)
+                if issubclass(w.category, tuple(reemit)):
+                    warnings.showwarning(
+                        w.message, w.category, w.filename, w.lineno, w.file, w.line
+                    )
+
             if self.expected_warning is not None:
                 if not any(issubclass(r.category, self.expected_warning) for r in self):
                     __tracebackhide__ = True

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -83,6 +83,20 @@ class TestWarningsRecorderChecker:
                     with rec:
                         pass  # can't enter twice
 
+    def test_no_suppress_deprecation_warnings(self) -> None:
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            with pytest.warns(DeprecationWarning), pytest.warns(
+                PendingDeprecationWarning
+            ):
+                with pytest.warns(UserWarning):
+                    warnings.warn("my warning", UserWarning)
+                    warnings.warn("some deprecation warning", DeprecationWarning)
+                    warnings.warn(
+                        "other deprecation warning", PendingDeprecationWarning
+                    )
+            assert len(record) == 0
+
 
 class TestDeprecatedCall:
     """test pytest.deprecated_call()"""
@@ -216,6 +230,14 @@ class TestDeprecatedCall:
         with pytest.raises(pytest.fail.Exception):
             with pytest.deprecated_call(match=r"must be \d+$"):
                 warnings.warn("this is not here", DeprecationWarning)
+
+    def test_suppress_deprecation_warnings(self) -> None:
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            with pytest.deprecated_call():
+                warnings.warn("some deprecation warning", DeprecationWarning)
+                warnings.warn("other deprecation warning", PendingDeprecationWarning)
+            assert len(record) == 0
 
 
 class TestWarns:


### PR DESCRIPTION
Only suppress deprecation types that are passed in `expected_warning` argument.

Fixes #9288

Looking for a feedback, are you ok with this change?

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
