### PR TITLE
testing: remove usages of testdir that sneaked back in

### DIFF
--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1299,12 +1299,12 @@ def test_no_brokenpipeerror_message(pytester: Pytester) -> None:
     popen.stderr.close()
 
 
-def test_function_return_non_none_warning(testdir) -> None:
-    testdir.makepyfile(
+def test_function_return_non_none_warning(pytester: Pytester) -> None:
+    pytester.makepyfile(
         """
         def test_stuff():
             return "something"
     """
     )
-    res = testdir.runpytest()
+    res = pytester.runpytest()
     res.stdout.fnmatch_lines(["*Did you mean to use `assert` instead of `return`?*"])

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1167,8 +1167,8 @@ def test_log_file_cli_subdirectories_are_successfully_created(
     assert result.ret == ExitCode.OK
 
 
-def test_disable_loggers(testdir):
-    testdir.makepyfile(
+def test_disable_loggers(pytester: Pytester) -> None:
+    pytester.makepyfile(
         """
         import logging
         import os
@@ -1181,13 +1181,13 @@ def test_disable_loggers(testdir):
                 assert caplog.record_tuples == [('test', 10, 'Visible text!')]
          """
     )
-    result = testdir.runpytest("--log-disable=disabled", "-s")
+    result = pytester.runpytest("--log-disable=disabled", "-s")
     assert result.ret == ExitCode.OK
     assert not result.stderr.lines
 
 
-def test_disable_loggers_does_not_propagate(testdir):
-    testdir.makepyfile(
+def test_disable_loggers_does_not_propagate(pytester: Pytester) -> None:
+    pytester.makepyfile(
         """
     import logging
     import os
@@ -1205,13 +1205,13 @@ def test_disable_loggers_does_not_propagate(testdir):
     """
     )
 
-    result = testdir.runpytest("--log-disable=parent.child", "-s")
+    result = pytester.runpytest("--log-disable=parent.child", "-s")
     assert result.ret == ExitCode.OK
     assert not result.stderr.lines
 
 
-def test_log_disabling_works_with_log_cli(testdir):
-    testdir.makepyfile(
+def test_log_disabling_works_with_log_cli(pytester: Pytester) -> None:
+    pytester.makepyfile(
         """
     import logging
     disabled_log = logging.getLogger('disabled')
@@ -1222,7 +1222,7 @@ def test_log_disabling_works_with_log_cli(testdir):
         disabled_log.warning("This string will be suppressed.")
     """
     )
-    result = testdir.runpytest(
+    result = pytester.runpytest(
         "--log-cli-level=DEBUG",
         "--log-disable=disabled",
     )


### PR DESCRIPTION
Since we've replaced all uses of testdir with pytester, a few were added back.