### PR TITLE
fix reference to non-existent module

### DIFF
--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from typing_extensions import Literal
 
     from _pytest._code.code import ExceptionRepr
-    from _pytest.code import ExceptionInfo
+    from _pytest._code.code import ExceptionInfo
     from _pytest.config import Config
     from _pytest.config import ExitCode
     from _pytest.config import PytestPluginManager


### PR DESCRIPTION
This is a minor fix to a reference to a no-longer-existing private module. There should be no runtime effects, because the fix is made under a `typing.TYPE_CHECKING` block.

---

I've read through #7469, where there was a public API typing change

> - [x] `_pytest.code.ExceptionInfo` -> `pytest.ExceptionInfo`

but as the rest of the references in the [same block in `_pytest/hookspec.py`](https://github.com/pytest-dev/pytest/blob/a88ae8289cd21d39dd360666bb2e83dfa98b215e/src/_pytest/hookspec.py#L23-L44) are all for private modules, I thought it would be best to continue using a private module instead of switching the reference to a public `from pytest import ExceptionInfo`.