### PR TITLE
Fix test reordering for indirect parameterization

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -321,6 +321,7 @@ Thomas Grainger
 Thomas Hisch
 Tim Hoffmann
 Tim Strazny
+Tobias Deiminger
 Tom Dalton
 Tom Viner
 Tomáš Gavenčiak

--- a/changelog/8914.bugfix.rst
+++ b/changelog/8914.bugfix.rst
@@ -1,0 +1,3 @@
+If fixtures had been indirectly parameterized via test function, e.g. using a
+``@pytest.mark.parametrize(indirect=True)`` marker, reordering of tests for the least possible fixture setup/teardown cycles
+did not work. Optimized test groups can now be determined given the user provided parameter type is hashable.

--- a/testing/example_scripts/issue_519.py
+++ b/testing/example_scripts/issue_519.py
@@ -22,13 +22,13 @@ def checked_order():
     assert order == [
         ("issue_519.py", "fix1", "arg1v1"),
         ("test_one[arg1v1-arg2v1]", "fix2", "arg2v1"),
-        ("test_two[arg1v1-arg2v1]", "fix2", "arg2v1"),
         ("test_one[arg1v1-arg2v2]", "fix2", "arg2v2"),
+        ("test_two[arg1v1-arg2v1]", "fix2", "arg2v1"),
         ("test_two[arg1v1-arg2v2]", "fix2", "arg2v2"),
         ("issue_519.py", "fix1", "arg1v2"),
         ("test_one[arg1v2-arg2v1]", "fix2", "arg2v1"),
-        ("test_two[arg1v2-arg2v1]", "fix2", "arg2v1"),
         ("test_one[arg1v2-arg2v2]", "fix2", "arg2v2"),
+        ("test_two[arg1v2-arg2v1]", "fix2", "arg2v1"),
         ("test_two[arg1v2-arg2v2]", "fix2", "arg2v2"),
     ]
 


### PR DESCRIPTION
`reorder_items` groups tests so that each group can share indirectly parameterized fixture instances. This optimizes for fewer fixture setup/teardown cycles. Prior to this PR, grouping considered an parameter's index, not the parameter value itself, to determine whether a parameter is "the same" and therefore can be shared.

Relying on indexes is fast, however only works when there's exactly one parameter list for one fixture. If we provide multiple (possibly different) lists for the same fixture, e.g. by decorating test items, one index can no longer refer to "the same" parameter. In order to still be able to group for fixture reuse, we have to group by parameter value.

Caution: The value ends up inside the key of another dict, and therefore must be hashable. This was true for indexes, but no longer is guaranteed for user provided values. A user may e.g. provide `dict`s or numpy arrays. The `SafeHashWrapper` ensures a fallback to `id()` in such a case.

Fixes #8914.