### PR TITLE
fix test pollution in test_assertrewrite

### DIFF
--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -802,11 +802,12 @@ class TestDoctests:
         p = pytester.makepyfile(
             setup="""
             from setuptools import setup, find_packages
-            setup(name='sample',
-                  version='0.0',
-                  description='description',
-                  packages=find_packages()
-            )
+            if __name__ == '__main__':
+                setup(name='sample',
+                      version='0.0',
+                      description='description',
+                      packages=find_packages()
+                )
         """
         )
         result = pytester.runpytest(p, "--doctest-modules")


### PR DESCRIPTION
originally reproduced with this pollution set:

```
testing/test_assertrewrite.py::TestEarlyRewriteBailout::test_pattern_contains_subdirectories
testing/test_assertrewrite.py::TestRewriteOnImport::test_remember_rewritten_modules
```
