### PR TITLE
Bugfix approx tuple repr

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -357,5 +357,6 @@ Yoav Caspi
 Yuval Shimon
 Zac Hatfield-Dodds
 Zachary Kneupper
+Zachary OBrien
 Zoltán Máté
 Zsolt Cserna

--- a/changelog/9917.bugfix.rst
+++ b/changelog/9917.bugfix.rst
@@ -1,0 +1,2 @@
+String representation for `ApproxSequenceLike` was failing on tuples, fixed by
+generalizing `_recursive_list_map` to all sequences. Renamed function to: `_recursive_sequence_map`.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -133,9 +133,11 @@ class ApproxBase:
         # raise if there are any non-numeric elements in the sequence.
 
 
-def _recursive_list_map(f, x):
-    if isinstance(x, list):
-        return [_recursive_list_map(f, xi) for xi in x]
+def _recursive_sequence_map(f, x):
+    """Recursively map a function over a sequence of arbitary depth"""
+    if isinstance(x, Sequence):
+        seq_type = type(x)
+        return seq_type(_recursive_sequence_map(f, xi) for xi in x)
     else:
         return f(x)
 
@@ -144,7 +146,9 @@ class ApproxNumpy(ApproxBase):
     """Perform approximate comparisons where the expected value is numpy array."""
 
     def __repr__(self) -> str:
-        list_scalars = _recursive_list_map(self._approx_scalar, self.expected.tolist())
+        list_scalars = _recursive_sequence_map(
+            self._approx_scalar, self.expected.tolist()
+        )
         return f"approx({list_scalars!r})"
 
     def _repr_compare(self, other_side: "ndarray") -> List[str]:
@@ -164,7 +168,7 @@ class ApproxNumpy(ApproxBase):
             return value
 
         np_array_shape = self.expected.shape
-        approx_side_as_list = _recursive_list_map(
+        approx_side_as_list = _recursive_sequence_map(
             self._approx_scalar, self.expected.tolist()
         )
 
@@ -326,7 +330,7 @@ class ApproxSequenceLike(ApproxBase):
                 f"Lengths: {len(self.expected)} and {len(other_side)}",
             ]
 
-        approx_side_as_map = _recursive_list_map(self._approx_scalar, self.expected)
+        approx_side_as_map = _recursive_sequence_map(self._approx_scalar, self.expected)
 
         number_of_elements = len(approx_side_as_map)
         max_abs_diff = -math.inf


### PR DESCRIPTION
closes #9917 

* Refactored `_recursive_list_map` to work on all sequences, and renamed it to `recursive_sequence_map`

Behavior now works as expected. The example originally given in the issue now works as follows:
```
    def test_ab():
>       assert a == pytest.approx(b, abs=0.01)
E       assert ((1+0j), (2+0j)) == approx((1 ± 1....2 ± 1.0e-02))
E         comparison failed. Mismatched elements: 1 / 2:
E         Max absolute difference: 0.20000000000000018
E         Max relative difference: 0.10000000000000009
E         Index | Obtained | Expected     
E         1     | (2+0j)   | 2.2 ± 1.0e-02

my_test.py:7: AssertionError
```


