### PR TITLE
Fix changelog URL in 7.0.0rc1 announcement

### DIFF
--- a/doc/en/announce/release-7.0.0rc1.rst
+++ b/doc/en/announce/release-7.0.0rc1.rst
@@ -19,7 +19,7 @@ You can upgrade from PyPI via:
 
 Users are encouraged to take a look at the CHANGELOG carefully:
 
-    https://docs.pytest.org/en/stable/changelog.html
+    https://docs.pytest.org/en/7.0.x/changelog.html
 
 Thanks to all the contributors to this release:
 


### PR DESCRIPTION
The changelog does not exist at /stable because an rc isn't stable...