### PR TITLE
allow running testids which contain :: in the parametrized portion

### DIFF
--- a/changelog/9642.bugfix.rst
+++ b/changelog/9642.bugfix.rst
@@ -1,0 +1,1 @@
+Fix running tests by id with ``::`` in the parametrize portion.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -870,7 +870,10 @@ def resolve_collection_argument(
     If the path doesn't exist, raise UsageError.
     If the path is a directory and selection parts are present, raise UsageError.
     """
-    strpath, *parts = str(arg).split("::")
+    base, squacket, rest = str(arg).partition("[")
+    strpath, *parts = base.split("::")
+    if parts:
+        parts[-1] = f"{parts[-1]}{squacket}{rest}"
     if as_pypath:
         strpath = search_pypath(strpath)
     fspath = invocation_path / strpath

--- a/testing/test_main.py
+++ b/testing/test_main.py
@@ -171,6 +171,12 @@ class TestResolveCollectionArgument:
                 invocation_path, "pkg::foo::bar", as_pypath=True
             )
 
+    def test_parametrized_name_with_colons(self, invocation_path: Path) -> None:
+        ret = resolve_collection_argument(
+            invocation_path, "src/pkg/test.py::test[a::b]"
+        )
+        assert ret == (invocation_path / "src/pkg/test.py", ["test[a::b]"])
+
     def test_does_not_exist(self, invocation_path: Path) -> None:
         """Given a file/module that does not exist raises UsageError."""
         with pytest.raises(


### PR DESCRIPTION
for example in pytest's suite:

before this was failing with:

```console
$ pytest testing/test_mark_expression.py::test_valid_idents[:::]
============================= test session starts ==============================
platform linux -- Python 3.8.10, pytest-7.1.0.dev178+g6f936aa97, pluggy-1.0.0
rootdir: /tmp/y/pytest, configfile: pyproject.toml
plugins: hypothesis-6.36.1
collected 0 items                                                              

============================ no tests ran in 0.03s =============================
ERROR: not found: /tmp/y/pytest/testing/test_mark_expression.py::test_valid_idents[:::]
(no name '/tmp/y/pytest/testing/test_mark_expression.py::test_valid_idents[:::]' in any of [<Module testing/test_mark_expression.py>])
```