### PR TITLE
Indicate support for a tuple of exceptions in xfail raises=

### DIFF
--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -245,7 +245,7 @@ Marks a test function as *expected to fail*.
     :keyword str reason:
         Reason why the test function is marked as xfail.
     :keyword Type[Exception] raises:
-        Exception subclass expected to be raised by the test function; other exceptions will fail the test.
+        Exception subclass (or tuple of subclasses) expected to be raised by the test function; other exceptions will fail the test.
     :keyword bool run:
         If the test function should actually be executed. If ``False``, the function will always xfail and will
         not be executed (useful if a function is segfaulting).


### PR DESCRIPTION
This PR adds a note in the reference documentation for `pytest.mark.xfail` that indicates that a tuple of exceptions is allowed. Currently, a user (:wave:) can only discover this functionality in the supplementary remarks about `xfail` in the [`skipping`](https://pytest.org/en/stable/how-to/skipping.html#raises-parameter) documentation.