### PR TITLE
Fix numbering and improve changelog entry for #9362

### DIFF
--- a/changelog/9326.bugfix.rst
+++ b/changelog/9326.bugfix.rst
@@ -1,1 +1,0 @@
-Pytest will now avoid specialized assert formatting when it is detected that the default __eq__ is overridden

--- a/changelog/9362.improvement.rst
+++ b/changelog/9362.improvement.rst
@@ -1,0 +1,1 @@
+pytest now avoids specialized assert formatting when it is detected that the default ``__eq__`` is overridden in ``attrs`` or ``dataclasses``.


### PR DESCRIPTION
While answering to https://github.com/pytest-dev/pytest/pull/9407#issuecomment-1049028494, I noticed the change log entry had a typo in its number. While at it I improved the text a bit.