### PR TITLE
Fix count of selected tests on terminal collection summary

### DIFF
--- a/changelog/9626.bugfix.rst
+++ b/changelog/9626.bugfix.rst
@@ -1,0 +1,3 @@
+Fix count of selected tests on terminal collection summary.
+
+If there were errors or skipped modules on collection, pytest would mistakenly subtract those from the selected count.

--- a/changelog/9626.bugfix.rst
+++ b/changelog/9626.bugfix.rst
@@ -1,3 +1,3 @@
-Fix count of selected tests on terminal collection summary.
+Fixed count of selected tests on terminal collection summary when there were errors or skipped modules.
 
 If there were errors or skipped modules on collection, pytest would mistakenly subtract those from the selected count.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -663,7 +663,7 @@ class TerminalReporter:
         errors = len(self.stats.get("error", []))
         skipped = len(self.stats.get("skipped", []))
         deselected = len(self.stats.get("deselected", []))
-        selected = self._numcollected - errors - skipped - deselected
+        selected = self._numcollected - deselected
         line = "collected " if final else "collecting "
         line += (
             str(self._numcollected) + " item" + ("" if self._numcollected == 1 else "s")
@@ -674,7 +674,7 @@ class TerminalReporter:
             line += " / %d deselected" % deselected
         if skipped:
             line += " / %d skipped" % skipped
-        if self._numcollected > selected > 0:
+        if self._numcollected > selected:
             line += " / %d selected" % selected
         if self.isatty:
             self.rewrite(line, bold=True, erase=True)

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -773,7 +773,7 @@ class TestLastFailed:
         result = pytester.runpytest("--lf", "--lfnf", "none")
         result.stdout.fnmatch_lines(
             [
-                "collected 2 items / 2 deselected",
+                "collected 2 items / 2 deselected / 0 selected",
                 "run-last-failure: no previously failed tests, deselecting all items.",
                 "deselected=2",
                 "* 2 deselected in *",

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -783,6 +783,33 @@ class TestTerminalFunctional:
         result.stdout.no_fnmatch_line("*= 1 deselected =*")
         assert result.ret == 0
 
+    def test_selected_count_with_error(self, pytester: Pytester) -> None:
+        testpath = pytester.makepyfile(
+            test_selected_count_3="""
+                def test_one():
+                    pass
+                def test_two():
+                    pass
+                def test_three():
+                    pass
+            """,
+            test_selected_count_error="""
+                5/0
+                def test_foo():
+                    pass
+                def test_bar():
+                    pass
+            """,
+        )
+        result = pytester.runpytest("-k", "test_t")
+        result.stdout.fnmatch_lines(
+            [
+                "collected 3 items / 1 error / 1 deselected / 2 selected",
+                "* ERROR collecting test_selected_count_error.py *",
+            ]
+        )
+        assert result.ret == ExitCode.INTERRUPTED
+
     def test_no_skip_summary_if_failure(self, pytester: Pytester) -> None:
         pytester.makepyfile(
             """

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -784,7 +784,7 @@ class TestTerminalFunctional:
         assert result.ret == 0
 
     def test_selected_count_with_error(self, pytester: Pytester) -> None:
-        testpath = pytester.makepyfile(
+        pytester.makepyfile(
             test_selected_count_3="""
                 def test_one():
                     pass


### PR DESCRIPTION
If there were errors or skipped modules on collection,
pytest would mistakenly subtract those from the selected count.

Close #9626

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ X] Include documentation when adding new features.
- [ X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
