### PR TITLE
Update import mode documentation to not refer to __import__() anymore.

### DIFF
--- a/doc/en/explanation/pythonpath.rst
+++ b/doc/en/explanation/pythonpath.rst
@@ -16,7 +16,7 @@ import process can be controlled through the ``--import-mode`` command-line flag
 these values:
 
 * ``prepend`` (default): the directory path containing each module will be inserted into the *beginning*
-  of :py:data:`sys.path` if not already there, and then imported with the :func:`__import__ <__import__>` builtin.
+  of :py:data:`sys.path` if not already there, and then imported with the :func:`importlib.import_module <importlib.import_module>` function.
 
   This requires test module names to be unique when the test directory tree is not arranged in
   packages, because the modules will put in :py:data:`sys.modules` after importing.
@@ -24,7 +24,7 @@ these values:
   This is the classic mechanism, dating back from the time Python 2 was still supported.
 
 * ``append``: the directory containing each module is appended to the end of :py:data:`sys.path` if not already
-  there, and imported with ``__import__``.
+  there, and imported with ``importlib.import_module``.
 
   This better allows to run test modules against installed versions of a package even if the
   package under test has the same import root. For example:
@@ -43,7 +43,7 @@ these values:
   Same as ``prepend``, requires test module names to be unique when the test directory tree is
   not arranged in packages, because the modules will put in :py:data:`sys.modules` after importing.
 
-* ``importlib``: new in pytest-6.0, this mode uses :mod:`importlib` to import test modules. This gives full control over the import process, and doesn't require changing :py:data:`sys.path`.
+* ``importlib``: new in pytest-6.0, this mode uses more fine control mechanisms provided by :mod:`importlib` to import test modules. This gives full control over the import process, and doesn't require changing :py:data:`sys.path`.
 
   For this reason this doesn't require test module names to be unique.
 

--- a/doc/en/explanation/pythonpath.rst
+++ b/doc/en/explanation/pythonpath.rst
@@ -24,7 +24,7 @@ these values:
   This is the classic mechanism, dating back from the time Python 2 was still supported.
 
 * ``append``: the directory containing each module is appended to the end of :py:data:`sys.path` if not already
-  there, and imported with ``importlib.import_module``.
+  there, and imported with :func:`importlib.import_module <importlib.import_module>`.
 
   This better allows to run test modules against installed versions of a package even if the
   package under test has the same import root. For example:

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -477,14 +477,14 @@ def import_path(
 
     * `mode == ImportMode.prepend`: the directory containing the module (or package, taking
       `__init__.py` files into account) will be put at the *start* of `sys.path` before
-      being imported with `__import__.
+      being imported with `importlib.import_module`.
 
     * `mode == ImportMode.append`: same as `prepend`, but the directory will be appended
       to the end of `sys.path`, if not already in `sys.path`.
 
     * `mode == ImportMode.importlib`: uses more fine control mechanisms provided by `importlib`
-      to import the module, which avoids having to use `__import__` and muck with `sys.path`
-      at all. It effectively allows having same-named test modules in different places.
+      to import the module, which avoids having to muck with `sys.path` at all. It effectively
+      allows having same-named test modules in different places.
 
     :param root:
         Used as an anchor when mode == ImportMode.importlib to obtain


### PR DESCRIPTION
Nowadays, the prepend and append import modes use importlib.import_module() instead of __import__().

There was a phrase “which avoids having to use `__import__`”, in which I couldn’t just replace `__import__` by `importlib.import_module` because the latter is used (in insert_missing_modules()) also when using importlib mode. Therefore I removed the part from the sentence.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
