### PR TITLE
Give warning when test function return other than None

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -63,6 +63,7 @@ Ceridwen
 Charles Cloud
 Charles Machalow
 Charnjit SiNGH (CCSJ)
+Cheuk Ting Ho
 Chris Lamb
 Chris NeJame
 Chris Rose

--- a/changelog/7337.improvement.rst
+++ b/changelog/7337.improvement.rst
@@ -1,1 +1,1 @@
-Warns for test functions that return non-None.
+A warning is now emitted if a test function returns something other than `None`. This prevents a common mistake among beginners that expect that returning a `bool` (for example `return foo(a, b) == result`) would cause a test to pass or fail, instead of using `assert`.

--- a/changelog/7337.improvement.rst
+++ b/changelog/7337.improvement.rst
@@ -1,1 +1,1 @@
-Warns for test functions that return non-None. Now in `pytest_pyfunc_call` after the `async_warn_and_skip` it will check for if the return is something other than None.
+Warns for test functions that return non-None.

--- a/changelog/7337.improvement.rst
+++ b/changelog/7337.improvement.rst
@@ -1,0 +1,1 @@
+Warns for test functions that return non-None. Now in `pytest_pyfunc_call` after the `async_warn_and_skip` it will check for if the return is something other than None.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -258,8 +258,33 @@ Returning non-None value in test functions
 
 .. deprecated:: 7.0
 
-:class:`pytest.PytestReturnNotNoneWarning` will be warn if a test function return values other than None.
-It is to avoid typo of an `assert` statement as `return` in a test function makes it passes the test without warning or failing, regardless of if the test should have pass or not.
+A :class:`pytest.PytestReturnNotNoneWarning` is now emitted if a test function returns something other than `None`. 
+
+This prevents a common mistake among beginners that expect that returning a `bool` would cause a test to pass or fail, for example:
+
+.. code-block:: python
+
+    @pytest.mark.parametrize(['a', 'b', 'result'], [
+      [1, 2, 5],
+      [2, 3, 8],
+      [5, 3, 18],
+    ])
+    def test_foo(a, b, result):
+        return foo(a, b) == result
+
+Given that pytest ignores the return value, this might be surprising that it will never fail.
+
+The proper fix is to change the `return` to an `assert`:
+
+.. code-block:: python
+
+    @pytest.mark.parametrize(['a', 'b', 'result'], [
+      [1, 2, 5],
+      [2, 3, 8],
+      [5, 3, 18],
+    ])
+    def test_foo(a, b, result):
+        assert foo(a, b) == result
 
 
 The ``--strict`` command-line option

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -252,6 +252,16 @@ or ``pytest.warns(Warning)``.
 
 See :ref:`warns use cases` for examples.
 
+
+Returning non-None value in test functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 7.0
+
+:class:`pytest.PytestReturnNotNoneWarning` will be warn if a test function return values other than None.
+It is to avoid typo of an `assert` statement as `return` in a test function makes it passes the test without warning or failing, regardless of if the test should have pass or not.
+
+
 The ``--strict`` command-line option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -258,17 +258,20 @@ Returning non-None value in test functions
 
 .. deprecated:: 7.0
 
-A :class:`pytest.PytestReturnNotNoneWarning` is now emitted if a test function returns something other than `None`. 
+A :class:`pytest.PytestReturnNotNoneWarning` is now emitted if a test function returns something other than `None`.
 
 This prevents a common mistake among beginners that expect that returning a `bool` would cause a test to pass or fail, for example:
 
 .. code-block:: python
 
-    @pytest.mark.parametrize(['a', 'b', 'result'], [
-      [1, 2, 5],
-      [2, 3, 8],
-      [5, 3, 18],
-    ])
+    @pytest.mark.parametrize(
+        ["a", "b", "result"],
+        [
+            [1, 2, 5],
+            [2, 3, 8],
+            [5, 3, 18],
+        ],
+    )
     def test_foo(a, b, result):
         return foo(a, b) == result
 
