### PR TITLE
Add docs on pytest.warns(None) deprecation

### DIFF
--- a/changelog/9404.doc.rst
+++ b/changelog/9404.doc.rst
@@ -1,0 +1,1 @@
+Added extra documentation on alternatives to common misuses of `pytest.warns(None)` ahead of its deprecation.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -221,11 +221,32 @@ Using ``pytest.warns(None)``
 
 .. deprecated:: 7.0
 
-:func:`pytest.warns(None) <pytest.warns>` is now deprecated because many people used
-it to mean "this code does not emit warnings", but it actually had the effect of
-checking that the code emits at least one warning of any type - like ``pytest.warns()``
+:func:`pytest.warns(None) <pytest.warns>` is now deprecated because it was frequently misused.
+Its correct usage was checking that the code emits at least one warning of any type - like ``pytest.warns()``
 or ``pytest.warns(Warning)``.
 
+If you are looking to:
+
+-  ensure that **no** warnings are emitted, consider using
+
+.. code-block:: python
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+- suppress warnings, you could use
+
+.. code-block:: python
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+- ensure that **any** warning is emitted, please use
+
+.. code-block:: python
+
+    with pytest.warns():
+        pass
 
 The ``--strict`` command-line option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -225,28 +225,7 @@ Using ``pytest.warns(None)``
 Its correct usage was checking that the code emits at least one warning of any type - like ``pytest.warns()``
 or ``pytest.warns(Warning)``.
 
-If you are looking to:
-
--  ensure that **no** warnings are emitted, consider using
-
-.. code-block:: python
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-
-- suppress warnings, you could use
-
-.. code-block:: python
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-
-- ensure that **any** warning is emitted, please use
-
-.. code-block:: python
-
-    with pytest.warns():
-        pass
+See https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests for use cases.
 
 The ``--strict`` command-line option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -225,7 +225,7 @@ Using ``pytest.warns(None)``
 Its correct usage was checking that the code emits at least one warning of any type - like ``pytest.warns()``
 or ``pytest.warns(Warning)``.
 
-See :ref:`warns-use-cases` for examples.
+See :ref:`warns use cases` for examples.
 
 The ``--strict`` command-line option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -225,7 +225,7 @@ Using ``pytest.warns(None)``
 Its correct usage was checking that the code emits at least one warning of any type - like ``pytest.warns()``
 or ``pytest.warns(Warning)``.
 
-See https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests for use cases.
+See :ref:`warns-use-cases` for examples.
 
 The ``--strict`` command-line option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -300,6 +300,32 @@ filter at the end of the test, so no global state is leaked.
 
 .. _recwarn:
 
+Additional use cases of warnings in tests
+-----------------------------------------
+
+Here are some use cases involving warnings that often come up in tests, and suggestions on how to deal with them:
+
+- To ensure that **any** warning is emitted, use:
+
+.. code-block:: python
+
+    with pytest.warns():
+        pass
+
+-  To ensure that **no** warnings are emitted, use:
+
+.. code-block:: python
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+- To suppress warnings, use:
+
+.. code-block:: python
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
 Recording warnings
 ------------------
 

--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -300,32 +300,6 @@ filter at the end of the test, so no global state is leaked.
 
 .. _recwarn:
 
-Additional use cases of warnings in tests
------------------------------------------
-
-Here are some use cases involving warnings that often come up in tests, and suggestions on how to deal with them:
-
-- To ensure that **any** warning is emitted, use:
-
-.. code-block:: python
-
-    with pytest.warns():
-        pass
-
--  To ensure that **no** warnings are emitted, use:
-
-.. code-block:: python
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-
-- To suppress warnings, use:
-
-.. code-block:: python
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-
 Recording warnings
 ------------------
 
@@ -369,6 +343,35 @@ warnings, or index into it to get a particular recorded warning.
 .. currentmodule:: _pytest.warnings
 
 Full API: :class:`~_pytest.recwarn.WarningsRecorder`.
