### PR TITLE
Improve on configuration file docs section

### DIFF
--- a/changelog/9505.trivial.rst
+++ b/changelog/9505.trivial.rst
@@ -1,0 +1,2 @@
+Clarify where the configuration files are located. To avoid confusions documentation mentions
+that configuration file is located in the root of the repository.

--- a/doc/en/reference/customize.rst
+++ b/doc/en/reference/customize.rst
@@ -20,8 +20,7 @@ Configuration file formats
 --------------------------
 
 Many :ref:`pytest settings <ini options ref>` can be set in a *configuration file*, which
-by convention resides on the root of your repository or in your
-tests folder.
+by convention resides on the root of your repository.
 
 A quick example of the configuration files supported by pytest:
 

--- a/doc/en/reference/customize.rst
+++ b/doc/en/reference/customize.rst
@@ -20,7 +20,7 @@ Configuration file formats
 --------------------------
 
 Many :ref:`pytest settings <ini options ref>` can be set in a *configuration file*, which
-by convention resides on the root of your repository.
+by convention resides in the root directory of your repository.
 
 A quick example of the configuration files supported by pytest:
 


### PR DESCRIPTION
To avoid confusions the part of that "the configuration file can
be locate on your tests folder" is removed.

closes #9505 

- [X] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

