### PR TITLE
scripts/update-plugin-list: Be liberal in accepted summaries

### DIFF
--- a/scripts/update-plugin-list.py
+++ b/scripts/update-plugin-list.py
@@ -90,7 +90,9 @@ def iter_plugins():
                 last_release = release_date.strftime("%b %d, %Y")
                 break
         name = f':pypi:`{info["name"]}`'
-        summary = escape_rst(info["summary"].replace("\n", ""))
+        summary = ""
+        if info["summary"]:
+            summary = escape_rst(info["summary"].replace("\n", ""))
         yield {
             "name": name,
             "summary": summary.strip(),


### PR DESCRIPTION
The update of the plugin list has been [failing for two months now](https://github.com/pytest-dev/pytest/actions/workflows/update-plugin-list.yml) due to a plugin that managed to put `null` in its summary (instead of the empty string). I have proposed [a fix to that package](https://github.com/thewtex/pytest-web3-data/pull/6), but we might as well make the update script a bit more robust.

I don't know how it is possible that a null summary was produced, potentially this is a bug in hatchling.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
