### PR TITLE
Adds a feature to control how directories created by the `tmp_path` fixture are kept.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -372,6 +372,7 @@ Xixi Zhao
 Xuan Luong
 Xuecong Liao
 Yoav Caspi
+Yusuke Kadowaki
 Yuval Shimon
 Zac Hatfield-Dodds
 Zachary Kneupper

--- a/changelog/8141.feature.rst
+++ b/changelog/8141.feature.rst
@@ -1,2 +1,2 @@
-Added `--tmp-path-retention-count` and `--tmp-path-retention-policy` options to control how directories created by the `tmp_path` fixture are kept.
-The default behavior has changed to remove all directories if all tests passed.
+Added :confval:`tmp_path_retention_count` and :confval:`tmp_path_retention_policy` configuration options to control how directories created by the :fixture:`tmp_path` fixture are kept.
+The default behavior has changed to keep only directories for failed tests, equivalent to `tmp_path_retention_policy="failed"`.

--- a/changelog/8141.feature.rst
+++ b/changelog/8141.feature.rst
@@ -1,1 +1,2 @@
 Added `--tmp-path-retention-count` and `--tmp-path-retention-policy` options to control how directories created by the `tmp_path` fixture are kept.
+The default behavior has changed to remove all directories if all tests passed.

--- a/changelog/8141.feature.rst
+++ b/changelog/8141.feature.rst
@@ -1,0 +1,1 @@
+Added `--tmp-path-retention-count` and `--tmp-path-retention-policy` options to control how directories created by the `tmp_path` fixture are kept.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1723,6 +1723,40 @@ passed multiple times. The expected format is ``name=value``. For example::
    directories when executing from the root directory.
 
 
+.. confval:: tmp_path_retention_count
+
+
+
+   How many sessions should we keep the `tmp_path` directories,
+   according to `tmp_path_retention_policy`.
+
+   .. code-block:: ini
+
+        [pytest]
+        tmp_path_retention_count = 3
+
+    Default: 3
+
+
+.. confval:: tmp_path_retention_policy
+
+
+
+   Controls which directories created by the `tmp_path` fixture are kept around,
+   based on test outcome.
+
+    * `all`: retains directories for all tests, regardless of the outcome.
+    * `failed`: retains directories only for tests with outcome `error` or `failed`.
+    * `none`: directories are always removed after each test ends, regardless of the outcome.
+
+   .. code-block:: ini
+
+        [pytest]
+        tmp_path_retention_policy = "all"
+
+    Default: failed
+
+
 .. confval:: usefixtures
 
     List of fixtures that will be applied to all test functions; this is semantically the same to apply

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -232,7 +232,7 @@ def pytest_addoption(parser: Parser) -> None:
         "--tmp-path-retention-count",
         dest="tmp_path_retention_count",
         default=3,
-        type="int",
+        type=int,
         metavar="num",
         help="How many sessions should we keep the `tmp_path` directories, according to `tmp_path_retention_policy`.",
     )

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -228,23 +228,6 @@ def pytest_addoption(parser: Parser) -> None:
         ),
     )
 
-    group.addoption(
-        "--tmp-path-retention-count",
-        dest="tmp_path_retention_count",
-        default=3,
-        type=int,
-        metavar="num",
-        help="How many sessions should we keep the `tmp_path` directories, according to `tmp_path_retention_policy`.",
-    )
-
-    group.addoption(
-        "--tmp-path-retention-policy",
-        default="failed",
-        choices=["all", "failed", "none"],
-        dest="tmp_path_retention_policy",
-        help="Controls which directories created by the `tmp_path` fixture are kept around, based on test outcome.",
-    )
-
 
 def validate_basetemp(path: str) -> str:
     # GH 7119

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -228,6 +228,22 @@ def pytest_addoption(parser: Parser) -> None:
         ),
     )
 
