### PR TITLE
docs: be more explicit about module level skip preventing collection

### DIFF
--- a/changelog/10753.doc.rst
+++ b/changelog/10753.doc.rst
@@ -1,0 +1,2 @@
+Change wording of the module level skip to be very explicit
+about not collecting and not executing the rest of the module.

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -159,7 +159,7 @@ def skip(
     :param allow_module_level:
         Allows this function to be called at module level.
         Raising the skip exception at module level will stop
-        the execution of the module and prevent the collection of all tests in the module, 
+        the execution of the module and prevent the collection of all tests in the module,
         even those defined before the `skip` call.
 
         Defaults to False.

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -157,8 +157,11 @@ def skip(
         The message to show the user as reason for the skip.
 
     :param allow_module_level:
-        Allows this function to be called at module level, skipping the rest
-        of the module. Defaults to False.
+        Allows this function to be called at module level.
+        Raising the skip exception in a module will stop the execution of the module.
+        Additionally, the module will no longer be collected.
+
+        Defaults to False.
 
     :param msg:
         Same as ``reason``, but deprecated. Will be removed in a future version, use ``reason`` instead.

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -159,7 +159,8 @@ def skip(
     :param allow_module_level:
         Allows this function to be called at module level.
         Raising the skip exception at module level will stop
-        the execution of the module and prevent the collection of all tests in the module, even those defined before the `skip` call.
+        the execution of the module and prevent the collection of all tests in the module, 
+        even those defined before the `skip` call.
 
         Defaults to False.
 

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -159,7 +159,7 @@ def skip(
     :param allow_module_level:
         Allows this function to be called at module level.
         Raising the skip exception at module level will stop
-        the execution of the module and prevent its collection. alltogether.
+        the execution of the module and prevent the collection of all tests in the module, even those defined before the `skip` call.
 
         Defaults to False.
 

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -158,8 +158,8 @@ def skip(
 
     :param allow_module_level:
         Allows this function to be called at module level.
-        Raising the skip exception in a module will stop the execution of the module.
-        Additionally, the module will no longer be collected.
+        Raising the skip exception at module level will stop
+        the execution of the module and prevent its collection. alltogether.
 
         Defaults to False.
 


### PR DESCRIPTION
this changes the wording of the module level skip to be very explicit about the effect