### PR TITLE
fix type in python_api.py

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,6 +57,7 @@ Brian Maissy
 Brian Okken
 Brianna Laugher
 Bruno Oliveira
+Cal Jacobson
 Cal Leeming
 Carl Friedrich Bolz
 Carlos Jenkins
@@ -182,8 +183,8 @@ Joseph Hunkeler
 Josh Karpel
 Joshua Bronson
 Jurko Gospodnetić
-Justyna Janczyszyn
 Justice Ndou
+Justyna Janczyszyn
 Kale Kundert
 Kamran Ahmad
 Karl O. Pinc
@@ -235,7 +236,6 @@ Matthias Hafner
 Maxim Filipenko
 Maximilian Cosmo Sitter
 mbyt
-Mickey Pashov
 Michael Aquilina
 Michael Birtwell
 Michael Droettboom
@@ -244,6 +244,7 @@ Michael Krebs
 Michael Seifert
 Michal Wajszczuk
 Michał Zięba
+Mickey Pashov
 Mihai Capotă
 Mike Hoyle (hoylemd)
 Mike Lundy
@@ -258,9 +259,9 @@ Niclas Olofsson
 Nicolas Delaby
 Nikolay Kondratyev
 Nipunn Koorapati
-Olga Matoula
 Oleg Pidsadnyi
 Oleg Sushchenko
+Olga Matoula
 Oliver Bestwalter
 Omar Kohl
 Omer Hadari
@@ -286,8 +287,8 @@ Pulkit Goyal
 Punyashloka Biswal
 Quentin Pradet
 Ralf Schmitt
-Ram Rachum
 Ralph Giles
+Ram Rachum
 Ran Benita
 Raphael Castaneda
 Raphael Pierzina

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -801,7 +801,7 @@ def raises(  # noqa: F811
     r"""Assert that a code block/function call raises an exception.
 
     :param typing.Type[E] | typing.Tuple[typing.Type[E], ...] expected_exception:
-        The excpected exception type, or a tuple if one of multiple possible
+        The expected exception type, or a tuple if one of multiple possible
         exception types are excepted.
     :kwparam str | typing.Pattern[str] | None match:
         If specified, a string containing a regular expression,


### PR DESCRIPTION
excpected -> expected

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
