### PR TITLE
Make sure `monkeypatch.undo()` is always called

### DIFF
--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -45,9 +45,8 @@ def monkeypatch() -> Generator["MonkeyPatch", None, None]:
     fixture has finished. The ``raising`` parameter determines if a KeyError
     or AttributeError will be raised if the set/deletion operation has no target.
     """
-    mpatch = MonkeyPatch()
-    yield mpatch
-    mpatch.undo()
+    with MonkeyPatch.context() as mpatch:
+        yield mpatch
 
 
 def resolve(name: str) -> object:


### PR DESCRIPTION
While reading the docs, I noticed that in one place (in the fixture), `monkeypatch.undo()` is not wrapped with try/finally, but the CM method in the class, it is. It seems this could lead to weird behaviors so I figured I'd offer this patch seeing that it should improve things. Not sure if a change note is needed, feel free to request it :)

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [ ] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
