### PR TITLE
Update to fix issue #6

### DIFF
--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -450,26 +450,25 @@ class ApproxScalar(ApproxBase):
         # for compatibility with complex numbers.
         if math.isinf(abs(self.expected)):  # type: ignore[arg-type]
             return False
-    
-        tolerance = self.tolerance    
+
+        tolerance = self.tolerance
         expected = self.expected
-        
-        if (isinstance(self.expected, Decimal) and not isinstance(actual, Decimal)):
+
+        if isinstance(self.expected, Decimal) and not isinstance(actual, Decimal):
             try:
                 actual = Decimal(str(actual))
                 tolerance = Decimal(str(tolerance))
-            except TypeError: # 
+            except TypeError:  #
                 return False
-        elif (isinstance(actual, Decimal) and not isinstance(self.expected, Decimal)):
-            try :
+        elif isinstance(actual, Decimal) and not isinstance(self.expected, Decimal):
+            try:
                 expected = Decimal(str(expected))
                 tolerance = Decimal(str(tolerance))
             except TypeError:
                 return False
-            
 
         # Return true if the two numbers are within the tolerance.
-        result: bool = (abs(actual - expected) <= tolerance ) # type: ignore[arg-type]
+        result: bool = abs(actual - expected) <= tolerance  # type: ignore[arg-type]
         return result
 
     # Ignore type because of https://github.com/python/mypy/issues/4266.
@@ -508,11 +507,11 @@ class ApproxScalar(ApproxBase):
         # we've made sure the user didn't ask for an absolute tolerance only,
         # because we don't want to raise errors about the relative tolerance if
         # we aren't even going to use it.
-        
+
         if isinstance(self.rel, Decimal):
             relative_tolerance = set_default(
                 self.rel, self.DEFAULT_RELATIVE_TOLERANCE
-            )*Decimal(str(abs(self.expected)))
+            ) * Decimal(str(abs(self.expected)))
         else:
             relative_tolerance = set_default(
                 self.rel, self.DEFAULT_RELATIVE_TOLERANCE

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -341,6 +341,8 @@ class TestApprox:
             (0.0, -0.0),
             (345678, 345678),
             (Decimal("1.0001"), Decimal("1.0001")),
+            (1.0001, Decimal("1.0001")),
+            (Decimal("1.0001"), 1.0001),
             (Fraction(1, 3), Fraction(-1, -3)),
         ]
         for a, x in examples:
@@ -515,6 +517,10 @@ class TestApprox:
         within_1e6 = [
             (Decimal("1.000001"), Decimal("1.0")),
             (Decimal("-1.000001"), Decimal("-1.0")),
+            (-1.000001, Decimal("-1.0")),
+            (1.000001, Decimal("1.0")),
+            (Decimal("1.000001"), 1.0),
+            (Decimal("-1.000001"), -1.0),
         ]
         for a, x in within_1e6:
             assert a == approx(x)
@@ -562,6 +568,15 @@ class TestApprox:
         expected = [Decimal("1"), Decimal("2")]
 
         assert actual == approx(expected)
+        
+        expected = [1, 2]
+        
+        assert actual == approx(expected)
+        
+        expected = [Decimal("1"), Decimal("2")]
+        actual = [1.000001, 2.000001]
+        
+        assert actual == approx(expected)
 
     def test_list_wrong_len(self):
         assert [1, 2] != approx([1])
@@ -602,6 +617,15 @@ class TestApprox:
         # to make sure it doesn't matter.
         expected = {"b": Decimal("2"), "a": Decimal("1")}
 
+        assert actual == approx(expected)
+        
+        actual = {"a": 1.000001, "b": 2.000001}
+        
+        assert actual == approx(expected)
+        
+        actual = {"a": Decimal("1.000001"), "b": Decimal("2.000001")}
+        expected = {"b": 2, "a": 1}
+        
         assert actual == approx(expected)
 
     def test_dict_wrong_len(self):
@@ -878,3 +902,4 @@ class TestApprox:
         """pytest.approx() should raise an error on unordered sequences (#9692)."""
         with pytest.raises(TypeError, match="only supports ordered sequences"):
             assert {1, 2, 3} == approx({1, 2, 3})
+    

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -568,14 +568,14 @@ class TestApprox:
         expected = [Decimal("1"), Decimal("2")]
 
         assert actual == approx(expected)
-        
+
         expected = [1, 2]
-        
+
         assert actual == approx(expected)
-        
+
         expected = [Decimal("1"), Decimal("2")]
         actual = [1.000001, 2.000001]
-        
+
         assert actual == approx(expected)
 
     def test_list_wrong_len(self):
@@ -618,14 +618,14 @@ class TestApprox:
         expected = {"b": Decimal("2"), "a": Decimal("1")}
 
         assert actual == approx(expected)
-        
+
         actual = {"a": 1.000001, "b": 2.000001}
-        
+
         assert actual == approx(expected)
-        
+
         actual = {"a": Decimal("1.000001"), "b": Decimal("2.000001")}
         expected = {"b": 2, "a": 1}
-        
+
         assert actual == approx(expected)
 
     def test_dict_wrong_len(self):
@@ -902,4 +902,3 @@ class TestApprox:
         """pytest.approx() should raise an error on unordered sequences (#9692)."""
         with pytest.raises(TypeError, match="only supports ordered sequences"):
             assert {1, 2, 3} == approx({1, 2, 3})
-    

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -51,7 +51,7 @@ class TestCollector:
 
         fn3 = pytester.collect_by_name(modcol, "test_fail")
         assert isinstance(fn3, pytest.Function)
-        assert not (fn1 == fn3)
+        assert fn1 != fn3
         assert fn1 != fn3
 
         for fn in fn1, fn2, fn3:


### PR DESCRIPTION
This commit adds a fixed enhancement for issue #6 to do with pytest not working for comparison of Decimal type and float (or other scalar) type

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
