### PR TITLE
Fix hook param name in nonpython example

### DIFF
--- a/doc/en/example/nonpython/conftest.py
+++ b/doc/en/example/nonpython/conftest.py
@@ -2,9 +2,9 @@
 import pytest
 
 
-def pytest_collect_file(parent, fspath):
-    if fspath.suffix == ".yaml" and fspath.name.startswith("test"):
-        return YamlFile.from_parent(parent, path=fspath)
+def pytest_collect_file(parent, file_path):
+    if file_path.suffix == ".yaml" and file_path.name.startswith("test"):
+        return YamlFile.from_parent(parent, path=file_path)
 
 
 class YamlFile(pytest.File):


### PR DESCRIPTION
Follow up to #9363

See https://github.com/pytest-dev/pytest/pull/9371/files#diff-523905715b1e18335a8ff84ab46e2c3a28f2c5fec4c63e001574286339fb8c74R30