### PR TITLE
Fix mypy pre-commit run

### DIFF
--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -281,7 +281,9 @@ class AssertionRewritingHook(importlib.abc.MetaPathFinder, importlib.abc.Loader)
             else:
                 from importlib.resources.readers import FileReader
 
-            return FileReader(types.SimpleNamespace(path=self._rewritten_names[name]))
+            return FileReader(  # type:ignore[no-any-return]
+                types.SimpleNamespace(path=self._rewritten_names[name])
+            )
 
 
 def _write_pyc_fp(


### PR DESCRIPTION
This started to fail recently with:

```
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

src/_pytest/assertion/rewrite.py:284: error: Returning Any from function declared to return "TraversableResources"  [no-any-return]
Found 1 error in 1 file (checked 219 source files)
```

Not sure why that started failing, but seems like ignoring that error specifically is OK.

