### PR TITLE
[7.0.x] Hide internal stack when using pytest.approx() in bool context (#9394)

### DIFF
--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -101,6 +101,7 @@ class ApproxBase:
         )
 
     def __bool__(self):
+        __tracebackhide__ = True
         raise AssertionError(
             "approx() is not supported in a boolean context.\nDid you mean: `assert a == approx(b)`?"
         )


### PR DESCRIPTION
This makes the error traceback point directly to the offending usage, rather
than to the internal `Approx.__bool__` method.

(cherry picked from commit 3ba9c01f9bfd442f2bcc4711e15612aa5b518cc3)

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