+    group.addoption(
+        "--tmp-path-retention-count",
+        dest="tmp_path_retention_count",
+        default=3,
+        metavar="num",
+        help="How many sessions should we keep the `tmp_path` directories, according to `tmp_path_retention_policy`.",
+    )
+
+    group.addoption(
+        "--tmp-path-retention-policy",
+        default="failed",
+        choices=["all", "failed", "none"],
+        dest="tmp_path_retention_policy",
+        help="Controls which directories created by the `tmp_path` fixture are kept around, based on test outcome.",
+    )
+
 
 def validate_basetemp(path: str) -> str:
     # GH 7119

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -232,6 +232,7 @@ def pytest_addoption(parser: Parser) -> None:
         "--tmp-path-retention-count",
         dest="tmp_path_retention_count",
         default=3,
+        type="int",
         metavar="num",
         help="How many sessions should we keep the `tmp_path` directories, according to `tmp_path_retention_policy`.",
     )

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -339,6 +339,8 @@ def cleanup_numbered_dir(
     root: Path, prefix: str, keep: int, consider_lock_dead_if_created_before: float
 ) -> None:
     """Cleanup for lock driven numbered directories."""
+    if not root.exists():
+        return
     for path in cleanup_candidates(root, prefix, keep):
         try_cleanup(path, consider_lock_dead_if_created_before)
     for path in root.glob("garbage-*"):
