### PR TITLE
Fix regen tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -104,7 +104,7 @@ deps =
     PyYAML
     regendoc>=0.8.1
     sphinx
-whitelist_externals =
+allowlist_externals =
     make
 commands =
     make regen


### PR DESCRIPTION
Since tox 4.0, the `whitelist_external` option has been renamed to [allowlist_externals](https://tox.wiki/en/4.2.6/config.html#allowlist_externals).

Noticed while trying to kick-off `7.2.1`: https://github.com/pytest-dev/pytest/actions/runs/3862747243/jobs/6584505508