### PR TITLE
Use an explicit encoding when opening `os.devnul`

### DIFF
--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -381,7 +381,7 @@ class FDCaptureBinary:
         self.targetfd_save = os.dup(targetfd)
 
         if targetfd == 0:
-            self.tmpfile = open(os.devnull)
+            self.tmpfile = open(os.devnull, encoding="utf-8")
             self.syscapture = SysCapture(targetfd)
         else:
             self.tmpfile = EncodedFile(


### PR DESCRIPTION
Although slightly pointless, this avoids an `EncodingWarning` in Python 3.10 or greater when running under the `-X warn_default_encoding` flag.

----

I think this meets the bar for triviality so I haven't included a changelog entry. PR created per @nicoddemus's request in #10326, though this is not sufficient to close that issue.

A