### PR TITLE
[7.0.x] Fix test_errors_in_xfail_skip_expressions for Python 3.10.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
             os: windows-latest
             tox_env: "py39-xdist"
           - name: "windows-py310"
-            python: "3.10-dev"
+            python: "3.10.1"
             os: windows-latest
             tox_env: "py310-xdist"
 
@@ -108,7 +108,7 @@ jobs:
             os: ubuntu-latest
             tox_env: "py39-xdist"
           - name: "ubuntu-py310"
-            python: "3.10-dev"
+            python: "3.10.1"
             os: ubuntu-latest
             tox_env: "py310-xdist"
           - name: "ubuntu-pypy3"

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -1143,8 +1143,6 @@ def test_errors_in_xfail_skip_expressions(pytester: Pytester) -> None:
     pypy_version_info = getattr(sys, "pypy_version_info", None)
     if pypy_version_info is not None and pypy_version_info < (6,):
         markline = markline[5:]
-    elif sys.version_info[:2] >= (3, 10):
-        markline = markline[11:]
     elif sys.version_info >= (3, 8) or hasattr(sys, "pypy_version_info"):
         markline = markline[4:]
 


### PR DESCRIPTION
Backport of https://github.com/pytest-dev/pytest/pull/9417