### PR TITLE
[7.0.x] Backport "python: skip nose setup/teardown fixtures if non-callable"

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -517,12 +517,18 @@ class Module(nodes.File, PyCollector):
             self.obj, ("setUpModule", "setup_module")
         )
         if setup_module is None and has_nose:
+            # The name "setup" is too common - only treat as fixture if callable.
             setup_module = _get_first_non_fixture_func(self.obj, ("setup",))
+            if not callable(setup_module):
+                setup_module = None
         teardown_module = _get_first_non_fixture_func(
             self.obj, ("tearDownModule", "teardown_module")
         )
         if teardown_module is None and has_nose:
             teardown_module = _get_first_non_fixture_func(self.obj, ("teardown",))
+            # Same as "setup" above - only treat as fixture if callable.
+            if not callable(teardown_module):
+                teardown_module = None
 
         if setup_module is None and teardown_module is None:
             return

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -477,3 +477,22 @@ def test_raises(pytester: Pytester) -> None:
             "* 1 failed, 2 passed *",
         ]
     )
+
+
+def test_nose_setup_skipped_if_non_callable(pytester: Pytester) -> None:
+    """Regression test for #9391."""
+    p = pytester.makepyfile(
+        __init__="",
+        setup="""
+        """,
+        teardown="""
+        """,
+        test_it="""
+        from . import setup, teardown
+
+        def test_it():
+            pass
+        """,
+    )
+    result = pytester.runpytest(p, "-p", "nose")
+    assert result.ret == 0


### PR DESCRIPTION
(cherry picked from commit 7fc2cf51c22c0ec6b1599662d9069f620374873a)

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
