### PR TITLE
python: unify code to generate ID from value

### DIFF
--- a/changelog/9678.improvement.rst
+++ b/changelog/9678.improvement.rst
@@ -1,0 +1,3 @@
+More types are now accepted in the ``ids`` argument to ``@pytest.mark.parametrize``.
+Previously only `str`, `float`, `int` and `bool` were accepted;
+now `bytes`, `complex`, `re.Pattern`, `Enum` and anything with a `__name__` are also accepted.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -939,10 +939,7 @@ class FixtureDef(Generic[FixtureValue]):
         params: Optional[Sequence[object]],
         unittest: bool = False,
         ids: Optional[
-            Union[
-                Tuple[Union[None, str, float, int, bool], ...],
-                Callable[[Any], Optional[object]],
-            ]
+            Union[Tuple[Optional[object], ...], Callable[[Any], Optional[object]]]
         ] = None,
     ) -> None:
         self._fixturemanager = fixturemanager
@@ -1093,18 +1090,8 @@ def pytest_fixture_setup(
 
 
 def _ensure_immutable_ids(
-    ids: Optional[
-        Union[
-            Iterable[Union[None, str, float, int, bool]],
-            Callable[[Any], Optional[object]],
-        ]
-    ],
-) -> Optional[
-    Union[
-        Tuple[Union[None, str, float, int, bool], ...],
-        Callable[[Any], Optional[object]],
-    ]
-]:
+    ids: Optional[Union[Sequence[Optional[object]], Callable[[Any], Optional[object]]]]
+) -> Optional[Union[Tuple[Optional[object], ...], Callable[[Any], Optional[object]]]]:
     if ids is None:
         return None
     if callable(ids):
@@ -1148,9 +1135,8 @@ class FixtureFunctionMarker:
     scope: "Union[_ScopeName, Callable[[str, Config], _ScopeName]]"
     params: Optional[Tuple[object, ...]] = attr.ib(converter=_params_converter)
     autouse: bool = False
