### PR TITLE
Fix hidden traceback entries of chained exceptions getting shown

### DIFF
--- a/changelog/1904.bugfix.rst
+++ b/changelog/1904.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed traceback entries hidden with ``__tracebackhide__ = True`` still being shown for chained exceptions (parts after "... the above exception ..." message).

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -49,6 +49,7 @@ from _pytest.pathlib import absolutepath
 from _pytest.pathlib import bestrelpath
 
 if TYPE_CHECKING:
+    from typing_extensions import Final
     from typing_extensions import Literal
     from typing_extensions import SupportsIndex
 
@@ -197,17 +198,19 @@ class TracebackEntry:
     def __init__(
         self,
         rawentry: TracebackType,
+        repr_style: Optional['Literal["short", "long"]'] = None,
     ) -> None:
-        self._rawentry = rawentry
-        self._repr_style: Optional['Literal["short", "long"]'] = None
+        self._rawentry: "Final" = rawentry
+        self._repr_style: "Final" = repr_style
+
+    def with_repr_style(
+        self, repr_style: Optional['Literal["short", "long"]']
+    ) -> "TracebackEntry":
+        return TracebackEntry(self._rawentry, repr_style)
 
     @property
     def lineno(self) -> int:
         return self._rawentry.tb_lineno - 1
-
-    def set_repr_style(self, mode: "Literal['short', 'long']") -> None:
-        assert mode in ("short", "long")
-        self._repr_style = mode
 
     @property
     def frame(self) -> Frame:

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -560,7 +560,7 @@ class Collector(Node):
             ntraceback = traceback.cut(path=self.path)
             if ntraceback == traceback:
                 ntraceback = ntraceback.cut(excludepath=tracebackcutdir)
-            excinfo.traceback = ntraceback.filter()
+            excinfo.traceback = ntraceback.filter(excinfo)
 
 
 def _check_initialpaths_for_relpath(session: "Session", path: Path) -> Optional[str]:

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -450,10 +450,13 @@ class Node(metaclass=NodeMeta):
                 style = "value"
         if isinstance(excinfo.value, FixtureLookupError):
             return excinfo.value.formatrepr()
+
+        tbfilter: Union[bool, Callable[[ExceptionInfo[BaseException]], Traceback]]
         if self.config.getoption("fulltrace", False):
             style = "long"
+            tbfilter = False
         else:
-            excinfo.traceback = self._traceback_filter(excinfo)
+            tbfilter = self._traceback_filter
             if style == "auto":
                 style = "long"
         # XXX should excinfo.getrepr record all data and toterminal() process it?
@@ -484,7 +487,7 @@ class Node(metaclass=NodeMeta):
             abspath=abspath,
             showlocals=self.config.getoption("showlocals", False),
             style=style,
-            tbfilter=False,  # pruned already, or in --fulltrace mode.
+            tbfilter=tbfilter,
             truncate_locals=truncate_locals,
         )
 

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -22,6 +22,7 @@ import _pytest._code
 from _pytest._code import getfslineno
 from _pytest._code.code import ExceptionInfo
 from _pytest._code.code import TerminalRepr
+from _pytest._code.code import Traceback
 from _pytest.compat import cached_property
 from _pytest.compat import LEGACY_PATH
 from _pytest.config import Config
@@ -432,8 +433,8 @@ class Node(metaclass=NodeMeta):
         assert current is None or isinstance(current, cls)
         return current
 