@@ -278,11 +281,14 @@ The proper fix is to change the `return` to an `assert`:
 
 .. code-block:: python
 
-    @pytest.mark.parametrize(['a', 'b', 'result'], [
-      [1, 2, 5],
-      [2, 3, 8],
-      [5, 3, 18],
-    ])
+    @pytest.mark.parametrize(
+        ["a", "b", "result"],
+        [
+            [1, 2, 5],
+            [2, 3, 8],
+            [5, 3, 18],
+        ],
+    )
     def test_foo(a, b, result):
         assert foo(a, b) == result
 

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -256,7 +256,7 @@ See :ref:`warns use cases` for examples.
 Returning non-None value in test functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. deprecated:: 7.0
+.. deprecated:: 7.2
 
 A :class:`pytest.PytestReturnNotNoneWarning` is now emitted if a test function returns something other than `None`.
 

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1130,6 +1130,9 @@ Custom warnings generated in some situations such as improper usage or deprecate
 .. autoclass:: pytest.PytestExperimentalApiWarning
    :show-inheritance:
 
+.. autoclass:: pytest.PytestReturnNotNoneWarning
+  :show-inheritance:
+
 .. autoclass:: pytest.PytestUnhandledCoroutineWarning
    :show-inheritance:
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -77,10 +77,12 @@ from _pytest.pathlib import parts
 from _pytest.pathlib import visit
 from _pytest.scope import Scope
 from _pytest.warning_types import PytestCollectionWarning
+from _pytest.warning_types import PytestReturnNotNoneWarning
 from _pytest.warning_types import PytestUnhandledCoroutineWarning
 
 if TYPE_CHECKING:
     from typing_extensions import Literal
+
     from _pytest.scope import _ScopeName
 
 
@@ -192,6 +194,14 @@ def pytest_pyfunc_call(pyfuncitem: "Function") -> Optional[object]:
     result = testfunction(**testargs)
     if hasattr(result, "__await__") or hasattr(result, "__aiter__"):
         async_warn_and_skip(pyfuncitem.nodeid)
+    elif result is not None:
+        warnings.warn(
+            PytestReturnNotNoneWarning(
+                "Test function returning {result}, do you mean to use `assert` instead or `return`?".format(
+                    result=result
+                )
+            )
+        )
     return True
 
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -197,7 +197,7 @@ def pytest_pyfunc_call(pyfuncitem: "Function") -> Optional[object]:
     elif result is not None:
         warnings.warn(
             PytestReturnNotNoneWarning(
-                f"Expected None, but the test returned {result!r}, which will be an error in a "
+                f"Expected None, but {pyfuncitem.nodeid} returned {result!r}, which will be an error in a "
                 "future version of pytest.  Did you mean to use `assert` instead of `return`?"
             )
         )

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -198,7 +198,7 @@ def pytest_pyfunc_call(pyfuncitem: "Function") -> Optional[object]:
         warnings.warn(
             PytestReturnNotNoneWarning(
                 f"Expected None, but the test returned {result!r}, which will be an error in a "
-                "future version of Pytest.  Did you mean to use `assert` instead of `return`?"
+                "future version of pytest.  Did you mean to use `assert` instead of `return`?"
             )
         )
     return True

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -197,9 +197,8 @@ def pytest_pyfunc_call(pyfuncitem: "Function") -> Optional[object]:
     elif result is not None:
         warnings.warn(
             PytestReturnNotNoneWarning(
-                "Test function returning {result}, do you mean to use `assert` instead or `return`?".format(
-                    result=result
-                )
+                f"Expected None, but the test returned {result!r}, which will be an error in a "
+                "future version of Pytest.  Did you mean to use `assert` instead of `return`?"
             )
         )
     return True

--- a/src/_pytest/warning_types.py
+++ b/src/_pytest/warning_types.py
@@ -42,13 +42,6 @@ class PytestCollectionWarning(PytestWarning):
     __module__ = "pytest"
 
 
