### PR TITLE
Declutter doc entry page

### DIFF
--- a/doc/en/_templates/globaltoc.html
+++ b/doc/en/_templates/globaltoc.html
@@ -30,5 +30,3 @@
 {%- endif %}
 
 <hr>
-<a href="{{ pathto('genindex') }}">Index</a>
-<hr>

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -247,7 +247,7 @@ html_sidebars = {
 html_domain_indices = True
 
 # If false, no index is generated.
-html_use_index = True
+html_use_index = False
 
 # If true, the index is split into individual pages for each letter.
 # html_split_index = False

--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -27,8 +27,6 @@ scale to support complex functional testing for applications and libraries.
 
 **PyPI package name**: :pypi:`pytest`
 
-**Documentation as PDF**: `download latest <https://media.readthedocs.org/pdf/pytest/latest/pytest.pdf>`_
-
 
 A quick example
 ---------------
@@ -104,11 +102,6 @@ Bugs/Requests
 Please use the `GitHub issue tracker <https://github.com/pytest-dev/pytest/issues>`_ to submit bugs or request features.
 
 
-Changelog
----------
-
-Consult the :ref:`Changelog <changelog>` page for fixes and enhancements of each version.
-
 Support pytest
 --------------
 
@@ -141,13 +134,3 @@ Security
 pytest has never been associated with a security vulnerability, but in any case, to report a
 security vulnerability please use the `Tidelift security contact <https://tidelift.com/security>`_.
 Tidelift will coordinate the fix and disclosure.
-
-
-License
--------
-
-Copyright Holger Krekel and others, 2004.
-
-Distributed under the terms of the `MIT`_ license, pytest is free and open source software.
-
-.. _`MIT`: https://github.com/pytest-dev/pytest/blob/main/LICENSE


### PR DESCRIPTION
- Remove the index page https://docs.pytest.org/en/7.1.x/genindex.html
  Such an index is reasonable in books but not so much in HTML pages.
  IMHO the integrated search is much more user-friendly and sufficient.

- Remove the PDF link from the entry page. The PDF is already linked
  in the sidebar. I anticipate that getting the PDF documentation is
  not a major concern for users.

  This is removed:  ![grafik](https://user-images.githubusercontent.com/2836374/168692889-905a71c8-9315-4248-9d95-54a2e536f371.png)
  
  because we still have
  ![grafik](https://user-images.githubusercontent.com/2836374/168692986-2099012a-6f7e-45d1-8561-b4a0915bcbfa.png)


- Remove the sections "Changelog" and "License" from the entry page.
  These section only contain links to the respective pages.
  The topics are purely technical. They should be easily accessible
  (which they still are through sidebar section "About the project"),
  but they don't need additional advertisement through a dedicated
  section on the entry page.

  Note: The entry page sections

  - Bugs/Requests
  - Support pytest
  - pytest for enterprise / Security

  are also duplicate or similar to the "About the project" sidebar.
  However, I left them in place for now since you might want to draw
  special attention to them.

before / after:

![grafik](https://user-images.githubusercontent.com/2836374/168690493-a5f003a9-f8a4-4b7f-9131-6d493e1c1537.png) ![grafik](https://user-images.githubusercontent.com/2836374/168690614-d6640159-8299-49be-979d-a1cb2249fe4e.png)
