### PR TITLE
doc: Streamline remote handling in releasing docs

### DIFF
--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -37,7 +37,7 @@ breaking changes or new features.
 
 For a new minor release, first create a new maintenance branch from ``main``::
 
-     git fetch --all
+     git fetch upstream
      git branch 7.1.x upstream/main
      git push upstream 7.1.x
 
@@ -63,7 +63,7 @@ Major releases
 
 1. Create a new maintenance branch from ``main``::
 
-        git fetch --all
+        git fetch upstream
         git branch 8.0.x upstream/main
         git push upstream 8.0.x
 
@@ -136,9 +136,9 @@ Both automatic and manual processes described above follow the same steps from t
 #. After all tests pass and the PR has been approved, tag the release commit
    in the ``release-MAJOR.MINOR.PATCH`` branch and push it. This will publish to PyPI::
 
-     git fetch --all
+     git fetch upstream
      git tag MAJOR.MINOR.PATCH upstream/release-MAJOR.MINOR.PATCH
-     git push git@github.com:pytest-dev/pytest.git MAJOR.MINOR.PATCH
+     git push upstream MAJOR.MINOR.PATCH
 
    Wait for the deploy to complete, then make sure it is `available on PyPI <https://pypi.org/project/pytest>`_.
 
@@ -146,7 +146,7 @@ Both automatic and manual processes described above follow the same steps from t
 
 #. Cherry-pick the CHANGELOG / announce files to the ``main`` branch::
 
-       git fetch --all --prune
+       git fetch upstream
        git checkout upstream/main -b cherry-pick-release
        git cherry-pick -x -m1 upstream/MAJOR.MINOR.x
 
@@ -158,7 +158,7 @@ Both automatic and manual processes described above follow the same steps from t
        git checkout main
        git pull
        git tag MAJOR.{MINOR+1}.0.dev0
-       git push git@github.com:pytest-dev/pytest.git MAJOR.{MINOR+1}.0.dev0
+       git push upstream MAJOR.{MINOR+1}.0.dev0
 
 #. Send an email announcement with the contents from::
 


### PR DESCRIPTION
The docs already assume an 'upstream' remote, so we can only fetch from there instead of fetching all remotes. We also don't need to hardcode the remote URL.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
