### PR TITLE
Document the --code-highlight default

### DIFF
--- a/changelog/9883.improvement.rst
+++ b/changelog/9883.improvement.rst
@@ -1,0 +1,1 @@
+Normalize the help description of all command-line options.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1809,11 +1809,11 @@ All the command-line flags can be obtained by running ``pytest --help``::
     $ pytest --help
     usage: pytest [options] [file_or_dir] [file_or_dir] [...]
 
-    positional arguments:
+    Positional arguments:
       file_or_dir
 
-    general:
-      -k EXPRESSION         only run tests which match the given substring
+    General:
+      -k EXPRESSION         Only run tests which match the given substring
                             expression. An expression is a python evaluatable
                             expression where all names are substring-matched
                             against test names and their parent classes.
@@ -1828,217 +1828,217 @@ All the command-line flags can be obtained by running ``pytest --help``::
                             'extra_keyword_matches' set, as well as functions
                             which have names assigned directly to them. The
                             matching is case-insensitive.
-      -m MARKEXPR           only run tests matching given mark expression.
+      -m MARKEXPR           Only run tests matching given mark expression.
                             For example: -m 'mark1 and not mark2'.
-      --markers             show markers (builtin, plugin and per-project ones).
-      -x, --exitfirst       exit instantly on first error or failed test.
+      --markers             Show markers (builtin, plugin and per-project ones)
+      -x, --exitfirst       Exit instantly on first error or failed test
       --fixtures, --funcargs
-                            show available fixtures, sorted by plugin appearance
+                            Show available fixtures, sorted by plugin appearance
                             (fixtures with leading '_' are only shown with '-v')
-      --fixtures-per-test   show fixtures per test
-      --pdb                 start the interactive Python debugger on errors or
-                            KeyboardInterrupt.
+      --fixtures-per-test   Show fixtures per test
+      --pdb                 Start the interactive Python debugger on errors or
+                            KeyboardInterrupt
       --pdbcls=modulename:classname
-                            specify a custom interactive Python debugger for use
-                            with --pdb.For example:
+                            Specify a custom interactive Python debugger for use
+                            with --pdb. For example:
                             --pdbcls=IPython.terminal.debugger:TerminalPdb
-      --trace               Immediately break when running each test.
-      --capture=method      per-test capturing method: one of fd|sys|no|tee-sys.
-      -s                    shortcut for --capture=no.
-      --runxfail            report the results of xfail tests as if they were
+      --trace               Immediately break when running each test
+      --capture=method      Per-test capturing method: one of fd|sys|no|tee-sys.
+      -s                    Shortcut for --capture=no.
+      --runxfail            Report the results of xfail tests as if they were
                             not marked
-      --lf, --last-failed   rerun only the tests that failed at the last run (or
+      --lf, --last-failed   Rerun only the tests that failed at the last run (or
                             all if none failed)
-      --ff, --failed-first  run all tests, but run the last failures first.
+      --ff, --failed-first  Run all tests, but run the last failures first
                             This may re-order tests and thus lead to repeated
-                            fixture setup/teardown.
-      --nf, --new-first     run tests from new files first, then the rest of the
+                            fixture setup/teardown
+      --nf, --new-first     Run tests from new files first, then the rest of the
                             tests sorted by file mtime
       --cache-show=[CACHESHOW]
-                            show cache contents, don't perform collection or
+                            Show cache contents, don't perform collection or
                             tests. Optional argument: glob (default: '*').
-      --cache-clear         remove all cache contents at start of test run.
+      --cache-clear         Remove all cache contents at start of test run
       --lfnf={all,none}, --last-failed-no-failures={all,none}
-                            which tests to run with no previously (known)
-                            failures.
-      --sw, --stepwise      exit on test failure and continue from last failing
+                            Which tests to run with no previously (known)
+                            failures
+      --sw, --stepwise      Exit on test failure and continue from last failing
                             test next time
       --sw-skip, --stepwise-skip
-                            ignore the first failing test but stop on the next
+                            Ignore the first failing test but stop on the next
                             failing test.
                             implicitly enables --stepwise.
 
-    reporting:
-      --durations=N         show N slowest setup/test durations (N=0 for all).
+    Reporting:
+      --durations=N         show N slowest setup/test durations (N=0 for all)
       --durations-min=N     Minimal duration in seconds for inclusion in slowest
-                            list. Default 0.005
-      -v, --verbose         increase verbosity.
-      --no-header           disable header
-      --no-summary          disable summary
-      -q, --quiet           decrease verbosity.
-      --verbosity=VERBOSE   set verbosity. Default is 0.
-      -r chars              show extra test summary info as specified by chars:
+                            list. Default: 0.005.
+      -v, --verbose         Increase verbosity
+      --no-header           Disable header
+      --no-summary          Disable summary
+      -q, --quiet           Decrease verbosity
+      --verbosity=VERBOSE   Set verbosity. Default: 0.
+      -r chars              Show extra test summary info as specified by chars:
                             (f)ailed, (E)rror, (s)kipped, (x)failed, (X)passed,
                             (p)assed, (P)assed with output, (a)ll except passed
                             (p/P), or (A)ll. (w)arnings are enabled by default
                             (see --disable-warnings), 'N' can be used to reset
                             the list. (default: 'fE').
       --disable-warnings, --disable-pytest-warnings
-                            disable warnings summary
-      -l, --showlocals      show locals in tracebacks (disabled by default).
-      --tb=style            traceback print mode
+                            Disable warnings summary
+      -l, --showlocals      Show locals in tracebacks (disabled by default)
+      --tb=style            Traceback print mode
                             (auto/long/short/line/native/no).
       --show-capture={no,stdout,stderr,log,all}
                             Controls how captured stdout/stderr/log is shown on
-                            failed tests. Default is 'all'.
-      --full-trace          don't cut any tracebacks (default is to cut).
-      --color=color         color terminal output (yes/no/auto).
+                            failed tests. Default: all.
+      --full-trace          Don't cut any tracebacks (default is to cut)
+      --color=color         Color terminal output (yes/no/auto)
       --code-highlight={yes,no}
                             Whether code should be highlighted (only if --color
-                            is also enabled)
-      --pastebin=mode       send failed|all info to bpaste.net pastebin service.
-      --junit-xml=path      create junit-xml style report file at given path.
-      --junit-prefix=str    prepend prefix to classnames in junit-xml output
+                            is also enabled). Default: yes.
+      --pastebin=mode       Send failed|all info to bpaste.net pastebin service
+      --junit-xml=path      Create junit-xml style report file at given path
+      --junit-prefix=str    Prepend prefix to classnames in junit-xml output
 
     pytest-warnings:
       -W PYTHONWARNINGS, --pythonwarnings=PYTHONWARNINGS
-                            set which warnings to report, see -W option of
-                            python itself.
-      --maxfail=num         exit after first num failures or errors.
-      --strict-config       any warnings encountered while parsing the `pytest`
-                            section of the configuration file raise errors.
-      --strict-markers      markers not registered in the `markers` section of
-                            the configuration file raise errors.
-      --strict              (deprecated) alias to --strict-markers.
-      -c file               load configuration from `file` instead of trying to
-                            locate one of the implicit configuration files.
+                            Set which warnings to report, see -W option of
+                            Python itself
+      --maxfail=num         Exit after first num failures or errors
+      --strict-config       Any warnings encountered while parsing the `pytest`
+                            section of the configuration file raise errors
+      --strict-markers      Markers not registered in the `markers` section of
+                            the configuration file raise errors
+      --strict              (Deprecated) alias to --strict-markers
+      -c file               Load configuration from `file` instead of trying to
+                            locate one of the implicit configuration files
       --continue-on-collection-errors
                             Force test execution even if collection errors
