### PR TITLE
Fix checking expected warnings when an exception is raised

### DIFF
--- a/changelog/9036.bugfix.rst
+++ b/changelog/9036.bugfix.rst
@@ -1,0 +1,1 @@
+``pytest.warns`` and similar functions now capture warnings when an exception is raised inside a ``with`` block.

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -179,6 +179,7 @@ class TestDeprecatedCall:
         """
 
         def f():
+            warnings.warn(DeprecationWarning("hi"))
             raise ValueError("some exception")
 
         with pytest.raises(ValueError, match="some exception"):


### PR DESCRIPTION
Fixes #9036 
The behavior in the issue is observed because `pytest.warn` don't capture warnings when an exception is raised inside a `with` block due to the condition in `WarningsChecker.__exit__`. 
It looks like removing this condition should fix this bug, Or is it needed to cover some case?
