### PR TITLE
docs(monkeypatch): Fix autodoc reference links

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -334,6 +334,7 @@ Tom Dalton
 Tom Viner
 Tomáš Gavenčiak
 Tomer Keren
+Tony Narlock
 Tor Colvin
 Trevor Bekolay
 Tyler Goodlet

--- a/doc/en/how-to/monkeypatch.rst
+++ b/doc/en/how-to/monkeypatch.rst
@@ -3,7 +3,7 @@
 How to monkeypatch/mock modules and environments
 ================================================================
 
-.. currentmodule:: _pytest.monkeypatch
+.. currentmodule:: pytest
 
 Sometimes tests need to invoke functionality which depends
 on global settings or which invokes code which cannot be easily
@@ -436,7 +436,7 @@ separate fixtures for each potential mock and reference them in the needed tests
             _ = app.create_connection_string()
 
 
-.. currentmodule:: _pytest.monkeypatch
+.. currentmodule:: pytest
 
 API Reference
 -------------


### PR DESCRIPTION
Since #8006 MonkeyPatch is publicly available on [`pytest.MonkeyPatch`](https://docs.pytest.org/en/7.1.x/reference/reference.html?#pytest.MonkeyPatch).

<details>

<summary>Before</summary>

![image](https://user-images.githubusercontent.com/26336/171483094-3095fbbc-2b71-4e88-ac99-4a39940bb32b.png)
![image](https://user-images.githubusercontent.com/26336/171483122-07a9c8a5-eb1e-4340-b04f-cf2ff2f6b0dc.png)

</details>

<details>

<summary>With PR</summary>

![image](https://user-images.githubusercontent.com/26336/171483166-41c819b5-028b-4883-8550-45a4197c4c61.png)
![image](https://user-images.githubusercontent.com/26336/171483184-2fb78e13-bcc3-4cac-9fd5-f1e4877272cf.png)

</details>

- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

- [x] Fixes #10014

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Small doc fix

- [x] Add yourself to `AUTHORS` in alphabetical order.