### PR TITLE
Bugfix nose teardown regression

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -348,6 +348,7 @@ Thomas Grainger
 Thomas Hisch
 Tim Hoffmann
 Tim Strazny
+TJ Bruno
 Tobias Diez
 Tom Dalton
 Tom Viner

--- a/changelog/10597.bugfix.rst
+++ b/changelog/10597.bugfix.rst
@@ -1,1 +1,1 @@
-Fix nose teardown fixture regressions.
+Fix bug where a fixture method named ``teardown`` would be called as part of ``nose`` teardown stage.

--- a/changelog/10597.bugfix.rst
+++ b/changelog/10597.bugfix.rst
@@ -1,0 +1,1 @@
+Fix nose teardown fixture regressions.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -847,7 +847,7 @@ class Class(PyCollector):
         other fixtures (#517).
         """
         setup_class = _get_first_non_fixture_func(self.obj, ("setup_class",))
-        teardown_class = getattr(self.obj, "teardown_class", None)
+        teardown_class = _get_first_non_fixture_func(self.obj, ("teardown_class",))
         if setup_class is None and teardown_class is None:
             return
 
@@ -884,12 +884,12 @@ class Class(PyCollector):
             emit_nose_setup_warning = True
             setup_method = _get_first_non_fixture_func(self.obj, (setup_name,))
         teardown_name = "teardown_method"
-        teardown_method = getattr(self.obj, teardown_name, None)
+        teardown_method = _get_first_non_fixture_func(self.obj, (teardown_name,))
         emit_nose_teardown_warning = False
         if teardown_method is None and has_nose:
             teardown_name = "teardown"
             emit_nose_teardown_warning = True
-            teardown_method = getattr(self.obj, teardown_name, None)
+            teardown_method = _get_first_non_fixture_func(self.obj, (teardown_name,))
         if setup_method is None and teardown_method is None:
             return
 

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -496,3 +496,24 @@ def test_nose_setup_skipped_if_non_callable(pytester: Pytester) -> None:
     )
     result = pytester.runpytest(p, "-p", "nose")
     assert result.ret == 0
+
+
+@pytest.mark.parametrize("fixture_name", ("teardown", "teardown_class"))
+def test_teardown_fixture_not_called_directly(fixture_name, pytester: Pytester) -> None:
+    """Regression test for #10597."""
+    p = pytester.makepyfile(
+        f"""
+        import pytest
+
+        class TestHello:
+
+            @pytest.fixture
+            def {fixture_name}(self):
+                yield
+
+            def test_hello(self, {fixture_name}):
+                assert True
+        """
+    )
+    result = pytester.runpytest(p, "-p", "nose")
+    assert result.ret == 0


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
Closes #10597 
This behavior seems to have been introduced in #9273

Since I noticed support for `nose` is being deprecated I didn't add any additional test coverage.
But I'm not familiar with how `pytest` should interact with `nose` so any additional verification is welcome :)
