### PR TITLE
Make `pytest.warns()` re-emit all non-matching warnings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -311,6 +311,7 @@ Raphael Pierzina
 Rafal Semik
 Raquel Alegre
 Ravi Chandra
+Reagan Lee
 Robert Holt
 Roberto Aldera
 Roberto Polli

--- a/changelog/9288.breaking.rst
+++ b/changelog/9288.breaking.rst
@@ -1,0 +1,1 @@
+Set :func:`warns` to re-emit unmatched warnings when the context closes

--- a/changelog/9288.breaking.rst
+++ b/changelog/9288.breaking.rst
@@ -1,1 +1,7 @@
-Set :func:`warns` to re-emit unmatched warnings when the context closes
+:func:`pytest.warns <warns>` now re-emits unmatched warnings when the context
+closes -- previously it would consume all warnings, hiding those that were not
+matched by the function.
+
+While this is a new feature, we decided to announce this as a breaking change
+because many test suites are configured to error-out on warnings, and will
+therefore fail on the newly-re-emitted warnings.

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -117,10 +117,10 @@ def warns(  # noqa: F811
     warning of that class or classes.
 
     This helper produces a list of :class:`warnings.WarningMessage` objects, one for
-    each warning raised (regardless of whether it is an ``expected_warning`` or not).
+    each warning emitted (regardless of whether it is an ``expected_warning`` or not).
+    Since pytest 8.0, unmatched warnings are also re-emitted when the context closes.
 
-    This function can be used as a context manager, which will capture all the raised
-    warnings inside it::
+    This function can be used as a context manager::
 
         >>> import pytest
         >>> with pytest.warns(RuntimeWarning):
@@ -149,10 +149,6 @@ def warns(  # noqa: F811
 
     This could be achieved in the same way as with exceptions, see
     :ref:`parametrizing_conditional_raising` for an example.
-
-    .. note::
-        Unlike the stdlib :func:`warnings.catch_warnings` context manager,
-        unmatched warnings will be re-emitted when the context closes.
 
     """
     __tracebackhide__ = True
@@ -328,7 +324,7 @@ class WarningsChecker(WarningsRecorder):
                 if not self.matches(w):
                     warnings.warn_explicit(
                         str(w.message),
-                        w.message.__class__,  # type: ignore
+                        w.message.__class__,  # type: ignore[arg-type]
                         w.filename,
                         w.lineno,
                         module=w.__module__,

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -135,8 +135,9 @@ def warns(  # noqa: F811
         >>> with pytest.warns(UserWarning, match=r'must be \d+$'):
         ...     warnings.warn("value must be 42", UserWarning)
 
-        >>> with pytest.warns(UserWarning, match=r'must be \d+$'):
-        ...     warnings.warn("this is not here", UserWarning)
+        >>> with pytest.warns(UserWarning):  # catch re-emitted warning
+        ...     with pytest.warns(UserWarning, match=r'must be \d+$'):
+        ...         warnings.warn("this is not here", UserWarning)
         Traceback (most recent call last):
           ...
         Failed: DID NOT WARN. No warnings of type ...UserWarning... were emitted...
@@ -327,7 +328,7 @@ class WarningsChecker(WarningsRecorder):
                 if not self.matches(w):
                     warnings.warn_explicit(
                         str(w.message),
-                        w.message.__class__,
+                        w.message.__class__,  # type: ignore
                         w.filename,
                         w.lineno,
                         module=w.__module__,

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -376,7 +376,7 @@ class TestWarns:
                 warnings.warn("value must be 42", UserWarning)
 
     def test_one_from_multiple_warns(self) -> None:
-        with pytest.raises(pytest.fail.Exception):
+        with pytest.raises(pytest.fail.Exception, match="DID NOT WARN"):
             with pytest.warns(UserWarning, match=r"aaa"):
                 with pytest.warns(UserWarning, match=r"aaa"):
                     warnings.warn("cccccccccc", UserWarning)
@@ -384,7 +384,7 @@ class TestWarns:
                     warnings.warn("aaaaaaaaaa", UserWarning)
 
     def test_none_of_multiple_warns(self) -> None:
-        with pytest.raises(pytest.fail.Exception):
+        with pytest.raises(pytest.fail.Exception, match="DID NOT WARN"):
             with pytest.warns(UserWarning, match=r"aaa"):
                 warnings.warn("bbbbbbbbbb", UserWarning)
                 warnings.warn("cccccccccc", UserWarning)
@@ -424,13 +424,13 @@ class TestWarns:
                 warnings.warn("some deprecation warning", DeprecationWarning)
 
     def test_re_emit_match_multiple(self) -> None:
-        # with pytest.warns(UserWarning):
-        with pytest.warns(UserWarning, match="user warning"):
-            warnings.warn("first user warning", UserWarning)
-            warnings.warn("second user warning", UserWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # if anything is re-emitted
+            with pytest.warns(UserWarning, match="user warning"):
+                warnings.warn("first user warning", UserWarning)
+                warnings.warn("second user warning", UserWarning)
 
     def test_re_emit_non_match_single(self) -> None:
-        # with pytest.warns(UserWarning):
         with pytest.warns(UserWarning, match="v2 warning"):
             with pytest.warns(UserWarning, match="v1 warning"):
                 warnings.warn("v1 warning", UserWarning)

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -376,10 +376,12 @@ class TestWarns:
                 warnings.warn("value must be 42", UserWarning)
 
     def test_one_from_multiple_warns(self) -> None:
-        with pytest.warns(UserWarning, match=r"aaa"):
-            warnings.warn("cccccccccc", UserWarning)
-            warnings.warn("bbbbbbbbbb", UserWarning)
-            warnings.warn("aaaaaaaaaa", UserWarning)
+        with pytest.raises(pytest.fail.Exception):
+            with pytest.warns(UserWarning, match=r"aaa"):
+                with pytest.warns(UserWarning, match=r"aaa"):
+                    warnings.warn("cccccccccc", UserWarning)
+                    warnings.warn("bbbbbbbbbb", UserWarning)
+                    warnings.warn("aaaaaaaaaa", UserWarning)
 
     def test_none_of_multiple_warns(self) -> None:
         with pytest.raises(pytest.fail.Exception):
@@ -403,3 +405,33 @@ class TestWarns:
             with pytest.warns(UserWarning, foo="bar"):  # type: ignore
                 pass
         assert "Unexpected keyword arguments" in str(excinfo.value)
+
+    def test_re_emit_single(self) -> None:
+        with pytest.warns(DeprecationWarning):
+            with pytest.warns(UserWarning):
+                warnings.warn("user warning", UserWarning)
+                warnings.warn("some deprecation warning", DeprecationWarning)
+
+    def test_re_emit_multiple(self) -> None:
+        with pytest.warns(UserWarning):
+            warnings.warn("first warning", UserWarning)
+            warnings.warn("second warning", UserWarning)
+
+    def test_re_emit_match_single(self) -> None:
+        with pytest.warns(DeprecationWarning):
+            with pytest.warns(UserWarning, match="user warning"):
+                warnings.warn("user warning", UserWarning)
+                warnings.warn("some deprecation warning", DeprecationWarning)
+
+    def test_re_emit_match_multiple(self) -> None:
+        # with pytest.warns(UserWarning):
+        with pytest.warns(UserWarning, match="user warning"):
+            warnings.warn("first user warning", UserWarning)
+            warnings.warn("second user warning", UserWarning)
+
+    def test_re_emit_non_match_single(self) -> None:
+        # with pytest.warns(UserWarning):
+        with pytest.warns(UserWarning, match="v2 warning"):
+            with pytest.warns(UserWarning, match="v1 warning"):
+                warnings.warn("v1 warning", UserWarning)
+                warnings.warn("non-matching v2 warning", UserWarning)

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -203,19 +203,21 @@ class TestDeprecatedCall:
             def f():
                 warnings.warn(warning("hi"))
 
-            with pytest.raises(pytest.fail.Exception):
-                pytest.deprecated_call(f)
-            with pytest.raises(pytest.fail.Exception):
-                with pytest.deprecated_call():
-                    f()
+            with pytest.warns(warning):
+                with pytest.raises(pytest.fail.Exception):
+                    pytest.deprecated_call(f)
+                with pytest.raises(pytest.fail.Exception):
+                    with pytest.deprecated_call():
+                        f()
 
     def test_deprecated_call_supports_match(self) -> None:
         with pytest.deprecated_call(match=r"must be \d+$"):
             warnings.warn("value must be 42", DeprecationWarning)
 
-        with pytest.raises(pytest.fail.Exception):
-            with pytest.deprecated_call(match=r"must be \d+$"):
-                warnings.warn("this is not here", DeprecationWarning)
+        with pytest.deprecated_call():
+            with pytest.raises(pytest.fail.Exception, match="DID NOT WARN"):
+                with pytest.deprecated_call(match=r"must be \d+$"):
+                    warnings.warn("this is not here", DeprecationWarning)
 
 
 class TestWarns:
@@ -227,8 +229,9 @@ class TestWarns:
     def test_several_messages(self) -> None:
         # different messages, b/c Python suppresses multiple identical warnings
         pytest.warns(RuntimeWarning, lambda: warnings.warn("w1", RuntimeWarning))
-        with pytest.raises(pytest.fail.Exception):
-            pytest.warns(UserWarning, lambda: warnings.warn("w2", RuntimeWarning))
+        with pytest.warns(RuntimeWarning):
+            with pytest.raises(pytest.fail.Exception):
+                pytest.warns(UserWarning, lambda: warnings.warn("w2", RuntimeWarning))
         pytest.warns(RuntimeWarning, lambda: warnings.warn("w3", RuntimeWarning))
 
     def test_function(self) -> None:
@@ -243,13 +246,14 @@ class TestWarns:
         pytest.warns(
             (RuntimeWarning, SyntaxWarning), lambda: warnings.warn("w2", SyntaxWarning)
         )
-        pytest.raises(
-            pytest.fail.Exception,
-            lambda: pytest.warns(
-                (RuntimeWarning, SyntaxWarning),
-                lambda: warnings.warn("w3", UserWarning),
-            ),
-        )
+        with pytest.warns():
+            pytest.raises(
+                pytest.fail.Exception,
+                lambda: pytest.warns(
+                    (RuntimeWarning, SyntaxWarning),
+                    lambda: warnings.warn("w3", UserWarning),
+                ),
+            )
 
     def test_as_contextmanager(self) -> None:
         with pytest.warns(RuntimeWarning):
@@ -258,20 +262,22 @@ class TestWarns:
         with pytest.warns(UserWarning):
             warnings.warn("user", UserWarning)
 
-        with pytest.raises(pytest.fail.Exception) as excinfo:
-            with pytest.warns(RuntimeWarning):
-                warnings.warn("user", UserWarning)
+        with pytest.warns():
+            with pytest.raises(pytest.fail.Exception) as excinfo:
+                with pytest.warns(RuntimeWarning):
+                    warnings.warn("user", UserWarning)
         excinfo.match(
             r"DID NOT WARN. No warnings of type \(.+RuntimeWarning.+,\) were emitted.\n"
-            r"The list of emitted warnings is: \[UserWarning\('user',?\)\]."
+            r" Emitted warnings: \[UserWarning\('user',?\)\]."
         )
 
-        with pytest.raises(pytest.fail.Exception) as excinfo:
-            with pytest.warns(UserWarning):
-                warnings.warn("runtime", RuntimeWarning)
+        with pytest.warns():
+            with pytest.raises(pytest.fail.Exception) as excinfo:
+                with pytest.warns(UserWarning):
+                    warnings.warn("runtime", RuntimeWarning)
         excinfo.match(
             r"DID NOT WARN. No warnings of type \(.+UserWarning.+,\) were emitted.\n"
-            r"The list of emitted warnings is: \[RuntimeWarning\('runtime',?\)]."
+            r" Emitted warnings: \[RuntimeWarning\('runtime',?\)]."
         )
 
         with pytest.raises(pytest.fail.Exception) as excinfo:
@@ -279,19 +285,20 @@ class TestWarns:
                 pass
         excinfo.match(
             r"DID NOT WARN. No warnings of type \(.+UserWarning.+,\) were emitted.\n"
-            r"The list of emitted warnings is: \[\]."
+            r" Emitted warnings: \[\]."
         )
 
         warning_classes = (UserWarning, FutureWarning)
-        with pytest.raises(pytest.fail.Exception) as excinfo:
-            with pytest.warns(warning_classes) as warninfo:
-                warnings.warn("runtime", RuntimeWarning)
-                warnings.warn("import", ImportWarning)
+        with pytest.warns():
+            with pytest.raises(pytest.fail.Exception) as excinfo:
+                with pytest.warns(warning_classes) as warninfo:
+                    warnings.warn("runtime", RuntimeWarning)
+                    warnings.warn("import", ImportWarning)
 
         messages = [each.message for each in warninfo]
         expected_str = (
             f"DID NOT WARN. No warnings of type {warning_classes} were emitted.\n"
-            f"The list of emitted warnings is: {messages}."
+            f" Emitted warnings: {messages}."
         )
 
         assert str(excinfo.value) == expected_str
@@ -367,27 +374,31 @@ class TestWarns:
         with pytest.warns(UserWarning, match=r"must be \d+$"):
             warnings.warn("value must be 42", UserWarning)
 
-        with pytest.raises(pytest.fail.Exception):
-            with pytest.warns(UserWarning, match=r"must be \d+$"):
-                warnings.warn("this is not here", UserWarning)
+        with pytest.warns():
+            with pytest.raises(pytest.fail.Exception):
+                with pytest.warns(UserWarning, match=r"must be \d+$"):
+                    warnings.warn("this is not here", UserWarning)
 
-        with pytest.raises(pytest.fail.Exception):
-            with pytest.warns(FutureWarning, match=r"must be \d+$"):
-                warnings.warn("value must be 42", UserWarning)
+        with pytest.warns():
+            with pytest.raises(pytest.fail.Exception):
+                with pytest.warns(FutureWarning, match=r"must be \d+$"):
+                    warnings.warn("value must be 42", UserWarning)
 
     def test_one_from_multiple_warns(self) -> None:
-        with pytest.raises(pytest.fail.Exception, match="DID NOT WARN"):
-            with pytest.warns(UserWarning, match=r"aaa"):
+        with pytest.warns():
+            with pytest.raises(pytest.fail.Exception, match="DID NOT WARN"):
                 with pytest.warns(UserWarning, match=r"aaa"):
-                    warnings.warn("cccccccccc", UserWarning)
-                    warnings.warn("bbbbbbbbbb", UserWarning)
-                    warnings.warn("aaaaaaaaaa", UserWarning)
+                    with pytest.warns(UserWarning, match=r"aaa"):
+                        warnings.warn("cccccccccc", UserWarning)
+                        warnings.warn("bbbbbbbbbb", UserWarning)
+                        warnings.warn("aaaaaaaaaa", UserWarning)
 
     def test_none_of_multiple_warns(self) -> None:
-        with pytest.raises(pytest.fail.Exception, match="DID NOT WARN"):
-            with pytest.warns(UserWarning, match=r"aaa"):
-                warnings.warn("bbbbbbbbbb", UserWarning)
-                warnings.warn("cccccccccc", UserWarning)
+        with pytest.warns():
+            with pytest.raises(pytest.fail.Exception, match="DID NOT WARN"):
+                with pytest.warns(UserWarning, match=r"aaa"):
+                    warnings.warn("bbbbbbbbbb", UserWarning)
+                    warnings.warn("cccccccccc", UserWarning)
 
     @pytest.mark.filterwarnings("ignore")
     def test_can_capture_previously_warned(self) -> None:


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

PR Description: 

This issue fixes part of issue #9288 by allowing ``pytest.warns()`` to emit all unmatched warnings. 

One question I have with the design is how to handle the exceptions once we re-emit them. Having ``pytest.warns()`` calls return all exceptions will require refactoring of other tests. There doesn't seem to be a way to check whether the code is within a WarningsChecker frame, so a way to solve this is an optional-argument for re-emitting? 