### PR TITLE
Avoid ast deprecation warnings on Python 3.12

### DIFF
--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -46,8 +46,14 @@ if TYPE_CHECKING:
 
 if sys.version_info >= (3, 8):
     namedExpr = ast.NamedExpr
+    astNameConstant = ast.Constant
+    astStr = ast.Constant
+    astNum = ast.Constant
 else:
     namedExpr = ast.Expr
+    astNameConstant = ast.NameConstant
+    astStr = ast.Str
+    astNum = ast.Num
 
 
 assertstate_key = StashKey["AssertionState"]()
@@ -680,7 +686,7 @@ class AssertionRewriter(ast.NodeVisitor):
             if (
                 expect_docstring
                 and isinstance(item, ast.Expr)
-                and isinstance(item.value, ast.Str)
+                and isinstance(item.value, astStr)
             ):
                 doc = item.value.s
                 if self.is_rewrite_disabled(doc):
@@ -814,7 +820,7 @@ class AssertionRewriter(ast.NodeVisitor):
         current = self.stack.pop()
         if self.stack:
             self.explanation_specifiers = self.stack[-1]
-        keys = [ast.Str(key) for key in current.keys()]
+        keys = [astStr(key) for key in current.keys()]
         format_dict = ast.Dict(keys, list(current.values()))
         form = ast.BinOp(expl_expr, ast.Mod(), format_dict)
         name = "@py_format" + str(next(self.variable_counter))
@@ -868,16 +874,16 @@ class AssertionRewriter(ast.NodeVisitor):
         negation = ast.UnaryOp(ast.Not(), top_condition)
 
         if self.enable_assertion_pass_hook:  # Experimental pytest_assertion_pass hook
-            msg = self.pop_format_context(ast.Str(explanation))
+            msg = self.pop_format_context(astStr(explanation))
 
             # Failed
             if assert_.msg:
                 assertmsg = self.helper("_format_assertmsg", assert_.msg)
                 gluestr = "\n>assert "
             else:
-                assertmsg = ast.Str("")
+                assertmsg = astStr("")
                 gluestr = "assert "
-            err_explanation = ast.BinOp(ast.Str(gluestr), ast.Add(), msg)
+            err_explanation = ast.BinOp(astStr(gluestr), ast.Add(), msg)
             err_msg = ast.BinOp(assertmsg, ast.Add(), err_explanation)
             err_name = ast.Name("AssertionError", ast.Load())
             fmt = self.helper("_format_explanation", err_msg)
@@ -893,8 +899,8 @@ class AssertionRewriter(ast.NodeVisitor):
             hook_call_pass = ast.Expr(
                 self.helper(
                     "_call_assertion_pass",
-                    ast.Num(assert_.lineno),
-                    ast.Str(orig),
+                    astNum(assert_.lineno),
+                    astStr(orig),
                     fmt_pass,
                 )
             )
@@ -913,7 +919,7 @@ class AssertionRewriter(ast.NodeVisitor):
                 variables = [
                     ast.Name(name, ast.Store()) for name in self.format_variables
                 ]
-                clear_format = ast.Assign(variables, ast.NameConstant(None))
+                clear_format = ast.Assign(variables, astNameConstant(None))
                 self.statements.append(clear_format)
 
         else:  # Original assertion rewriting
@@ -924,9 +930,9 @@ class AssertionRewriter(ast.NodeVisitor):
                 assertmsg = self.helper("_format_assertmsg", assert_.msg)
                 explanation = "\n>assert " + explanation
             else:
-                assertmsg = ast.Str("")
+                assertmsg = astStr("")
                 explanation = "assert " + explanation
-            template = ast.BinOp(assertmsg, ast.Add(), ast.Str(explanation))
+            template = ast.BinOp(assertmsg, ast.Add(), astStr(explanation))
             msg = self.pop_format_context(template)
             fmt = self.helper("_format_explanation", msg)
             err_name = ast.Name("AssertionError", ast.Load())
@@ -938,7 +944,7 @@ class AssertionRewriter(ast.NodeVisitor):
         # Clear temporary variables by setting them to None.
         if self.variables:
             variables = [ast.Name(name, ast.Store()) for name in self.variables]
-            clear = ast.Assign(variables, ast.NameConstant(None))
+            clear = ast.Assign(variables, astNameConstant(None))
             self.statements.append(clear)
         # Fix locations (line numbers/column offsets).
         for stmt in self.statements:
