### PR TITLE
Refactored implementation of `iterparentnodeids` in `nodes`.

### DIFF
--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -66,31 +66,30 @@ def iterparentnodeids(nodeid: str) -> Iterator[str]:
 
     Note that / components are only considered until the first ::.
     """
-    pos = 0
-    first_colons: Optional[int] = nodeid.find("::")
-    if first_colons == -1:
-        first_colons = None
     # The root Session node - always present.
     yield ""
-    # Eagerly consume SEP parts until first colons.
-    while True:
-        at = nodeid.find(SEP, pos, first_colons)
-        if at == -1:
-            break
-        if at > 0:
-            yield nodeid[:at]
-        pos = at + len(SEP)
-    # Eagerly consume :: parts.
-    while True:
-        at = nodeid.find("::", pos)
-        if at == -1:
-            break
-        if at > 0:
-            yield nodeid[:at]
-        pos = at + len("::")
-    # The node ID itself.
-    if nodeid:
+
+    if nodeid == '':
+        return
+
+    if nodeid.startswith('::'):
+        # Weird case of '::x' (no path)
         yield nodeid
+        return
+
+    path, sep, node = nodeid.partition('::')
+
+    sections = path.split(SEP)
+    for i, _ in enumerate(sections, start=1):
+        yield SEP.join(sections[:i])
+
+    if sep == '':
+        # Only a path
+        return
+
+    nodes = node.split('::')
+    for i, _ in enumerate(nodes, start=1):
+        yield '::'.join([path] + nodes[:i])
 
 
 def _check_path(path: Path, fspath: LEGACY_PATH) -> None:

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -69,27 +69,27 @@ def iterparentnodeids(nodeid: str) -> Iterator[str]:
     # The root Session node - always present.
     yield ""
 
-    if nodeid == '':
+    if nodeid == "":
         return
 
-    if nodeid.startswith('::'):
+    if nodeid.startswith("::"):
         # Weird case of '::x' (no path)
         yield nodeid
         return
 
-    path, sep, node = nodeid.partition('::')
+    path, sep, node = nodeid.partition("::")
 
     sections = path.split(SEP)
     for i, _ in enumerate(sections, start=1):
         yield SEP.join(sections[:i])
 
-    if sep == '':
+    if sep == "":
         # Only a path
         return
 
-    nodes = node.split('::')
+    nodes = node.split("::")
     for i, _ in enumerate(nodes, start=1):
-        yield '::'.join([path] + nodes[:i])
+        yield "::".join([path] + nodes[:i])
 
 
 def _check_path(path: Path, fspath: LEGACY_PATH) -> None:


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
Refactored `iterparentnodeids` in the `nodes` module to simplify the implementation and improve readability. 