### PR TITLE
CLI: Allow spaces in -p arguments

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -376,6 +376,7 @@ Wouter van Ackooy
 Xixi Zhao
 Xuan Luong
 Xuecong Liao
+Yannick Péroux
 Yoav Caspi
 Yusuke Kadowaki
 Yuval Shimon

--- a/changelog/10658.improvement.rst
+++ b/changelog/10658.improvement.rst
@@ -1,0 +1,3 @@
+Allow ``-p`` arguments to include spaces (eg: ``-p no:logging`` instead of
+``-pno:logging``). Mostly useful in the ``addopts`` section of the configuration
+file.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -697,6 +697,7 @@ class PytestPluginManager(PluginManager):
                     parg = opt[2:]
                 else:
                     continue
+                parg = parg.strip()
                 if exclude_only and not parg.startswith("no:"):
                     continue
                 self.consider_pluginarg(parg)

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1809,6 +1809,10 @@ def test_config_does_not_load_blocked_plugin_from_args(pytester: Pytester) -> No
     result.stderr.fnmatch_lines(["*: error: unrecognized arguments: -s"])
     assert result.ret == ExitCode.USAGE_ERROR
 
+    result = pytester.runpytest(str(p), "-p no:capture", "-s")
+    result.stderr.fnmatch_lines(["*: error: unrecognized arguments: -s"])
+    assert result.ret == ExitCode.USAGE_ERROR
+
 
 def test_invocation_args(pytester: Pytester) -> None:
     """Ensure that Config.invocation_* arguments are correctly defined"""


### PR DESCRIPTION
Most pytest CLI arguments expecting a value accept the form `--arg=value`, which
makes it easy to have a single line per argument in the `addopts = [...]` section of
the configuration.

This is not the case for `-p` (to enable or disable pluggins), because it is
parsed in a different step. This argument must either consist of two strings
(`"-p", "<value>"`), or a single string without space (`"-p<value>"`). This is
perfectly fine for the CLI, but less intuitive for the config file. This PR
allows `"-p <value>"` to work as well.

Basically, this PR makes the following config work:
```toml
[tool.pytest.ini_options]
addopts = [
    # ...
    "-p no:logging",
    # ...
]
```

Note that this is mostly an esthetic change, the behavior remains the same.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
