### PR TITLE
Reference "Status of Python Versions" in backwards-compatibility policy

### DIFF
--- a/doc/en/backwards-compatibility.rst
+++ b/doc/en/backwards-compatibility.rst
@@ -92,3 +92,5 @@ pytest version  min. Python version
 5.0 - 6.1       3.5+
 3.3 - 4.6       2.7, 3.4+
 ==============  ===================
+
+`Status of Python Versions <https://devguide.python.org/versions/>`__.


### PR DESCRIPTION
As suggested in #10981.

