### PR TITLE
changelog: add missing entry for PR #9248 (Sphinx 5)

### DIFF
--- a/changelog/9248.doc.rst
+++ b/changelog/9248.doc.rst
@@ -1,0 +1,1 @@
+The documentation is now built using Sphinx 5.x (up from 3.x previously).


### PR DESCRIPTION
I forgot to add a changelog entry for #9248. It might be relevant for some distributions, and also if there are any regressions.