@@ -357,7 +359,7 @@ def make_numbered_dir_with_cleanup(
     for i in range(10):
         try:
             p = make_numbered_dir(root, prefix, mode)
-            # Do not lock the current dir when keep is 0
+            # Only lock the current dir when keep is not 0
             if keep != 0:
                 lock_path = create_cleanup_lock(p)
                 register_cleanup_lock_removal(lock_path)

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -346,6 +346,12 @@ def cleanup_numbered_dir(
     for path in root.glob("garbage-*"):
         try_cleanup(path, consider_lock_dead_if_created_before)
 
+    # remove dead symlink
+    for left_dir in root.iterdir():
+        if left_dir.is_symlink():
+            if not left_dir.resolve().exists():
+                left_dir.unlink()
+
 
 def make_numbered_dir_with_cleanup(
     root: Path,

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -335,6 +335,13 @@ def cleanup_candidates(root: Path, prefix: str, keep: int) -> Iterator[Path]:
             yield path
 
 
+def cleanup_dead_symlink(root: Path):
+    for left_dir in root.iterdir():
+        if left_dir.is_symlink():
+            if not left_dir.resolve().exists():
+                left_dir.unlink()
+
+
 def cleanup_numbered_dir(
     root: Path, prefix: str, keep: int, consider_lock_dead_if_created_before: float
 ) -> None:
@@ -346,11 +353,7 @@ def cleanup_numbered_dir(
     for path in root.glob("garbage-*"):
         try_cleanup(path, consider_lock_dead_if_created_before)
 
-    # remove dead symlink
-    for left_dir in root.iterdir():
-        if left_dir.is_symlink():
-            if not left_dir.resolve().exists():
-                left_dir.unlink()
+    cleanup_dead_symlink(root)
 
 
 def make_numbered_dir_with_cleanup(

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -357,8 +357,10 @@ def make_numbered_dir_with_cleanup(
     for i in range(10):
         try:
             p = make_numbered_dir(root, prefix, mode)
-            lock_path = create_cleanup_lock(p)
-            register_cleanup_lock_removal(lock_path)
+            # Do not lock the current dir when keep is 0
+            if keep != 0:
+                lock_path = create_cleanup_lock(p)
+                register_cleanup_lock_removal(lock_path)
         except Exception as exc:
             e = exc
         else:

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -19,8 +19,6 @@ if TYPE_CHECKING:
 import attr
 from _pytest.config.argparsing import Parser
 
-from pytest import hookimpl
-
 from .pathlib import LOCK_TIMEOUT
 from .pathlib import make_numbered_dir
 from .pathlib import make_numbered_dir_with_cleanup
@@ -28,6 +26,7 @@ from .pathlib import rm_rf
 from _pytest.compat import final
 from _pytest.config import Config
 from _pytest.config import ExitCode
+from _pytest.config import hookimpl
 from _pytest.deprecated import check_ispytest
 from _pytest.fixtures import fixture
 from _pytest.fixtures import FixtureRequest

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -154,10 +154,13 @@ class TempPathFactory:
                         )
                     if (rootdir_stat.st_mode & 0o077) != 0:
                         os.chmod(rootdir, rootdir_stat.st_mode & ~0o077)
+            keep = self._retention_count
+            if self._retention_policy == "none":
+                keep = 0
             basetemp = make_numbered_dir_with_cleanup(
                 prefix="pytest-",
                 root=rootdir,
-                keep=self._retention_count,
+                keep=keep,
                 lock_timeout=LOCK_TIMEOUT,
                 mode=0o700,
             )

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -31,10 +31,14 @@ class TempPathFactory:
     _given_basetemp = attr.ib(type=Optional[Path])
     _trace = attr.ib()
     _basetemp = attr.ib(type=Optional[Path])
+    _retention_count = attr.ib(type=Optional[int])
+    _retention_policy = attr.ib(type=Optional[str])
 
     def __init__(
         self,
         given_basetemp: Optional[Path],
+        retention_count: Optional[int],
+        retention_policy: Optional[str],
         trace,
         basetemp: Optional[Path] = None,
         *,
@@ -49,6 +53,8 @@ class TempPathFactory:
             # Path.absolute() exists, but it is not public (see https://bugs.python.org/issue25012).
             self._given_basetemp = Path(os.path.abspath(str(given_basetemp)))
         self._trace = trace
+        self._retention_count = retention_count
+        self._retention_policy = retention_policy
         self._basetemp = basetemp
 
     @classmethod
@@ -66,6 +72,8 @@ class TempPathFactory:
         return cls(
             given_basetemp=config.option.basetemp,
             trace=config.trace.get("tmpdir"),
+            retention_count=config.option.tmp_path_retention_count,
+            retention_policy=config.option.tmp_path_retention_policy,
             _ispytest=True,
         )
 

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -272,7 +272,7 @@ def tmp_path(
     # Remove the tmpdir if the policy is "failed" and the test passed.
     tmp_path_factory: TempPathFactory = request.session.config._tmp_path_factory  # type: ignore
     policy = tmp_path_factory._retention_policy
-    if policy == "failed" and request.node.result_call.passed:
+    if policy == "failed" and request.node._tmp_path_result_call.passed:
         # We do a "best effort" to remove files, but it might not be possible due to some leaked resource,
         # permissions, etc, in which case we ignore it.
         rmtree(path, ignore_errors=True)
@@ -311,4 +311,4 @@ def pytest_sessionfinish(session, exitstatus: Union[int, ExitCode]):
 def pytest_runtest_makereport(item, call):
     outcome = yield
     result = outcome.get_result()
-    setattr(item, "result_" + result.when, result)
+    setattr(item, "_tmp_path_result_" + result.when, result)

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -13,6 +13,8 @@ from typing import Union
 if TYPE_CHECKING:
     from typing_extensions import Literal
 
+    RetentionType = Literal["all", "failed", "none"]
+
 
 import attr
 from _pytest.config.argparsing import Parser
@@ -45,13 +47,13 @@ class TempPathFactory:
     _trace = attr.ib()
     _basetemp = attr.ib(type=Optional[Path])
     _retention_count = attr.ib(type=int)
-    _retention_policy = attr.ib(type=RetentionPolicy)
+    _retention_policy = attr.ib(type="RetentionType")
 
     def __init__(
         self,
         given_basetemp: Optional[Path],
         retention_count: int,
-        retention_policy: RetentionPolicy,
+        retention_policy: "RetentionType",
         trace,
         basetemp: Optional[Path] = None,
         *,

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -31,14 +31,14 @@ class TempPathFactory:
     _given_basetemp = attr.ib(type=Optional[Path])
     _trace = attr.ib()
     _basetemp = attr.ib(type=Optional[Path])
-    _retention_count = attr.ib(type=Optional[int])
-    _retention_policy = attr.ib(type=Optional[str])
+    _retention_count = attr.ib(type=int)
+    _retention_policy = attr.ib(type=str)
 
     def __init__(
         self,
         given_basetemp: Optional[Path],
-        retention_count: Optional[int],
-        retention_policy: Optional[str],
+        retention_count: int,
+        retention_policy: str,
         trace,
         basetemp: Optional[Path] = None,
         *,
@@ -157,7 +157,7 @@ class TempPathFactory:
             basetemp = make_numbered_dir_with_cleanup(
                 prefix="pytest-",
                 root=rootdir,
-                keep=3,
+                keep=self._retention_count,
                 lock_timeout=LOCK_TIMEOUT,
                 mode=0o700,
             )

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -23,6 +23,7 @@ from .pathlib import LOCK_TIMEOUT
 from .pathlib import make_numbered_dir
 from .pathlib import make_numbered_dir_with_cleanup
 from .pathlib import rm_rf
+from .pathlib import cleanup_dead_symlink
 from _pytest.compat import final
 from _pytest.config import Config
 from _pytest.config import ExitCode
@@ -281,10 +282,7 @@ def tmp_path(
     basetemp = tmp_path_factory._basetemp
     if basetemp is None:
         return
-    for left_dir in basetemp.iterdir():
-        if left_dir.is_symlink():
-            if not left_dir.resolve().exists():
-                left_dir.unlink()
+    cleanup_dead_symlink(basetemp)
 
 
 def pytest_sessionfinish(session, exitstatus: Union[int, ExitCode]):

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -34,8 +34,6 @@ def test_tmp_path_fixture(pytester: Pytester) -> None:
 @attr.s
 class FakeConfig:
     basetemp = attr.ib()
-    tmp_path_retention_count = attr.ib(default=3)
-    tmp_path_retention_policy = attr.ib(default="failed")
 
     @property
     def trace(self):
@@ -43,6 +41,14 @@ class FakeConfig:
 
     def get(self, key):
         return lambda *k: None
+
+    def getini(self, name):
+        if name == "tmp_path_retention_count":
+            return 3
+        elif name == "tmp_path_retention_policy":
+            return "failed"
+        else:
+            assert False
 
     @property
     def option(self):
@@ -453,7 +459,7 @@ def test_tmp_path_factory_create_directory_with_safe_permissions(
     """Verify that pytest creates directories under /tmp with private permissions."""
     # Use the test's tmp_path as the system temproot (/tmp).
     monkeypatch.setenv("PYTEST_DEBUG_TEMPROOT", str(tmp_path))
-    tmp_factory = TempPathFactory(None, 3, "fail", lambda *args: None, _ispytest=True)
+    tmp_factory = TempPathFactory(None, 3, "failed", lambda *args: None, _ispytest=True)
     basetemp = tmp_factory.getbasetemp()
 
     # No world-readable permissions.
@@ -473,14 +479,14 @@ def test_tmp_path_factory_fixes_up_world_readable_permissions(
     """
     # Use the test's tmp_path as the system temproot (/tmp).
     monkeypatch.setenv("PYTEST_DEBUG_TEMPROOT", str(tmp_path))
-    tmp_factory = TempPathFactory(None, 3, "fail", lambda *args: None, _ispytest=True)
+    tmp_factory = TempPathFactory(None, 3, "failed", lambda *args: None, _ispytest=True)
     basetemp = tmp_factory.getbasetemp()
 
     # Before - simulate bad perms.
     os.chmod(basetemp.parent, 0o777)
     assert (basetemp.parent.stat().st_mode & 0o077) != 0
 
-    tmp_factory = TempPathFactory(None, 3, "fail", lambda *args: None, _ispytest=True)
+    tmp_factory = TempPathFactory(None, 3, "failed", lambda *args: None, _ispytest=True)
     basetemp = tmp_factory.getbasetemp()
 
     # After - fixed.

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -34,6 +34,8 @@ def test_tmp_path_fixture(pytester: Pytester) -> None:
 @attr.s
 class FakeConfig:
     basetemp = attr.ib()
+    tmp_path_retention_count = attr.ib(default=3)
+    tmp_path_retention_policy = attr.ib(default="failed")
 
     @property
     def trace(self):
@@ -446,7 +448,7 @@ def test_tmp_path_factory_create_directory_with_safe_permissions(
     """Verify that pytest creates directories under /tmp with private permissions."""
     # Use the test's tmp_path as the system temproot (/tmp).
     monkeypatch.setenv("PYTEST_DEBUG_TEMPROOT", str(tmp_path))
-    tmp_factory = TempPathFactory(None, lambda *args: None, _ispytest=True)
+    tmp_factory = TempPathFactory(None, 3, "fail", lambda *args: None, _ispytest=True)
     basetemp = tmp_factory.getbasetemp()
 
     # No world-readable permissions.
@@ -466,14 +468,14 @@ def test_tmp_path_factory_fixes_up_world_readable_permissions(
     """
     # Use the test's tmp_path as the system temproot (/tmp).
     monkeypatch.setenv("PYTEST_DEBUG_TEMPROOT", str(tmp_path))
-    tmp_factory = TempPathFactory(None, lambda *args: None, _ispytest=True)
+    tmp_factory = TempPathFactory(None, 3, "fail", lambda *args: None, _ispytest=True)
     basetemp = tmp_factory.getbasetemp()
 
     # Before - simulate bad perms.
     os.chmod(basetemp.parent, 0o777)
     assert (basetemp.parent.stat().st_mode & 0o077) != 0
 
-    tmp_factory = TempPathFactory(None, lambda *args: None, _ispytest=True)
+    tmp_factory = TempPathFactory(None, 3, "fail", lambda *args: None, _ispytest=True)
     basetemp = tmp_factory.getbasetemp()
 
     # After - fixed.

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -277,12 +277,12 @@ class TestNumberedDir:
 
         assert not lock.exists()
 
-    def _do_cleanup(self, tmp_path: Path) -> None:
+    def _do_cleanup(self, tmp_path: Path, keep: int = 2) -> None:
         self.test_make(tmp_path)
         cleanup_numbered_dir(
             root=tmp_path,
             prefix=self.PREFIX,
-            keep=2,
+            keep=keep,
             consider_lock_dead_if_created_before=0,
         )
 
@@ -290,6 +290,11 @@ class TestNumberedDir:
         self._do_cleanup(tmp_path)
         a, b = (x for x in tmp_path.iterdir() if not x.is_symlink())
         print(a, b)
+
+    def test_cleanup_keep_0(self, tmp_path: Path):
+        self._do_cleanup(tmp_path, 0)
+        dir_num = len(list(tmp_path.iterdir()))
+        assert dir_num == 0
 
     def test_cleanup_locked(self, tmp_path):
         p = make_numbered_dir(root=tmp_path, prefix=self.PREFIX)

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -132,6 +132,9 @@ class TestConfigTmpPath:
         pytester.inline_run(p)
         root = pytester._test_tmproot
         for child in root.iterdir():
+            # This symlink will be deleted by cleanup_numbered_dir **after**
+            # the test finishes because it's triggered by atexit.
+            # So it has to be ignored here.
             base_dir = filter(lambda x: not x.is_symlink(), child.iterdir())
             # Check the base dir itself is gone
             assert len(list(base_dir)) == 0


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X ] Include documentation when adding new features.
- [X ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
-->

closes #8141

I recognize that the tests are insufficient but I couldn't find a good reference. Is there any integration tests that actually make sure only 3 directories remain after executing a test that uses `tmp_dir` fixture for multiple times? I assume no and it's probably because it's difficult to deal with `atexit.register`?
