### PR TITLE
fall back to native when handeling to exception groups

### DIFF
--- a/changelog/9159.bugfix.rst
+++ b/changelog/9159.bugfix.rst
@@ -1,0 +1,1 @@
+Showing inner exceptions in ``ExceptionGroups`` when using display options other than ``--tb=native``.

--- a/changelog/9159.bugfix.rst
+++ b/changelog/9159.bugfix.rst
@@ -1,1 +1,1 @@
-Showing inner exceptions in ``ExceptionGroups`` when using display options other than ``--tb=native``.
+Showing inner exceptions by forcing native display in ``ExceptionGroups`` even when using display options other than ``--tb=native``. A temporary step before full implementation of pytest-native display for inner exceptions in ``ExceptionGroups``.

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -923,7 +923,12 @@ class FormattedExcinfo:
         seen: Set[int] = set()
         while e is not None and id(e) not in seen:
             seen.add(id(e))
-            if excinfo_:
+            if isinstance(e, ExceptionGroup):
+                reprtraceback = ReprTracebackNative(
+                    traceback.format_exception(type(e), e, excinfo.traceback[0]._rawentry)
+                )
+                reprcrash = None
+            elif excinfo_:
                 reprtraceback = self.repr_traceback(excinfo_)
                 reprcrash: Optional[ReprFileLocation] = (
                     excinfo_._getreprcrash() if self.style != "value" else None

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -925,7 +925,9 @@ class FormattedExcinfo:
             seen.add(id(e))
             if isinstance(e, ExceptionGroup):
                 reprtraceback = ReprTracebackNative(
-                    traceback.format_exception(type(e), e, excinfo.traceback[0]._rawentry)
+                    traceback.format_exception(
+                        type(e), e, excinfo.traceback[0]._rawentry
+                    )
                 )
                 reprcrash = None
             elif excinfo_:

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -68,6 +68,7 @@ try:
 except ModuleNotFoundError:
     pass  # No backport is installed
 
+
 class Code:
     """Wrapper around Python code objects."""
 
@@ -935,17 +936,19 @@ class FormattedExcinfo:
         while e is not None and id(e) not in seen:
             seen.add(id(e))
             if isinstance(e, ExceptionGroupTypes):
-                reprtraceback: Union[ReprTracebackNative, ReprTraceback] = ReprTracebackNative(
+                reprtraceback: Union[
+                    ReprTracebackNative, ReprTraceback
+                ] = ReprTracebackNative(
                     traceback.format_exception(
-                        type(excinfo.value), excinfo.value, excinfo.traceback[0]._rawentry
+                        type(excinfo.value),
+                        excinfo.value,
+                        excinfo.traceback[0]._rawentry,
                     )
                 )
                 reprcrash: Optional[ReprFileLocation] = None
             elif excinfo_:
                 reprtraceback = self.repr_traceback(excinfo_)
-                reprcrash = (
-                    excinfo_._getreprcrash() if self.style != "value" else None
-                )
+                reprcrash = excinfo_._getreprcrash() if self.style != "value" else None
             else:
                 # Fallback to native repr if the exception doesn't have a traceback:
                 # ExceptionInfo objects require a full traceback to work.

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -56,9 +56,9 @@ if TYPE_CHECKING:
 
     _TracebackStyle = Literal["long", "short", "line", "no", "native", "value", "auto"]
 
-ExceptionGroupTypes: tuple = ()
+ExceptionGroupTypes: tuple = ()  # type: ignore
 try:
-    ExceptionGroupTypes += (ExceptionGroup,)
+    ExceptionGroupTypes += (ExceptionGroup,)  # type: ignore
 except NameError:
     pass  # Is missing for `python<3.10`
 try:
@@ -67,7 +67,6 @@ try:
     ExceptionGroupTypes += (exceptiongroup.ExceptionGroup,)
 except ModuleNotFoundError:
     pass  # No backport is installed
-
 
 class Code:
     """Wrapper around Python code objects."""
@@ -936,15 +935,15 @@ class FormattedExcinfo:
         while e is not None and id(e) not in seen:
             seen.add(id(e))
             if isinstance(e, ExceptionGroupTypes):
-                reprtraceback = ReprTracebackNative(
+                reprtraceback: Union[ReprTracebackNative, ReprTraceback] = ReprTracebackNative(
                     traceback.format_exception(
-                        type(e), e, excinfo.traceback[0]._rawentry
+                        type(excinfo.value), excinfo.value, excinfo.traceback[0]._rawentry
                     )
                 )
-                reprcrash = None
+                reprcrash: Optional[ReprFileLocation] = None
             elif excinfo_:
                 reprtraceback = self.repr_traceback(excinfo_)
-                reprcrash: Optional[ReprFileLocation] = (
+                reprcrash = (
                     excinfo_._getreprcrash() if self.style != "value" else None
                 )
             else:

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -56,6 +56,18 @@ if TYPE_CHECKING:
 
     _TracebackStyle = Literal["long", "short", "line", "no", "native", "value", "auto"]
 
+ExceptionGroupTypes: tuple = ()
+try:
+    ExceptionGroupTypes += (ExceptionGroup,)
+except NameError:
+    pass  # Is missing for `python<3.10`
+try:
+    import exceptiongroup
+
+    ExceptionGroupTypes += (exceptiongroup.ExceptionGroup,)
+except ModuleNotFoundError:
+    pass  # No backport is installed
+
 
 class Code:
     """Wrapper around Python code objects."""
@@ -923,7 +935,7 @@ class FormattedExcinfo:
         seen: Set[int] = set()
         while e is not None and id(e) not in seen:
             seen.add(id(e))
-            if isinstance(e, ExceptionGroup):
+            if isinstance(e, ExceptionGroupTypes):
                 reprtraceback = ReprTracebackNative(
                     traceback.format_exception(
                         type(e), e, excinfo.traceback[0]._rawentry

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -1470,3 +1470,35 @@ def test_no_recursion_index_on_recursion_error():
     with pytest.raises(RuntimeError) as excinfo:
         RecursionDepthError().trigger
     assert "maximum recursion" in str(excinfo.getrepr())
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="requires python3.11 or higher")
+def test_exceptiongroup(pytester: Pytester) -> None:
+    pytester.makepyfile(
+        """
+        def f(): raise ValueError("From f()")
+        def g(): raise RuntimeError("From g()")
+
+        def main():
+            excs = []
+            for callback in [f, g]:
+                try:
+                    callback()
+                except Exception as err:
+                    excs.append(err)
+            if excs:
+                raise ExceptionGroup("Oops", excs)
+
+        def test():
+            main()
+    """
+    )
+    result = pytester.runpytest()
+    assert result.ret != 0
+
+    match = [
+        r"  | ExceptionGroup: Oops (2 sub-exceptions)",
+        r"    | ValueError: From f()",
+        r"    | RuntimeError: From g()",
+    ]
+    result.stdout.re_match_lines(match)

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -1472,7 +1472,6 @@ def test_no_recursion_index_on_recursion_error():
     assert "maximum recursion" in str(excinfo.getrepr())
 
 
-@pytest.mark.skipif(sys.version_info < (3, 11), reason="requires python3.11 or higher")
 def test_exceptiongroup(pytester: Pytester) -> None:
     pytester.makepyfile(
         """

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ setenv =
 extras = testing
 deps =
     doctesting: PyYAML
+    exceptiongroup: exceptiongroup>=1.0.0
     numpy: numpy>=1.19.4
     pexpect: pexpect>=4.8.0
     pluggymain: pluggy @ git+https://github.com/pytest-dev/pluggy.git


### PR DESCRIPTION
Showing inner exceptions in `ExceptionGroups` when using display options other than `--tb=native`.

Currently, the solution is it falls back on using a native display to show the inner exceptions but is happy to do a more custom display if needed.

see #9159 

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
