### PR TITLE
Update fixtures.rst w/ finalizer order

### DIFF
--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -768,6 +768,32 @@ Consider the differences in the following examples:
         print("after_yield_2")
 
 
+.. code-block:: pytest
+
+    $ pytest test_module.py
+    =========================== test session starts ============================
+    platform linux -- Python 3.x.y, pytest-7.x.y, pluggy-1.x.y
+    collected 1 item
+
+    test_module.py test_bar
+    .after_yield_2
+    after_yield_1
+
+
+.. code-block:: python
+
+    import pytest
+
+
+    @pytest.fixture
+    def fix_w_finalizers(request):
+        request.addfinalizer(partial(print, "finalizer_2"))
+        request.addfinalizer(partial(print, "finalizer_1"))
+
+
+    @pytest.fixture
+    def test_bar(fix_w_finalizers):
+        print("test_bar")
 
 
 .. code-block:: pytest
@@ -775,17 +801,11 @@ Consider the differences in the following examples:
     $ pytest test_module.py
     =========================== test session starts ============================
     platform linux -- Python 3.x.y, pytest-7.x.y, pluggy-1.x.y
-    collected 2 items
+    collected 1 item
 
-    main.py
-    test_foo
+    test_module.py test_bar
     .finalizer_1
     finalizer_2
-
-    test_bar
-    .after_yield_1
-    after_yield_2
-
 
 
 .. _`safe teardowns`:

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -738,6 +738,8 @@ Note on finalizer order
 Finalizers are executed in a first-in-last-out order, while operations after yield are executed sequentially.
 Consider the differences in the following examples:
 
+.. regendoc:wipe
+
 .. code-block:: python
 
     import pytest

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -742,7 +742,7 @@ Note on finalizer order
 """"""""""""""""""""""""
 
 Finalizers are executed in a first-in-last-out order.
-For yield fixtures, the first fixture to run is the right-most one, i.e. the last test parameter.
+For yield fixtures, the first teardown code to run is from the right-most fixture, i.e. the last test parameter.
 
 .. regendoc:wipe
 

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -759,7 +759,6 @@ Consider the differences in the following examples:
 
     def test_foo(fix_w_finalizers):
         print("test_foo")
-        pass
 
 
     def test_bar(fix_w_yield):

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -786,6 +786,7 @@ Consider the differences in the following examples:
 
 
 .. code-block:: pytest
+
    $ pytest -q test_emaillib.py
   .                                                                    [100%]
   1 passed in 0.12s

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -680,6 +680,8 @@ So to make sure we don't run the finalizer code when we wouldn't need to, we
 would only add the finalizer once the fixture would have done something that
 we'd need to teardown.
 
+Here's how the previous example would look using the ``addfinalizer`` method:
+
 .. code-block:: python
 
     # content of test_emaillib.py
@@ -727,7 +729,6 @@ we'd need to teardown.
         assert email in receiving_user.inbox
 
 
-Here's how the previous example would look using the ``addfinalizer`` method:
 It's a bit longer than yield fixtures and a bit more complex, but it
 does offer some nuances for when you're in a pinch.
 

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -750,6 +750,7 @@ Consider the differences in the following examples:
         request.addfinalizer(partial(print, "finalizer_2"))
         request.addfinalizer(partial(print, "finalizer_1"))
 
+
     @pytest.fixture
     def fix_w_yield():
         yield

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -763,7 +763,6 @@ Consider the differences in the following examples:
 
     def test_bar(fix_w_yield):
         print("test_bar")
-        pass
 
 
 

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -741,8 +741,8 @@ does offer some nuances for when you're in a pinch.
 Note on finalizer order
 """"""""""""""""""""""""
 
-Finalizers are executed in a first-in-last-out order, while operations after yield are executed sequentially.
-Consider the differences in the following examples:
+Finalizers are executed in a first-in-last-out order.
+For yield fixtures, the first fixture to run is the right-most one, i.e. the last test parameter.
 
 .. regendoc:wipe
 
@@ -751,7 +751,6 @@ Consider the differences in the following examples:
     import pytest
 
 
