### PR TITLE
Try to import module before creating dummy modules with 'importmode=importlib'

### DIFF
--- a/changelog/9645.bugfix.rst
+++ b/changelog/9645.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed regression where ``--import-mode=importlib`` used together with :envvar:`PYTHONPATH` or :confval:`pythonpath` would cause import errors in test suites.

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -1507,6 +1507,35 @@ class TestImportModeImportlib:
             ]
         )
 
+    def test_using_python_path(self, pytester: Pytester) -> None:
+        """
+        Dummy modules created by insert_missing_modules should not get in
+        the way of modules that could be imported via python path (#9645).
+        """
+        pytester.makeini(
+            """
+            [pytest]
+            pythonpath = .
+            addopts = --import-mode importlib
+            """
+        )
+        pytester.makepyfile(
+            **{
+                "tests/__init__.py": "",
+                "tests/conftest.py": "",
+                "tests/subpath/__init__.py": "",
+                "tests/subpath/helper.py": "",
+                "tests/subpath/test_something.py": """
+                import tests.subpath.helper
+
+                def test_something():
+                    assert True
+                """,
+            }
+        )
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines("*1 passed in*")
+
 
 def test_does_not_crash_on_error_from_decorated_function(pytester: Pytester) -> None:
     """Regression test for an issue around bad exception formatting due to

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -562,15 +562,20 @@ class TestImportLibMode:
         result = module_name_from_path(Path("/home/foo/test_foo.py"), Path("/bar"))
         assert result == "home.foo.test_foo"
 
-    def test_insert_missing_modules(self) -> None:
-        modules = {"src.tests.foo": ModuleType("src.tests.foo")}
-        insert_missing_modules(modules, "src.tests.foo")
-        assert sorted(modules) == ["src", "src.tests", "src.tests.foo"]
+    def test_insert_missing_modules(
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        # Use 'xxx' and 'xxy' as parent names as they are unlikely to exist and
+        # don't end up being imported.
+        modules = {"xxx.tests.foo": ModuleType("xxx.tests.foo")}
+        insert_missing_modules(modules, "xxx.tests.foo")
+        assert sorted(modules) == ["xxx", "xxx.tests", "xxx.tests.foo"]
 
         mod = ModuleType("mod", doc="My Module")
-        modules = {"src": mod}
-        insert_missing_modules(modules, "src")
-        assert modules == {"src": mod}
+        modules = {"xxy": mod}
+        insert_missing_modules(modules, "xxy")
+        assert modules == {"xxy": mod}
 
         modules = {}
         insert_missing_modules(modules, "")


### PR DESCRIPTION
The dummy modules we introduce in `insert_missing_modules` (due to #7856 and #7859) 
would cause problems if the dummy modules end up replacing modules 
which could be imported normally because they are available in `PYTHONPATH`.

Now we attempt to first import the module via normal mechanisms, and only
introduce the dummy modules if the intermediary modules don't actually exist.

Close #9645

---
Original PR text, when opened as a draft, for reference:

I spent some time investigating this and narrowed it down to this function:

https://github.com/pytest-dev/pytest/blob/c01a5c177b7bcabc0fbfc1d80b4c841088f8d14b/src/_pytest/pathlib.py#L595-L612

which is called during `import_path` when `importmode=importlib`.

The function was introduced because of #7856 and #7859, and it did feel like a hack at the time, but since everything seemed to work fine, it was merged in.

Stepping into the debugger, I can see that the function is called with `"tests.conftest"`, with `"test.conftest"` already being in `sys.modules` by then, then it creates this empty/dummy module for `"tests"`.

OK the reported error makes sense: we are telling `tests` is a plain module, it should be a package according to the message. 

I dig around a bit in the import lib resources, looking for the code which generated that error message (`"is not a pacakge"`) to understand what `importlib` looked for in a module to recognize it as a package, and found this code in the standard library:

```python
# importlib/_bootstrap.py
def _find_and_load_unlocked(name, import_):
    path = None
    parent = name.rpartition('.')[0]
    if parent:
        if parent not in sys.modules:
            _call_with_frames_removed(import_, parent)
        # Crazy side-effects!
        if name in sys.modules:
            return sys.modules[name]
        parent_module = sys.modules[parent]
        try:
            path = parent_module.__path__
        except AttributeError:
            msg = (_ERR_MSG + '; {!r} is not a package').format(name, parent)
            raise ModuleNotFoundError(msg, name=name) from None
```

So it seems it expects the parent module (`tests` in our case) to have a `__path__` attribute, so I went ahead and quickly hacked this together to see how it behaves:

```diff
index def5fa94b..c105c6948 100644
--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -601,15 +601,20 @@ def insert_missing_modules(modules: Dict[str, ModuleType], module_name: str) ->
     otherwise "src.tests.test_foo" is not importable by ``__import__``.
     """
     module_parts = module_name.split(".")
+    first=True
     while module_name:
         if module_name not in modules:
             module = ModuleType(
                 module_name,
                 doc="Empty module created by pytest's importmode=importlib.",
             )
+            if not first:
+                module.__package__ = module_name
+                module.__path__ = module_name
             modules[module_name] = module
         module_parts.pop(-1)
         module_name = ".".join(module_parts)
+        first = False
```

This did not work however, and we get the exact same error.

Then I had another thought, what if we try to use `__import__` first, and only if that fails we attempt generate the dummy intermediate modules?

The code in this PR follows that approach and works with the original issue and the rest of the test suite [^1], but I'm opening this as a draft to gather the opinion of people more knowledgeable of the import machinery (@asottile). 

If this looks good enough, I will add tests and a changelog entry.

[^1]: Except for one test but that's because we call `__import__` with an empty `sys.meta_path`, which raises a warning, this can easily be fixed by checking `sys.meta_path` first before calling `__import__`.