### PR TITLE
Correct log_file's inconsistent behavior

### DIFF
--- a/changelog/7336.breaking.rst
+++ b/changelog/7336.breaking.rst
@@ -1,0 +1,1 @@
+The pytest ``log_file`` ini marker is now relative to the configs ``inifile`` directory, as it was always the intention. It was originally introduced as relative to the current working directory unintentionally.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -560,6 +560,12 @@ class LoggingPlugin:
             if not os.path.isdir(directory):
                 os.makedirs(directory)
 
+            # Log file should be relative to cwd when passed as a cmd argument and
+            # relative to the config file otherwise.
+            is_inifile_argument = "--log-file" not in config.invocation_params.args
+            if config.inipath is not None and is_inifile_argument:
+                log_file = os.path.join(config.inipath.parent, log_file)
+
         self.log_file_handler = _FileHandler(log_file, mode="w", encoding="UTF-8")
         log_file_format = get_option_ini(config, "log_file_format", "log_format")
         log_file_date_format = get_option_ini(

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -560,8 +560,8 @@ class LoggingPlugin:
             if not os.path.isdir(directory):
                 os.makedirs(directory)
 
-            # Log file should be relative to cwd when passed as a cmd argument and
-            # relative to the config file otherwise.
+            # Log file should be relative to invocation location when passed as a cli argument
+            # and relative to the config file otherwise.
             is_inifile_argument = "--log-file" not in config.invocation_params.args
             if config.inipath is not None and is_inifile_argument:
                 log_file = os.path.join(config.inipath.parent, log_file)

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1221,7 +1221,7 @@ def test_log_file_in_subdir_when_specified_and_pytest_invoked_in_subdir(
     assert "tox.ini" not in files_in_subdir
 
 
-def test_log_file_relative_to_invocation_dir_when_passed_as_cmd_argument(
+def test_log_file_relative_to_invocation_dir_when_passed_as_cli_argument(
     pytester, monkeypatch
 ):
     """PR #7350 comment related to issue #7350 (https://github.com/pytest-dev/pytest/pull/7350#pullrequestreview-429803796).


### PR DESCRIPTION
Close #7336

Per @symonk's [comment](https://github.com/pytest-dev/pytest/issues/7336#issuecomment-719897704) on that issue I took his PR #7350 as a starting point, and extended it per @bluetech's [first insight](https://github.com/pytest-dev/pytest/pull/7350#pullrequestreview-429803796) in that PR. Not sure whether I should tackle the second one as well,

In summary:
* When `--log-file` is passed as a cli argument, its location is relative to the invocation path.
* When `--log-file` isn't passed as a cli argument and `log_file` option is present in the config, log file's location is relative to the config file.