### PR TITLE
Reorder the reference guides in the docs

### DIFF
--- a/doc/en/reference/index.rst
+++ b/doc/en/reference/index.rst
@@ -8,8 +8,8 @@ Reference guides
 .. toctree::
    :maxdepth: 1
 
-   fixtures
-   plugin_list
-   customize
    reference
+   fixtures
+   customize
    exit-codes
+   plugin_list


### PR DESCRIPTION
This changes the order to:

- API Reference
- Fixtures reference
- Configuration
- Exit codes
- Plugin List

which is approximately sorted from general to specific and often used to less used.
Plugin List ist at the end because it points to further external resources.
