### PR TITLE
Fail gracefully when line number is out-of-bounds and negative

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -163,6 +163,7 @@ Ionuț Turturică
 Itxaso Aizpurua
 Iwan Briquemont
 Jaap Broekhuizen
+Jake VanderPlas
 Jakob van Santen
 Jakub Mitoraj
 James Bourbeau

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -743,7 +743,7 @@ class FormattedExcinfo:
     ) -> List[str]:
         """Return formatted and marked up source lines."""
         lines = []
-        if source is None or line_index >= len(source.lines):
+        if source is None or line_index >= len(source.lines) or line_index < -len(source.lines):
             source = Source("???")
             line_index = 0
         if line_index < 0:

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -743,7 +743,11 @@ class FormattedExcinfo:
     ) -> List[str]:
         """Return formatted and marked up source lines."""
         lines = []
-        if source is None or line_index >= len(source.lines) or line_index < -len(source.lines):
+        if (
+            source is None
+            or line_index >= len(source.lines)
+            or line_index < -len(source.lines)
+        ):
             source = Source("???")
             line_index = 0
         if line_index < 0:

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -461,6 +461,24 @@ class TestFormattedExcinfo:
         assert lines[0] == "|   def f(x):"
         assert lines[1] == "        pass"
 
+    def test_repr_source_out_of_bounds(self):
+        pr = FormattedExcinfo()
+        source = _pytest._code.Source(
+            """\
+            def f(x):
+                pass
+            """
+        ).strip()
+        pr.flow_marker = "|"  # type: ignore[misc]
+
+        lines = pr.get_source(source, 100)
+        assert len(lines) == 1
+        assert lines[0] == "|   ???"
+
+        lines = pr.get_source(source, -100)
+        assert len(lines) == 1
+        assert lines[0] == "|   ???"
+
     def test_repr_source_excinfo(self) -> None:
         """Check if indentation is right."""
         try:


### PR DESCRIPTION
This fixes an issue I ran into that is similar to #752.

I don't have a self-contained repro for this failure, but an example of the failure is in the nightly CI for the JAX project: https://github.com/google/jax/actions/runs/4607513902/jobs/8142126075. The last few lines of the traceback looks like this:
```
INTERNALERROR> E                 reprtraceback = self.repr_traceback(excinfo_)
INTERNALERROR> E                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.11.2/x64/lib/python3.11/site-packages/_pytest/_code/code.py", line 871, in repr_traceback
INTERNALERROR> E                 reprentry = self.repr_traceback_entry(entry, einfo)
INTERNALERROR> E                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.11.2/x64/lib/python3.11/site-packages/_pytest/_code/code.py", line 822, in repr_traceback_entry
INTERNALERROR> E                 s = self.get_source(source, line_index, excinfo, short=short)
INTERNALERROR> E                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR> E               File "/opt/hostedtoolcache/Python/3.11.2/x64/lib/python3.11/site-packages/_pytest/_code/code.py", line 751, in get_source
INTERNALERROR> E                 lines.append(space_prefix + source.lines[line_index].strip())
INTERNALERROR> E                                             ~~~~~~~~~~~~^^^^^^^^^^^^
INTERNALERROR> E             IndexError: list index out of range
```
Reading through the source, I see that positive out-of-bound indices are already handled gracefully: https://github.com/pytest-dev/pytest/blob/31d0b51039fc295dfb14bfc5d2baddebe11bb746/src/_pytest/_code/code.py#L746-L748
Given this, I suspect the only possible way to hit the error I'm seeing is if the list index is out of range and negative.