### PR TITLE
Added file-like methods to DontReadFromInput

### DIFF
--- a/changelog/10150.bugfix.rst
+++ b/changelog/10150.bugfix.rst
@@ -1,0 +1,1 @@
+:data:`sys.stdin` now contains all expected methods of a file-like object when capture is enabled.

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -203,11 +203,37 @@ class DontReadFromInput:
     def fileno(self) -> int:
         raise UnsupportedOperation("redirected stdin is pseudofile, has no fileno()")
 
+    def flush(self) -> None:
+        raise UnsupportedOperation("redirected stdin is pseudofile, has no flush()")
+
     def isatty(self) -> bool:
         return False
 
     def close(self) -> None:
         pass
+
+    def readable(self) -> bool:
+        return False
+
+    def seek(self, offset: int) -> int:
+        raise UnsupportedOperation("redirected stdin is pseudofile, has no seek(int)")
+
+    def seekable(self) -> bool:
+        return False
+
+    def tell(self) -> int:
+        raise UnsupportedOperation("redirected stdin is pseudofile, has no tell()")
+
+    def truncate(self, size: int) -> None:
+        raise UnsupportedOperation("cannont truncate stdin")
+
+    def write(self, byte) -> None:
+        raise UnsupportedOperation("cannot write to stdin")
+
+    writelines = write
+
+    def writable(self) -> bool:
+        return False
 
     @property
     def buffer(self):

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -227,10 +227,11 @@ class DontReadFromInput:
     def truncate(self, size: int) -> None:
         raise UnsupportedOperation("cannont truncate stdin")
 
-    def write(self, byte) -> None:
+    def write(self, *args) -> None:
         raise UnsupportedOperation("cannot write to stdin")
 
-    writelines = write
+    def writelines(self, *args) -> None:
+        raise UnsupportedOperation("Cannot write to stdin")
 
     def writable(self) -> bool:
         return False

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -897,6 +897,15 @@ def test_dontreadfrominput() -> None:
     iter_f = iter(f)
     pytest.raises(OSError, next, iter_f)
     pytest.raises(UnsupportedOperation, f.fileno)
+    pytest.raises(UnsupportedOperation, f.flush)
+    assert not f.readable()
+    pytest.raises(UnsupportedOperation, f.seek, 0)
+    assert not f.seekable()
+    pytest.raises(UnsupportedOperation, f.tell)
+    pytest.raises(UnsupportedOperation, f.truncate, 0)
+    pytest.raises(UnsupportedOperation, f.write, b"")
+    pytest.raises(UnsupportedOperation, f.writelines, [])
+    assert not f.writable()
     f.close()  # just for completeness
 
 


### PR DESCRIPTION
Fixes #10150 

head-fork: PurityLake/pytest
compare: fix-file-like-object

base-fork: pytest-dev/pytest
base: main

Fixes an issue with `DontReadFromInput` class by added methods that a "file-like" object may contain.

Methods added:
* flush - raises UnsupportedOperation
* readable - returns False
* seek - raises UnsupportedOperation
* seekable - returns False
* tell - raises UnsupportedOperation
* truncate - raises UnsupportedOperation
* write - raises UnsupportedOperation
* writelines - raises UnsupportedOperation
* writable - returns False