### PR TITLE
fix comparison of dataclasses with `InitVar`

### DIFF
--- a/changelog/9820.bugfix.rst
+++ b/changelog/9820.bugfix.rst
@@ -1,0 +1,1 @@
+Fix comparison of  ``dataclasses`` with ``InitVar``.

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -437,8 +437,10 @@ def _compare_eq_cls(left: Any, right: Any, verbose: int) -> List[str]:
     if not has_default_eq(left):
         return []
     if isdatacls(left):
-        all_fields = left.__dataclass_fields__
-        fields_to_check = [field for field, info in all_fields.items() if info.compare]
+        import dataclasses
+
+        all_fields = dataclasses.fields(left)
+        fields_to_check = [info.name for info in all_fields if info.compare]
     elif isattrs(left):
         all_fields = left.__attrs_attrs__
         fields_to_check = [field.name for field in all_fields if getattr(field, "eq")]

--- a/testing/example_scripts/dataclasses/test_compare_initvar.py
+++ b/testing/example_scripts/dataclasses/test_compare_initvar.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import InitVar
+
+
+@dataclass
+class Foo:
+    init_only: InitVar[int]
+    real_attr: int
+
+
+def test_demonstrate():
+    assert Foo(1, 2) == Foo(1, 3)

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -882,6 +882,13 @@ class TestAssert_reprcompare_dataclass:
         result.assert_outcomes(failed=1, passed=0)
         result.stdout.no_re_match_line(".*Differing attributes.*")
 
+    def test_data_classes_with_initvar(self, pytester: Pytester) -> None:
+        p = pytester.copy_example("dataclasses/test_compare_initvar.py")
+        # issue 9820
+        result = pytester.runpytest(p, "-vv")
+        result.assert_outcomes(failed=1, passed=0)
+        result.stdout.no_re_match_line(".*AttributeError.*")
+
 
 class TestAssert_reprcompare_attrsclass:
     def test_attrs(self) -> None:


### PR DESCRIPTION
resolves #9820

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [x] Include documentation when adding new features. **N/A**
- [x] Include new tests or update existing tests when applicable.
- [x] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
-->
