### PR TITLE
testing: fix Path.rglob("") failures in Python 3.11b1

### DIFF
--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -553,7 +553,7 @@ class TestConftestVisibility:
             )
         )
         print("created directory structure:")
-        for x in pytester.path.rglob(""):
+        for x in pytester.path.glob("**/"):
             print("   " + str(x.relative_to(pytester.path)))
 
         return {"runner": runner, "package": package, "swc": swc, "snc": snc}


### PR DESCRIPTION
Fix #9930.