### PR TITLE
Do Not Truncate Crash Messages In Short Test Summary on CI

### DIFF
--- a/changelog/9920.improvement.rst
+++ b/changelog/9920.improvement.rst
@@ -1,1 +1,1 @@
-Display full crash messages in ``short test summary info``, when runng in a CI environment. CI environment is detected based on the presence of a ``CI`` environment variable.
+Display full crash messages in ``short test summary info``, when runng in a CI environment.

--- a/changelog/9920.improvement.rst
+++ b/changelog/9920.improvement.rst
@@ -1,0 +1,1 @@
+Display full crash messages in ``short test summary info``, when runng in a CI environment. CI environment is detected based on the presence of a ``CI`` environment variable.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -5,7 +5,6 @@ This is a good source for looking at the various reporting hooks.
 import argparse
 import datetime
 import inspect
-import os
 import platform
 import sys
 import warnings
@@ -37,6 +36,7 @@ from _pytest import timing
 from _pytest._code import ExceptionInfo
 from _pytest._code.code import ExceptionRepr
 from _pytest._io.wcwidth import wcswidth
+from _pytest.assertion.util import running_on_ci
 from _pytest.compat import final
 from _pytest.config import _PluggyPlugin
 from _pytest.config import Config
@@ -1296,7 +1296,7 @@ def _get_line_with_reprcrash_message(
     except AttributeError:
         pass
     else:
-        if not os.environ.get("CI", False):
+        if not running_on_ci():
             available_width = termwidth - line_width
             msg = _format_trimmed(" - {}", msg, available_width)
         else:

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -5,6 +5,7 @@ This is a good source for looking at the various reporting hooks.
 import argparse
 import datetime
 import inspect
+import os
 import platform
 import sys
 import warnings
@@ -1295,8 +1296,11 @@ def _get_line_with_reprcrash_message(
     except AttributeError:
         pass
     else:
-        available_width = termwidth - line_width
-        msg = _format_trimmed(" - {}", msg, available_width)
+        if not os.environ.get("CI", False):
+            available_width = termwidth - line_width
+            msg = _format_trimmed(" - {}", msg, available_width)
+        else:
+            msg = f" - {msg}"
         if msg is not None:
             line += msg
 

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1140,15 +1140,17 @@ class TestTerminalFunctional:
 
 
 @pytest.mark.parametrize(
-    "use_CI",
+    ("use_ci", "expected_message"),
     (
         (True, f"- AssertionError: {'this_failed'*100}"),
         (False, "- AssertionError: this_failedt..."),
     ),
     ids=("on CI", "not on CI"),
 )
-def test_fail_extra_reporting(pytester: Pytester, monkeypatch, use_CI) -> None:
-    if use_CI[0]:
+def test_fail_extra_reporting(
+    pytester: Pytester, monkeypatch, use_ci: bool, expected_message: str
+) -> None:
+    if use_ci:
         monkeypatch.setenv("CI", "true")
     else:
         monkeypatch.delenv("CI", raising=False)
@@ -1160,7 +1162,7 @@ def test_fail_extra_reporting(pytester: Pytester, monkeypatch, use_CI) -> None:
     result.stdout.fnmatch_lines(
         [
             "*test summary*",
-            f"FAILED test_fail_extra_reporting.py::test_this {use_CI[1]}",
+            f"FAILED test_fail_extra_reporting.py::test_this {expected_message}",
         ]
     )
 


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Fixes #9920

This skips crash message truncation, if a `CI` environment variable is set and truthy.

Should this be mentioned in the docs, maybe as a note? https://github.com/pytest-dev/pytest/blob/main/doc/en/how-to/output.rst#producing-a-detailed-summary-report

*Thanks to blueyed for some hints in #5284.*

