### PR TITLE
Clarify error message in case no collectors are found for a file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -325,6 +325,7 @@ Thomas Grainger
 Thomas Hisch
 Tim Hoffmann
 Tim Strazny
+Tobias Diez
 Tom Dalton
 Tom Viner
 Tomáš Gavenčiak

--- a/changelog/9823.improvement.rst
+++ b/changelog/9823.improvement.rst
@@ -1,0 +1,1 @@
+Improved error message that is shown when no collector is found for a given file.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -646,7 +646,7 @@ class Session(nodes.FSCollector):
             if self._notfound:
                 errors = []
                 for arg, collectors in self._notfound:
-                    if cols:
+                    if collectors:
                         errors.append(
                             f"not found: {arg}\n(no name {arg!r} in any of {collectors!r})"
                         )

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -647,10 +647,12 @@ class Session(nodes.FSCollector):
                 errors = []
                 for arg, collectors in self._notfound:
                     if cols:
-                        errors.append(f"not found: {arg}\n(no name {arg!r} in any of {collectors!r})")
+                        errors.append(
+                            f"not found: {arg}\n(no name {arg!r} in any of {collectors!r})"
+                        )
                     else:
                         errors.append(f"found no collectors for {arg}")
-                    
+
                 raise UsageError(*errors)
             if not genitems:
                 items = rep.result

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -645,9 +645,12 @@ class Session(nodes.FSCollector):
             self.trace.root.indent -= 1
             if self._notfound:
                 errors = []
-                for arg, cols in self._notfound:
-                    line = f"(no name {arg!r} in any of {cols!r})"
-                    errors.append(f"not found: {arg}\n{line}")
+                for arg, collectors in self._notfound:
+                    if cols:
+                        errors.append(f"not found: {arg}\n(no name {arg!r} in any of {collectors!r})")
+                    else:
+                        errors.append(f"found no collectors for {arg}")
+                    
                 raise UsageError(*errors)
             if not genitems:
                 items = rep.result

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -186,8 +186,7 @@ class TestGeneralUsage:
         assert result.ret == ExitCode.USAGE_ERROR
         result.stderr.fnmatch_lines(
             [
-                f"ERROR: not found: {p2}",
-                f"(no name {str(p2)!r} in any of [[][]])",
+                f"ERROR: found no collectors for {p2}",
                 "",
             ]
         )

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1855,8 +1855,7 @@ def test_config_blocked_default_plugins(pytester: Pytester, plugin: str) -> None
         assert result.ret == ExitCode.USAGE_ERROR
         result.stderr.fnmatch_lines(
             [
-                "ERROR: not found: */test_config_blocked_default_plugins.py",
-                "(no name '*/test_config_blocked_default_plugins.py' in any of [])",
+                "ERROR: found no collectors for */test_config_blocked_default_plugins.py",
             ]
         )
         return


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

In case no collector is found for a given file (e.g. if you run `pytest something.unrecognized`), then the somewhat cryptic error message
```
ERROR: not found: something.unrecognized
(no name 'something.unrecognized' in any of [])
``` 
With this PR, a more meaningful error message is displayed.

Not sure if such an almost-trivial change warrants an a changelog and authors entry.