### PR TITLE
Fix default encoding in cacheprovider

### DIFF
--- a/changelog/9910.trivial.rst
+++ b/changelog/9910.trivial.rst
@@ -1,0 +1,1 @@
+Fix default encoding warning (``EncodingWarning``) in ``cacheprovider``

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -157,7 +157,7 @@ class Cache:
         """
         path = self._getvaluepath(key)
         try:
-            with path.open("r") as f:
+            with path.open("r", encoding="UTF-8") as f:
                 return json.load(f)
         except (ValueError, OSError):
             return default
@@ -184,9 +184,9 @@ class Cache:
             return
         if not cache_dir_exists_already:
             self._ensure_supporting_files()
-        data = json.dumps(value, indent=2)
+        data = json.dumps(value, ensure_ascii=False, indent=2)
         try:
-            f = path.open("w")
+            f = path.open("w", encoding="UTF-8")
         except OSError:
             self.warn("cache could not write path {path}", path=path, _ispytest=True)
         else:
@@ -196,7 +196,7 @@ class Cache:
     def _ensure_supporting_files(self) -> None:
         """Create supporting files in the cache dir that are not really part of the cache."""
         readme_path = self._cachedir / "README.md"
-        readme_path.write_text(README_CONTENT)
+        readme_path.write_text(README_CONTENT, encoding="UTF-8")
 
         gitignore_path = self._cachedir.joinpath(".gitignore")
         msg = "# Created by pytest automatically.\n*\n"


### PR DESCRIPTION
Add `encoding="UTF-8"` and `ensure_ascii=False` in `_pytest/cacheprovider.py` to fix `EncodingWarning`.

Closes #9910 

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
