### PR TITLE
Added Docstring description for the Path property of FixtureRequest #9975

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -261,6 +261,7 @@ Oscar Benjamin
 Parth Patel
 Patrick Hayes
 Paul Müller
+Paul Reece
 Pauli Virtanen
 Pavel Karateev
 Paweł Adamczak

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -486,6 +486,7 @@ class FixtureRequest:
 
     @property
     def path(self) -> Path:
+        """Path where the test function was collected."""
         if self.scope not in ("function", "class", "module", "package"):
             raise AttributeError(f"path not available in {self.scope}-scoped context")
         # TODO: Remove ignore once _pyfuncitem is properly typed.


### PR DESCRIPTION
Changed:
`  def path(self) -> Path:
        if self.scope not in ("function", "class", "module", "package"):
            raise AttributeError(f"path not available in {self.scope}-scoped context")
        # TODO: Remove ignore once _pyfuncitem is properly typed.`
To:
`  def path(self) -> Path:
        """Path where the test function was collected."""
        if self.scope not in ("function", "class", "module", "package"):
            raise AttributeError(f"path not available in {self.scope}-scoped context")
        # TODO: Remove ignore once _pyfuncitem is properly typed.`

Here is a quick checklist that should be present in PRs.

- [X ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ x] Add yourself to `AUTHORS` in alphabetical order.

