### PR TITLE
Remove ignoring SkipTest during collection.

### DIFF
--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -375,10 +375,6 @@ def pytest_make_collect_report(collector: Collector) -> CollectReport:
         outcome: Literal["passed", "skipped", "failed"] = "passed"
     else:
         skip_exceptions = [Skipped]
-        unittest = sys.modules.get("unittest")
-        if unittest is not None:
-            # Type ignored because unittest is loaded dynamically.
-            skip_exceptions.append(unittest.SkipTest)  # type: ignore
         if isinstance(call.excinfo.value, tuple(skip_exceptions)):
             outcome = "skipped"
             r_ = collector._repr_failure_py(call.excinfo, "line")

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -345,7 +345,7 @@ def test_SkipTest_during_collection(pytester: Pytester) -> None:
         """
     )
     result = pytester.runpytest(p)
-    result.assert_outcomes(skipped=1, warnings=0)
+    result.assert_outcomes(errors=1, skipped=0, warnings=0)
 
 
 def test_SkipTest_in_test(pytester: Pytester) -> None:

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1562,6 +1562,6 @@ def test_raising_unittest_skiptest_during_collection(
     passed, skipped, failed = reprec.countoutcomes()
     assert passed == 0
     # Unittest reports one fake test for a skipped module.
-    assert skipped == 1
-    assert failed == 0
-    assert reprec.ret == ExitCode.NO_TESTS_COLLECTED
+    assert skipped == 0
+    assert failed == 1
+    assert reprec.ret == ExitCode.INTERRUPTED


### PR DESCRIPTION
Addresses #10821

Now it will raise an error and failure during collection instead of skipping making it similar with the actual unittest behaviour.

