### PR TITLE
Re-export importlib.metadata from _pytest.compat

### DIFF
--- a/changelog/9906.trivial.rst
+++ b/changelog/9906.trivial.rst
@@ -1,0 +1,1 @@
+Made ``_pytest.compat`` re-export ``importlib_metadata`` in the eyes of type checkers.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -50,9 +50,11 @@ NOTSET: "Final" = NotSetType.token  # noqa: E305
 # fmt: on
 
 if sys.version_info >= (3, 8):
-    from importlib import metadata as importlib_metadata
+    import importlib.metadata
+
+    importlib_metadata = importlib.metadata
 else:
-    import importlib_metadata  # noqa: F401
+    import importlib_metadata as importlib_metadata  # noqa: F401
 
 
 def _format_args(func: Callable[..., Any]) -> str:


### PR DESCRIPTION
I'm fixing a bug in mypy's `--no-implicit-reexport` logic in
https://github.com/python/mypy/pull/12704 and mypy-primer flagged this