### PR TITLE
Replace entrypoint example with `pyproject.toml` in docs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -356,6 +356,7 @@ Victor Uriarte
 Vidar T. Fauske
 Virgil Dupras
 Vitaly Lashmanov
+Vivaan Verma
 Vlad Dragos
 Vlad Radziuk
 Vladyslav Rachek

--- a/changelog/10344.doc.rst
+++ b/changelog/10344.doc.rst
@@ -1,0 +1,1 @@
+Update information on writing plugins to use ``pyproject.toml`` instead of ``setup.py``.

--- a/doc/en/how-to/writing_plugins.rst
+++ b/doc/en/how-to/writing_plugins.rst
@@ -147,10 +147,11 @@ Making your plugin installable by others
 
 If you want to make your plugin externally available, you
 may define a so-called entry point for your distribution so
-that ``pytest`` finds your plugin module.  Entry points are
-a feature that is provided by :std:doc:`setuptools:index`. pytest looks up
-the ``pytest11`` entrypoint to discover its
-plugins and you can thus make your plugin available by defining
+that ``pytest`` finds your plugin module. Entry points are
+a feature that is provided by :std:doc:`setuptools <setuptools:index>`.
+
+pytest looks up the ``pytest11`` entrypoint to discover its
+plugins, thus you can make your plugin available by defining
 it in your ``pyproject.toml`` file.
 
 .. sourcecode:: toml

--- a/doc/en/how-to/writing_plugins.rst
+++ b/doc/en/how-to/writing_plugins.rst
@@ -151,23 +151,28 @@ that ``pytest`` finds your plugin module.  Entry points are
 a feature that is provided by :std:doc:`setuptools:index`. pytest looks up
 the ``pytest11`` entrypoint to discover its
 plugins and you can thus make your plugin available by defining
-it in your setuptools-invocation:
+it in your ``pyproject.toml`` file.
 
-.. sourcecode:: python
+.. sourcecode:: toml
 
-    # sample ./setup.py file
-    from setuptools import setup
+    # sample ./pyproject.toml file
+    [build-system]
+    requires = ["setuptools"]
+    build-backend = "setuptools.build_meta"
 
+    [project]
+    name = "myproject"
+    classifiers = [
+        "Framework :: Pytest",
+    ]
 
-    name_of_plugin = "myproject"  # register plugin with this name
-    setup(
-        name="myproject",
-        packages=["myproject"],
-        # the following makes a plugin available to pytest
-        entry_points={"pytest11": [f"{name_of_plugin} = myproject.pluginmodule"]},
-        # custom PyPI classifier for pytest plugins
-        classifiers=["Framework :: Pytest"],
-    )
+    [tool.setuptools]
+    packages = ["myproject"]
+
+    [project.entry_points]
+    pytest11 = [
+        "myproject = myproject.pluginmodule",
+    ]
 
 If a package is installed this way, ``pytest`` will load
 ``myproject.pluginmodule`` as a plugin which can define

--- a/doc/en/how-to/writing_plugins.rst
+++ b/doc/en/how-to/writing_plugins.rst
@@ -157,8 +157,8 @@ it in your ``pyproject.toml`` file.
 
     # sample ./pyproject.toml file
     [build-system]
-    requires = ["setuptools"]
-    build-backend = "setuptools.build_meta"
+    requires = ["hatchling"]
+    build-backend = "hatchling.build"
 
     [project]
     name = "myproject"


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->

This PR replaces the documentation on writing plugins and making them discoverable to Pytest
by favouring the use of `pyproject.toml` instead of `setuptools.py`

Closes #10344.