### PR TITLE
Normalize how changelog entries are written

### DIFF
--- a/changelog/10533.bugfix.rst
+++ b/changelog/10533.bugfix.rst
@@ -1,1 +1,1 @@
-Fix :func:`pytest.approx` handling of dictionaries containing one or more values of `0.0` in class ApproxMapping.
+Fixed :func:`pytest.approx` handling of dictionaries containing one or more values of `0.0`.

--- a/changelog/10597.bugfix.rst
+++ b/changelog/10597.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug where a fixture method named ``teardown`` would be called as part of ``nose`` teardown stage.
+Fixed bug where a fixture method named ``teardown`` would be called as part of ``nose`` teardown stage.

--- a/changelog/10626.bugfix.rst
+++ b/changelog/10626.bugfix.rst
@@ -1,1 +1,1 @@
-Fix crash if ``--fixtures`` and ``--help`` are passed at the same time.
+Fixed crash if ``--fixtures`` and ``--help`` are passed at the same time.

--- a/changelog/10660.bugfix.rst
+++ b/changelog/10660.bugfix.rst
@@ -1,2 +1,2 @@
-Fix :py:func:`pytest.raises` to return a 'ContextManager' so that type-checkers could narrow
+Fixed :py:func:`pytest.raises` to return a 'ContextManager' so that type-checkers could narrow
 :code:`pytest.raises(...) if ... else nullcontext()` down to 'ContextManager' rather than 'object'.

--- a/changelog/10753.doc.rst
+++ b/changelog/10753.doc.rst
@@ -1,2 +1,2 @@
-Change wording of the module level skip to be very explicit
-about not collecting and not executing the rest of the module.
+Changed wording of the module level skip to be very explicit
+about not collecting tests and not executing the rest of the module.


### PR DESCRIPTION
Went over all changelog entries making sure they follow our guidelines as written at:

https://github.com/pytest-dev/pytest/blob/88c9e92258a15697c4f125ea1b930856ebe2975f/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L18-L21

