### PR TITLE
Add remove_finalizer function

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -285,6 +285,7 @@ Roberto Polli
 Roland Puntaier
 Romain Dorgueil
 Roman Bolshakov
+Roni Kishner
 Ronny Pfannschmidt
 Ross Lawley
 Ruaridh Williamson

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -730,6 +730,11 @@ Here's how the previous example would look using the ``addfinalizer`` method:
 It's a bit longer than yield fixtures and a bit more complex, but it
 does offer some nuances for when you're in a pinch.
 
+In addition you can use the remove_finalizer method to remove a finalizer you added
+to the teardown stage.
+The remove_finalizer method will remove the first finalizer match it finds and return True,
+if no match was found the function will return None.
+
 .. code-block:: pytest
 
    $ pytest -q test_emaillib.py

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -760,6 +760,11 @@ class SubRequest(FixtureRequest):
         within the requesting test context finished execution."""
         self._fixturedef.addfinalizer(finalizer)
 
+    def remove_finalizer(self, finalizer: Callable[[], object]) -> None:
+        """Remove finalizer/teardown function to be called after the last test
+        within the requesting test context finished execution."""
+        return self._fixturedef.remove_finalizer(finalizer)
+
     def _schedule_finalizers(
         self, fixturedef: "FixtureDef[object]", subrequest: "SubRequest"
     ) -> None:
@@ -1002,6 +1007,12 @@ class FixtureDef(Generic[FixtureValue]):
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         self._finalizers.append(finalizer)
+
+    def remove_finalizer(self, finalizer: Callable[[], object]) -> None:
+        for finalizer_index, finalizer_func in enumerate(self._finalizers):
+            if finalizer_func.__qualname__ == finalizer.__qualname__:
+                del self._finalizers[finalizer_index]
+                return True
 
     def finish(self, request: SubRequest) -> None:
         exc = None

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -503,6 +503,20 @@ class SetupState:
         assert node in self.stack, (node, self.stack)
         self.stack[node][0].append(finalizer)
 
+    def remove_finalizer(self, finalizer: Callable[[], object], node: Node) -> None:
+        """Remove a finalizer in the given node by name.
+
+        The node must be currently active in the stack.
+        The first finalizer by name will be removed.
+        """
+        assert node and not isinstance(node, tuple)
+        assert callable(finalizer)
+        assert node in self.stack, (node, self.stack)
+        for finalizer_index, finalizer_func in enumerate(self.stack[node][0]):
+            if finalizer_func.__qualname__ == finalizer.__qualname__:
+                del self.stack[node][0][finalizer_index]
+                return True
+
     def teardown_exact(self, nextitem: Optional[Item]) -> None:
         """Teardown the current stack up until reaching nodes that nextitem
         also descends from.


### PR DESCRIPTION
This PR adds remove_finalizer function to pytest.

This will enable removing a finalizer once it was added.
This is usefull in sitautions where you want to add finalizers at start of fixture, but in some conditions remove that finalizer.