-                            occur.
+                            occur
       --rootdir=ROOTDIR     Define root directory for tests. Can be relative
                             path: 'root_dir', './root_dir',
                             'root_dir/another_dir/'; absolute path:
                             '/home/user/root_dir'; path with variables:
                             '$HOME/root_dir'.
 
-    collection:
-      --collect-only, --co  only collect tests, don't execute them.
-      --pyargs              try to interpret all arguments as python packages.
-      --ignore=path         ignore path during collection (multi-allowed).
-      --ignore-glob=path    ignore path pattern during collection (multi-
-                            allowed).
+    Collection:
+      --collect-only, --co  Only collect tests, don't execute them
+      --pyargs              Try to interpret all arguments as Python packages
+      --ignore=path         Ignore path during collection (multi-allowed)
+      --ignore-glob=path    Ignore path pattern during collection (multi-
+                            allowed)
       --deselect=nodeid_prefix
-                            deselect item (via node id prefix) during collection
-                            (multi-allowed).
-      --confcutdir=dir      only load conftest.py's relative to specified dir.
-      --noconftest          Don't load any conftest.py files.
-      --keep-duplicates     Keep duplicate tests.
+                            Deselect item (via node id prefix) during collection
+                            (multi-allowed)
+      --confcutdir=dir      Only load conftest.py's relative to specified dir
+      --noconftest          Don't load any conftest.py files
+      --keep-duplicates     Keep duplicate tests
       --collect-in-virtualenv
                             Don't ignore tests in a local virtualenv directory
       --import-mode={prepend,append,importlib}
-                            prepend/append to sys.path when importing test
-                            modules and conftest files, default is to prepend.
-      --doctest-modules     run doctests in all .py modules
+                            Prepend/append to sys.path when importing test
+                            modules and conftest files. Default: prepend.
+      --doctest-modules     Run doctests in all .py modules
       --doctest-report={none,cdiff,ndiff,udiff,only_first_failure}
-                            choose another output format for diffs on doctest
+                            Choose another output format for diffs on doctest
                             failure
-      --doctest-glob=pat    doctests file matching pattern, default: test*.txt
+      --doctest-glob=pat    Doctests file matching pattern, default: test*.txt
       --doctest-ignore-import-errors
-                            ignore doctest ImportErrors
+                            Ignore doctest ImportErrors
       --doctest-continue-on-failure
-                            for a given doctest, continue to run after the first
+                            For a given doctest, continue to run after the first
                             failure
 
-    test session debugging and configuration:
-      --basetemp=dir        base temporary directory for this test run.(warning:
-                            this directory is removed if it exists)
-      -V, --version         display pytest version and information about
+    Test session debugging and configuration:
+      --basetemp=dir        Base temporary directory for this test run. (Warning:
+                            this directory is removed if it exists.)
+      -V, --version         Display pytest version and information about
                             plugins. When given twice, also display information
                             about plugins.
-      -h, --help            show help message and configuration info
-      -p name               early-load given plugin module name or entry point
-                            (multi-allowed).
+      -h, --help            Show help message and configuration info
+      -p name               Early-load given plugin module name or entry point
+                            (multi-allowed)
                             To avoid loading of plugins, use the `no:` prefix,
-                            e.g. `no:doctest`.
-      --trace-config        trace considerations of conftest.py files.
+                            e.g. `no:doctest`
+      --trace-config        Trace considerations of conftest.py files
       --debug=[DEBUG_FILE_NAME]
-                            store internal tracing debug information in this log
+                            Store internal tracing debug information in this log
                             file.
                             This file is opened with 'w' and truncated as a
                             result, care advised.
-                            Defaults to 'pytestdebug.log'.
+                            Default: pytestdebug.log.
       -o OVERRIDE_INI, --override-ini=OVERRIDE_INI
-                            override ini option with "option=value" style, e.g.
-                            `-o xfail_strict=True -o cache_dir=cache`.
+                            Override ini option with "option=value" style, e.g.
+                            `-o xfail_strict=True -o cache_dir=cache`
       --assert=MODE         Control assertion debugging tools.
                             'plain' performs no assertion debugging.
                             'rewrite' (the default) rewrites assert statements
                             in test modules on import to provide assert
                             expression information.
-      --setup-only          only setup fixtures, do not execute tests.
-      --setup-show          show setup of fixtures while executing tests.
-      --setup-plan          show what fixtures and tests would be executed but
-                            don't execute anything.
+      --setup-only          Only setup fixtures, do not execute tests
+      --setup-show          Show setup of fixtures while executing tests
+      --setup-plan          Show what fixtures and tests would be executed but
+                            don't execute anything
 
-    logging:
-      --log-level=LEVEL     level of messages to catch/display.
+    Logging:
+      --log-level=LEVEL     Level of messages to catch/display.
                             Not set by default, so it depends on the root/parent
                             log handler's effective level, where it is "WARNING"
                             by default.
       --log-format=LOG_FORMAT
-                            log format as used by the logging module.
+                            Log format used by the logging module
       --log-date-format=LOG_DATE_FORMAT
-                            log date format as used by the logging module.
+                            Log date format used by the logging module
       --log-cli-level=LOG_CLI_LEVEL
-                            cli logging level.
+                            CLI logging level
       --log-cli-format=LOG_CLI_FORMAT
-                            log format as used by the logging module.
+                            Log format used by the logging module
       --log-cli-date-format=LOG_CLI_DATE_FORMAT
-                            log date format as used by the logging module.
-      --log-file=LOG_FILE   path to a file when logging will be written to.
+                            Log date format used by the logging module
+      --log-file=LOG_FILE   Path to a file when logging will be written to
       --log-file-level=LOG_FILE_LEVEL
-                            log file logging level.
+                            Log file logging level
       --log-file-format=LOG_FILE_FORMAT
-                            log format as used by the logging module.
+                            Log format used by the logging module
       --log-file-date-format=LOG_FILE_DATE_FORMAT
-                            log date format as used by the logging module.
+                            Log date format used by the logging module
       --log-auto-indent=LOG_AUTO_INDENT
                             Auto-indent multiline messages passed to the logging
                             module. Accepts true|on, false|off or an integer.
 
     [pytest] ini-options in the first pytest.ini|tox.ini|setup.cfg file found:
 
-      markers (linelist):   markers for test functions
+      markers (linelist):   Markers for test functions
       empty_parameter_set_mark (string):
-                            default marker for empty parametersets
-      norecursedirs (args): directory patterns to avoid for recursion
-      testpaths (args):     directories to search for tests when no files or
-                            directories are given in the command line.
+                            Default marker for empty parametersets
+      norecursedirs (args): Directory patterns to avoid for recursion
+      testpaths (args):     Directories to search for tests when no files or
+                            directories are given in the command line
       filterwarnings (linelist):
                             Each line specifies a pattern for
                             warnings.filterwarnings. Processed after
                             -W/--pythonwarnings.
