### PR TITLE
split up report header lines for config, rootdir and testpaths

### DIFF
--- a/changelog/10727.improvement.rst
+++ b/changelog/10727.improvement.rst
@@ -1,0 +1,1 @@
+Split the report header for ``rootdir``, ``config file`` and ``testpaths`` so each has its own line.

--- a/doc/en/builtin.rst
+++ b/doc/en/builtin.rst
@@ -22,7 +22,7 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
     cachedir: .pytest_cache
     rootdir: /home/sweet/project
     collected 0 items
-    cache -- .../_pytest/cacheprovider.py:509
+    cache -- .../_pytest/cacheprovider.py:510
         Return a cache object that can persist state between testing sessions.
 
         cache.get(key, default)
@@ -33,25 +33,7 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
 
         Values can be any object handled by the json stdlib module.
 
-    capsys -- .../_pytest/capture.py:905
-        Enable text capturing of writes to ``sys.stdout`` and ``sys.stderr``.
-
-        The captured output is made available via ``capsys.readouterr()`` method
-        calls, which return a ``(out, err)`` namedtuple.
-        ``out`` and ``err`` will be ``text`` objects.
-
-        Returns an instance of :class:`CaptureFixture[str] <pytest.CaptureFixture>`.
-
-        Example:
-
-        .. code-block:: python
-
-            def test_output(capsys):
-                print("hello")
-                captured = capsys.readouterr()
-                assert captured.out == "hello\n"
-
-    capsysbinary -- .../_pytest/capture.py:933
+    capsysbinary -- .../_pytest/capture.py:1001
         Enable bytes capturing of writes to ``sys.stdout`` and ``sys.stderr``.
 
         The captured output is made available via ``capsysbinary.readouterr()``
@@ -69,7 +51,7 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
                 captured = capsysbinary.readouterr()
                 assert captured.out == b"hello\n"
 
-    capfd -- .../_pytest/capture.py:961
+    capfd -- .../_pytest/capture.py:1029
         Enable text capturing of writes to file descriptors ``1`` and ``2``.
 
         The captured output is made available via ``capfd.readouterr()`` method
@@ -87,7 +69,7 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
                 captured = capfd.readouterr()
                 assert captured.out == "hello\n"
 
-    capfdbinary -- .../_pytest/capture.py:989
+    capfdbinary -- .../_pytest/capture.py:1057
         Enable bytes capturing of writes to file descriptors ``1`` and ``2``.
 
         The captured output is made available via ``capfd.readouterr()`` method
@@ -105,7 +87,25 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
                 captured = capfdbinary.readouterr()
                 assert captured.out == b"hello\n"
 
-    doctest_namespace [session scope] -- .../_pytest/doctest.py:738
+    capsys -- .../_pytest/capture.py:973
+        Enable text capturing of writes to ``sys.stdout`` and ``sys.stderr``.
+
+        The captured output is made available via ``capsys.readouterr()`` method
+        calls, which return a ``(out, err)`` namedtuple.
+        ``out`` and ``err`` will be ``text`` objects.
+
+        Returns an instance of :class:`CaptureFixture[str] <pytest.CaptureFixture>`.
+
+        Example:
+
+        .. code-block:: python
+
+            def test_output(capsys):
+                print("hello")
+                captured = capsys.readouterr()
+                assert captured.out == "hello\n"
+
+    doctest_namespace [session scope] -- .../_pytest/doctest.py:737
         Fixture that returns a :py:class:`dict` that will be injected into the
         namespace of doctests.
 
@@ -119,7 +119,7 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
 
         For more details: :ref:`doctest_namespace`.
 
-    pytestconfig [session scope] -- .../_pytest/fixtures.py:1356
+    pytestconfig [session scope] -- .../_pytest/fixtures.py:1360
         Session-scoped fixture that returns the session's :class:`pytest.Config`
         object.
 
@@ -196,7 +196,7 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
 
         .. _legacy_path: https://py.readthedocs.io/en/latest/path.html
 
-    caplog -- .../_pytest/logging.py:491
+    caplog -- .../_pytest/logging.py:498
         Access and control log capturing.
 
         Captured logs are available through the following properties/methods::
@@ -237,17 +237,19 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
         See https://docs.pytest.org/en/latest/how-to/capture-warnings.html for information
         on warning categories.
 
-    tmp_path_factory [session scope] -- .../_pytest/tmpdir.py:188
+    tmp_path_factory [session scope] -- .../_pytest/tmpdir.py:245
         Return a :class:`pytest.TempPathFactory` instance for the test session.
 
