### PR TITLE
[7.0.x] Backport "doc/reference: add 4 missing hooks to reference"

### DIFF
--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -727,6 +727,11 @@ you can use the following hook:
 .. hook:: pytest_make_parametrize_id
 .. autofunction:: pytest_make_parametrize_id
 
+Hooks for influencing test skipping:
+
+.. hook:: pytest_markeval_namespace
+.. autofunction:: pytest_markeval_namespace
+
 After collection is complete, you can modify the order of
 items, delete or otherwise amend the test items:
 
@@ -791,6 +796,10 @@ Session related reporting hooks:
 .. autofunction:: pytest_report_collectionfinish
 .. hook:: pytest_report_teststatus
 .. autofunction:: pytest_report_teststatus
+.. hook:: pytest_report_to_serializable
+.. autofunction:: pytest_report_to_serializable
+.. hook:: pytest_report_from_serializable
+.. autofunction:: pytest_report_from_serializable
 .. hook:: pytest_terminal_summary
 .. autofunction:: pytest_terminal_summary
 .. hook:: pytest_fixture_setup
@@ -829,6 +838,8 @@ reporting or interaction with exceptions:
 .. autofunction:: pytest_exception_interact
 .. hook:: pytest_enter_pdb
 .. autofunction:: pytest_enter_pdb
+.. hook:: pytest_leave_pdb
+.. autofunction:: pytest_leave_pdb
 
 
 Objects


### PR DESCRIPTION
(cherry picked from commit 7a42db2bf03e021d8c3a409c279cd9ef27e3c122)

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