-      usefixtures (args):   list of default fixtures to be used with this
+      usefixtures (args):   List of default fixtures to be used with this
                             project
-      python_files (args):  glob-style file patterns for Python test module
+      python_files (args):  Glob-style file patterns for Python test module
                             discovery
       python_classes (args):
-                            prefixes or glob names for Python test class
+                            Prefixes or glob names for Python test class
                             discovery
       python_functions (args):
-                            prefixes or glob names for Python test function and
+                            Prefixes or glob names for Python test function and
                             method discovery
       disable_test_id_escaping_and_forfeit_all_rights_to_community_support (bool):
-                            disable string escape non-ascii characters, might
+                            Disable string escape non-ASCII characters, might
                             cause unwanted side effects(use at your own risk)
       console_output_style (string):
-                            console output: "classic", or with additional
+                            Console output: "classic", or with additional
                             progress information ("progress" (percentage) |
-                            "count").
-      xfail_strict (bool):  default for the strict parameter of xfail markers
+                            "count")
+      xfail_strict (bool):  Default for the strict parameter of xfail markers
                             when not given explicitly (default: False)
       enable_assertion_pass_hook (bool):
-                            Enables the pytest_assertion_pass hook.Make sure to
+                            Enables the pytest_assertion_pass hook. Make sure to
                             delete any previously generated pyc cache files.
       junit_suite_name (string):
                             Test suite name for JUnit report
@@ -2053,45 +2053,45 @@ All the command-line flags can be obtained by running ``pytest --help``::
       junit_family (string):
                             Emit XML for schema: one of legacy|xunit1|xunit2
       doctest_optionflags (args):
-                            option flags for doctests
+                            Option flags for doctests
       doctest_encoding (string):
-                            encoding used for doctest files
-      cache_dir (string):   cache directory path.
-      log_level (string):   default value for --log-level
-      log_format (string):  default value for --log-format
+                            Encoding used for doctest files
+      cache_dir (string):   Cache directory path
+      log_level (string):   Default value for --log-level
+      log_format (string):  Default value for --log-format
       log_date_format (string):
-                            default value for --log-date-format
-      log_cli (bool):       enable log display during test run (also known as
-                            "live logging").
+                            Default value for --log-date-format
+      log_cli (bool):       Enable log display during test run (also known as
+                            "live logging")
       log_cli_level (string):
-                            default value for --log-cli-level
+                            Default value for --log-cli-level
       log_cli_format (string):
-                            default value for --log-cli-format
+                            Default value for --log-cli-format
       log_cli_date_format (string):
-                            default value for --log-cli-date-format
-      log_file (string):    default value for --log-file
+                            Default value for --log-cli-date-format
+      log_file (string):    Default value for --log-file
       log_file_level (string):
-                            default value for --log-file-level
+                            Default value for --log-file-level
       log_file_format (string):
-                            default value for --log-file-format
+                            Default value for --log-file-format
       log_file_date_format (string):
-                            default value for --log-file-date-format
+                            Default value for --log-file-date-format
       log_auto_indent (string):
-                            default value for --log-auto-indent
+                            Default value for --log-auto-indent
       pythonpath (paths):   Add paths to sys.path
       faulthandler_timeout (string):
                             Dump the traceback of all threads if a test takes
-                            more than TIMEOUT seconds to finish.
-      addopts (args):       extra command line options
-      minversion (string):  minimally required pytest version
+                            more than TIMEOUT seconds to finish
+      addopts (args):       Extra command line options
+      minversion (string):  Minimally required pytest version
       required_plugins (args):
-                            plugins that must be present for pytest to run
+                            Plugins that must be present for pytest to run
 
-    environment variables:
-      PYTEST_ADDOPTS           extra command line options
-      PYTEST_PLUGINS           comma-separated plugins to load during startup
-      PYTEST_DISABLE_PLUGIN_AUTOLOAD set to disable plugin auto-loading
-      PYTEST_DEBUG             set to enable debug tracing of pytest's internals
+    Environment variables:
+      PYTEST_ADDOPTS           Extra command line options
+      PYTEST_PLUGINS           Comma-separated plugins to load during startup
+      PYTEST_DISABLE_PLUGIN_AUTOLOAD Set to disable plugin auto-loading
+      PYTEST_DEBUG             Set to enable debug tracing of pytest's internals
 
 
     to see available markers type: pytest --markers

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -39,7 +39,7 @@ def pytest_addoption(parser: Parser) -> None:
         "enable_assertion_pass_hook",
         type="bool",
         default=False,
-        help="Enables the pytest_assertion_pass hook."
+        help="Enables the pytest_assertion_pass hook. "
         "Make sure to delete any previously generated pyc cache files.",
     )
 

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -440,7 +440,7 @@ def pytest_addoption(parser: Parser) -> None:
         "--last-failed",
         action="store_true",
         dest="lf",
-        help="rerun only the tests that failed "
+        help="Rerun only the tests that failed "
         "at the last run (or all if none failed)",
     )
     group.addoption(
@@ -448,7 +448,7 @@ def pytest_addoption(parser: Parser) -> None:
         "--failed-first",
         action="store_true",
         dest="failedfirst",
-        help="run all tests, but run the last failures first.\n"
+        help="Run all tests, but run the last failures first.\n"
         "This may re-order tests and thus lead to "
         "repeated fixture setup/teardown.",
     )
@@ -457,7 +457,7 @@ def pytest_addoption(parser: Parser) -> None:
         "--new-first",
         action="store_true",
         dest="newfirst",
-        help="run tests from new files first, then the rest of the tests "
+        help="Run tests from new files first, then the rest of the tests "
         "sorted by file mtime",
     )
     group.addoption(
@@ -466,7 +466,7 @@ def pytest_addoption(parser: Parser) -> None:
         nargs="?",
         dest="cacheshow",
         help=(
-            "show cache contents, don't perform collection or tests. "
+            "Show cache contents, don't perform collection or tests. "
             "Optional argument: glob (default: '*')."
         ),
     )
@@ -474,12 +474,12 @@ def pytest_addoption(parser: Parser) -> None:
         "--cache-clear",
         action="store_true",
         dest="cacheclear",
-        help="remove all cache contents at start of test run.",
+        help="Remove all cache contents at start of test run",
     )
     cache_dir_default = ".pytest_cache"
     if "TOX_ENV_DIR" in os.environ:
         cache_dir_default = os.path.join(os.environ["TOX_ENV_DIR"], cache_dir_default)
-    parser.addini("cache_dir", default=cache_dir_default, help="cache directory path.")
+    parser.addini("cache_dir", default=cache_dir_default, help="Cache directory path")
     group.addoption(
         "--lfnf",
         "--last-failed-no-failures",
@@ -487,7 +487,7 @@ def pytest_addoption(parser: Parser) -> None:
         dest="last_failed_no_failures",
         choices=("all", "none"),
         default="all",
-        help="which tests to run with no previously (known) failures.",
+        help="Which tests to run with no previously (known) failures",
     )
 
 

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -448,7 +448,7 @@ def pytest_addoption(parser: Parser) -> None:
         "--failed-first",
         action="store_true",
         dest="failedfirst",
