### PR TITLE
Enable `PYTHONWARNDEFAULTENCODING=1` and fix violations

### DIFF
--- a/changelog/7781.bugfix.rst
+++ b/changelog/7781.bugfix.rst
@@ -1,0 +1,1 @@
+Fix writing non-encodable text to log file when using ``--debug``.

--- a/scripts/towncrier-draft-to-file.py
+++ b/scripts/towncrier-draft-to-file.py
@@ -7,7 +7,9 @@ def main():
     Platform agnostic wrapper script for towncrier.
     Fixes the issue (#7251) where windows users are unable to natively run tox -e docs to build pytest docs.
     """
-    with open("doc/en/_changelog_towncrier_draft.rst", "w") as draft_file:
+    with open(
+        "doc/en/_changelog_towncrier_draft.rst", "w", encoding="utf-8"
+    ) as draft_file:
         return call(("towncrier", "--draft"), stdout=draft_file)
 
 

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -105,7 +105,7 @@ def pytest_cmdline_parse():
     if config.option.debug:
         # --debug | --debug <file.log> was provided.
         path = config.option.debug
-        debugfile = open(path, "w")
+        debugfile = open(path, "w", encoding="utf-8")
         debugfile.write(
             "versions pytest-%s, "
             "python-%s\ncwd=%s\nargs=%s\n\n"

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -6,6 +6,7 @@ import collections.abc
 import contextlib
 import gc
 import importlib
+import locale
 import os
 import platform
 import re
@@ -129,6 +130,7 @@ class LsofFdLeakChecker:
             stderr=subprocess.DEVNULL,
             check=True,
             text=True,
+            encoding=locale.getpreferredencoding(False),
         ).stdout
 
         def isopen(line: str) -> bool:

--- a/testing/_py/test_local.py
+++ b/testing/_py/test_local.py
@@ -1,12 +1,22 @@
+import contextlib
 import multiprocessing
 import os
 import sys
 import time
+import warnings
 from unittest import mock
 
 import pytest
 from py import error
 from py.path import local
+
+
+@contextlib.contextmanager
+def ignore_encoding_warning():
+    with warnings.catch_warnings():
+        with contextlib.suppress(NameError):  # new in 3.10
+            warnings.simplefilter("ignore", EncodingWarning)
+        yield
 
 
 class CommonFSTests:
@@ -223,7 +233,8 @@ class CommonFSTests:
         assert not (path1 < path1)
 
     def test_simple_read(self, path1):
-        x = path1.join("samplefile").read("r")
+        with ignore_encoding_warning():
+            x = path1.join("samplefile").read("r")
         assert x == "samplefile\n"
 
     def test_join_div_operator(self, path1):
@@ -265,12 +276,14 @@ class CommonFSTests:
 
     def test_readlines(self, path1):
         fn = path1.join("samplefile")
-        contents = fn.readlines()
+        with ignore_encoding_warning():
+            contents = fn.readlines()
         assert contents == ["samplefile\n"]
 
     def test_readlines_nocr(self, path1):
         fn = path1.join("samplefile")
-        contents = fn.readlines(cr=0)
+        with ignore_encoding_warning():
+            contents = fn.readlines(cr=0)
         assert contents == ["samplefile", ""]
 
     def test_file(self, path1):
@@ -362,8 +375,8 @@ class CommonFSTests:
         initpy.copy(copied)
         try:
             assert copied.check()
-            s1 = initpy.read()
-            s2 = copied.read()
+            s1 = initpy.read_text(encoding="utf-8")
+            s2 = copied.read_text(encoding="utf-8")
             assert s1 == s2
         finally:
             if copied.check():
@@ -376,8 +389,8 @@ class CommonFSTests:
             otherdir.copy(copied)
             assert copied.check(dir=1)
             assert copied.join("__init__.py").check(file=1)
-            s1 = otherdir.join("__init__.py").read()
-            s2 = copied.join("__init__.py").read()
+            s1 = otherdir.join("__init__.py").read_text(encoding="utf-8")
+            s2 = copied.join("__init__.py").read_text(encoding="utf-8")
             assert s1 == s2
         finally:
             if copied.check(dir=1):
@@ -463,13 +476,13 @@ def setuptestfs(path):
         return
     # print "setting up test fs for", repr(path)
     samplefile = path.ensure("samplefile")
-    samplefile.write("samplefile\n")
+    samplefile.write_text("samplefile\n", encoding="utf-8")
 
     execfile = path.ensure("execfile")
-    execfile.write("x=42")
+    execfile.write_text("x=42", encoding="utf-8")
 
     execfilepy = path.ensure("execfile.py")
-    execfilepy.write("x=42")
+    execfilepy.write_text("x=42", encoding="utf-8")
 
     d = {1: 2, "hello": "world", "answer": 42}
     path.ensure("samplepickle").dump(d)
@@ -481,22 +494,24 @@ def setuptestfs(path):
     otherdir.ensure("__init__.py")
 
     module_a = otherdir.ensure("a.py")
-    module_a.write("from .b import stuff as result\n")
+    module_a.write_text("from .b import stuff as result\n", encoding="utf-8")
     module_b = otherdir.ensure("b.py")
-    module_b.write('stuff="got it"\n')
+    module_b.write_text('stuff="got it"\n', encoding="utf-8")
     module_c = otherdir.ensure("c.py")
-    module_c.write(
+    module_c.write_text(
         """import py;
 import otherdir.a
 value = otherdir.a.result
-"""
+""",
+        encoding="utf-8",
     )
     module_d = otherdir.ensure("d.py")
