### PR TITLE
Fix rst markup in TempdirFactory's docstring.

### DIFF
--- a/src/_pytest/legacypath.py
+++ b/src/_pytest/legacypath.py
@@ -270,8 +270,8 @@ class LegacyTestdirPlugin:
 @final
 @attr.s(init=False, auto_attribs=True)
 class TempdirFactory:
-    """Backward compatibility wrapper that implements :class:``_pytest.compat.LEGACY_PATH``
-    for :class:``TempPathFactory``."""
+    """Backward compatibility wrapper that implements :class:`_pytest.compat.LEGACY_PATH`
+    for :class:`TempPathFactory`."""
 
     _tmppath_factory: TempPathFactory
 


### PR DESCRIPTION
The docstring of `TempdirFactory` has two markup errors that are visible at https://docs.pytest.org/en/6.2.x/reference.html#pytest.TempdirFactory (since the autodoc directive fetches the docstring):

![image](https://user-images.githubusercontent.com/25624924/168736303-928e916d-aaf2-42fd-ada0-87c7bb0aee6b.png)

This PR fixes the markup.