-        help="Run all tests, but run the last failures first.\n"
+        help="Run all tests, but run the last failures first. "
         "This may re-order tests and thus lead to "
         "repeated fixture setup/teardown.",
     )

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -42,14 +42,14 @@ def pytest_addoption(parser: Parser) -> None:
         default="fd",
         metavar="method",
         choices=["fd", "sys", "no", "tee-sys"],
-        help="per-test capturing method: one of fd|sys|no|tee-sys.",
+        help="Per-test capturing method: one of fd|sys|no|tee-sys",
     )
     group._addoption(
         "-s",
         action="store_const",
         const="no",
         dest="capture",
-        help="shortcut for --capture=no.",
+        help="Shortcut for --capture=no",
     )
 
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1101,11 +1101,11 @@ class Config:
         self.inicfg = inicfg
         self._parser.extra_info["rootdir"] = str(self.rootpath)
         self._parser.extra_info["inifile"] = str(self.inipath)
-        self._parser.addini("addopts", "extra command line options", "args")
-        self._parser.addini("minversion", "minimally required pytest version")
+        self._parser.addini("addopts", "Extra command line options", "args")
+        self._parser.addini("minversion", "Minimally required pytest version")
         self._parser.addini(
             "required_plugins",
-            "plugins that must be present for pytest to run",
+            "Plugins that must be present for pytest to run",
             type="args",
             default=[],
         )

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -48,7 +48,7 @@ class Parser:
         _ispytest: bool = False,
     ) -> None:
         check_ispytest(_ispytest)
-        self._anonymous = OptionGroup("custom options", parser=self, _ispytest=True)
+        self._anonymous = OptionGroup("Custom options", parser=self, _ispytest=True)
         self._groups: List[OptionGroup] = []
         self._processopt = processopt
         self._usage = usage

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -46,21 +46,21 @@ def pytest_addoption(parser: Parser) -> None:
         "--pdb",
         dest="usepdb",
         action="store_true",
-        help="start the interactive Python debugger on errors or KeyboardInterrupt.",
+        help="Start the interactive Python debugger on errors or KeyboardInterrupt",
     )
     group._addoption(
         "--pdbcls",
         dest="usepdb_cls",
         metavar="modulename:classname",
         type=_validate_usepdb_cls,
-        help="specify a custom interactive Python debugger for use with --pdb."
+        help="Specify a custom interactive Python debugger for use with --pdb."
         "For example: --pdbcls=IPython.terminal.debugger:TerminalPdb",
     )
     group._addoption(
         "--trace",
         dest="trace",
         action="store_true",
-        help="Immediately break when running each test.",
+        help="Immediately break when running each test",
     )
 
 

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -66,26 +66,26 @@ CHECKER_CLASS: Optional[Type["doctest.OutputChecker"]] = None
 def pytest_addoption(parser: Parser) -> None:
     parser.addini(
         "doctest_optionflags",
-        "option flags for doctests",
+        "Option flags for doctests",
         type="args",
         default=["ELLIPSIS"],
     )
     parser.addini(
-        "doctest_encoding", "encoding used for doctest files", default="utf-8"
+        "doctest_encoding", "Encoding used for doctest files", default="utf-8"
     )
     group = parser.getgroup("collect")
     group.addoption(
         "--doctest-modules",
         action="store_true",
         default=False,
-        help="run doctests in all .py modules",
+        help="Run doctests in all .py modules",
         dest="doctestmodules",
     )
     group.addoption(
         "--doctest-report",
         type=str.lower,
         default="udiff",
-        help="choose another output format for diffs on doctest failure",
+        help="Choose another output format for diffs on doctest failure",
         choices=DOCTEST_REPORT_CHOICES,
         dest="doctestreport",
     )
@@ -94,21 +94,21 @@ def pytest_addoption(parser: Parser) -> None:
         action="append",
         default=[],
         metavar="pat",
-        help="doctests file matching pattern, default: test*.txt",
+        help="Doctests file matching pattern, default: test*.txt",
         dest="doctestglob",
     )
     group.addoption(
         "--doctest-ignore-import-errors",
         action="store_true",
         default=False,
-        help="ignore doctest ImportErrors",
+        help="Ignore doctest ImportErrors",
         dest="doctest_ignore_import_errors",
     )
     group.addoption(
         "--doctest-continue-on-failure",
         action="store_true",
         default=False,
-        help="for a given doctest, continue to run after the first failure",
+        help="For a given doctest, continue to run after the first failure",
         dest="doctest_continue_on_failure",
     )
 

--- a/src/_pytest/faulthandler.py
+++ b/src/_pytest/faulthandler.py
@@ -18,7 +18,7 @@ fault_handler_originally_enabled_key = StashKey[bool]()
 def pytest_addoption(parser: Parser) -> None:
     help = (
         "Dump the traceback of all threads if a test takes "
-        "more than TIMEOUT seconds to finish."
+        "more than TIMEOUT seconds to finish"
     )
     parser.addini("faulthandler_timeout", help, default=0.0)
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1350,7 +1350,7 @@ def pytest_addoption(parser: Parser) -> None:
         "usefixtures",
         type="args",
         default=[],
-        help="list of default fixtures to be used with this project",
+        help="List of default fixtures to be used with this project",
     )
 
 

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -49,7 +49,7 @@ def pytest_addoption(parser: Parser) -> None:
         action="count",
         default=0,
         dest="version",
-        help="display pytest version and information about plugins. "
+        help="Display pytest version and information about plugins. "
         "When given twice, also display information about plugins.",
     )
     group._addoption(
@@ -57,7 +57,7 @@ def pytest_addoption(parser: Parser) -> None:
         "--help",
         action=HelpAction,
         dest="help",
-        help="show help message and configuration info",
+        help="Show help message and configuration info",
     )
     group._addoption(
         "-p",
@@ -65,7 +65,7 @@ def pytest_addoption(parser: Parser) -> None:
         dest="plugins",
         default=[],
         metavar="name",
-        help="early-load given plugin module name or entry point (multi-allowed).\n"
+        help="Early-load given plugin module name or entry point (multi-allowed).\n"
         "To avoid loading of plugins, use the `no:` prefix, e.g. "
         "`no:doctest`.",
     )
@@ -74,7 +74,7 @@ def pytest_addoption(parser: Parser) -> None:
         "--trace-config",
         action="store_true",
         default=False,
-        help="trace considerations of conftest.py files.",
+        help="Trace considerations of conftest.py files",
     )
     group.addoption(
         "--debug",
@@ -83,16 +83,17 @@ def pytest_addoption(parser: Parser) -> None:
         const="pytestdebug.log",
         dest="debug",
         metavar="DEBUG_FILE_NAME",
-        help="store internal tracing debug information in this log file.\n"
+        help="Store internal tracing debug information in this log file.\n"
         "This file is opened with 'w' and truncated as a result, care advised.\n"
-        "Defaults to 'pytestdebug.log'.",
+        "Default: pytestdebug.log.",
     )
     group._addoption(
         "-o",
         "--override-ini",
         dest="override_ini",
         action="append",
-        help='override ini option with "option=value" style, e.g. `-o xfail_strict=True -o cache_dir=cache`.',
+        help='override ini option with "option=value" style, '
+        "e.g. `-o xfail_strict=True -o cache_dir=cache`.",
     )
 
 
