### PR TITLE
[7431] Add --suppress-logger CLI option

### DIFF
--- a/changelog/7431.feature.rst
+++ b/changelog/7431.feature.rst
@@ -1,1 +1,1 @@
-``--logger-disable`` CLI option added to disable individual loggers.
+``--log-disable`` CLI option added to disable individual loggers.

--- a/changelog/7431.feature.rst
+++ b/changelog/7431.feature.rst
@@ -1,1 +1,1 @@
-``--logger-disabled`` CLI option added to disable individual loggers.
+``--logger-disable`` CLI option added to disable individual loggers.

--- a/changelog/7431.feature.rst
+++ b/changelog/7431.feature.rst
@@ -1,1 +1,1 @@
-``--suppress-logger`` CLI option added to suppress output from individual loggers.
+``--logger-disabled`` CLI option added to disable individual loggers.

--- a/changelog/7431.feature.rst
+++ b/changelog/7431.feature.rst
@@ -1,0 +1,1 @@
+``--suppress-logger`` CLI option added to suppress output from individual loggers.

--- a/doc/en/how-to/logging.rst
+++ b/doc/en/how-to/logging.rst
@@ -59,6 +59,7 @@ Specific loggers can be disabled via ``--log-disable={logger_name}``.
 This argument can be passed multiple times:
 
 .. code-block:: bash
+
     pytest --log-disable=main --log-disable=testing
 
 Further it is possible to disable reporting of captured content (stdout,

--- a/doc/en/how-to/logging.rst
+++ b/doc/en/how-to/logging.rst
@@ -55,6 +55,12 @@ These options can also be customized through ``pytest.ini`` file:
     log_format = %(asctime)s %(levelname)s %(message)s
     log_date_format = %Y-%m-%d %H:%M:%S
 
+Specific loggers can be disabled via ``--log-disable={logger_name}``.
+This argument can be passed multiple times:
+
+.. code-block:: bash
+    pytest --log-disable=main --log-disable=testing
+
 Further it is possible to disable reporting of captured content (stdout,
 stderr and logs) on failed tests completely with:
 

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -297,6 +297,13 @@ def pytest_addoption(parser: Parser) -> None:
         default=None,
         help="Auto-indent multiline messages passed to the logging module. Accepts true|on, false|off or an integer.",
     )
+    group.addoption(
+        "--suppress-logger",
+        action="append",
+        default=[],
+        dest="suppress_logger",
+        help="Suppress logger by name",
+    )
 
 
 _HandlerType = TypeVar("_HandlerType", bound=logging.Handler)
@@ -594,6 +601,16 @@ class LoggingPlugin:
             get_option_ini(config, "log_auto_indent"),
         )
         self.log_cli_handler.setFormatter(log_cli_formatter)
+
+        if config.option.suppress_logger:
+            self._suppress_loggers()
+
+    def _suppress_loggers(self) -> None:
+        logger_names_to_suppress = set(self._config.option.suppress_logger)
+        for name in logger_names_to_suppress:
+            logger = logging.getLogger(name)
+            logger.addFilter(lambda _: 0)
+
 
     def _create_formatter(self, log_format, log_date_format, auto_indent):
         # Color option doesn't exist if terminal plugin is disabled.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -302,7 +302,7 @@ def pytest_addoption(parser: Parser) -> None:
         action="append",
         default=[],
         dest="suppress_logger",
-        help="Suppress logger by name",
+        help="Suppress loggers by name",
     )
 
 
@@ -610,7 +610,6 @@ class LoggingPlugin:
         for name in logger_names_to_suppress:
             logger = logging.getLogger(name)
             logger.addFilter(lambda _: 0)
