### PR TITLE
fix: move 'import getpass' statement to try-clause

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -256,6 +256,7 @@ Ondřej Súkup
 Oscar Benjamin
 Parth Patel
 Patrick Hayes
+Paul Müller
 Pauli Virtanen
 Pavel Karateev
 Paweł Adamczak

--- a/changelog/9871.bugfix.rst
+++ b/changelog/9871.bugfix.rst
@@ -1,0 +1,1 @@
+Handle ``ImportError`` for ``getpass`` import in ``_pytest.tempdir.get_user``

--- a/changelog/9871.bugfix.rst
+++ b/changelog/9871.bugfix.rst
@@ -1,1 +1,2 @@
-Handle ``ImportError`` for ``getpass`` import in ``_pytest.tempdir.get_user``
+Fix a bizarre (and fortunately rare) bug where the `temp_path` fixture could raise
+an internal error while attempting to get the current user's username.

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -158,9 +158,9 @@ class TempPathFactory:
 def get_user() -> Optional[str]:
     """Return the current user name, or None if getuser() does not work
     in the current environment (see #1010)."""
-    import getpass
-
     try:
+        # In some exotic environments, getpass may not be importable.
+        import getpass
         return getpass.getuser()
     except (ImportError, KeyError):
         return None

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -161,7 +161,6 @@ def get_user() -> Optional[str]:
     try:
         # In some exotic environments, getpass may not be importable.
         import getpass
-
         return getpass.getuser()
     except (ImportError, KeyError):
         return None

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -161,6 +161,7 @@ def get_user() -> Optional[str]:
     try:
         # In some exotic environments, getpass may not be importable.
         import getpass
+
         return getpass.getuser()
     except (ImportError, KeyError):
         return None


### PR DESCRIPTION
This fixes an [issue that I have](https://github.com/ZELLMECHANIK-DRESDEN/dclab/runs/6099944514?check_suite_focus=true) in combination with coverage and the `tmp_path` fixture:

I am not sure what exactly causes this. Maybe coverage hides some environment variables. I also find it strange that It is not possible to import a module from the standard library. But in any case, I think this fix is light-weight and should not cause any trouble in the future.

The error message goes like this:
```
==================================== ERRORS ====================================
_______________ ERROR at setup of test_store_and_get_certificate _______________

cls = <class '_pytest.runner.CallInfo'>
func = <function call_runtest_hook.<locals>.<lambda> at 0x7f8bd786f7f0>
when = 'setup'
reraise = (<class '_pytest.outcomes.Exit'>, <class 'KeyboardInterrupt'>)

    @classmethod
    def from_call(
        cls,
        func: "Callable[[], TResult]",
        when: "Literal['collect', 'setup', 'call', 'teardown']",
        reraise: Optional[
            Union[Type[BaseException], Tuple[Type[BaseException], ...]]
        ] = None,
    ) -> "CallInfo[TResult]":
        """Call func, wrapping the result in a CallInfo.
    
        :param func:
            The function to call. Called without arguments.
        :param when:
            The phase in which the function is called.
        :param reraise:
            Exception or exceptions that shall propagate if raised by the
            function, instead of being wrapped in the CallInfo.
        """
        excinfo = None
        start = timing.time()
        precise_start = timing.perf_counter()
        try:
>           result: Optional[TResult] = func()

/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/runner.py:338: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/runner.py:259: in <lambda>
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/pluggy/_hooks.py:265: in __call__
    return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/pluggy/_manager.py:80: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/runner.py:154: in pytest_runtest_setup
    item.session._setupstate.setup(item)
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/runner.py:494: in setup
    raise exc
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/runner.py:491: in setup
    col.setup()
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/python.py:1764: in setup
    self._request._fillfixtures()
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/fixtures.py:541: in _fillfixtures
    item.funcargs[argname] = self.getfixturevalue(argname)
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/fixtures.py:554: in getfixturevalue
    fixturedef = self._get_active_fixturedef(argname)
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/fixtures.py:573: in _get_active_fixturedef
    self._compute_fixture_value(fixturedef)
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/fixtures.py:659: in _compute_fixture_value
    fixturedef.execute(request=subrequest)
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/fixtures.py:1057: in execute
    result = ihook.pytest_fixture_setup(fixturedef=self, request=request)
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/pluggy/_hooks.py:265: in __call__
    return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/pluggy/_manager.py:80: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/fixtures.py:1111: in pytest_fixture_setup
    result = call_fixture_func(fixturefunc, request, kwargs)
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/fixtures.py:890: in call_fixture_func
    fixture_result = fixturefunc(**kwargs)
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/tmpdir.py:211: in tmp_path
    return _mk_tmp(request, tmp_path_factory)
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/tmpdir.py:194: in _mk_tmp
    return factory.mktemp(name, numbered=True)
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/tmpdir.py:93: in mktemp
    basename = self._ensure_relative_to_basetemp(basename)
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/tmpdir.py:74: in _ensure_relative_to_basetemp
    if (self.getbasetemp() / basename).resolve().parent != self.getbasetemp():
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/tmpdir.py:116: in getbasetemp
    user = get_user() or "unknown"
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def get_user() -> Optional[str]:
        """Return the current user name, or None if getuser() does not work
        in the current environment (see #1010)."""
>       import getpass
E       ModuleNotFoundError: No module named 'getpass'

/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/tmpdir.py:161: ModuleNotFoundError
```