### PR TITLE
[7.0.x] ci: Bump up timeout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ permissions: {}
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
 


### PR DESCRIPTION
macOS apparently can be slow, https://github.com/pytest-dev/pytest/runs/4965510831 for #9556 got cancelled at 91%

(cherry picked from commit 7bffcd0ac46befcf17708452fa3bed8b68116235)

Manual backport of #9560