### PR TITLE
fix #7792: consider marks from the mro

### DIFF
--- a/changelog/7792.bugfix.rst
+++ b/changelog/7792.bugfix.rst
@@ -1,1 +1,5 @@
-Consider the full mro when getting marks from classes.
+Marks are now inherited according to the full MRO in test classes. Previously, if a test class inherited from two or more classes, only marks from the first super-class would apply.
+
+When inheriting marks from super-classes, marks from the sub-classes are now ordered before marks from the super-classes, in MRO order. Previously it was the reverse.
+
+When inheriting marks from super-classes, the `pytestmark` attribute of the sub-class now only contains the marks directly applied to it. Previously, it also contained marks from its super-classes. Please note that this attribute should not normally be accessed directly; use :func:`pytest.Node.iter_markers` instead.

--- a/changelog/7792.bugfix.rst
+++ b/changelog/7792.bugfix.rst
@@ -1,0 +1,1 @@
+Consider the full mro when getting marks from classes.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -356,7 +356,7 @@ class MarkDecorator:
 
 
 def get_unpacked_marks(
-    obj: object | type,
+    obj: Union[object, type],
     consider_mro: bool = True,
 ) -> List[Mark]:
     """Obtain the unpacked marks that are stored on an object."""

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -357,9 +357,15 @@ class MarkDecorator:
 
 def get_unpacked_marks(
     obj: Union[object, type],
+    *,
     consider_mro: bool = True,
 ) -> List[Mark]:
-    """Obtain the unpacked marks that are stored on an object."""
+    """Obtain the unpacked marks that are stored on an object.
+    
+    If obj is a class and consider_mro is true, return marks applied to
+    this class and all of its super-classes in MRO order. If consider_mro
+    is false, only return marks applied directly to this class.
+    """
     if isinstance(obj, type):
         if not consider_mro:
             mark_lists = [obj.__dict__.get("pytestmark", [])]

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -355,12 +355,29 @@ class MarkDecorator:
         return self.with_args(*args, **kwargs)
 
 
-def get_unpacked_marks(obj: object) -> Iterable[Mark]:
+def get_unpacked_marks(
+    obj: object | type,
+    consider_mro: bool = True,
+) -> List[Mark]:
     """Obtain the unpacked marks that are stored on an object."""
-    mark_list = getattr(obj, "pytestmark", [])
-    if not isinstance(mark_list, list):
-        mark_list = [mark_list]
-    return normalize_mark_list(mark_list)
+    if isinstance(obj, type):
+        if not consider_mro:
+            mark_lists = [obj.__dict__.get("pytestmark", [])]
+        else:
+            mark_lists = [x.__dict__.get("pytestmark", []) for x in obj.__mro__]
+        mark_list = []
+        for item in mark_lists:
+            if isinstance(item, list):
+                mark_list.extend(item)
+            else:
+                mark_list.append(item)
+    else:
+        mark_attribute = getattr(obj, "pytestmark", [])
+        if isinstance(mark_attribute, list):
+            mark_list = mark_attribute
+        else:
+            mark_list = [mark_attribute]
+    return list(normalize_mark_list(mark_list))
 
 
 def normalize_mark_list(
@@ -388,7 +405,7 @@ def store_mark(obj, mark: Mark) -> None:
     assert isinstance(mark, Mark), mark
     # Always reassign name to avoid updating pytestmark in a reference that
     # was only borrowed.
-    obj.pytestmark = [*get_unpacked_marks(obj), mark]
+    obj.pytestmark = [*get_unpacked_marks(obj, consider_mro=False), mark]
 
 
 # Typing for builtin pytest marks. This is cheating; it gives builtin marks

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -361,7 +361,7 @@ def get_unpacked_marks(
     consider_mro: bool = True,
 ) -> List[Mark]:
     """Obtain the unpacked marks that are stored on an object.
-    
+
     If obj is a class and consider_mro is true, return marks applied to
     this class and all of its super-classes in MRO order. If consider_mro
     is false, only return marks applied directly to this class.

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1132,4 +1132,4 @@ def test_mark_mro():
 
     assert all_marks == [xfail("c").mark, xfail("a").mark, xfail("b").mark]
 
-    assert get_unpacked_marks(C, consider_mro=False) == [pytest.mark.xfail("c").mark]
+    assert get_unpacked_marks(C, consider_mro=False) == [xfail("c").mark]

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1112,23 +1112,24 @@ def test_marker_expr_eval_failure_handling(pytester: Pytester, expr) -> None:
 
 
 def test_mark_mro():
-    @pytest.mark.xfail("a")
+    xfail = pytest.mark.xfail
+
+    @xfail("a")
     class A:
         pass
 
-    @pytest.mark.xfail("b")
+    @xfail("b")
     class B:
         pass
 
-    @pytest.mark.xfail("c")
+    @xfail("c")
     class C(A, B):
         pass
 
     from _pytest.mark.structures import get_unpacked_marks
 
-    all_marks = list(get_unpacked_marks(C))
+    all_marks = get_unpacked_marks(C)
 
-    nk = [(x.name, x.args[0]) for x in all_marks]
-    assert nk == [("xfail", "c"), ("xfail", "a"), ("xfail", "b")]
+    assert all_marks == [xfail("c").mark, xfail("a").mark, xfail("b").mark]
 
-    assert list(get_unpacked_marks(C, consider_mro=False)) == []
+    assert get_unpacked_marks(C, consider_mro=False) == [pytest.mark.xfail("c").mark]

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1111,7 +1111,7 @@ def test_marker_expr_eval_failure_handling(pytester: Pytester, expr) -> None:
     assert result.ret == ExitCode.USAGE_ERROR
 
 
-def test_mark_mro():
+def test_mark_mro() -> None:
     xfail = pytest.mark.xfail
 
     @xfail("a")


### PR DESCRIPTION
fixes #7792
closes #9105 as superseeded

adding extra reviewers as this can be seen as breaking change wrt the contents of the pytestmark attribute

it may be necessary (and a good idea) to start to deprecate pytestmark as name and start using a private name as a follow up