### PR TITLE
Modify documentation to use `.stash` when storing test results.

### DIFF
--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -906,10 +906,7 @@ here is a little example implemented via a local plugin:
 
         # store test results for each phase of a call, which can
         # be "setup", "call", "teardown"
-        if your_unique_key not in item.stash:
-            item.stash[your_unique_key] = {rep.when: rep.passed}
-        else:
-            item.stash[your_unique_key][rep.when] = rep.passed
+        item.stash.setdefault(your_unique_key, {})[rep.when] = rep
 
 
     @pytest.fixture

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -915,12 +915,10 @@ here is a little example implemented via a local plugin:
         # request.node is an "item" because we use the default
         # "function" scope
         report = request.node.stash[phase_report_key]
-        if ("setup" not in report) or report["setup"].failed:
+        if report["setup"].failed:
             print("setting up a test failed or skipped", request.node.nodeid)
         elif ("call" not in report) or report["call"].failed:
             print("executing test failed or skipped", request.node.nodeid)
-        elif ("teardown" not in report) or report["teardown"].failed:
-            print("tear down test failed or skipped", request.node.nodeid)
 
 
 if you then have failing tests:

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -895,7 +895,7 @@ here is a little example implemented via a local plugin:
 
     import pytest
 
-    your_unique_key = StashKey[Dict[str, bool]]()
+    phase_report_key = StashKey[Dict[str, CollectReport]]()
 
 
     @pytest.hookimpl(tryfirst=True, hookwrapper=True)
@@ -906,7 +906,7 @@ here is a little example implemented via a local plugin:
 
         # store test results for each phase of a call, which can
         # be "setup", "call", "teardown"
-        item.stash.setdefault(your_unique_key, {})[rep.when] = rep
+        item.stash.setdefault(phase_report_key, {})[rep.when] = rep
 
 
     @pytest.fixture
@@ -914,13 +914,13 @@ here is a little example implemented via a local plugin:
         yield
         # request.node is an "item" because we use the default
         # "function" scope
-        result = request.node.stash[your_unique_key]
-        if not result.get("setup", False):
-            print("setting up a test failed!", request.node.nodeid)
-        elif not result.get("call", False):
-            print("executing test failed", request.node.nodeid)
-        elif not result("teardown", False):
-            print("tear down test failed", request.node.nodeid)
+        report = request.node.stash[phase_report_key]
+        if ("setup" not in report) or report["setup"].failed:
+            print("setting up a test failed or skipped", request.node.nodeid)
+        elif ("call" not in report) or report["call"].failed:
+            print("executing test failed or skipped", request.node.nodeid)
+        elif ("teardown" not in report) or report["teardown"].failed:
+            print("tear down test failed or skipped", request.node.nodeid)
 
 
 if you then have failing tests:

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -13,6 +13,7 @@ from typing import Union
 
 from _pytest.nodes import Item
 from _pytest.stash import StashKey
+from pytest import CollectReport
 
 if TYPE_CHECKING:
     from typing_extensions import Literal
@@ -318,9 +319,7 @@ def pytest_sessionfinish(session, exitstatus: Union[int, ExitCode]):
 @hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item: Item, call):
     outcome = yield
-    result = outcome.get_result()
+    result: CollectReport = outcome.get_result()
 
-    if tmppath_result_key not in item.stash:
-        item.stash[tmppath_result_key] = {result.when: result.passed}
-    else:
-        item.stash[tmppath_result_key][result.when] = result.passed
+    empty: Dict[str, bool] = {}
+    item.stash.setdefault(tmppath_result_key, empty)[result.when] = result.passed

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -12,8 +12,8 @@ from typing import TYPE_CHECKING
 from typing import Union
 
 from _pytest.nodes import Item
+from _pytest.reports import CollectReport
 from _pytest.stash import StashKey
-from pytest import CollectReport
 
 if TYPE_CHECKING:
     from typing_extensions import Literal


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

To store test results, it's better to use `.stash` instead of adding attributes on items. However, the documentation currently advises to add attributes. So it's probably better to update the documentation.

Some contexts: 
https://github.com/pytest-dev/pytest/pull/10442#discussion_r1023643840
https://github.com/pytest-dev/pytest/pull/10517