### PR TITLE
Avoid truncation when truncating means longer output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -280,6 +280,7 @@ Paweł Adamczak
 Pedro Algarvio
 Petter Strandmark
 Philipp Loose
+Pierre Sassoulas
 Pieter Mulder
 Piotr Banaszkiewicz
 Piotr Helm

--- a/changelog/6267.improvement.rst
+++ b/changelog/6267.improvement.rst
@@ -1,0 +1,2 @@
+The full output of a test is no longer truncated if the truncation message would be longer than
+the hidden text. The line number shown has also been fixed.

--- a/src/_pytest/assertion/truncate.py
+++ b/src/_pytest/assertion/truncate.py
@@ -62,13 +62,13 @@ def _truncate_explanation(
     # Append useful message to explanation
     truncated_line_count = len(input_lines) - len(truncated_explanation)
     truncated_line_count += 1  # Account for the part-truncated final line
-    msg = "...Full output truncated"
-    if truncated_line_count == 1:
-        msg += f" ({truncated_line_count} line hidden)"
-    else:
-        msg += f" ({truncated_line_count} lines hidden)"
-    msg += f", {USAGE_MSG}"
-    truncated_explanation.extend(["", str(msg)])
+    truncated_explanation.extend(
+        [
+            "",  # Line break
+            f"...Full output truncated ({truncated_line_count} line"
+            f"{'' if truncated_line_count == 1 else 's'} hidden), {USAGE_MSG}",
+        ]
+    )
     return truncated_explanation
 
 

--- a/src/_pytest/assertion/truncate.py
+++ b/src/_pytest/assertion/truncate.py
@@ -38,9 +38,9 @@ def _truncate_explanation(
     """Truncate given list of strings that makes up the assertion explanation.
 
     Truncates to either 8 lines, or 640 characters - whichever the input reaches
-    first. The remaining lines will be replaced by a usage message.
+    first, taking the truncation explanation into account. The remaining lines
+    will be replaced by a usage message.
     """
-
     if max_lines is None:
         max_lines = DEFAULT_MAX_LINES
     if max_chars is None:
@@ -48,35 +48,56 @@ def _truncate_explanation(
 
     # Check if truncation required
     input_char_count = len("".join(input_lines))
-    if len(input_lines) <= max_lines and input_char_count <= max_chars:
-        return input_lines
-
-    # Truncate first to max_lines, and then truncate to max_chars if max_chars
-    # is exceeded.
-    truncated_explanation = input_lines[:max_lines]
-    truncated_explanation = _truncate_by_char_count(truncated_explanation, max_chars)
-
-    # Add ellipsis to final line
-    truncated_explanation[-1] = truncated_explanation[-1] + "..."
-
-    # Append useful message to explanation
-    truncated_line_count = len(input_lines) - len(truncated_explanation)
-    truncated_line_count += 1  # Account for the part-truncated final line
-    truncated_explanation.extend(
-        [
-            "",  # Line break
-            f"...Full output truncated ({truncated_line_count} line"
-            f"{'' if truncated_line_count == 1 else 's'} hidden), {USAGE_MSG}",
-        ]
+    # The length of the truncation explanation depends on the number of lines
+    # removed but is at least 68 characters:
+    # The real value is
+    # 64 (for the base message:
+    # '...\n...Full output truncated (1 line hidden), use '-vv' to show")'
+    # )
+    # + 1 (for plural)
+    # + int(math.log10(len(input_lines) - max_lines)) (number of hidden line, at least 1)
+    # + 3 for the '...' added to the truncated line
+    # But if there's more than 100 lines it's very likely that we're going to
+    # truncate, so we don't need the exact value using log10.
+    tolerable_max_chars = (
+        max_chars + 70  # 64 + 1 (for plural) + 2 (for '99') + 3 for '...'
     )
-    return truncated_explanation
+    # The truncation explanation add two lines to the output
+    tolerable_max_lines = max_lines + 2
+    if (
+        len(input_lines) <= tolerable_max_lines
+        and input_char_count <= tolerable_max_chars
+    ):
+        return input_lines
+    # Truncate first to max_lines, and then truncate to max_chars if necessary
+    truncated_explanation = input_lines[:max_lines]
+    truncated_char = True
+    # We reevaluate the need to truncate chars following removal of some lines
+    if len("".join(truncated_explanation)) > tolerable_max_chars:
+        truncated_explanation = _truncate_by_char_count(
+            truncated_explanation, max_chars
+        )
+    else:
+        truncated_char = False
+
+    truncated_line_count = len(input_lines) - len(truncated_explanation)
+    if truncated_explanation[-1]:
+        # Add ellipsis and take into account part-truncated final line
+        truncated_explanation[-1] = truncated_explanation[-1] + "..."
+        if truncated_char:
+            # It's possible that we did not remove any char from this line
+            truncated_line_count += 1
+    else:
+        # Add proper ellipsis when we were able to fit a full line exactly
+        truncated_explanation[-1] = "..."
+    return truncated_explanation + [
+        "",
+        f"...Full output truncated ({truncated_line_count} line"
+        f"{'' if truncated_line_count == 1 else 's'} hidden), {USAGE_MSG}",
+    ]
 
 
 def _truncate_by_char_count(input_lines: List[str], max_chars: int) -> List[str]:
-    # Check if truncation required
-    if len("".join(input_lines)) <= max_chars:
-        return input_lines
-
     # Find point at which input length exceeds total allowed length
     iterated_char_count = 0
     for iterated_index, input_line in enumerate(input_lines):


### PR DESCRIPTION
The full output of a test is no longer truncated if the truncation message would be longer than
the hidden text. The line number shown has also been fixed.

I also used f-string for faster string formatting in a previous commit, I don't think this warrant another MR though.

Closes #6267