-    module_d.write(
+    module_d.write_text(
         """import py;
 from otherdir import a
 value2 = a.result
-"""
+""",
+        encoding="utf-8",
     )
 
 
@@ -534,9 +549,11 @@ def batch_make_numbered_dirs(rootdir, repeats):
     for i in range(repeats):
         dir_ = local.make_numbered_dir(prefix="repro-", rootdir=rootdir)
         file_ = dir_.join("foo")
-        file_.write("%s" % i)
-        actual = int(file_.read())
-        assert actual == i, f"int(file_.read()) is {actual} instead of {i}"
+        file_.write_text("%s" % i, encoding="utf-8")
+        actual = int(file_.read_text(encoding="utf-8"))
+        assert (
+            actual == i
+        ), f"int(file_.read_text(encoding='utf-8')) is {actual} instead of {i}"
         dir_.join(".lock").remove(ignore_errors=True)
     return True
 
@@ -692,14 +709,14 @@ class TestLocalPath(CommonFSTests):
 
     def test_open_and_ensure(self, path1):
         p = path1.join("sub1", "sub2", "file")
-        with p.open("w", ensure=1) as f:
+        with p.open("w", ensure=1, encoding="utf-8") as f:
             f.write("hello")
-        assert p.read() == "hello"
+        assert p.read_text(encoding="utf-8") == "hello"
 
     def test_write_and_ensure(self, path1):
         p = path1.join("sub1", "sub2", "file")
-        p.write("hello", ensure=1)
-        assert p.read() == "hello"
+        p.write_text("hello", ensure=1, encoding="utf-8")
+        assert p.read_text(encoding="utf-8") == "hello"
 
     @pytest.mark.parametrize("bin", (False, True))
     def test_dump(self, tmpdir, bin):
@@ -770,9 +787,9 @@ class TestLocalPath(CommonFSTests):
         newfile = tmpdir.join("test1", "test")
         newfile.ensure()
         assert newfile.check(file=1)
-        newfile.write("42")
+        newfile.write_text("42", encoding="utf-8")
         newfile.ensure()
-        s = newfile.read()
+        s = newfile.read_text(encoding="utf-8")
         assert s == "42"
 
     def test_ensure_filepath_withoutdir(self, tmpdir):
@@ -806,9 +823,9 @@ class TestLocalPath(CommonFSTests):
         newfilename = "/test" * 60  # type:ignore[unreachable]
         l1 = tmpdir.join(newfilename)
         l1.ensure(file=True)
-        l1.write("foo")
+        l1.write_text("foo", encoding="utf-8")
         l2 = tmpdir.join(newfilename)
-        assert l2.read() == "foo"
+        assert l2.read_text(encoding="utf-8") == "foo"
 
     def test_visit_depth_first(self, tmpdir):
         tmpdir.ensure("a", "1")
@@ -1278,14 +1295,14 @@ class TestPOSIXLocalPath:
     def test_hardlink(self, tmpdir):
         linkpath = tmpdir.join("test")
         filepath = tmpdir.join("file")
-        filepath.write("Hello")
+        filepath.write_text("Hello", encoding="utf-8")
         nlink = filepath.stat().nlink
         linkpath.mklinkto(filepath)
         assert filepath.stat().nlink == nlink + 1
 
     def test_symlink_are_identical(self, tmpdir):
         filepath = tmpdir.join("file")
-        filepath.write("Hello")
+        filepath.write_text("Hello", encoding="utf-8")
         linkpath = tmpdir.join("test")
         linkpath.mksymlinkto(filepath)
         assert linkpath.readlink() == str(filepath)
@@ -1293,7 +1310,7 @@ class TestPOSIXLocalPath:
     def test_symlink_isfile(self, tmpdir):
         linkpath = tmpdir.join("test")
         filepath = tmpdir.join("file")
-        filepath.write("")
+        filepath.write_text("", encoding="utf-8")
         linkpath.mksymlinkto(filepath)
         assert linkpath.check(file=1)
         assert not linkpath.check(link=0, file=1)
@@ -1302,10 +1319,12 @@ class TestPOSIXLocalPath:
     def test_symlink_relative(self, tmpdir):
         linkpath = tmpdir.join("test")
         filepath = tmpdir.join("file")
-        filepath.write("Hello")
+        filepath.write_text("Hello", encoding="utf-8")
         linkpath.mksymlinkto(filepath, absolute=False)
         assert linkpath.readlink() == "file"
-        assert filepath.read() == linkpath.read()
+        assert filepath.read_text(encoding="utf-8") == linkpath.read_text(
+            encoding="utf-8"
+        )
 
     def test_symlink_not_existing(self, tmpdir):
         linkpath = tmpdir.join("testnotexisting")
@@ -1338,7 +1357,7 @@ class TestPOSIXLocalPath:
     def test_realpath_file(self, tmpdir):
         linkpath = tmpdir.join("test")
         filepath = tmpdir.join("file")
-        filepath.write("")
+        filepath.write_text("", encoding="utf-8")
         linkpath.mksymlinkto(filepath)
         realpath = linkpath.realpath()
         assert realpath.basename == "file"
@@ -1383,7 +1402,7 @@ class TestPOSIXLocalPath:
         atime1 = path.atime()
         # we could wait here but timer resolution is very
         # system dependent
-        path.read()
+        path.read_binary()
         time.sleep(ATIME_RESOLUTION)
         atime2 = path.atime()
         time.sleep(ATIME_RESOLUTION)
@@ -1467,7 +1486,7 @@ class TestPOSIXLocalPath:
         test_files = ["a", "b", "c"]
         src = tmpdir.join("src")
         for f in test_files:
-            src.join(f).write(f, ensure=True)
+            src.join(f).write_text(f, ensure=True, encoding="utf-8")
         dst = tmpdir.join("dst")
         # a small delay before the copy
         time.sleep(ATIME_RESOLUTION)
@@ -1521,10 +1540,11 @@ class TestUnicodePy2Py3:
     def test_read_write(self, tmpdir):
         x = tmpdir.join("hello")
         part = "hällo"
-        x.write(part)
-        assert x.read() == part
-        x.write(part.encode(sys.getdefaultencoding()))
-        assert x.read() == part.encode(sys.getdefaultencoding())
+        with ignore_encoding_warning():
+            x.write(part)
+            assert x.read() == part
+            x.write(part.encode(sys.getdefaultencoding()))
+            assert x.read() == part.encode(sys.getdefaultencoding())
 
 
 class TestBinaryAndTextMethods:

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -613,7 +613,7 @@ class TestInvocationVariants:
 
     def test_pyargs_filename_looks_like_module(self, pytester: Pytester) -> None:
         pytester.path.joinpath("conftest.py").touch()
-        pytester.path.joinpath("t.py").write_text("def test(): pass")
+        pytester.path.joinpath("t.py").write_text("def test(): pass", encoding="utf-8")
         result = pytester.runpytest("--pyargs", "t.py")
         assert result.ret == ExitCode.OK
 
@@ -622,8 +622,12 @@ class TestInvocationVariants:
 
         monkeypatch.delenv("PYTHONDONTWRITEBYTECODE", False)
         path = pytester.mkpydir("tpkg")
-        path.joinpath("test_hello.py").write_text("def test_hello(): pass")
-        path.joinpath("test_world.py").write_text("def test_world(): pass")
+        path.joinpath("test_hello.py").write_text(
+            "def test_hello(): pass", encoding="utf-8"
+        )
+        path.joinpath("test_world.py").write_text(
+            "def test_world(): pass", encoding="utf-8"
+        )
         result = pytester.runpytest("--pyargs", "tpkg")
         assert result.ret == 0
         result.stdout.fnmatch_lines(["*2 passed*"])
@@ -662,13 +666,15 @@ class TestInvocationVariants:
             ns = d.joinpath("ns_pkg")
             ns.mkdir()
             ns.joinpath("__init__.py").write_text(
-                "__import__('pkg_resources').declare_namespace(__name__)"
+                "__import__('pkg_resources').declare_namespace(__name__)",
+                encoding="utf-8",
             )
             lib = ns.joinpath(dirname)
             lib.mkdir()
             lib.joinpath("__init__.py").touch()
             lib.joinpath(f"test_{dirname}.py").write_text(
-                f"def test_{dirname}(): pass\ndef test_other():pass"
+                f"def test_{dirname}(): pass\ndef test_other():pass",
+                encoding="utf-8",
             )
 
         # The structure of the test directory is now:
@@ -754,10 +760,10 @@ class TestInvocationVariants:
         lib.mkdir()
         lib.joinpath("__init__.py").touch()
         lib.joinpath("test_bar.py").write_text(
-            "def test_bar(): pass\ndef test_other(a_fixture):pass"
+            "def test_bar(): pass\ndef test_other(a_fixture):pass", encoding="utf-8"
         )
         lib.joinpath("conftest.py").write_text(
-            "import pytest\n@pytest.fixture\ndef a_fixture():pass"
+            "import pytest\n@pytest.fixture\ndef a_fixture():pass", encoding="utf-8"
         )
 
         d_local = pytester.mkdir("symlink_root")
@@ -1276,8 +1282,7 @@ def test_tee_stdio_captures_and_live_prints(pytester: Pytester) -> None:
     result.stderr.fnmatch_lines(["*@this is stderr@*"])
 
     # now ensure the output is in the junitxml
-    with open(pytester.path.joinpath("output.xml")) as f:
-        fullXml = f.read()
+    fullXml = pytester.path.joinpath("output.xml").read_text(encoding="utf-8")
     assert "@this is stdout@\n" in fullXml
     assert "@this is stderr@\n" in fullXml
 

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -267,7 +267,7 @@ class TestGeneralUsage:
     def test_issue109_sibling_conftests_not_loaded(self, pytester: Pytester) -> None:
         sub1 = pytester.mkdir("sub1")
         sub2 = pytester.mkdir("sub2")
-        sub1.joinpath("conftest.py").write_text("assert 0")
+        sub1.joinpath("conftest.py").write_text("assert 0", encoding="utf-8")
         result = pytester.runpytest(sub2)
         assert result.ret == ExitCode.NO_TESTS_COLLECTED
         sub2.joinpath("__init__.py").touch()
@@ -467,7 +467,7 @@ class TestGeneralUsage:
         assert "invalid" in str(excinfo.value)
 
         p = pytester.path.joinpath("test_test_plugins_given_as_strings.py")
-        p.write_text("def test_foo(): pass")
+        p.write_text("def test_foo(): pass", encoding="utf-8")
         mod = types.ModuleType("myplugin")
         monkeypatch.setitem(sys.modules, "myplugin", mod)
         assert pytest.main(args=[str(pytester.path)], plugins=["myplugin"]) == 0
@@ -587,7 +587,7 @@ class TestInvocationVariants:
     def test_pyargs_importerror(self, pytester: Pytester, monkeypatch) -> None:
         monkeypatch.delenv("PYTHONDONTWRITEBYTECODE", False)
         path = pytester.mkpydir("tpkg")
-        path.joinpath("test_hello.py").write_text("raise ImportError")
+        path.joinpath("test_hello.py").write_text("raise ImportError", encoding="utf-8")
 
         result = pytester.runpytest("--pyargs", "tpkg.test_hello", syspathinsert=True)
         assert result.ret != 0
@@ -597,10 +597,10 @@ class TestInvocationVariants:
     def test_pyargs_only_imported_once(self, pytester: Pytester) -> None:
         pkg = pytester.mkpydir("foo")
         pkg.joinpath("test_foo.py").write_text(
-            "print('hello from test_foo')\ndef test(): pass"
+            "print('hello from test_foo')\ndef test(): pass", encoding="utf-8"
         )
         pkg.joinpath("conftest.py").write_text(
-            "def pytest_configure(config): print('configuring')"
+            "def pytest_configure(config): print('configuring')", encoding="utf-8"
         )
 
         result = pytester.runpytest(

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -374,7 +374,7 @@ def test_excinfo_no_sourcecode():
 
 def test_excinfo_no_python_sourcecode(tmp_path: Path) -> None:
     # XXX: simplified locally testable version
-    tmp_path.joinpath("test.txt").write_text("{{ h()}}:")
+    tmp_path.joinpath("test.txt").write_text("{{ h()}}:", encoding="utf-8")
 
     jinja2 = pytest.importorskip("jinja2")
     loader = jinja2.FileSystemLoader(str(tmp_path))
@@ -451,7 +451,7 @@ class TestFormattedExcinfo:
             source = textwrap.dedent(source)
             modpath = tmp_path.joinpath("mod.py")
             tmp_path.joinpath("__init__.py").touch()
-            modpath.write_text(source)
+            modpath.write_text(source, encoding="utf-8")
             importlib.invalidate_caches()
             return import_path(modpath, root=tmp_path)
 
@@ -1023,7 +1023,7 @@ raise ValueError()
         """
         )
         excinfo = pytest.raises(ValueError, mod.f)
-        tmp_path.joinpath("mod.py").write_text("asdf")
+        tmp_path.joinpath("mod.py").write_text("asdf", encoding="utf-8")
         excinfo.traceback = excinfo.traceback.filter(excinfo)
         repr = excinfo.getrepr()
         repr.toterminal(tw_mock)

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -294,7 +294,7 @@ def test_source_of_class_at_eof_without_newline(_sys_snapshot, tmp_path: Path) -
     """
     )
     path = tmp_path.joinpath("a.py")
-    path.write_text(str(source))
+    path.write_text(str(source), encoding="utf-8")
     mod: Any = import_path(path, root=tmp_path)
     s2 = Source(mod.A)
     assert str(source).strip() == str(s2).strip()

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -81,7 +81,7 @@ def test_root_logger_affected(pytester: Pytester) -> None:
     # not the info one, because the default level of the root logger is
     # WARNING.
     assert os.path.isfile(log_file)
-    with open(log_file) as rfh:
+    with open(log_file, encoding="utf-8") as rfh:
         contents = rfh.read()
         assert "info text going to logger" not in contents
         assert "warning text going to logger" in contents
@@ -656,7 +656,7 @@ def test_log_file_cli(pytester: Pytester) -> None:
     # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0
     assert os.path.isfile(log_file)
-    with open(log_file) as rfh:
+    with open(log_file, encoding="utf-8") as rfh:
         contents = rfh.read()
         assert "This log message will be shown" in contents
         assert "This log message won't be shown" not in contents
@@ -687,7 +687,7 @@ def test_log_file_cli_level(pytester: Pytester) -> None:
     # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0
     assert os.path.isfile(log_file)
-    with open(log_file) as rfh:
+    with open(log_file, encoding="utf-8") as rfh:
         contents = rfh.read()
         assert "This log message will be shown" in contents
         assert "This log message won't be shown" not in contents
@@ -738,7 +738,7 @@ def test_log_file_ini(pytester: Pytester) -> None:
     # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0
     assert os.path.isfile(log_file)
-    with open(log_file) as rfh:
+    with open(log_file, encoding="utf-8") as rfh:
         contents = rfh.read()
         assert "This log message will be shown" in contents
         assert "This log message won't be shown" not in contents
@@ -777,7 +777,7 @@ def test_log_file_ini_level(pytester: Pytester) -> None:
     # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0
     assert os.path.isfile(log_file)
-    with open(log_file) as rfh:
+    with open(log_file, encoding="utf-8") as rfh:
         contents = rfh.read()
         assert "This log message will be shown" in contents
         assert "This log message won't be shown" not in contents
@@ -985,7 +985,7 @@ def test_log_in_hooks(pytester: Pytester) -> None:
     )
     result = pytester.runpytest()
     result.stdout.fnmatch_lines(["*sessionstart*", "*runtestloop*", "*sessionfinish*"])
-    with open(log_file) as rfh:
+    with open(log_file, encoding="utf-8") as rfh:
         contents = rfh.read()
         assert "sessionstart" in contents
         assert "runtestloop" in contents
@@ -1021,7 +1021,7 @@ def test_log_in_runtest_logreport(pytester: Pytester) -> None:
         """
     )
     pytester.runpytest()