-    @pytest.fixture
     def test_bar(fix_w_yield1, fix_w_yield2):
         print("test_bar")
 
@@ -780,6 +779,9 @@ Consider the differences in the following examples:
     after_yield_1
 
 
+
+For finalizers, the first fixture to run is last call to `request.addfinalizer`.
+
 .. code-block:: python
 
     import pytest
@@ -791,7 +793,6 @@ Consider the differences in the following examples:
         request.addfinalizer(partial(print, "finalizer_1"))
 
 
-    @pytest.fixture
     def test_bar(fix_w_finalizers):
         print("test_bar")
 
@@ -806,6 +807,8 @@ Consider the differences in the following examples:
     test_module.py test_bar
     .finalizer_1
     finalizer_2
+
+This is so because yield fixtures use addfinalizer behind the scenes: when the fixture executes, addfinalizer registers a function that resumes the generator, which in turn calls the teardown code.
 
 
 .. _`safe teardowns`:

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -680,8 +680,6 @@ So to make sure we don't run the finalizer code when we wouldn't need to, we
 would only add the finalizer once the fixture would have done something that
 we'd need to teardown.
 
-Here's how the previous example would look using the ``addfinalizer`` method:
-
 .. code-block:: python
 
     # content of test_emaillib.py
@@ -730,8 +728,8 @@ Here's how the previous example would look using the ``addfinalizer`` method:
 
 
 Here's how the previous example would look using the ``addfinalizer`` method:
- It's a bit longer than yield fixtures and a bit more complex, but it
- does offer some nuances for when you're in a pinch.
+It's a bit longer than yield fixtures and a bit more complex, but it
+does offer some nuances for when you're in a pinch.
 
 Note on finalizer order
 """"""""""""""""""""""""

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -808,7 +808,7 @@ For finalizers, the first fixture to run is last call to `request.addfinalizer`.
     .finalizer_1
     finalizer_2
 
-This is so because yield fixtures use addfinalizer behind the scenes: when the fixture executes, addfinalizer registers a function that resumes the generator, which in turn calls the teardown code.
+This is so because yield fixtures use `addfinalizer` behind the scenes: when the fixture executes, `addfinalizer` registers a function that resumes the generator, which in turn calls the teardown code.
 
 
 .. _`safe teardowns`:

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -732,6 +732,12 @@ Here's how the previous example would look using the ``addfinalizer`` method:
 It's a bit longer than yield fixtures and a bit more complex, but it
 does offer some nuances for when you're in a pinch.
 
+.. code-block:: pytest
+
+   $ pytest -q test_emaillib.py
+  .                                                                    [100%]
+  1 passed in 0.12s
+
 Note on finalizer order
 """"""""""""""""""""""""
 
@@ -743,28 +749,24 @@ Consider the differences in the following examples:
 .. code-block:: python
 
     import pytest
-    from functools import partial
 
 
     @pytest.fixture
-    def fix_w_finalizers(request):
-        request.addfinalizer(partial(print, "finalizer_2"))
-        request.addfinalizer(partial(print, "finalizer_1"))
+    def test_bar(fix_w_yield1, fix_w_yield2):
+        print("test_bar")
 
 
     @pytest.fixture
-    def fix_w_yield():
+    def fix_w_yield1():
         yield
         print("after_yield_1")
+
+
+    @pytest.fixture
+    def fix_w_yield2():
+        yield
         print("after_yield_2")
 
-
-    def test_foo(fix_w_finalizers):
-        print("test_foo")
-
-
-    def test_bar(fix_w_yield):
-        print("test_bar")
 
 
 
@@ -785,11 +787,7 @@ Consider the differences in the following examples:
     after_yield_2
 
 
-.. code-block:: pytest
 
-   $ pytest -q test_emaillib.py
-  .                                                                    [100%]
-  1 passed in 0.12s
 .. _`safe teardowns`:
 
 Safe teardowns


### PR DESCRIPTION
Fixes #10023 
Add note to clarify the difference in execution order between after-yield finalizers and `request.addfinalizer` finalizers.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