-    ids: Union[
-        Tuple[Union[None, str, float, int, bool], ...],
-        Callable[[Any], Optional[object]],
+    ids: Optional[
+        Union[Tuple[Optional[object], ...], Callable[[Any], Optional[object]]]
     ] = attr.ib(
         default=None,
         converter=_ensure_immutable_ids,
@@ -1191,10 +1177,7 @@ def fixture(
     params: Optional[Iterable[object]] = ...,
     autouse: bool = ...,
     ids: Optional[
-        Union[
-            Iterable[Union[None, str, float, int, bool]],
-            Callable[[Any], Optional[object]],
-        ]
+        Union[Sequence[Optional[object]], Callable[[Any], Optional[object]]]
     ] = ...,
     name: Optional[str] = ...,
 ) -> FixtureFunction:
@@ -1209,10 +1192,7 @@ def fixture(
     params: Optional[Iterable[object]] = ...,
     autouse: bool = ...,
     ids: Optional[
-        Union[
-            Iterable[Union[None, str, float, int, bool]],
-            Callable[[Any], Optional[object]],
-        ]
+        Union[Sequence[Optional[object]], Callable[[Any], Optional[object]]]
     ] = ...,
     name: Optional[str] = None,
 ) -> FixtureFunctionMarker:
@@ -1226,10 +1206,7 @@ def fixture(
     params: Optional[Iterable[object]] = None,
     autouse: bool = False,
     ids: Optional[
-        Union[
-            Iterable[Union[None, str, float, int, bool]],
-            Callable[[Any], Optional[object]],
-        ]
+        Union[Sequence[Optional[object]], Callable[[Any], Optional[object]]]
     ] = None,
     name: Optional[str] = None,
 ) -> Union[FixtureFunctionMarker, FixtureFunction]:
@@ -1271,7 +1248,7 @@ def fixture(
         the fixture.
 
     :param ids:
-        List of string ids each corresponding to the params so that they are
+        Sequence of ids each corresponding to the params so that they are
         part of the test id. If no ids are provided they will be generated
         automatically from the params.
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -940,7 +940,7 @@ class IdMaker:
     # ParameterSet.
     idfn: Optional[Callable[[Any], Optional[object]]]
     # Optionally, explicit IDs for ParameterSets by index.
-    ids: Optional[Sequence[Union[None, str]]]
+    ids: Optional[Sequence[Optional[object]]]
     # Optionally, the pytest config.
     # Used for controlling ASCII escaping, and for calling the
     # :hook:`pytest_make_parametrize_id` hook.
@@ -948,6 +948,9 @@ class IdMaker:
     # Optionally, the ID of the node being parametrized.
     # Used only for clearer error messages.
     nodeid: Optional[str]
+    # Optionally, the ID of the function being parametrized.
+    # Used only for clearer error messages.
+    func_name: Optional[str]
 
     def make_unique_parameterset_ids(self) -> List[str]:
         """Make a unique identifier for each ParameterSet, that may be used to
@@ -982,9 +985,7 @@ class IdMaker:
                 yield parameterset.id
             elif self.ids and idx < len(self.ids) and self.ids[idx] is not None:
                 # ID provided in the IDs list - parametrize(..., ids=[...]).
-                id = self.ids[idx]
-                assert id is not None
-                yield _ascii_escaped_by_config(id, self.config)
+                yield self._idval_from_value_required(self.ids[idx], idx)
             else:
                 # ID not provided - generate it.
                 yield "-".join(
@@ -1052,6 +1053,25 @@ class IdMaker:
             name: str = getattr(val, "__name__")
             return name
         return None
+
+    def _idval_from_value_required(self, val: object, idx: int) -> str:
+        """Like _idval_from_value(), but fails if the type is not supported."""
+        id = self._idval_from_value(val)
+        if id is not None:
+            return id
+
+        # Fail.
+        if self.func_name is not None:
+            prefix = f"In {self.func_name}: "
+        elif self.nodeid is not None:
+            prefix = f"In {self.nodeid}: "
+        else:
+            prefix = ""
+        msg = (
+            f"{prefix}ids contains unsupported value {saferepr(val)} (type: {type(val)!r}) at index {idx}. "
+            "Supported types are: str, bytes, int, float, complex, bool, enum, regex or anything with a __name__."
+        )
+        fail(msg, pytrace=False)
 
     @staticmethod
     def _idval_from_argname(argname: str, idx: int) -> str:
@@ -1182,10 +1202,7 @@ class Metafunc:
         argvalues: Iterable[Union[ParameterSet, Sequence[object], object]],
         indirect: Union[bool, Sequence[str]] = False,
         ids: Optional[
-            Union[
-                Iterable[Union[None, str, float, int, bool]],
-                Callable[[Any], Optional[object]],
-            ]
+            Union[Iterable[Optional[object]], Callable[[Any], Optional[object]]]
         ] = None,
         scope: "Optional[_ScopeName]" = None,
         *,
@@ -1316,10 +1333,7 @@ class Metafunc:
         self,
         argnames: Sequence[str],
         ids: Optional[
-            Union[
-                Iterable[Union[None, str, float, int, bool]],
-                Callable[[Any], Optional[object]],
-            ]
+            Union[Iterable[Optional[object]], Callable[[Any], Optional[object]]]
         ],
         parametersets: Sequence[ParameterSet],
         nodeid: str,
@@ -1349,16 +1363,22 @@ class Metafunc:
             idfn = None
             ids_ = self._validate_ids(ids, parametersets, self.function.__name__)
         id_maker = IdMaker(
-            argnames, parametersets, idfn, ids_, self.config, nodeid=nodeid
+            argnames,
+            parametersets,
+            idfn,
+            ids_,
+            self.config,
+            nodeid=nodeid,
+            func_name=self.function.__name__,
         )
         return id_maker.make_unique_parameterset_ids()
 
     def _validate_ids(
         self,
-        ids: Iterable[Union[None, str, float, int, bool]],
+        ids: Iterable[Optional[object]],
         parametersets: Sequence[ParameterSet],
         func_name: str,
-    ) -> List[Union[None, str]]:
+    ) -> List[Optional[object]]:
         try:
             num_ids = len(ids)  # type: ignore[arg-type]
         except TypeError:
@@ -1373,22 +1393,7 @@ class Metafunc:
             msg = "In {}: {} parameter sets specified, with different number of ids: {}"
             fail(msg.format(func_name, len(parametersets), num_ids), pytrace=False)
 
-        new_ids = []
-        for idx, id_value in enumerate(itertools.islice(ids, num_ids)):
-            if id_value is None or isinstance(id_value, str):
-                new_ids.append(id_value)
-            elif isinstance(id_value, (float, int, bool)):
-                new_ids.append(str(id_value))
-            else:
-                msg = (  # type: ignore[unreachable]
-                    "In {}: ids must be list of string/float/int/bool, "
-                    "found: {} (type: {!r}) at index {}"
-                )
-                fail(
-                    msg.format(func_name, saferepr(id_value), type(id_value), idx),
-                    pytrace=False,
-                )
-        return new_ids
+        return list(itertools.islice(ids, num_ids))
 
     def _resolve_arg_value_types(
         self,


### PR DESCRIPTION
In the following

```py
@pytest.mark.parametrize(..., ids=[val])
```

the ID values are only allowed to be `str`, `float`, `int` or `bool`.

In the following

```py
@pytest.mark.parametrize(..., [val])
```
```py
@pytest.mark.parametrize(..., [pytest.param(..., id=val])
```

a different code path is used, which also allows `bytes`, `complex`, `re.Pattern`, `Enum` and anything with a `__name__`.

In the interest of consistency, use the latter code path for all cases.