-    with open(log_file) as rfh:
+    with open(log_file, encoding="utf-8") as rfh:
         contents = rfh.read()
         assert contents.count("logreport") == 3
 
@@ -1065,11 +1065,11 @@ def test_log_set_path(pytester: Pytester) -> None:
         """
     )
     pytester.runpytest()
-    with open(os.path.join(report_dir_base, "test_first")) as rfh:
+    with open(os.path.join(report_dir_base, "test_first"), encoding="utf-8") as rfh:
         content = rfh.read()
         assert "message from test 1" in content
 
-    with open(os.path.join(report_dir_base, "test_second")) as rfh:
+    with open(os.path.join(report_dir_base, "test_second"), encoding="utf-8") as rfh:
         content = rfh.read()
         assert "message from test 2" in content
 

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -60,7 +60,8 @@ class TestModule:
                 """.format(
                     str(root2)
                 )
-            )
+            ),
+            encoding="utf-8",
         )
         with monkeypatch.context() as mp:
             mp.chdir(root2)
@@ -832,7 +833,8 @@ class TestConftestCustomization:
                     mod = outcome.get_result()
                     mod.obj.hello = "world"
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         b.joinpath("test_module.py").write_text(
             textwrap.dedent(
@@ -840,7 +842,8 @@ class TestConftestCustomization:
                 def test_hello():
                     assert hello == "world"
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         reprec = pytester.inline_run()
         reprec.assertoutcome(passed=1)
@@ -861,7 +864,8 @@ class TestConftestCustomization:
                             for func in result:
                                 func._some123 = "world"
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         b.joinpath("test_module.py").write_text(
             textwrap.dedent(
@@ -874,7 +878,8 @@ class TestConftestCustomization:
                 def test_hello(obj):
                     assert obj == "world"
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         reprec = pytester.inline_run()
         reprec.assertoutcome(passed=1)
@@ -974,7 +979,8 @@ def test_setup_only_available_in_subdir(pytester: Pytester) -> None:
             def pytest_runtest_teardown(item):
                 assert item.path.stem == "test_in_sub1"
             """
-        )
+        ),
+        encoding="utf-8",
     )
     sub2.joinpath("conftest.py").write_text(
         textwrap.dedent(
@@ -987,10 +993,11 @@ def test_setup_only_available_in_subdir(pytester: Pytester) -> None:
             def pytest_runtest_teardown(item):
                 assert item.path.stem == "test_in_sub2"
             """
-        )
+        ),
+        encoding="utf-8",
     )
-    sub1.joinpath("test_in_sub1.py").write_text("def test_1(): pass")
-    sub2.joinpath("test_in_sub2.py").write_text("def test_2(): pass")
+    sub1.joinpath("test_in_sub1.py").write_text("def test_1(): pass", encoding="utf-8")
+    sub2.joinpath("test_in_sub2.py").write_text("def test_2(): pass", encoding="utf-8")
     result = pytester.runpytest("-v", "-s")
     result.assert_outcomes(passed=2)
 
@@ -1378,7 +1385,8 @@ def test_skip_duplicates_by_default(pytester: Pytester) -> None:
             def test_real():
                 pass
             """
-        )
+        ),
+        encoding="utf-8",
     )
     result = pytester.runpytest(str(a), str(a))
     result.stdout.fnmatch_lines(["*collected 1 item*"])
@@ -1398,7 +1406,8 @@ def test_keep_duplicates(pytester: Pytester) -> None:
             def test_real():
                 pass
             """
-        )
+        ),
+        encoding="utf-8",
     )
     result = pytester.runpytest("--keep-duplicates", str(a), str(a))
     result.stdout.fnmatch_lines(["*collected 2 item*"])
@@ -1443,8 +1452,12 @@ def test_package_with_modules(pytester: Pytester) -> None:
     sub2_test = sub2.joinpath("test")
     sub2_test.mkdir(parents=True)
 
-    sub1_test.joinpath("test_in_sub1.py").write_text("def test_1(): pass")
-    sub2_test.joinpath("test_in_sub2.py").write_text("def test_2(): pass")
+    sub1_test.joinpath("test_in_sub1.py").write_text(
+        "def test_1(): pass", encoding="utf-8"
+    )
+    sub2_test.joinpath("test_in_sub2.py").write_text(
+        "def test_2(): pass", encoding="utf-8"
+    )
 
     # Execute from .
     result = pytester.runpytest("-v", "-s")
@@ -1488,9 +1501,11 @@ def test_package_ordering(pytester: Pytester) -> None:
     sub2_test = sub2.joinpath("test")
     sub2_test.mkdir(parents=True)
 
-    root.joinpath("Test_root.py").write_text("def test_1(): pass")
-    sub1.joinpath("Test_sub1.py").write_text("def test_2(): pass")
-    sub2_test.joinpath("test_sub2.py").write_text("def test_3(): pass")
+    root.joinpath("Test_root.py").write_text("def test_1(): pass", encoding="utf-8")
+    sub1.joinpath("Test_sub1.py").write_text("def test_2(): pass", encoding="utf-8")
+    sub2_test.joinpath("test_sub2.py").write_text(
+        "def test_3(): pass", encoding="utf-8"
+    )
 
     # Execute from .
     result = pytester.runpytest("-v", "-s")

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -287,7 +287,8 @@ class TestFillFixtures:
                 def spam():
                     return 'spam'
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         testfile = subdir.joinpath("test_spam.py")
         testfile.write_text(
@@ -296,7 +297,8 @@ class TestFillFixtures:
                 def test_spam(spam):
                     assert spam == "spam"
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         result = pytester.runpytest()
         result.stdout.fnmatch_lines(["*1 passed*"])
@@ -359,7 +361,8 @@ class TestFillFixtures:
                 def spam(request):
                     return request.param
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         testfile = subdir.joinpath("test_spam.py")
         testfile.write_text(
@@ -371,7 +374,8 @@ class TestFillFixtures:
                     assert spam == params['spam']
                     params['spam'] += 1
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         result = pytester.runpytest()
         result.stdout.fnmatch_lines(["*3 passed*"])
@@ -403,7 +407,8 @@ class TestFillFixtures:
                 def spam(request):
                     return request.param
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         testfile = subdir.joinpath("test_spam.py")
         testfile.write_text(
@@ -415,7 +420,8 @@ class TestFillFixtures:
                     assert spam == params['spam']
                     params['spam'] += 1
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         result = pytester.runpytest()
         result.stdout.fnmatch_lines(["*3 passed*"])
@@ -1037,10 +1043,11 @@ class TestRequestBasic:
                 def arg1():
                     pass
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         p = b.joinpath("test_module.py")
-        p.write_text("def test_func(arg1): pass")
+        p.write_text("def test_func(arg1): pass", encoding="utf-8")
         result = pytester.runpytest(p, "--fixtures")
         assert result.ret == 0
         result.stdout.fnmatch_lines(
@@ -1617,7 +1624,8 @@ class TestFixtureManagerParseFactories:
             def one():
                 return 1
             """
-            )
+            ),
+            encoding="utf-8",
         )
         package.joinpath("test_x.py").write_text(
             textwrap.dedent(
@@ -1625,7 +1633,8 @@ class TestFixtureManagerParseFactories:
                 def test_x(one):
                     assert one == 1
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         sub = package.joinpath("sub")
         sub.mkdir()
@@ -1638,7 +1647,8 @@ class TestFixtureManagerParseFactories:
                 def one():
                     return 2
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         sub.joinpath("test_y.py").write_text(
             textwrap.dedent(
@@ -1646,7 +1656,8 @@ class TestFixtureManagerParseFactories:
                 def test_x(one):
                     assert one == 2
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         reprec = pytester.inline_run()
         reprec.assertoutcome(passed=2)
@@ -1671,7 +1682,8 @@ class TestFixtureManagerParseFactories:
                 def teardown_module():
                     values[:] = []
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         package.joinpath("test_x.py").write_text(
             textwrap.dedent(
@@ -1680,7 +1692,8 @@ class TestFixtureManagerParseFactories:
                 def test_x():
                     assert values == ["package"]
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         package = pytester.mkdir("package2")
         package.joinpath("__init__.py").write_text(
@@ -1692,7 +1705,8 @@ class TestFixtureManagerParseFactories:
                 def teardown_module():
                     values[:] = []
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         package.joinpath("test_x.py").write_text(
             textwrap.dedent(
@@ -1701,7 +1715,8 @@ class TestFixtureManagerParseFactories:
                 def test_x():
                     assert values == ["package2"]
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         reprec = pytester.inline_run()
         reprec.assertoutcome(passed=2)
@@ -1714,7 +1729,7 @@ class TestFixtureManagerParseFactories:
         )
         pytester.syspathinsert(pytester.path.name)
         package = pytester.mkdir("package")
-        package.joinpath("__init__.py").write_text("")
+        package.joinpath("__init__.py").write_text("", encoding="utf-8")
         package.joinpath("conftest.py").write_text(
             textwrap.dedent(
                 """\
@@ -1731,7 +1746,8 @@ class TestFixtureManagerParseFactories:
                     yield values
                     values.pop()
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         package.joinpath("test_x.py").write_text(
             textwrap.dedent(
@@ -1742,7 +1758,8 @@ class TestFixtureManagerParseFactories:
                 def test_package(one):
                     assert values == ["package-auto", "package"]
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         reprec = pytester.inline_run()
         reprec.assertoutcome(passed=2)
@@ -1892,8 +1909,12 @@ class TestAutouseDiscovery:
         """
         )
         conftest.rename(a.joinpath(conftest.name))
-        a.joinpath("test_something.py").write_text("def test_func(): pass")
-        b.joinpath("test_otherthing.py").write_text("def test_func(): pass")
+        a.joinpath("test_something.py").write_text(
+            "def test_func(): pass", encoding="utf-8"
+        )
+        b.joinpath("test_otherthing.py").write_text(
+            "def test_func(): pass", encoding="utf-8"
+        )
         result = pytester.runpytest()
         result.stdout.fnmatch_lines(
             """
@@ -1939,7 +1960,8 @@ class TestAutouseManagement:
                     import sys
                     sys._myapp = "hello"
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         sub = pkgdir.joinpath("tests")
         sub.mkdir()
@@ -1952,7 +1974,8 @@ class TestAutouseManagement:
                 def test_app():
                     assert sys._myapp == "hello"
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         reprec = pytester.inline_run("-s")
         reprec.assertoutcome(passed=1)
@@ -2882,7 +2905,7 @@ class TestFixtureMarker:
             def browser(request):
 
                 def finalize():
-                    sys.stdout.write_text('Finalized')
+                    sys.stdout.write_text('Finalized', encoding='utf-8')
                 request.addfinalizer(finalize)
                 return {}
         """
@@ -2900,7 +2923,8 @@ class TestFixtureMarker:
                 def test_browser(browser):
                     assert browser['visited'] is True
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         reprec = pytester.runpytest("-s")
         for test in ["test_browser"]:
@@ -3855,7 +3879,8 @@ class TestParameterizedSubRequest:
                 def fix_with_param(request):
                     return request.param
                 """
-            )
+            ),
+            encoding="utf-8",
         )
 
         testfile = tests_dir.joinpath("test_foos.py")
@@ -3867,7 +3892,8 @@ class TestParameterizedSubRequest:
                 def test_foo(request):
                     request.getfixturevalue('fix_with_param')
                 """
-            )
+            ),
+            encoding="utf-8",
         )
 
         os.chdir(tests_dir)
@@ -4196,7 +4222,7 @@ class TestScopeOrdering:
                 └── test_2.py
         """
         root = pytester.mkdir("root")
-        root.joinpath("__init__.py").write_text("values = []")
+        root.joinpath("__init__.py").write_text("values = []", encoding="utf-8")
         sub1 = root.joinpath("sub1")
         sub1.mkdir()
         sub1.joinpath("__init__.py").touch()
@@ -4211,7 +4237,8 @@ class TestScopeOrdering:
                 yield values
                 assert values.pop() == "pre-sub1"
         """
-            )
+            ),
+            encoding="utf-8",
         )
         sub1.joinpath("test_1.py").write_text(
             textwrap.dedent(
@@ -4220,7 +4247,8 @@ class TestScopeOrdering:
             def test_1(fix):
                 assert values == ["pre-sub1"]
         """
-            )
+            ),
+            encoding="utf-8",
         )
         sub2 = root.joinpath("sub2")
         sub2.mkdir()
