### PR TITLE
Backport #9417 to 6.2.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
             os: windows-latest
             tox_env: "py39-xdist"
           - name: "windows-py310"
-            python: "3.10-dev"
+            python: "3.10.1"
             os: windows-latest
             tox_env: "py310-xdist"
 
@@ -105,7 +105,7 @@ jobs:
             os: ubuntu-latest
             tox_env: "py39-xdist"
           - name: "ubuntu-py310"
-            python: "3.10-dev"
+            python: "3.10.1"
             os: ubuntu-latest
             tox_env: "py310-xdist"
           - name: "ubuntu-pypy3"

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -1126,8 +1126,6 @@ def test_errors_in_xfail_skip_expressions(pytester: Pytester) -> None:
     pypy_version_info = getattr(sys, "pypy_version_info", None)
     if pypy_version_info is not None and pypy_version_info < (6,):
         markline = markline[5:]
-    elif sys.version_info[:2] >= (3, 10):
-        markline = markline[11:]
     elif sys.version_info >= (3, 8) or hasattr(sys, "pypy_version_info"):
         markline = markline[4:]
 


### PR DESCRIPTION
Please backport the py3.10 fix to 6.2.x. It applies cleanly and fixes the test failures. It will take some time before everyone's ready for 7.0.0, so fixing 6.2.x seems to be the right thing to do.