### PR TITLE
Don't break into pdb when `raise unittest.SkipTest()` appears top-level in a file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -129,6 +129,7 @@ Feng Ma
 Florian Bruhin
 Florian Dahlitz
 Floris Bruynooghe
+Gabriel Landau
 Gabriel Reis
 Garvit Shubham
 Gene Wood

--- a/changelog/10382.bugfix.rst
+++ b/changelog/10382.bugfix.rst
@@ -1,0 +1,1 @@
+Do not break into pdb when ``raise unittest.SkipTest()`` appears top-level in a file.

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -3,6 +3,7 @@ import argparse
 import functools
 import sys
 import types
+import unittest
 from typing import Any
 from typing import Callable
 from typing import Generator
@@ -293,7 +294,9 @@ class PdbInvoke:
             sys.stdout.write(out)
             sys.stdout.write(err)
         assert call.excinfo is not None
-        _enter_pdb(node, call.excinfo, report)
+
+        if not isinstance(call.excinfo.value, unittest.SkipTest):
+            _enter_pdb(node, call.excinfo, report)
 
     def pytest_internalerror(self, excinfo: ExceptionInfo[BaseException]) -> None:
         tb = _postmortem_traceback(excinfo)

--- a/testing/test_debugging.py
+++ b/testing/test_debugging.py
@@ -123,6 +123,18 @@ class TestPDB:
         )
         assert rep.skipped
         assert len(pdblist) == 0
+        
+    def test_pdb_on_raise_skiptest(self, pytester, pdblist) -> None:
+        rep = runpdb_and_get_report(
+            pytester,
+            """
+            import unittest
+            
+            raise unittest.SkipTest("This is a common way to skip an entire file.")
+        """,
+        )
+        assert rep.skipped
+        assert len(pdblist) == 0
 
     def test_pdb_on_BdbQuit(self, pytester, pdblist) -> None:
         rep = runpdb_and_get_report(

--- a/testing/test_debugging.py
+++ b/testing/test_debugging.py
@@ -20,9 +20,18 @@ def pdb_env(request):
         pytester._monkeypatch.setenv("PDBPP_HIJACK_PDB", "0")
 
 
-def runpdb_and_get_report(pytester: Pytester, source: str):
+def runpdb(pytester: Pytester, source: str):
     p = pytester.makepyfile(source)
-    result = pytester.runpytest_inprocess("--pdb", p)
+    return pytester.runpytest_inprocess("--pdb", p)
+
+
+def runpdb_and_get_stdout(pytester: Pytester, source: str):
+    result = runpdb(pytester, source)
+    return result.stdout.str()
+
+
+def runpdb_and_get_report(pytester: Pytester, source: str):
+    result = runpdb(pytester, source)
     reports = result.reprec.getreports("pytest_runtest_logreport")  # type: ignore[attr-defined]
     assert len(reports) == 3, reports  # setup/call/teardown
     return reports[1]
@@ -123,18 +132,16 @@ class TestPDB:
         )
         assert rep.skipped
         assert len(pdblist) == 0
-        
-    def test_pdb_on_raise_skiptest(self, pytester, pdblist) -> None:
-        rep = runpdb_and_get_report(
+
+    def test_pdb_on_top_level_raise_skiptest(self, pytester, pdblist) -> None:
+        stdout = runpdb_and_get_stdout(
             pytester,
             """
             import unittest
-            
             raise unittest.SkipTest("This is a common way to skip an entire file.")
         """,
         )
-        assert rep.skipped
-        assert len(pdblist) == 0
+        assert "entering PDB" not in stdout, stdout
 
     def test_pdb_on_BdbQuit(self, pytester, pdblist) -> None:
         rep = runpdb_and_get_report(


### PR DESCRIPTION
Closes https://github.com/pytest-dev/pytest/issues/10382

Don't break into pdb when `raise unittest.SkipTest()` appears top-level in a file.

I attempted to follow the instructions [here](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#long-version).  Please let me know if I missed anything.

I can't run the pytests directly, so let's see what CI says once I open this PR.  Both the `pip` and `tox` [instructions](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#long-version) fail with a `minversion` error:

<details><summary>tox error</summary>

```
(venv) user@virtual-machine:~/pytest$ git checkout main
Already on 'main'
Your branch is up to date with 'origin/main'.
(venv) user@virtual-machine:~/pytest$ git rev-parse HEAD
15ac0349b2c7d8dc48fe2e25a1b4fa47c9fda25c
(venv) user@virtual-machine:~/pytest$ tox -e linting,py310
/home/user/pytest/.tox/.package/lib/python3.10/site-packages/setuptools/config/setupcfg.py:508: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
  warnings.warn(msg, warning_class)
/home/user/pytest/.tox/.package/lib/python3.10/site-packages/setuptools/config/setupcfg.py:508: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
  warnings.warn(msg, warning_class)
linting installed: cfgv==3.3.1,distlib==0.3.6,filelock==3.8.0,identify==2.5.6,nodeenv==1.7.0,platformdirs==2.5.2,pre-commit==2.20.0,PyYAML==6.0,toml==0.10.2,virtualenv==20.16.5
linting run-test-pre: PYTHONHASHSEED='3208460783'
linting run-test: commands[0] | pre-commit run --all-files --show-diff-on-failure
black....................................................................Passed
blacken-docs.............................................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
fix python encoding pragma...............................................Passed
check yaml...............................................................Passed
debug statements (python)................................................Passed
autoflake................................................................Passed
flake8...................................................................Passed
Reorder python imports...................................................Passed
pyupgrade................................................................Passed
setup-cfg-fmt............................................................Passed
type annotations not comments............................................Passed
mypy.....................................................................Passed
rst......................................................................Passed
changelog filenames..................................(no files to check)Skipped
py library is deprecated.................................................Passed
py.path usage is deprecated..............................................Passed
py310 inst-nodeps: /home/user/pytest/.tox/.tmp/package/1/pytest-0.1.dev14703+g15ac034.tar.gz
py310 installed: argcomplete==2.0.0,attrs==22.1.0,certifi==2022.9.24,charset-normalizer==2.1.1,elementpath==3.0.2,exceptiongroup==1.0.0rc9,hypothesis==6.56.2,idna==3.4,iniconfig==1.1.1,mock==4.0.3,nose==1.3.7,packaging==21.3,pluggy==1.0.0,py==1.11.0,Pygments==2.13.0,pyparsing==3.0.9,pytest @ file:///home/user/pytest/.tox/.tmp/package/1/pytest-0.1.dev14703%2Bg15ac034.tar.gz,requests==2.28.1,sortedcontainers==2.4.0,tomli==2.0.1,urllib3==1.26.12,xmlschema==2.1.1
py310 run-test-pre: PYTHONHASHSEED='3208460783'
py310 run-test: commands[0] | pytest
ERROR: /home/user/pytest/pyproject.toml: 'minversion' requires pytest-2.0, actual pytest-0.1.dev14703+g15ac034'

ERROR: InvocationError for command /home/user/pytest/.tox/py310/bin/pytest (exited with code 4)
_______________________________________________________________________________________________ summary ________________________________________________________________________________________________
  linting: commands succeeded
ERROR:   py310: commands failed
(venv) user@virtual-machine:~/pytest$
```
</details>

I verified the undesirable behavior is remedied when I install via `python3 setup.py develop` and test a minimal repro file as documented in the [original bug ticket](https://github.com/pytest-dev/pytest/issues/10382).

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
