### PR TITLE
Expose FixtureDef and SubRequest

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,6 +26,7 @@ Andrea Cimatoribus
 Andreas Motl
 Andreas Zeidler
 Andrew Shapton
+Andrew Svetlov
 Andrey Paramonov
 Andrzej Klajnert
 Andrzej Ostrowski

--- a/changelog/9510.feature.rst
+++ b/changelog/9510.feature.rst
@@ -1,0 +1,9 @@
+Fixture types are now exported so the may be used in pytest plugin hooks.
+
+  The newly-exported types are:
+
+  - ``pytest.FixtureDef`` for :class:`FixtureDef <pytest.FixtureDef>`
+  - ``pytest.SubRequest`` for ``_pytest.fixtures.SubRequest``  (derived from :class:`FixtureRequest <pytest.FixtureRequest`).
+
+
+  They are used by ``pytest_fixture_setup`` and ``pytest_fixture_post_finalizer`` hook definitions.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -905,7 +905,7 @@ File
 FixtureDef
 ~~~~~~~~~~
 
-.. autoclass:: _pytest.fixtures.FixtureDef()
+.. autoclass:: pytest.FixtureDef()
     :members:
     :show-inheritance:
 

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -19,8 +19,10 @@ from _pytest.config.argparsing import OptionGroup
 from _pytest.config.argparsing import Parser
 from _pytest.debugging import pytestPDB as __pytestPDB
 from _pytest.fixtures import fixture
+from _pytest.fixtures import FixtureDef
 from _pytest.fixtures import FixtureLookupError
 from _pytest.fixtures import FixtureRequest
+from _pytest.fixtures import SubRequest
 from _pytest.fixtures import yield_fixture
 from _pytest.freeze_support import freeze_includes
 from _pytest.legacypath import TempdirFactory
@@ -97,8 +99,10 @@ __all__ = [
     "fail",
     "File",
     "fixture",
+    "FixtureDef",
     "FixtureLookupError",
     "FixtureRequest",
+    "SubRequest",
     "freeze_includes",
     "Function",
     "hookimpl",


### PR DESCRIPTION
Export names required by `pytest_fixture_setup` and `pytest_fixture_post_finalizer` hook specs.