### PR TITLE
Do not display empty worker info

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -129,6 +129,7 @@ Garvit Shubham
 Gene Wood
 George Kussumoto
 Georgy Dyuldin
+Gergely Kalmár
 Gleb Nikonorov
 Graeme Smecher
 Graham Horler

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -76,7 +76,9 @@ class BaseReport:
 
     def toterminal(self, out: TerminalWriter) -> None:
         if hasattr(self, "node"):
-            out.line(getworkerinfoline(self.node))
+            worker_info = getworkerinfoline(self.node)
+            if worker_info:
+                out.line(worker_info)
 
         longrepr = self.longrepr
         if longrepr is None:


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
-->

This PR fixes an issue where empty workerinfo lines are displayed (resulting in an unnecessary newline in that case) when using xdist. Closes https://github.com/pytest-dev/pytest/issues/9316.