-    def _prunetraceback(self, excinfo: ExceptionInfo[BaseException]) -> None:
-        pass
+    def _traceback_filter(self, excinfo: ExceptionInfo[BaseException]) -> Traceback:
+        return excinfo.traceback
 
     def _repr_failure_py(
         self,
@@ -452,7 +453,7 @@ class Node(metaclass=NodeMeta):
         if self.config.getoption("fulltrace", False):
             style = "long"
         else:
-            self._prunetraceback(excinfo)
+            excinfo.traceback = self._traceback_filter(excinfo)
             if style == "auto":
                 style = "long"
         # XXX should excinfo.getrepr record all data and toterminal() process it?
@@ -554,13 +555,14 @@ class Collector(Node):
 
         return self._repr_failure_py(excinfo, style=tbstyle)
 
-    def _prunetraceback(self, excinfo: ExceptionInfo[BaseException]) -> None:
+    def _traceback_filter(self, excinfo: ExceptionInfo[BaseException]) -> Traceback:
         if hasattr(self, "path"):
             traceback = excinfo.traceback
             ntraceback = traceback.cut(path=self.path)
             if ntraceback == traceback:
                 ntraceback = ntraceback.cut(excludepath=tracebackcutdir)
-            excinfo.traceback = ntraceback.filter(excinfo)
+            return excinfo.traceback.filter(excinfo)
+        return excinfo.traceback
 
 
 def _check_initialpaths_for_relpath(session: "Session", path: Path) -> Optional[str]:

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1814,7 +1814,7 @@ class Function(PyobjMixin, nodes.Item):
                     if not ntraceback:
                         ntraceback = traceback
 
-            excinfo.traceback = ntraceback.filter()
+            excinfo.traceback = ntraceback.filter(excinfo)
             # issue364: mark all but first and last frames to
             # only show a single-line message for each frame.
             if self.config.getoption("tbstyle", "auto") == "auto":

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1802,7 +1802,7 @@ class Function(PyobjMixin, nodes.Item):
     def setup(self) -> None:
         self._request._fillfixtures()
 
-    def _prunetraceback(self, excinfo: ExceptionInfo[BaseException]) -> None:
+    def _traceback_filter(self, excinfo: ExceptionInfo[BaseException]) -> Traceback:
         if hasattr(self, "_obj") and not self.config.getoption("fulltrace", False):
             code = _pytest._code.Code.from_function(get_real_func(self.obj))
             path, firstlineno = code.path, code.firstlineno
@@ -1814,18 +1814,21 @@ class Function(PyobjMixin, nodes.Item):
                     ntraceback = ntraceback.filter(filter_traceback)
                     if not ntraceback:
                         ntraceback = traceback
+            ntraceback = ntraceback.filter(excinfo)
 
-            excinfo.traceback = ntraceback.filter(excinfo)
             # issue364: mark all but first and last frames to
             # only show a single-line message for each frame.
             if self.config.getoption("tbstyle", "auto") == "auto":
-                if len(excinfo.traceback) > 2:
-                    excinfo.traceback = Traceback(
+                if len(ntraceback) > 2:
+                    ntraceback = Traceback(
                         entry
-                        if i == 0 or i == len(excinfo.traceback) - 1
+                        if i == 0 or i == len(ntraceback) - 1
                         else entry.with_repr_style("short")
-                        for i, entry in enumerate(excinfo.traceback)
+                        for i, entry in enumerate(ntraceback)
                     )
+
+            return ntraceback
+        return excinfo.traceback
 
     # TODO: Type ignored -- breaks Liskov Substitution.
     def repr_failure(  # type: ignore[override]

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -35,6 +35,7 @@ from _pytest._code import filter_traceback
 from _pytest._code import getfslineno
 from _pytest._code.code import ExceptionInfo
 from _pytest._code.code import TerminalRepr
+from _pytest._code.code import Traceback
 from _pytest._io import TerminalWriter
 from _pytest._io.saferepr import saferepr
 from _pytest.compat import ascii_escaped
@@ -1819,8 +1820,12 @@ class Function(PyobjMixin, nodes.Item):
             # only show a single-line message for each frame.
             if self.config.getoption("tbstyle", "auto") == "auto":
                 if len(excinfo.traceback) > 2:
-                    for entry in excinfo.traceback[1:-1]:
-                        entry.set_repr_style("short")
+                    excinfo.traceback = Traceback(
+                        entry
+                        if i == 0 or i == len(excinfo.traceback) - 1
+                        else entry.with_repr_style("short")
+                        for i, entry in enumerate(excinfo.traceback)
+                    )
 
     # TODO: Type ignored -- breaks Liskov Substitution.
     def repr_failure(  # type: ignore[override]

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -334,15 +334,16 @@ class TestCaseFunction(Function):
             finally:
                 delattr(self._testcase, self.name)
 
-    def _prunetraceback(
+    def _traceback_filter(
         self, excinfo: _pytest._code.ExceptionInfo[BaseException]
-    ) -> None:
-        super()._prunetraceback(excinfo)
-        traceback = excinfo.traceback.filter(
+    ) -> _pytest._code.Traceback:
+        traceback = super()._traceback_filter(excinfo)
+        ntraceback = traceback.filter(
             lambda x: not x.frame.f_globals.get("__unittest"),
         )
-        if traceback:
-            excinfo.traceback = traceback
+        if not ntraceback:
+            ntraceback = traceback
+        return ntraceback
 
 
 @hookimpl(tryfirst=True)

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -339,7 +339,7 @@ class TestCaseFunction(Function):
     ) -> None:
         super()._prunetraceback(excinfo)
         traceback = excinfo.traceback.filter(
-            lambda x: not x.frame.f_globals.get("__unittest")
+            lambda x: not x.frame.f_globals.get("__unittest"),
         )
         if traceback:
             excinfo.traceback = traceback

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -1122,8 +1122,10 @@ raise ValueError()
         )
         excinfo = pytest.raises(ValueError, mod.f)
         excinfo.traceback = excinfo.traceback.filter(excinfo)
-        excinfo.traceback[1].set_repr_style("short")
-        excinfo.traceback[2].set_repr_style("short")
+        excinfo.traceback = _pytest._code.Traceback(
+            entry if i not in (1, 2) else entry.with_repr_style("short")
+            for i, entry in enumerate(excinfo.traceback)
+        )
         r = excinfo.getrepr(style="long")
         r.toterminal(tw_mock)
         for line in tw_mock.lines:

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -11,7 +11,7 @@ from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import Union
 
-import _pytest
+import _pytest._code
 import pytest
 from _pytest._code.code import ExceptionChainRepr
 from _pytest._code.code import ExceptionInfo
@@ -290,7 +290,7 @@ class TestTraceback_f_g_h:
         excinfo = pytest.raises(ValueError, fail)
         assert excinfo.traceback.recursionindex() is None
 
-    def test_traceback_getcrashentry(self):
+    def test_getreprcrash(self):
         def i():
             __tracebackhide__ = True
             raise ValueError
@@ -306,15 +306,13 @@ class TestTraceback_f_g_h:
             g()
 
         excinfo = pytest.raises(ValueError, f)
-        tb = excinfo.traceback
-        entry = tb.getcrashentry(excinfo)
-        assert entry is not None
+        reprcrash = excinfo._getreprcrash()
+        assert reprcrash is not None
         co = _pytest._code.Code.from_function(h)
-        assert entry.frame.code.path == co.path
-        assert entry.lineno == co.firstlineno + 1
-        assert entry.frame.code.name == "h"
+        assert reprcrash.path == str(co.path)
+        assert reprcrash.lineno == co.firstlineno + 1 + 1
 
-    def test_traceback_getcrashentry_empty(self):
+    def test_getreprcrash_empty(self):
         def g():
             __tracebackhide__ = True
             raise ValueError
@@ -324,7 +322,7 @@ class TestTraceback_f_g_h:
             g()
 
         excinfo = pytest.raises(ValueError, f)
-        assert excinfo.traceback.getcrashentry(excinfo) is None
+        assert excinfo._getreprcrash() is None
 
 
 def test_excinfo_exconly():

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -186,7 +186,7 @@ class TestTraceback_f_g_h:
 
     def test_traceback_filter(self):
         traceback = self.excinfo.traceback
-        ntraceback = traceback.filter()
+        ntraceback = traceback.filter(self.excinfo)
         assert len(ntraceback) == len(traceback) - 1
 
     @pytest.mark.parametrize(
@@ -217,7 +217,7 @@ class TestTraceback_f_g_h:
 
         excinfo = pytest.raises(ValueError, h)
         traceback = excinfo.traceback
-        ntraceback = traceback.filter()
+        ntraceback = traceback.filter(excinfo)
         print(f"old: {traceback!r}")
         print(f"new: {ntraceback!r}")
 
@@ -307,7 +307,7 @@ class TestTraceback_f_g_h:
 
         excinfo = pytest.raises(ValueError, f)
         tb = excinfo.traceback
-        entry = tb.getcrashentry()
+        entry = tb.getcrashentry(excinfo)
         assert entry is not None
         co = _pytest._code.Code.from_function(h)
         assert entry.frame.code.path == co.path
@@ -324,7 +324,7 @@ class TestTraceback_f_g_h:
             g()
 
         excinfo = pytest.raises(ValueError, f)
-        assert excinfo.traceback.getcrashentry() is None
+        assert excinfo.traceback.getcrashentry(excinfo) is None
 
 
 def test_excinfo_exconly():
@@ -626,7 +626,7 @@ raise ValueError()
         """
         )
         excinfo = pytest.raises(ValueError, mod.func1)
-        excinfo.traceback = excinfo.traceback.filter()
+        excinfo.traceback = excinfo.traceback.filter(excinfo)
         p = FormattedExcinfo()
         reprtb = p.repr_traceback_entry(excinfo.traceback[-1])
 
@@ -659,7 +659,7 @@ raise ValueError()
         """
         )
         excinfo = pytest.raises(ValueError, mod.func1, "m" * 90, 5, 13, "z" * 120)
-        excinfo.traceback = excinfo.traceback.filter()
+        excinfo.traceback = excinfo.traceback.filter(excinfo)
         entry = excinfo.traceback[-1]
         p = FormattedExcinfo(funcargs=True)
         reprfuncargs = p.repr_args(entry)
@@ -686,7 +686,7 @@ raise ValueError()
         """
         )
         excinfo = pytest.raises(ValueError, mod.func1, "a", "b", c="d")
-        excinfo.traceback = excinfo.traceback.filter()
+        excinfo.traceback = excinfo.traceback.filter(excinfo)
         entry = excinfo.traceback[-1]
         p = FormattedExcinfo(funcargs=True)
         reprfuncargs = p.repr_args(entry)
@@ -960,7 +960,7 @@ raise ValueError()
         """
         )
         excinfo = pytest.raises(ValueError, mod.f)
-        excinfo.traceback = excinfo.traceback.filter()
+        excinfo.traceback = excinfo.traceback.filter(excinfo)
         repr = excinfo.getrepr()
         repr.toterminal(tw_mock)
         assert tw_mock.lines[0] == ""
@@ -994,7 +994,7 @@ raise ValueError()
         )
         excinfo = pytest.raises(ValueError, mod.f)
         tmp_path.joinpath("mod.py").unlink()
-        excinfo.traceback = excinfo.traceback.filter()
+        excinfo.traceback = excinfo.traceback.filter(excinfo)
         repr = excinfo.getrepr()
         repr.toterminal(tw_mock)
         assert tw_mock.lines[0] == ""
@@ -1026,7 +1026,7 @@ raise ValueError()
         )
         excinfo = pytest.raises(ValueError, mod.f)
         tmp_path.joinpath("mod.py").write_text("asdf")
