### PR TITLE
[7.2.x] Fix crash if `--cache-show` and `--help` are passed at the same time

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -374,6 +374,8 @@ Xixi Zhao
 Xuan Luong
 Xuecong Liao
 Yoav Caspi
+Yuliang Shao
+Yusuke Kadowaki
 Yuval Shimon
 Zac Hatfield-Dodds
 Zachary Kneupper

--- a/changelog/10592.bugfix.rst
+++ b/changelog/10592.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed crash if `--cache-show` and `--help` are passed at the same time.

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -32,7 +32,6 @@ from _pytest.python import Module
 from _pytest.python import Package
 from _pytest.reports import TestReport
 
-
 README_CONTENT = """\
 # pytest cache directory #
 
@@ -492,7 +491,7 @@ def pytest_addoption(parser: Parser) -> None:
 
 
 def pytest_cmdline_main(config: Config) -> Optional[Union[int, ExitCode]]:
-    if config.option.cacheshow:
+    if config.option.cacheshow and not config.option.help:
         from _pytest.main import wrap_session
 
         return wrap_session(config, cacheshow)

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -1249,3 +1249,8 @@ def test_cachedir_tag(pytester: Pytester) -> None:
     cache.set("foo", "bar")
     cachedir_tag_path = cache._cachedir.joinpath("CACHEDIR.TAG")
     assert cachedir_tag_path.read_bytes() == CACHEDIR_TAG_CONTENT
+
+
+def test_clioption_with_cacheshow_and_help(pytester: Pytester) -> None:
+    result = pytester.runpytest("--cache-show", "--help")
+    assert result.ret == 0


### PR DESCRIPTION
Closes #10592

(cherry picked from commit 4d4ed42c34fbd6b30bff1bbdf664aeac3300a83a)
