### PR TITLE
Fix test_cmdline_python_namespace_package

### DIFF
--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -693,7 +693,14 @@ class TestInvocationVariants:
 
         # mixed module and filenames:
         monkeypatch.chdir("world")
-        result = pytester.runpytest("--pyargs", "-v", "ns_pkg.hello", "ns_pkg/world")
+
+        # pgk_resources.declare_namespace has been deprecated in favor of implicit namespace packages.
+        # While we could change the test to use implicit namespace packages, seems better
+        # to still ensure the old declaration via declare_namespace still works.
+        ignore_w = r"-Wignore:Deprecated call to `pkg_resources.declare_namespace"
+        result = pytester.runpytest(
+            "--pyargs", "-v", "ns_pkg.hello", "ns_pkg/world", ignore_w
+        )
         assert result.ret == 0
         result.stdout.fnmatch_lines(
             [

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -425,6 +425,9 @@ def test_context_classmethod() -> None:
     assert A.x == 1
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Deprecated call to `pkg_resources.declare_namespace"
+)
 def test_syspath_prepend_with_namespace_packages(
     pytester: Pytester, monkeypatch: MonkeyPatch
 ) -> None:


### PR DESCRIPTION
`pgk_resources.declare_namespace` has been deprecated, so added an ignore warnings option to the test.
