### PR TITLE
Fix tmp_path regression introduced in 7.3.0

### DIFF
--- a/changelog/10896.bugfix.rst
+++ b/changelog/10896.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed performance regression related to :fixture:`tmp_path` and the new :confval:`tmp_path_retention_policy` option.

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -353,7 +353,7 @@ def cleanup_candidates(root: Path, prefix: str, keep: int) -> Iterator[Path]:
             yield path
 
 
-def cleanup_dead_symlink(root: Path):
+def cleanup_dead_symlinks(root: Path):
     for left_dir in root.iterdir():
         if left_dir.is_symlink():
             if not left_dir.resolve().exists():
@@ -371,7 +371,7 @@ def cleanup_numbered_dir(
     for path in root.glob("garbage-*"):
         try_cleanup(path, consider_lock_dead_if_created_before)
 
-    cleanup_dead_symlink(root)
+    cleanup_dead_symlinks(root)
 
 
 def make_numbered_dir_with_cleanup(

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -309,7 +309,7 @@ def pytest_sessionfinish(session, exitstatus: Union[int, ExitCode]):
             # We do a "best effort" to remove files, but it might not be possible due to some leaked resource,
             # permissions, etc, in which case we ignore it.
             rmtree(passed_dir, ignore_errors=True)
-    
+
     # Remove dead symlinks.
     cleanup_dead_symlinks(basetemp)
 

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -299,20 +299,19 @@ def pytest_sessionfinish(session, exitstatus: Union[int, ExitCode]):
     if basetemp is None:
         return
 
-    # Remove dead symlinks.
-    cleanup_dead_symlinks(basetemp)
-
     policy = tmp_path_factory._retention_policy
     if (
         exitstatus == 0
         and policy == "failed"
         and tmp_path_factory._given_basetemp is None
     ):
-        passed_dir = basetemp
-        if passed_dir.exists():
+        if basetemp.exists():
             # We do a "best effort" to remove files, but it might not be possible due to some leaked resource,
             # permissions, etc, in which case we ignore it.
             rmtree(passed_dir, ignore_errors=True)
+    
+    # Remove dead symlinks.
+    cleanup_dead_symlinks(basetemp)
 
 
 @hookimpl(tryfirst=True, hookwrapper=True)

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -305,14 +305,14 @@ def pytest_sessionfinish(session, exitstatus: Union[int, ExitCode]):
         and policy == "failed"
         and tmp_path_factory._given_basetemp is None
     ):
-        if basetemp.exists():
+        if basetemp.is_dir():
             # We do a "best effort" to remove files, but it might not be possible due to some leaked resource,
             # permissions, etc, in which case we ignore it.
             rmtree(basetemp, ignore_errors=True)
-            return
 
     # Remove dead symlinks.
-    cleanup_dead_symlinks(basetemp)
+    if basetemp.is_dir():
+        cleanup_dead_symlinks(basetemp)
 
 
 @hookimpl(tryfirst=True, hookwrapper=True)

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -309,6 +309,7 @@ def pytest_sessionfinish(session, exitstatus: Union[int, ExitCode]):
             # We do a "best effort" to remove files, but it might not be possible due to some leaked resource,
             # permissions, etc, in which case we ignore it.
             rmtree(passed_dir, ignore_errors=True)
+            return
 
     # Remove dead symlinks.
     cleanup_dead_symlinks(basetemp)

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -308,7 +308,7 @@ def pytest_sessionfinish(session, exitstatus: Union[int, ExitCode]):
         if basetemp.exists():
             # We do a "best effort" to remove files, but it might not be possible due to some leaked resource,
             # permissions, etc, in which case we ignore it.
-            rmtree(passed_dir, ignore_errors=True)
+            rmtree(basetemp, ignore_errors=True)
             return
 
     # Remove dead symlinks.


### PR DESCRIPTION
The problem is that we would loop over all directories of the basetemp directory searching for dead symlinks, for each test, which would compound over the test session run.

Doing the cleanup just once, at the end of the session, fixes the problem.

Fix #10896
