### PR TITLE
ci: Try backporting via pull_request_target

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,7 +1,7 @@
 name: backport
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 # Set permissions at the job level.

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,12 @@
 name: backport
 
 on:
+  # Note that `pull_request_target` has security implications:
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  # In particular:
+  # - Only allow triggers that can be used only be trusted users
+  # - Don't execute any code from the target branch
+  # - Don't use cache
   pull_request_target:
     types: [labeled]
 
@@ -9,7 +15,7 @@ permissions: {}
 
 jobs:
   backport:
-    if: ${{ startsWith(github.event.label.name, 'backport ') }}
+    if: startsWith(github.event.label.name, 'backport ') && github.event.pull_request.merged
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
In #9416, @bluetech says:

> So the backport workflow doesn't work - permission error: https://github.com/pytest-dev/pytest/runs/4546997247?check_suite_focus=true. It did work for me in a private test repo, so I'll try to figure out why it fails here. Will create a manual backport for now.

And indeed the [debug output](https://github.com/pytest-dev/pytest/runs/4546997247?check_suite_focus=true#step:1:13) reveals:

```
GITHUB_TOKEN Permissions
  Contents: read
  Metadata: read
  PullRequests: read
Secret source: None
```

which I think is due to [this](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request):

> When you create a pull request from a forked repository to the base repository, GitHub sends the `pull_request` event to the base repository and no pull request events occur on the forked repository. [...] With the exception of `GITHUB_TOKEN`, secrets are not passed to the runner when a workflow is triggered from a forked repository. The permissions for the `GITHUB_TOKEN` in forked repositories is read-only. For more information, see "Authenticating with the GITHUB_TOKEN."

I assume it worked in @bluetech's test because that wasn't a PR from a forked repository?

When using [`pull_request_target`](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target) instead, things look different:

> This event runs in the context of the base of the pull request, rather than in the merge commit as the `pull_request` event does. This prevents executing unsafe workflow code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows you to do things like create workflows that label and comment on pull requests based on the contents of the event payload.

Note the security warning:

> Warning: The pull_request_target event is granted a read/write repository token and can access secrets, even when it is triggered from a fork. Although the workflow runs in the context of the base of the pull request, you should make sure that you do not check out, build, or run untrusted code from the pull request with this event. [...]

But I *think* we should be fine here: We don't run anything, and this is triggered by labeling PRs, so it should not run on untrusted stuff anyways. For some more context and security considerations, see [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests | GitHub Security Lab](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

I don't really understand whether the workflow itself will need any changes due to the context now referring to the base - but we can't really know until we try, I guess.