### PR TITLE
Added logging-level link to logging level table

### DIFF
--- a/doc/en/logging.rst
+++ b/doc/en/logging.rst
@@ -270,3 +270,5 @@ file:
 
 More details about the discussion that lead to this changes can be read in
 issue `#3013 <https://github.com/pytest-dev/pytest/issues/3013>`_.
+
+Log level table can be read at `logging-level <https://docs.python.org/3/library/logging.html#logging-levels>`_

--- a/doc/en/logging.rst
+++ b/doc/en/logging.rst
@@ -183,7 +183,7 @@ logging records as they are emitted directly into the console.
 
 You can specify the logging level for which log records with equal or higher
 level are printed to the console by passing ``--log-cli-level``. This setting
-accepts the logging level names as seen in python's documentation or an integer
+accepts the logging level names as seen in `python's documentation <https://docs.python.org/3/library/logging.html#logging-levels>`_ or an integer
 as the logging level num.
 
 Additionally, you can also specify ``--log-cli-format`` and
@@ -270,5 +270,3 @@ file:
 
 More details about the discussion that lead to this changes can be read in
 issue `#3013 <https://github.com/pytest-dev/pytest/issues/3013>`_.
-
-Log level table can be read at `logging-level <https://docs.python.org/3/library/logging.html#logging-levels>`_


### PR DESCRIPTION
This PR adds a link to the log level table for quick look up of all logging options.