### PR TITLE
Add HTML output for docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,3 +16,4 @@ build:
 formats:
   - epub
   - pdf
+  - htmlzip


### PR DESCRIPTION
Adds HTML zip output to the docs.

We could also use the `all` keyword.

Closes #9340 .