### PR TITLE
releasing: Add template for major releases

### DIFF
--- a/scripts/prepare-release-pr.py
+++ b/scripts/prepare-release-pr.py
@@ -88,7 +88,9 @@ def prepare_release_pr(
 
     print(f"Branch {Fore.CYAN}{release_branch}{Fore.RESET} created.")
 
-    if prerelease:
+    if is_major:
+        template_name = "release.major.rst"
+    elif prerelease:
         template_name = "release.pre.rst"
     elif is_feature_release:
         template_name = "release.minor.rst"

--- a/scripts/release.major.rst
+++ b/scripts/release.major.rst
@@ -3,8 +3,8 @@ pytest-{version}
 
 The pytest team is proud to announce the {version} release!
 
-This release contains new features, improvements, and bug fixes,
-A full list of changes is available in the changelog:
+This release contains new features, improvements, bug fixes, and breaking changes, so users
+are encouraged to take a look at the CHANGELOG carefully:
 
     https://docs.pytest.org/en/stable/changelog.html
 

--- a/scripts/release.minor.rst
+++ b/scripts/release.minor.rst
@@ -4,7 +4,7 @@ pytest-{version}
 The pytest team is proud to announce the {version} release!
 
 This release contains new features, improvements, and bug fixes,
-A full list of changes is available in the changelog:
+the full list of changes is available in the changelog:
 
     https://docs.pytest.org/en/stable/changelog.html
 


### PR DESCRIPTION
With pytest 6.0.0, we still used a manual releasing workflow (at least if I
remember correctly), and apparently we never wrote a release announcement
template for major releases. Instead, the minor release template claimed that
the release would contain "breaking changes", which doesn't seem reasonable.
Thus, this adds a new major template based on the former minor template, and
adjusts the latter to only mention fixes and new features instead.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