-        excinfo.traceback = excinfo.traceback.filter()
+        excinfo.traceback = excinfo.traceback.filter(excinfo)
         repr = excinfo.getrepr()
         repr.toterminal(tw_mock)
         assert tw_mock.lines[0] == ""
@@ -1123,7 +1123,7 @@ raise ValueError()
         """
         )
         excinfo = pytest.raises(ValueError, mod.f)
-        excinfo.traceback = excinfo.traceback.filter()
+        excinfo.traceback = excinfo.traceback.filter(excinfo)
         excinfo.traceback[1].set_repr_style("short")
         excinfo.traceback[2].set_repr_style("short")
         r = excinfo.getrepr(style="long")
@@ -1391,7 +1391,7 @@ raise ValueError()
         with pytest.raises(TypeError) as excinfo:
             mod.f()
         # previously crashed with `AttributeError: list has no attribute get`
-        excinfo.traceback.filter()
+        excinfo.traceback.filter(excinfo)
 
 
 @pytest.mark.parametrize("style", ["short", "long"])

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -1003,9 +1003,9 @@ class TestTracebackCutting:
         with pytest.raises(pytest.skip.Exception) as excinfo:
             pytest.skip("xxx")
         assert excinfo.traceback[-1].frame.code.name == "skip"
-        assert excinfo.traceback[-1].ishidden()
+        assert excinfo.traceback[-1].ishidden(excinfo)
         assert excinfo.traceback[-2].frame.code.name == "test_skip_simple"
-        assert not excinfo.traceback[-2].ishidden()
+        assert not excinfo.traceback[-2].ishidden(excinfo)
 
     def test_traceback_argsetup(self, pytester: Pytester) -> None:
         pytester.makeconftest(


### PR DESCRIPTION
This PR is my proposal for fixing #1904 (previous attempt 431ec6d34ef99d80f90b330876ed6231144a3ce7 was reverted).

### Root cause analysis

The main entry for rendering the traceback for a test exception is `Node._repr_failure_py`. It takes the excinfo and returns a `TerminalRepr`. Two parts of it are relevant here:

https://github.com/pytest-dev/pytest/blob/4eca6063c8df11a0bb8dbe23745294aa5d5fec67/src/_pytest/nodes.py#L452-L457

This calls the node's `_prunetraceback` method with the excinfo, which then proceeds to filter out internal entries, hide `__tracebackhide__ = True` frames, etc. It modifies the `excinfo` in-place by updating its `excinfo.traceback` field.

https://github.com/pytest-dev/pytest/blob/4eca6063c8df11a0bb8dbe23745294aa5d5fec67/src/_pytest/nodes.py#L481-L488

This calls into the main `FormattedExcinfo` machinery to do the bulk of the work, but passes `tbfilter=False` because it already did the filtering itself, in a `Node`-customizable manner, so doesn't want the generic filtering that `FormattedExcinfo` does.

Next, need to look at how `FormattedExcinfo` handles exception chaining.

https://github.com/pytest-dev/pytest/blob/4eca6063c8df11a0bb8dbe23745294aa5d5fec67/src/_pytest/_code/code.py#L951

It starts with the excinfo it was passed, which is the main exception. It renders it, then checks if it has any chained exceptions (either `__cause__` or `__context__`), and if so, creates an `ExceptionInfo` for them, renders them, and does the same in a loop.

If you've followed closely you see the issue - the main exception got the filtering treatment from the `Node`'s `_prune_traceback` before it was even passed to `FormattedExcinfo`. But the chained `ExceptionInfo`'s are created inside `FormattedExcinfo`, and we've passed `tbfilter=False` so they don't even get the basic filtering.

### Proposed solution

I think it would have been best if the chained `ExceptionInfo` were represented in the `ExceptionInfo` itself, like how base exceptions work. Then the `_prunetraceback` stuff would also prune them before passing to `FormattedExcinfo` and all is well. But this is somewhat difficult to achieve, so I went with something easier but less clean.

Instead of doing the `_prunetraceback` before `FormattedExcinfo`, I allow `tbfilter` to also be a callback in addition to the existing False/True. Then we pass `tbfilter=self._prunetraceback` instead of calling it ourselves and passing `tbfilter=False`. This then causes the chained exceptions to be filtered exactly like the main exception.

### Technical notes

As mentioned above, the `_prunetraceback` mutates the `excinfo` in-place. I really didn't like this behavior for the `tbfilter` callback. So instead, I changed it to be `(ExceptionInfo) -> Traceback`. This breaks the `_prunetraceback` interface, so I renamed it to `_traceback_filter`.

There is also some internal refactoring to make this possible, namely removing the ghastly `WeakReference` cycle which makes `TracebackEntry` know about its `ExceptionInfo`, and also making `TracebackEntry` immutable. These are separate commits.