### PR TITLE
[7.0.x] Fix changelog URL in 7.0.0rc1 announcement (#9379)

### DIFF
--- a/doc/en/announce/release-7.0.0rc1.rst
+++ b/doc/en/announce/release-7.0.0rc1.rst
@@ -19,7 +19,7 @@ You can upgrade from PyPI via:
 
 Users are encouraged to take a look at the CHANGELOG carefully:
 
-    https://docs.pytest.org/en/stable/changelog.html
+    https://docs.pytest.org/en/7.0.x/changelog.html
 
 Thanks to all the contributors to this release:
 


### PR DESCRIPTION
The changelog does not exist at /stable because an rc isn't stable...

(cherry picked from commit 5cb50fa13cfc2485f4ea4fcac4eec295aa93f94b)