### PR TITLE
add a warning about modifying the root logger during tests

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -128,6 +128,7 @@ Eric Hunsberger
 Eric Liu
 Eric Siegerman
 Erik Aronesty
+Erik Hasse
 Erik M. Bray
 Evan Kepner
 Fabien Zarifian

--- a/changelog/11011.doc.rst
+++ b/changelog/11011.doc.rst
@@ -1,0 +1,1 @@
+Added a warning about modifying the root logger during tests when using ``caplog``.

--- a/doc/en/how-to/logging.rst
+++ b/doc/en/how-to/logging.rst
@@ -172,6 +172,13 @@ the records for the ``setup`` and ``call`` stages during teardown like so:
 
 The full API is available at :class:`pytest.LogCaptureFixture`.
 
+.. warning::
+
+    The ``caplog`` fixture adds a handler to the root logger to capture logs. If the root logger is
+    modified during a test, for example with ``logging.config.dictConfig``, this handler may be
+    removed and cause no logs to be captured. To avoid this, ensure that any root logger configuration
+    only adds to the existing handlers.
+
 
 .. _live_logs:
 


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
-->

Add a warning to the documentation based on my findings for #11011 