### PR TITLE
Fix option error

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -377,6 +377,7 @@ Xixi Zhao
 Xuan Luong
 Xuecong Liao
 Yoav Caspi
+Yuliang Shao
 Yusuke Kadowaki
 Yuval Shimon
 Zac Hatfield-Dodds

--- a/changelog/10592.bugfix.rst
+++ b/changelog/10592.bugfix.rst
@@ -1,1 +1,1 @@
-Fix the bug "--cache-show --help" triggers an internal error
+Fixed crash if `--cache-show` and `--help` are passed at the same time.

--- a/changelog/10592.bugfix.rst
+++ b/changelog/10592.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the bug "--cache-show --help" triggers an internal error

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -32,7 +32,6 @@ from _pytest.python import Module
 from _pytest.python import Package
 from _pytest.reports import TestReport
 
-
 README_CONTENT = """\
 # pytest cache directory #
 
@@ -492,7 +491,7 @@ def pytest_addoption(parser: Parser) -> None:
 
 
 def pytest_cmdline_main(config: Config) -> Optional[Union[int, ExitCode]]:
-    if config.option.cacheshow:
+    if config.option.cacheshow and not config.option.help:
         from _pytest.main import wrap_session
 
         return wrap_session(config, cacheshow)

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1074,6 +1074,12 @@ class Config:
                 )
 
             raise
+        except PrintHelp:
+            self._parser._getparser().print_help()
+            sys.stdout.write(
+                "\nNOTE: displaying only minimal help due to UsageError.\n\n"
+            )
+            raise UsageError
 
         return self
 
@@ -1368,7 +1374,7 @@ class Config:
             self.args = args
             self.args_source = source
         except PrintHelp:
-            pass
+            raise
 
     def issue_config_time_warning(self, warning: Warning, stacklevel: int) -> None:
         """Issue and handle a warning during the "configure" stage.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1074,12 +1074,6 @@ class Config:
                 )
 
             raise
-        except PrintHelp:
-            self._parser._getparser().print_help()
-            sys.stdout.write(
-                "\nNOTE: displaying only minimal help due to UsageError.\n\n"
-            )
-            raise UsageError
 
         return self
 
@@ -1374,7 +1368,7 @@ class Config:
             self.args = args
             self.args_source = source
         except PrintHelp:
-            raise
+            pass
 
     def issue_config_time_warning(self, warning: Warning, stacklevel: int) -> None:
         """Issue and handle a warning during the "configure" stage.

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -1249,3 +1249,8 @@ def test_cachedir_tag(pytester: Pytester) -> None:
     cache.set("foo", "bar")
     cachedir_tag_path = cache._cachedir.joinpath("CACHEDIR.TAG")
     assert cachedir_tag_path.read_bytes() == CACHEDIR_TAG_CONTENT
+
+
+def test_clioption_with_cacheshow_and_help(pytester: Pytester) -> None:
+    result = pytester.runpytest("--cache-show", "--help")
+    assert result.ret == 0


### PR DESCRIPTION
Close #10592

if the cmdline contains both the `--cache-show` and `--help` option will cause the internal error .  But if contains the `--collect-only` and `--help` will just output the help message.

the root cause is inside `pytest_cmdline_main` of `cacheprovider` , it will really execute the `wrap_session` , but it will raise   exception due to missing variable assignment .  so add the condition express to avoid the conflict .