-    tmp_path -- .../_pytest/tmpdir.py:203
+    tmp_path -- .../_pytest/tmpdir.py:260
         Return a temporary directory path object which is unique to each test
         function invocation, created as a sub directory of the base temporary
         directory.
 
         By default, a new base temporary directory is created each test session,
-        and old bases are removed after 3 sessions, to aid in debugging. If
-        ``--basetemp`` is used then it is cleared each session. See :ref:`base
+        and old bases are removed after 3 sessions, to aid in debugging.
+        This behavior can be configured with :confval:`tmp_path_retention_count` and
+        :confval:`tmp_path_retention_policy`.
+        If ``--basetemp`` is used then it is cleared each session. See :ref:`base
         temporary directory`.
 
         The returned object is a :class:`pathlib.Path` object.

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -502,12 +502,8 @@ Running it results in some skips if we don't have all the python interpreters in
 .. code-block:: pytest
 
    . $ pytest -rs -q multipython.py
-   sssssssssssssssssssssssssss                                          [100%]
-   ========================= short test summary info ==========================
-   SKIPPED [9] multipython.py:69: 'python3.5' not found
-   SKIPPED [9] multipython.py:69: 'python3.6' not found
-   SKIPPED [9] multipython.py:69: 'python3.7' not found
-   27 skipped in 0.12s
+   ...........................                                          [100%]
+   27 passed in 0.12s
 
 Indirect parametrization of optional implementations/imports
 --------------------------------------------------------------------

--- a/doc/en/example/pythoncollection.rst
+++ b/doc/en/example/pythoncollection.rst
@@ -148,7 +148,8 @@ The test collection would look like this:
     $ pytest --collect-only
     =========================== test session starts ============================
     platform linux -- Python 3.x.y, pytest-7.x.y, pluggy-1.x.y
-    rootdir: /home/sweet/project, configfile: pytest.ini
+    rootdir: /home/sweet/project
+    configfile: pytest.ini
     collected 2 items
 
     <Module check_myapp.py>
@@ -209,7 +210,8 @@ You can always peek at the collection tree without running tests like this:
     . $ pytest --collect-only pythoncollection.py
     =========================== test session starts ============================
     platform linux -- Python 3.x.y, pytest-7.x.y, pluggy-1.x.y
-    rootdir: /home/sweet/project, configfile: pytest.ini
+    rootdir: /home/sweet/project
+    configfile: pytest.ini
     collected 3 items
 
     <Module CWD/pythoncollection.py>
@@ -290,7 +292,8 @@ file will be left out:
     $ pytest --collect-only
     =========================== test session starts ============================
     platform linux -- Python 3.x.y, pytest-7.x.y, pluggy-1.x.y
-    rootdir: /home/sweet/project, configfile: pytest.ini
+    rootdir: /home/sweet/project
+    configfile: pytest.ini
     collected 0 items
 
     ======================= no tests collected in 0.12s ========================

--- a/doc/en/example/reportingdemo.rst
+++ b/doc/en/example/reportingdemo.rst
@@ -70,12 +70,12 @@ Here is a nice run of several failures and how ``pytest`` presents things:
 
     >       assert not f()
     E       assert not 42
-    E        +  where 42 = <function TestFailing.test_not.<locals>.f at 0xdeadbeef0006>()
+    E        +  where 42 = <function TestFailing.test_not.<locals>.f at 0xdeadbeef0002>()
 
     failure_demo.py:39: AssertionError
     _________________ TestSpecialisedExplanations.test_eq_text _________________
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0007>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0006>
 
         def test_eq_text(self):
     >       assert "spam" == "eggs"
@@ -86,7 +86,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:44: AssertionError
     _____________ TestSpecialisedExplanations.test_eq_similar_text _____________
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0008>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0007>
 
         def test_eq_similar_text(self):
     >       assert "foo 1 bar" == "foo 2 bar"
@@ -99,7 +99,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:47: AssertionError
     ____________ TestSpecialisedExplanations.test_eq_multiline_text ____________
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0009>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0008>
 
         def test_eq_multiline_text(self):
     >       assert "foo\nspam\nbar" == "foo\neggs\nbar"
@@ -112,7 +112,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:50: AssertionError
     ______________ TestSpecialisedExplanations.test_eq_long_text _______________
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef000a>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0009>
 
         def test_eq_long_text(self):
             a = "1" * 100 + "a" + "2" * 100
@@ -129,7 +129,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:55: AssertionError
     _________ TestSpecialisedExplanations.test_eq_long_text_multiline __________
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef000b>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef000a>
 
         def test_eq_long_text_multiline(self):
             a = "1\n" * 100 + "a" + "2\n" * 100
@@ -144,12 +144,12 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     E           1
     E           1...
     E
-    E         ...Full output truncated (7 lines hidden), use '-vv' to show
+    E         ...Full output truncated (6 lines hidden), use '-vv' to show
 
     failure_demo.py:60: AssertionError
     _________________ TestSpecialisedExplanations.test_eq_list _________________
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef000c>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef000b>
 
         def test_eq_list(self):
     >       assert [0, 1, 2] == [0, 1, 3]
@@ -160,7 +160,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:63: AssertionError
     ______________ TestSpecialisedExplanations.test_eq_list_long _______________
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef000d>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef000c>
 
         def test_eq_list_long(self):
             a = [0] * 100 + [1] + [3] * 100
@@ -173,7 +173,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:68: AssertionError
     _________________ TestSpecialisedExplanations.test_eq_dict _________________
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef000e>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef000d>
 
         def test_eq_dict(self):
     >       assert {"a": 0, "b": 1, "c": 0} == {"a": 0, "b": 2, "d": 0}
@@ -184,32 +184,30 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     E         Left contains 1 more item:
     E         {'c': 0}
     E         Right contains 1 more item:
-    E         {'d': 0}...
-    E
-    E         ...Full output truncated (2 lines hidden), use '-vv' to show
+    E         {'d': 0}
+    E         Use -v to get more diff
 
     failure_demo.py:71: AssertionError
     _________________ TestSpecialisedExplanations.test_eq_set __________________
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef000f>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef000e>
 
         def test_eq_set(self):
     >       assert {0, 10, 11, 12} == {0, 20, 21}
-    E       AssertionError: assert {0, 10, 11, 12} == {0, 20, 21}
+    E       assert {0, 10, 11, 12} == {0, 20, 21}
     E         Extra items in the left set:
     E         10
     E         11
     E         12
     E         Extra items in the right set:
     E         20
-    E         21...
-    E
-    E         ...Full output truncated (2 lines hidden), use '-vv' to show
+    E         21
+    E         Use -v to get more diff
 
     failure_demo.py:74: AssertionError
     _____________ TestSpecialisedExplanations.test_eq_longer_list ______________
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0010>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef000f>
 
         def test_eq_longer_list(self):
     >       assert [1, 2] == [1, 2, 3]
@@ -220,7 +218,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:77: AssertionError
     _________________ TestSpecialisedExplanations.test_in_list _________________
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0011>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0010>
 
         def test_in_list(self):
     >       assert 1 in [0, 2, 3, 4, 5]
@@ -229,7 +227,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:80: AssertionError
     __________ TestSpecialisedExplanations.test_not_in_text_multiline __________
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0012>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0011>
 
         def test_not_in_text_multiline(self):
             text = "some multiline\ntext\nwhich\nincludes foo\nand a\ntail"
@@ -241,14 +239,13 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     E           which
     E           includes foo
     E         ?          +++
-    E           and a...
-    E
-    E         ...Full output truncated (2 lines hidden), use '-vv' to show
+    E           and a
+    E           tail
 
     failure_demo.py:84: AssertionError
     ___________ TestSpecialisedExplanations.test_not_in_text_single ____________
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0013>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0012>
 
         def test_not_in_text_single(self):
             text = "single foo line"
@@ -261,7 +258,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:88: AssertionError
     _________ TestSpecialisedExplanations.test_not_in_text_single_long _________
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0014>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0013>
 
         def test_not_in_text_single_long(self):
             text = "head " * 50 + "foo " + "tail " * 20
@@ -274,7 +271,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:92: AssertionError
     ______ TestSpecialisedExplanations.test_not_in_text_single_long_term _______
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0015>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0014>
 
         def test_not_in_text_single_long_term(self):
             text = "head " * 50 + "f" * 70 + "tail " * 20
@@ -287,7 +284,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:96: AssertionError
     ______________ TestSpecialisedExplanations.test_eq_dataclass _______________
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0016>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0015>
 
         def test_eq_dataclass(self):
             from dataclasses import dataclass
@@ -307,14 +304,14 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     E         ['b']
     E
     E         Drill down into differing attribute b:
-    E           b: 'b' != 'c'...
-    E
-    E         ...Full output truncated (3 lines hidden), use '-vv' to show
+    E           b: 'b' != 'c'
+    E           - c
+    E           + b
 
     failure_demo.py:108: AssertionError
     ________________ TestSpecialisedExplanations.test_eq_attrs _________________
 
-    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0017>
+    self = <failure_demo.TestSpecialisedExplanations object at 0xdeadbeef0016>
 
         def test_eq_attrs(self):
             import attr
@@ -334,9 +331,9 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     E         ['b']
     E
     E         Drill down into differing attribute b:
-    E           b: 'b' != 'c'...
-    E
-    E         ...Full output truncated (3 lines hidden), use '-vv' to show
+    E           b: 'b' != 'c'
+    E           - c
+    E           + b
 
     failure_demo.py:120: AssertionError
     ______________________________ test_attribute ______________________________
@@ -348,7 +345,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
             i = Foo()
     >       assert i.b == 2
     E       assert 1 == 2
-    E        +  where 1 = <failure_demo.test_attribute.<locals>.Foo object at 0xdeadbeef0018>.b
+    E        +  where 1 = <failure_demo.test_attribute.<locals>.Foo object at 0xdeadbeef0017>.b
 
     failure_demo.py:128: AssertionError
     _________________________ test_attribute_instance __________________________
@@ -359,8 +356,8 @@ Here is a nice run of several failures and how ``pytest`` presents things:
 
     >       assert Foo().b == 2
     E       AssertionError: assert 1 == 2
-    E        +  where 1 = <failure_demo.test_attribute_instance.<locals>.Foo object at 0xdeadbeef0019>.b
-    E        +    where <failure_demo.test_attribute_instance.<locals>.Foo object at 0xdeadbeef0019> = <class 'failure_demo.test_attribute_instance.<locals>.Foo'>()
+    E        +  where 1 = <failure_demo.test_attribute_instance.<locals>.Foo object at 0xdeadbeef0018>.b
+    E        +    where <failure_demo.test_attribute_instance.<locals>.Foo object at 0xdeadbeef0018> = <class 'failure_demo.test_attribute_instance.<locals>.Foo'>()
 
     failure_demo.py:135: AssertionError
     __________________________ test_attribute_failure __________________________
@@ -378,7 +375,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:146:
     _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 
-    self = <failure_demo.test_attribute_failure.<locals>.Foo object at 0xdeadbeef001a>
+    self = <failure_demo.test_attribute_failure.<locals>.Foo object at 0xdeadbeef0019>
 
         def _get_b(self):
     >       raise Exception("Failed to get attrib")
@@ -396,15 +393,15 @@ Here is a nice run of several failures and how ``pytest`` presents things:
 
     >       assert Foo().b == Bar().b
     E       AssertionError: assert 1 == 2
-    E        +  where 1 = <failure_demo.test_attribute_multiple.<locals>.Foo object at 0xdeadbeef001b>.b
-    E        +    where <failure_demo.test_attribute_multiple.<locals>.Foo object at 0xdeadbeef001b> = <class 'failure_demo.test_attribute_multiple.<locals>.Foo'>()
-    E        +  and   2 = <failure_demo.test_attribute_multiple.<locals>.Bar object at 0xdeadbeef001c>.b
-    E        +    where <failure_demo.test_attribute_multiple.<locals>.Bar object at 0xdeadbeef001c> = <class 'failure_demo.test_attribute_multiple.<locals>.Bar'>()
+    E        +  where 1 = <failure_demo.test_attribute_multiple.<locals>.Foo object at 0xdeadbeef001a>.b
+    E        +    where <failure_demo.test_attribute_multiple.<locals>.Foo object at 0xdeadbeef001a> = <class 'failure_demo.test_attribute_multiple.<locals>.Foo'>()
+    E        +  and   2 = <failure_demo.test_attribute_multiple.<locals>.Bar object at 0xdeadbeef001b>.b
+    E        +    where <failure_demo.test_attribute_multiple.<locals>.Bar object at 0xdeadbeef001b> = <class 'failure_demo.test_attribute_multiple.<locals>.Bar'>()
 
     failure_demo.py:156: AssertionError
     __________________________ TestRaises.test_raises __________________________
 
-    self = <failure_demo.TestRaises object at 0xdeadbeef001d>
+    self = <failure_demo.TestRaises object at 0xdeadbeef001c>
 
         def test_raises(self):
             s = "qwe"
@@ -414,7 +411,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:166: ValueError
     ______________________ TestRaises.test_raises_doesnt _______________________
 
-    self = <failure_demo.TestRaises object at 0xdeadbeef001e>
+    self = <failure_demo.TestRaises object at 0xdeadbeef001d>
 
         def test_raises_doesnt(self):
     >       raises(OSError, int, "3")
@@ -423,7 +420,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:169: Failed
     __________________________ TestRaises.test_raise ___________________________
 
-    self = <failure_demo.TestRaises object at 0xdeadbeef001f>
+    self = <failure_demo.TestRaises object at 0xdeadbeef001e>
 
         def test_raise(self):
     >       raise ValueError("demo error")
@@ -432,7 +429,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:172: ValueError
     ________________________ TestRaises.test_tupleerror ________________________
 
-    self = <failure_demo.TestRaises object at 0xdeadbeef0020>
+    self = <failure_demo.TestRaises object at 0xdeadbeef001f>
 
         def test_tupleerror(self):
     >       a, b = [1]  # NOQA
@@ -441,7 +438,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:175: ValueError
     ______ TestRaises.test_reinterpret_fails_with_print_for_the_fun_of_it ______
 
-    self = <failure_demo.TestRaises object at 0xdeadbeef0021>
+    self = <failure_demo.TestRaises object at 0xdeadbeef0020>
 
         def test_reinterpret_fails_with_print_for_the_fun_of_it(self):
             items = [1, 2, 3]
@@ -454,7 +451,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     items is [1, 2, 3]
     ________________________ TestRaises.test_some_error ________________________
 
-    self = <failure_demo.TestRaises object at 0xdeadbeef0022>
+    self = <failure_demo.TestRaises object at 0xdeadbeef0021>
 
         def test_some_error(self):
     >       if namenotexi:  # NOQA
@@ -485,7 +482,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     abc-123:2: AssertionError
     ____________________ TestMoreErrors.test_complex_error _____________________
 
-    self = <failure_demo.TestMoreErrors object at 0xdeadbeef0023>
+    self = <failure_demo.TestMoreErrors object at 0xdeadbeef0022>
 
         def test_complex_error(self):
             def f():
@@ -511,7 +508,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:6: AssertionError
     ___________________ TestMoreErrors.test_z1_unpack_error ____________________
 
-    self = <failure_demo.TestMoreErrors object at 0xdeadbeef0024>
+    self = <failure_demo.TestMoreErrors object at 0xdeadbeef0023>
 
         def test_z1_unpack_error(self):
             items = []
@@ -521,7 +518,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:217: ValueError
     ____________________ TestMoreErrors.test_z2_type_error _____________________
 
-    self = <failure_demo.TestMoreErrors object at 0xdeadbeef0025>
+    self = <failure_demo.TestMoreErrors object at 0xdeadbeef0024>
 
         def test_z2_type_error(self):
             items = 3
@@ -531,20 +528,20 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:221: TypeError
     ______________________ TestMoreErrors.test_startswith ______________________
 
-    self = <failure_demo.TestMoreErrors object at 0xdeadbeef0026>
+    self = <failure_demo.TestMoreErrors object at 0xdeadbeef0025>
 
         def test_startswith(self):
             s = "123"
             g = "456"
     >       assert s.startswith(g)
     E       AssertionError: assert False
-    E        +  where False = <built-in method startswith of str object at 0xdeadbeef0027>('456')
-    E        +    where <built-in method startswith of str object at 0xdeadbeef0027> = '123'.startswith
+    E        +  where False = <built-in method startswith of str object at 0xdeadbeef0026>('456')
+    E        +    where <built-in method startswith of str object at 0xdeadbeef0026> = '123'.startswith
 
     failure_demo.py:226: AssertionError
     __________________ TestMoreErrors.test_startswith_nested ___________________
 
-    self = <failure_demo.TestMoreErrors object at 0xdeadbeef0028>
+    self = <failure_demo.TestMoreErrors object at 0xdeadbeef0027>
 
         def test_startswith_nested(self):
             def f():
@@ -555,15 +552,15 @@ Here is a nice run of several failures and how ``pytest`` presents things:
 
     >       assert f().startswith(g())
     E       AssertionError: assert False
-    E        +  where False = <built-in method startswith of str object at 0xdeadbeef0027>('456')
-    E        +    where <built-in method startswith of str object at 0xdeadbeef0027> = '123'.startswith
-    E        +      where '123' = <function TestMoreErrors.test_startswith_nested.<locals>.f at 0xdeadbeef0029>()
-    E        +    and   '456' = <function TestMoreErrors.test_startswith_nested.<locals>.g at 0xdeadbeef002a>()
+    E        +  where False = <built-in method startswith of str object at 0xdeadbeef0026>('456')
+    E        +    where <built-in method startswith of str object at 0xdeadbeef0026> = '123'.startswith
+    E        +      where '123' = <function TestMoreErrors.test_startswith_nested.<locals>.f at 0xdeadbeef0028>()
+    E        +    and   '456' = <function TestMoreErrors.test_startswith_nested.<locals>.g at 0xdeadbeef0029>()
 
     failure_demo.py:235: AssertionError
     _____________________ TestMoreErrors.test_global_func ______________________
 
-    self = <failure_demo.TestMoreErrors object at 0xdeadbeef002b>
+    self = <failure_demo.TestMoreErrors object at 0xdeadbeef002a>
 
         def test_global_func(self):
     >       assert isinstance(globf(42), float)
@@ -574,18 +571,18 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:238: AssertionError
     _______________________ TestMoreErrors.test_instance _______________________
 
-    self = <failure_demo.TestMoreErrors object at 0xdeadbeef002c>
+    self = <failure_demo.TestMoreErrors object at 0xdeadbeef002b>
 
         def test_instance(self):
             self.x = 6 * 7
     >       assert self.x != 42
     E       assert 42 != 42
-    E        +  where 42 = <failure_demo.TestMoreErrors object at 0xdeadbeef002c>.x
+    E        +  where 42 = <failure_demo.TestMoreErrors object at 0xdeadbeef002b>.x
 
     failure_demo.py:242: AssertionError
     _______________________ TestMoreErrors.test_compare ________________________
 
-    self = <failure_demo.TestMoreErrors object at 0xdeadbeef002d>
+    self = <failure_demo.TestMoreErrors object at 0xdeadbeef002c>
 
         def test_compare(self):
     >       assert globf(10) < 5
@@ -595,7 +592,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:245: AssertionError
     _____________________ TestMoreErrors.test_try_finally ______________________
 
-    self = <failure_demo.TestMoreErrors object at 0xdeadbeef002e>
+    self = <failure_demo.TestMoreErrors object at 0xdeadbeef002d>
 
         def test_try_finally(self):
             x = 1
@@ -606,7 +603,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:250: AssertionError
     ___________________ TestCustomAssertMsg.test_single_line ___________________
 
-    self = <failure_demo.TestCustomAssertMsg object at 0xdeadbeef002f>
+    self = <failure_demo.TestCustomAssertMsg object at 0xdeadbeef002e>
 
         def test_single_line(self):
             class A:
@@ -621,7 +618,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:261: AssertionError
     ____________________ TestCustomAssertMsg.test_multiline ____________________
 
-    self = <failure_demo.TestCustomAssertMsg object at 0xdeadbeef0030>
+    self = <failure_demo.TestCustomAssertMsg object at 0xdeadbeef002f>
 
         def test_multiline(self):
             class A:
@@ -640,7 +637,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:268: AssertionError
     ___________________ TestCustomAssertMsg.test_custom_repr ___________________
 
-    self = <failure_demo.TestCustomAssertMsg object at 0xdeadbeef0031>
+    self = <failure_demo.TestCustomAssertMsg object at 0xdeadbeef0030>
 
         def test_custom_repr(self):
             class JSON:
@@ -673,7 +670,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     FAILED failure_demo.py::TestSpecialisedExplanations::test_eq_list - asser...
     FAILED failure_demo.py::TestSpecialisedExplanations::test_eq_list_long - ...
     FAILED failure_demo.py::TestSpecialisedExplanations::test_eq_dict - Asser...
-    FAILED failure_demo.py::TestSpecialisedExplanations::test_eq_set - Assert...
+    FAILED failure_demo.py::TestSpecialisedExplanations::test_eq_set - assert...
     FAILED failure_demo.py::TestSpecialisedExplanations::test_eq_longer_list
     FAILED failure_demo.py::TestSpecialisedExplanations::test_in_list - asser...
     FAILED failure_demo.py::TestSpecialisedExplanations::test_not_in_text_multiline

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -892,8 +892,9 @@ here is a little example implemented via a local plugin:
 .. code-block:: python
 
     # content of conftest.py
-
+    from typing import Dict
     import pytest
+    from pytest import StashKey, CollectReport
 
     phase_report_key = StashKey[Dict[str, CollectReport]]()
 
@@ -951,10 +952,46 @@ and run it:
 .. code-block:: pytest
 
     $ pytest -s test_module.py
-    ImportError while loading conftest '/home/sweet/project/conftest.py'.
-    conftest.py:4: in <module>
-        phase_report_key = StashKey[Dict[str, CollectReport]]()
-    E   NameError: name 'StashKey' is not defined
+    =========================== test session starts ============================
+    platform linux -- Python 3.x.y, pytest-7.x.y, pluggy-1.x.y
+    rootdir: /home/sweet/project
+    collected 3 items
+
+    test_module.py Esetting up a test failed or skipped test_module.py::test_setup_fails
+    Fexecuting test failed or skipped test_module.py::test_call_fails
+    F
+
+    ================================== ERRORS ==================================
+    ____________________ ERROR at setup of test_setup_fails ____________________
+
+        @pytest.fixture
+        def other():
+    >       assert 0
+    E       assert 0
+
+    test_module.py:7: AssertionError
+    ================================= FAILURES =================================
+    _____________________________ test_call_fails ______________________________
+
+    something = None
+
+        def test_call_fails(something):
+    >       assert 0
+    E       assert 0
+
+    test_module.py:15: AssertionError
+    ________________________________ test_fail2 ________________________________
+
+        def test_fail2():
+    >       assert 0
+    E       assert 0
+
+    test_module.py:19: AssertionError
+    ========================= short test summary info ==========================
+    FAILED test_module.py::test_call_fails - assert 0
+    FAILED test_module.py::test_fail2 - assert 0
+    ERROR test_module.py::test_setup_fails - assert 0
+    ======================== 2 failed, 1 error in 0.12s ========================
 
 You'll see that the fixture finalizers could use the precise reporting
 information.

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -951,46 +951,10 @@ and run it:
 .. code-block:: pytest
 
     $ pytest -s test_module.py
-    =========================== test session starts ============================
-    platform linux -- Python 3.x.y, pytest-7.x.y, pluggy-1.x.y
-    rootdir: /home/sweet/project
-    collected 3 items
-
-    test_module.py Esetting up a test failed! test_module.py::test_setup_fails
-    Fexecuting test failed test_module.py::test_call_fails
-    F
-
-    ================================== ERRORS ==================================
-    ____________________ ERROR at setup of test_setup_fails ____________________
-
-        @pytest.fixture
-        def other():
-    >       assert 0
-    E       assert 0
-
-    test_module.py:7: AssertionError
-    ================================= FAILURES =================================
-    _____________________________ test_call_fails ______________________________
-
-    something = None
-
-        def test_call_fails(something):
-    >       assert 0
-    E       assert 0
-
-    test_module.py:15: AssertionError
-    ________________________________ test_fail2 ________________________________
-
-        def test_fail2():
-    >       assert 0
-    E       assert 0
-
-    test_module.py:19: AssertionError
-    ========================= short test summary info ==========================
-    FAILED test_module.py::test_call_fails - assert 0
-    FAILED test_module.py::test_fail2 - assert 0
-    ERROR test_module.py::test_setup_fails - assert 0
-    ======================== 2 failed, 1 error in 0.12s ========================
+    ImportError while loading conftest '/home/sweet/project/conftest.py'.
+    conftest.py:4: in <module>
+        phase_report_key = StashKey[Dict[str, CollectReport]]()
+    E   NameError: name 'StashKey' is not defined
 
 You'll see that the fixture finalizers could use the precise reporting
 information.

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -22,7 +22,7 @@ Install ``pytest``
 .. code-block:: bash
 
     $ pytest --version
-    pytest 7.2.0.dev533+gd08c8e337
+    pytest 7.2.0.dev534+ga2c84caaa.d20230317
 
 .. _`simpletest`:
 

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -22,7 +22,7 @@ Install ``pytest``
 .. code-block:: bash
 
     $ pytest --version
-    pytest 7.2.2
+    pytest 7.2.0.dev533+gd08c8e337
 
 .. _`simpletest`:
 

--- a/doc/en/how-to/output.rst
+++ b/doc/en/how-to/output.rst
@@ -167,9 +167,9 @@ Now we can increase pytest's verbosity:
     E         Right contains 4 more items:
     E         {'10': 10, '20': 20, '30': 30, '40': 40}
     E         Full diff:
-    E         - {'0': 0, '10': 10, '20': 20, '30': 30, '40': 40}...
-    E
-    E         ...Full output truncated (3 lines hidden), use '-vv' to show
+    E         - {'0': 0, '10': 10, '20': 20, '30': 30, '40': 40}
+    E         ?            -    -    -    -    -    -    -    -
+    E         + {'0': 0, '1': 1, '2': 2, '3': 3, '4': 4}
 
     test_verbosity_example.py:14: AssertionError
     ___________________________ test_long_text_fail ____________________________

--- a/doc/en/how-to/writing_plugins.rst
+++ b/doc/en/how-to/writing_plugins.rst
@@ -449,7 +449,8 @@ in our ``pytest.ini`` to tell pytest where to look for example files.
     $ pytest
     =========================== test session starts ============================
     platform linux -- Python 3.x.y, pytest-7.x.y, pluggy-1.x.y
-    rootdir: /home/sweet/project, configfile: pytest.ini
+    rootdir: /home/sweet/project
+    configfile: pytest.ini
     collected 2 items
 
     test_example.py ..                                                   [100%]

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1995,6 +1995,9 @@ All the command-line flags can be obtained by running ``pytest --help``::
       --log-auto-indent=LOG_AUTO_INDENT
                             Auto-indent multiline messages passed to the logging
                             module. Accepts true|on, false|off or an integer.
+      --log-disable=LOGGER_DISABLE
+                            Disable a logger by name. Can be passed multipe
+                            times.
 
     [pytest] ini-options in the first pytest.ini|tox.ini|setup.cfg|pyproject.toml file found:
 
@@ -2024,9 +2027,18 @@ All the command-line flags can be obtained by running ``pytest --help``::
       console_output_style (string):
                             Console output: "classic", or with additional
                             progress information ("progress" (percentage) |
-                            "count")
+                            "count" | "progress-even-when-capture-no" (forces
+                            progress even when capture=no)
       xfail_strict (bool):  Default for the strict parameter of xfail markers
                             when not given explicitly (default: False)
+      tmp_path_retention_count (string):
+                            How many sessions should we keep the `tmp_path`
+                            directories, according to
+                            `tmp_path_retention_policy`.
+      tmp_path_retention_policy (string):
+                            Controls which directories created by the `tmp_path`
+                            fixture are kept around, based on test outcome.
+                            (all/failed/none)
       enable_assertion_pass_hook (bool):
                             Enables the pytest_assertion_pass hook. Make sure to
                             delete any previously generated pyc cache files.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -739,16 +739,14 @@ class TerminalReporter:
                     self.write_line(line)
 
     def pytest_report_header(self, config: Config) -> List[str]:
-        line = "rootdir: %s" % config.rootpath
+        result = [f"rootdir: {config.rootpath}"]
 
         if config.inipath:
-            line += ", configfile: " + bestrelpath(config.rootpath, config.inipath)
+            result.append("configfile: " + bestrelpath(config.rootpath, config.inipath))
 
         if config.args_source == Config.ArgsSource.TESTPATHS:
             testpaths: List[str] = config.getini("testpaths")
-            line += ", testpaths: {}".format(", ".join(testpaths))
-
-        result = [line]
+            result.append("testpaths: {}".format(", ".join(testpaths)))
 
         plugininfo = config.pluginmanager.list_plugin_distinfo()
         if plugininfo:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -74,7 +74,7 @@ class TestParseIni:
             % p1.name,
         )
         result = pytester.runpytest()
-        result.stdout.fnmatch_lines(["*, configfile: setup.cfg, *", "* 1 passed in *"])
+        result.stdout.fnmatch_lines(["configfile: setup.cfg", "* 1 passed in *"])
         assert result.ret == 0
 
     def test_append_parse_args(

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -909,7 +909,7 @@ class TestTerminalFunctional:
         # with configfile
         pytester.makeini("""[pytest]""")
         result = pytester.runpytest()
-        result.stdout.fnmatch_lines(["rootdir: *test_header0, configfile: tox.ini"])
+        result.stdout.fnmatch_lines(["rootdir: *test_header0", "configfile: tox.ini"])
 
         # with testpaths option, and not passing anything in the command-line
         pytester.makeini(
@@ -920,12 +920,12 @@ class TestTerminalFunctional:
         )
         result = pytester.runpytest()
         result.stdout.fnmatch_lines(
-            ["rootdir: *test_header0, configfile: tox.ini, testpaths: tests, gui"]
+            ["rootdir: *test_header0", "configfile: tox.ini", "testpaths: tests, gui"]
         )
 
         # with testpaths option, passing directory in command-line: do not show testpaths then
         result = pytester.runpytest("tests")
-        result.stdout.fnmatch_lines(["rootdir: *test_header0, configfile: tox.ini"])
+        result.stdout.fnmatch_lines(["rootdir: *test_header0", "configfile: tox.ini"])
 
     def test_header_absolute_testpath(
         self, pytester: Pytester, monkeypatch: MonkeyPatch
@@ -944,9 +944,9 @@ class TestTerminalFunctional:
         result = pytester.runpytest()
         result.stdout.fnmatch_lines(
             [
-                "rootdir: *absolute_testpath0, configfile: pyproject.toml, testpaths: {}".format(
-                    tests
-                )
+                "rootdir: *absolute_testpath0",
+                "configfile: pyproject.toml",
+                f"testpaths: {tests}",
             ]
         )
 


### PR DESCRIPTION
i found it painful to read crammed in a single line thus rootdir, config file and testpaths now have own lines

- [x] basic tests
- [x] changelog
- [x] regendoc (skipped as there seem to be more changes i didn't intend)