### PR TITLE
Use symbolic NoReturn as a type annotation

### DIFF
--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -10,8 +10,8 @@ from pathlib import Path
 from typing import Any
 from typing import Callable
 from typing import Generic
-from typing import Optional
 from typing import NoReturn
+from typing import Optional
 from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import TypeVar

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -11,6 +11,7 @@ from typing import Any
 from typing import Callable
 from typing import Generic
 from typing import Optional
+from typing import NoReturn
 from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import TypeVar
@@ -20,7 +21,6 @@ import attr
 import py
 
 if TYPE_CHECKING:
-    from typing import NoReturn
     from typing_extensions import Final
 
 
@@ -403,5 +403,5 @@ else:
 # previously.
 #
 # This also work for Enums (if you use `is` to compare) and Literals.
-def assert_never(value: "NoReturn") -> "NoReturn":
+def assert_never(value: NoReturn) -> NoReturn:
     assert False, f"Unhandled value: {value} ({type(value).__name__})"

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -9,6 +9,7 @@ from typing import cast
 from typing import Dict
 from typing import List
 from typing import Mapping
+from typing import NoReturn
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
@@ -24,7 +25,6 @@ from _pytest.deprecated import ARGUMENT_TYPE_STR_CHOICE
 from _pytest.deprecated import check_ispytest
 
 if TYPE_CHECKING:
-    from typing import NoReturn
     from typing_extensions import Literal
 
 FILE_OR_DIR = "file_or_dir"
@@ -403,7 +403,7 @@ class MyOptionParser(argparse.ArgumentParser):
         # an usage error to provide more contextual information to the user.
         self.extra_info = extra_info if extra_info else {}
 
-    def error(self, message: str) -> "NoReturn":
+    def error(self, message: str) -> NoReturn:
         """Transform argparse error message into UsageError."""
         msg = f"{self.prog}: error: {message}"
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -18,6 +18,7 @@ from typing import Iterable
 from typing import Iterator
 from typing import List
 from typing import MutableMapping
+from typing import NoReturn
 from typing import Optional
 from typing import overload
 from typing import Sequence
@@ -67,7 +68,6 @@ from _pytest.stash import StashKey
 
 if TYPE_CHECKING:
     from typing import Deque
-    from typing import NoReturn
 
     from _pytest.scope import _ScopeName
     from _pytest.main import Session
@@ -524,7 +524,7 @@ class FixtureRequest:
         """
         self.node.add_marker(marker)
 
-    def raiseerror(self, msg: Optional[str]) -> "NoReturn":
+    def raiseerror(self, msg: Optional[str]) -> NoReturn:
         """Raise a FixtureLookupError with the given message."""
         raise self._fixturemanager.FixtureLookupError(None, self, msg)
 
@@ -866,7 +866,7 @@ class FixtureLookupErrorRepr(TerminalRepr):
         tw.line("%s:%d" % (os.fspath(self.filename), self.firstlineno + 1))
 
 
-def fail_fixturefunc(fixturefunc, msg: str) -> "NoReturn":
+def fail_fixturefunc(fixturefunc, msg: str) -> NoReturn:
     fs, lineno = getfslineno(fixturefunc)
     location = f"{fs}:{lineno + 1}"
     source = _pytest._code.Source(fixturefunc)

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -21,14 +21,11 @@ import types
 from typing import Callable
 from typing import Iterator
 from typing import Mapping
+from typing import NoReturn
 from typing import Optional
 from typing import Sequence
-from typing import TYPE_CHECKING
 
 import attr
-
-if TYPE_CHECKING:
-    from typing import NoReturn
 
 
 __all__ = [
@@ -117,7 +114,7 @@ class Scanner:
             self.reject((type,))
         return None
 
-    def reject(self, expected: Sequence[TokenType]) -> "NoReturn":
+    def reject(self, expected: Sequence[TokenType]) -> NoReturn:
         raise ParseError(
             self.current.pos + 1,
             "expected {}; got {}".format(

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -5,6 +5,7 @@ import warnings
 from typing import Any
 from typing import Callable
 from typing import cast
+from typing import NoReturn
 from typing import Optional
 from typing import Type
 from typing import TypeVar
@@ -14,7 +15,6 @@ from _pytest.deprecated import KEYWORD_MSG_ARG
 TYPE_CHECKING = False  # Avoid circular import through compat.
 
 if TYPE_CHECKING:
-    from typing import NoReturn
     from typing_extensions import Protocol
 else:
     # typing.Protocol is only available starting from Python 3.8. It is also
@@ -115,7 +115,7 @@ def _with_exception(exception_type: _ET) -> Callable[[_F], _WithException[_F, _E
 @_with_exception(Exit)
 def exit(
     reason: str = "", returncode: Optional[int] = None, *, msg: Optional[str] = None
-) -> "NoReturn":
+) -> NoReturn:
     """Exit testing process.
 
     :param reason:
@@ -146,7 +146,7 @@ def exit(
 @_with_exception(Skipped)
 def skip(
     reason: str = "", *, allow_module_level: bool = False, msg: Optional[str] = None
-) -> "NoReturn":
+) -> NoReturn:
     """Skip an executing test with the given message.
 
     This function should be called only during testing (setup, call or teardown) or
@@ -176,9 +176,7 @@ def skip(
 
 
 @_with_exception(Failed)
-def fail(
-    reason: str = "", pytrace: bool = True, msg: Optional[str] = None
-) -> "NoReturn":
+def fail(reason: str = "", pytrace: bool = True, msg: Optional[str] = None) -> NoReturn:
     """Explicitly fail an executing test with the given message.
 
     :param reason:
@@ -238,7 +236,7 @@ class XFailed(Failed):
 
 
 @_with_exception(XFailed)
-def xfail(reason: str = "") -> "NoReturn":
+def xfail(reason: str = "") -> NoReturn:
     """Imperatively xfail an executing test or setup function with the given reason.
 
     This function should be called only during testing (setup, call or teardown).

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -8,6 +8,7 @@ from typing import Iterable
 from typing import Iterator
 from typing import List
 from typing import Mapping
+from typing import NoReturn
 from typing import Optional
 from typing import Tuple
 from typing import Type
@@ -36,7 +37,6 @@ from _pytest.nodes import Item
 from _pytest.outcomes import skip
 
 if TYPE_CHECKING:
-    from typing import NoReturn
     from typing_extensions import Literal
 
     from _pytest.runner import CallInfo
@@ -229,7 +229,7 @@ class BaseReport:
 
 def _report_unserialization_failure(
     type_name: str, report_class: Type[BaseReport], reportdict
-) -> "NoReturn":
+) -> NoReturn:
     url = "https://github.com/pytest-dev/pytest/issues"
     stream = StringIO()
     pprint("-" * 100, stream=stream)


### PR DESCRIPTION
This is a very minor PR that repairs a false positive with PyLint: https://github.com/PyCQA/pylint/issues/6815