### PR TITLE
Change example to reference from within same page

### DIFF
--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -175,7 +175,8 @@ Back to fixtures
 everything that test needs to do its thing.
 
 At a basic level, test functions request fixtures by declaring them as
-arguments, as in the ``test_ehlo(smtp_connection):`` in the previous example.
+arguments, as ``my_fruit`` and ``fruit_basket`` in the 
+``test_my_fruit_in_basket(my_fruit, fruit_basket):`` example below.
 
 In pytest, "fixtures" are functions you define that serve this purpose. But they
 don't have to be limited to just the **arrange** steps. They can provide the

--- a/doc/en/fixture.rst
+++ b/doc/en/fixture.rst
@@ -175,7 +175,7 @@ Back to fixtures
 everything that test needs to do its thing.
 
 At a basic level, test functions request fixtures by declaring them as
-arguments, as ``my_fruit`` and ``fruit_basket`` in the 
+arguments, as ``my_fruit`` and ``fruit_basket`` in the
 ``test_my_fruit_in_basket(my_fruit, fruit_basket):`` example below.
 
 In pytest, "fixtures" are functions you define that serve this purpose. But they


### PR DESCRIPTION
The text references a "previous example" that doesn't exist in the document. Readers coming directly to this document via a search engine may not have seen the previous example. It is possible that the example has been removed from the documentation.

This change makes a reference to a test case within the same document, so the reader is able to find the example.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
