### PR TITLE
Doc update: clarify -W syntax

### DIFF
--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -45,9 +45,9 @@ Running pytest now produces this output:
 Controlling warnings
 --------------------
 
-Similar to Python's `warning filter` and :option:`-W option <python:-W>` flag, pytest provides
+Similar to Python's `warning filter`_ and :option:`-W option <python:-W>` flag, pytest provides
 its own ``-W`` flag to control which warnings are ignored, displayed, or turned into
-errors. See the `warning filter_` documentation for more
+errors. See the `warning filter`_ documentation for more
 advanced use-cases.
 
 .. _`warning filter`: https://docs.python.org/3/library/warnings.html#warning-filter

--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -46,7 +46,7 @@ Controlling warnings
 --------------------
 
 Similar to Python's `warning filter` and :option:`-W option <python:-W>` flag, pytest provides
-its own a ``-W`` flag to control which warnings are ignored, displayed, or turned into
+its own ``-W`` flag to control which warnings are ignored, displayed, or turned into
 errors. See the `warning filter` documentation for more
 advanced use-cases.
 

--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -47,7 +47,7 @@ Controlling warnings
 
 Similar to Python's `warning filter` and :option:`-W option <python:-W>` flag, pytest provides
 its own ``-W`` flag to control which warnings are ignored, displayed, or turned into
-errors. See the `warning filter` documentation for more
+errors. See the `warning filter_` documentation for more
 advanced use-cases.
 
 .. _`warning filter`: https://docs.python.org/3/library/warnings.html#warning-filter

--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -42,8 +42,18 @@ Running pytest now produces this output:
     -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
     ======================= 1 passed, 1 warning in 0.12s =======================
 
-The ``-W`` flag can be passed to control which warnings will be displayed or even turn
-them into errors:
+Controlling warnings
+--------------------
+
+Similar to Python's `warning filter` and :option:`-W option <python:-W>` flag, pytest provides
+its own a ``-W`` flag to control which warnings are ignored, displayed, or turned into
+errors. See the `warning filter` documentation for more
+advanced use-cases.
+
+.. _`warning filter`: https://docs.python.org/3/library/warnings.html#warning-filter
+
+This code sample shows how to treat any ``UserWarning`` category class of warning
+as an error:
 
 .. code-block:: pytest
 
@@ -96,9 +106,11 @@ all other warnings into errors.
 When a warning matches more than one option in the list, the action for the last matching option
 is performed.
 
+Syntax
+------
+
 Both ``-W`` command-line option and ``filterwarnings`` ini option are based on Python's own
-:option:`-W option <python:-W>` and :func:`warnings.simplefilter`, so please refer to those sections in the Python
-documentation for other examples and advanced usage.
+
 
 .. _`filterwarnings`:
 

--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -106,11 +106,6 @@ all other warnings into errors.
 When a warning matches more than one option in the list, the action for the last matching option
 is performed.
 
-Syntax
-------
-
-Both ``-W`` command-line option and ``filterwarnings`` ini option are based on Python's own
-
 
 .. _`filterwarnings`:
 


### PR DESCRIPTION
As a new user ([I'm not the only one](https://stackoverflow.com/questions/58645563/how-does-pytest-mark-filterwarnings-work)) I was a bit lost on what syntax I should be using, and that Python itself heavily documents this.

I've updated the documentation to bring this towards the top under its own heading, and linked to the specific user facing Python documentation. 
