### PR TITLE
doc: Add ellipsis to warning usecase list

### DIFF
--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -363,7 +363,7 @@ Here are some use cases involving warnings that often come up in tests, and sugg
 .. code-block:: python
 
     with pytest.warns():
-        pass
+        ...
 
 -  To ensure that **no** warnings are emitted, use:
 
@@ -371,6 +371,7 @@ Here are some use cases involving warnings that often come up in tests, and sugg
 
     with warnings.catch_warnings():
         warnings.simplefilter("error")
+        ...
 
 - To suppress warnings, use:
 
@@ -378,6 +379,7 @@ Here are some use cases involving warnings that often come up in tests, and sugg
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
+        ...
 
 
 .. _custom_failure_messages:


### PR DESCRIPTION
I feel like this makes it clearer where the code which was inside 'pytest.warns' is supposed to go.

Follow-up for #9495 - great work there, @olgarithms, this is just something minor that only came to mind when I re-read it now.