### PR TITLE
code: add `ExceptionInfo.from_exception`

### DIFF
--- a/changelog/10901.feature.rst
+++ b/changelog/10901.feature.rst
@@ -1,0 +1,2 @@
+Added :func:`ExceptionInfo.from_exception() <pytest.ExceptionInfo.from_exception>`, a simpler way to create an :class:`~pytest.ExceptionInfo` from an exception.
+This can replace :func:`ExceptionInfo.from_exc_info() <pytest.ExceptionInfo.from_exc_info()>` for most uses.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -950,11 +950,7 @@ def raises(  # noqa: F811
         try:
             func(*args[1:], **kwargs)
         except expected_exception as e:
-            # We just caught the exception - there is a traceback.
-            assert e.__traceback__ is not None
-            return _pytest._code.ExceptionInfo.from_exc_info(
-                (type(e), e, e.__traceback__)
-            )
+            return _pytest._code.ExceptionInfo.from_exception(e)
     fail(message)
 
 

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -53,6 +53,20 @@ def test_excinfo_from_exc_info_simple() -> None:
     assert info.type == ValueError
 
 
+def test_excinfo_from_exception_simple() -> None:
+    try:
+        raise ValueError
+    except ValueError as e:
+        assert e.__traceback__ is not None
+        info = _pytest._code.ExceptionInfo.from_exception(e)
+    assert info.type == ValueError
+
+
+def test_excinfo_from_exception_missing_traceback_assertion() -> None:
+    with pytest.raises(AssertionError, match=r"must have.*__traceback__"):
+        _pytest._code.ExceptionInfo.from_exception(ValueError())
+
+
 def test_excinfo_getstatement():
     def g():
         raise ValueError


### PR DESCRIPTION
The old-style `sys.exc_info()` triplet is redundant nowadays with `(type(exc), exc, exc.__traceback__)`, and is beginning to get soft-deprecated in Python 3.12.

Add a nicer API to ExceptionInfo which takes just the exc instead of the triplet. There are already a few internal uses which benefit.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
