### PR TITLE
Revamp good practices

### DIFF
--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -393,6 +393,7 @@ intersphinx_mapping = {
     "tox": ("https://tox.wiki/en/stable", None),
     "virtualenv": ("https://virtualenv.pypa.io/en/stable", None),
     "setuptools": ("https://setuptools.pypa.io/en/stable", None),
+    "packaging": ("https://packaging.python.org/en/latest", None),
 }
 
 

--- a/doc/en/explanation/goodpractices.rst
+++ b/doc/en/explanation/goodpractices.rst
@@ -117,7 +117,6 @@ Here, your application root package resides in a sub-directory of your root:
 .. code-block:: text
 
     pyproject.toml
-    setup.cfg
     src/
         mypkg/
             __init__.py
@@ -139,7 +138,6 @@ want to distribute them along with your application:
 .. code-block:: text
 
     pyproject.toml
-    setup.cfg
     mypkg/
         __init__.py
         app.py

--- a/doc/en/explanation/goodpractices.rst
+++ b/doc/en/explanation/goodpractices.rst
@@ -74,7 +74,6 @@ to keep tests separate from actual application code (often a good idea):
 .. code-block:: text
 
     pyproject.toml
-    setup.cfg
     mypkg/
         __init__.py
         app.py
@@ -245,7 +244,7 @@ setuptools intends to
     The test files in the first example would be imported as
     ``test_app`` and ``test_view`` top-level modules by adding ``tests/`` to ``sys.path``.
 
-    This results in the following drawback compared to the import mode ``import-lib``:
+    This results in a drawback compared to the import mode ``import-lib``:
     your test files must have **unique names**.
 
     If you need to have test modules with the same name,
@@ -255,7 +254,6 @@ setuptools intends to
     .. code-block:: text
 
         pyproject.toml
-        setup.cfg
         mypkg/
             ...
         tests/

--- a/doc/en/explanation/goodpractices.rst
+++ b/doc/en/explanation/goodpractices.rst
@@ -96,8 +96,7 @@ This has the following benefits:
     See :ref:`pytest vs python -m pytest` for more information about the difference between calling ``pytest`` and
     ``python -m pytest``.
 
-For the most convenient experience,
-choose the ``import-lib`` :ref:`import mode <import-modes>`.
+For new projects, we recommend to use ``importlib`` :ref:`import mode <import-modes>` (see [1]_ for a detailed explanation).
 To this end, add the following to your ``pyproject.toml``:
 
 .. code-block:: toml
@@ -111,7 +110,7 @@ The default :ref:`import mode <import-modes>` ``prepend`` has several drawbacks 
 
 .. _`src-layout`:
 
-Generally, but especially if you use the default import mode,
+Generally, but especially if you use the default import mode ``prepend``,
 it is **strongly** suggested to use a ``src`` layout.
 Here, your application root package resides in a sub-directory of your root:
 
@@ -244,7 +243,7 @@ setuptools intends to
     The test files in the first example would be imported as
     ``test_app`` and ``test_view`` top-level modules by adding ``tests/`` to ``sys.path``.
 
-    This results in a drawback compared to the import mode ``import-lib``:
+    This results in a drawback compared to the import mode ``importlib``:
     your test files must have **unique names**.
 
     If you need to have test modules with the same name,

--- a/doc/en/explanation/goodpractices.rst
+++ b/doc/en/explanation/goodpractices.rst
@@ -12,41 +12,26 @@ For development, we recommend you use :mod:`venv` for virtual environments and
 as well as the ``pytest`` package itself.
 This ensures your code and dependencies are isolated from your system Python installation.
 
-Next, place a ``pyproject.toml`` file in the root of your package:
+Create a ``pyproject.toml`` file in the root of your repository as described in
+:doc:`packaging:tutorials/packaging-projects`.
+The first few lines should look like this:
 
 .. code-block:: toml
 
     [build-system]
-    requires = ["setuptools>=42", "wheel"]
-    build-backend = "setuptools.build_meta"
-
-and a ``setup.cfg`` file containing your package's metadata with the following minimum content:
-
-.. code-block:: ini
+    requires = ["hatchling"]
+    build-backend = "hatchling.build"
 
     [metadata]
-    name = PACKAGENAME
-
-    [options]
-    packages = find:
+    name = "PACKAGENAME"
 
 where ``PACKAGENAME`` is the name of your package.
-
-.. note::
-
-    If your pip version is older than ``21.3``, you'll also need a ``setup.py`` file:
-
-    .. code-block:: python
-
-        from setuptools import setup
-
-        setup()
 
 You can then install your package in "editable" mode by running from the same directory:
 
 .. code-block:: bash
 
-     pip install -e .
+    pip install -e .
 
 which lets you change your source code (both tests and application) and rerun tests at will.
 
@@ -112,43 +97,24 @@ This has the following benefits:
     See :ref:`pytest vs python -m pytest` for more information about the difference between calling ``pytest`` and
     ``python -m pytest``.
 
-Note that this scheme has a drawback if you are using ``prepend`` :ref:`import mode <import-modes>`
-(which is the default): your test files must have **unique names**, because
-``pytest`` will import them as *top-level* modules since there are no packages
-to derive a full package name from. In other words, the test files in the example above will
-be imported as ``test_app`` and ``test_view`` top-level modules by adding ``tests/`` to
-``sys.path``.
+For the most convenient experience,
+choose the ``import-lib`` :ref:`import mode <import-modes>`.
+To this end, add the following to your ``pyproject.toml``:
 
-If you need to have test modules with the same name, you might add ``__init__.py`` files to your
-``tests`` folder and subfolders, changing them to packages:
+.. code-block:: toml
 