@@ -952,20 +958,20 @@ class AssertionRewriter(ast.NodeVisitor):
         # thinks it's acceptable.
         locs = ast.Call(self.builtin("locals"), [], [])
         target_id = name.target.id  # type: ignore[attr-defined]
-        inlocs = ast.Compare(ast.Str(target_id), [ast.In()], [locs])
+        inlocs = ast.Compare(astStr(target_id), [ast.In()], [locs])
         dorepr = self.helper("_should_repr_global_name", name)
         test = ast.BoolOp(ast.Or(), [inlocs, dorepr])
-        expr = ast.IfExp(test, self.display(name), ast.Str(target_id))
+        expr = ast.IfExp(test, self.display(name), astStr(target_id))
         return name, self.explanation_param(expr)
 
     def visit_Name(self, name: ast.Name) -> Tuple[ast.Name, str]:
         # Display the repr of the name if it's a local variable or
         # _should_repr_global_name() thinks it's acceptable.
         locs = ast.Call(self.builtin("locals"), [], [])
-        inlocs = ast.Compare(ast.Str(name.id), [ast.In()], [locs])
+        inlocs = ast.Compare(astStr(name.id), [ast.In()], [locs])
         dorepr = self.helper("_should_repr_global_name", name)
         test = ast.BoolOp(ast.Or(), [inlocs, dorepr])
-        expr = ast.IfExp(test, self.display(name), ast.Str(name.id))
+        expr = ast.IfExp(test, self.display(name), astStr(name.id))
         return name, self.explanation_param(expr)
 
     def visit_BoolOp(self, boolop: ast.BoolOp) -> Tuple[ast.Name, str]:
@@ -1001,7 +1007,7 @@ class AssertionRewriter(ast.NodeVisitor):
             self.push_format_context()
             res, expl = self.visit(v)
             body.append(ast.Assign([ast.Name(res_var, ast.Store())], res))
-            expl_format = self.pop_format_context(ast.Str(expl))
+            expl_format = self.pop_format_context(astStr(expl))
             call = ast.Call(app, [expl_format], [])
             self.expl_stmts.append(ast.Expr(call))
             if i < levels:
@@ -1013,7 +1019,7 @@ class AssertionRewriter(ast.NodeVisitor):
                 self.statements = body = inner
         self.statements = save
         self.expl_stmts = fail_save
-        expl_template = self.helper("_format_boolop", expl_list, ast.Num(is_or))
+        expl_template = self.helper("_format_boolop", expl_list, astNum(is_or))
         expl = self.pop_format_context(expl_template)
         return ast.Name(res_var, ast.Load()), self.explanation_param(expl)
 
@@ -1099,9 +1105,9 @@ class AssertionRewriter(ast.NodeVisitor):
                 next_expl = f"({next_expl})"
             results.append(next_res)
             sym = BINOP_MAP[op.__class__]
-            syms.append(ast.Str(sym))
+            syms.append(astStr(sym))
             expl = f"{left_expl} {sym} {next_expl}"
-            expls.append(ast.Str(expl))
+            expls.append(astStr(expl))
             res_expr = ast.Compare(left_res, [op], [next_res])
             self.statements.append(ast.Assign([store_names[i]], res_expr))
             left_res, left_expl = next_res, next_expl

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -18,6 +18,7 @@ import ast
 import dataclasses
 import enum
 import re
+import sys
 import types
 from typing import Callable
 from typing import Iterator
@@ -25,6 +26,11 @@ from typing import Mapping
 from typing import NoReturn
 from typing import Optional
 from typing import Sequence
+
+if sys.version_info >= (3, 8):
+    astNameConstant = ast.Constant
+else:
+    astNameConstant = ast.NameConstant
 
 
 __all__ = [
@@ -132,7 +138,7 @@ IDENT_PREFIX = "$"
 
 def expression(s: Scanner) -> ast.Expression:
     if s.accept(TokenType.EOF):
-        ret: ast.expr = ast.NameConstant(False)
+        ret: ast.expr = astNameConstant(False)
     else:
         ret = expr(s)
         s.accept(TokenType.EOF, reject=True)


### PR DESCRIPTION
Fix #10977.

Marking as draft until we can verify the fix on next py312 alpha/beta release.