### PR TITLE
Fix couple of EncodingWarnings

### DIFF
--- a/src/_pytest/_py/path.py
+++ b/src/_pytest/_py/path.py
@@ -953,7 +953,7 @@ class LocalPath:
         else:
             p.dirpath()._ensuredirs()
             if not p.check(file=1):
-                p.open("w").close()
+                p.open("wb").close()
             return p
 
     @overload

--- a/src/_pytest/faulthandler.py
+++ b/src/_pytest/faulthandler.py
@@ -27,7 +27,7 @@ def pytest_configure(config: Config) -> None:
     import faulthandler
 
     stderr_fd_copy = os.dup(get_stderr_fileno())
-    config.stash[fault_handler_stderr_key] = open(stderr_fd_copy, "w")
+    config.stash[fault_handler_stderr_key] = open(stderr_fd_copy, "w", encoding=sys.stderr.encoding)
     config.stash[fault_handler_originally_enabled_key] = faulthandler.is_enabled()
     faulthandler.enable(file=config.stash[fault_handler_stderr_key])
 

--- a/src/_pytest/faulthandler.py
+++ b/src/_pytest/faulthandler.py
@@ -27,7 +27,9 @@ def pytest_configure(config: Config) -> None:
     import faulthandler
 
     stderr_fd_copy = os.dup(get_stderr_fileno())
-    config.stash[fault_handler_stderr_key] = open(stderr_fd_copy, "w", encoding=sys.stderr.encoding)
+    config.stash[fault_handler_stderr_key] = open(
+        stderr_fd_copy, "w", encoding=sys.stderr.encoding
+    )
     config.stash[fault_handler_originally_enabled_key] = faulthandler.is_enabled()
     faulthandler.enable(file=config.stash[fault_handler_stderr_key])
 


### PR DESCRIPTION
See https://github.com/pytest-dev/pytest/pull/10328#issuecomment-1528045842 for context.

The `py.path` one might be better to leave as-is, but I lean toward fixing.