### PR TITLE
tox: remove `dataclasses` dependency from `regen`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -100,7 +100,6 @@ basepython = python3
 passenv =
     SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTEST
 deps =
-    dataclasses
     PyYAML
     regendoc>=0.8.1
     sphinx


### PR DESCRIPTION
This dep is not needed on newer Pythons.