### PR TITLE
allow a progress bar even when capture=no

### DIFF
--- a/changelog/10755.feature.rst
+++ b/changelog/10755.feature.rst
@@ -1,0 +1,1 @@
+:confval:`console_output_style` now supports ``progress-even-when-capture-no`` to force the use of the progress output even when capture is disabled. This is useful in large test suites where capture may have significant performance impact.

--- a/changelog/10755.improvement.rst
+++ b/changelog/10755.improvement.rst
@@ -1,1 +1,0 @@
-``console_output_style`` now supports ``progress-even-when-capture-no`` to force the use of the progress output even when capture is disabled. This is useful in large test suites where capture may have significant performance impact.

--- a/changelog/10755.improvement.rst
+++ b/changelog/10755.improvement.rst
@@ -1,0 +1,1 @@
+``console_output_style`` now supports ``progress-even-when-capture-no`` to force the use of the progress output even when capture is disabled. This is useful in large test suites where capture may have significant performance impact.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1212,6 +1212,7 @@ passed multiple times. The expected format is ``name=value``. For example::
 
    * ``classic``: classic pytest output.
    * ``progress``: like classic pytest output, but with a progress indicator.
+   * ``progress-even-when-capture-no``: allows the use of the progress indicator even when ``capture=no``.
    * ``count``: like progress, but shows progress as the number of tests completed instead of a percent.
 
    The default is ``progress``, but you can fallback to ``classic`` if you prefer or

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -230,7 +230,7 @@ def pytest_addoption(parser: Parser) -> None:
         "console_output_style",
         help='Console output: "classic", or with additional progress information '
         '("progress" (percentage) | "count" | "progress-even-when-capture-no" (forces '
-        'progress even when capture=no)',
+        "progress even when capture=no)",
         default="progress",
     )
 

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -2213,6 +2213,24 @@ class TestProgressOutputStyle:
         output = pytester.runpytest("--capture=no")
         output.stdout.no_fnmatch_line("*%]*")
 
+    def test_capture_no_progress_enabled(
+        self, many_tests_files, pytester: Pytester
+    ) -> None:
+        pytester.makeini(
+            """
+            [pytest]
+            console_output_style = progress-even-when-capture-no
+        """
+        )
+        output = pytester.runpytest("-s")
+        output.stdout.re_match_lines(
+            [
+                r"test_bar.py \.{10} \s+ \[ 50%\]",
+                r"test_foo.py \.{5} \s+ \[ 75%\]",
+                r"test_foobar.py \.{5} \s+ \[100%\]",
+            ]
+        )
+
 
 class TestProgressWithTeardown:
     """Ensure we show the correct percentages for tests that fail during teardown (#3088)"""


### PR DESCRIPTION
This PR is missing documentation and changelog! It is intended to jumpstart a discussion about the best approach for allowing progress bars when capture=no. The rationale and more background is in https://github.com/pytest-dev/pytest/issues/10737 along with some possible alternative approaches to solve our underlying "lines too long" problem.

I don't love this solution (and the value is a placeholder!), but a separate ini variable or CLI flag is also inelegant since their purpose is to affect the behavior of a combination of `console_output_style` being `progress` and `capture` being set to `no`.