### PR TITLE
pytester now requests monkeypatch instead of creating its own instance

### DIFF
--- a/changelog/9708.bugfix.rst
+++ b/changelog/9708.bugfix.rst
@@ -1,0 +1,1 @@
+:fixture:`pytester` now requests a :fixture:`monkeypatch` fixture instead of creating one internally. This solves some issues with tests that involve pytest environment variables.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -477,7 +477,9 @@ def LineMatcher_fixture(request: FixtureRequest) -> Type["LineMatcher"]:
 
 
 @fixture
-def pytester(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> "Pytester":
+def pytester(
+    request: FixtureRequest, tmp_path_factory: TempPathFactory, monkeypatch: MonkeyPatch
+) -> "Pytester":
     """
     Facilities to write tests/configuration files, execute pytest in isolation, and match
     against expected output, perfect for black-box testing of pytest plugins.
@@ -488,7 +490,7 @@ def pytester(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> "Pyt
     It is particularly useful for testing plugins. It is similar to the :fixture:`tmp_path`
     fixture but provides methods which aid in testing pytest itself.
     """
-    return Pytester(request, tmp_path_factory, _ispytest=True)
+    return Pytester(request, tmp_path_factory, monkeypatch, _ispytest=True)
 
 
 @fixture
@@ -683,6 +685,7 @@ class Pytester:
         self,
         request: FixtureRequest,
         tmp_path_factory: TempPathFactory,
+        monkeypatch: MonkeyPatch,
         *,
         _ispytest: bool = False,
     ) -> None:
@@ -706,7 +709,7 @@ class Pytester:
         self._method = self._request.config.getoption("--runpytest")
         self._test_tmproot = tmp_path_factory.mktemp(f"tmp-{name}", numbered=True)
 
-        self._monkeypatch = mp = MonkeyPatch()
+        self._monkeypatch = mp = monkeypatch
         mp.setenv("PYTEST_DEBUG_TEMPROOT", str(self._test_tmproot))
         # Ensure no unexpected caching via tox.
         mp.delenv("TOX_ENV_DIR", raising=False)
@@ -738,7 +741,6 @@ class Pytester:
         self._sys_modules_snapshot.restore()
         self._sys_path_snapshot.restore()
         self._cwd_snapshot.restore()
-        self._monkeypatch.undo()
 
     def __take_sys_modules_snapshot(self) -> SysModulesSnapshot:
         # Some zope modules used by twisted-related tests keep internal state

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -618,14 +618,9 @@ def test_linematcher_string_api() -> None:
 
 
 def test_pytest_addopts_before_pytester(request, monkeypatch: MonkeyPatch) -> None:
-    orig = os.environ.get("PYTEST_ADDOPTS", None)
     monkeypatch.setenv("PYTEST_ADDOPTS", "--orig-unused")
-    pytester: Pytester = request.getfixturevalue("pytester")
+    _: Pytester = request.getfixturevalue("pytester")
     assert "PYTEST_ADDOPTS" not in os.environ
-    pytester._finalize()
-    assert os.environ.get("PYTEST_ADDOPTS") == "--orig-unused"
-    monkeypatch.undo()
-    assert os.environ.get("PYTEST_ADDOPTS") == orig
 
 
 def test_run_stdin(pytester: Pytester) -> None:


### PR DESCRIPTION
It is tempting to use `monkeypatch` to replace the other mechanisms in pytester which change global 
state: `CwdSnapshot`, `SysModulesSnapshot`, `SysPathsSnapshot`, however those are more delicate 
than they look at first glance so leaving those alone for now.

Close #9708