### PR TITLE
Revert "Fix Dead link in README for 'assert statements' "

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Due to ``pytest``'s detailed assertion introspection, only plain ``assert`` stat
 Features
 --------
 
-- Detailed info on failing `assert statements <https://docs.pytest.org/en/stable/assert.html>`_ (no need to remember ``self.assert*`` names)
+- Detailed info on failing `assert statements <https://docs.pytest.org/en/stable/how-to/assert.html>`_ (no need to remember ``self.assert*`` names)
 
 - `Auto-discovery
   <https://docs.pytest.org/en/stable/explanation/goodpractices.html#python-test-discovery>`_


### PR DESCRIPTION
This reverts commit 15989ddc8f20e49602858e6e4a2631b71e8b9ef1.

Reverts #8945, thus reintroducing #8926 temporarily, but we should be close to
the 7.0.0 release now, where this is the correct URL to use.

Closes #8831 as follow-up to #8858.