### PR TITLE
Backport #9512 to 6.2.x

### DIFF
--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1247,9 +1247,19 @@ def test_load_initial_conftest_last_ordering(_config_for_test):
     m = My()
     pm.register(m)
     hc = pm.hook.pytest_load_initial_conftests
-    values = hc._nonwrappers + hc._wrappers
-    expected = ["_pytest.config", m.__module__, "_pytest.capture", "_pytest.warnings"]
-    assert [x.function.__module__ for x in values] == expected
+    hookimpls = [
+        (
+            hookimpl.function.__module__,
+            "wrapper" if hookimpl.hookwrapper else "nonwrapper",
+        )
+        for hookimpl in hc.get_hookimpls()
+    ]
+    assert hookimpls == [
+        ("_pytest.config", "nonwrapper"),
+        (m.__module__, "nonwrapper"),
+        ("_pytest.capture", "wrapper"),
+        ("_pytest.warnings", "wrapper"),
+    ]
 
 
 def test_get_plugin_specs_as_list() -> None:


### PR DESCRIPTION
I had to update the `hookimpls` list to match the original as of 6.2.x.