### PR TITLE
Export `pytest.DoctestItem` for typing / runtime purposes

### DIFF
--- a/changelog/10313.trivial.rst
+++ b/changelog/10313.trivial.rst
@@ -1,0 +1,3 @@
+Made ``_pytest.doctest.DoctestItem`` export ``pytest.DoctestItem`` for
+type check and runtime purposes. Made `_pytest.doctest` use internal APIs
+to avoid circular imports.

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -32,6 +32,7 @@ from _pytest._io import TerminalWriter
 from _pytest.compat import safe_getattr
 from _pytest.config import Config
 from _pytest.config.argparsing import Parser
+from _pytest.fixtures import fixture
 from _pytest.fixtures import FixtureRequest
 from _pytest.nodes import Collector
 from _pytest.nodes import Item
@@ -733,7 +734,7 @@ def _get_report_choice(key: str) -> int:
     }[key]
 
 
-@pytest.fixture(scope="session")
+@fixture(scope="session")
 def doctest_namespace() -> Dict[str, Any]:
     """Fixture that returns a :py:class:`dict` that will be injected into the
     namespace of doctests.

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -38,6 +38,7 @@ from _pytest.nodes import Item
 from _pytest.outcomes import OutcomeException
 from _pytest.pathlib import fnmatch_ex
 from _pytest.pathlib import import_path
+from _pytest.python import Module
 from _pytest.python_api import approx
 from _pytest.warning_types import PytestWarning
 
@@ -412,7 +413,7 @@ def _get_continue_on_failure(config):
     return continue_on_failure
 
 
-class DoctestTextfile(pytest.Module):
+class DoctestTextfile(Module):
     obj = None
 
     def collect(self) -> Iterable[DoctestItem]:
@@ -492,7 +493,7 @@ def _patch_unwrap_mock_aware() -> Generator[None, None, None]:
         inspect.unwrap = real_unwrap
 
 
-class DoctestModule(pytest.Module):
+class DoctestModule(Module):
     def collect(self) -> Iterable[DoctestItem]:
         import doctest
 

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -23,7 +23,6 @@ from typing import Type
 from typing import TYPE_CHECKING
 from typing import Union
 
-import pytest
 from _pytest import outcomes
 from _pytest._code.code import ExceptionInfo
 from _pytest._code.code import ReprFileLocation
@@ -37,6 +36,7 @@ from _pytest.fixtures import FixtureRequest
 from _pytest.nodes import Collector
 from _pytest.nodes import Item
 from _pytest.outcomes import OutcomeException
+from _pytest.outcomes import skip
 from _pytest.pathlib import fnmatch_ex
 from _pytest.pathlib import import_path
 from _pytest.python import Module
@@ -452,7 +452,7 @@ def _check_all_skipped(test: "doctest.DocTest") -> None:
 
     all_skipped = all(x.options.get(doctest.SKIP, False) for x in test.examples)
     if all_skipped:
-        pytest.skip("all tests skipped by +SKIP option")
+        skip("all tests skipped by +SKIP option")
 
 
 def _is_mocked(obj: object) -> bool:
@@ -552,7 +552,7 @@ class DoctestModule(Module):
                 )
             except ImportError:
                 if self.config.getvalue("doctest_ignore_import_errors"):
-                    pytest.skip("unable to import module %r" % self.path)
+                    skip("unable to import module %r" % self.path)
                 else:
                     raise
         # Uses internal doctest module parsing mechanism.

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -34,6 +34,7 @@ from _pytest.config import Config
 from _pytest.config.argparsing import Parser
 from _pytest.fixtures import FixtureRequest
 from _pytest.nodes import Collector
+from _pytest.nodes import Item
 from _pytest.outcomes import OutcomeException
 from _pytest.pathlib import fnmatch_ex
 from _pytest.pathlib import import_path
@@ -246,7 +247,7 @@ def _get_runner(
     )
 
 
-class DoctestItem(pytest.Item):
+class DoctestItem(Item):
     def __init__(
         self,
         name: str,

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -18,6 +18,7 @@ from _pytest.config import UsageError
 from _pytest.config.argparsing import OptionGroup
 from _pytest.config.argparsing import Parser
 from _pytest.debugging import pytestPDB as __pytestPDB
+from _pytest.doctest import DoctestItem
 from _pytest.fixtures import fixture
 from _pytest.fixtures import FixtureLookupError
 from _pytest.fixtures import FixtureRequest
@@ -92,6 +93,7 @@ __all__ = [
     "Config",
     "console_main",
     "deprecated_call",
+    "DoctestItem",
     "exit",
     "ExceptionInfo",
     "ExitCode",


### PR DESCRIPTION
Fixes #10312 


- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.
- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.