@@ -203,12 +204,12 @@ def showhelp(config: Config) -> None:
                     tw.line(indent + line)
 
     tw.line()
-    tw.line("environment variables:")
+    tw.line("Environment variables:")
     vars = [
-        ("PYTEST_ADDOPTS", "extra command line options"),
-        ("PYTEST_PLUGINS", "comma-separated plugins to load during startup"),
-        ("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "set to disable plugin auto-loading"),
-        ("PYTEST_DEBUG", "set to enable debug tracing of pytest's internals"),
+        ("PYTEST_ADDOPTS", "Extra command line options"),
+        ("PYTEST_PLUGINS", "Comma-separated plugins to load during startup"),
+        ("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "Set to disable plugin auto-loading"),
+        ("PYTEST_DEBUG", "Set to enable debug tracing of pytest's internals"),
     ]
     for name, help in vars:
         tw.line(f"  {name:<24} {help}")

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -65,7 +65,7 @@ def pytest_addoption(parser: Parser) -> None:
         dest="plugins",
         default=[],
         metavar="name",
-        help="Early-load given plugin module name or entry point (multi-allowed).\n"
+        help="Early-load given plugin module name or entry point (multi-allowed). "
         "To avoid loading of plugins, use the `no:` prefix, e.g. "
         "`no:doctest`.",
     )
@@ -83,8 +83,8 @@ def pytest_addoption(parser: Parser) -> None:
         const="pytestdebug.log",
         dest="debug",
         metavar="DEBUG_FILE_NAME",
-        help="Store internal tracing debug information in this log file.\n"
-        "This file is opened with 'w' and truncated as a result, care advised.\n"
+        help="Store internal tracing debug information in this log file. "
+        "This file is opened with 'w' and truncated as a result, care advised. "
         "Default: pytestdebug.log.",
     )
     group._addoption(

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -92,7 +92,7 @@ def pytest_addoption(parser: Parser) -> None:
         "--override-ini",
         dest="override_ini",
         action="append",
-        help='override ini option with "option=value" style, '
+        help='Override ini option with "option=value" style, '
         "e.g. `-o xfail_strict=True -o cache_dir=cache`.",
     )
 

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -386,7 +386,7 @@ def pytest_addoption(parser: Parser) -> None:
         metavar="path",
         type=functools.partial(filename_arg, optname="--junitxml"),
         default=None,
-        help="create junit-xml style report file at given path.",
+        help="Create junit-xml style report file at given path",
     )
     group.addoption(
         "--junitprefix",
@@ -394,7 +394,7 @@ def pytest_addoption(parser: Parser) -> None:
         action="store",
         metavar="str",
         default=None,
-        help="prepend prefix to classnames in junit-xml output",
+        help="Prepend prefix to classnames in junit-xml output",
     )
     parser.addini(
         "junit_suite_name", "Test suite name for JUnit report", default="pytest"

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -218,7 +218,7 @@ def pytest_addoption(parser: Parser) -> None:
 
     def add_option_ini(option, dest, default=None, type=None, **kwargs):
         parser.addini(
-            dest, default=default, type=type, help="default value for " + option
+            dest, default=default, type=type, help="Default value for " + option
         )
         group.addoption(option, dest=dest, **kwargs)
 
@@ -228,7 +228,7 @@ def pytest_addoption(parser: Parser) -> None:
         default=None,
         metavar="LEVEL",
         help=(
-            "level of messages to catch/display.\n"
+            "Level of messages to catch/display.\n"
             "Not set by default, so it depends on the root/parent log handler's"
             ' effective level, where it is "WARNING" by default.'
         ),
@@ -237,58 +237,58 @@ def pytest_addoption(parser: Parser) -> None:
         "--log-format",
         dest="log_format",
         default=DEFAULT_LOG_FORMAT,
-        help="log format as used by the logging module.",
+        help="Log format used by the logging module",
     )
     add_option_ini(
         "--log-date-format",
         dest="log_date_format",
         default=DEFAULT_LOG_DATE_FORMAT,
-        help="log date format as used by the logging module.",
+        help="Log date format used by the logging module",
     )
     parser.addini(
         "log_cli",
         default=False,
         type="bool",
-        help='enable log display during test run (also known as "live logging").',
+        help='Enable log display during test run (also known as "live logging")',
     )
     add_option_ini(
-        "--log-cli-level", dest="log_cli_level", default=None, help="cli logging level."
+        "--log-cli-level", dest="log_cli_level", default=None, help="CLI logging level"
     )
     add_option_ini(
         "--log-cli-format",
         dest="log_cli_format",
         default=None,
-        help="log format as used by the logging module.",
+        help="Log format used by the logging module",
     )
     add_option_ini(
         "--log-cli-date-format",
         dest="log_cli_date_format",
         default=None,
-        help="log date format as used by the logging module.",
+        help="Log date format used by the logging module",
     )
     add_option_ini(
         "--log-file",
         dest="log_file",
         default=None,
-        help="path to a file when logging will be written to.",
+        help="Path to a file when logging will be written to",
     )
     add_option_ini(
         "--log-file-level",
         dest="log_file_level",
         default=None,
-        help="log file logging level.",
+        help="Log file logging level",
     )
     add_option_ini(
         "--log-file-format",
         dest="log_file_format",
         default=DEFAULT_LOG_FORMAT,
-        help="log format as used by the logging module.",
+        help="Log format used by the logging module",
     )
     add_option_ini(
         "--log-file-date-format",
         dest="log_file_date_format",
         default=DEFAULT_LOG_DATE_FORMAT,
-        help="log date format as used by the logging module.",
+        help="Log date format used by the logging module",
     )
     add_option_ini(
         "--log-auto-indent",

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -228,8 +228,8 @@ def pytest_addoption(parser: Parser) -> None:
         default=None,
         metavar="LEVEL",
         help=(
-            "Level of messages to catch/display.\n"
-            "Not set by default, so it depends on the root/parent log handler's"
+            "Level of messages to catch/display."
+            " Not set by default, so it depends on the root/parent log handler's"
             ' effective level, where it is "WARNING" by default.'
         ),
     )

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 def pytest_addoption(parser: Parser) -> None:
     parser.addini(
         "norecursedirs",
-        "directory patterns to avoid for recursion",
+        "Directory patterns to avoid for recursion",
         type="args",
         default=[
             "*.egg",
@@ -67,26 +67,26 @@ def pytest_addoption(parser: Parser) -> None:
     )
     parser.addini(
         "testpaths",
-        "directories to search for tests when no files or directories are given in the "
-        "command line.",
+        "Directories to search for tests when no files or directories are given on the "
+        "command line",
         type="args",
         default=[],
     )
-    group = parser.getgroup("general", "running and selection options")
+    group = parser.getgroup("general", "Running and selection options")
     group._addoption(
         "-x",
         "--exitfirst",
         action="store_const",
         dest="maxfail",
         const=1,
-        help="exit instantly on first error or failed test.",
+        help="Exit instantly on first error or failed test",
     )
     group = parser.getgroup("pytest-warnings")
     group.addoption(
         "-W",
         "--pythonwarnings",
         action="append",
-        help="set which warnings to report, see -W option of Python itself.",
+        help="Set which warnings to report, see -W option of Python itself",
     )
     parser.addini(
         "filterwarnings",
@@ -102,37 +102,39 @@ def pytest_addoption(parser: Parser) -> None:
         type=int,
         dest="maxfail",
         default=0,
-        help="exit after first num failures or errors.",
+        help="Exit after first num failures or errors",
     )
     group._addoption(
         "--strict-config",
         action="store_true",
-        help="any warnings encountered while parsing the `pytest` section of the configuration file raise errors.",
+        help="Any warnings encountered while parsing the `pytest` section of the "
+        "configuration file raise errors",
     )
     group._addoption(
         "--strict-markers",
         action="store_true",
-        help="markers not registered in the `markers` section of the configuration file raise errors.",
+        help="Markers not registered in the `markers` section of the configuration "
+        "file raise errors",
     )
     group._addoption(
         "--strict",
         action="store_true",
-        help="(deprecated) alias to --strict-markers.",
+        help="(Deprecated) alias to --strict-markers",
     )
     group._addoption(
         "-c",
         metavar="file",
         type=str,
         dest="inifilename",
-        help="load configuration from `file` instead of trying to locate one of the implicit "
-        "configuration files.",
+        help="Load configuration from `file` instead of trying to locate one of the "
+        "implicit configuration files",
     )
     group._addoption(
         "--continue-on-collection-errors",
         action="store_true",
         default=False,
         dest="continue_on_collection_errors",
-        help="Force test execution even if collection errors occur.",
+        help="Force test execution even if collection errors occur",
     )
     group._addoption(
         "--rootdir",
@@ -149,30 +151,30 @@ def pytest_addoption(parser: Parser) -> None:
         "--collect-only",
         "--co",
         action="store_true",
-        help="only collect tests, don't execute them.",
+        help="Only collect tests, don't execute them",
     )
     group.addoption(
         "--pyargs",
         action="store_true",
-        help="try to interpret all arguments as Python packages.",
+        help="Try to interpret all arguments as Python packages",
     )
     group.addoption(
         "--ignore",
         action="append",
         metavar="path",
-        help="ignore path during collection (multi-allowed).",
+        help="Ignore path during collection (multi-allowed)",
     )
     group.addoption(
         "--ignore-glob",
         action="append",
         metavar="path",
-        help="ignore path pattern during collection (multi-allowed).",
+        help="Ignore path pattern during collection (multi-allowed)",
     )
     group.addoption(
         "--deselect",
         action="append",
         metavar="nodeid_prefix",
-        help="deselect item (via node id prefix) during collection (multi-allowed).",
+        help="Deselect item (via node id prefix) during collection (multi-allowed)",
     )
     group.addoption(
         "--confcutdir",
@@ -180,14 +182,14 @@ def pytest_addoption(parser: Parser) -> None:
         default=None,
         metavar="dir",
         type=functools.partial(directory_arg, optname="--confcutdir"),
-        help="only load conftest.py's relative to specified dir.",
+        help="Only load conftest.py's relative to specified dir",
     )
     group.addoption(
         "--noconftest",
         action="store_true",
         dest="noconftest",
         default=False,
-        help="Don't load any conftest.py files.",
+        help="Don't load any conftest.py files",
     )
     group.addoption(
         "--keepduplicates",
@@ -195,7 +197,7 @@ def pytest_addoption(parser: Parser) -> None:
         action="store_true",
         dest="keepduplicates",
         default=False,
-        help="Keep duplicate tests.",
+        help="Keep duplicate tests",
     )
     group.addoption(
         "--collect-in-virtualenv",
@@ -209,8 +211,8 @@ def pytest_addoption(parser: Parser) -> None:
         default="prepend",
         choices=["prepend", "append", "importlib"],
         dest="importmode",
-        help="prepend/append to sys.path when importing test modules and conftest files, "
-        "default is to prepend.",
+        help="Prepend/append to sys.path when importing test modules and conftest "
+        "files. Default: prepend.",
     )
 
     group = parser.getgroup("debugconfig", "test session debugging and configuration")
@@ -221,8 +223,8 @@ def pytest_addoption(parser: Parser) -> None:
         type=validate_basetemp,
         metavar="dir",
         help=(
-            "base temporary directory for this test run. "
-            "(warning: this directory is removed if it exists)"
+            "Base temporary directory for this test run. "
+            "(Warning: this directory is removed if it exists.)"
         ),
     )
 

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -86,7 +86,7 @@ def pytest_addoption(parser: Parser) -> None:
         "-W",
         "--pythonwarnings",
         action="append",
