### PR TITLE
Add note in documentation to help modernize code bases to use pathlib

### DIFF
--- a/doc/en/how-to/tmp_path.rst
+++ b/doc/en/how-to/tmp_path.rst
@@ -109,6 +109,17 @@ rather than standard :class:`pathlib.Path` objects.
 .. note::
     These days, it is preferred to use ``tmp_path`` and ``tmp_path_factory``.
 
+    In order to help modernize old code bases, one can run pytest with the legacypath
+    plugin disabled:
+
+    .. code-block:: bash
+
+        pytest -p no:legacypath
+
+    This will trigger errors on tests using the legacy paths.
+    It can also be permanently set as part of the :confval:`addopts` parameter in the
+    config file.
+
 See :fixture:`tmpdir <tmpdir>` :fixture:`tmpdir_factory <tmpdir_factory>`
 API for details.
 


### PR DESCRIPTION
The legacypath plugin handles the tmpdir and tmpdir_factory which should be update to their modern counterparts that uses pathlib.

Disabling this plugin allows developer to easily find and thus update the use of these fixtures.

Fixes #10199
