### PR TITLE
monkeypatch: add support for TypedDict

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Abdeali JK
 Abdelrahman Elbehery
 Abhijeet Kasurde
 Adam Johnson
+Adam Stewart
 Adam Uhlir
 Ahn Ki-Wook
 Akiomi Kamakura

--- a/changelog/10999.bugfix.rst
+++ b/changelog/10999.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug where monkeypatch setitem/delitem type annotations didn't support typing.TypedDict.

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -129,7 +129,7 @@ class MonkeyPatch:
 
     def __init__(self) -> None:
         self._setattr: List[Tuple[object, str, object]] = []
-        self._setitem: List[Tuple[MutableMapping[Any, Any], object, object]] = []
+        self._setitem: List[Tuple[Union[MutableMapping[Any, Any], "TypedDict[Any, Any]", object, object]] = []
         self._cwd: Optional[str] = None
         self._savesyspath: Optional[List[str]] = None
 
@@ -290,12 +290,12 @@ class MonkeyPatch:
             self._setattr.append((target, name, oldval))
             delattr(target, name)
 
-    def setitem(self, dic: MutableMapping[K, V], name: K, value: V) -> None:
+    def setitem(self, dic: Union[MutableMapping[K, V], "TypedDict[K, V]"], name: K, value: V) -> None:
         """Set dictionary entry ``name`` to value."""
         self._setitem.append((dic, name, dic.get(name, notset)))
         dic[name] = value
 
-    def delitem(self, dic: MutableMapping[K, V], name: K, raising: bool = True) -> None:
+    def delitem(self, dic: Union[MutableMapping[K, V], "TypedDict[K, V"], name: K, raising: bool = True) -> None:
         """Delete ``name`` from dict.
 
         Raises ``KeyError`` if it doesn't exist, unless ``raising`` is set to


### PR DESCRIPTION
Closes #10999

This feature was added in Python 3.8. It looks like pytest still supports Python 3.7 (I'm guessing that will change in about [6 weeks](https://endoflife.date/python)). For now, it isn't easy to test or annotate this properly.