### PR TITLE
[7.0.x] Backport "doc: fix a reference in "Writing hook functions""

### DIFF
--- a/doc/en/how-to/writing_hook_functions.rst
+++ b/doc/en/how-to/writing_hook_functions.rst
@@ -321,7 +321,7 @@ Plugins often need to store data on :class:`~pytest.Item`\s in one hook
 implementation, and access it in another. One common solution is to just
 assign some private attribute directly on the item, but type-checkers like
 mypy frown upon this, and it may also cause conflicts with other plugins.
-So pytest offers a better way to do this, :attr:`_pytest.nodes.Node.stash <item.stash>`.
+So pytest offers a better way to do this, :attr:`item.stash <_pytest.nodes.Node.stash>`.
 
 To use the "stash" in your plugins, first create "stash keys" somewhere at the
 top level of your plugin:


### PR DESCRIPTION
doc: fix a reference in "Writing hook functions"
(cherry picked from commit 443aa0219c0b5170a2f858c1ccea013cf88c6a6c)

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
