### PR TITLE
Remove redundant Python 3.6 code

### DIFF
--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -1,5 +1,4 @@
 import operator
-import sys
 from contextlib import contextmanager
 from decimal import Decimal
 from fractions import Fraction
@@ -810,7 +809,6 @@ class TestApprox:
         assert 1.0 != approx([None])
         assert None != approx([1.0])  # noqa: E711
 
-    @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires ordered dicts")
     def test_nonnumeric_dict_repr(self):
         """Dicts with non-numerics and infinites have no tolerances"""
         x1 = {"foo": 1.0000005, "bar": None, "foobar": inf}

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -796,7 +796,6 @@ class TestAssert_reprcompare:
 
 
 class TestAssert_reprcompare_dataclass:
-    @pytest.mark.skipif(sys.version_info < (3, 7), reason="Dataclasses in Python3.7+")
     def test_dataclasses(self, pytester: Pytester) -> None:
         p = pytester.copy_example("dataclasses/test_compare_dataclasses.py")
         result = pytester.runpytest(p)
@@ -815,7 +814,6 @@ class TestAssert_reprcompare_dataclass:
             consecutive=True,
         )
 
-    @pytest.mark.skipif(sys.version_info < (3, 7), reason="Dataclasses in Python3.7+")
     def test_recursive_dataclasses(self, pytester: Pytester) -> None:
         p = pytester.copy_example("dataclasses/test_compare_recursive_dataclasses.py")
         result = pytester.runpytest(p)
@@ -834,7 +832,6 @@ class TestAssert_reprcompare_dataclass:
             consecutive=True,
         )
 
-    @pytest.mark.skipif(sys.version_info < (3, 7), reason="Dataclasses in Python3.7+")
     def test_recursive_dataclasses_verbose(self, pytester: Pytester) -> None:
         p = pytester.copy_example("dataclasses/test_compare_recursive_dataclasses.py")
         result = pytester.runpytest(p, "-vv")
@@ -867,7 +864,6 @@ class TestAssert_reprcompare_dataclass:
             consecutive=True,
         )
 
-    @pytest.mark.skipif(sys.version_info < (3, 7), reason="Dataclasses in Python3.7+")
     def test_dataclasses_verbose(self, pytester: Pytester) -> None:
         p = pytester.copy_example("dataclasses/test_compare_dataclasses_verbose.py")
         result = pytester.runpytest(p, "-vv")
@@ -881,7 +877,6 @@ class TestAssert_reprcompare_dataclass:
             ]
         )
 
-    @pytest.mark.skipif(sys.version_info < (3, 7), reason="Dataclasses in Python3.7+")
     def test_dataclasses_with_attribute_comparison_off(
         self, pytester: Pytester
     ) -> None:
@@ -891,7 +886,6 @@ class TestAssert_reprcompare_dataclass:
         result = pytester.runpytest(p, "-vv")
         result.assert_outcomes(failed=0, passed=1)
 
-    @pytest.mark.skipif(sys.version_info < (3, 7), reason="Dataclasses in Python3.7+")
     def test_comparing_two_different_data_classes(self, pytester: Pytester) -> None:
         p = pytester.copy_example(
             "dataclasses/test_compare_two_different_dataclasses.py"
@@ -899,7 +893,6 @@ class TestAssert_reprcompare_dataclass:
         result = pytester.runpytest(p, "-vv")
         result.assert_outcomes(failed=0, passed=1)
 
-    @pytest.mark.skipif(sys.version_info < (3, 7), reason="Dataclasses in Python3.7+")
     def test_data_classes_with_custom_eq(self, pytester: Pytester) -> None:
         p = pytester.copy_example(
             "dataclasses/test_compare_dataclasses_with_custom_eq.py"


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Follow on from #9442 / #9437, remove some more redundant code for EOL Python 3.6, part two.

Sorry for the second PR, I missed some stuff in https://github.com/pytest-dev/pytest/pull/9460: because feature branches aren't built on the CI, I usually temporarily remove the restriction, but this time did it in `main` and sent the PR from the old feature branch instead.

Relatedly, perhaps remove the feature branch restriction?