-.. code-block:: text
+    [tool.pytest.ini_options]
+    addopts = [
+        "--import-mode=importlib",
+    ]
 
-    pyproject.toml
-    setup.cfg
-    mypkg/
-        ...
-    tests/
-        __init__.py
-        foo/
-            __init__.py
-            test_view.py
-        bar/
-            __init__.py
-            test_view.py
-
-Now pytest will load the modules as ``tests.foo.test_view`` and ``tests.bar.test_view``, allowing
-you to have modules with the same name. But now this introduces a subtle problem: in order to load
-the test modules from the ``tests`` directory, pytest prepends the root of the repository to
-``sys.path``, which adds the side-effect that now ``mypkg`` is also importable.
-
-This is problematic if you are using a tool like `tox`_ to test your package in a virtual environment,
-because you want to test the *installed* version of your package, not the local code from the repository.
+The default :ref:`import mode <import-modes>` ``prepend`` has several drawbacks [1]_.
 
 .. _`src-layout`:
 
-In this situation, it is **strongly** suggested to use a ``src`` layout where application root package resides in a
-sub-directory of your root:
+Generally, but especially if you use the default import mode,
+it is **strongly** suggested to use a ``src`` layout.
+Here, your application root package resides in a sub-directory of your root:
 
 .. code-block:: text
 
@@ -159,25 +125,10 @@ sub-directory of your root:
             __init__.py
             app.py
             view.py
-    tests/
-        __init__.py
-        foo/
-            __init__.py
-            test_view.py
-        bar/
-            __init__.py
-            test_view.py
-
+    tests/...
 
 This layout prevents a lot of common pitfalls and has many benefits, which are better explained in this excellent
 `blog post by Ionel Cristian Mărieș <https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure>`_.
-
-.. note::
-    The ``--import-mode=importlib`` option (see :ref:`import-modes`) does not have
-    any of the drawbacks above because ``sys.path`` is not changed when importing
-    test modules, so users that run into this issue are strongly encouraged to try it.
-
-    The ``src`` directory layout is still strongly recommended however.
 
 
 Tests as part of application code
@@ -285,3 +236,47 @@ See also `pypa/setuptools#1684 <https://github.com/pypa/setuptools/issues/1684>`
 
 setuptools intends to
 `remove the test command <https://github.com/pypa/setuptools/issues/931>`_.
+
+
+.. [1] The default ``prepend`` :ref:`import mode <import-modes>` works as follows:
+
+    Since there are no packages to derive a full package name from,
+    ``pytest`` will import your test files as *top-level* modules.
+    The test files in the first example would be imported as
+    ``test_app`` and ``test_view`` top-level modules by adding ``tests/`` to ``sys.path``.
+
+    This results in the following drawback compared to the import mode ``import-lib``:
+    your test files must have **unique names**.
+
+    If you need to have test modules with the same name,
+    as a workaround you might add ``__init__.py`` files to your ``tests`` folder and subfolders,
+    changing them to packages:
+
+    .. code-block:: text
+
+        pyproject.toml
+        setup.cfg
+        mypkg/
+            ...
+        tests/
+            __init__.py
+            foo/
+                __init__.py
+                test_view.py
+            bar/
+                __init__.py
+                test_view.py
+
+    Now pytest will load the modules as ``tests.foo.test_view`` and ``tests.bar.test_view``,
+    allowing you to have modules with the same name.
+    But now this introduces a subtle problem:
+    in order to load the test modules from the ``tests`` directory,
+    pytest prepends the root of the repository to ``sys.path``,
+    which adds the side-effect that now ``mypkg`` is also importable.
+
+    This is problematic if you are using a tool like `tox`_ to test your package in a virtual environment,
+    because you want to test the *installed* version of your package,
+    not the local code from the repository.
+
+    The ``importlib`` import mode does not have any of the drawbacks above,
+    because ``sys.path`` is not changed when importing test modules.

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -1689,8 +1689,6 @@ Given the tests file structure is:
 ::
 
     tests/
-        __init__.py
-
         conftest.py
             # content of tests/conftest.py
             import pytest
@@ -1705,8 +1703,6 @@ Given the tests file structure is:
                 assert username == 'username'
 
         subfolder/
-            __init__.py
-
             conftest.py
                 # content of tests/subfolder/conftest.py
                 import pytest
@@ -1715,8 +1711,8 @@ Given the tests file structure is:
                 def username(username):
                     return 'overridden-' + username
 
-            test_something.py
-                # content of tests/subfolder/test_something.py
+            test_something_else.py
+                # content of tests/subfolder/test_something_else.py
                 def test_username(username):
                     assert username == 'overridden-username'
 
@@ -1732,8 +1728,6 @@ Given the tests file structure is:
 ::
 
     tests/
-        __init__.py
-
         conftest.py
             # content of tests/conftest.py
             import pytest
@@ -1775,8 +1769,6 @@ Given the tests file structure is:
 ::
 
     tests/
-        __init__.py
-
         conftest.py
             # content of tests/conftest.py
             import pytest
@@ -1813,8 +1805,6 @@ Given the tests file structure is:
 ::
 
     tests/
-        __init__.py
-
         conftest.py
             # content of tests/conftest.py
             import pytest


### PR DESCRIPTION
The importlib import mode has no* drawbacks while the default mode `prepend` has a major footgun. That one has one popular workaround which in turn has further drawbacks.

Also one of the sections correctly says “subfolder”, but others misleadingly say “subpackage”. Should I get rid of that too?

*I consider the fact that you can’t import from test files a feature, as it cleans up the distinction between test files and python packages. It encourages to keep your test utils in one location and reduces dependencies between test files.