### PR TITLE
 Update :class:`pytest.PytestUnhandledCoroutineWarning` to a deprecation; it will raise an error in pytest 8. [SQUASH]

### DIFF
--- a/changelog/10012.deprecation.rst
+++ b/changelog/10012.deprecation.rst
@@ -1,0 +1,1 @@
+ upgrade PytestUnhandledCoroutineWarning to PytestDeprecationWarning

--- a/changelog/10012.deprecation.rst
+++ b/changelog/10012.deprecation.rst
@@ -1,1 +1,1 @@
- upgrade PytestUnhandledCoroutineWarning to PytestDeprecationWarning
+upgrade :class:`pytest.PytestUnhandledCoroutineWarning` it will raise an error in pytest 8

--- a/changelog/10012.deprecation.rst
+++ b/changelog/10012.deprecation.rst
@@ -1,1 +1,1 @@
-upgrade :class:`pytest.PytestUnhandledCoroutineWarning` it will raise an error in pytest 8
+upgrade :class:`pytest.PytestUnhandledCoroutineWarning` to a deprecation it will raise an error in pytest 8

--- a/changelog/10012.deprecation.rst
+++ b/changelog/10012.deprecation.rst
@@ -1,1 +1,1 @@
-upgrade :class:`pytest.PytestUnhandledCoroutineWarning` to a deprecation it will raise an error in pytest 8
+Update :class:`pytest.PytestUnhandledCoroutineWarning` to a deprecation; it will raise an error in pytest 8.

--- a/src/_pytest/warning_types.py
+++ b/src/_pytest/warning_types.py
@@ -55,7 +55,6 @@ class PytestRemovedIn8Warning(PytestDeprecationWarning):
     __module__ = "pytest"
 
 
-@final
 class PytestReturnNotNoneWarning(PytestDeprecationWarning):
     """Warning emitted when a test function is returning value other than None."""
 
@@ -82,7 +81,7 @@ class PytestExperimentalApiWarning(PytestWarning, FutureWarning):
 
 
 @final
-class PytestUnhandledCoroutineWarning(PytestWarning):
+class PytestUnhandledCoroutineWarning(PytestReturnNotNoneWarning):
     """Warning emitted for an unhandled coroutine.
 
     A coroutine was encountered when collecting test functions, but was not


### PR DESCRIPTION
currently the PytestUnhandledCoroutineWarning are a regular PytestWarning. However really they are just a more important special case of PytestReturnNotNoneWarning

If the plan is to upbraid PytestReturnNotNoneWarning into a PytestReturnNotNoneError in pytest 8, we should turn both of these into an error at the same time.

See https://github.com/pytest-dev/pytest/pull/9956#issuecomment-1143853734
And https://github.com/pytest-dev/pytest/issues/7363

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Fixes https://github.com/pytest-dev/pytest/issues/7337#issuecomment-1143836566
If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
