### PR TITLE
Add monkeypatch.context() to how-to doc intro

### DIFF
--- a/doc/en/how-to/monkeypatch.rst
+++ b/doc/en/how-to/monkeypatch.rst
@@ -25,6 +25,7 @@ functionality in tests:
     monkeypatch.delenv(name, raising=True)
     monkeypatch.syspath_prepend(path)
     monkeypatch.chdir(path)
+    monkeypatch.context()
 
 All modifications will be undone after the requesting
 test function or fixture has finished. The ``raising``
@@ -54,6 +55,9 @@ during a test.
 
 5. Use :py:meth:`monkeypatch.syspath_prepend <MonkeyPatch.syspath_prepend>` to modify ``sys.path`` which will also
 call ``pkg_resources.fixup_namespace_packages`` and :py:func:`importlib.invalidate_caches`.
+
+6. Use :py:meth:`monkeypatch.context <MonkeyPatch.context>` to apply patches only in a specific scope, which can help
+control teardown of complex fixtures or patches to the stdlib.
 
 See the `monkeypatch blog post`_ for some introduction material
 and a discussion of its motivation.


### PR DESCRIPTION
This is just a small doc addition.

I consider myself a moderately experienced pytest user, but I had no idea about `monkeypatch.context()` until today. (And I am very happy to start using it where I still had `mock.patch` calls!) I think making it more prominent will help more users like me.