### PR TITLE
code: drop Experimental API label from ExceptionInfo.from_exc_info

### DIFF
--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -476,10 +476,6 @@ class ExceptionInfo(Generic[E]):
     ) -> "ExceptionInfo[E]":
         """Return an ExceptionInfo for an existing exc_info tuple.
 
-        .. warning::
-
-            Experimental API
-
         :param exprinfo:
             A text string helping to determine if we should strip
             ``AssertionError`` from the output. Defaults to the exception


### PR DESCRIPTION
This API is OK, I don't think we're going to change something about it at this point.