### PR TITLE
Split test/deploy workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: deploy
+
+on:
+  push:
+    tags:
+      # These tags are protected, see:
+      # https://github.com/pytest-dev/pytest/settings/tag_protection
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
+
+
+# Set permissions at the job level.
+permissions: {}
+
+jobs:
+
+  deploy:
+    if: github.repository == 'pytest-dev/pytest'
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.7"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade build tox
+
+    - name: Build package
+      run: |
+        python -m build
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_token }}
+
+    - name: Publish GitHub release notes
+      env:
+        GH_RELEASE_NOTES_TOKEN: ${{ github.token }}
+      run: |
+        sudo apt-get install pandoc
+        tox -e publish-gh-release-notes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: main
+name: test
 
 on:
   push:
@@ -187,46 +187,3 @@ jobs:
         fail_ci_if_error: true
         files: ./coverage.xml
         verbose: true
-
-  deploy:
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && github.repository == 'pytest-dev/pytest'
-
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: write
-
-    needs: [build]
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        persist-credentials: false
-
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.7"
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install --upgrade build tox
-
-    - name: Build package
-      run: |
-        python -m build
-
-    - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_token }}
-
-    - name: Publish GitHub release notes
-      env:
-        GH_RELEASE_NOTES_TOKEN: ${{ github.token }}
-      run: |
-        sudo apt-get install pandoc
-        tox -e publish-gh-release-notes

--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,8 @@
     :target: https://codecov.io/gh/pytest-dev/pytest
     :alt: Code coverage Status
 
-.. image:: https://github.com/pytest-dev/pytest/workflows/main/badge.svg
-    :target: https://github.com/pytest-dev/pytest/actions?query=workflow%3Amain
+.. image:: https://github.com/pytest-dev/pytest/workflows/test/badge.svg
+    :target: https://github.com/pytest-dev/pytest/actions?query=workflow%3Atest
 
 .. image:: https://results.pre-commit.ci/badge/github/pytest-dev/pytest/main.svg
    :target: https://results.pre-commit.ci/latest/github/pytest-dev/pytest/main


### PR DESCRIPTION
This will trigger a deploy directly when a tag is pushed, avoiding
having to wait for another lenghty build.

This is safe since we only push release tags after the release PR has passed all its tests.

See comments in #9793.

Close #9793