### PR TITLE
Enable Python 3.10's ``EncodingWarning``

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,10 @@ passenv =
 setenv =
     _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_POSARGS_DOCTESTING:} {env:_PYTEST_TOX_POSARGS_LSOF:} {env:_PYTEST_TOX_POSARGS_XDIST:}
 
+    # Warn where default encoding is used
+    # https://docs.python.org/3/library/io.html#io-encoding-warning
+    PYTHONWARNDEFAULTENCODING=1
+
     # Configuration to run with coverage similar to CI, e.g.
     # "tox -e py37-coverage".
     coverage: _PYTEST_TOX_COVERAGE_RUN=coverage run -m


### PR DESCRIPTION
This warns on the default encoding being used in ``open`` or ``io.open``, which can lead to cross-platform bugs (for example on Windows where the default codepage is cp1252), or with the upcoming change to the default Python encoding (PEP 686, Make UTF-8 mode default https://peps.python.org/pep-0686/)

-----

I think this meets the bar for triviality so I haven't included a changelog entry. PR created per @nicoddemus's request in #10326, though this is not sufficient to close that issue.

A