### PR TITLE
Change directories during some tests in test_collection.py

### DIFF
--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -651,7 +651,7 @@ class Test_getinitialnodes:
         for parent in col.listchain():
             assert parent.config is config
 
-    def test_pkgfile(self, pytester: Pytester) -> None:
+    def test_pkgfile(self, pytester: Pytester, monkeypatch: MonkeyPatch) -> None:
         """Verify nesting when a module is within a package.
         The parent chain should match: Module<x.py> -> Package<subdir> -> Session.
             Session's parent should always be None.
@@ -660,7 +660,9 @@ class Test_getinitialnodes:
         subdir = tmp_path.joinpath("subdir")
         x = ensure_file(subdir / "x.py")
         ensure_file(subdir / "__init__.py")
-        config = pytester.parseconfigure(x)
+        with monkeypatch.context() as mp:
+            mp.chdir(subdir)
+            config = pytester.parseconfigure(x)
         col = pytester.getnode(config, x)
         assert col is not None
         assert col.name == "x.py"
@@ -1221,7 +1223,9 @@ def test_collect_pyargs_with_testpaths(
         )
     )
     monkeypatch.setenv("PYTHONPATH", str(pytester.path), prepend=os.pathsep)
-    result = pytester.runpytest_subprocess()
+    with monkeypatch.context() as mp:
+        mp.chdir(root)
+        result = pytester.runpytest_subprocess()
     result.stdout.fnmatch_lines(["*1 passed in*"])
 
 


### PR DESCRIPTION
As discussed in https://github.com/pytest-dev/pytest/pull/9800, this uses monkeypatch to change directories for two tests in `test_collection.py`, to preserve their original purpose (even if just removing it doesn't seem to affect the outcome).