-        help="set which warnings to report, see -W option of python itself.",
+        help="set which warnings to report, see -W option of Python itself.",
     )
     parser.addini(
         "filterwarnings",
@@ -154,7 +154,7 @@ def pytest_addoption(parser: Parser) -> None:
     group.addoption(
         "--pyargs",
         action="store_true",
-        help="try to interpret all arguments as python packages.",
+        help="try to interpret all arguments as Python packages.",
     )
     group.addoption(
         "--ignore",

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -221,7 +221,7 @@ def pytest_addoption(parser: Parser) -> None:
         type=validate_basetemp,
         metavar="dir",
         help=(
-            "base temporary directory for this test run."
+            "base temporary directory for this test run. "
             "(warning: this directory is removed if it exists)"
         ),
     )

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -96,7 +96,7 @@ def pytest_addoption(parser: Parser) -> None:
         dest="markexpr",
         default="",
         metavar="MARKEXPR",
-        help="Only run tests matching given mark expression.\n"
+        help="Only run tests matching given mark expression. "
         "For example: -m 'mark1 and not mark2'.",
     )
 

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -77,7 +77,7 @@ def pytest_addoption(parser: Parser) -> None:
         default="",
         metavar="EXPRESSION",
         help="only run tests which match the given substring expression. "
-        "An expression is a python evaluatable expression "
+        "An expression is a Python evaluatable expression "
         "where all names are substring-matched against test names "
         "and their parent classes. Example: -k 'test_method or test_"
         "other' matches all test functions and classes whose name "

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -76,7 +76,7 @@ def pytest_addoption(parser: Parser) -> None:
         dest="keyword",
         default="",
         metavar="EXPRESSION",
-        help="only run tests which match the given substring expression. "
+        help="Only run tests which match the given substring expression. "
         "An expression is a Python evaluatable expression "
         "where all names are substring-matched against test names "
         "and their parent classes. Example: -k 'test_method or test_"
@@ -96,7 +96,7 @@ def pytest_addoption(parser: Parser) -> None:
         dest="markexpr",
         default="",
         metavar="MARKEXPR",
-        help="only run tests matching given mark expression.\n"
+        help="Only run tests matching given mark expression.\n"
         "For example: -m 'mark1 and not mark2'.",
     )
 
@@ -106,8 +106,8 @@ def pytest_addoption(parser: Parser) -> None:
         help="show markers (builtin, plugin and per-project ones).",
     )
 
-    parser.addini("markers", "markers for test functions", "linelist")
-    parser.addini(EMPTY_PARAMETERSET_OPTION, "default marker for empty parametersets")
+    parser.addini("markers", "Markers for test functions", "linelist")
+    parser.addini(EMPTY_PARAMETERSET_OPTION, "Default marker for empty parametersets")
 
 
 @hookimpl(tryfirst=True)