+
+.. _`warns use cases`:
+
+Additional use cases of warnings in tests
+-----------------------------------------
+
+Here are some use cases involving warnings that often come up in tests, and suggestions on how to deal with them:
+
+- To ensure that **any** warning is emitted, use:
+
+.. code-block:: python
+
+    with pytest.warns():
+        pass
+
+-  To ensure that **no** warnings are emitted, use:
+
+.. code-block:: python
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+- To suppress warnings, use:
+
+.. code-block:: python
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
 
 .. _custom_failure_messages:
 

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -91,7 +91,7 @@ WARNS_NONE_ARG = PytestRemovedIn8Warning(
     "Passing None has been deprecated.\n"
     "See https://docs.pytest.org/en/latest/how-to/capture-warnings.html"
     "#additional-use-cases-of-warnings-in-tests"
-    " for alternativesin common use cases."
+    " for alternatives in common use cases."
 )
 
 KEYWORD_MSG_ARG = UnformattedWarning(

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -89,7 +89,10 @@ NODE_CTOR_FSPATH_ARG = UnformattedWarning(
 
 WARNS_NONE_ARG = PytestRemovedIn8Warning(
     "Passing None to catch any warning has been deprecated, pass no arguments instead:\n"
-    " Replace pytest.warns(None) by simply pytest.warns()."
+    "Replace pytest.warns(None) by simply pytest.warns().\n"
+    "See https://docs.pytest.org/en/latest/deprecations.html"
+    "#using-pytest-warns-none"
+    " on asserting no warnings were emitted."
 )
 
 KEYWORD_MSG_ARG = UnformattedWarning(

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -88,11 +88,10 @@ NODE_CTOR_FSPATH_ARG = UnformattedWarning(
 )
 
 WARNS_NONE_ARG = PytestRemovedIn8Warning(
-    "Passing None to catch any warning has been deprecated, pass no arguments instead:\n"
-    "Replace pytest.warns(None) by simply pytest.warns().\n"
-    "See https://docs.pytest.org/en/latest/deprecations.html"
-    "#using-pytest-warns-none"
-    " on asserting no warnings were emitted."
+    "Passing None has been deprecated.\n"
+    "See https://docs.pytest.org/en/latest/how-to/capture-warnings.html"
+    "#additional-use-cases-of-warnings-in-tests"
+    " for alternativesin common use cases."
 )
 
 KEYWORD_MSG_ARG = UnformattedWarning(

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -138,8 +138,11 @@ def test_warns_none_is_deprecated():
     with pytest.warns(
         PytestDeprecationWarning,
         match=re.escape(
-            "Passing None to catch any warning has been deprecated, pass no arguments instead:\n "
-            "Replace pytest.warns(None) by simply pytest.warns()."
+            "Passing None to catch any warning has been deprecated, pass no arguments instead:\n"
+            "Replace pytest.warns(None) by simply pytest.warns().\n"
+            "See https://docs.pytest.org/en/latest/deprecations.html"
+            "#using-pytest-warns-none"
+            " on asserting no warnings were emitted."
         ),
     ):
         with pytest.warns(None):  # type: ignore[call-overload]

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -138,11 +138,10 @@ def test_warns_none_is_deprecated():
     with pytest.warns(
         PytestDeprecationWarning,
         match=re.escape(
-            "Passing None to catch any warning has been deprecated, pass no arguments instead:\n"
-            "Replace pytest.warns(None) by simply pytest.warns().\n"
-            "See https://docs.pytest.org/en/latest/deprecations.html"
-            "#using-pytest-warns-none"
-            " on asserting no warnings were emitted."
+            "Passing None has been deprecated.\n"
+            "See https://docs.pytest.org/en/latest/how-to/capture-warnings.html"
+            "#additional-use-cases-of-warnings-in-tests"
+            " for alternativesin common use cases."
         ),
     ):
         with pytest.warns(None):  # type: ignore[call-overload]

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -141,7 +141,7 @@ def test_warns_none_is_deprecated():
             "Passing None has been deprecated.\n"
             "See https://docs.pytest.org/en/latest/how-to/capture-warnings.html"
             "#additional-use-cases-of-warnings-in-tests"
-            " for alternativesin common use cases."
+            " for alternatives in common use cases."
         ),
     ):
         with pytest.warns(None):  # type: ignore[call-overload]


### PR DESCRIPTION
Closes https://github.com/pytest-dev/pytest/issues/9404.

I added more context on the deprecation doc, but I have been wondering whether it would be useful to have these example on [the main doc of `pytest.warns()`](https://docs.pytest.org/en/latest/reference/reference.html?highlight=warns#pytest-warns), as people might not reach the first one.

Thoughts?

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
