### PR TITLE
Fix 'importlib.abc.TraversableResources' deprecation warning in Python 3.12

### DIFF
--- a/changelog/10452.bugfix.rst
+++ b/changelog/10452.bugfix.rst
@@ -1,0 +1,1 @@
+Fix 'importlib.abc.TraversableResources' deprecation warning in Python 3.12.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -275,7 +275,12 @@ class AssertionRewritingHook(importlib.abc.MetaPathFinder, importlib.abc.Loader)
 
     if sys.version_info >= (3, 10):
 
-        def get_resource_reader(self, name: str) -> importlib.abc.TraversableResources:  # type: ignore
+        if sys.version_info >= (3, 12):
+            from importlib.resources.abc import TraversableResources
+        else:
+            from importlib.abc import TraversableResources
+
+        def get_resource_reader(self, name: str) -> TraversableResources:  # type: ignore
             if sys.version_info < (3, 11):
                 from importlib.readers import FileReader
             else:

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     py39
     py310
     py311
+    py312
     pypy3
     py37-{pexpect,xdist,unittestextras,numpy,pluggymain,pylib}
     doctesting


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [n/a] Include documentation when adding new features.
- [n/a] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
-->


Python 3.12 alpha 1 is [now out](https://discuss.python.org/t/python-3-12-0-alpha-1-released/20298?u=hugovk) and `importlib.abc.TraversableResources` is deprecated in favour of `importlib.resources.abc.TraversableResources`, with the old one set to be removed in Python 3.14:

* https://docs.python.org/3.12/whatsnew/3.12.html#pending-removal-in-python-3-14
* https://github.com/python/cpython/issues/93963

Here's a fix to avoid deprecation warnings during early testing of 3.12 with pytest:

```
DeprecationWarning: 'importlib.abc.TraversableResources' is deprecated and slated for removal in Python 3.14
```



I added 3.12 to `tox.ini` but not to GitHub Actions because it's not there yet, but should be soon:

* https://github.com/actions/setup-python/issues/514

If you prefer, we could test 3.12 via deadsnakes, similar to `3.9-dev` was? (https://github.com/pytest-dev/pytest/pull/7249). In the meantime, local testing:

# Before

```console
$ tox -e py311,py312 -- testing/test_meta.py -x
/Users/hugo/github/pytest/.tox/.package/lib/python3.10/site-packages/setuptools/config/setupcfg.py:508: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
  warnings.warn(msg, warning_class)
/Users/hugo/github/pytest/.tox/.package/lib/python3.10/site-packages/setuptools/config/setupcfg.py:508: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
  warnings.warn(msg, warning_class)
py311 inst-nodeps: /Users/hugo/github/pytest/.tox/.tmp/package/1/pytest-7.2.0.dev400+g8e2de91bf.tar.gz
py311 installed: argcomplete==2.0.0,attrs==22.1.0,certifi==2022.9.24,charset-normalizer==2.1.1,elementpath==3.0.2,hypothesis==6.56.4,idna==3.4,iniconfig==1.1.1,mock==4.0.3,nose==1.3.7,packaging==21.3,pluggy==1.0.0,Pygments==2.13.0,pyparsing==3.0.9,pytest @ file:///Users/hugo/github/pytest/.tox/.tmp/package/1/pytest-7.2.0.dev400%2Bg8e2de91bf.tar.gz,requests==2.28.1,sortedcontainers==2.4.0,urllib3==1.26.12,xmlschema==2.1.1
py311 run-test-pre: PYTHONHASHSEED='4034023584'
py311 run-test: commands[0] | pytest testing/test_meta.py -x
========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.11.0, pytest-7.2.0.dev400+g8e2de91bf, pluggy-1.0.0
cachedir: .tox/py311/.pytest_cache
rootdir: /Users/hugo/github/pytest, configfile: pyproject.toml
plugins: hypothesis-6.56.4
collected 67 items

testing/test_meta.py ...................................................................                                                                           [100%]

=========================================================================== 67 passed in 4.08s ===========================================================================
py312 inst-nodeps: /Users/hugo/github/pytest/.tox/.tmp/package/1/pytest-7.2.0.dev400+g8e2de91bf.tar.gz
py312 installed: argcomplete==2.0.0,attrs==22.1.0,certifi==2022.9.24,charset-normalizer==2.1.1,elementpath==3.0.2,hypothesis==6.56.4,idna==3.4,iniconfig==1.1.1,mock==4.0.3,nose==1.3.7,packaging==21.3,pluggy==1.0.0,Pygments==2.13.0,pyparsing==3.0.9,pytest @ file:///Users/hugo/github/pytest/.tox/.tmp/package/1/pytest-7.2.0.dev400%2Bg8e2de91bf.tar.gz,requests==2.28.1,sortedcontainers==2.4.0,urllib3==1.26.12,xmlschema==2.1.1
py312 run-test-pre: PYTHONHASHSEED='4034023584'
py312 run-test: commands[0] | pytest testing/test_meta.py -x
========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.12.0a1, pytest-7.2.0.dev400+g8e2de91bf, pluggy-1.0.0
cachedir: .tox/py312/.pytest_cache
rootdir: /Users/hugo/github/pytest, configfile: pyproject.toml
plugins: hypothesis-6.56.4
collected 67 items

testing/test_meta.py ............F

================================================================================ FAILURES ================================================================================
__________________________________________________________________ test_no_warnings[_pytest.assertion] ___________________________________________________________________

module = '_pytest.assertion'

    @pytest.mark.slow
    @pytest.mark.parametrize("module", _modules())
    def test_no_warnings(module: str) -> None:
        # fmt: off
>       subprocess.check_call((
            sys.executable,
            "-W", "error",
            "-c", f"__import__({module!r})",
        ))

testing/test_meta.py:27:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

popenargs = (('/Users/hugo/github/pytest/.tox/py312/bin/python', '-W', 'error', '-c', "__import__('_pytest.assertion')"),), kwargs = {}, retcode = 1
cmd = ('/Users/hugo/github/pytest/.tox/py312/bin/python', '-W', 'error', '-c', "__import__('_pytest.assertion')")

    def check_call(*popenargs, **kwargs):
        """Run command with arguments.  Wait for command to complete.  If
        the exit code was zero then return, otherwise raise
        CalledProcessError.  The CalledProcessError object will have the
        return code in the returncode attribute.

        The arguments are the same as for the call function.  Example:

        check_call(["ls", "-l"])
        """
        retcode = call(*popenargs, **kwargs)
        if retcode:
            cmd = kwargs.get("args")
            if cmd is None:
                cmd = popenargs[0]
>           raise CalledProcessError(retcode, cmd)
E           subprocess.CalledProcessError: Command '('/Users/hugo/github/pytest/.tox/py312/bin/python', '-W', 'error', '-c', "__import__('_pytest.assertion')")' returned non-zero exit status 1.

/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/subprocess.py:413: CalledProcessError
-------------------------------------------------------------------------- Captured stderr call --------------------------------------------------------------------------
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/hugo/github/pytest/.tox/py312/lib/python3.12/site-packages/_pytest/assertion/__init__.py", line 9, in <module>
    from _pytest.assertion import rewrite
  File "/Users/hugo/github/pytest/.tox/py312/lib/python3.12/site-packages/_pytest/assertion/rewrite.py", line 57, in <module>
    class AssertionRewritingHook(importlib.abc.MetaPathFinder, importlib.abc.Loader):
  File "/Users/hugo/github/pytest/.tox/py312/lib/python3.12/site-packages/_pytest/assertion/rewrite.py", line 278, in AssertionRewritingHook
    def get_resource_reader(self, name: str) -> importlib.abc.TraversableResources:  # type: ignore
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/abc.py", line 35, in __getattr__
    warnings._deprecated(f"{__name__}.{name}", remove=(3, 14))
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/warnings.py", line 514, in _deprecated
    warn(msg, DeprecationWarning, stacklevel=3)
DeprecationWarning: 'importlib.abc.TraversableResources' is deprecated and slated for removal in Python 3.14
======================================================================== short test summary info =========================================================================
FAILED testing/test_meta.py::test_no_warnings[_pytest.assertion] - subprocess.CalledProcessError: Command '('/Users/hugo/github/pytest/.tox/py312/bin/python', '-W', 'error', '-c', "__import__('_pytest.assertion')")' returned non-zer...
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
====================================================================== 1 failed, 12 passed in 0.62s ======================================================================
ERROR: InvocationError for command /Users/hugo/github/pytest/.tox/py312/bin/pytest testing/test_meta.py -x (exited with code 1)
________________________________________________________________________________ summary _________________________________________________________________________________
  py311: commands succeeded
ERROR:   py312: commands failed
```


# After

```console
$ tox -e py311,py312 -- testing/test_meta.py -x
/Users/hugo/github/pytest/.tox/.package/lib/python3.10/site-packages/setuptools/config/setupcfg.py:508: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
  warnings.warn(msg, warning_class)
/Users/hugo/github/pytest/.tox/.package/lib/python3.10/site-packages/setuptools/config/setupcfg.py:508: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
  warnings.warn(msg, warning_class)
py311 inst-nodeps: /Users/hugo/github/pytest/.tox/.tmp/package/1/pytest-7.2.0.dev402+gc58dc6de0.tar.gz
py311 installed: argcomplete==2.0.0,attrs==22.1.0,certifi==2022.9.24,charset-normalizer==2.1.1,elementpath==3.0.2,hypothesis==6.56.4,idna==3.4,iniconfig==1.1.1,mock==4.0.3,nose==1.3.7,packaging==21.3,pluggy==1.0.0,Pygments==2.13.0,pyparsing==3.0.9,pytest @ file:///Users/hugo/github/pytest/.tox/.tmp/package/1/pytest-7.2.0.dev402%2Bgc58dc6de0.tar.gz,requests==2.28.1,sortedcontainers==2.4.0,urllib3==1.26.12,xmlschema==2.1.1
py311 run-test-pre: PYTHONHASHSEED='2441326816'
py311 run-test: commands[0] | pytest testing/test_meta.py -x
========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.11.0, pytest-7.2.0.dev402+gc58dc6de0, pluggy-1.0.0
cachedir: .tox/py311/.pytest_cache
rootdir: /Users/hugo/github/pytest, configfile: pyproject.toml
plugins: hypothesis-6.56.4
collected 67 items

testing/test_meta.py ...................................................................                                                                           [100%]

=========================================================================== 67 passed in 4.14s ===========================================================================
py312 inst-nodeps: /Users/hugo/github/pytest/.tox/.tmp/package/1/pytest-7.2.0.dev402+gc58dc6de0.tar.gz
py312 installed: argcomplete==2.0.0,attrs==22.1.0,certifi==2022.9.24,charset-normalizer==2.1.1,elementpath==3.0.2,hypothesis==6.56.4,idna==3.4,iniconfig==1.1.1,mock==4.0.3,nose==1.3.7,packaging==21.3,pluggy==1.0.0,Pygments==2.13.0,pyparsing==3.0.9,pytest @ file:///Users/hugo/github/pytest/.tox/.tmp/package/1/pytest-7.2.0.dev402%2Bgc58dc6de0.tar.gz,requests==2.28.1,sortedcontainers==2.4.0,urllib3==1.26.12,xmlschema==2.1.1
py312 run-test-pre: PYTHONHASHSEED='2441326816'
py312 run-test: commands[0] | pytest testing/test_meta.py -x
========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.12.0a1, pytest-7.2.0.dev402+gc58dc6de0, pluggy-1.0.0
cachedir: .tox/py312/.pytest_cache
rootdir: /Users/hugo/github/pytest, configfile: pyproject.toml
plugins: hypothesis-6.56.4
collected 67 items

testing/test_meta.py ...................................................................                                                                           [100%]

=========================================================================== 67 passed in 4.35s ===========================================================================
________________________________________________________________________________ summary _________________________________________________________________________________
  py311: commands succeeded
  py312: commands succeeded
  congratulations :)
```
