### PR TITLE
mark/structures: use class-based NamedTuple syntax

### DIFF
--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -72,16 +72,11 @@ def get_empty_parameterset_mark(
     return mark
 
 
-class ParameterSet(
-    NamedTuple(
-        "ParameterSet",
-        [
-            ("values", Sequence[Union[object, NotSetType]]),
-            ("marks", Collection[Union["MarkDecorator", "Mark"]]),
-            ("id", Optional[str]),
-        ],
-    )
-):
+class ParameterSet(NamedTuple):
+    values: Sequence[Union[object, NotSetType]]
+    marks: Collection[Union["MarkDecorator", "Mark"]]
+    id: Optional[str]
+
     @classmethod
     def param(
         cls,


### PR DESCRIPTION
Should hopefully work now in Python>=3.7.