### PR TITLE
fallback to native traceback when handling ExceptionGroup (take 2) [SQUASH]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
           "ubuntu-py39",
           "ubuntu-py310",
           "ubuntu-py311",
+          "ubuntu-py311-exceptiongroup",
           "ubuntu-pypy3",
 
           "macos-py37",
@@ -114,6 +115,10 @@ jobs:
             python: "3.11-dev"
             os: ubuntu-latest
             tox_env: "py311"
+          - name: "ubuntu-py311-exceptiongroup"
+            python: "3.11-dev"
+            os: ubuntu-latest
+            tox_env: "py311-exceptiongroup"
           - name: "ubuntu-pypy3"
             python: "pypy-3.7"
             os: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,7 @@ jobs:
             python: "3.11-dev"
             os: ubuntu-latest
             tox_env: "py311"
+            use_coverage: true
           - name: "ubuntu-py311-exceptiongroup"
             python: "3.11-dev"
             os: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,6 @@ jobs:
           "ubuntu-py39",
           "ubuntu-py310",
           "ubuntu-py311",
-          "ubuntu-py311-exceptiongroup",
           "ubuntu-pypy3",
 
           "macos-py37",
@@ -116,10 +115,6 @@ jobs:
             os: ubuntu-latest
             tox_env: "py311"
             use_coverage: true
-          - name: "ubuntu-py311-exceptiongroup"
-            python: "3.11-dev"
-            os: ubuntu-latest
-            tox_env: "py311-exceptiongroup"
           - name: "ubuntu-pypy3"
             python: "pypy-3.7"
             os: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,7 @@ repos:
           - packaging
           - tomli
           - types-pkg_resources
+            # for python>=3.11
           - exceptiongroup>=1.0.0rc8
 -   repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,7 @@ repos:
           - packaging
           - tomli
           - types-pkg_resources
+          - exceptiongroup>=1.0.0rc8
 -   repo: local
     hooks:
     -   id: rst

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,8 @@ repos:
           - packaging
           - tomli
           - types-pkg_resources
-            # for python>=3.11
+            # for mypy running on python>=3.11 since exceptiongroup is only a dependency
+            # on <3.11
           - exceptiongroup>=1.0.0rc8
 -   repo: local
     hooks:

--- a/AUTHORS
+++ b/AUTHORS
@@ -168,6 +168,7 @@ Jeff Rackauckas
 Jeff Widman
 Jenni Rinker
 John Eddie Ayson
+John Litborn
 John Towler
 Jon Parise
 Jon Sonesen

--- a/changelog/9159.bugfix.rst
+++ b/changelog/9159.bugfix.rst
@@ -1,0 +1,1 @@
+Showing inner exceptions by forcing native display in ``ExceptionGroups`` even when using display options other than ``--tb=native``. A temporary step before full implementation of pytest-native display for inner exceptions in ``ExceptionGroups``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ install_requires =
     pluggy>=0.12,<2.0
     py>=1.8.2
     colorama;sys_platform=="win32"
+    exceptiongroup>=1.0.0rc8;python_version<"3.11"
     importlib-metadata>=0.12;python_version<"3.8"
     tomli>=1.0.0;python_version<"3.11"
 python_requires = >=3.7

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -56,14 +56,11 @@ if TYPE_CHECKING:
 
     _TracebackStyle = Literal["long", "short", "line", "no", "native", "value", "auto"]
 
-BaseExceptionGroup: Optional[Type[BaseException]]
+BaseExceptionGroup: Type[BaseException]
 try:
     BaseExceptionGroup = BaseExceptionGroup  # type: ignore
 except NameError:
-    try:
-        from exceptiongroup import BaseExceptionGroup
-    except ModuleNotFoundError:
-        BaseExceptionGroup = None
+    from exceptiongroup import BaseExceptionGroup
 
 
 class Code:
@@ -936,7 +933,7 @@ class FormattedExcinfo:
                 # Fall back to native traceback as a temporary workaround until
                 # full support for exception groups added to ExceptionInfo.
                 # See https://github.com/pytest-dev/pytest/issues/9159
-                if BaseExceptionGroup is not None and isinstance(e, BaseExceptionGroup):
+                if isinstance(e, BaseExceptionGroup):
                     reprtraceback: Union[
                         ReprTracebackNative, ReprTraceback
                     ] = ReprTracebackNative(

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -56,10 +56,7 @@ if TYPE_CHECKING:
 
     _TracebackStyle = Literal["long", "short", "line", "no", "native", "value", "auto"]
 
-BaseExceptionGroup: Type[BaseException]
-try:
-    BaseExceptionGroup = BaseExceptionGroup  # type: ignore
-except NameError:
+if sys.version_info[:2] < (3, 11):
     from exceptiongroup import BaseExceptionGroup
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,12 +11,15 @@ envlist =
     py311
     pypy3
     py37-{pexpect,xdist,unittestextras,numpy,pluggymain}
-    py311-exceptiongroup
     doctesting
     plugins
     py37-freeze
     docs
     docs-checklinks
+
+    # checks that 3.11 native ExceptionGroup works with exceptiongroup
+    # not included in CI.
+    py311-exceptiongroup
 
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,9 @@ envlist =
     py39
     py310
     py311
-    py311-exceptiongroup
     pypy3
-    py37-{pexpect,xdist,unittestextras,numpy,pluggymain,exceptiongroup}
+    py37-{pexpect,xdist,unittestextras,numpy,pluggymain}
+    py311-exceptiongroup
     doctesting
     plugins
     py37-freeze

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,9 @@ envlist =
     py39
     py310
     py311
+    py311-exceptiongroup
     pypy3
-    py37-{pexpect,xdist,unittestextras,numpy,pluggymain}
+    py37-{pexpect,xdist,unittestextras,numpy,pluggymain,exceptiongroup}
     doctesting
     plugins
     py37-freeze
@@ -46,7 +47,7 @@ setenv =
 extras = testing
 deps =
     doctesting: PyYAML
-    exceptiongroup: exceptiongroup>=1.0.0
+    exceptiongroup: exceptiongroup>=1.0.0rc8
     numpy: numpy>=1.19.4
     pexpect: pexpect>=4.8.0
     pluggymain: pluggy @ git+https://github.com/pytest-dev/pluggy.git

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ setenv =
 extras = testing
 deps =
     doctesting: PyYAML
+    exceptiongroup: exceptiongroup>=1.0.0
     numpy: numpy>=1.19.4
     pexpect: pexpect>=4.8.0
     pluggymain: pluggy @ git+https://github.com/pytest-dev/pluggy.git


### PR DESCRIPTION
Picking up work on and therefore closes #10071 to temporarily address #9159

Improvements over the previous PR:
* Handles `BaseExceptionGroup`
* Handles exception chains properly, using `excinfo_` instead of `excinfo`, and sets `reprcrash`
* fixed tox.ini
* rewrote tests extending them, previous ones also had regex bugs


I'm not entirely sure how to handle the envlist in tox.ini, since hypothesis currently depends on `exceptiongroup`, making an extra environment for it redundant. I also wanted a test for py311 without `exceptiongroup` installed, but it got messy setting up a separate testenv without `extras=testing`. An alternative is a 3.11-only test that modifies `_pytest._code.code.ExceptionGroups` removing `exceptiongroup.BaseExceptionGroup` from it.

The test is still somewhat WIP, I want some extra matching lines to differentiate the parametrized variables, but thought I'd push my current work for initial review.

@Zac-HD 