### PR TITLE
Updated diff to show \t in string comparison assertions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -120,6 +120,7 @@ Eduardo Schettino
 Eli Boyarski
 Elizaveta Shashkova
 Éloi Rivard
+Emmeline Wetzel
 Endre Galaczi
 Eric Hunsberger
 Eric Liu
@@ -219,6 +220,7 @@ Loic Esteve
 Lukas Bednar
 Luke Murphy
 Maciek Fijalkowski
+Madeline Thai-Tang
 Maho
 Maik Figura
 Mandeep Bhutani

--- a/changelog/10704.improvement.rst
+++ b/changelog/10704.improvement.rst
@@ -1,0 +1,1 @@
+Changed the diff explanation for string comparison assertions when there is a tab in the string to show ``\t`` instead of ``    ``

--- a/changelog/10704.improvement.rst
+++ b/changelog/10704.improvement.rst
@@ -1,1 +1,1 @@
-Changed the diff explanation for string comparison assertions when there is a tab in the string to show ``\t`` instead of ``    ``
+Changed the diff explanation for string comparison assertions when there is a tab in the string to show ``\t`` instead of four spaces.

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -291,8 +291,8 @@ def _diff_text(left: str, right: str, verbose: int = 0) -> List[str]:
     ]
     for i in range(len(explanation)):
         if "?    " not in explanation[i]:  # dont replace diff message tab
-            explanation[i] = explanation[i].replace("+     ", "+ \t")
-            explanation[i] = explanation[i].replace("    ", "\t")
+            explanation[i] = explanation[i].replace("+     ", "+ \\t")
+            explanation[i] = explanation[i].replace("    ", "\\t")
     return explanation
 
 

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -290,10 +290,9 @@ def _diff_text(left: str, right: str, verbose: int = 0) -> List[str]:
         for line in ndiff(right.splitlines(keepends), left.splitlines(keepends))
     ]
     for i in range(len(explanation)):
-        explanation[i] = explanation[i].replace("+     ", "+ \t")
-        explanation[i] = explanation[i].replace("    ", "\t")
-    print("**********************LOOK HERE***********************")
-    print(explanation)
+        if "?    " not in explanation[i]:  # dont replace diff message tab
+            explanation[i] = explanation[i].replace("+     ", "+ \t")
+            explanation[i] = explanation[i].replace("    ", "\t")
     return explanation
 
 

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -290,7 +290,10 @@ def _diff_text(left: str, right: str, verbose: int = 0) -> List[str]:
         for line in ndiff(right.splitlines(keepends), left.splitlines(keepends))
     ]
     for i in range(len(explanation)):
+        explanation[i] = explanation[i].replace("+     ", "+ \t")
         explanation[i] = explanation[i].replace("    ", "\t")
+    print("**********************LOOK HERE***********************")
+    print(explanation)
     return explanation
 
 

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -289,6 +289,8 @@ def _diff_text(left: str, right: str, verbose: int = 0) -> List[str]:
         line.strip("\n")
         for line in ndiff(right.splitlines(keepends), left.splitlines(keepends))
     ]
+    for i in range(len(explanation)):
+        explanation[i] = explanation[i].replace("    ", "\t")
     return explanation
 
 

--- a/testing/test_error_diffs.py
+++ b/testing/test_error_diffs.py
@@ -274,8 +274,8 @@ TESTCASES = [
         >       assert result == desired
         E       AssertionError: assert 'spam    bacon\\n    eggs love' == 'spam bacon eggs love'
         E         - spam bacon eggs love
-        E         + spam\tbacon
-        E         + \teggs love
+        E         + spam\\tbacon
+        E         + \\teggs love
         """,
         id='Test "not in" string',
     ),

--- a/testing/test_error_diffs.py
+++ b/testing/test_error_diffs.py
@@ -277,7 +277,7 @@ TESTCASES = [
         E         + spam\\tbacon
         E         + \\teggs love
         """,
-        id='Test "not in" string',
+        id="Test tab repr in diff",
     ),
 ]
 

--- a/testing/test_error_diffs.py
+++ b/testing/test_error_diffs.py
@@ -272,10 +272,10 @@ TESTCASES = [
         """,
         """
         >       assert result == desired
-        E       AssertionError: assert 'spam\\tbacon\\n\\teggs love' == 'spam bacon eggs love'
+        E       AssertionError: assert 'spam    bacon\\n    eggs love' == 'spam bacon eggs love'
         E         - spam bacon eggs love
-        E         + spam    bacon
-        E         +     eggs love
+        E         + spam\tbacon
+        E         + \teggs love
         """,
         id='Test "not in" string',
     ),

--- a/testing/test_error_diffs.py
+++ b/testing/test_error_diffs.py
@@ -272,7 +272,7 @@ TESTCASES = [
         """,
         """
         >       assert result == desired
-        E       AssertionError: assert 'spam    bacon\\n    eggs love' == 'spam bacon eggs love'
+        E       AssertionError: assert 'spam\\tbacon\\n\\teggs love' == 'spam bacon eggs love'
         E         - spam bacon eggs love
         E         + spam    bacon
         E         +     eggs love

--- a/testing/test_error_diffs.py
+++ b/testing/test_error_diffs.py
@@ -262,6 +262,23 @@ TESTCASES = [
         """,
         id="Compare attrs classes",
     ),
+    pytest.param(
+        """
+        def test_this():
+            result =   '''spam    bacon
+            eggs love'''
+            desired = "spam bacon eggs love"
+            assert result == desired
+        """,
+        """
+        >       assert result == desired
+        E       AssertionError: assert 'spam    bacon\\n    eggs love' == 'spam bacon eggs love'
+        E         - spam bacon eggs love
+        E         + spam    bacon
+        E         +     eggs love
+        """,
+        id='Test "not in" string',
+    ),
 ]
 
 


### PR DESCRIPTION
Closes #10704 

Added "\t" characters to the diff message, did not add "\n" because the diff already creates each line on a separate line and it shows in the "AssertionError: ______" section of the error message. 
Updated test suite to reflect this change.

Before:
<img width="1071" alt="A21FBA6C-69C9-4DB4-8560-2359DFF974AC" src="https://user-images.githubusercontent.com/98917607/235961748-1e0584a7-6e8a-4e28-a1ab-fb458f62f335.png">

After:
```
pytest.param(
        """
        def test_this():
            result =   '''spam    bacon
            eggs love'''
            desired = "spam bacon eggs love"
            assert result == desired
        """,
        """
        >       assert result == desired
        E       AssertionError: assert 'spam    bacon\\n    eggs love' == 'spam bacon eggs love'
        E         - spam bacon eggs love
        E         + spam\\tbacon
        E         + \\teggs love
        """,
        id='Test "not in" string',
    ),
```

Worked with @egwetzel on this issue in team with @HSamiul.