@@ -4236,7 +4264,8 @@ class TestScopeOrdering:
                 yield values
                 assert values.pop() == "pre-sub2"
         """
-            )
+            ),
+            encoding="utf-8",
         )
         sub2.joinpath("test_2.py").write_text(
             textwrap.dedent(
@@ -4245,7 +4274,8 @@ class TestScopeOrdering:
             def test_2(fix):
                 assert values == ["pre-sub2"]
         """
-            )
+            ),
+            encoding="utf-8",
         )
         reprec = pytester.inline_run()
         reprec.assertoutcome(passed=2)

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1443,7 +1443,8 @@ class TestMetafuncFunctional:
                 def pytest_generate_tests(metafunc):
                     assert metafunc.function.__name__ == "test_1"
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         sub2.joinpath("conftest.py").write_text(
             textwrap.dedent(
@@ -1451,10 +1452,15 @@ class TestMetafuncFunctional:
                 def pytest_generate_tests(metafunc):
                     assert metafunc.function.__name__ == "test_2"
                 """
-            )
+            ),
+            encoding="utf-8",
         )
-        sub1.joinpath("test_in_sub1.py").write_text("def test_1(): pass")
-        sub2.joinpath("test_in_sub2.py").write_text("def test_2(): pass")
+        sub1.joinpath("test_in_sub1.py").write_text(
+            "def test_1(): pass", encoding="utf-8"
+        )
+        sub2.joinpath("test_in_sub2.py").write_text(
+            "def test_2(): pass", encoding="utf-8"
+        )
         result = pytester.runpytest("--keep-duplicates", "-v", "-s", sub1, sub2, sub1)
         result.assert_outcomes(passed=3)
 

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1392,14 +1392,14 @@ def test_sequence_comparison_uses_repr(pytester: Pytester) -> None:
 def test_assertrepr_loaded_per_dir(pytester: Pytester) -> None:
     pytester.makepyfile(test_base=["def test_base(): assert 1 == 2"])
     a = pytester.mkdir("a")
-    a.joinpath("test_a.py").write_text("def test_a(): assert 1 == 2")
+    a.joinpath("test_a.py").write_text("def test_a(): assert 1 == 2", encoding="utf-8")
     a.joinpath("conftest.py").write_text(
-        'def pytest_assertrepr_compare(): return ["summary a"]'
+        'def pytest_assertrepr_compare(): return ["summary a"]', encoding="utf-8"
     )
     b = pytester.mkdir("b")
-    b.joinpath("test_b.py").write_text("def test_b(): assert 1 == 2")
+    b.joinpath("test_b.py").write_text("def test_b(): assert 1 == 2", encoding="utf-8")
     b.joinpath("conftest.py").write_text(
-        'def pytest_assertrepr_compare(): return ["summary b"]'
+        'def pytest_assertrepr_compare(): return ["summary b"]', encoding="utf-8"
     )
 
     result = pytester.runpytest()

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1161,7 +1161,7 @@ class TestAssertionRewriteHookDetails:
                 return False
 
             def rewrite_self():
-                with open(__file__, 'w') as self:
+                with open(__file__, 'w', encoding='utf-8') as self:
                     self.write('def reloaded(): return True')
             """,
             test_fun="""

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -160,7 +160,8 @@ class TestAssertionRewrite:
             "def special_asserter():\n"
             "    def special_assert(x, y):\n"
             "        assert x == y\n"
-            "    return special_assert\n"
+            "    return special_assert\n",
+            encoding="utf-8",
         )
         pytester.makeconftest('pytest_plugins = ["plugin"]')
         pytester.makepyfile("def test(special_asserter): special_asserter(1, 2)\n")
@@ -173,7 +174,9 @@ class TestAssertionRewrite:
         pytester.makepyfile(test_y="x = 1")
         xdir = pytester.mkdir("x")
         pytester.mkpydir(str(xdir.joinpath("test_Y")))
-        xdir.joinpath("test_Y").joinpath("__init__.py").write_text("x = 2")
+        xdir.joinpath("test_Y").joinpath("__init__.py").write_text(
+            "x = 2", encoding="utf-8"
+        )
         pytester.makepyfile(
             "import test_y\n"
             "import test_Y\n"
@@ -726,7 +729,7 @@ class TestAssertionRewrite:
 
 class TestRewriteOnImport:
     def test_pycache_is_a_file(self, pytester: Pytester) -> None:
-        pytester.path.joinpath("__pycache__").write_text("Hello")
+        pytester.path.joinpath("__pycache__").write_text("Hello", encoding="utf-8")
         pytester.makepyfile(
             """
             def test_rewritten():
@@ -903,7 +906,8 @@ def test_rewritten():
         pkg.joinpath("test_blah.py").write_text(
             """
 def test_rewritten():
-    assert "@py_builtins" in globals()"""
+    assert "@py_builtins" in globals()""",
+            encoding="utf-8",
         )
         assert pytester.runpytest().ret == 0
 
@@ -1066,7 +1070,7 @@ class TestAssertionRewriteHookDetails:
         source = tmp_path / "source.py"
         pyc = Path(str(source) + "c")
 
-        source.write_text("def test(): pass")
+        source.write_text("def test(): pass", encoding="utf-8")
         py_compile.compile(str(source), str(pyc))
 
         contents = pyc.read_bytes()
@@ -1092,7 +1096,7 @@ class TestAssertionRewriteHookDetails:
         fn = tmp_path / "source.py"
         pyc = Path(str(fn) + "c")
 
-        fn.write_text("def test(): assert True")
+        fn.write_text("def test(): assert True", encoding="utf-8")
 
         source_stat, co = _rewrite_test(fn, config)
         _write_pyc(state, co, source_stat, pyc)
@@ -1187,9 +1191,10 @@ class TestAssertionRewriteHookDetails:
                         data = pkgutil.get_data('foo.test_foo', 'data.txt')
                         assert data == b'Hey'
                 """
-            )
+            ),
+            encoding="utf-8",
         )
-        path.joinpath("data.txt").write_text("Hey")
+        path.joinpath("data.txt").write_text("Hey", encoding="utf-8")
         result = pytester.runpytest()
         result.stdout.fnmatch_lines(["*1 passed*"])
 

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -38,7 +38,9 @@ class TestNewAPI:
     @pytest.mark.filterwarnings("ignore:could not create cache path")
     def test_cache_writefail_cachfile_silent(self, pytester: Pytester) -> None:
         pytester.makeini("[pytest]")
-        pytester.path.joinpath(".pytest_cache").write_text("gone wrong")
+        pytester.path.joinpath(".pytest_cache").write_text(
+            "gone wrong", encoding="utf-8"
+        )
         config = pytester.parseconfigure()
         cache = config.cache
         assert cache is not None
@@ -1134,7 +1136,9 @@ class TestNewFirst:
             ["*test_2/test_2.py::test_1 PASSED*", "*test_1/test_1.py::test_1 PASSED*"]
         )
 
-        p1.write_text("def test_1(): assert 1\n" "def test_2(): assert 1\n")
+        p1.write_text(
+            "def test_1(): assert 1\n" "def test_2(): assert 1\n", encoding="utf-8"
+        )
         os.utime(p1, ns=(p1.stat().st_atime_ns, int(1e9)))
 
         result = pytester.runpytest("--nf", "--collect-only", "-q")
@@ -1207,7 +1211,8 @@ class TestNewFirst:
         p1.write_text(
             "import pytest\n"
             "@pytest.mark.parametrize('num', [1, 2, 3])\n"
-            "def test_1(num): assert num\n"
+            "def test_1(num): assert num\n",
+            encoding="utf-8",
         )
         os.utime(p1, ns=(p1.stat().st_atime_ns, int(1e9)))
 
@@ -1259,7 +1264,7 @@ def test_gitignore(pytester: Pytester) -> None:
     assert gitignore_path.read_text(encoding="UTF-8") == msg
 
     # Does not overwrite existing/custom one.
-    gitignore_path.write_text("custom")
+    gitignore_path.write_text("custom", encoding="utf-8")
     cache.set("something", "else")
     assert gitignore_path.read_text(encoding="UTF-8") == "custom"
 

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -750,9 +750,10 @@ def test_setup_failure_does_not_kill_capturing(pytester: Pytester) -> None:
             def pytest_runtest_setup(item):
                 raise ValueError(42)
             """
-        )
+        ),
+        encoding="utf-8",
     )
-    sub1.joinpath("test_mod.py").write_text("def test_func1(): pass")
+    sub1.joinpath("test_mod.py").write_text("def test_func1(): pass", encoding="utf-8")
     result = pytester.runpytest(pytester.path, "--traceconfig")
     result.stdout.fnmatch_lines(["*ValueError(42)*", "*1 error*"])
 
@@ -1523,9 +1524,9 @@ def test_global_capture_with_live_logging(pytester: Pytester) -> None:
         def pytest_runtest_logreport(report):
             if "test_global" in report.nodeid:
                 if report.when == "teardown":
-                    with open("caplog", "w") as f:
+                    with open("caplog", "w", encoding="utf-8") as f:
                         f.write(report.caplog)
-                    with open("capstdout", "w") as f:
+                    with open("capstdout", "w", encoding="utf-8") as f:
                         f.write(report.capstdout)
         """
     )
@@ -1555,14 +1556,14 @@ def test_global_capture_with_live_logging(pytester: Pytester) -> None:
     result = pytester.runpytest_subprocess("--log-cli-level=INFO")
     assert result.ret == 0
 
-    with open("caplog") as f:
+    with open("caplog", encoding="utf-8") as f:
         caplog = f.read()
 
     assert "fix setup" in caplog
     assert "something in test" in caplog
     assert "fix teardown" in caplog
 
-    with open("capstdout") as f:
+    with open("capstdout", encoding="utf-8") as f:
         capstdout = f.read()
 
     assert "fix setup" in capstdout

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -1273,7 +1273,8 @@ def test_initial_conftests_with_testpaths(pytester: Pytester) -> None:
             def pytest_sessionstart(session):
                 raise Exception("pytest_sessionstart hook successfully run")
             """
-        )
+        ),
+        encoding="utf-8",
     )
     pytester.makeini(
         """
@@ -1369,12 +1370,16 @@ def test_collect_symlink_dir(pytester: Pytester) -> None:
 def test_collectignore_via_conftest(pytester: Pytester) -> None:
     """collect_ignore in parent conftest skips importing child (issue #4592)."""
     tests = pytester.mkpydir("tests")
-    tests.joinpath("conftest.py").write_text("collect_ignore = ['ignore_me']")
+    tests.joinpath("conftest.py").write_text(
+        "collect_ignore = ['ignore_me']", encoding="utf-8"
+    )
 
     ignore_me = tests.joinpath("ignore_me")
     ignore_me.mkdir()
     ignore_me.joinpath("__init__.py").touch()
-    ignore_me.joinpath("conftest.py").write_text("assert 0, 'should_not_be_called'")
+    ignore_me.joinpath("conftest.py").write_text(
+        "assert 0, 'should_not_be_called'", encoding="utf-8"
+    )
 
     result = pytester.runpytest()
     assert result.ret == ExitCode.NO_TESTS_COLLECTED
@@ -1383,9 +1388,9 @@ def test_collectignore_via_conftest(pytester: Pytester) -> None:
 def test_collect_pkg_init_and_file_in_args(pytester: Pytester) -> None:
     subdir = pytester.mkdir("sub")
     init = subdir.joinpath("__init__.py")
-    init.write_text("def test_init(): pass")
+    init.write_text("def test_init(): pass", encoding="utf-8")
     p = subdir.joinpath("test_file.py")
-    p.write_text("def test_file(): pass")
+    p.write_text("def test_file(): pass", encoding="utf-8")
 
     # NOTE: without "-o python_files=*.py" this collects test_file.py twice.
     # This changed/broke with "Add package scoped fixtures #2283" (2b1410895)
@@ -1412,7 +1417,7 @@ def test_collect_pkg_init_and_file_in_args(pytester: Pytester) -> None:
 def test_collect_pkg_init_only(pytester: Pytester) -> None:
     subdir = pytester.mkdir("sub")
     init = subdir.joinpath("__init__.py")
-    init.write_text("def test_init(): pass")
+    init.write_text("def test_init(): pass", encoding="utf-8")
 
     result = pytester.runpytest(str(init))
     result.stdout.fnmatch_lines(["*no tests ran in*"])
@@ -1427,7 +1432,7 @@ def test_collect_sub_with_symlinks(use_pkg: bool, pytester: Pytester) -> None:
     sub = pytester.mkdir("sub")
     if use_pkg:
         sub.joinpath("__init__.py").touch()
-    sub.joinpath("test_file.py").write_text("def test_file(): pass")
+    sub.joinpath("test_file.py").write_text("def test_file(): pass", encoding="utf-8")
 
     # Create a broken symlink.
     symlink_or_skip("test_doesnotexist.py", sub.joinpath("test_broken.py"))
@@ -1465,7 +1470,7 @@ def test_collector_respects_tbstyle(pytester: Pytester) -> None:
 def test_does_not_eagerly_collect_packages(pytester: Pytester) -> None:
     pytester.makepyfile("def test(): pass")
     pydir = pytester.mkpydir("foopkg")
-    pydir.joinpath("__init__.py").write_text("assert False")
+    pydir.joinpath("__init__.py").write_text("assert False", encoding="utf-8")
     result = pytester.runpytest()
     assert result.ret == ExitCode.OK
 

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -140,7 +140,7 @@ class TestCollectFS:
         ensure_file(tmp_path / ".bzr" / "test_notfound.py")
         ensure_file(tmp_path / "normal" / "test_found.py")
         for x in tmp_path.rglob("test_*.py"):
-            x.write_text("def test_hello(): pass", "utf-8")
+            x.write_text("def test_hello(): pass", encoding="utf-8")
 
         result = pytester.runpytest("--collect-only")
         s = result.stdout.str()
@@ -162,7 +162,7 @@ class TestCollectFS:
         bindir = "Scripts" if sys.platform.startswith("win") else "bin"
         ensure_file(pytester.path / "virtual" / bindir / fname)
         testfile = ensure_file(pytester.path / "virtual" / "test_invenv.py")
-        testfile.write_text("def test_hello(): pass")
+        testfile.write_text("def test_hello(): pass", encoding="utf-8")
 
         # by default, ignore tests inside a virtualenv
         result = pytester.runpytest()
@@ -192,7 +192,7 @@ class TestCollectFS:
         # norecursedirs takes priority
         ensure_file(pytester.path / ".virtual" / bindir / fname)
         testfile = ensure_file(pytester.path / ".virtual" / "test_invenv.py")
-        testfile.write_text("def test_hello(): pass")
+        testfile.write_text("def test_hello(): pass", encoding="utf-8")
         result = pytester.runpytest("--collect-in-virtualenv")
         result.stdout.no_fnmatch_line("*test_invenv*")
         # ...unless the virtualenv is explicitly given on the CLI
@@ -231,10 +231,14 @@ class TestCollectFS:
         )
         tmp_path = pytester.path
         ensure_file(tmp_path / "mydir" / "test_hello.py").write_text(
-            "def test_1(): pass"
+            "def test_1(): pass", encoding="utf-8"
         )
-        ensure_file(tmp_path / "xyz123" / "test_2.py").write_text("def test_2(): 0/0")
-        ensure_file(tmp_path / "xy" / "test_ok.py").write_text("def test_3(): pass")
+        ensure_file(tmp_path / "xyz123" / "test_2.py").write_text(
+            "def test_2(): 0/0", encoding="utf-8"
+        )
+        ensure_file(tmp_path / "xy" / "test_ok.py").write_text(
+            "def test_3(): pass", encoding="utf-8"
+        )
         rec = pytester.inline_run()
         rec.assertoutcome(passed=1)
         rec = pytester.inline_run("xyz123/test_2.py")
@@ -248,12 +252,14 @@ class TestCollectFS:
         """
         )
         tmp_path = pytester.path
-        ensure_file(tmp_path / "a" / "test_1.py").write_text("def test_a(): pass")
+        ensure_file(tmp_path / "a" / "test_1.py").write_text(
+            "def test_a(): pass", encoding="utf-8"
+        )
         ensure_file(tmp_path / "b" / "tests" / "test_2.py").write_text(
-            "def test_b(): pass"
+            "def test_b(): pass", encoding="utf-8"
         )
         ensure_file(tmp_path / "c" / "tests" / "test_3.py").write_text(
-            "def test_c(): pass"
+            "def test_c(): pass", encoding="utf-8"
         )
 
         # executing from rootdir only tests from `testpaths` directories
@@ -349,8 +355,8 @@ class TestCustomConftests:
         """
         )
         sub = pytester.mkdir("xy123")
-        ensure_file(sub / "test_hello.py").write_text("syntax error")
-        sub.joinpath("conftest.py").write_text("syntax error")
+        ensure_file(sub / "test_hello.py").write_text("syntax error", encoding="utf-8")
+        sub.joinpath("conftest.py").write_text("syntax error", encoding="utf-8")
         pytester.makepyfile("def test_hello(): pass")
         pytester.makepyfile(test_one="syntax error")
         result = pytester.runpytest("--fulltrace")
@@ -1060,13 +1066,18 @@ def test_fixture_scope_sibling_conftests(pytester: Pytester) -> None:
             def fix():
                 return 1
             """
-        )
+        ),
+        encoding="utf-8",
     )
-    foo_path.joinpath("test_foo.py").write_text("def test_foo(fix): assert fix == 1")
+    foo_path.joinpath("test_foo.py").write_text(
+        "def test_foo(fix): assert fix == 1", encoding="utf-8"
+    )
 
     # Tests in `food/` should not see the conftest fixture from `foo/`
     food_path = pytester.mkpydir("food")
-    food_path.joinpath("test_food.py").write_text("def test_food(fix): assert fix == 1")
+    food_path.joinpath("test_food.py").write_text(
+        "def test_food(fix): assert fix == 1", encoding="utf-8"
+    )
 
     res = pytester.runpytest()
     assert res.ret == 1
@@ -1197,7 +1208,8 @@ def test_collect_with_chdir_during_import(pytester: Pytester) -> None:
             os.chdir(%r)
             """
             % (str(subdir),)
-        )
+        ),
+        encoding="utf-8",
     )
     pytester.makepyfile(
         """
@@ -1227,8 +1239,12 @@ def test_collect_pyargs_with_testpaths(
 ) -> None:
     testmod = pytester.mkdir("testmod")
     # NOTE: __init__.py is not collected since it does not match python_files.
-    testmod.joinpath("__init__.py").write_text("def test_func(): pass")
-    testmod.joinpath("test_file.py").write_text("def test_func(): pass")
+    testmod.joinpath("__init__.py").write_text(
+        "def test_func(): pass", encoding="utf-8"
+    )
+    testmod.joinpath("test_file.py").write_text(
+        "def test_func(): pass", encoding="utf-8"
+    )
 
     root = pytester.mkdir("root")
     root.joinpath("pytest.ini").write_text(
@@ -1238,7 +1254,8 @@ def test_collect_pyargs_with_testpaths(
         addopts = --pyargs
         testpaths = testmod
     """
-        )
+        ),
+        encoding="utf-8",
     )
     monkeypatch.setenv("PYTHONPATH", str(pytester.path), prepend=os.pathsep)
     with monkeypatch.context() as mp:
