### PR TITLE
Remove "Python 2.7 and 3.4 Support" from globaltoc

### DIFF
--- a/doc/en/_templates/globaltoc.html
+++ b/doc/en/_templates/globaltoc.html
@@ -17,7 +17,6 @@
   <li><a href="{{ pathto('changelog') }}">Changelog</a></li>
   <li><a href="{{ pathto('contributing') }}">Contributing</a></li>
   <li><a href="{{ pathto('backwards-compatibility') }}">Backwards Compatibility</a></li>
-  <li><a href="{{ pathto('py27-py34-deprecation') }}">Python 2.7 and 3.4 Support</a></li>
   <li><a href="{{ pathto('sponsor') }}">Sponsor</a></li>
   <li><a href="{{ pathto('tidelift') }}">pytest for Enterprise</a></li>
   <li><a href="{{ pathto('license') }}">License</a></li>


### PR DESCRIPTION
Follow up to #9957 - I missed that the globaltoc is hard-coded
and the page needs to be removed there as well.
