### PR TITLE
Add 'assert_truncate_level' to show the full diff without ``-vv``

### DIFF
--- a/changelog/3962.feature.rst
+++ b/changelog/3962.feature.rst
@@ -1,0 +1,1 @@
+``assert_truncate_level`` option added to be able to get the full diff without using ``-vv``.

--- a/doc/en/how-to/output.rst
+++ b/doc/en/how-to/output.rst
@@ -270,6 +270,10 @@ situations, for example you are shown even fixtures that start with ``_`` if you
 Using higher verbosity levels (``-vvv``, ``-vvvv``, ...) is supported, but has no effect in pytest itself at the moment,
 however some plugins might make use of higher verbosity.
 
+By default for verbosity inferior to ``-vv`` really long output are truncated. It's also possible to
+control the truncation directly using the ``assert_truncate_level`` option. You can use ``assert_truncate_level=0``
+to get the full diff regardless of the verbosity level.
+
 .. _`pytest.detailed_failed_tests_usage`:
 
 Producing a detailed summary report

--- a/src/_pytest/assertion/truncate.py
+++ b/src/_pytest/assertion/truncate.py
@@ -25,9 +25,12 @@ def truncate_if_required(
 
 
 def _should_truncate_item(item: Item) -> bool:
-    """Whether or not this test item is eligible for truncation."""
+    """Whether this test item is eligible for truncation."""
+    level = item.config.getini("assert_truncate_level")
     verbose = item.config.option.verbose
-    return verbose < 2 and not util.running_on_ci()
+    if level == "auto":
+        return verbose < 2 and not util.running_on_ci()
+    return bool(int(level) > verbose)
 
 
 def _truncate_explanation(

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -256,6 +256,17 @@ def pytest_addoption(parser: Parser) -> None:
         default="progress",
     )
 
+    # Experimental.
+    parser.addini(
+        "assert_truncate_level",
+        help=(
+            "Truncate explanations of assertion failures?  "
+            '("auto" (when verbosity < 2, and not running on CI), '
+            "or minimum verbosity level to trigger it (i.e. 0 for no truncation)."
+        ),
+        default="auto",
+    )
+
 
 def pytest_configure(config: Config) -> None:
     reporter = TerminalReporter(config, sys.stdout)

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1290,6 +1290,16 @@ class TestTruncateExplanation:
             ]
         )
 
+        # test assert_truncate_level ini option.
+        result = pytester.runpytest("-o", "assert_truncate_level=1")
+        result.stdout.fnmatch_lines(
+            ["E         ...Full output truncated (2 lines hidden), use '-vv' to show"]
+        )
+        result = pytester.runpytest("-o", "assert_truncate_level=0")
+        result.stdout.fnmatch_lines(["* 6*"])
+        result = pytester.runpytest("-v", "-o", "assert_truncate_level=0")
+        result.stdout.fnmatch_lines(["* 6*"])
+
         result = pytester.runpytest("-vv")
         result.stdout.fnmatch_lines(["* 6*"])
 
@@ -1689,7 +1699,9 @@ def test_raise_assertion_error_raising_repr(pytester: Pytester) -> None:
     """
     )
     result = pytester.runpytest()
-    result.stdout.fnmatch_lines(["E       AssertionError: <exception str() failed>"])
+    result.stdout.fnmatch_lines(
+        ["E       AssertionError: <unprintable AssertionError object>"]
+    )
 
 
 def test_issue_1944(pytester: Pytester) -> None:


### PR DESCRIPTION
Add an option to get the full diff regardless of the verbosity. 

This would Closes #3962

Co-authored-by: Daniel Hahler <github@thequod.de> (expanded from it and adapted from the fork. I kept the option name but changing it wouldn't be that hard).