@@ -1323,6 +1340,7 @@ def test_collect_symlink_out_of_tree(pytester: Pytester) -> None:
             assert request.node.nodeid == "test_real.py::test_nodeid"
         """
         ),
+        encoding="utf-8",
     )
 
     out_of_tree = pytester.mkdir("out_of_tree")

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -87,7 +87,8 @@ class TestParseIni:
                 [pytest]
                 addopts = --verbose
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         config = pytester.parseconfig(tmp_path)
         assert config.option.color == "no"
@@ -127,7 +128,8 @@ class TestParseIni:
         """.format(
                     section=section
                 )
-            )
+            ),
+            encoding="utf-8",
         )
         config = pytester.parseconfig()
         assert config.getini("minversion") == "3.36"
@@ -150,7 +152,8 @@ class TestParseIni:
             [pytest]
             minversion = 2.0
         """
-            )
+            ),
+            encoding="utf-8",
         )
         pytester.path.joinpath("pytest.ini").write_text(
             textwrap.dedent(
@@ -158,13 +161,16 @@ class TestParseIni:
             [pytest]
             minversion = 1.5
         """
-            )
+            ),
+            encoding="utf-8",
         )
         config = pytester.parseconfigure(sub)
         assert config.getini("minversion") == "2.0"
 
     def test_ini_parse_error(self, pytester: Pytester) -> None:
-        pytester.path.joinpath("pytest.ini").write_text("addopts = -x")
+        pytester.path.joinpath("pytest.ini").write_text(
+            "addopts = -x", encoding="utf-8"
+        )
         result = pytester.runpytest()
         assert result.ret != 0
         result.stderr.fnmatch_lines("ERROR: *pytest.ini:1: no section header defined")
@@ -634,7 +640,7 @@ class TestConfigAPI:
     def test_getconftest_pathlist(self, pytester: Pytester, tmp_path: Path) -> None:
         somepath = tmp_path.joinpath("x", "y", "z")
         p = tmp_path.joinpath("conftest.py")
-        p.write_text(f"mylist = {['.', str(somepath)]}")
+        p.write_text(f"mylist = {['.', str(somepath)]}", encoding="utf-8")
         config = pytester.parseconfigure(p)
         assert (
             config._getconftest_pathlist("notexist", path=tmp_path, rootpath=tmp_path)
@@ -910,7 +916,8 @@ class TestConfigFromdictargs:
                 [pytest]
                 name = value
                 """
-            )
+            ),
+            encoding="utf-8",
         )
 
         inifilename = "../../foo/bar.ini"
@@ -927,7 +934,8 @@ class TestConfigFromdictargs:
                 name = wrong-value
                 should_not_be_set = true
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         with MonkeyPatch.context() as mp:
             mp.chdir(cwd)
@@ -1387,7 +1395,7 @@ class TestRootdir:
     )
     def test_with_ini(self, tmp_path: Path, name: str, contents: str) -> None:
         inipath = tmp_path / name
-        inipath.write_text(contents, "utf-8")
+        inipath.write_text(contents, encoding="utf-8")
 
         a = tmp_path / "a"
         a.mkdir()
@@ -1446,7 +1454,7 @@ class TestRootdir:
     ) -> None:
         p = tmp_path / name
         p.touch()
-        p.write_text(contents, "utf-8")
+        p.write_text(contents, encoding="utf-8")
         rootpath, inipath, ini_config = determine_setup(str(p), [str(tmp_path)])
         assert rootpath == tmp_path
         assert inipath == p
@@ -1542,7 +1550,8 @@ class TestOverrideIniArgs:
             custom = 1.0""".format(
                     section=section
                 )
-            )
+            ),
+            encoding="utf-8",
         )
         pytester.makeconftest(
             """

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -47,8 +47,12 @@ class TestConftestValueAccessGlobal:
     ) -> Generator[Path, None, None]:
         tmp_path = tmp_path_factory.mktemp("basedir", numbered=True)
         tmp_path.joinpath("adir/b").mkdir(parents=True)
-        tmp_path.joinpath("adir/conftest.py").write_text("a=1 ; Directory = 3")
-        tmp_path.joinpath("adir/b/conftest.py").write_text("b=2 ; a = 1.5")
+        tmp_path.joinpath("adir/conftest.py").write_text(
+            "a=1 ; Directory = 3", encoding="utf-8"
+        )
+        tmp_path.joinpath("adir/b/conftest.py").write_text(
+            "b=2 ; a = 1.5", encoding="utf-8"
+        )
         if request.param == "inpackage":
             tmp_path.joinpath("adir/__init__.py").touch()
             tmp_path.joinpath("adir/b/__init__.py").touch()
@@ -123,8 +127,12 @@ class TestConftestValueAccessGlobal:
 
 def test_conftest_in_nonpkg_with_init(tmp_path: Path, _sys_snapshot) -> None:
     tmp_path.joinpath("adir-1.0/b").mkdir(parents=True)
-    tmp_path.joinpath("adir-1.0/conftest.py").write_text("a=1 ; Directory = 3")
-    tmp_path.joinpath("adir-1.0/b/conftest.py").write_text("b=2 ; a = 1.5")
+    tmp_path.joinpath("adir-1.0/conftest.py").write_text(
+        "a=1 ; Directory = 3", encoding="utf-8"
+    )
+    tmp_path.joinpath("adir-1.0/b/conftest.py").write_text(
+        "b=2 ; a = 1.5", encoding="utf-8"
+    )
     tmp_path.joinpath("adir-1.0/b/__init__.py").touch()
     tmp_path.joinpath("adir-1.0/__init__.py").touch()
     ConftestWithSetinitial(tmp_path.joinpath("adir-1.0", "b"))
@@ -167,7 +175,7 @@ def test_conftest_global_import(pytester: Pytester) -> None:
         sub = Path("sub")
         sub.mkdir()
         subconf = sub / "conftest.py"
-        subconf.write_text("y=4")
+        subconf.write_text("y=4", encoding="utf-8")
         mod2 = conf._importconftest(subconf, importmode="prepend", rootpath=Path.cwd())
         assert mod != mod2
         assert mod2.y == 4
@@ -246,7 +254,8 @@ def test_conftest_confcutdir(pytester: Pytester) -> None:
             def pytest_addoption(parser):
                 parser.addoption("--xyz", action="store_true")
             """
-        )
+        ),
+        encoding="utf-8",
     )
     result = pytester.runpytest("-h", "--confcutdir=%s" % x, x)
     result.stdout.fnmatch_lines(["*--xyz*"])
@@ -274,9 +283,12 @@ def test_installed_conftest_is_picked_up(pytester: Pytester, tmp_path: Path) -> 
             @pytest.fixture
             def fix(): return None
             """
-        )
+        ),
+        encoding="utf-8",
     )
-    tmp_path.joinpath("foo", "test_it.py").write_text("def test_it(fix): pass")
+    tmp_path.joinpath("foo", "test_it.py").write_text(
+        "def test_it(fix): pass", encoding="utf-8"
+    )
     result = pytester.runpytest("--pyargs", "foo")
     assert result.ret == 0
 
@@ -401,7 +413,8 @@ def test_conftest_existing_junitxml(pytester: Pytester) -> None:
             def pytest_addoption(parser):
                 parser.addoption("--xyz", action="store_true")
             """
-        )
+        ),
+        encoding="utf-8",
     )
     pytester.makefile(ext=".xml", junit="")  # Writes junit.xml
     result = pytester.runpytest("-h", "--junitxml", "junit.xml")
@@ -412,7 +425,7 @@ def test_conftest_import_order(pytester: Pytester, monkeypatch: MonkeyPatch) -> 
     ct1 = pytester.makeconftest("")
     sub = pytester.mkdir("sub")
     ct2 = sub / "conftest.py"
-    ct2.write_text("")
+    ct2.write_text("", encoding="utf-8")
 
     def impct(p, importmode, root):
         return p
@@ -450,7 +463,8 @@ def test_fixture_dependency(pytester: Pytester) -> None:
             def bar(foo):
                 return 'bar'
             """
-        )
+        ),
+        encoding="utf-8",
     )
     subsub = sub.joinpath("subsub")
     subsub.mkdir()
@@ -467,7 +481,8 @@ def test_fixture_dependency(pytester: Pytester) -> None:
             def test_event_fixture(bar):
                 assert bar == 'sub bar'
             """
-        )
+        ),
+        encoding="utf-8",
     )
     result = pytester.runpytest("sub")
     result.stdout.fnmatch_lines(["*1 passed*"])
@@ -481,10 +496,11 @@ def test_conftest_found_with_double_dash(pytester: Pytester) -> None:
             def pytest_addoption(parser):
                 parser.addoption("--hello-world", action="store_true")
             """
-        )
+        ),
+        encoding="utf-8",
     )
     p = sub.joinpath("test_hello.py")
-    p.write_text("def test_hello(): pass")
+    p.write_text("def test_hello(): pass", encoding="utf-8")
     result = pytester.runpytest(str(p) + "::test_hello", "-h")
     result.stdout.fnmatch_lines(
         """
@@ -508,7 +524,8 @@ class TestConftestVisibility:
                 def fxtr():
                     return "from-package"
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         package.joinpath("test_pkgroot.py").write_text(
             textwrap.dedent(
@@ -516,7 +533,8 @@ class TestConftestVisibility:
                 def test_pkgroot(fxtr):
                     assert fxtr == "from-package"
                 """
-            )
+            ),
+            encoding="utf-8",
         )
 
         swc = package.joinpath("swc")
@@ -530,7 +548,8 @@ class TestConftestVisibility:
                 def fxtr():
                     return "from-swc"
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         swc.joinpath("test_with_conftest.py").write_text(
             textwrap.dedent(
@@ -538,7 +557,8 @@ class TestConftestVisibility:
                 def test_with_conftest(fxtr):
                     assert fxtr == "from-swc"
                 """
-            )
+            ),
+            encoding="utf-8",
         )
 
         snc = package.joinpath("snc")
@@ -551,7 +571,8 @@ class TestConftestVisibility:
                     assert fxtr == "from-package"   # No local conftest.py, so should
                                                     # use value from parent dir's
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         print("created directory structure:")
         for x in pytester.path.glob("**/"):
