### PR TITLE
11028 - Fix warlus operator behavior when called by a function

### DIFF
--- a/changelog/11028.bugfix.rst
+++ b/changelog/11028.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug related to the walrus operator in asserts. Now a variable that is assigned with the walrus operator can be used later in a function call.
+Fixed bug in assertion rewriting where a variable assigned with the walrus operator could not be used later in a function call.

--- a/changelog/11028.bugfix.rst
+++ b/changelog/11028.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug related to the walrus operator in asserts. Now a variable that is assigned with the walrus operator can be used later in a function call.

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1518,7 +1518,7 @@ class TestIssue11028:
                 return a + 1
 
             def test_gt():
-              assert (object := 4) > add_one(object)
+              assert (obj := 4) > add_one(obj)
         """
         )
         result = pytester.runpytest()


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
In #10758 we introduced the support for the use of the walrus operator in the test cases. There was a case which was not handled that caused a bug report #11028. This PR aims to fix the issue and also to improve how the walrus operator is handled in the AssertionRewriter class.

closes #11028

Made during ![Open Source Saturday Italy](https://img.shields.io/badge/Open%20Source%20Saturday-Italy-red)