### PR TITLE
[7.1.x] update does_not_raise docs now that pytest is 3.7+ only

### DIFF
--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -657,18 +657,15 @@ Use :func:`pytest.raises` with the
 :ref:`pytest.mark.parametrize ref` decorator to write parametrized tests
 in which some tests raise exceptions and others do not.
 
-It is helpful to define a no-op context manager ``does_not_raise`` to serve
-as a complement to ``raises``. For example:
+It may be helpful to use ``nullcontext`` as a complement to ``raises``.
+
+For example:
 
 .. code-block:: python
 
-    from contextlib import contextmanager
+    from contextlib import nullcontext as does_not_raise
+
     import pytest
-
-
-    @contextmanager
-    def does_not_raise():
-        yield
 
 
     @pytest.mark.parametrize(
@@ -687,22 +684,3 @@ as a complement to ``raises``. For example:
 
 In the example above, the first three test cases should run unexceptionally,
 while the fourth should raise ``ZeroDivisionError``.
-
-If you're only supporting Python 3.7+, you can simply use ``nullcontext``
-to define ``does_not_raise``:
-
-.. code-block:: python
-
-    from contextlib import nullcontext as does_not_raise
-
-Or, if you're supporting Python 3.3+ you can use:
-
-.. code-block:: python
-
-    from contextlib import ExitStack as does_not_raise
-
-Or, if desired, you can ``pip install contextlib2`` and use:
-
-.. code-block:: python
-
-    from contextlib2 import nullcontext as does_not_raise

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -82,12 +82,8 @@ class TestRaises:
     def test_does_not_raise(self, pytester: Pytester) -> None:
         pytester.makepyfile(
             """
-            from contextlib import contextmanager
+            from contextlib import nullcontext as does_not_raise
             import pytest
-
-            @contextmanager
-            def does_not_raise():
-                yield
 
             @pytest.mark.parametrize('example_input,expectation', [
                 (3, does_not_raise()),
@@ -107,12 +103,8 @@ class TestRaises:
     def test_does_not_raise_does_raise(self, pytester: Pytester) -> None:
         pytester.makepyfile(
             """
-            from contextlib import contextmanager
+            from contextlib import nullcontext as does_not_raise
             import pytest
-
-            @contextmanager
-            def does_not_raise():
-                yield
 
             @pytest.mark.parametrize('example_input,expectation', [
                 (0, does_not_raise()),


### PR DESCRIPTION
(cherry picked from commit 2941da0f2bdc58cabfc6977f45bea3c9404493ea)

backport of #10090 (conflict occurred)