### PR TITLE
Revert "ci: fix PR not triggering workflows by switching back to pytestbot access token"

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -48,4 +48,4 @@ jobs:
           --title "${subject}" \
           --body "Backport of PR #${{ github.event.number }} to $target_branch branch. PR created by backport workflow."
       env:
-        GITHUB_TOKEN: ${{ secrets.CHATOPS }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -44,9 +44,9 @@ jobs:
     - name: Prepare release PR (minor/patch release)
       if: github.event.inputs.major == 'no'
       run: |
-        tox -e prepare-release-pr -- ${{ github.event.inputs.branch }} ${{ secrets.CHATOPS }} --prerelease='${{ github.event.inputs.prerelease }}'
+        tox -e prepare-release-pr -- ${{ github.event.inputs.branch }} ${{ github.token }} --prerelease='${{ github.event.inputs.prerelease }}'
 
     - name: Prepare release PR (major release)
       if: github.event.inputs.major == 'yes'
       run: |
-        tox -e prepare-release-pr -- ${{ github.event.inputs.branch }} ${{ secrets.CHATOPS }} --major --prerelease='${{ github.event.inputs.prerelease }}'
+        tox -e prepare-release-pr -- ${{ github.event.inputs.branch }} ${{ github.token }} --major --prerelease='${{ github.event.inputs.prerelease }}'

--- a/.github/workflows/update-plugin-list.yml
+++ b/.github/workflows/update-plugin-list.yml
@@ -38,7 +38,7 @@ jobs:
         run: python scripts/update-plugin-list.py
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@671dc9c9e0c2d73f07fa45a3eb0220e1622f0c5f
+        uses: peter-evans/create-pull-request@2455e1596942c2902952003bbb574afbbe2ab2e6
         with:
           commit-message: '[automated] Update plugin list'
           author: 'pytest bot <pytestbot@users.noreply.github.com>'
@@ -47,4 +47,3 @@ jobs:
           branch-suffix: short-commit-hash
           title: '[automated] Update plugin list'
           body: '[automated] Update plugin list'
-          token: ${{ secrets.CHATOPS }}


### PR DESCRIPTION
Reverts pytest-dev/pytest#10346

Unfortunately the CHATOPS credentials no longer work, or don't have the necessary permissions. Was worth a try.

For now let's revert to get things working again, but can try again if:

- Someone who has access to `pytestbot` can refresh the `CHATOPS` secret (with maybe a more appropriate name...)
- We create a new machine user