### PR TITLE
testing: fix tests when run under `-v` or `-vv`

### DIFF
--- a/extra/setup-py.test/setup.py
+++ b/extra/setup-py.test/setup.py
@@ -1,4 +1,5 @@
 import sys
+
 from distutils.core import setup
 
 if __name__ == "__main__":

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -204,16 +204,8 @@ class TestAssertionRewrite:
         def f4() -> None:
             assert sys == 42  # type: ignore[comparison-overlap]
 
-        verbose = request.config.getoption("verbose")
         msg = getmsg(f4, {"sys": sys})
-        if verbose > 0:
-            assert msg == (
-                "assert <module 'sys' (built-in)> == 42\n"
-                "  +<module 'sys' (built-in)>\n"
-                "  -42"
-            )
-        else:
-            assert msg == "assert sys == 42"
+        assert msg == "assert sys == 42"
 
         def f5() -> None:
             assert cls == 42  # type: ignore[name-defined]  # noqa: F821
@@ -224,20 +216,7 @@ class TestAssertionRewrite:
         msg = getmsg(f5, {"cls": X})
         assert msg is not None
         lines = msg.splitlines()
-        if verbose > 1:
-            assert lines == [
-                f"assert {X!r} == 42",
-                f"  +{X!r}",
-                "  -42",
-            ]
-        elif verbose > 0:
-            assert lines == [
-                "assert <class 'test_...e.<locals>.X'> == 42",
-                f"  +{X!r}",
-                "  -42",
-            ]
-        else:
-            assert lines == ["assert cls == 42"]
+        assert lines == ["assert cls == 42"]
 
     def test_assertrepr_compare_same_width(self, request) -> None:
         """Should use same width/truncation with same initial width."""
@@ -279,14 +258,11 @@ class TestAssertionRewrite:
         msg = getmsg(f, {"cls": Y})
         assert msg is not None
         lines = msg.splitlines()
-        if request.config.getoption("verbose") > 0:
-            assert lines == ["assert 3 == 2", "  +3", "  -2"]
-        else:
-            assert lines == [
-                "assert 3 == 2",
-                " +  where 3 = Y.foo",
-                " +    where Y = cls()",
-            ]
+        assert lines == [
+            "assert 3 == 2",
+            " +  where 3 = Y.foo",
+            " +    where Y = cls()",
+        ]
 
     def test_assert_already_has_message(self) -> None:
         def f():
@@ -663,10 +639,7 @@ class TestAssertionRewrite:
             assert len(values) == 11
 
         msg = getmsg(f)
-        if request.config.getoption("verbose") > 0:
-            assert msg == "assert 10 == 11\n  +10\n  -11"
-        else:
-            assert msg == "assert 10 == 11\n +  where 10 = len([0, 1, 2, 3, 4, 5, ...])"
+        assert msg == "assert 10 == 11\n +  where 10 = len([0, 1, 2, 3, 4, 5, ...])"
 
     def test_custom_reprcompare(self, monkeypatch) -> None:
         def my_reprcompare1(op, left, right) -> str:
@@ -732,10 +705,7 @@ class TestAssertionRewrite:
         msg = getmsg(f)
         assert msg is not None
         lines = util._format_lines([msg])
-        if request.config.getoption("verbose") > 0:
-            assert lines == ["assert 0 == 1\n  +0\n  -1"]
-        else:
-            assert lines == ["assert 0 == 1\n +  where 1 = \\n{ \\n~ \\n}.a"]
+        assert lines == ["assert 0 == 1\n +  where 1 = \\n{ \\n~ \\n}.a"]
 
     def test_custom_repr_non_ascii(self) -> None:
         def f() -> None:


### PR DESCRIPTION
Regressed in fac8f284cd6ffd44c7d401093c67799766473be1, didn't notice
since we don't run tests in CI with `-v`.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
