### PR TITLE
Fix diff output for data types where `-v` would show less information

### DIFF
--- a/changelog/5192.improvement.rst
+++ b/changelog/5192.improvement.rst
@@ -1,0 +1,3 @@
+Fixed test output for some data types where ``-v`` would show less information.
+
+Also, when showing diffs for sequences, ``-q`` would produce full diffs instead of the expected diff.

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -223,8 +223,6 @@ def _compare_eq_any(left: Any, right: Any, verbose: int = 0) -> List[str]:
             explanation = _compare_eq_set(left, right, verbose)
         elif isdict(left) and isdict(right):
             explanation = _compare_eq_dict(left, right, verbose)
-        elif verbose > 0:
-            explanation = _compare_eq_verbose(left, right)
 
         if isiterable(left) and isiterable(right):
             expl = _compare_eq_iterable(left, right, verbose)
@@ -281,18 +279,6 @@ def _diff_text(left: str, right: str, verbose: int = 0) -> List[str]:
     return explanation
 
 
-def _compare_eq_verbose(left: Any, right: Any) -> List[str]:
-    keepends = True
-    left_lines = repr(left).splitlines(keepends)
-    right_lines = repr(right).splitlines(keepends)
-
-    explanation: List[str] = []
-    explanation += ["+" + line for line in left_lines]
-    explanation += ["-" + line for line in right_lines]
-
-    return explanation
-
-
 def _surrounding_parens_on_own_lines(lines: List[str]) -> None:
     """Move opening/closing parenthesis/bracket to own lines."""
     opening = lines[0][:1]
@@ -308,8 +294,8 @@ def _surrounding_parens_on_own_lines(lines: List[str]) -> None:
 def _compare_eq_iterable(
     left: Iterable[Any], right: Iterable[Any], verbose: int = 0
 ) -> List[str]:
-    if not verbose and not running_on_ci():
-        return ["Use -v to get the full diff"]
+    if verbose <= 0 and not running_on_ci():
+        return ["Use -v to get more diff"]
     # dynamic import to speedup pytest
     import difflib
 

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1238,8 +1238,6 @@ def test_pdb_can_be_rewritten(pytester: Pytester) -> None:
             "    def check():",
             ">       assert 1 == 2",
             "E       assert 1 == 2",
-            "E         +1",
-            "E         -2",
             "",
             "pdb.py:2: AssertionError",
             "*= 1 failed in *",

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -83,7 +83,7 @@ class TestImportHookInstallation:
                 "E       assert {'failed': 1,... 'skipped': 0} == {'failed': 0,... 'skipped': 0}",
                 "E         Omitting 1 identical items, use -vv to show",
                 "E         Differing items:",
-                "E         Use -v to get the full diff",
+                "E         Use -v to get more diff",
             ]
         )
         # XXX: unstable output.
@@ -376,7 +376,7 @@ class TestAssert_reprcompare:
         assert diff == [
             "b'spam' == b'eggs'",
             "At index 0 diff: b's' != b'e'",
-            "Use -v to get the full diff",
+            "Use -v to get more diff",
         ]
 
     def test_bytes_diff_verbose(self) -> None:
@@ -444,10 +444,18 @@ class TestAssert_reprcompare:
         """
         expl = callequal(left, right, verbose=0)
         assert expl is not None
-        assert expl[-1] == "Use -v to get the full diff"
+        assert expl[-1] == "Use -v to get more diff"
         verbose_expl = callequal(left, right, verbose=1)
         assert verbose_expl is not None
         assert "\n".join(verbose_expl).endswith(textwrap.dedent(expected).strip())
+
+    def test_iterable_quiet(self) -> None:
+        expl = callequal([1, 2], [10, 2], verbose=-1)
+        assert expl == [
+            "[1, 2] == [10, 2]",
+            "At index 0 diff: 1 != 10",
+            "Use -v to get more diff",
+        ]
 
     def test_iterable_full_diff_ci(
         self, monkeypatch: MonkeyPatch, pytester: Pytester
@@ -466,7 +474,7 @@ class TestAssert_reprcompare:
 
         monkeypatch.delenv("CI", raising=False)
         result = pytester.runpytest()
-        result.stdout.fnmatch_lines(["E         Use -v to get the full diff"])
+        result.stdout.fnmatch_lines(["E         Use -v to get more diff"])
 
     def test_list_different_lengths(self) -> None:
         expl = callequal([0, 1], [0, 1, 2])
@@ -699,32 +707,6 @@ class TestAssert_reprcompare:
         assert expl is not None
         assert len(expl) > 1
 
-    def test_repr_verbose(self) -> None:
-        class Nums:
-            def __init__(self, nums):
-                self.nums = nums
-
-            def __repr__(self):
-                return str(self.nums)
-
-        list_x = list(range(5000))
-        list_y = list(range(5000))
-        list_y[len(list_y) // 2] = 3
-        nums_x = Nums(list_x)
-        nums_y = Nums(list_y)
-
-        assert callequal(nums_x, nums_y) is None
-
-        expl = callequal(nums_x, nums_y, verbose=1)
-        assert expl is not None
-        assert "+" + repr(nums_x) in expl
-        assert "-" + repr(nums_y) in expl
-
-        expl = callequal(nums_x, nums_y, verbose=2)
-        assert expl is not None
-        assert "+" + repr(nums_x) in expl
-        assert "-" + repr(nums_y) in expl
-
     def test_list_bad_repr(self) -> None:
         class A:
             def __repr__(self):
@@ -851,8 +833,6 @@ class TestAssert_reprcompare_dataclass:
                 "E           ",
                 "E           Drill down into differing attribute a:",
                 "E             a: 10 != 20",
-                "E             +10",
-                "E             -20",
                 "E           ",
                 "E           Drill down into differing attribute b:",
                 "E             b: 'ten' != 'xxx'",
@@ -1059,7 +1039,7 @@ class TestAssert_reprcompare_namedtuple:
             "  b: 'b' != 'c'",
             "  - c",
             "  + b",
-            "Use -v to get the full diff",
+            "Use -v to get more diff",
         ]
 
     def test_comparing_two_different_namedtuple(self) -> None:
@@ -1074,7 +1054,7 @@ class TestAssert_reprcompare_namedtuple:
         assert lines == [
             "NT1(a=1, b='b') == NT2(a=2, b='b')",
             "At index 0 diff: 1 != 2",
-            "Use -v to get the full diff",
+            "Use -v to get more diff",
         ]
 
 

--- a/testing/test_error_diffs.py
+++ b/testing/test_error_diffs.py
@@ -231,8 +231,6 @@ TESTCASES = [
         E         ['a']
         E         Drill down into differing attribute a:
         E           a: 1 != 2
-        E           +1
-        E           -2
         """,
         id="Compare data classes",
     ),


### PR DESCRIPTION
`_compare_eq_verbose` doesn't seem to useful in the end, with the examples we
have in the test suite.

Close #5192

cc @mdmintz