### PR TITLE
scripts/update-plugin-list: Improve requirement detection

### DIFF
--- a/scripts/update-plugin-list.py
+++ b/scripts/update-plugin-list.py
@@ -78,7 +78,7 @@ def iter_plugins():
         requires = "N/A"
         if info["requires_dist"]:
             for requirement in info["requires_dist"]:
-                if requirement == "pytest" or "pytest " in requirement:
+                if re.match(r"pytest(?![-.\w])", requirement):
                     requires = requirement
                     break
         releases = response.json()["releases"]


### PR DESCRIPTION
PEP 566 does not require a space after the dependency name.

I tested this change and found that it detected all dependencies previously detected, plus some more. There were no unwanted detections. Note that the old test was technically wrong: `"pytest " in requirement` may trigger on a `pytest` suffix. The new test may be slower, but this was not noticeable (the script is not fast anyway).

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
