### PR TITLE
[6.2.x] docs(monkeypatch): Fix autodoc reference links

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -302,6 +302,7 @@ Tom Dalton
 Tom Viner
 Tomáš Gavenčiak
 Tomer Keren
+Tony Narlock
 Tor Colvin
 Trevor Bekolay
 Tyler Goodlet

--- a/doc/en/monkeypatch.rst
+++ b/doc/en/monkeypatch.rst
@@ -2,7 +2,7 @@
 Monkeypatching/mocking modules and environments
 ================================================================
 
-.. currentmodule:: _pytest.monkeypatch
+.. currentmodule:: pytest
 
 Sometimes tests need to invoke functionality which depends
 on global settings or which invokes code which cannot be easily
@@ -434,7 +434,7 @@ separate fixtures for each potential mock and reference them in the needed tests
             _ = app.create_connection_string()
 
 
-.. currentmodule:: _pytest.monkeypatch
+.. currentmodule:: pytest
 
 API Reference
 -------------

--- a/extra/setup-py.test/setup.py
+++ b/extra/setup-py.test/setup.py
@@ -1,4 +1,5 @@
 import sys
+
 from distutils.core import setup
 
 if __name__ == "__main__":


### PR DESCRIPTION
Backport of PR https://github.com/pytest-dev/pytest/pull/10013 to 6.2.x branch.

PR created by @tony per @nicoddemus conversation in https://github.com/pytest-dev/pytest/pull/10015#issuecomment-1144873243


<details>

<summary>Before</summary>

![image](https://user-images.githubusercontent.com/26336/171642377-ffb934d7-d471-4dba-8ab7-eeab2c21b2cf.png)
![image](https://user-images.githubusercontent.com/26336/171642391-47661306-b250-46fb-b476-5e3f43c5eeb3.png)

</details>

<details>

<summary>After</summary>

![image](https://user-images.githubusercontent.com/26336/171642344-b2e83c09-daaf-43fe-a314-edfc0fe49071.png)

![image](https://user-images.githubusercontent.com/26336/171642353-a13c5961-1da8-43a1-9aa2-036e01042d34.png)

</details>