### PR TITLE
Drop `wheel` from `pyproject.toml` example

### DIFF
--- a/doc/en/explanation/goodpractices.rst
+++ b/doc/en/explanation/goodpractices.rst
@@ -17,7 +17,7 @@ Next, place a ``pyproject.toml`` file in the root of your package:
 .. code-block:: toml
 
     [build-system]
-    requires = ["setuptools>=42", "wheel"]
+    requires = ["setuptools >= 42"]
     build-backend = "setuptools.build_meta"
 
 and a ``setup.cfg`` file containing your package's metadata with the following minimum content:


### PR DESCRIPTION
It is unnecessary and has been deleted from the setuptools' docs too.
The setuptools' PEP 517 build backend implementation has been
auto-adding the `wheel` dependency since it's first been implemented.

Looks like it's been dropped from the main packaging config too, recently: https://github.com/pytest-dev/pytest/commit/56862c03cbb3f9cae3464c33390fbbaf8a91823a.