### PR TITLE
config: fix incorrect cache hit check in _getconftestmodules

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -538,7 +538,7 @@ class PytestPluginManager(PluginManager):
         # Optimization: avoid repeated searches in the same directory.
         # Assumes always called with same importmode and rootpath.
         existing_clist = self._dirpath2confmods.get(directory)
-        if existing_clist:
+        if existing_clist is not None:
             return existing_clist
 
         # XXX these days we may rather want to use config.rootpath


### PR DESCRIPTION
This made the cache not work as intended, causing a major slowdown.

See #9478 for discussion and context.

Authored-by: @asottile