### PR TITLE
Clarify docs for `match` regarding escaping

### DIFF
--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -276,23 +276,27 @@ first be escaped with ``re.escape``.
 
 Some examples:
 
-.. code-block: python
+.. code-block:: pycon
 
 
-    >>> with warns(UserWarning, match='must be 0 or None'):
+    >>> with warns(UserWarning, match="must be 0 or None"):
     ...     warnings.warn("value must be 0 or None", UserWarning)
+    ...
 
-    >>> with warns(UserWarning, match=r'must be \d+$'):
+    >>> with warns(UserWarning, match=r"must be \d+$"):
     ...     warnings.warn("value must be 42", UserWarning)
+    ...
 
-    >>> with warns(UserWarning, match=r'must be \d+$'):
+    >>> with warns(UserWarning, match=r"must be \d+$"):
     ...     warnings.warn("this is not here", UserWarning)
+    ...
     Traceback (most recent call last):
       ...
     Failed: DID NOT WARN. No warnings of type ...UserWarning... were emitted...
 
-    >>> with warns(UserWarning, match=re.escape('issue with foo() func')):
+    >>> with warns(UserWarning, match=re.escape("issue with foo() func")):
     ...     warnings.warn("issue with foo() func")
+    ...
 
 You can also call :func:`pytest.warns` on a function or code string:
 

--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -270,7 +270,11 @@ which works in a similar manner to :ref:`raises <assertraises>` (except that
             warnings.warn("my warning", UserWarning)
 
 The test will fail if the warning in question is not raised. Use the keyword
-argument ``match`` to assert that the warning matches a text or regex::
+argument ``match`` to assert that the warning matches a text or regex.
+To match a literal string that may contain regular expression metacharacters like ``(`` or ``.``, the pattern can
+first be escaped with ``re.escape``.
+
+Some examples:
 
     >>> with warns(UserWarning, match='must be 0 or None'):
     ...     warnings.warn("value must be 0 or None", UserWarning)
@@ -283,6 +287,9 @@ argument ``match`` to assert that the warning matches a text or regex::
     Traceback (most recent call last):
       ...
     Failed: DID NOT WARN. No warnings of type ...UserWarning... were emitted...
+
+    >>> with warns(UserWarning, match=re.escape('issue with foo() func')):
+    ...     warnings.warn("issue with foo() func")
 
 You can also call :func:`pytest.warns` on a function or code string:
 

--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -276,6 +276,9 @@ first be escaped with ``re.escape``.
 
 Some examples:
 
+.. code-block: python
+
+
     >>> with warns(UserWarning, match='must be 0 or None'):
     ...     warnings.warn("value must be 0 or None", UserWarning)
 


### PR DESCRIPTION
Add example using `re.escape` to escape arbitrary literal strings which might contain regular expression characters like ( or .

Also discussed in https://github.com/pytest-dev/pytest/issues/10595