### PR TITLE
Fix OSError in tmpdir on emscripten due to missing getuid()

### DIFF
--- a/changelog/10765.bugfix.rst
+++ b/changelog/10765.bugfix.rst
@@ -1,1 +1,1 @@
-Fix temp_path fixture always raising OSError on emscripten due to missing getuid
+Fixed :fixture:`temp_path` fixture always raising :class:`OSError` on ``emscripten`` platform due to missing :func:`os.getuid`.

--- a/changelog/10765.bugfix.rst
+++ b/changelog/10765.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed :fixture:`temp_path` fixture always raising :class:`OSError` on ``emscripten`` platform due to missing :func:`os.getuid`.
+Fixed :fixture:`tmp_path` fixture always raising :class:`OSError` on ``emscripten`` platform due to missing :func:`os.getuid`.

--- a/changelog/10765.bugfix.rst
+++ b/changelog/10765.bugfix.rst
@@ -1,0 +1,1 @@
+Fix temp_path fixture always raising OSError on emscripten due to missing getuid

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -1,4 +1,6 @@
 """Python version compatibility code."""
+from __future__ import annotations
+
 import dataclasses
 import enum
 import functools
@@ -12,11 +14,8 @@ from typing import Any
 from typing import Callable
 from typing import Generic
 from typing import NoReturn
-from typing import Optional
-from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import TypeVar
-from typing import Union
 
 import py
 
@@ -46,7 +45,7 @@ LEGACY_PATH = py.path. local
 # fmt: on
 
 
-def legacy_path(path: Union[str, "os.PathLike[str]"]) -> LEGACY_PATH:
+def legacy_path(path: str | os.PathLike[str]) -> LEGACY_PATH:
     """Internal wrapper to prepare lazy proxies for legacy_path instances"""
     return LEGACY_PATH(path)
 
@@ -56,7 +55,7 @@ def legacy_path(path: Union[str, "os.PathLike[str]"]) -> LEGACY_PATH:
 # https://www.python.org/dev/peps/pep-0484/#support-for-singleton-types-in-unions
 class NotSetType(enum.Enum):
     token = 0
-NOTSET: "Final" = NotSetType.token  # noqa: E305
+NOTSET: Final = NotSetType.token  # noqa: E305
 # fmt: on
 
 if sys.version_info >= (3, 8):
@@ -94,7 +93,7 @@ def is_async_function(func: object) -> bool:
     return iscoroutinefunction(func) or inspect.isasyncgenfunction(func)
 
 
-def getlocation(function, curdir: Optional[str] = None) -> str:
+def getlocation(function, curdir: str | None = None) -> str:
     function = get_real_func(function)
     fn = Path(inspect.getfile(function))
     lineno = function.__code__.co_firstlineno
@@ -132,8 +131,8 @@ def getfuncargnames(
     *,
     name: str = "",
     is_method: bool = False,
-    cls: Optional[type] = None,
-) -> Tuple[str, ...]:
+    cls: type | None = None,
+) -> tuple[str, ...]:
     """Return the names of a function's mandatory arguments.
 
     Should return the names of all function arguments that:
@@ -197,7 +196,7 @@ def getfuncargnames(
     return arg_names
 
 
-def get_default_arg_names(function: Callable[..., Any]) -> Tuple[str, ...]:
+def get_default_arg_names(function: Callable[..., Any]) -> tuple[str, ...]:
     # Note: this code intentionally mirrors the code at the beginning of
     # getfuncargnames, to get the arguments which were excluded from its result
     # because they had default values.
@@ -228,7 +227,7 @@ def _bytes_to_ascii(val: bytes) -> str:
     return val.decode("ascii", "backslashreplace")
 
 
-def ascii_escaped(val: Union[bytes, str]) -> str:
+def ascii_escaped(val: bytes | str) -> str:
     r"""If val is pure ASCII, return it as an str, otherwise, escape
     bytes objects into a sequence of escaped bytes:
 
@@ -355,7 +354,6 @@ else:
 if sys.version_info >= (3, 8):
     from functools import cached_property as cached_property
 else:
-    from typing import Type
 
     class cached_property(Generic[_S, _T]):
         __slots__ = ("func", "__doc__")
@@ -366,12 +364,12 @@ else:
 
         @overload
         def __get__(
-            self, instance: None, owner: Optional[Type[_S]] = ...
-        ) -> "cached_property[_S, _T]":
+            self, instance: None, owner: type[_S] | None = ...
+        ) -> cached_property[_S, _T]:
             ...
 
         @overload
-        def __get__(self, instance: _S, owner: Optional[Type[_S]] = ...) -> _T:
+        def __get__(self, instance: _S, owner: type[_S] | None = ...) -> _T:
             ...
 
         def __get__(self, instance, owner=None):
@@ -379,6 +377,18 @@ else:
                 return self
             value = instance.__dict__[self.func.__name__] = self.func(instance)
             return value
+
+
+def get_user_id() -> int | None:
+    """Return the current user id, or None if we cannot get it reliably on the current platform."""
+    # win32 does not have a getuid() function.
+    # On Emscripten, getuid() is a stub that always returns 0.
+    if sys.platform in ("win32", "emscripten"):
+        return None
+    # getuid shouldn't fail, but cpython defines such a case.
+    # Let's hope for the best.
+    uid = os.getuid()
+    return uid if uid != -1 else None
 
 
 # Perform exhaustiveness checking.

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -176,7 +176,7 @@ class TempPathFactory:
             # Also, to keep things private, fixup any world-readable temp
             # rootdir's permissions. Historically 0o755 was used, so we can't
             # just error out on this, at least for a while.
-            if sys.platform != "win32":
+            if sys.platform != "win32" and sys.platform != "emscripten":
                 uid = os.getuid()
                 rootdir_stat = rootdir.stat()
                 # getuid shouldn't fail, but cpython defines such a case.


### PR DESCRIPTION
Emscripten defines `getuid()` as a stub that always returns 0.  This change is necessary for our unit testing suite to pass under node.js.

Have no need to be added to AUTHORS for such a trivial change.

Closes #10765