### PR TITLE
Fix `MonkeyPatch.setattr`/`delattr` binding descriptors when `raising=False`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -134,6 +134,7 @@ Florian Dahlitz
 Floris Bruynooghe
 Gabriel Landau
 Gabriel Reis
+Ganden Schaffner
 Garvit Shubham
 Gene Wood
 George Kussumoto

--- a/changelog/10644.bugfix.rst
+++ b/changelog/10644.bugfix.rst
@@ -1,0 +1,3 @@
+`monkeypatch.setattr` no longer leaves a leftover item in the target's dictionary after cleanup when patching an inherited attribute of a non-class object. This fixes a bug where a `__get__` descriptor's dynamic lookup was blocked and replaced by a cached static lookup after `monkeypatch` teardown.
+
+Previously `monkeypatch.setattr` avoided leaving leftover items in the target's dictionary when patching class objects but not when patching non-class objects.

--- a/changelog/10646.bugfix.rst
+++ b/changelog/10646.bugfix.rst
@@ -1,0 +1,3 @@
+Fix bug where `monkeypatch.setattr` and `monkeypatch.delattr` bind descriptors (possibly causing unwanted side-effects) to implement their `hasattr` checks even when their checks are disabled by `raising=False`.
+
+Note that they still must bind descriptors to implement their checks if `raising=True`.

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -281,7 +281,7 @@ class MonkeyPatch:
 
         if not hasattr(target, name):
             if raising:
-                raise AttributeError(name)
+                raise AttributeError(f"{target!r} has no attribute {name!r}")
         else:
             oldval = getattr(target, name, notset)
             # Avoid class descriptors like staticmethod/classmethod.

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -5,11 +5,29 @@ import textwrap
 from pathlib import Path
 from typing import Dict
 from typing import Generator
+from typing import Optional
+from typing import overload
 from typing import Type
+from typing import TypeVar
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pytester import Pytester
+
+T = TypeVar("T")
+
+
+class SomeDescriptor:
+    @overload
+    def __get__(self, instance: None, owner: type) -> int:
+        ...
+
+    @overload
+    def __get__(self, instance: T, owner: Optional[Type[T]] = ...) -> int:
+        ...
+
+    def __get__(self, instance: Optional[T], owner: Optional[Type[T]] = None) -> int:
+        return 1
 
 
 @pytest.fixture
@@ -22,15 +40,21 @@ def mp() -> Generator[MonkeyPatch, None, None]:
 
 
 def test_setattr() -> None:
+    import inspect
+
     class A:
         x = 1
+        y = SomeDescriptor()
 
     monkeypatch = MonkeyPatch()
     pytest.raises(AttributeError, monkeypatch.setattr, A, "notexists", 2)
-    monkeypatch.setattr(A, "y", 2, raising=False)
-    assert A.y == 2  # type: ignore
+    monkeypatch.setattr(A, "w", 2, raising=False)
+    assert A.w == 2  # type: ignore
     monkeypatch.undo()
-    assert not hasattr(A, "y")
+    assert not hasattr(A, "w")
+
+    with pytest.raises(TypeError):
+        monkeypatch.setattr(A, "w")  # type: ignore[call-overload]
 
     monkeypatch = MonkeyPatch()
     monkeypatch.setattr(A, "x", 2)
@@ -44,8 +68,23 @@ def test_setattr() -> None:
     monkeypatch.undo()  # double-undo makes no modification
     assert A.x == 5
 
-    with pytest.raises(TypeError):
-        monkeypatch.setattr(A, "y")  # type: ignore[call-overload]
+    # Test that inherited attributes don't get written into the target's instance
+    # dictionary.
+    a = A()
+    monkeypatch = MonkeyPatch()
+    assert "x" not in vars(a)
+    monkeypatch.setattr(a, "x", 2)
+    monkeypatch.undo()
+    assert "x" not in vars(a)
+
+    # Test that class/instance descriptors don't get bound and written into the target's
+    # dictionary.
+    for obj in (A, A()):
+        monkeypatch = MonkeyPatch()
+        assert isinstance(inspect.getattr_static(obj, "y"), SomeDescriptor)
+        monkeypatch.setattr(obj, "y", 2)
+        monkeypatch.undo()
+        assert isinstance(inspect.getattr_static(obj, "y"), SomeDescriptor)
 
 
 class TestSetattrWithImportPath:
@@ -96,8 +135,11 @@ class TestSetattrWithImportPath:
 
 
 def test_delattr() -> None:
+    import inspect
+
     class A:
         x = 1
+        y = SomeDescriptor()
 
     monkeypatch = MonkeyPatch()
     monkeypatch.delattr(A, "x")
@@ -106,13 +148,21 @@ def test_delattr() -> None:
     assert A.x == 1
 
     monkeypatch = MonkeyPatch()
+    pytest.raises(AttributeError, monkeypatch.delattr, A, "w")
+    monkeypatch.delattr(A, "w", raising=False)
     monkeypatch.delattr(A, "x")
-    pytest.raises(AttributeError, monkeypatch.delattr, A, "y")
-    monkeypatch.delattr(A, "y", raising=False)
     monkeypatch.setattr(A, "x", 5, raising=False)
     assert A.x == 5
     monkeypatch.undo()
     assert A.x == 1
+
+    # Test that (non-inherited) class descriptors don't get bound and written into the
+    # target's dictionary.
+    monkeypatch = MonkeyPatch()
+    assert isinstance(inspect.getattr_static(A, "y"), SomeDescriptor)
+    monkeypatch.delattr(A, "y")
+    monkeypatch.undo()
+    assert isinstance(inspect.getattr_static(A, "y"), SomeDescriptor)
 
 
 def test_setitem() -> None:


### PR DESCRIPTION
closes #10646.

this PR is marked as a draft because these changes are written atop #10645, and it would be silly to rebase this onto main now and resolve conflicts only to revert that conflict resolution after #10645 is merged (if #10645 gets merged, that is).