### PR TITLE
[7.1.x] replace atomicwrites with os.replace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,6 @@ repos:
           - attrs>=19.2.0
           - packaging
           - tomli
-          - types-atomicwrites
           - types-pkg_resources
 -   repo: local
     hooks:

--- a/changelog/10114.trivial.rst
+++ b/changelog/10114.trivial.rst
@@ -1,0 +1,1 @@
+Replace `atomicwrites <https://github.com/untitaker/python-atomicwrites>`__ dependency on windows with `os.replace`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,6 @@ install_requires =
     pluggy>=0.12,<2.0
     py>=1.8.2
     tomli>=1.0.0
-    atomicwrites>=1.0;sys_platform=="win32"
     colorama;sys_platform=="win32"
     importlib-metadata>=0.12;python_version<"3.8"
 python_requires = >=3.7

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -302,53 +302,29 @@ def _write_pyc_fp(
     fp.write(marshal.dumps(co))
 
 
-if sys.platform == "win32":
-    from atomicwrites import atomic_write
-
-    def _write_pyc(
-        state: "AssertionState",
-        co: types.CodeType,
-        source_stat: os.stat_result,
-        pyc: Path,
-    ) -> bool:
-        try:
-            with atomic_write(os.fspath(pyc), mode="wb", overwrite=True) as fp:
-                _write_pyc_fp(fp, source_stat, co)
-        except OSError as e:
-            state.trace(f"error writing pyc file at {pyc}: {e}")
-            # we ignore any failure to write the cache file
-            # there are many reasons, permission-denied, pycache dir being a
-            # file etc.
-            return False
-        return True
-
-else:
-
-    def _write_pyc(
-        state: "AssertionState",
-        co: types.CodeType,
-        source_stat: os.stat_result,
-        pyc: Path,
-    ) -> bool:
-        proc_pyc = f"{pyc}.{os.getpid()}"
-        try:
-            fp = open(proc_pyc, "wb")
-        except OSError as e:
-            state.trace(f"error writing pyc file at {proc_pyc}: errno={e.errno}")
-            return False
-
-        try:
+def _write_pyc(
+    state: "AssertionState",
+    co: types.CodeType,
+    source_stat: os.stat_result,
+    pyc: Path,
+) -> bool:
+    proc_pyc = f"{pyc}.{os.getpid()}"
+    try:
+        with open(proc_pyc, "wb") as fp:
             _write_pyc_fp(fp, source_stat, co)
-            os.rename(proc_pyc, pyc)
-        except OSError as e:
-            state.trace(f"error writing pyc file at {pyc}: {e}")
-            # we ignore any failure to write the cache file
-            # there are many reasons, permission-denied, pycache dir being a
-            # file etc.
-            return False
-        finally:
-            fp.close()
-        return True
+    except OSError as e:
+        state.trace(f"error writing pyc file at {proc_pyc}: errno={e.errno}")
+        return False
+
+    try:
+        os.replace(proc_pyc, pyc)
+    except OSError as e:
+        state.trace(f"error writing pyc file at {pyc}: {e}")
+        # we ignore any failure to write the cache file
+        # there are many reasons, permission-denied, pycache dir being a
+        # file etc.
+        return False
+    return True
 
 
 def _rewrite_test(fn: Path, config: Config) -> Tuple[os.stat_result, types.CodeType]:


### PR DESCRIPTION
(cherry picked from commit 7dc540f258cf898b7ffe540f5d460490bd825425)

manually resolved the conflicts