### PR TITLE
doc: remove django intersphinx mapping

### DIFF
--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -382,7 +382,6 @@ texinfo_documents = [
 ]
 
 
-# Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "pluggy": ("https://pluggy.readthedocs.io/en/stable", None),
     "python": ("https://docs.python.org/3", None),
@@ -390,10 +389,6 @@ intersphinx_mapping = {
     "pip": ("https://pip.pypa.io/en/stable", None),
     "tox": ("https://tox.wiki/en/stable", None),
     "virtualenv": ("https://virtualenv.pypa.io/en/stable", None),
-    "django": (
-        "http://docs.djangoproject.com/en/stable",
-        "http://docs.djangoproject.com/en/stable/_objects",
-    ),
     "setuptools": ("https://setuptools.pypa.io/en/stable", None),
 }
 

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -16,7 +16,7 @@ Deprecated Features
 -------------------
 
 Below is a complete list of all pytest features which are considered deprecated. Using those features will issue
-:class:`PytestWarning` or subclasses, which can be filtered using :ref:`standard warning filters <warnings>`.
+:class:`~pytest.PytestWarning` or subclasses, which can be filtered using :ref:`standard warning filters <warnings>`.
 
 .. _instance-collector-deprecation:
 

--- a/doc/en/how-to/plugins.rst
+++ b/doc/en/how-to/plugins.rst
@@ -21,7 +21,7 @@ there is no need to activate it.
 Here is a little annotated list for some popular plugins:
 
 * :pypi:`pytest-django`: write tests
-  for :std:doc:`django <django:index>` apps, using pytest integration.
+  for `django <https://docs.djangoproject.com/>`_ apps, using pytest integration.
 
 * :pypi:`pytest-twisted`: write tests
   for `twisted <https://twistedmatrix.com/>`_ apps, starting a reactor and


### PR DESCRIPTION
Initially I just wanted to fix http -> https, but I think it's not worth
having at all just for this one reference.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
