### PR TITLE
code: handle repr'ing empty tracebacks gracefully

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -128,6 +128,7 @@ Erik M. Bray
 Evan Kepner
 Fabien Zarifian
 Fabio Zadrozny
+Felix Hofstätter
 Felix Nieuwenhuizen
 Feng Ma
 Florian Bruhin

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -452,10 +452,7 @@ class Node(metaclass=NodeMeta):
         if self.config.getoption("fulltrace", False):
             style = "long"
         else:
-            tb = _pytest._code.Traceback([excinfo.traceback[-1]])
             self._prunetraceback(excinfo)
-            if len(excinfo.traceback) == 0:
-                excinfo.traceback = tb
             if style == "auto":
                 style = "long"
         # XXX should excinfo.getrepr record all data and toterminal() process it?

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -347,6 +347,9 @@ class TestReport(BaseReport):
             elif isinstance(excinfo.value, skip.Exception):
                 outcome = "skipped"
                 r = excinfo._getreprcrash()
+                assert (
+                    r is not None
+                ), "There should always be a traceback entry for skipping a test."
                 if excinfo.value._use_item_location:
                     path, line = item.reportinfo()[:2]
                     assert line is not None


### PR DESCRIPTION
By "empty traceback" I mean a traceback all of whose entries have been filtered/cut/pruned out.

Currently, if an empty traceback needs to be repr'ed, the last entry before the filtering is used instead (added in
accd962c9f88dbd5b2b0eef6efe7bf6fe5444b29).

Showing a hidden frame is not so good IMO. This commit does the following instead:

1. Shows details of the exception.
2. Shows a message about how the full trace can be seen.

Example:

```
_____________ test _____________

E   ZeroDivisionError: division by zero
All traceback entries are hidden. Pass `--full-trace` to see hidden and internal frames.
```

Also handles `--tb=native`, though there the `--full-trace` bit is not shown.

This commit contains some pieces from
431ec6d34ef99d80f90b330876ed6231144a3ce7 (which has been reverted).

Helps towards fixing issue #1904.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