-@final
-class PytestReturnNotNoneWarning(PytestWarning):
-    """Warning emitted when a test function is returning value other than None."""
-
-    __module__ = "pytest"
-
-
 class PytestDeprecationWarning(PytestWarning, DeprecationWarning):
     """Warning class for features that will be removed in a future version."""
 
@@ -58,6 +51,13 @@ class PytestDeprecationWarning(PytestWarning, DeprecationWarning):
 @final
 class PytestRemovedIn8Warning(PytestDeprecationWarning):
     """Warning class for features that will be removed in pytest 8."""
+
+    __module__ = "pytest"
+
+
+@final
+class PytestReturnNotNoneWarning(PytestDeprecationWarning):
+    """Warning emitted when a test function is returning value other than None."""
 
     __module__ = "pytest"
 

--- a/src/_pytest/warning_types.py
+++ b/src/_pytest/warning_types.py
@@ -42,6 +42,13 @@ class PytestCollectionWarning(PytestWarning):
     __module__ = "pytest"
 
 
+@final
+class PytestReturnNotNoneWarning(PytestWarning):
+    """Warning emitted when a test function is returning value other than None."""
+
+    __module__ = "pytest"
+
+
 class PytestDeprecationWarning(PytestWarning, DeprecationWarning):
     """Warning class for features that will be removed in a future version."""
 

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -69,6 +69,7 @@ from _pytest.warning_types import PytestConfigWarning
 from _pytest.warning_types import PytestDeprecationWarning
 from _pytest.warning_types import PytestExperimentalApiWarning
 from _pytest.warning_types import PytestRemovedIn8Warning
+from _pytest.warning_types import PytestReturnNotNoneWarning
 from _pytest.warning_types import PytestUnhandledCoroutineWarning
 from _pytest.warning_types import PytestUnhandledThreadExceptionWarning
 from _pytest.warning_types import PytestUnknownMarkWarning
@@ -127,6 +128,7 @@ __all__ = [
     "PytestDeprecationWarning",
     "PytestExperimentalApiWarning",
     "PytestRemovedIn8Warning",
+    "PytestReturnNotNoneWarning",
     "Pytester",
     "PytestPluginManager",
     "PytestUnhandledCoroutineWarning",

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1303,5 +1303,5 @@ def test_function_return_non_none_warning(testdir) -> None:
     )
     res = testdir.runpytest()
     res.stdout.fnmatch_lines(
-        ["*PytestReturnNotNoneWarning: Expected None, but the test returned*"]
+        ["*Did you mean to use `assert` instead of `return`?*"]
     )

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1292,3 +1292,14 @@ def test_no_brokenpipeerror_message(pytester: Pytester) -> None:
 
     # Cleanup.
     popen.stderr.close()
+
+
+def test_function_return_non_none_warning(testdir) -> None:
+    testdir.makepyfile(
+        """
+        def test_stuff():
+            return "something"
+    """
+    )
+    res = testdir.runpytest()
+    res.stdout.fnmatch_lines(["*PytestReturnNotNoneWarning: Test function returning*"])

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1302,6 +1302,4 @@ def test_function_return_non_none_warning(testdir) -> None:
     """
     )
     res = testdir.runpytest()
-    res.stdout.fnmatch_lines(
-        ["*Did you mean to use `assert` instead of `return`?*"]
-    )
+    res.stdout.fnmatch_lines(["*Did you mean to use `assert` instead of `return`?*"])

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1302,4 +1302,6 @@ def test_function_return_non_none_warning(testdir) -> None:
     """
     )
     res = testdir.runpytest()
-    res.stdout.fnmatch_lines(["*PytestReturnNotNoneWarning: Test function returning*"])
+    res.stdout.fnmatch_lines(
+        ["*PytestReturnNotNoneWarning: Expected None, but the test returned*"]
+    )


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->

Adding a warning in `pytest_pyfunc_call` after the `async_warn_and_skip` will check if the return is something other than `None`.

Closes #7337; see that issue for details.

CC @Zac-HD 