### PR TITLE
upgrade flake8-typing-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     -   id: flake8
         language_version: python3
         additional_dependencies:
-          - flake8-typing-imports==1.9.0
+          - flake8-typing-imports==1.12.0
           - flake8-docstrings==1.5.0
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v2.6.0


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos