### PR TITLE
Add 2024 pytest training

### DIFF
--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -1,11 +1,10 @@
 :orphan:
 
-..
-    .. sidebar:: Next Open Trainings
+.. sidebar:: Next Open Trainings
 
-       - `Professional Testing with Python <https://python-academy.com/courses/python_course_testing.html>`_, via `Python Academy <https://www.python-academy.com/>`_, March 7th to 9th 2023 (3 day in-depth training), Remote
+   - `Professional Testing with Python <https://python-academy.com/courses/python_course_testing.html>`_, via `Python Academy <https://www.python-academy.com/>`_, March 5th to 7th 2024 (3 day in-depth training), Remote
 
-       Also see :doc:`previous talks and blogposts <talks>`.
+   Also see :doc:`previous talks and blogposts <talks>`.
 
 .. _features:
 


### PR DESCRIPTION
There we go again! There might be more coming up (submitted to [Europython](https://ep2023.europython.eu/), planning to submit to [Workshoptage](https://workshoptage.ch/), and possibly [enterPy](https://www.enterpy.de/) if it is again), but ironically, the one most in the future is the first one to be definitive :upside_down_face: 