### PR TITLE
releasing: Always set doc_version

### DIFF
--- a/scripts/prepare-release-pr.py
+++ b/scripts/prepare-release-pr.py
@@ -90,13 +90,10 @@ def prepare_release_pr(
 
     if prerelease:
         template_name = "release.pre.rst"
-        doc_version = release_branch
     elif is_feature_release:
         template_name = "release.minor.rst"
-        doc_version = ""  # unused in template
     else:
         template_name = "release.patch.rst"
-        doc_version = ""  # unused in template
 
     # important to use tox here because we have changed branches, so dependencies
     # might have changed as well
@@ -107,7 +104,7 @@ def prepare_release_pr(
         "--",
         version,
         template_name,
-        doc_version,
+        release_branch,  # doc_version
         "--skip-check-links",
     ]
     print("Running", " ".join(cmdline))


### PR DESCRIPTION
Looks like something (tox?) does not deal with empty arguments being passed to release.py correctly...

See https://github.com/pytest-dev/pytest/runs/5049339603?check_suite_focus=true#step:6:61