### PR TITLE
Hide internal stack when using pytest.approx() in bool context

### DIFF
--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -101,6 +101,7 @@ class ApproxBase:
         )
 
     def __bool__(self):
+        __tracebackhide__ = True
         raise AssertionError(
             "approx() is not supported in a boolean context.\nDid you mean: `assert a == approx(b)`?"
         )


### PR DESCRIPTION
This makes the error traceback point directly to the offending usage, rather
than to the internal `Approx.__bool__` method.

Not sure if this warrants a test.