### PR TITLE
unittest: restore `UnitTestFunction.obj` to return unbound rather than bound method

### DIFF
--- a/changelog/9610.bugfix.rst
+++ b/changelog/9610.bugfix.rst
@@ -1,0 +1,3 @@
+Restore `UnitTestFunction.obj` to return unbound rather than bound method.
+Fixes a crash during a failed teardown in unittest TestCases with non-default `__init__`.
+Regressed in pytest 7.0.0.

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -185,6 +185,15 @@ class TestCaseFunction(Function):
     _excinfo: Optional[List[_pytest._code.ExceptionInfo[BaseException]]] = None
     _testcase: Optional["unittest.TestCase"] = None
 
+    def _getobj(self):
+        assert self.parent is not None
+        # Unlike a regular Function in a Class, where `item.obj` returns
+        # a *bound* method (attached to an instance), TestCaseFunction's
+        # `obj` returns an *unbound* method (not attached to an instance).
+        # This inconsistency is probably not desirable, but needs some
+        # consideration before changing.
+        return getattr(self.parent.obj, self.originalname)  # type: ignore[attr-defined]
+
     def setup(self) -> None:
         # A bound method to be called during teardown() if set (see 'runtest()').
         self._explicit_tearDown: Optional[Callable[[], None]] = None


### PR DESCRIPTION
This fixes #9610. Test case by @jiridanek.

pytest 7.0.0 (unintentionally) changed `UnitTestFunction.obj`'s behavior
to match `Function.obj`. That is probably a good thing to have, however
it evidently causes some regressions as described in the issue, so
restore the previous behavior for now. In the future we might want to
make this change again, but with proper consideration.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
