### PR TITLE
Make 'warnings' and 'deselected' in assert_outcomes optional

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -596,11 +596,15 @@ class RunResult:
         errors: int = 0,
         xpassed: int = 0,
         xfailed: int = 0,
-        warnings: int = 0,
-        deselected: int = 0,
+        warnings: Optional[int] = None,
+        deselected: Optional[int] = None,
     ) -> None:
-        """Assert that the specified outcomes appear with the respective
-        numbers (0 means it didn't occur) in the text output from a test run."""
+        """
+        Assert that the specified outcomes appear with the respective
+        numbers (0 means it didn't occur) in the text output from a test run.
+
+        ``warnings`` and ``deselected`` are only checked if not None.
+        """
         __tracebackhide__ = True
         from _pytest.pytester_assertions import assert_outcomes
 

--- a/src/_pytest/pytester_assertions.py
+++ b/src/_pytest/pytester_assertions.py
@@ -4,6 +4,7 @@
 # hence cannot be subject to assertion rewriting, which requires a
 # module to not be already imported.
 from typing import Dict
+from typing import Optional
 from typing import Sequence
 from typing import Tuple
 from typing import Union
@@ -42,8 +43,8 @@ def assert_outcomes(
     errors: int = 0,
     xpassed: int = 0,
     xfailed: int = 0,
-    warnings: int = 0,
-    deselected: int = 0,
+    warnings: Optional[int] = None,
+    deselected: Optional[int] = None,
 ) -> None:
     """Assert that the specified outcomes appear with the respective
     numbers (0 means it didn't occur) in the text output from a test run."""
@@ -56,8 +57,6 @@ def assert_outcomes(
         "errors": outcomes.get("errors", 0),
         "xpassed": outcomes.get("xpassed", 0),
         "xfailed": outcomes.get("xfailed", 0),
-        "warnings": outcomes.get("warnings", 0),
-        "deselected": outcomes.get("deselected", 0),
     }
     expected = {
         "passed": passed,
@@ -66,7 +65,11 @@ def assert_outcomes(
         "errors": errors,
         "xpassed": xpassed,
         "xfailed": xfailed,
-        "warnings": warnings,
-        "deselected": deselected,
     }
+    if warnings is not None:
+        obtained["warnings"] = outcomes.get("warnings", 0)
+        expected["warnings"] = warnings
+    if deselected is not None:
+        obtained["deselected"] = outcomes.get("deselected", 0)
+        expected["deselected"] = deselected
     assert obtained == expected

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -835,6 +835,8 @@ def test_pytester_assert_outcomes_warnings(pytester: Pytester) -> None:
     )
     result = pytester.runpytest()
     result.assert_outcomes(passed=1, warnings=1)
+    # If warnings is not passed, it is not checked at all.
+    result.assert_outcomes(passed=1)
 
 
 def test_pytester_outcomes_deselected(pytester: Pytester) -> None:
@@ -849,3 +851,5 @@ def test_pytester_outcomes_deselected(pytester: Pytester) -> None:
     )
     result = pytester.runpytest("-k", "test_one")
     result.assert_outcomes(passed=1, deselected=1)
+    # If deselected is not passed, it is not checked at all.
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
Fix #9471

I don't think we need a CHANGELOG here, as this has not really been officially released yet.