### PR TITLE
Make ApproxScalar hashable

### DIFF
--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -459,8 +459,8 @@ class ApproxScalar(ApproxBase):
         result: bool = abs(self.expected - actual) <= self.tolerance
         return result
 
-    # Ignore type because of https://github.com/python/mypy/issues/4266.
-    __hash__ = None  # type: ignore
+    def __hash__(self):
+        return hash(self.expected)
 
     @property
     def tolerance(self):

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -348,7 +348,7 @@ class TestApprox:
 
     def test_hash(self):
         assert {1} == {approx(1, rel=1e-6, abs=1e-12)}
-        assert {1+1e-5} != {approx(1, rel=1e-6, abs=1e-12)}
+        assert {1 + 1e-5} != {approx(1, rel=1e-6, abs=1e-12)}
 
     def test_exactly_equal(self):
         examples = [

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -346,6 +346,10 @@ class TestApprox:
         assert 10 != approx(1, rel=1e-6, abs=1e-12)
         assert not (10 == approx(1, rel=1e-6, abs=1e-12))
 
+    def test_hash(self):
+        assert {1} == {approx(1, rel=1e-6, abs=1e-12)}
+        assert {1+1e-5} != {approx(1, rel=1e-6, abs=1e-12)}
+
     def test_exactly_equal(self):
         examples = [
             (2.0, 2.0),


### PR DESCRIPTION
This PR allows the following:
```
assert {1, 2} == {approx(1), approx(2)}
```
Currently it is not possible to construct the set on the right-hand side of this expression, because `ApproxScalar` is not hashable.

To me this seems like a bug, since `ApproxScalar` instances are meant to behave like floats, which are hashable.  That said, I was surprised to find that the lack of hashing is not an oversight: hashing is explicitly disabled with `ApproxScalar.__hash__ = None`.  I don't understand why the code would be written like this, so perhaps there's some larger issue I'm overlooking.  Implementing a hash function doesn't seem to break any tests, though.