### PR TITLE
ci: run plugins job with python 3.9 instead of 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,7 +127,7 @@ jobs:
             use_coverage: true
 
           - name: "plugins"
-            python: "3.7"
+            python: "3.9"
             os: ubuntu-latest
             tox_env: "plugins"
 

--- a/tox.ini
+++ b/tox.ini
@@ -100,9 +100,9 @@ commands =
 [testenv:plugins]
 # use latest versions of all plugins, including pre-releases
 pip_pre=true
-# use latest pip and new dependency resolver (#7783)
+# use latest pip to get new dependency resolver (#7783)
 download=true
-install_command=python -m pip --use-feature=2020-resolver install {opts} {packages}
+install_command=python -m pip install {opts} {packages}
 changedir = testing/plugins_integration
 deps = -rtesting/plugins_integration/requirements.txt
 setenv =


### PR DESCRIPTION
Latest Django release dropped support for 3.7.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
