### PR TITLE
importlib.readers not valid until python 3.10

### DIFF
--- a/changelog/9608.bugfix.rst
+++ b/changelog/9608.bugfix.rst
@@ -1,0 +1,1 @@
+Fix invalid importing of ``importlib.reader`` in Python 3.9.

--- a/changelog/9608.bugfix.rst
+++ b/changelog/9608.bugfix.rst
@@ -1,1 +1,1 @@
-Fix invalid importing of ``importlib.reader`` in Python 3.9.
+Fix invalid importing of ``importlib.readers`` in Python 3.9.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -43,7 +43,7 @@ from _pytest.stash import StashKey
 
 if TYPE_CHECKING:
     from _pytest.assertion import AssertionState
-    
+
 
 assertstate_key = StashKey["AssertionState"]()
 
@@ -280,7 +280,7 @@ class AssertionRewritingHook(importlib.abc.MetaPathFinder, importlib.abc.Loader)
                 from importlib.readers import FileReader
             else:
                 from importlib.resources.readers import FileReader
-                
+
             return FileReader(types.SimpleNamespace(path=self._rewritten_names[name]))
 
 

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -43,11 +43,7 @@ from _pytest.stash import StashKey
 
 if TYPE_CHECKING:
     from _pytest.assertion import AssertionState
-
-if sys.version_info >= (3, 11):
-    from importlib.resources.readers import FileReader
-elif sys.version_info >= (3, 10):
-    from importlib.readers import FileReader
+    
 
 assertstate_key = StashKey["AssertionState"]()
 
@@ -280,6 +276,11 @@ class AssertionRewritingHook(importlib.abc.MetaPathFinder, importlib.abc.Loader)
     if sys.version_info >= (3, 10):
 
         def get_resource_reader(self, name: str) -> importlib.abc.TraversableResources:  # type: ignore
+            if sys.version_info < (3, 11):
+                from importlib.readers import FileReader
+            else:
+                from importlib.resources.readers import FileReader
+                
             return FileReader(types.SimpleNamespace(path=self._rewritten_names[name]))
 
 

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -44,6 +44,8 @@ from _pytest.stash import StashKey
 if TYPE_CHECKING:
     from _pytest.assertion import AssertionState
 
+if sys.version_info >= (3, 10):
+    from importlib.readers import FileReader
 
 assertstate_key = StashKey["AssertionState"]()
 
@@ -276,10 +278,7 @@ class AssertionRewritingHook(importlib.abc.MetaPathFinder, importlib.abc.Loader)
     if sys.version_info >= (3, 10):
 
         def get_resource_reader(self, name: str) -> importlib.abc.TraversableResources:  # type: ignore
-            from types import SimpleNamespace
-            from importlib.readers import FileReader
-
-            return FileReader(SimpleNamespace(path=self._rewritten_names[name]))
+            return FileReader(types.SimpleNamespace(path=self._rewritten_names[name]))
 
 
 def _write_pyc_fp(

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -44,7 +44,9 @@ from _pytest.stash import StashKey
 if TYPE_CHECKING:
     from _pytest.assertion import AssertionState
 
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 11):
+    from importlib.resources.readers import FileReader
+elif sys.version_info >= (3, 10):
     from importlib.readers import FileReader
 
 assertstate_key = StashKey["AssertionState"]()

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -273,7 +273,7 @@ class AssertionRewritingHook(importlib.abc.MetaPathFinder, importlib.abc.Loader)
         with open(pathname, "rb") as f:
             return f.read()
 
-    if sys.version_info >= (3, 9):
+    if sys.version_info >= (3, 10):
 
         def get_resource_reader(self, name: str) -> importlib.abc.TraversableResources:  # type: ignore
             from types import SimpleNamespace


### PR DESCRIPTION
This exists https://github.com/python/cpython/blob/3.10/Lib/importlib/readers.py and FileReader is in there
This is a 404 https://github.com/python/cpython/blob/3.9/Lib/importlib/readers.py

This change needs to get backported to the 7.0.z branch(s) too
closes https://github.com/pytest-dev/pytest/issues/9608

I'm going to go ahead and open this PR, if you think we need a changelog for this LMK

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
