### PR TITLE
Issue #10506

### DIFF
--- a/changelog/10506.bugfix.rst
+++ b/changelog/10506.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where sometimes pytest would use the file system root directory as :ref:`rootdir <rootdir>` on Windows.

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -203,8 +203,7 @@ def determine_setup(
                     else:
                         cwd = Path.cwd()
                     rootdir = get_common_ancestor([cwd, ancestor])
-                    is_fs_root = os.path.splitdrive(str(rootdir))[1] == os.sep
-                    if is_fs_root:
+                    if is_fs_root(rootdir):
                         rootdir = ancestor
     if rootdir_cmd_arg:
         rootdir = absolutepath(os.path.expandvars(rootdir_cmd_arg))
@@ -216,3 +215,11 @@ def determine_setup(
             )
     assert rootdir is not None
     return rootdir, inipath, inicfg or {}
+
+
+def is_fs_root(p: Path) -> bool:
+    r"""
+    Return True if the given path is pointing to the root of the
+    file system ("/" on Unix and "C:\\" on Windows for example).
+    """
+    return os.path.splitdrive(str(p))[1] == os.sep

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -203,7 +203,7 @@ def determine_setup(
                     else:
                         cwd = Path.cwd()
                     rootdir = get_common_ancestor([cwd, ancestor])
-                    is_fs_root = os.path.splitdrive(str(rootdir))[1] == "/"
+                    is_fs_root = os.path.splitdrive(str(rootdir))[1] == os.sep
                     if is_fs_root:
                         rootdir = ancestor
     if rootdir_cmd_arg:

--- a/testing/test_findpaths.py
+++ b/testing/test_findpaths.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from textwrap import dedent
 
@@ -5,6 +6,7 @@ import pytest
 from _pytest.config import UsageError
 from _pytest.config.findpaths import get_common_ancestor
 from _pytest.config.findpaths import get_dirs_from_args
+from _pytest.config.findpaths import is_fs_root
 from _pytest.config.findpaths import load_config_dict_from_file
 
 
@@ -133,3 +135,16 @@ def test_get_dirs_from_args(tmp_path):
     assert get_dirs_from_args(
         [str(fn), str(tmp_path / "does_not_exist"), str(d), option, xdist_rsync_option]
     ) == [fn.parent, d]
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        (Path(f"e:{os.sep}"), True),
+        (Path(f"{os.sep}"), True),
+        (Path(f"e:{os.sep}projects"), False),
+        (Path(f"{os.sep}projects"), False),
+    ],
+)
+def test_is_fs_root(path: Path, expected: bool) -> None:
+    assert is_fs_root(path) is expected

--- a/testing/test_findpaths.py
+++ b/testing/test_findpaths.py
@@ -140,11 +140,13 @@ def test_get_dirs_from_args(tmp_path):
 @pytest.mark.parametrize(
     "path, expected",
     [
-        (Path(f"e:{os.sep}"), True),
-        (Path(f"{os.sep}"), True),
-        (Path(f"e:{os.sep}projects"), False),
-        (Path(f"{os.sep}projects"), False),
+        pytest.param(
+            f"e:{os.sep}", True, marks=pytest.mark.skipif("sys.platform != 'win32'")
+        ),
+        (f"{os.sep}", True),
+        (f"e:{os.sep}projects", False),
+        (f"{os.sep}projects", False),
     ],
 )
 def test_is_fs_root(path: Path, expected: bool) -> None:
-    assert is_fs_root(path) is expected
+    assert is_fs_root(Path(path)) is expected


### PR DESCRIPTION
Closes #10506 
Helps run pytest on machines where the root directory being "C:\" 
is an issue some people have "C://" as their root directory so os.sep fixes this issue, os.path.sep can also work.
