### PR TITLE
config: restore pre-pytest 7.1.0 confcutdir exclusion behavior

### DIFF
--- a/changelog/9767.bugfix.rst
+++ b/changelog/9767.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a regression in pytest 7.1.0 where some conftest.py files outside of the source tree (e.g. in the `site-packages` directory) were not picked up.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -540,11 +540,7 @@ class PytestPluginManager(PluginManager):
         """
         if self._confcutdir is None:
             return True
-        try:
-            path.relative_to(self._confcutdir)
-        except ValueError:
-            return False
-        return True
+        return path not in self._confcutdir.parents
 
     def _try_load_conftest(
         self, anchor: Path, importmode: Union[str, ImportMode], rootpath: Path

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -252,6 +252,34 @@ def test_conftest_confcutdir(pytester: Pytester) -> None:
     result.stdout.no_fnmatch_line("*warning: could not load initial*")
 
 
+def test_installed_conftest_is_picked_up(pytester: Pytester, tmp_path: Path) -> None:
+    """When using `--pyargs` to run tests in an installed packages (located e.g.
+    in a site-packages in the PYTHONPATH), conftest files in there are picked
+    up.
+
+    Regression test for #9767.
+    """
+    # pytester dir - the source tree.
+    # tmp_path - the simulated site-packages dir (not in source tree).
+
+    pytester.syspathinsert(tmp_path)
+    pytester.makepyprojecttoml("[tool.pytest.ini_options]")
+    tmp_path.joinpath("foo").mkdir()
+    tmp_path.joinpath("foo", "__init__.py").touch()
+    tmp_path.joinpath("foo", "conftest.py").write_text(
+        textwrap.dedent(
+            """\
+            import pytest
+            @pytest.fixture
+            def fix(): return None
+            """
+        )
+    )
+    tmp_path.joinpath("foo", "test_it.py").write_text("def test_it(fix): pass")
+    result = pytester.runpytest("--pyargs", "foo")
+    assert result.ret == 0
+
+
 def test_conftest_symlink(pytester: Pytester) -> None:
     """`conftest.py` discovery follows normal path resolution and does not resolve symlinks."""
     # Structure:


### PR DESCRIPTION
The change from `path not in confuctdir.parents` to the `relative_to` check in 0c98f1923101e5905c54ba07650a043fca374f4b broke picking up conftest files when running against an installed package/site-packages. See the issue for more details.

Fix #9767.