### PR TITLE
Typo correction

### DIFF
--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -110,7 +110,7 @@ def warns(
     r"""Assert that code raises a particular class of warning.
 
     Specifically, the parameter ``expected_warning`` can be a warning class or
-    sequence of warning classes, and the inside the ``with`` block must issue a warning of that class or
+    sequence of warning classes, and the code inside the ``with`` block must issue a warning of that class or
     classes.
 
     This helper produces a list of :class:`warnings.WarningMessage` objects,


### PR DESCRIPTION
A word was missing in the docstring of the warns function.

As the change is trivial, I didn't run any test or add anything to the changelog.