### PR TITLE
Mitigate directory creation race condition

### DIFF
--- a/changelog/10607.bugfix.rst
+++ b/changelog/10607.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a race condition when creating junitxml reports, which could occur when multiple instances of pytest execute in parallel.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -645,8 +645,8 @@ class LogXML:
 
     def pytest_sessionfinish(self) -> None:
         dirname = os.path.dirname(os.path.abspath(self.logfile))
-        if not os.path.isdir(dirname):
-            os.makedirs(dirname, exist_ok=True)
+        # exist_ok avoids filesystem race conditions between checking path existence and requesting creation
+        os.makedirs(dirname, exist_ok=True)
 
         with open(self.logfile, "w", encoding="utf-8") as logfile:
             suite_stop_time = timing.time()

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -646,7 +646,7 @@ class LogXML:
     def pytest_sessionfinish(self) -> None:
         dirname = os.path.dirname(os.path.abspath(self.logfile))
         if not os.path.isdir(dirname):
-            os.makedirs(dirname)
+            os.makedirs(dirname, exist_ok=True)
 
         with open(self.logfile, "w", encoding="utf-8") as logfile:
             suite_stop_time = timing.time()


### PR DESCRIPTION
Closes https://github.com/pytest-dev/pytest/issues/10604 which could intermittently display unexpected behavior between checking if the path exists and requesting creation. This was relatively common when pytest was being invoked in parallel by another test runner (CTest) and trying to create the same parent-folder for multiple XMLs. A modest amount of testing did not reproduce additional filesystem race conditions.

This notably does not work around another edge case where the parent path of the XML could be created as a file instead of a folder or link. That vanishingly rare case should cause file creation to fail on the next line, with a fairly obvious exception message.