### PR TITLE
Fix wrong `log_file` docs

### DIFF
--- a/doc/en/how-to/logging.rst
+++ b/doc/en/how-to/logging.rst
@@ -198,6 +198,9 @@ option names are:
 If you need to record the whole test suite logging calls to a file, you can pass
 ``--log-file=/path/to/log/file``. This log file is opened in write mode which
 means that it will be overwritten at each run tests session.
+Note that relative paths for the log-file location are always resolved relative
+to the current working directory, whether passed on the CLI or declared in a
+config file.
 
 You can also specify the logging level for the log file by passing
 ``--log-file-level``. This setting accepts the logging level names as seen in

--- a/doc/en/how-to/logging.rst
+++ b/doc/en/how-to/logging.rst
@@ -198,9 +198,8 @@ option names are:
 If you need to record the whole test suite logging calls to a file, you can pass
 ``--log-file=/path/to/log/file``. This log file is opened in write mode which
 means that it will be overwritten at each run tests session.
-Note that relative paths for the log-file location are always resolved relative
-to the current working directory, whether passed on the CLI or declared in a
-config file.
+Note that relative paths for the log-file location, whether passed on the CLI or declared in a
+config file, are always resolved relative to the current working directory.
 
 You can also specify the logging level for the log file by passing
 ``--log-file-level``. This setting accepts the logging level names as seen in

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1514,7 +1514,7 @@ passed multiple times. The expected format is ``name=value``. For example::
 
 
 
-    Sets a file name relative to the ``pytest.ini`` file where log messages should be written to, in addition
+    Sets a file name relative to the current working directory where log messages should be written to, in addition
     to the other logging facilities that are active.
 
     .. code-block:: ini


### PR DESCRIPTION
If a relative path is passed for the `--log-file` CLI argument, *or* the `log_file` config option is set, it is always resolved relative to the current working directory - pytest doesn't have any special logic beyond that in the standard library `logging.FileHandler`.

Unfortunately this was incorrectly documented as being relative to the `pytest.ini` file (*not* rootdir), which kicked off a considerable chain of confusion.  This PR therefore fixes #7336, closes #7350, and closes #9700.

Any proposal to change the current internally-consistent behaviour should start from a fresh issue, and include a description of why the alternative semantics are more desirable, and how to manage the backwards-compatibility implications of moving so many users' log files.