### PR TITLE
- instead of throwing exception, return empty sequence

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1126,12 +1126,12 @@ class Config:
             return
 
         def _get_files(dist):
-            #dist.files does not make sense for dists
-            #who are not stored on a filesystem
-            #at least pyoxidizer does throw a
-            #not implemented assertion in this case
+            # dist.files does not make sense for dists
+            # who are not stored on a filesystem
+            # at least pyoxidizer does throw a
+            # not implemented assertion in this case
             try:
-                return dist.files 
+                return dist.files
             except NotImplementedError:
                 return []
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1125,11 +1125,21 @@ class Config:
             # We don't autoload from setuptools entry points, no need to continue.
             return
 
+        def _get_files(dist):
+            #dist.files does not make sense for dists
+            #who are not stored on a filesystem
+            #at least pyoxidizer does throw a
+            #not implemented assertion in this case
+            try:
+                return dist.files 
+            except NotImplementedError:
+                return []
+
         package_files = (
             str(file)
             for dist in importlib_metadata.distributions()
             if any(ep.group == "pytest11" for ep in dist.entry_points)
-            for file in dist.files or []
+            for file in _get_files(dist) or []
         )
 
         for name in _iter_rewritable_modules(package_files):

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1115,7 +1115,6 @@ class Config:
                 self._mark_plugins_for_rewrite(hook)
         self._warn_about_missing_assertion(mode)
 
-
     def _mark_plugins_for_rewrite(self, hook) -> None:
         """Given an importhook, mark for rewrite any top-level
         modules or packages in the distribution package for
@@ -1137,9 +1136,11 @@ class Config:
             for name in _iter_rewritable_modules(package_files):
                 hook.mark_rewrite(name)
         except Exception as e:
-            apropriate_output_function("unexpected exception %s while marking plugins for assertion rewrites, see LINK TO HELPFULL DOCUMENTATION", e)
+            apropriate_output_function(
+                "unexpected exception %s while marking plugins for assertion rewrites, see LINK TO HELPFULL DOCUMENTATION",
+                e,
+            )
             raise e
-
 
     def _validate_args(self, args: List[str], via: str) -> List[str]:
         """Validate known args."""


### PR DESCRIPTION
When using pytest to test pyoxidizer projects, it was necessary to have the source code under test on the file system, instead of inside the single file executable. For me this meant that the actuall final product, could not be tested by pytest.

this was due to the fact that pytest needs a file path in order to rewrite assertions.

By returning a empty sequence instead, the tests can be executed. (without the rewriting).

An alternative would be to use  the --assert=plain switch.
however, i did not find a way how to set this flag from inside a repl...

Thanks for the great tool!