### PR TITLE
Explicit note that tmpdir fixture is discouraged in favour of tmp_path #9937

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -87,6 +87,7 @@ Damian Skrzypczak
 Daniel Grana
 Daniel Hahler
 Daniel Nuri
+Daniel Sánchez Castelló
 Daniel Wandschneider
 Daniele Procida
 Danielle Jenkins
@@ -190,6 +191,7 @@ Katerina Koukiou
 Keri Volans
 Kevin C
 Kevin Cox
+Kevin Hierro Carrasco
 Kevin J. Foley
 Kian Eliasi
 Kian-Meng Ang
@@ -327,6 +329,7 @@ Taneli Hukkinen
 Tanvi Mehta
 Tarcisio Fischer
 Tareq Alayan
+Tatiana Ovary
 Ted Xiao
 Terje Runde
 Thomas Grainger
@@ -345,6 +348,7 @@ Tyler Goodlet
 Tzu-ping Chung
 Vasily Kuznetsov
 Victor Maryama
+Victor Rodriguez
 Victor Uriarte
 Vidar T. Fauske
 Virgil Dupras

--- a/changelog/9937.doc.rst
+++ b/changelog/9937.doc.rst
@@ -1,0 +1,1 @@
+Explicit note that ``tmpdir`` fixture is discouraged in favour of ``tmp_path``.

--- a/changelog/9937.doc.rst
+++ b/changelog/9937.doc.rst
@@ -1,1 +1,1 @@
-Explicit note that ``tmpdir`` fixture is discouraged in favour of ``tmp_path``.
+Explicit note that :fixture:`tmpdir` fixture is discouraged in favour of :fixture:`tmp_path`.

--- a/doc/en/how-to/tmp_path.rst
+++ b/doc/en/how-to/tmp_path.rst
@@ -104,8 +104,10 @@ The ``tmpdir`` and ``tmpdir_factory`` fixtures
 
 The ``tmpdir`` and ``tmpdir_factory`` fixtures are similar to ``tmp_path``
 and ``tmp_path_factory``, but use/return legacy `py.path.local`_ objects
-rather than standard :class:`pathlib.Path` objects. These days, prefer to
-use ``tmp_path`` and ``tmp_path_factory``.
+rather than standard :class:`pathlib.Path` objects.
+
+.. note::
+    These days, it is preferred to use ``tmp_path`` and ``tmp_path_factory``.
 
 See :fixture:`tmpdir <tmpdir>` :fixture:`tmpdir_factory <tmpdir_factory>`
 API for details.

--- a/src/_pytest/legacypath.py
+++ b/src/_pytest/legacypath.py
@@ -271,7 +271,14 @@ class LegacyTestdirPlugin:
 @attr.s(init=False, auto_attribs=True)
 class TempdirFactory:
     """Backward compatibility wrapper that implements :class:`py.path.local`
-    for :class:`TempPathFactory`."""
+    for :class:`TempPathFactory`.
+
+    .. note::
+        These days, it is preferred to use ``tmp_path_factory``.
+
+        :ref:`About the tmpdir and tmpdir_factory fixtures<tmpdir and tmpdir_factory>`.
+
+    """
 
     _tmppath_factory: TempPathFactory
 
@@ -311,6 +318,11 @@ class LegacyTmpdirPlugin:
         temporary directory`.
 
         The returned object is a `legacy_path`_ object.
+
+        .. note::
+            These days, it is preferred to use ``tmp_path``.
+
+            :ref:`About the tmpdir and tmpdir_factory fixtures<tmpdir and tmpdir_factory>`.
 
         .. _legacy_path: https://py.readthedocs.io/en/latest/path.html
         """


### PR DESCRIPTION
Explicit note that ``tmpdir`` fixture is discouraged in favour of ``tmp_path``.

Closes #9937 

- [N/A] Include documentation when adding new features.
- [N/A] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.
- [X] Add yourself to `AUTHORS` in alphabetical order.
