### PR TITLE
Update location of `usage.rst` to fix manpage compilation

### DIFF
--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -320,7 +320,7 @@ latex_domain_indices = False
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [("usage", "pytest", "pytest usage", ["holger krekel at merlinux eu"], 1)]
+man_pages = [("how-to/usage", "pytest", "pytest usage", ["holger krekel at merlinux eu"], 1)]
 
 
 # -- Options for Epub output ---------------------------------------------------


### PR DESCRIPTION
`usage.rst` has been moved from `doc/en` to `doc/en/how-to`, so the `man_pages` configuration
value needs to be updated to the new location, so that we dont get this warning:

    writing... WARNING: "man_pages" config value references unknown document usage