### PR TITLE
Restore {Code,TracebackEntry}.path to py.path and add alternative

### DIFF
--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -473,8 +473,8 @@ Trivial/Internal Changes
 
 - `#8174 <https://github.com/pytest-dev/pytest/issues/8174>`_: The following changes have been made to internal pytest types/functions:
 
-  - The ``path`` property of ``_pytest.code.Code`` returns ``Path`` instead of ``py.path.local``.
-  - The ``path`` property of ``_pytest.code.TracebackEntry`` returns ``Path`` instead of ``py.path.local``.
+  - ``_pytest.code.Code`` has a new attribute ``source_path`` which returns ``Path`` as an alternative to ``path`` which returns ``py.path.local``.
+  - ``_pytest.code.TracebackEntry`` has a new attribute ``source_path`` which returns ``Path`` as an alternative to ``path`` which returns ``py.path.local``.
   - The ``_pytest.code.getfslineno()`` function returns ``Path`` instead of ``py.path.local``.
   - The ``_pytest.python.path_matches_patterns()`` function takes ``Path`` instead of ``py.path.local``.
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -127,7 +127,9 @@ def filter_traceback_for_conftest_import_failure(
     Make a special case for importlib because we use it to import test modules and conftest files
     in _pytest.pathlib.import_path.
     """
-    return filter_traceback(entry) and "importlib" not in str(entry.path).split(os.sep)
+    return filter_traceback(entry) and "importlib" not in str(entry.source_path).split(
+        os.sep
+    )
 
 
 def main(

--- a/src/_pytest/legacypath.py
+++ b/src/_pytest/legacypath.py
@@ -11,6 +11,8 @@ import attr
 from iniconfig import SectionWrapper
 
 import pytest
+from _pytest._code import Code
+from _pytest._code import TracebackEntry
 from _pytest.compat import final
 from _pytest.compat import LEGACY_PATH
 from _pytest.compat import legacy_path
@@ -400,6 +402,19 @@ def Node_fspath_set(self: Node, value: LEGACY_PATH) -> None:
     self.path = Path(value)
 
 
+def Code_path(self: Code) -> Union[str, LEGACY_PATH]:
+    """Return a path object pointing to source code, or an ``str`` in
+    case of ``OSError`` / non-existing file."""
+    path = self.source_path
+    return path if isinstance(path, str) else legacy_path(path)
+
+
+def TracebackEntry_path(self: TracebackEntry) -> Union[str, LEGACY_PATH]:
+    """Path to the source code."""
+    path = self.source_path
+    return path if isinstance(path, str) else legacy_path(path)
+
+
 @pytest.hookimpl
 def pytest_configure(config: pytest.Config) -> None:
     mp = pytest.MonkeyPatch()
@@ -450,6 +465,12 @@ def pytest_configure(config: pytest.Config) -> None:
 
     # Add Node.fspath property.
     mp.setattr(Node, "fspath", property(Node_fspath, Node_fspath_set), raising=False)
+
+    # Add Code.path property.
+    mp.setattr(Code, "path", property(Code_path), raising=False)
+
+    # Add TracebackEntry.path property.
+    mp.setattr(TracebackEntry, "path", property(TracebackEntry_path), raising=False)
 
 
 @pytest.hookimpl

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1721,7 +1721,7 @@ class Function(PyobjMixin, nodes.Item):
     def _prunetraceback(self, excinfo: ExceptionInfo[BaseException]) -> None:
         if hasattr(self, "_obj") and not self.config.getoption("fulltrace", False):
             code = _pytest._code.Code.from_function(get_real_func(self.obj))
-            path, firstlineno = code.path, code.firstlineno
+            path, firstlineno = code.source_path, code.firstlineno
             traceback = excinfo.traceback
             ntraceback = traceback.cut(path=path, firstlineno=firstlineno)
             if ntraceback == traceback:

--- a/testing/code/test_code.py
+++ b/testing/code/test_code.py
@@ -24,7 +24,7 @@ def test_code_gives_back_name_for_not_existing_file() -> None:
     co_code = compile("pass\n", name, "exec")
     assert co_code.co_filename == name
     code = Code(co_code)
-    assert str(code.path) == name
+    assert str(code.source_path) == name
     assert code.fullsource is None
 
 
@@ -76,7 +76,7 @@ def test_getstatement_empty_fullsource() -> None:
 def test_code_from_func() -> None:
     co = Code.from_function(test_frame_getsourcelineno_myself)
     assert co.firstlineno
-    assert co.path
+    assert co.source_path
 
 
 def test_unicode_handling() -> None:

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -151,7 +151,7 @@ class TestTraceback_f_g_h:
 
     def test_traceback_cut(self) -> None:
         co = _pytest._code.Code.from_function(f)
-        path, firstlineno = co.path, co.firstlineno
+        path, firstlineno = co.source_path, co.firstlineno
         assert isinstance(path, Path)
         traceback = self.excinfo.traceback
         newtraceback = traceback.cut(path=path, firstlineno=firstlineno)
@@ -166,9 +166,9 @@ class TestTraceback_f_g_h:
         basedir = Path(pytest.__file__).parent
         newtraceback = excinfo.traceback.cut(excludepath=basedir)
         for x in newtraceback:
-            assert isinstance(x.path, Path)
-            assert basedir not in x.path.parents
-        assert newtraceback[-1].frame.code.path == p
+            assert isinstance(x.source_path, Path)
+            assert basedir not in x.source_path.parents
+        assert newtraceback[-1].frame.code.source_path == p
 
     def test_traceback_filter(self):
         traceback = self.excinfo.traceback
@@ -295,7 +295,7 @@ class TestTraceback_f_g_h:
         tb = excinfo.traceback
         entry = tb.getcrashentry()
         co = _pytest._code.Code.from_function(h)
-        assert entry.frame.code.path == co.path
+        assert entry.frame.code.source_path == co.source_path
         assert entry.lineno == co.firstlineno + 1
         assert entry.frame.code.name == "h"
 
@@ -312,7 +312,7 @@ class TestTraceback_f_g_h:
         tb = excinfo.traceback
         entry = tb.getcrashentry()
         co = _pytest._code.Code.from_function(g)
-        assert entry.frame.code.path == co.path
+        assert entry.frame.code.source_path == co.source_path
         assert entry.lineno == co.firstlineno + 2
         assert entry.frame.code.name == "g"
 
@@ -376,7 +376,7 @@ def test_excinfo_no_python_sourcecode(tmp_path: Path) -> None:
     for item in excinfo.traceback:
         print(item)  # XXX: for some reason jinja.Template.render is printed in full
         item.source  # shouldn't fail
-        if isinstance(item.path, Path) and item.path.name == "test.txt":
+        if isinstance(item.source_path, Path) and item.source_path.name == "test.txt":
             assert str(item.source) == "{{ h()}}:"
 
 
@@ -398,7 +398,7 @@ def test_codepath_Queue_example() -> None:
     except queue.Empty:
         excinfo = _pytest._code.ExceptionInfo.from_current()
     entry = excinfo.traceback[-1]
-    path = entry.path
+    path = entry.source_path
     assert isinstance(path, Path)
     assert path.name.lower() == "queue.py"
     assert path.exists()

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -1102,7 +1102,7 @@ class TestTracebackCutting:
 
         assert tb is not None
         traceback = _pytest._code.Traceback(tb)
-        assert isinstance(traceback[-1].path, str)
+        assert isinstance(traceback[-1].source_path, str)
         assert not filter_traceback(traceback[-1])
 
     def test_filter_traceback_path_no_longer_valid(self, pytester: Pytester) -> None:
@@ -1132,7 +1132,7 @@ class TestTracebackCutting:
         assert tb is not None
         pytester.path.joinpath("filter_traceback_entry_as_str.py").unlink()
         traceback = _pytest._code.Traceback(tb)
-        assert isinstance(traceback[-1].path, str)
+        assert isinstance(traceback[-1].source_path, str)
         assert filter_traceback(traceback[-1])
 
 

--- a/testing/test_legacypath.py
+++ b/testing/test_legacypath.py
@@ -161,3 +161,10 @@ def test_override_ini_paths(pytester: pytest.Pytester) -> None:
     )
     result = pytester.runpytest("--override-ini", "paths=foo/bar1.py foo/bar2.py", "-s")
     result.stdout.fnmatch_lines(["user_path:bar1.py", "user_path:bar2.py"])
+
+
+def test_code_path() -> None:
+    with pytest.raises(Exception) as excinfo:
+        raise Exception()
+    assert isinstance(excinfo.traceback[0].path, LEGACY_PATH)  # type: ignore[attr-defined]
+    assert isinstance(excinfo.traceback[0].frame.code.path, LEGACY_PATH)  # type: ignore[attr-defined]


### PR DESCRIPTION
In 92ba96b0612e6b06bb8f4ab05bd75481d2504806 we have changed the `path`
attribute to return a `pathlib.Path` instead of `py.path.local` without
a deprecation hoping it would be alright. But these types are somewhat
public, reachable through `ExceptionInfo.traceback`, and broke code in
practice. So restore them in the legacypath plugin and add `Path`
alternatives under a different name - `source_path`.

Fix #9423.