@@ -625,7 +646,8 @@ def test_search_conftest_up_to_inifile(
             @pytest.fixture
             def fix1(): pass
             """
-        )
+        ),
+        encoding="utf-8",
     )
     src.joinpath("test_foo.py").write_text(
         textwrap.dedent(
@@ -635,7 +657,8 @@ def test_search_conftest_up_to_inifile(
             def test_2(out_of_reach):
                 pass
             """
-        )
+        ),
+        encoding="utf-8",
     )
     root.joinpath("conftest.py").write_text(
         textwrap.dedent(
@@ -644,7 +667,8 @@ def test_search_conftest_up_to_inifile(
             @pytest.fixture
             def out_of_reach(): pass
             """
-        )
+        ),
+        encoding="utf-8",
     )
 
     args = [str(src)]
@@ -727,7 +751,8 @@ def test_required_option_help(pytester: Pytester) -> None:
             def pytest_addoption(parser):
                 parser.addoption("--xyz", action="store_true", required=True)
             """
-        )
+        ),
+        encoding="utf-8",
     )
     result = pytester.runpytest("-h", x)
     result.stdout.no_fnmatch_line("*argument --xyz is required*")

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -638,7 +638,7 @@ def test_search_conftest_up_to_inifile(
     root = pytester.path
     src = root.joinpath("src")
     src.mkdir()
-    src.joinpath("pytest.ini").write_text("[pytest]")
+    src.joinpath("pytest.ini").write_text("[pytest]", encoding="utf-8")
     src.joinpath("conftest.py").write_text(
         textwrap.dedent(
             """\

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -357,7 +357,8 @@ class TestDoctests:
                         >>> 1/0
                         '''
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         result = pytester.runpytest("--doctest-modules")
         result.stdout.fnmatch_lines(
@@ -448,7 +449,8 @@ class TestDoctests:
                 """\
                 import asdalsdkjaslkdjasd
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         pytester.maketxtfile(
             """
@@ -492,7 +494,8 @@ class TestDoctests:
                         2
                     '''
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         result = pytester.runpytest(p, "--doctest-modules")
         result.stdout.fnmatch_lines(
@@ -1566,7 +1569,9 @@ def test_warning_on_unwrap_of_broken_object(
 
 def test_is_setup_py_not_named_setup_py(tmp_path: Path) -> None:
     not_setup_py = tmp_path.joinpath("not_setup.py")
-    not_setup_py.write_text('from setuptools import setup; setup(name="foo")')
+    not_setup_py.write_text(
+        'from setuptools import setup; setup(name="foo")', encoding="utf-8"
+    )
     assert not _is_setup_py(not_setup_py)
 
 

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -28,7 +28,7 @@ from _pytest.stash import Stash
 def schema() -> xmlschema.XMLSchema:
     """Return an xmlschema.XMLSchema object for the junit-10.xsd file."""
     fn = Path(__file__).parent / "example_scripts/junit-10.xsd"
-    with fn.open() as f:
+    with fn.open(encoding="utf-8") as f:
         return xmlschema.XMLSchema(f)
 
 
@@ -45,7 +45,7 @@ class RunAndParse:
         xml_path = self.pytester.path.joinpath("junit.xml")
         result = self.pytester.runpytest("--junitxml=%s" % xml_path, *args)
         if family == "xunit2":
-            with xml_path.open() as f:
+            with xml_path.open(encoding="utf-8") as f:
                 self.schema.validate(f)
         xmldoc = minidom.parse(str(xml_path))
         return result, DomNode(xmldoc)
@@ -469,7 +469,7 @@ class TestPython:
         self, pytester: Pytester, run_and_parse: RunAndParse, xunit_family: str
     ) -> None:
         p = pytester.mkdir("sub").joinpath("test_hello.py")
-        p.write_text("def test_func(): 0/0")
+        p.write_text("def test_func(): 0/0", encoding="utf-8")
         result, dom = run_and_parse(family=xunit_family)
         assert result.ret
         node = dom.find_first_by_tag("testsuite")
@@ -987,7 +987,7 @@ class TestNonPython:
                     return "custom item runtest failed"
         """
         )
-        pytester.path.joinpath("myfile.xyz").write_text("hello")
+        pytester.path.joinpath("myfile.xyz").write_text("hello", encoding="utf-8")
         result, dom = run_and_parse(family=xunit_family)
         assert result.ret
         node = dom.find_first_by_tag("testsuite")
@@ -1013,7 +1013,7 @@ def test_nullbyte(pytester: Pytester, junit_logging: str) -> None:
     )
     xmlf = pytester.path.joinpath("junit.xml")
     pytester.runpytest("--junitxml=%s" % xmlf, "-o", "junit_logging=%s" % junit_logging)
-    text = xmlf.read_text()
+    text = xmlf.read_text(encoding="utf-8")
     assert "\x00" not in text
     if junit_logging == "system-out":
         assert "#x00" in text
@@ -1035,7 +1035,7 @@ def test_nullbyte_replace(pytester: Pytester, junit_logging: str) -> None:
     )
     xmlf = pytester.path.joinpath("junit.xml")
     pytester.runpytest("--junitxml=%s" % xmlf, "-o", "junit_logging=%s" % junit_logging)
-    text = xmlf.read_text()
+    text = xmlf.read_text(encoding="utf-8")
     if junit_logging == "system-out":
         assert "#x0" in text
     if junit_logging == "no":

--- a/testing/test_link_resolve.py
+++ b/testing/test_link_resolve.py
@@ -59,7 +59,8 @@ def test_link_resolve(pytester: Pytester) -> None:
         def test_foo():
             raise AssertionError()
         """
-        )
+        ),
+        encoding="utf-8",
     )
 
     subst = subst_path_linux

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -324,7 +324,8 @@ def test_importerror(pytester: Pytester) -> None:
 
         x = 1
     """
-        )
+        ),
+        encoding="utf-8",
     )
     pytester.path.joinpath("test_importerror.py").write_text(
         textwrap.dedent(
@@ -332,7 +333,8 @@ def test_importerror(pytester: Pytester) -> None:
         def test_importerror(monkeypatch):
             monkeypatch.setattr('package.a.x', 2)
     """
-        )
+        ),
+        encoding="utf-8",
     )
     result = pytester.runpytest()
     result.stdout.fnmatch_lines(
@@ -434,11 +436,13 @@ def test_syspath_prepend_with_namespace_packages(
         ns = d.joinpath("ns_pkg")
         ns.mkdir()
         ns.joinpath("__init__.py").write_text(
-            "__import__('pkg_resources').declare_namespace(__name__)"
+            "__import__('pkg_resources').declare_namespace(__name__)", encoding="utf-8"
         )
         lib = ns.joinpath(dirname)
         lib.mkdir()
-        lib.joinpath("__init__.py").write_text("def check(): return %r" % dirname)
+        lib.joinpath("__init__.py").write_text(
+            "def check(): return %r" % dirname, encoding="utf-8"
+        )
 
     monkeypatch.syspath_prepend("hello")
     import ns_pkg.hello

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -461,5 +461,5 @@ def test_syspath_prepend_with_namespace_packages(
     # Should invalidate caches via importlib.invalidate_caches.
     modules_tmpdir = pytester.mkdir("modules_tmpdir")
     monkeypatch.syspath_prepend(str(modules_tmpdir))
-    modules_tmpdir.joinpath("main_app.py").write_text("app = True")
+    modules_tmpdir.joinpath("main_app.py").write_text("app = True", encoding="utf-8")
     from main_app import app  # noqa: F401

--- a/testing/test_parseopt.py
+++ b/testing/test_parseopt.py
@@ -311,7 +311,7 @@ def test_argcomplete(pytester: Pytester, monkeypatch: MonkeyPatch) -> None:
 
     script = str(pytester.path.joinpath("test_argcomplete"))
 
-    with open(str(script), "w") as fp:
+    with open(str(script), "w", encoding="utf-8") as fp:
         # redirect output from argcomplete to stdin and stderr is not trivial
         # http://stackoverflow.com/q/12589419/1307905
         # so we use bash

--- a/testing/test_parseopt.py
+++ b/testing/test_parseopt.py
@@ -1,4 +1,5 @@
 import argparse
+import locale
 import os
 import shlex
 import subprocess
@@ -290,12 +291,17 @@ class TestParser:
 
 def test_argcomplete(pytester: Pytester, monkeypatch: MonkeyPatch) -> None:
     try:
+        encoding = locale.getencoding()  # New in Python 3.11, ignores utf-8 mode
+    except AttributeError:
+        encoding = locale.getpreferredencoding(False)
+    try:
         bash_version = subprocess.run(
             ["bash", "--version"],
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             check=True,
             text=True,
+            encoding=encoding,
         ).stdout
     except (OSError, subprocess.CalledProcessError):
         pytest.skip("bash is not available")

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -100,13 +100,13 @@ class TestImportPath:
     def setuptestfs(self, path: Path) -> None:
         # print "setting up test fs for", repr(path)
         samplefile = path / "samplefile"
-        samplefile.write_text("samplefile\n")
+        samplefile.write_text("samplefile\n", encoding="utf-8")
 
         execfile = path / "execfile"
-        execfile.write_text("x=42")
+        execfile.write_text("x=42", encoding="utf-8")
 
         execfilepy = path / "execfile.py"
-        execfilepy.write_text("x=42")
+        execfilepy.write_text("x=42", encoding="utf-8")
 
         d = {1: 2, "hello": "world", "answer": 42}
         path.joinpath("samplepickle").write_bytes(pickle.dumps(d, 1))

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -120,9 +120,9 @@ class TestImportPath:
         otherdir.joinpath("__init__.py").touch()
 
         module_a = otherdir / "a.py"
-        module_a.write_text("from .b import stuff as result\n")
+        module_a.write_text("from .b import stuff as result\n", encoding="utf-8")
         module_b = otherdir / "b.py"
-        module_b.write_text('stuff="got it"\n')
+        module_b.write_text('stuff="got it"\n', encoding="utf-8")
         module_c = otherdir / "c.py"
         module_c.write_text(
             dedent(
@@ -131,7 +131,8 @@ class TestImportPath:
             import otherdir.a
             value = otherdir.a.result
         """
-            )
+            ),
+            encoding="utf-8",
         )
         module_d = otherdir / "d.py"
         module_d.write_text(
@@ -141,7 +142,8 @@ class TestImportPath:
             from otherdir import a
             value2 = a.result
         """
-            )
+            ),
+            encoding="utf-8",
         )
 
     def test_smoke_test(self, path1: Path) -> None:
@@ -283,7 +285,7 @@ class TestImportPath:
     def simple_module(self, tmp_path: Path) -> Path:
         fn = tmp_path / "_src/tests/mymod.py"
         fn.parent.mkdir(parents=True)
-        fn.write_text("def foo(x): return 40 + x")
+        fn.write_text("def foo(x): return 40 + x", encoding="utf-8")
         return fn
 
     def test_importmode_importlib(self, simple_module: Path, tmp_path: Path) -> None:
@@ -447,7 +449,7 @@ def test_samefile_false_negatives(tmp_path: Path, monkeypatch: MonkeyPatch) -> N
     return False, even when they are clearly equal.
     """
     module_path = tmp_path.joinpath("my_module.py")
-    module_path.write_text("def foo(): return 42")
+    module_path.write_text("def foo(): return 42", encoding="utf-8")
     monkeypatch.syspath_prepend(tmp_path)
 
     with monkeypatch.context() as mp:
@@ -473,7 +475,8 @@ class TestImportLibMode:
                 class Data:
                     value: str
                 """
-            )
+            ),
+            encoding="utf-8",
         )
 
         module = import_path(fn, mode="importlib", root=tmp_path)
@@ -498,7 +501,8 @@ class TestImportLibMode:
                     s = pickle.dumps(_action)
                     return pickle.loads(s)
                 """
-            )
+            ),
+            encoding="utf-8",
         )
 
         module = import_path(fn, mode="importlib", root=tmp_path)
