### PR TITLE
Fixes #9303, throw if addoption called after preparse with no default

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -185,6 +185,7 @@ Katerina Koukiou
 Keri Volans
 Kevin Cox
 Kevin J. Foley
+Kevin Santana
 Kodi B. Arfer
 Kostis Anagnostopoulos
 Kristoffer Nordström

--- a/changelog/9303.bugfix.rst
+++ b/changelog/9303.bugfix.rst
@@ -1,0 +1,2 @@
+`Parser.addoption` now throws a value error if an attempt is made at adding an option
+after the pre_parsing process without including a default.

--- a/changelog/9303.bugfix.rst
+++ b/changelog/9303.bugfix.rst
@@ -1,2 +1,8 @@
 `Parser.addoption` now throws a value error if an attempt is made at adding an option
-after the pre_parsing process without including a default.
+after the pre_parsing process without including a default. If the user decides to
+provides a default a warning will be given since the option will not be available
+for use in the command line.
+
+This occurs if conftest files aren't in the root directory or any sub directory
+matching the `test*` regex. conftest files which match the previous statement
+will have their options added after the configuration and parsing phase.

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -362,6 +362,11 @@ class OptionGroup:
         results in help showing ``--two-words`` only, but ``--twowords`` gets
         accepted **and** the automatic destination is in ``args.twowords``.
         """
+        if getattr(self.parser, "after_preparse", False) and "default" not in attrs:
+            raise ValueError(
+                "Cannot add options without default after initial conftest discovery"
+            )
+
         conflict = set(optnames).intersection(
             name for opt in self.options for name in opt.names()
         )

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -22,6 +22,7 @@ from _pytest.deprecated import ARGUMENT_PERCENT_DEFAULT
 from _pytest.deprecated import ARGUMENT_TYPE_STR
 from _pytest.deprecated import ARGUMENT_TYPE_STR_CHOICE
 from _pytest.deprecated import check_ispytest
+from _pytest.warning_types import PytestConfigWarning
 
 if TYPE_CHECKING:
     from typing import NoReturn
@@ -363,9 +364,12 @@ class OptionGroup:
         accepted **and** the automatic destination is in ``args.twowords``.
         """
         if getattr(self.parser, "after_preparse", False) and "default" not in attrs:
-            raise ValueError(
-                "Cannot add options without default after initial conftest discovery"
+            raise UsageError("Cannot add options after initial conftest discovery")
+        elif getattr(self.parser, "after_preparse", False):
+            warn = ("Adding option {option} after configuration phase").format(
+                option=optnames
             )
+            warnings.warn(PytestConfigWarning(warn), stacklevel=3)
 
         conflict = set(optnames).intersection(
             name for opt in self.options for name in opt.names()

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -78,6 +78,21 @@ class TestPytestPluginInteractions:
         )
         assert config.option.test123
 
+    def test_do_option_postinit_nodefault(self, pytester: Pytester) -> None:
+        config = pytester.parseconfigure()
+        assert not hasattr(config.option, "deadbeef")
+        p = pytester.makepyfile(
+            """
+            def pytest_addoption(parser):
+                parser.addoption('--deadbeef', action="store_true")
+        """
+        )
+        with pytest.raises(ValueError):
+            config.pluginmanager._importconftest(
+                p, importmode="prepend", rootpath=pytester.path
+            )
+        assert not hasattr(config.option, "deadbeef")
+
     def test_configure(self, pytester: Pytester) -> None:
         config = pytester.parseconfig()
         values = []


### PR DESCRIPTION
Fixes #9303 where calling `parser.addoption` after the preparsing process with the actions `['store_true, store_false]` and no default would throw a value error when accesing it via `request.config.getoption` since the option was not parsed and subsequently not added to the config options. This became apparent when conftests existed within sub directories not following the `test*` regex and would be picked up during the collection phase of pytest if not using that directory as the root directory.

please review @RonnyPfannschmidt 
