### PR TITLE
python: add back `instance` accessor to all python nodes, not just Function

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -284,6 +284,16 @@ class PyobjMixin(nodes.Node):
         return node.obj if node is not None else None
 
     @property
+    def instance(self):
+        """Python instance object the function is bound to.
+
+        Returns None if not a test method, e.g. for a standalone test function,
+        a staticmethod, a class or a module.
+        """
+        node = self.getparent(Function)
+        return getattr(node.obj, "__self__", None) if node is not None else None
+
+    @property
     def obj(self):
         """Underlying Python object."""
         obj = getattr(self, "_obj", None)
@@ -1692,15 +1702,6 @@ class Function(PyobjMixin, nodes.Item):
     def function(self):
         """Underlying python 'function' object."""
         return getimfunc(self.obj)
-
-    @property
-    def instance(self):
-        """Python instance object the function is bound to.
-
-        Returns None if not a test method, e.g. for a standalone test function
-        or a staticmethod.
-        """
-        return getattr(self.obj, "__self__", None)
 
     def _getobj(self):
         assert self.parent is not None

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -64,7 +64,7 @@ class TestCollector:
 
         assert pytester.collect_by_name(modcol, "doesnotexist") is None
 
-    def test_getparent(self, pytester: Pytester) -> None:
+    def test_getparent_and_accessors(self, pytester: Pytester) -> None:
         modcol = pytester.getmodulecol(
             """
             class TestClass:
@@ -77,14 +77,21 @@ class TestCollector:
         fn = pytester.collect_by_name(cls, "test_foo")
         assert isinstance(fn, pytest.Function)
 
-        module_parent = fn.getparent(pytest.Module)
-        assert module_parent is modcol
+        assert fn.getparent(pytest.Module) is modcol
+        assert modcol.module is not None
+        assert modcol.cls is None
+        assert modcol.instance is None
 
-        function_parent = fn.getparent(pytest.Function)
-        assert function_parent is fn
+        assert fn.getparent(pytest.Class) is cls
+        assert cls.module is not None
+        assert cls.cls is not None
+        assert cls.instance is None
 
-        class_parent = fn.getparent(pytest.Class)
-        assert class_parent is cls
+        assert fn.getparent(pytest.Function) is fn
+        assert fn.module is not None
+        assert fn.cls is not None
+        assert fn.instance is not None
+        assert fn.function is not None
 
     def test_getcustomfile_roundtrip(self, pytester: Pytester) -> None:
         hello = pytester.makefile(".xxx", hello="world")


### PR DESCRIPTION
Regressed in 062d91ab4 (pytest 7.0.0rc1 only).

Fix #9486.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
