### PR TITLE
Fix stage caplog records not clear

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -363,5 +363,6 @@ Yuval Shimon
 Zac Hatfield-Dodds
 Zachary Kneupper
 Zachary OBrien
+Zhouxin Qiu
 Zoltán Máté
 Zsolt Cserna

--- a/changelog/9877.bugfix.rst
+++ b/changelog/9877.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``caplog.get_records(when)`` still get the stage records after ``caplog.clear()``

--- a/changelog/9877.bugfix.rst
+++ b/changelog/9877.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed ``caplog.get_records(when)`` still get the stage records after ``caplog.clear()``
+ensure ``caplog.get_records(when)`` returns current/correct data after invoking ``caplog.clear()``

--- a/changelog/9877.bugfix.rst
+++ b/changelog/9877.bugfix.rst
@@ -1,1 +1,1 @@
-ensure ``caplog.get_records(when)`` returns current/correct data after invoking ``caplog.clear()``
+Ensure ``caplog.get_records(when)`` returns current/correct data after invoking ``caplog.clear()``.

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -184,6 +184,11 @@ def test_clear_for_call_stage(caplog, logging_during_setup_and_teardown):
     assert [x.message for x in caplog.get_records("setup")] == ["a_setup_log"]
     assert set(caplog._item.stash[caplog_records_key]) == {"setup", "call"}
 
+    logging.info("a_call_log_after_clear")
+    assert [x.message for x in caplog.get_records("call")] == ["a_call_log_after_clear"]
+    assert [x.message for x in caplog.get_records("setup")] == ["a_setup_log"]
+    assert set(caplog._item.stash[caplog_records_key]) == {"setup", "call"}
+
 
 def test_ini_controls_global_log_level(pytester: Pytester) -> None:
     pytester.makepyfile(

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -172,6 +172,19 @@ def test_caplog_captures_for_all_stages(caplog, logging_during_setup_and_teardow
     assert set(caplog._item.stash[caplog_records_key]) == {"setup", "call"}
 
 
+def test_clear_for_call_stage(caplog, logging_during_setup_and_teardown):
+    logger.info("a_call_log")
+    assert [x.message for x in caplog.get_records("call")] == ["a_call_log"]
+    assert [x.message for x in caplog.get_records("setup")] == ["a_setup_log"]
+    assert set(caplog._item.stash[caplog_records_key]) == {"setup", "call"}
+
+    caplog.clear()
+
+    assert caplog.get_records("call") == []
+    assert [x.message for x in caplog.get_records("setup")] == ["a_setup_log"]
+    assert set(caplog._item.stash[caplog_records_key]) == {"setup", "call"}
+
+
 def test_ini_controls_global_log_level(pytester: Pytester) -> None:
     pytester.makepyfile(
         """


### PR DESCRIPTION
Closes #9877

~~Add "when" property to `LogCaptureHandler` in `_pytest/logging.py`  to fix caplog stage records not reset after `caplog.clear()`~~

`caplog_handler.reset()` set LogCaptureHandler.records a new list object, which lost bind to item.stash

As each running stage use one caplog_handler object and it's records object reference in item.stash `item.stash[caplog_records_key][when] = caplog_handler.records`. So after clear, any log records can not be captured to item.stash
