### PR TITLE
Pass importmode to import_path in DoctestModule

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Alan Velasco
 Alexander Johnson
 Alexander King
 Alexei Kozlenok
+Alice Purcell
 Allan Feldman
 Aly Sivji
 Amir Elkess

--- a/changelog/3396.improvement.rst
+++ b/changelog/3396.improvement.rst
@@ -1,0 +1,1 @@
+Doctests now respect the ``--import-mode`` flag.

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -542,7 +542,11 @@ class DoctestModule(pytest.Module):
             )
         else:
             try:
-                module = import_path(self.path, root=self.config.rootpath)
+                module = import_path(
+                    self.path,
+                    root=self.config.rootpath,
+                    mode=self.config.getoption("importmode"),
+                )
             except ImportError:
                 if self.config.getvalue("doctest_ignore_import_errors"):
                     pytest.skip("unable to import module %r" % self.path)

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -113,6 +113,28 @@ class TestDoctests:
         reprec = pytester.inline_run(p)
         reprec.assertoutcome(failed=1)
 
+    def test_importmode(self, pytester: Pytester):
+        p = pytester.makepyfile(
+            **{
+                "namespacepkg/innerpkg/__init__.py": "",
+                "namespacepkg/innerpkg/a.py": """
+                  def some_func():
+                    return 42
+                """,
+                "namespacepkg/innerpkg/b.py": """
+                  from namespacepkg.innerpkg.a import some_func
+                  def my_func():
+                    '''
+                    >>> my_func()
+                    42
+                    '''
+                    return some_func()
+                """,
+            }
+        )
+        reprec = pytester.inline_run(p, "--doctest-modules", "--import-mode=importlib")
+        reprec.assertoutcome(passed=1)
+
     def test_new_pattern(self, pytester: Pytester):
         p = pytester.maketxtfile(
             xdoc="""


### PR DESCRIPTION
This allows doctest to be used with namespace modules in tox, as illustrated in the new unit test. See also #3396.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] ~Include documentation when adding new features.~
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
