### PR TITLE
Use PurePath directly instead of os.path.sep in rewrite.py

### DIFF
--- a/changelog/9791.bugfix.rst
+++ b/changelog/9791.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a path handling code in ``rewrite.py`` that seems to work fine, but was incorrect and fails in some systems.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -190,7 +190,7 @@ class AssertionRewritingHook(importlib.abc.MetaPathFinder, importlib.abc.Loader)
             return False
 
         # For matching the name it must be as if it was a filename.
-        path = PurePath(os.path.sep.join(parts) + ".py")
+        path = PurePath(*parts).with_suffix(".py")
 
         for pat in self.fnpats:
             # if the pattern contains subdirectories ("tests/**.py" for example) we can't bail out based


### PR DESCRIPTION
Given we are already creating a `PurePath`, just pass the parts directly to it.

This avoids using `os.path.sep`, that although is an official API, seems not to be available in all systems.

Fix #9791