@@ -525,7 +529,8 @@ class TestImportLibMode:
                 class Data:
                     x: int = 42
                 """
-            )
+            ),
+            encoding="utf-8",
         )
 
         fn2 = tmp_path.joinpath("_src/m2/tests/test.py")
@@ -540,7 +545,8 @@ class TestImportLibMode:
                 class Data:
                     x: str = ""
                 """
-            )
+            ),
+            encoding="utf-8",
         )
 
         import pickle

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -347,7 +347,7 @@ class TestPytestPluginManager:
         pytest.raises(ImportError, pytestpm.import_plugin, "pytest_qweqwex.y")
 
         pytester.syspathinsert()
-        pytester.mkpydir("pkg").joinpath("plug.py").write_text("x=3")
+        pytester.mkpydir("pkg").joinpath("plug.py").write_text("x=3", encoding="utf-8")
         pluginname = "pkg.plug"
         pytestpm.import_plugin(pluginname)
         mod = pytestpm.get_plugin("pkg.plug")

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -222,7 +222,7 @@ class TestInlineRunModulesCleanup:
         result = pytester.inline_run(str(test_mod))
         assert result.ret == ExitCode.OK
         # rewrite module, now test should fail if module was re-imported
-        test_mod.write_text("def test_foo(): assert False")
+        test_mod.write_text("def test_foo(): assert False", encoding="utf-8")
         result2 = pytester.inline_run(str(test_mod))
         assert result2.ret == ExitCode.TESTS_FAILED
 

--- a/testing/test_reports.py
+++ b/testing/test_reports.py
@@ -410,7 +410,7 @@ class TestReportSerialization:
     ) -> None:
         sub_dir = pytester.path.joinpath("ns")
         sub_dir.mkdir()
-        sub_dir.joinpath("conftest.py").write_text("import unknown")
+        sub_dir.joinpath("conftest.py").write_text("import unknown", encoding="utf-8")
 
         result = pytester.runpytest_subprocess(".")
         result.stdout.fnmatch_lines(["E   *Error: No module named 'unknown'"])

--- a/testing/test_session.py
+++ b/testing/test_session.py
@@ -265,9 +265,9 @@ def test_plugin_already_exists(pytester: Pytester) -> None:
 
 def test_exclude(pytester: Pytester) -> None:
     hellodir = pytester.mkdir("hello")
-    hellodir.joinpath("test_hello.py").write_text("x y syntaxerror")
+    hellodir.joinpath("test_hello.py").write_text("x y syntaxerror", encoding="utf-8")
     hello2dir = pytester.mkdir("hello2")
-    hello2dir.joinpath("test_hello2.py").write_text("x y syntaxerror")
+    hello2dir.joinpath("test_hello2.py").write_text("x y syntaxerror", encoding="utf-8")
     pytester.makepyfile(test_ok="def test_pass(): pass")
     result = pytester.runpytest("--ignore=hello", "--ignore=hello2")
     assert result.ret == 0
@@ -276,13 +276,13 @@ def test_exclude(pytester: Pytester) -> None:
 
 def test_exclude_glob(pytester: Pytester) -> None:
     hellodir = pytester.mkdir("hello")
-    hellodir.joinpath("test_hello.py").write_text("x y syntaxerror")
+    hellodir.joinpath("test_hello.py").write_text("x y syntaxerror", encoding="utf-8")
     hello2dir = pytester.mkdir("hello2")
-    hello2dir.joinpath("test_hello2.py").write_text("x y syntaxerror")
+    hello2dir.joinpath("test_hello2.py").write_text("x y syntaxerror", encoding="utf-8")
     hello3dir = pytester.mkdir("hallo3")
-    hello3dir.joinpath("test_hello3.py").write_text("x y syntaxerror")
+    hello3dir.joinpath("test_hello3.py").write_text("x y syntaxerror", encoding="utf-8")
     subdir = pytester.mkdir("sub")
-    subdir.joinpath("test_hello4.py").write_text("x y syntaxerror")
+    subdir.joinpath("test_hello4.py").write_text("x y syntaxerror", encoding="utf-8")
     pytester.makepyfile(test_ok="def test_pass(): pass")
     result = pytester.runpytest("--ignore-glob=*h[ea]llo*")
     assert result.ret == 0

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -195,7 +195,8 @@ class TestEvaluation:
             def pytest_markeval_namespace():
                 return {"arg": "root"}
             """
-            )
+            ),
+            encoding="utf-8",
         )
         root.joinpath("test_root.py").write_text(
             textwrap.dedent(
@@ -206,7 +207,8 @@ class TestEvaluation:
             def test_root():
                 assert False
             """
-            )
+            ),
+            encoding="utf-8",
         )
         foo = root.joinpath("foo")
         foo.mkdir()
@@ -219,7 +221,8 @@ class TestEvaluation:
             def pytest_markeval_namespace():
                 return {"arg": "foo"}
             """
-            )
+            ),
+            encoding="utf-8",
         )
         foo.joinpath("test_foo.py").write_text(
             textwrap.dedent(
@@ -230,7 +233,8 @@ class TestEvaluation:
             def test_foo():
                 assert False
             """
-            )
+            ),
+            encoding="utf-8",
         )
         bar = root.joinpath("bar")
         bar.mkdir()
@@ -243,7 +247,8 @@ class TestEvaluation:
             def pytest_markeval_namespace():
                 return {"arg": "bar"}
             """
-            )
+            ),
+            encoding="utf-8",
         )
         bar.joinpath("test_bar.py").write_text(
             textwrap.dedent(
@@ -254,7 +259,8 @@ class TestEvaluation:
             def test_bar():
                 assert False
             """
-            )
+            ),
+            encoding="utf-8",
         )
 
         reprec = pytester.inline_run("-vs", "--capture=no")
@@ -629,7 +635,8 @@ class TestXFail:
 
             @pytest.mark.xfail(reason='unsupported feature', strict=%s)
             def test_foo():
-                with open('foo_executed', 'w'): pass  # make sure test executes
+                with open('foo_executed', 'w', encoding='utf-8'):
+                    pass  # make sure test executes
         """
             % strict
         )

--- a/testing/test_stepwise.py
+++ b/testing/test_stepwise.py
@@ -352,6 +352,6 @@ def test_one():
     assert result.ret == 0
 
     assert Path(stepwise_cache_file).exists()
-    with stepwise_cache_file.open() as file_handle:
+    with stepwise_cache_file.open(encoding="utf-8") as file_handle:
         observed_value = file_handle.readlines()
     assert [expected_value] == observed_value

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -244,7 +244,8 @@ class TestTerminal:
                     def test_method(self):
                         pass
                 """
-            )
+            ),
+            encoding="utf-8",
         )
         result = pytester.runpytest("-vv")
         assert result.ret == 0
@@ -1567,7 +1568,8 @@ class TestGenericReporting:
             """
 def pytest_report_header(config, start_path):
     return ["line1", str(start_path)]
-"""
+""",
+            encoding="utf-8",
         )
         result = pytester.runpytest("a")
         result.stdout.fnmatch_lines(["*hello: 42*", "line1", str(pytester.path)])
@@ -1671,7 +1673,7 @@ def test_fdopen_kept_alive_issue124(pytester: Pytester) -> None:
         import os, sys
         k = []
         def test_open_file_and_keep_alive(capfd):
-            stdout = os.fdopen(1, 'w', 1)
+            stdout = os.fdopen(1, 'w', buffering=1, encoding='utf-8')
             k.append(stdout)
 
         def test_close_kept_alive_file():

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -561,7 +561,7 @@ def test_basetemp_with_read_only_files(pytester: Pytester) -> None:
 
         def test(tmp_path):
             fn = tmp_path / 'foo.txt'
-            fn.write_text('hello')
+            fn.write_text('hello', encoding='utf-8')
             mode = os.stat(str(fn)).st_mode
             os.chmod(str(fn), mode & ~stat.S_IREAD)
     """

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -810,12 +810,12 @@ def test_resource_warning(pytester: Pytester, monkeypatch: pytest.MonkeyPatch) -
     pytester.makepyfile(
         """
         def open_file(p):
-            f = p.open("r")
+            f = p.open("r", encoding="utf-8")
             assert p.read_text() == "hello"
 
         def test_resource_warning(tmp_path):
             p = tmp_path.joinpath("foo.txt")
-            p.write_text("hello")
+            p.write_text("hello", encoding="utf-8")
             open_file(p)
         """
     )

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,10 @@ passenv =
 setenv =
     _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_POSARGS_DOCTESTING:} {env:_PYTEST_TOX_POSARGS_LSOF:} {env:_PYTEST_TOX_POSARGS_XDIST:}
 
+    # See https://docs.python.org/3/library/io.html#io-encoding-warning
+    # If we don't enable this, neither can any of our downstream users!
+    PYTHONWARNDEFAULTENCODING=1
+
     # Configuration to run with coverage similar to CI, e.g.
     # "tox -e py37-coverage".
     coverage: _PYTEST_TOX_COVERAGE_RUN=coverage run -m


### PR DESCRIPTION
Updated attempt to check encoding warnings as in https://github.com/pytest-dev/pytest/pull/10328/, as dependencies have been updated in the past 6 months.

(Zac edit: now also fixes https://github.com/pytest-dev/pytest/issues/7781)