### PR TITLE
Some conftest changes

### DIFF
--- a/changelog/9493.bugfix.rst
+++ b/changelog/9493.bugfix.rst
@@ -1,0 +1,10 @@
+Symbolic link components are no longer resolved in conftest paths.
+This means that if a conftest appears twice in collection tree, using symlinks, it will be executed twice.
+For example, given
+
+    tests/real/conftest.py
+    tests/real/test_it.py
+    tests/link -> tests/real
+
+running ``pytest tests`` now imports the conftest twice, once as ``tests/real/conftest.py`` and once as ``tests/link/conftest.py``.
+This is a fix to match a similar change made to test collection itself in pytest 6.0 (see :pull:`6523` for details).

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -602,7 +602,7 @@ class PytestPluginManager(PluginManager):
         dirpath = conftestpath.parent
         if dirpath in self._dirpath2confmods:
             for path, mods in self._dirpath2confmods.items():
-                if path and dirpath in path.parents or path == dirpath:
+                if dirpath in path.parents or path == dirpath:
                     assert mod not in mods
                     mods.append(mod)
         self.trace(f"loading conftestmodule {mod!r}")

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -592,15 +592,8 @@ class PytestPluginManager(PluginManager):
     def _importconftest(
         self, conftestpath: Path, importmode: Union[str, ImportMode], rootpath: Path
     ) -> types.ModuleType:
-        # Use a resolved Path object as key to avoid loading the same conftest
-        # twice with build systems that create build directories containing
-        # symlinks to actual files.
-        # Using Path().resolve() is better than py.path.realpath because
-        # it resolves to the correct path/drive in case-insensitive file systems (#5792)
-        key = conftestpath.resolve()
-
         with contextlib.suppress(KeyError):
-            return self._conftestpath2mod[key]
+            return self._conftestpath2mod[conftestpath]
 
         pkgpath = resolve_package_path(conftestpath)
         if pkgpath is None:
@@ -616,7 +609,7 @@ class PytestPluginManager(PluginManager):
         self._check_non_top_pytest_plugins(mod, conftestpath)
 
         self._conftest_plugins.add(mod)
-        self._conftestpath2mod[key] = mod
+        self._conftestpath2mod[conftestpath] = mod
         dirpath = conftestpath.parent
         if dirpath in self._dirpath2confmods:
             for path, mods in self._dirpath2confmods.items():

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -345,14 +345,21 @@ class PytestPluginManager(PluginManager):
         import _pytest.assertion
 
         super().__init__("pytest")
-        # The objects are module objects, only used generically.
-        self._conftest_plugins: Set[types.ModuleType] = set()
 
-        # State related to local conftest plugins.
+        # -- State related to local conftest plugins.
+        # All loaded conftest modules.
+        self._conftest_plugins: Set[types.ModuleType] = set()
+        # All conftest modules applicable for a directory.
+        # This includes the directory's own conftest modules as well
+        # as those of its parent directories.
         self._dirpath2confmods: Dict[Path, List[types.ModuleType]] = {}
+        # The conftest module of a conftest path.
         self._conftestpath2mod: Dict[Path, types.ModuleType] = {}
+        # Cutoff directory above which conftests are no longer discovered.
         self._confcutdir: Optional[Path] = None
+        # If set, conftest loading is skipped.
         self._noconftest = False
+
         self._duplicatepaths: Set[Path] = set()
 
         # plugins that were explicitly skipped with pytest.skip

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -546,7 +546,7 @@ class PytestPluginManager(PluginManager):
 
     def _getconftestmodules(
         self, path: Path, importmode: Union[str, ImportMode], rootpath: Path
-    ) -> List[types.ModuleType]:
+    ) -> Sequence[types.ModuleType]:
         if self._noconftest:
             return []
 

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -689,9 +689,8 @@ class Session(nodes.FSCollector):
             # No point in finding packages when collecting doctests.
             if not self.config.getoption("doctestmodules", False):
                 pm = self.config.pluginmanager
-                confcutdir = pm._confcutdir
                 for parent in (argpath, *argpath.parents):
-                    if confcutdir and parent in confcutdir.parents:
+                    if not pm._is_in_confcutdir(argpath):
                         break
 
                     if parent.is_dir():

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -50,21 +50,24 @@ def test_setattr() -> None:
 
 class TestSetattrWithImportPath:
     def test_string_expression(self, monkeypatch: MonkeyPatch) -> None:
-        monkeypatch.setattr("os.path.abspath", lambda x: "hello2")
-        assert os.path.abspath("123") == "hello2"
+        with monkeypatch.context() as mp:
+            mp.setattr("os.path.abspath", lambda x: "hello2")
+            assert os.path.abspath("123") == "hello2"
 
     def test_string_expression_class(self, monkeypatch: MonkeyPatch) -> None:
-        monkeypatch.setattr("_pytest.config.Config", 42)
-        import _pytest
+        with monkeypatch.context() as mp:
+            mp.setattr("_pytest.config.Config", 42)
+            import _pytest
 
-        assert _pytest.config.Config == 42  # type: ignore
+            assert _pytest.config.Config == 42  # type: ignore
 
     def test_unicode_string(self, monkeypatch: MonkeyPatch) -> None:
-        monkeypatch.setattr("_pytest.config.Config", 42)
-        import _pytest
+        with monkeypatch.context() as mp:
+            mp.setattr("_pytest.config.Config", 42)
+            import _pytest
 
-        assert _pytest.config.Config == 42  # type: ignore
-        monkeypatch.delattr("_pytest.config.Config")
+            assert _pytest.config.Config == 42  # type: ignore
+            mp.delattr("_pytest.config.Config")
 
     def test_wrong_target(self, monkeypatch: MonkeyPatch) -> None:
         with pytest.raises(TypeError):
@@ -80,14 +83,16 @@ class TestSetattrWithImportPath:
 
     def test_unknown_attr_non_raising(self, monkeypatch: MonkeyPatch) -> None:
         # https://github.com/pytest-dev/pytest/issues/746
-        monkeypatch.setattr("os.path.qweqwe", 42, raising=False)
-        assert os.path.qweqwe == 42  # type: ignore
+        with monkeypatch.context() as mp:
+            mp.setattr("os.path.qweqwe", 42, raising=False)
+            assert os.path.qweqwe == 42  # type: ignore
 
     def test_delattr(self, monkeypatch: MonkeyPatch) -> None:
-        monkeypatch.delattr("os.path.abspath")
-        assert not hasattr(os.path, "abspath")
-        monkeypatch.undo()
-        assert os.path.abspath
+        with monkeypatch.context() as mp:
+            mp.delattr("os.path.abspath")
+            assert not hasattr(os.path, "abspath")
+            mp.undo()
+            assert os.path.abspath
 
 
 def test_delattr() -> None:


### PR DESCRIPTION
As a follow up to #9478, I started looking at the conftest code. I have some ideas (`_dirpath2confmods` is actually quite tricky. also ideally all conftest loading will be done purely during collection), but ran out of time so these are the changes thus far.

There is one logic change related to symlinks, see the changelog entry. I consider it a bugfix, and think it will allow further improvements since it aligns how conftests are loaded with how collection works.

Better viewed per-commit.