### PR TITLE
Ignore editable installation modules

### DIFF
--- a/changelog/10230.bugfix.rst
+++ b/changelog/10230.bugfix.rst
@@ -1,0 +1,1 @@
+Ignore ``.py`` files created by ``pyproject.toml``-based editable builds introduced in `pip 21.3 <https://pip.pypa.io/en/stable/news/#v21-3>`__.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -836,7 +836,8 @@ def _iter_rewritable_modules(package_files: Iterable[str]) -> Iterator[str]:
         if is_simple_module:
             module_name, _ = os.path.splitext(fn)
             # we ignore "setup.py" at the root of the distribution
-            if module_name != "setup":
+            # as well as editable installation finder modules made by setuptools
+            if module_name != "setup" and not module_name.startswith('__editable__'):
                 seen_some = True
                 yield module_name
         elif is_package:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -842,6 +842,9 @@ class TestConfigAPI:
             (["src/bar/__init__.py"], ["bar"]),
             (["src/bar/__init__.py", "setup.py"], ["bar"]),
             (["source/python/bar/__init__.py", "setup.py"], ["bar"]),
+            # editable installation finder modules
+            (["__editable___xyz_finder.py"], []),
+            (["bar/__init__.py", "__editable___xyz_finder.py"], ["bar"]),
         ],
     )
     def test_iter_rewritable_modules(self, names, expected) -> None:


### PR DESCRIPTION
Fixes #10230, relatively trivial change.

- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

- [x] Add yourself to `AUTHORS` in alphabetical order.
