### PR TITLE
Fix test_raising_repr test

### DIFF
--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1664,15 +1664,7 @@ def test_raise_assertion_error_raising_repr(pytester: Pytester) -> None:
     """
     )
     result = pytester.runpytest()
-    if sys.version_info >= (3, 11):
-        # python 3.11 has native support for un-str-able exceptions
-        result.stdout.fnmatch_lines(
-            ["E       AssertionError: <exception str() failed>"]
-        )
-    else:
-        result.stdout.fnmatch_lines(
-            ["E       AssertionError: <unprintable AssertionError object>"]
-        )
+    result.stdout.fnmatch_lines(["E       AssertionError: <exception str() failed>"])
 
 
 def test_issue_1944(pytester: Pytester) -> None:


### PR DESCRIPTION
Closes #10473

Python <3.11 versions depend on `exceptiongroup>=1.0.0rc8`, and they released version `1.0.1` 6 days ago (2022/11/03) that as a side-effect changed the output of exceptions.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
