### PR TITLE
prevent import-time side-effects from setuptools bundled importlib-metadata

### DIFF
--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -803,8 +803,8 @@ class TestDoctests:
         """
         p = pytester.makepyfile(
             setup="""
-            from setuptools import setup, find_packages
             if __name__ == '__main__':
+                from setuptools import setup, find_packages
                 setup(name='sample',
                       version='0.0',
                       description='description',


### PR DESCRIPTION
this works around the pollution identified here by avoiding the import of `setuptools` entirely: https://github.com/pytest-dev/pytest/pull/9714#issuecomment-1051068152