### PR TITLE
Adjust tests for a last minute Python 3.11 change in the traceback format

### DIFF
--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -223,7 +223,11 @@ class TestDoctests:
                 "Traceback (most recent call last):",
                 '  File "*/doctest.py", line *, in __run',
                 "    *",
-                *((" *^^^^*",) if sys.version_info >= (3, 11) else ()),
+                *(
+                    (" *^^^^*",)
+                    if (3, 11, 0, "beta", 4) > sys.version_info >= (3, 11)
+                    else ()
+                ),
                 '  File "<doctest test_doctest_unexpected_exception.txt[1]>", line 1, in <module>',
                 "ZeroDivisionError: division by zero",
                 "*/test_doctest_unexpected_exception.txt:2: UnexpectedException",

--- a/testing/test_main.py
+++ b/testing/test_main.py
@@ -47,7 +47,7 @@ def test_wrap_session_notify_exception(ret_exc, pytester: Pytester) -> None:
 
     end_lines = (
         result.stdout.lines[-4:]
-        if sys.version_info >= (3, 11)
+        if (3, 11, 0, "beta", 4) > sys.version_info >= (3, 11)
         else result.stdout.lines[-3:]
     )
 
@@ -57,7 +57,7 @@ def test_wrap_session_notify_exception(ret_exc, pytester: Pytester) -> None:
             'INTERNALERROR>     raise SystemExit("boom")',
             *(
                 ("INTERNALERROR>     ^^^^^^^^^^^^^^^^^^^^^^^^",)
-                if sys.version_info >= (3, 11)
+                if (3, 11, 0, "beta", 4) > sys.version_info >= (3, 11)
                 else ()
             ),
             "INTERNALERROR> SystemExit: boom",
@@ -68,7 +68,7 @@ def test_wrap_session_notify_exception(ret_exc, pytester: Pytester) -> None:
             'INTERNALERROR>     raise ValueError("boom")',
             *(
                 ("INTERNALERROR>     ^^^^^^^^^^^^^^^^^^^^^^^^",)
-                if sys.version_info >= (3, 11)
+                if (3, 11, 0, "beta", 4) > sys.version_info >= (3, 11)
                 else ()
             ),
             "INTERNALERROR> ValueError: boom",


### PR DESCRIPTION

See https://github.com/python/cpython/issues/93883
and https://github.com/python/cpython/pull/93994

Fixes https://github.com/pytest-dev/pytest/issues/10131

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features. -- not a new feature
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.
 - I consider this trivial.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
-->