--- a/src/_pytest/pastebin.py
+++ b/src/_pytest/pastebin.py
@@ -24,7 +24,7 @@ def pytest_addoption(parser: Parser) -> None:
         dest="pastebin",
         default=None,
         choices=["failed", "all"],
-        help="send failed|all info to bpaste.net pastebin service.",
+        help="Send failed|all info to bpaste.net pastebin service",
     )
 
 

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -89,7 +89,7 @@ def pytest_addoption(parser: Parser) -> None:
         action="store_true",
         dest="lsof",
         default=False,
-        help="run FD checks if lsof is available",
+        help="Run FD checks if lsof is available",
     )
 
     parser.addoption(
@@ -98,13 +98,13 @@ def pytest_addoption(parser: Parser) -> None:
         dest="runpytest",
         choices=("inprocess", "subprocess"),
         help=(
-            "run pytest sub runs in tests using an 'inprocess' "
+            "Run pytest sub runs in tests using an 'inprocess' "
             "or 'subprocess' (python -m main) method"
         ),
     )
 
     parser.addini(
-        "pytester_example_dir", help="directory to take the pytester example files from"
+        "pytester_example_dir", help="Directory to take the pytester example files from"
     )
 
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -95,7 +95,7 @@ def pytest_addoption(parser: Parser) -> None:
         action="store_true",
         dest="showfixtures",
         default=False,
-        help="show available fixtures, sorted by plugin appearance "
+        help="Show available fixtures, sorted by plugin appearance "
         "(fixtures with leading '_' are only shown with '-v')",
     )
     group.addoption(
@@ -103,32 +103,32 @@ def pytest_addoption(parser: Parser) -> None:
         action="store_true",
         dest="show_fixtures_per_test",
         default=False,
-        help="show fixtures per test",
+        help="Show fixtures per test",
     )
     parser.addini(
         "python_files",
         type="args",
         # NOTE: default is also used in AssertionRewritingHook.
         default=["test_*.py", "*_test.py"],
-        help="glob-style file patterns for Python test module discovery",
+        help="Glob-style file patterns for Python test module discovery",
     )
     parser.addini(
         "python_classes",
         type="args",
         default=["Test"],
-        help="prefixes or glob names for Python test class discovery",
+        help="Prefixes or glob names for Python test class discovery",
     )
     parser.addini(
         "python_functions",
         type="args",
         default=["test"],
-        help="prefixes or glob names for Python test function and method discovery",
+        help="Prefixes or glob names for Python test function and method discovery",
     )
     parser.addini(
         "disable_test_id_escaping_and_forfeit_all_rights_to_community_support",
         type="bool",
         default=False,
-        help="disable string escape non-ascii characters, might cause unwanted "
+        help="Disable string escape non-ASCII characters, might cause unwanted "
         "side effects(use at your own risk)",
     )
 

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -46,14 +46,14 @@ if TYPE_CHECKING:
 
 
 def pytest_addoption(parser: Parser) -> None:
-    group = parser.getgroup("terminal reporting", "reporting", after="general")
+    group = parser.getgroup("terminal reporting", "Reporting", after="general")
     group.addoption(
         "--durations",
         action="store",
         type=int,
         default=None,
         metavar="N",
-        help="show N slowest setup/test durations (N=0 for all).",
+        help="Show N slowest setup/test durations (N=0 for all)",
     )
     group.addoption(
         "--durations-min",
@@ -61,7 +61,8 @@ def pytest_addoption(parser: Parser) -> None:
         type=float,
         default=0.005,
         metavar="N",
-        help="Minimal duration in seconds for inclusion in slowest list. Default 0.005",
+        help="Minimal duration in seconds for inclusion in slowest list. "
+        "Default: 0.005.",
     )
 
 

--- a/src/_pytest/setuponly.py
+++ b/src/_pytest/setuponly.py
@@ -18,13 +18,13 @@ def pytest_addoption(parser: Parser) -> None:
         "--setuponly",
         "--setup-only",
         action="store_true",
-        help="only setup fixtures, do not execute tests.",
+        help="Only setup fixtures, do not execute tests",
     )
     group.addoption(
         "--setupshow",
         "--setup-show",
         action="store_true",
-        help="show setup of fixtures while executing tests.",
+        help="Show setup of fixtures while executing tests",
     )
 
 

--- a/src/_pytest/setupplan.py
+++ b/src/_pytest/setupplan.py
@@ -15,8 +15,8 @@ def pytest_addoption(parser: Parser) -> None:
         "--setupplan",
         "--setup-plan",
         action="store_true",
-        help="show what fixtures and tests would be executed but "
-        "don't execute anything.",
+        help="Show what fixtures and tests would be executed but "
+        "don't execute anything",
     )
 
 

--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -31,12 +31,12 @@ def pytest_addoption(parser: Parser) -> None:
         action="store_true",
         dest="runxfail",
         default=False,
-        help="report the results of xfail tests as if they were not marked",
+        help="Report the results of xfail tests as if they were not marked",
     )
 
     parser.addini(
         "xfail_strict",
-        "default for the strict parameter of xfail "
+        "Default for the strict parameter of xfail "
         "markers when not given explicitly (default: False)",
         default=False,
         type="bool",

--- a/src/_pytest/stepwise.py
+++ b/src/_pytest/stepwise.py
@@ -23,7 +23,7 @@ def pytest_addoption(parser: Parser) -> None:
         action="store_true",
         default=False,
         dest="stepwise",
-        help="exit on test failure and continue from last failing test next time",
+        help="Exit on test failure and continue from last failing test next time",
     )
     group.addoption(
         "--sw-skip",
@@ -31,8 +31,8 @@ def pytest_addoption(parser: Parser) -> None:
         action="store_true",
         default=False,
         dest="stepwise_skip",
-        help="ignore the first failing test but stop on the next failing test.\n"
-        "implicitly enables --stepwise.",
+        help="Ignore the first failing test but stop on the next failing test.\n"
+        "Implicitly enables --stepwise.",
     )
 
 

--- a/src/_pytest/stepwise.py
+++ b/src/_pytest/stepwise.py
@@ -31,7 +31,7 @@ def pytest_addoption(parser: Parser) -> None:
         action="store_true",
         default=False,
         dest="stepwise_skip",
-        help="Ignore the first failing test but stop on the next failing test.\n"
+        help="Ignore the first failing test but stop on the next failing test. "
         "Implicitly enables --stepwise.",
     )
 

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -110,28 +110,28 @@ class MoreQuietAction(argparse.Action):
 
 
 def pytest_addoption(parser: Parser) -> None:
-    group = parser.getgroup("terminal reporting", "reporting", after="general")
+    group = parser.getgroup("terminal reporting", "Reporting", after="general")
     group._addoption(
         "-v",
         "--verbose",
         action="count",
         default=0,
         dest="verbose",
-        help="increase verbosity.",
+        help="Increase verbosity",
     )
     group._addoption(
         "--no-header",
         action="store_true",
         default=False,
         dest="no_header",
-        help="disable header",
+        help="Disable header",
     )
     group._addoption(
         "--no-summary",
         action="store_true",
         default=False,
         dest="no_summary",
-        help="disable summary",
+        help="Disable summary",
     )
     group._addoption(
         "-q",
@@ -139,14 +139,14 @@ def pytest_addoption(parser: Parser) -> None:
         action=MoreQuietAction,
         default=0,
         dest="verbose",
-        help="decrease verbosity.",
+        help="Decrease verbosity",
     )
     group._addoption(
         "--verbosity",
         dest="verbose",
         type=int,
         default=0,
-        help="set verbosity. Default is 0.",
+        help="Set verbosity. Default: 0.",
     )
     group._addoption(
         "-r",
@@ -154,7 +154,7 @@ def pytest_addoption(parser: Parser) -> None:
         dest="reportchars",
         default=_REPORTCHARS_DEFAULT,
         metavar="chars",
-        help="show extra test summary info as specified by chars: (f)ailed, "
+        help="Show extra test summary info as specified by chars: (f)ailed, "
         "(E)rror, (s)kipped, (x)failed, (X)passed, "
         "(p)assed, (P)assed with output, (a)ll except passed (p/P), or (A)ll. "
         "(w)arnings are enabled by default (see --disable-warnings), "
@@ -166,7 +166,7 @@ def pytest_addoption(parser: Parser) -> None:
         default=False,
         dest="disable_warnings",
         action="store_true",
-        help="disable warnings summary",
+        help="Disable warnings summary",
     )
     group._addoption(
         "-l",
@@ -174,7 +174,7 @@ def pytest_addoption(parser: Parser) -> None:
         action="store_true",
         dest="showlocals",
         default=False,
-        help="show locals in tracebacks (disabled by default).",
+        help="Show locals in tracebacks (disabled by default)",
     )
     group._addoption(
         "--tb",
@@ -183,7 +183,7 @@ def pytest_addoption(parser: Parser) -> None:
         dest="tbstyle",
         default="auto",
         choices=["auto", "long", "short", "no", "line", "native"],
-        help="traceback print mode (auto/long/short/line/native/no).",
+        help="Traceback print mode (auto/long/short/line/native/no)",
     )
     group._addoption(
         "--show-capture",
@@ -192,14 +192,14 @@ def pytest_addoption(parser: Parser) -> None:
         choices=["no", "stdout", "stderr", "log", "all"],
         default="all",
         help="Controls how captured stdout/stderr/log is shown on failed tests. "
-        "Default is 'all'.",
+        "Default: all.",
     )
     group._addoption(
         "--fulltrace",
         "--full-trace",
         action="store_true",
         default=False,
-        help="don't cut any tracebacks (default is to cut).",
+        help="Don't cut any tracebacks (default is to cut)",
     )
     group._addoption(
         "--color",
@@ -208,19 +208,20 @@ def pytest_addoption(parser: Parser) -> None:
         dest="color",
         default="auto",
         choices=["yes", "no", "auto"],
-        help="color terminal output (yes/no/auto).",
+        help="Color terminal output (yes/no/auto)",
     )
     group._addoption(
         "--code-highlight",
         default="yes",
         choices=["yes", "no"],
         help="Whether code should be highlighted (only if --color is also enabled). "
-        "Default: yes",
+        "Default: yes.",
     )
 
     parser.addini(
         "console_output_style",
-        help='console output: "classic", or with additional progress information ("progress" (percentage) | "count").',
+        help='Console output: "classic", or with additional progress information '
+        '("progress" (percentage) | "count")',
         default="progress",
     )
 

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -214,7 +214,8 @@ def pytest_addoption(parser: Parser) -> None:
         "--code-highlight",
         default="yes",
         choices=["yes", "no"],
-        help="Whether code should be highlighted (only if --color is also enabled)",
+        help="Whether code should be highlighted (only if --color is also enabled). "
+        "Default: yes",
     )
 
     parser.addini(

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -2117,8 +2117,8 @@ class TestDebugOptions:
         result = pytester.runpytest("-h")
         result.stdout.fnmatch_lines(
             [
-                "*store internal tracing debug information in this log*",
+                "*Store internal tracing debug information in this log*",
                 "*This file is opened with 'w' and truncated as a result*",
-                "*Defaults to 'pytestdebug.log'.",
+                "*Default: pytestdebug.log.",
             ]
         )

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -2118,7 +2118,7 @@ class TestDebugOptions:
         result.stdout.fnmatch_lines(
             [
                 "*Store internal tracing debug information in this log*",
-                "*This file is opened with 'w' and truncated as a result*",
+                "*file. This file is opened with 'w' and truncated as a*",
                 "*Default: pytestdebug.log.",
             ]
         )

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -30,11 +30,11 @@ def test_help(pytester: Pytester) -> None:
     assert result.ret == 0
     result.stdout.fnmatch_lines(
         """
-          -m MARKEXPR           only run tests matching given mark expression.
+          -m MARKEXPR           Only run tests matching given mark expression.
                                 For example: -m 'mark1 and not mark2'.
-        reporting:
+        Reporting:
           --durations=N *
-          -V, --version         display pytest version and information about plugins.
+          -V, --version         Display pytest version and information about plugins.
                                 When given twice, also display information about
                                 plugins.
         *setup.cfg*
@@ -71,9 +71,9 @@ def test_empty_help_param(pytester: Pytester) -> None:
     assert result.ret == 0
     lines = [
         "  required_plugins (args):",
-        "                        plugins that must be present for pytest to run*",
+        "                        Plugins that must be present for pytest to run*",
         "  test_ini (bool):*",
-        "environment variables:",
+        "Environment variables:",
     ]
     result.stdout.fnmatch_lines(lines, consecutive=True)
 

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -30,8 +30,8 @@ def test_help(pytester: Pytester) -> None:
     assert result.ret == 0
     result.stdout.fnmatch_lines(
         """
-          -m MARKEXPR           Only run tests matching given mark expression.
-                                For example: -m 'mark1 and not mark2'.
+          -m MARKEXPR           Only run tests matching given mark expression. For
+                                example: -m 'mark1 and not mark2'.
         Reporting:
           --durations=N *
           -V, --version         Display pytest version and information about plugins.

--- a/testing/test_stepwise.py
+++ b/testing/test_stepwise.py
@@ -277,4 +277,4 @@ def test_stepwise_skip_is_independent(pytester: Pytester) -> None:
 
 def test_sw_skip_help(pytester: Pytester) -> None:
     result = pytester.runpytest("-h")
-    result.stdout.fnmatch_lines("*implicitly enables --stepwise.")
+    result.stdout.fnmatch_lines("*Implicitly enables --stepwise.")


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Recently had to look this up in the source code.

So include in help text it shows during `pytest --help` and on https://docs.pytest.org/en/7.1.x/reference/reference.html#command-line-flags

---

Whilst looking at the the help texts at https://docs.pytest.org/en/7.1.x/reference/reference.html#command-line-flags, there's quite a bit of variation in case and whether to use a full stop after a single or multiple sentence:

* Sentence case
* Sentence case.
* Sentence case. Sentence case.
* Sentence case. Sentence case
* lower case
* lower case.
* lower case. Sentence case
* lower case. Sentence case.

I can update them if you have a preference? 

I suggest: use sentence case, no full stop for single sentence. If there's more than one sentence, end each with a full stop.

