### PR TITLE
Fix nodeid parser edge case in test selection

### DIFF
--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -886,7 +886,8 @@ def resolve_collection_argument(
         parts[-1] = f"{parts[-1]}{squacket}{rest}"
     if as_pypath:
         strpath = search_pypath(strpath)
-    fspath = absolutepath(invocation_path / strpath)
+    fspath = invocation_path / strpath
+    fspath = absolutepath(fspath)
     if not fspath.exists():
         msg = (
             "module or package not found: {arg} (missing __init__.py?)"

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -877,14 +877,16 @@ def resolve_collection_argument(
     If the path doesn't exist, raise UsageError.
     If the path is a directory and selection parts are present, raise UsageError.
     """
-    base, squacket, rest = str(arg).partition("[")
-    strpath, *parts = base.split("::")
-    if parts:
+    strpath, selection, rest = arg.partition("::")
+    test_name, squacket, rest = rest.partition("[")
+    parts = []
+
+    if test_name:
+        parts = test_name.split("::")
         parts[-1] = f"{parts[-1]}{squacket}{rest}"
     if as_pypath:
         strpath = search_pypath(strpath)
-    fspath = invocation_path / strpath
-    fspath = absolutepath(fspath)
+    fspath = absolutepath(invocation_path / strpath)
     if not fspath.exists():
         msg = (
             "module or package not found: {arg} (missing __init__.py?)"
@@ -892,7 +894,7 @@ def resolve_collection_argument(
             else "file or directory not found: {arg}"
         )
         raise UsageError(msg.format(arg=arg))
-    if parts and fspath.is_dir():
+    if selection and fspath.is_dir():
         msg = (
             "package argument cannot contain :: selection parts: {arg}"
             if as_pypath

--- a/testing/test_main.py
+++ b/testing/test_main.py
@@ -180,6 +180,10 @@ class TestResolveCollectionArgument:
             invocation_path / "src/pkg",
             [],
         )
+        assert resolve_collection_argument(invocation_path, "src/pkg/test.py::") == (
+            invocation_path / "src/pkg/test.py",
+            [],
+        )
 
         with pytest.raises(
             UsageError, match=r"package argument cannot contain :: selection parts"
@@ -206,6 +210,12 @@ class TestResolveCollectionArgument:
             match=re.escape("file or directory not found: src/pkg/test.py[a::b]"),
         ):
             resolve_collection_argument(invocation_path, "src/pkg/test.py[a::b]")
+
+        with pytest.raises(
+            UsageError,
+            match=re.escape("file or directory not found: src/pkg/test.py[foobar]"),
+        ):
+            resolve_collection_argument(invocation_path, "src/pkg/test.py[foobar]")
 
         with pytest.raises(
             UsageError,

--- a/testing/test_main.py
+++ b/testing/test_main.py
@@ -142,7 +142,7 @@ class TestResolveCollectionArgument:
         )
         assert resolve_collection_argument(invocation_path, "src/pkg/test.py::") == (
             invocation_path / "src/pkg/test.py",
-            [""],
+            [],
         )
         assert resolve_collection_argument(
             invocation_path, "src/pkg/test.py::foo::bar"
@@ -200,6 +200,12 @@ class TestResolveCollectionArgument:
             UsageError, match=re.escape("file or directory not found: foobar")
         ):
             resolve_collection_argument(invocation_path, "foobar")
+
+        with pytest.raises(
+            UsageError,
+            match=re.escape("file or directory not found: src/pkg/test.py[a::b]"),
+        ):
+            resolve_collection_argument(invocation_path, "src/pkg/test.py[a::b]")
 
         with pytest.raises(
             UsageError,


### PR DESCRIPTION
Fixes #10273 and also a small change in `resolve_collection_argument`

Before this commit `resolve_collection_argument` returned a list with empty string if the `::` selection operator was appended to the given file name E.g.

```python
assert resolve_collection_argument(Path(), "test_foo.py::")[1] == ['']  # why empty string ?
assert resolve_collection_argument(Path(), "test_foo.py")[1] == []

# for dir selection
assert resolve_collection_argument(Path(), "test_bar/")[1] == []
assert resolve_collection_argument(Path(), "test_bar")[1] == []
```

I think if the `/` operator *selects* parts (which file in a dir) and with/out adding this operator `resolve_collection_argument` returns `[]` for the `parts` value, then same thing can be applied to the `::` selection operator (which function/class in a file)

Not really sure if code assumes somewhere that when `::` is appended to the file name a list with empty string must be returned or not.

Appreciate your feedback

