### PR TITLE
Change the default `tmp_path_retention_policy` to `all`

### DIFF
--- a/changelog/8141.feature.rst
+++ b/changelog/8141.feature.rst
@@ -1,2 +1,1 @@
 Added :confval:`tmp_path_retention_count` and :confval:`tmp_path_retention_policy` configuration options to control how directories created by the :fixture:`tmp_path` fixture are kept.
-The default behavior has changed to keep only directories for failed tests, equivalent to `tmp_path_retention_policy="failed"`.

--- a/doc/en/how-to/tmp_path.rst
+++ b/doc/en/how-to/tmp_path.rst
@@ -132,8 +132,7 @@ The default base temporary directory
 Temporary directories are by default created as sub-directories of
 the system temporary directory.  The base name will be ``pytest-NUM`` where
 ``NUM`` will be incremented with each test run.
-By default, only the directories of failed tests will be kept.
-Also only the last 3 directries will remain at most.
+By default, entries older than 3 temporary directories will be removed.
 This behavior can be configured with :confval:`tmp_path_retention_count` and
 :confval:`tmp_path_retention_policy`.
 

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1754,7 +1754,7 @@ passed multiple times. The expected format is ``name=value``. For example::
         [pytest]
         tmp_path_retention_policy = "all"
 
-    Default: failed
+    Default: all
 
 
 .. confval:: usefixtures

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -239,7 +239,7 @@ def pytest_addoption(parser: Parser) -> None:
         "tmp_path_retention_policy",
         help="Controls which directories created by the `tmp_path` fixture are kept around, based on test outcome. "
         "(all/failed/none)",
-        default="failed",
+        default="all",
     )
 
 
@@ -267,8 +267,8 @@ def tmp_path(
     directory.
 
     By default, a new base temporary directory is created each test session,
-    and only the base of failed session is kept. Also it only keeps the last 3 bases
-    at most. This can be configured with :confval:`tmp_path_retention_count` and
+    and old bases are removed after 3 sessions, to aid in debugging.
+    This behavior can be configured with :confval:`tmp_path_retention_count` and
     :confval:`tmp_path_retention_policy`.
     If ``--basetemp`` is used then it is cleared each session. See :ref:`base
     temporary directory`.

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -46,7 +46,7 @@ class FakeConfig:
         if name == "tmp_path_retention_count":
             return 3
         elif name == "tmp_path_retention_policy":
-            return "failed"
+            return "all"
         else:
             assert False
 
@@ -101,6 +101,12 @@ class TestConfigTmpPath:
                 assert 0 == 1
         """
         )
+        pytester.makepyprojecttoml(
+            """
+            [tool.pytest.ini_options]
+            tmp_path_retention_policy = "failed"
+        """
+        )
 
         pytester.inline_run(p)
         root = pytester._test_tmproot
@@ -126,6 +132,12 @@ class TestConfigTmpPath:
             """
             def test_1(tmp_path):
                 assert 0 == 0
+        """
+        )
+        pytester.makepyprojecttoml(
+            """
+            [tool.pytest.ini_options]
+            tmp_path_retention_policy = "failed"
         """
         )
 
@@ -155,6 +167,13 @@ class TestConfigTmpPath:
                 pass
         """
         )
+        pytester.makepyprojecttoml(
+            """
+            [tool.pytest.ini_options]
+            tmp_path_retention_policy = "failed"
+        """
+        )
+
         pytester.inline_run(p)
 
         # Check if the whole directory is removed
@@ -570,7 +589,7 @@ def test_tmp_path_factory_create_directory_with_safe_permissions(
     """Verify that pytest creates directories under /tmp with private permissions."""
     # Use the test's tmp_path as the system temproot (/tmp).
     monkeypatch.setenv("PYTEST_DEBUG_TEMPROOT", str(tmp_path))
-    tmp_factory = TempPathFactory(None, 3, "failed", lambda *args: None, _ispytest=True)
+    tmp_factory = TempPathFactory(None, 3, "all", lambda *args: None, _ispytest=True)
     basetemp = tmp_factory.getbasetemp()
 
     # No world-readable permissions.
@@ -590,14 +609,14 @@ def test_tmp_path_factory_fixes_up_world_readable_permissions(
     """
     # Use the test's tmp_path as the system temproot (/tmp).
     monkeypatch.setenv("PYTEST_DEBUG_TEMPROOT", str(tmp_path))
-    tmp_factory = TempPathFactory(None, 3, "failed", lambda *args: None, _ispytest=True)
+    tmp_factory = TempPathFactory(None, 3, "all", lambda *args: None, _ispytest=True)
     basetemp = tmp_factory.getbasetemp()
 
     # Before - simulate bad perms.
     os.chmod(basetemp.parent, 0o777)
     assert (basetemp.parent.stat().st_mode & 0o077) != 0
 
-    tmp_factory = TempPathFactory(None, 3, "failed", lambda *args: None, _ispytest=True)
+    tmp_factory = TempPathFactory(None, 3, "all", lambda *args: None, _ispytest=True)
     basetemp = tmp_factory.getbasetemp()
 
     # After - fixed.


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Partially addresses #10564.
In any case, we should set the default to `all`.