### PR TITLE
pre-commit: remove `default_language_version` setting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-    python: "3.10"
 repos:
 -   repo: https://github.com/psf/black
     rev: 23.3.0


### PR DESCRIPTION
This makes it difficult to run on newer python versions than the one specified.