### PR TITLE
[7.2.x] Use build-and-inspect-python-package action (#10722)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,24 +28,29 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - name: Build and Check Package
+      uses: hynek/build-and-inspect-python-package@v1.5
+
+    - name: Download Package
+      uses: actions/download-artifact@v3
       with:
-        python-version: "3.7"
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install --upgrade build tox
-
-    - name: Build package
-      run: |
-        python -m build
+        name: Packages
+        path: dist
 
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.pypi_token }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.7"
+
+    - name: Install tox
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade tox
 
     - name: Publish GitHub release notes
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,11 @@ on:
 env:
   PYTEST_ADDOPTS: "--color=yes"
 
+# Cancel running jobs for the same workflow and branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Set permissions at the job level.
 permissions: {}
 
@@ -189,3 +194,10 @@ jobs:
         fail_ci_if_error: true
         files: ./coverage.xml
         verbose: true
+
+  check-package:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build and Check Package
+      uses: hynek/build-and-inspect-python-package@v1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,3 +114,8 @@ template = "changelog/_template.rst"
 
 [tool.black]
 target-version = ['py37']
+
+# check-wheel-contents is executed by the build-and-inspect-python-package action.
+[tool.check-wheel-contents]
+# W009: Wheel contains multiple toplevel library entries
+ignore = "W009"


### PR DESCRIPTION
This uses https://github.com/hynek/build-and-inspect-python-package to ensure our package is correct, both during testing and deploy,

Backport of #10722