### PR TITLE
Add new "pytest_modify_args" hook

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -98,6 +98,7 @@ David Szotten
 David Vierra
 Daw-Ran Liou
 Debi Mishra
+Delgan
 Denis Kirisov
 Denivy Braiam Rück
 Dhiren Serai

--- a/changelog/9619.feature.rst
+++ b/changelog/9619.feature.rst
@@ -1,0 +1,1 @@
+Added a new ``pytest_modify_args`` hook.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -627,6 +627,8 @@ Initialization hooks
 
 Initialization hooks called for plugins and ``conftest.py`` files.
 
+.. hook:: pytest_modify_args
+.. autofunction:: pytest_modify_args
 .. hook:: pytest_addoption
 .. autofunction:: pytest_addoption
 .. hook:: pytest_addhooks

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1318,6 +1318,7 @@ class Config:
             kwargs=dict(pluginmanager=self.pluginmanager)
         )
         self._preparse(args, addopts=addopts)
+        self.hook.pytest_modify_args(args=args)
         # XXX deprecated hook:
         self.hook.pytest_cmdline_preparse(config=self, args=args)
         self._parser.after_preparse = True  # type: ignore

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -172,6 +172,13 @@ def pytest_cmdline_preparse(config: "Config", args: List[str]) -> None:
     """
 
 
+def pytest_modify_args(args: List[str]) -> None:
+    """Modify command line arguments before option parsing.
+    
+    :param List[str] args: Arguments passed on the command line.
+    """
+
+
 @hookspec(firstresult=True)
 def pytest_cmdline_main(config: "Config") -> Optional[Union["ExitCode", int]]:
     """Called for performing the main command line action. The default

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1296,6 +1296,17 @@ def test_load_initial_conftest_last_ordering(_config_for_test):
     ]
 
 
+def test_modify_args_hook(pytester: Pytester) -> None:
+    pytester.makeconftest(
+        """
+        def pytest_modify_args(args):
+            args.append("-h")
+    """
+    )
+    result = pytester.runpytest()
+    result.stdout.fnmatch_lines(["*pytest*", "*-h*"])
+
+
 def test_get_plugin_specs_as_list() -> None:
     def exp_match(val: object) -> str:
         return (


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
-->

Hi.

I would like to suggest a new hook callable from `conftest.py` and in charge of modifying command line arguments at runtime.

Current solution is to use [`pytest_cmdline_preparse()`](https://docs.pytest.org/en/latest/reference/reference.html?highlight=preparse#std-hook-pytest_cmdline_preparse) but it's usage is deprecated. The [`pytest_load_initial_conftests()`](https://docs.pytest.org/en/latest/reference/reference.html?highlight=preparse#pytest.hookspec.pytest_load_initial_conftests) hook is advised as a replacement, but it does not work for `conftest.py` (while `pytest_cmdline_preparse()` does contrary to what states the documentation). I'm worried of `pytest_cmdline_preparse()` being removed with no alternative solution.

I chosen to create a new `pytest_modify_args()` hook, but other solutions are possible:
* Don't deprecate `pytest_cmdline_preparse()` (I don't know why it was deprecated in the first place)
* Make `pytest_load_initial_conftests()` callbable from `conftest.py` (I could not manage to pass the unit tests with such change)

I'm willing to update this PR and implement whichever solution you prefer. I'm just looking for a reliable way to update the arguments parsed by `pytest` before running the tests.

To give a concrete use case example:
* I'm using the [`pytest-mypy-plugins`](https://github.com/typeddjango/pytest-mypy-plugins) plugin
* It accepts a `.ini` file as `--mypy-ini-file` argument
* The argument must be ignored for older Python version
* The argument path is resolved relative to the working directory
* I would like to dynamically add the argument so that the `pytest` command works in all cases

Related issues:
* https://github.com/pytest-dev/pytest/issues/9619
* https://github.com/pytest-dev/pytest/issues/5024
* https://github.com/pytest-dev/pytest/issues/8591
* https://github.com/pytest-dev/pytest/issues/4482

Also maybe we could update the documentation to make it clearer which hook should be used in `conftests.py`: [Dynamically adding command line options](https://docs.pytest.org/en/7.1.x/example/simple.html#dynamically-adding-command-line-options).

Does is improvement suggestion seems fair to you? How can I help?

