### PR TITLE
capture: `CaptureResult` can be a namedtuple again

### DIFF
--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -509,6 +509,8 @@ else:
     ):
         """The result of :method:`CaptureFixture.readouterr`."""
 
+        __slots__ = ()
+
 
 class MultiCapture(Generic[AnyStr]):
     _state = None

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -503,8 +503,11 @@ if sys.version_info >= (3, 11) or TYPE_CHECKING:
         err: AnyStr
 
 else:
-    CaptureResult = collections.namedtuple("CaptureResult", ["out", "err"])
-    CaptureResult.__doc__ = """The result of :method:`CaptureFixture.readouterr`."""
+
+    class CaptureResult(
+        collections.namedtuple("CaptureResult", ["out", "err"]), Generic[AnyStr]
+    ):
+        __doc__ = """The result of :method:`CaptureFixture.readouterr`."""
 
 
 class MultiCapture(Generic[AnyStr]):

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -507,7 +507,7 @@ else:
     class CaptureResult(
         collections.namedtuple("CaptureResult", ["out", "err"]), Generic[AnyStr]
     ):
-        __doc__ = """The result of :method:`CaptureFixture.readouterr`."""
+        """The result of :method:`CaptureFixture.readouterr`."""
 
 
 class MultiCapture(Generic[AnyStr]):


### PR DESCRIPTION
mypy now supports generic NamedTuple.