-
 
     def _create_formatter(self, log_format, log_date_format, auto_indent):
         # Color option doesn't exist if terminal plugin is disabled.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -298,11 +298,11 @@ def pytest_addoption(parser: Parser) -> None:
         help="Auto-indent multiline messages passed to the logging module. Accepts true|on, false|off or an integer.",
     )
     group.addoption(
-        "--logger-disable",
+        "--log-disable",
         action="append",
         default=[],
         dest="logger_disable",
-        help="Disable loggers by name",
+        help="Disable a logger by name. Can be passed multipe times.",
     )
 
 
@@ -601,14 +601,13 @@ class LoggingPlugin:
             get_option_ini(config, "log_auto_indent"),
         )
         self.log_cli_handler.setFormatter(log_cli_formatter)
-        self._disable_logger(loggers_to_disable=config.option.logger_disable)
+        self._disable_loggers(loggers_to_disable=config.option.logger_disable)
 
-    def _disable_logger(self, loggers_to_disable: List[str]) -> None:
+    def _disable_loggers(self, loggers_to_disable: List[str]) -> None:
         if not loggers_to_disable:
             return
 
-        logger_names_to_suppress = set(loggers_to_disable)
-        for name in logger_names_to_suppress:
+        for name in loggers_to_disable:
             logger = logging.getLogger(name)
             logger.disabled = True
 

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -298,10 +298,10 @@ def pytest_addoption(parser: Parser) -> None:
         help="Auto-indent multiline messages passed to the logging module. Accepts true|on, false|off or an integer.",
     )
     group.addoption(
-        "--logger-disabled",
+        "--logger-disable",
         action="append",
         default=[],
-        dest="logger_disabled",
+        dest="logger_disable",
         help="Disable loggers by name",
     )
 
@@ -601,7 +601,7 @@ class LoggingPlugin:
             get_option_ini(config, "log_auto_indent"),
         )
         self.log_cli_handler.setFormatter(log_cli_formatter)
-        self._disable_logger(loggers_to_disable=config.option.logger_disabled)
+        self._disable_logger(loggers_to_disable=config.option.logger_disable)
 
     def _disable_logger(self, loggers_to_disable: List[str]) -> None:
         if not loggers_to_disable:
@@ -610,7 +610,7 @@ class LoggingPlugin:
         logger_names_to_suppress = set(loggers_to_disable)
         for name in logger_names_to_suppress:
             logger = logging.getLogger(name)
-            logger.addFilter(lambda _: 0)
+            logger.disabled = True
 
     def _create_formatter(self, log_format, log_date_format, auto_indent):
         # Color option doesn't exist if terminal plugin is disabled.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -298,11 +298,11 @@ def pytest_addoption(parser: Parser) -> None:
         help="Auto-indent multiline messages passed to the logging module. Accepts true|on, false|off or an integer.",
     )
     group.addoption(
-        "--suppress-logger",
+        "--logger-disabled",
         action="append",
         default=[],
-        dest="suppress_logger",
-        help="Suppress loggers by name",
+        dest="logger_disabled",
+        help="Disable loggers by name",
     )
 
 
@@ -601,12 +601,13 @@ class LoggingPlugin:
             get_option_ini(config, "log_auto_indent"),
         )
         self.log_cli_handler.setFormatter(log_cli_formatter)
+        self._disable_logger(loggers_to_disable=config.option.logger_disabled)
 
-        if config.option.suppress_logger:
-            self._suppress_loggers()
+    def _disable_logger(self, loggers_to_disable: List[str]) -> None:
+        if not loggers_to_disable:
+            return
 
-    def _suppress_loggers(self) -> None:
-        logger_names_to_suppress = set(self._config.option.suppress_logger)
+        logger_names_to_suppress = set(loggers_to_disable)
         for name in logger_names_to_suppress:
             logger = logging.getLogger(name)
             logger.addFilter(lambda _: 0)

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1182,7 +1182,7 @@ def test_disable_loggers(testdir):
                 assert caplog.record_tuples == [('test', 10, 'Visible text!')]
          """
     )
-    result = testdir.runpytest("--logger-disabled=disabled", "-s")
+    result = testdir.runpytest("--logger-disable=disabled", "-s")
     assert result.ret == ExitCode.OK
     assert not result.stderr.lines
 
@@ -1204,7 +1204,7 @@ def test_disable_loggers_does_not_propagate(testdir):
     """
     )
 
