### PR TITLE
capture: improve typing

### DIFF
--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -858,7 +858,9 @@ class CaptureFixture(Generic[AnyStr]):
     @contextlib.contextmanager
     def disabled(self) -> Generator[None, None, None]:
         """Temporarily disable capturing while inside the ``with`` block."""
-        capmanager = self.request.config.pluginmanager.getplugin("capturemanager")
+        capmanager: CaptureManager = self.request.config.pluginmanager.getplugin(
+            "capturemanager"
+        )
         with capmanager.global_and_fixture_disabled():
             yield
 
@@ -885,7 +887,7 @@ def capsys(request: SubRequest) -> Generator[CaptureFixture[str], None, None]:
             captured = capsys.readouterr()
             assert captured.out == "hello\n"
     """
-    capman = request.config.pluginmanager.getplugin("capturemanager")
+    capman: CaptureManager = request.config.pluginmanager.getplugin("capturemanager")
     capture_fixture = CaptureFixture[str](SysCapture, request, _ispytest=True)
     capman.set_fixture(capture_fixture)
     capture_fixture._start()
@@ -913,7 +915,7 @@ def capsysbinary(request: SubRequest) -> Generator[CaptureFixture[bytes], None, 
             captured = capsysbinary.readouterr()
             assert captured.out == b"hello\n"
     """
-    capman = request.config.pluginmanager.getplugin("capturemanager")
+    capman: CaptureManager = request.config.pluginmanager.getplugin("capturemanager")
     capture_fixture = CaptureFixture[bytes](SysCaptureBinary, request, _ispytest=True)
     capman.set_fixture(capture_fixture)
     capture_fixture._start()
@@ -941,7 +943,7 @@ def capfd(request: SubRequest) -> Generator[CaptureFixture[str], None, None]:
             captured = capfd.readouterr()
             assert captured.out == "hello\n"
     """
-    capman = request.config.pluginmanager.getplugin("capturemanager")
+    capman: CaptureManager = request.config.pluginmanager.getplugin("capturemanager")
     capture_fixture = CaptureFixture[str](FDCapture, request, _ispytest=True)
     capman.set_fixture(capture_fixture)
     capture_fixture._start()
@@ -970,7 +972,7 @@ def capfdbinary(request: SubRequest) -> Generator[CaptureFixture[bytes], None, N
             assert captured.out == b"hello\n"
 
     """
-    capman = request.config.pluginmanager.getplugin("capturemanager")
+    capman: CaptureManager = request.config.pluginmanager.getplugin("capturemanager")
     capture_fixture = CaptureFixture[bytes](FDCaptureBinary, request, _ispytest=True)
     capman.set_fixture(capture_fixture)
     capture_fixture._start()

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -306,9 +306,29 @@ class CaptureBase(abc.ABC, Generic[AnyStr]):
 patchsysdict = {0: "stdin", 1: "stdout", 2: "stderr"}
 
 
-class NoCapture:
-    EMPTY_BUFFER = None
-    __init__ = start = done = suspend = resume = lambda *args: None
+class NoCapture(CaptureBase[str]):
+    EMPTY_BUFFER = ""
+
+    def __init__(self, fd: int) -> None:
+        pass
+
+    def start(self) -> None:
+        pass
+
+    def done(self) -> None:
+        pass
+
+    def suspend(self) -> None:
+        pass
+
+    def resume(self) -> None:
+        pass
+
+    def snap(self) -> str:
+        return ""
+
+    def writeorg(self, data: str) -> None:
+        pass
 
 
 class SysCaptureBase(CaptureBase[AnyStr]):
@@ -439,7 +459,7 @@ class FDCaptureBase(CaptureBase[AnyStr]):
 
         if targetfd == 0:
             self.tmpfile = open(os.devnull, encoding="utf-8")
-            self.syscapture = SysCapture(targetfd)
+            self.syscapture: CaptureBase[str] = SysCapture(targetfd)
         else:
             self.tmpfile = EncodedFile(
                 TemporaryFile(buffering=0),
@@ -451,7 +471,7 @@ class FDCaptureBase(CaptureBase[AnyStr]):
             if targetfd in patchsysdict:
                 self.syscapture = SysCapture(targetfd, self.tmpfile)
             else:
-                self.syscapture = NoCapture()
+                self.syscapture = NoCapture(targetfd)
 
         self._state = "initialized"
 

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -36,6 +36,7 @@ from _pytest.nodes import File
 from _pytest.nodes import Item
 
 if TYPE_CHECKING:
+    from typing_extensions import Final
     from typing_extensions import Literal
 
     _CaptureMethod = Literal["fd", "sys", "no", "tee-sys"]
@@ -723,7 +724,7 @@ class CaptureManager:
     """
 
     def __init__(self, method: "_CaptureMethod") -> None:
-        self._method = method
+        self._method: Final = method
         self._global_capturing: Optional[MultiCapture[str]] = None
         self._capture_fixture: Optional[CaptureFixture[Any]] = None
 

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -890,7 +890,7 @@ def test_dontreadfrominput() -> None:
     from _pytest.capture import DontReadFromInput
 
     f = DontReadFromInput()
-    assert f.buffer is f
+    assert f.buffer is f  # type: ignore[comparison-overlap]
     assert not f.isatty()
     pytest.raises(OSError, f.read)
     pytest.raises(OSError, f.readlines)
@@ -906,7 +906,10 @@ def test_dontreadfrominput() -> None:
     pytest.raises(UnsupportedOperation, f.write, b"")
     pytest.raises(UnsupportedOperation, f.writelines, [])
     assert not f.writable()
+    assert isinstance(f.encoding, str)
     f.close()  # just for completeness
+    with f:
+        pass
 
 
 def test_captureresult() -> None:

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1352,6 +1352,7 @@ def test_capsys_results_accessible_by_attribute(capsys: CaptureFixture[str]) -> 
 
 def test_fdcapture_tmpfile_remains_the_same() -> None:
     cap = StdCaptureFD(out=False, err=True)
+    assert isinstance(cap.err, capture.FDCapture)
     try:
         cap.start_capturing()
         capfile = cap.err.tmpfile

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1052,6 +1052,7 @@ class TestFDCapture:
                 )
             )
             # Should not crash with missing "_old".
+            assert isinstance(cap.syscapture, capture.SysCapture)
             assert repr(cap.syscapture) == (
                 "<SysCapture stdout _old=<UNSET> _state='done' tmpfile={!r}>".format(
                     cap.syscapture.tmpfile


### PR DESCRIPTION
I'm looking at improving the capture plugin again, but first I thought I'd finish the typing. Adds some verbosity but needed to "capture" the current usage.

Might be easier to review commit by commit.