### PR TITLE
doc: Fix 2024 training location

### DIFF
--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -2,7 +2,7 @@
 
 .. sidebar:: Next Open Trainings
 
-   - `Professional Testing with Python <https://python-academy.com/courses/python_course_testing.html>`_, via `Python Academy <https://www.python-academy.com/>`_, March 5th to 7th 2024 (3 day in-depth training), Remote
+   - `Professional Testing with Python <https://python-academy.com/courses/python_course_testing.html>`_, via `Python Academy <https://www.python-academy.com/>`_, March 5th to 7th 2024 (3 day in-depth training), Leipzig/Remote
 
    Also see :doc:`previous talks and blogposts <talks>`.
 


### PR DESCRIPTION
Sorry for the noise - missed that with the original PR, based on the 2023 data. Hopefully it'll be a hybrid one in 2024 again!