### PR TITLE
:wrench: `--no-showlocals` to negate `addopts` w/ `--showlocals`

### DIFF
--- a/changelog/10381.improvement.rst
+++ b/changelog/10381.improvement.rst
@@ -1,0 +1,1 @@
+The ``--no-showlocals`` flag has been added. This can be passed directly to tests to override ``--showlocals`` declared through ``addopts``.

--- a/doc/en/how-to/output.rst
+++ b/doc/en/how-to/output.rst
@@ -12,8 +12,9 @@ Examples for modifying traceback printing:
 
 .. code-block:: bash
 
-    pytest --showlocals # show local variables in tracebacks
-    pytest -l           # show local variables (shortcut)
+    pytest --showlocals     # show local variables in tracebacks
+    pytest -l               # show local variables (shortcut)
+    pytest --no-showlocals  # hide local variables (if addopts enables them)
 
     pytest --tb=auto    # (default) 'long' tracebacks for the first and last
                          # entry, but 'short' style for the other entries

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -179,6 +179,12 @@ def pytest_addoption(parser: Parser) -> None:
         help="Show locals in tracebacks (disabled by default)",
     )
     group._addoption(
+        "--no-showlocals",
+        action="store_false",
+        dest="showlocals",
+        help="Hide locals in tracebacks (negate --showlocals passed through addopts)",
+    )
+    group._addoption(
         "--tb",
         metavar="style",
         action="store",

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -998,6 +998,22 @@ class TestTerminalFunctional:
             ]
         )
 
+    def test_noshowlocals_addopts_override(self, pytester: Pytester) -> None:
+        pytester.makeini("[pytest]\naddopts=--showlocals")
+        p1 = pytester.makepyfile(
+            """
+            def test_noshowlocals():
+                x = 3
+                y = "x" * 5000
+                assert 0
+        """
+        )
+
+        # Override global --showlocals for py.test via arg
+        result = pytester.runpytest(p1, "--no-showlocals")
+        result.stdout.no_fnmatch_line("x* = 3")
+        result.stdout.no_fnmatch_line("y* = 'xxxxxx*")
+
     def test_showlocals_short(self, pytester: Pytester) -> None:
         p1 = pytester.makepyfile(
             """


### PR DESCRIPTION
Fixes #10381


This is necessary for `addopts=--showlocals` where individual test runs need to not show locals.

- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.