-    result = testdir.runpytest("--logger-disabled=parent.child", "-s")
+    result = testdir.runpytest("--logger-disable=parent.child", "-s")
     assert result.ret == ExitCode.OK
     assert not result.stderr.lines
 
@@ -1212,7 +1212,7 @@ def test_disable_loggers_does_not_propagate(testdir):
 def test_disabled_loggers_help(testdir):
     result = testdir.runpytest("-h")
     result.stdout.fnmatch_lines(
-        ["  --logger-disabled=LOGGER_DISABLED", "*Disable loggers by name*"]
+        ["  --logger-disable=LOGGER_DISABLE", "*Disable loggers by name*"]
     )
 
 
@@ -1230,7 +1230,7 @@ def test_log_disabling_works_with_log_cli(testdir):
     )
     result = testdir.runpytest(
         "--log-cli-level=DEBUG",
-        "--logger-disabled=disabled",
+        "--logger-disable=disabled",
     )
     assert result.ret == ExitCode.OK
     result.stdout.fnmatch_lines(

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1200,6 +1200,8 @@ def test_disable_loggers_does_not_propagate(testdir):
                 parent_logger.warning("some parent logger message")
                 child_logger.warning("some child logger message")
                 assert len(caplog.record_tuples) == 1
+                assert caplog.record_tuples[0][0] == "parent"
+                assert caplog.record_tuples[0][2] == "some parent logger message"
     """
     )
 

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1178,11 +1178,10 @@ def test_disable_loggers(testdir):
             with caplog.at_level(logging.DEBUG):
                 disabled_log.warning("no log; no stderr")
                 test_log.debug("Visible text!")
-                print(os.linesep)
                 assert caplog.record_tuples == [('test', 10, 'Visible text!')]
          """
     )
-    result = testdir.runpytest("--logger-disable=disabled", "-s")
+    result = testdir.runpytest("--log-disable=disabled", "-s")
     assert result.ret == ExitCode.OK
     assert not result.stderr.lines
 
@@ -1198,22 +1197,15 @@ def test_disable_loggers_does_not_propagate(testdir):
 
     def test_logger_propagation_to_parent(caplog):
             with caplog.at_level(logging.DEBUG):
-                child_logger.warning("some message")
-                print(os.linesep)
-                assert not caplog.record_tuples
+                parent_logger.warning("some parent logger message")
+                child_logger.warning("some child logger message")
+                assert len(caplog.record_tuples) == 1
     """
     )
 
-    result = testdir.runpytest("--logger-disable=parent.child", "-s")
+    result = testdir.runpytest("--log-disable=parent.child", "-s")
     assert result.ret == ExitCode.OK
     assert not result.stderr.lines
-
-
-def test_disabled_loggers_help(testdir):
-    result = testdir.runpytest("-h")
-    result.stdout.fnmatch_lines(
-        ["  --logger-disable=LOGGER_DISABLE", "*Disable loggers by name*"]
-    )
 
 
 def test_log_disabling_works_with_log_cli(testdir):
@@ -1230,7 +1222,7 @@ def test_log_disabling_works_with_log_cli(testdir):
     )
     result = testdir.runpytest(
         "--log-cli-level=DEBUG",
-        "--logger-disable=disabled",
+        "--log-disable=disabled",
     )
     assert result.ret == ExitCode.OK
     result.stdout.fnmatch_lines(


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!
Here is a quick checklist that should be present in PRs.

- [] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
## Issue
Users want to suppress logger by name when invoking pytest.

## Proposed solution
- Added new CLI option to suppress loggers by name.
- A null filter is added to each logger, which returns False for every log entry.

Based off https://github.com/pytest-dev/pytest/pull/7873/files from @symonk 
Closes #7431