### PR TITLE
Mention basetemp in docs as a way to only keep last temp dir

### DIFF
--- a/doc/en/how-to/tmp_path.rst
+++ b/doc/en/how-to/tmp_path.rst
@@ -122,7 +122,7 @@ the system temporary directory.  The base name will be ``pytest-NUM`` where
 than 3 temporary directories will be removed.
 
 The number of entries currently cannot be changed, but using the ``--basetemp``
-option will remove the directory before every run. Effectively meaning the tempfiles
+option will remove the directory before every run, effectively meaning the temporary directories
 of only the most recent run will be kept.
 
 You can override the default temporary directory setting like this:

--- a/doc/en/how-to/tmp_path.rst
+++ b/doc/en/how-to/tmp_path.rst
@@ -121,6 +121,10 @@ the system temporary directory.  The base name will be ``pytest-NUM`` where
 ``NUM`` will be incremented with each test run.  Moreover, entries older
 than 3 temporary directories will be removed.
 
+The number of entries currently cannot be changed, but using the ``--basetemp``
+option will remove the directory before every run. Effectively meaning the tempfiles
+of only the most recent run will be kept.
+
 You can override the default temporary directory setting like this:
 
 .. code-block:: bash


### PR DESCRIPTION
Help people who might want to reduce the number of temporary directories kept. See #9599