### PR TITLE
Let mkdir() and mkpydir() receive PathLike names

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -904,13 +904,13 @@ class Pytester:
 
         self._monkeypatch.syspath_prepend(str(path))
 
-    def mkdir(self, name: str) -> Path:
+    def mkdir(self, name: Union[str, "os.PathLike[str]"]) -> Path:
         """Create a new (sub)directory."""
         p = self.path / name
         p.mkdir()
         return p
 
-    def mkpydir(self, name: str) -> Path:
+    def mkpydir(self, name: Union[str, "os.PathLike[str]"]) -> Path:
         """Create a new python package.
 
         This creates a (sub)directory with an empty ``__init__.py`` file so it


### PR DESCRIPTION
These pytester utility methods were annotated to only receive `str`
names, but they naturally support os.PathLike values, as well.

This makes writing some pytester calls a little nicer, such as when
creating a directory based on a `.joinpath()` call. We previously needed
to cast that intermediate value to a `str`.