### PR TITLE
Add workflow to close "needs information" labeled issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: close needs-information issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          debug-only: true
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+          only-labels: ["status: needs information"]
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,6 +2,7 @@ name: close needs-information issues
 on:
   schedule:
     - cron: "30 1 * * *"
+  workflow_dispatch:    
 
 jobs:
   close-issues:


### PR DESCRIPTION
This introduces a workflow to automatically close issues with the label `status: needs information` after a number of days of inactivity.

This work has been done manually for a number of years, but I think it is safe to close issues with this label automatically.

Not tested yet, but it is in `debug-only` mode so we can watch what it does before deciding to turn it on (however it needs to be in `main` for it to run).

Based off: 

* https://docs.github.com/en/actions/managing-issues-and-pull-requests/closing-inactive-issues
* https://github.com/marketplace/actions/close-stale-issues

