### PR TITLE
Backport 8664 to 6.2.x

### DIFF
--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -533,7 +533,9 @@ class TestTrialUnittest:
                 # will crash both at test time and at teardown
         """
         )
-        result = testdir.runpytest("-vv", "-oconsole_output_style=classic")
+        result = testdir.runpytest(
+            "-vv", "-oconsole_output_style=classic", "-W", "ignore::DeprecationWarning"
+        )
         result.stdout.fnmatch_lines(
             [
                 "test_trial_error.py::TC::test_four FAILED",


### PR DESCRIPTION
Please backport #8664 to 6.2.x branch. Note that I had to modify the code to keep using `testdir.runpytest()`.