### PR TITLE
fix logreport

### DIFF
--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -137,6 +137,8 @@ Bug Fixes
 - `#9877 <https://github.com/pytest-dev/pytest/issues/9877>`_: Ensure ``caplog.get_records(when)`` returns current/correct data after invoking ``caplog.clear()``.
 
 
+- `#10491 <https://github.com/pytest-dev/pytest/issues/10491>`_: Method ``pytest_runtest_logreport`` generated report in case test passed or test failed and ``when=='call'``.
+
 
 Improved Documentation
 ----------------------

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -561,32 +561,6 @@ class LogXML:
                 reporter = self._opentestcase(report)
                 reporter.append_pass(report)
                 reporter.write_captured_output(report)
-
-            if report.when == "teardown":
-                reporter = self._opentestcase(report)
-                reporter.write_captured_output(report)
-
-                for propname, propvalue in report.user_properties:
-                    reporter.add_property(propname, str(propvalue))
-
-                self.finalize(report)
-                report_wid = getattr(report, "worker_id", None)
-                report_ii = getattr(report, "item_index", None)
-                close_report = next(
-                    (
-                        rep
-                        for rep in self.open_reports
-                        if (
-                            rep.nodeid == report.nodeid
-                            and getattr(rep, "item_index", None) == report_ii
-                            and getattr(rep, "worker_id", None) == report_wid
-                        )
-                    ),
-                    None,
-                )
-                if close_report:
-                    self.open_reports.remove(close_report)
-
         elif report.failed:
             if report.when == "teardown":
                 # The following vars are needed when xdist plugin is used.
@@ -621,6 +595,30 @@ class LogXML:
             reporter = self._opentestcase(report)
             reporter.append_skipped(report)
         self.update_testcase_duration(report)
+        if report.when == "teardown":
+            reporter = self._opentestcase(report)
+            reporter.write_captured_output(report)
+
+            for propname, propvalue in report.user_properties:
+                reporter.add_property(propname, str(propvalue))
+
+            self.finalize(report)
+            report_wid = getattr(report, "worker_id", None)
+            report_ii = getattr(report, "item_index", None)
+            close_report = next(
+                (
+                    rep
+                    for rep in self.open_reports
+                    if (
+                        rep.nodeid == report.nodeid
+                        and getattr(rep, "item_index", None) == report_ii
+                        and getattr(rep, "worker_id", None) == report_wid
+                    )
+                ),
+                None,
+            )
+            if close_report:
+                self.open_reports.remove(close_report)
 
     def update_testcase_duration(self, report: TestReport) -> None:
         """Accumulate total duration for nodeid from given report and update

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -561,6 +561,32 @@ class LogXML:
                 reporter = self._opentestcase(report)
                 reporter.append_pass(report)
                 reporter.write_captured_output(report)
+
+            if report.when == "teardown":
+                reporter = self._opentestcase(report)
+                reporter.write_captured_output(report)
+
+                for propname, propvalue in report.user_properties:
+                    reporter.add_property(propname, str(propvalue))
+
+                self.finalize(report)
+                report_wid = getattr(report, "worker_id", None)
+                report_ii = getattr(report, "item_index", None)
+                close_report = next(
+                    (
+                        rep
+                        for rep in self.open_reports
+                        if (
+                            rep.nodeid == report.nodeid
+                            and getattr(rep, "item_index", None) == report_ii
+                            and getattr(rep, "worker_id", None) == report_wid
+                        )
+                    ),
+                    None,
+                )
+                if close_report:
+                    self.open_reports.remove(close_report)
+
         elif report.failed:
             if report.when == "teardown":
                 # The following vars are needed when xdist plugin is used.
@@ -595,30 +621,6 @@ class LogXML:
             reporter = self._opentestcase(report)
             reporter.append_skipped(report)
         self.update_testcase_duration(report)
-        if report.when == "teardown":
-            reporter = self._opentestcase(report)
-            reporter.write_captured_output(report)
-
-            for propname, propvalue in report.user_properties:
-                reporter.add_property(propname, str(propvalue))
-
-            self.finalize(report)
-            report_wid = getattr(report, "worker_id", None)
-            report_ii = getattr(report, "item_index", None)
-            close_report = next(
-                (
-                    rep
-                    for rep in self.open_reports
-                    if (
-                        rep.nodeid == report.nodeid
-                        and getattr(rep, "item_index", None) == report_ii
-                        and getattr(rep, "worker_id", None) == report_wid
-                    )
-                ),
-                None,
-            )
-            if close_report:
-                self.open_reports.remove(close_report)
 
     def update_testcase_duration(self, report: TestReport) -> None:
         """Accumulate total duration for nodeid from given report and update

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -560,8 +560,6 @@ class LogXML:
             if report.when == "call":  # ignore setup/teardown
                 reporter = self._opentestcase(report)
                 reporter.append_pass(report)
-                if not self.log_passing_tests:
-                    reporter.write_captured_output(report)
         elif report.failed:
             if report.when == "teardown":
                 # The following vars are needed when xdist plugin is used.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -560,7 +560,8 @@ class LogXML:
             if report.when == "call":  # ignore setup/teardown
                 reporter = self._opentestcase(report)
                 reporter.append_pass(report)
-                reporter.write_captured_output(report)
+                if not self.log_passing_tests:
+                    reporter.write_captured_output(report)
         elif report.failed:
             if report.when == "teardown":
                 # The following vars are needed when xdist plugin is used.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -560,6 +560,7 @@ class LogXML:
             if report.when == "call":  # ignore setup/teardown
                 reporter = self._opentestcase(report)
                 reporter.append_pass(report)
+                reporter.write_captured_output(report)
         elif report.failed:
             if report.when == "teardown":
                 # The following vars are needed when xdist plugin is used.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -587,8 +587,7 @@ class LogXML:
             if report.when == "call":
                 reporter.append_failure(report)
                 self.open_reports.append(report)
-                if not self.log_passing_tests:
-                    reporter.write_captured_output(report)
+                reporter.write_captured_output(report)
             else:
                 reporter.append_error(report)
         elif report.skipped:


### PR DESCRIPTION
Hello!  I use the `pytest_runtest_logreport` method to get subtest reports.  A report is generated for `when='call'`, but if the test failed, the `report` is not generated. I think this is because the `log_passing_tests=True` attribute is used in the `elif report.failed:` block. If the test failed, then if `when == 'call'` we don't step into the code block:
```python
if not self.log_passing_tests:        
    reporter.write_captured_output(report)
```
and the report is not generated. I don't understand why  `self.log_passing_test using` in `report.failed`.  Maybe this is a mistake.  If you remove the '```if not self.log_passing_tests: ```', then the report for the failed tests for `when='call'` is generated without problems.

I suggest making `reporter.write_captured_output(report)` unconditional

#https://github.com/pytest-dev/pytest/issues/10491

OS: win10
pytest_ver:  #7.2.0
![log_passing_tests](https://user-images.githubusercontent.com/65860480/201186826-45eaba3a-2d7c-4363-bfad-a894d72b47b8.jpg)


