### PR TITLE
Improve error message for malformed pyproject.toml files

### DIFF
--- a/changelog/9730.bugfix.rst
+++ b/changelog/9730.bugfix.rst
@@ -1,0 +1,1 @@
+Malformed ``pyproject.toml`` files now produce a clearer error message.

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -70,7 +70,7 @@ def load_config_dict_from_file(
         try:
             config = tomli.loads(toml_text)
         except tomli.TOMLDecodeError as exc:
-            raise UsageError(str(exc)) from exc
+            raise UsageError(f"{filepath}: {exc}") from exc
 
         result = config.get("tool", {}).get("pytest", {}).get("ini_options", None)
         if result is not None:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -163,7 +163,17 @@ class TestParseIni:
         pytester.path.joinpath("pytest.ini").write_text("addopts = -x")
         result = pytester.runpytest()
         assert result.ret != 0
-        result.stderr.fnmatch_lines(["ERROR: *pytest.ini:1: no section header defined"])
+        result.stderr.fnmatch_lines("ERROR: *pytest.ini:1: no section header defined")
+
+    def test_toml_parse_error(self, pytester: Pytester) -> None:
+        pytester.makepyprojecttoml(
+            """
+            \\"
+            """
+        )
+        result = pytester.runpytest()
+        assert result.ret != 0
+        result.stderr.fnmatch_lines("ERROR: *pyproject.toml: Invalid statement*")
 
     @pytest.mark.xfail(reason="probably not needed")
     def test_confcutdir(self, pytester: Pytester) -> None:


### PR DESCRIPTION
Including the file name is enough to let the user know what the problem is.

The same is not needed for `.ini` files because their error message includes the path to the file by default.

Fix #9730