### PR TITLE
fix #10342: put location into warning exceptions

### DIFF
--- a/src/_pytest/warning_types.py
+++ b/src/_pytest/warning_types.py
@@ -168,4 +168,5 @@ def warn_explicit_for(method: FunctionType, message: PytestWarning) -> None:
             lineno=lineno,
         )
     except Warning as w:
+        # If warnings are errors (e.g. -Werror), location information gets lost, so we add it to the message.
         raise type(w)(f"{w}\n at {filename}:{lineno}") from None

--- a/src/_pytest/warning_types.py
+++ b/src/_pytest/warning_types.py
@@ -158,12 +158,14 @@ def warn_explicit_for(method: FunctionType, message: PytestWarning) -> None:
     filename = inspect.getfile(method)
     module = method.__module__
     mod_globals = method.__globals__
-
-    warnings.warn_explicit(
-        message,
-        type(message),
-        filename=filename,
-        module=module,
-        registry=mod_globals.setdefault("__warningregistry__", {}),
-        lineno=lineno,
-    )
+    try:
+        warnings.warn_explicit(
+            message,
+            type(message),
+            filename=filename,
+            module=module,
+            registry=mod_globals.setdefault("__warningregistry__", {}),
+            lineno=lineno,
+        )
+    except Warning as w:
+        raise type(w)(f"{w}\n at {filename}:{lineno}") from None

--- a/testing/test_warning_types.py
+++ b/testing/test_warning_types.py
@@ -36,3 +36,11 @@ def test_pytest_warnings_repr_integration_test(pytester: Pytester) -> None:
     )
     result = pytester.runpytest()
     result.stdout.fnmatch_lines(["E       pytest.PytestWarning: some warning"])
+
+
+@pytest.mark.filterwarnings("error")
+def test_warn_explicit_for_annotates_errors_with_location():
+    with pytest.raises(Warning, match="(?m)test\n at .*python_api.py:\\d+"):
+        warning_types.warn_explicit_for(
+            pytest.raises, warning_types.PytestWarning("test")  # type: ignore
+        )


### PR DESCRIPTION
as the warning systems own warn_explicit looses the information we add them explicitly to the warning exceptions

@The-Compiler this should resolve the issue you noted

closes #10342 