### PR TITLE
ci: add a workflow for backporting to other branches

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,45 @@
+name: backport
+
+on:
+  pull_request:
+    types: [labeled]
+
+# Set permissions at the job level.
+permissions: {}
+
+jobs:
+  backport:
+    if: ${{ startsWith(github.event.label.name, 'backport ') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        persist-credentials: true
+
+    - name: Create backport PR
+      run: |
+        set -eux
+
+        git config --global user.name "pytest bot"
+        git config --global user.email "pytestbot@gmail.com"
+
+        label='${{ github.event.label.name }}'
+        target_branch="${label#backport }"
+        backport_branch=backport-${{ github.event.number }}-to-"${target_branch}"
+        subject="[$target_branch] $(gh pr view --json title -q .title ${{ github.event.number }})"
+
+        git checkout origin/"${target_branch}" -b "${backport_branch}"
+        git cherry-pick -x --mainline 1 ${{ github.event.pull_request.merge_commit_sha }}
+        git commit --amend --message "$subject"
+        git push --set-upstream origin --force-with-lease "${backport_branch}"
+        gh pr create \
+          --base "${target_branch}" \
+          --title "${subject}" \
+          --body "Backport of PR #${{ github.event.number }} to $target_branch branch. PR created by backport workflow."
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -391,6 +391,13 @@ actual latest release). The procedure for this is:
    request, as described above. An exception to this is if the bug fix is not
    applicable to ``main`` anymore.
 
+Automatic method:
+
+Add a ``backport 1.2.x`` label to the PR you want to backport. This will create
+a backport PR against the ``1.2.x`` branch.
+
+Manual method:
+
 #. ``git checkout origin/1.2.x -b backport-XXXX`` # use the main PR number here
 
 #. Locate the merge commit on the PR, in the *merged* message, for example:


### PR DESCRIPTION
To backport a PR, e.g. 1000, to another branch, e.g. `7.0.x`, add a
label `backport 7.0.x` to the PR. This will trigger a workflow which
will create a branch `backport-1000-to-7.0.x` based on the `7.0.x`
branch with a cherry-pick of the PR's merge commit, and create a new PR
for it against the `7.0.x` branch.

It is very simplistic, for instance it doesn't handle cherry-pick
failure gracefully, doesn't validate the state of the PR, doesn't check
if the branch already exists, etc. But we can improve on it later as
needed.

Finally, PRs created by github actions do not themselves trigger further
actions, i.e. the PR isn't checked. You need to close & reopen the PR
for the checks to trigger. There are workarounds for this but they are
either less secure or require more setup.