### PR TITLE
python: change `pytest pkg/__init__.py` to only collect the `__init__.py` Module

### DIFF
--- a/changelog/8976.breaking.rst
+++ b/changelog/8976.breaking.rst
@@ -1,0 +1,5 @@
+Running `pytest pkg/__init__.py` now collects the `pkg/__init__.py` file (module) only.
+Previously, it collected the entire `pkg` package, including other test files in the directory, but excluding tests in the `__init__.py` file itself
+(unless :confval:`python_files` was changed to allow `__init__.py` file).
+
+To collect the entire package, specify just the directory: `pytest pkg`.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -467,11 +467,25 @@ The ``yield_fixture`` function/decorator
 It has been so for a very long time, so can be search/replaced safely.
 
 
-Removed Features
-----------------
+Removed Features and Breaking Changes
+-------------------------------------
 
 As stated in our :ref:`backwards-compatibility` policy, deprecated features are removed only in major releases after
 an appropriate period of deprecation has passed.
+
+Some breaking changes which could not be deprecated are also listed.
+
+
+Collecting ``__init__.py`` files no longer collects package
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionremoved:: 8.0
+
+Running `pytest pkg/__init__.py` now collects the `pkg/__init__.py` file (module) only.
+Previously, it collected the entire `pkg` package, including other test files in the directory, but excluding tests in the `__init__.py` file itself
+(unless :confval:`python_files` was changed to allow `__init__.py` file).
+
+To collect the entire package, specify just the directory: `pytest pkg`.
 
 
 The ``pytest.collect`` module

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -736,7 +736,9 @@ class Package(Module):
         this_path = self.path.parent
 
         # Always collect the __init__ first.
-        if path_matches_patterns(self.path, self.config.getini("python_files")):
+        if self.session.isinitpath(self.path) or path_matches_patterns(
+            self.path, self.config.getini("python_files")
+        ):
             yield Module.from_parent(self, path=self.path)
 
         pkg_prefixes: Set[Path] = set()

--- a/testing/example_scripts/collect/package_init_given_as_arg/pkg/__init__.py
+++ b/testing/example_scripts/collect/package_init_given_as_arg/pkg/__init__.py
@@ -1,0 +1,2 @@
+def test_init():
+    pass

--- a/testing/example_scripts/collect/package_init_given_as_arg/pkg/test_foo.py
+++ b/testing/example_scripts/collect/package_init_given_as_arg/pkg/test_foo.py
@@ -1,2 +1,2 @@
-def test():
+def test_foo():
     pass

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -1420,10 +1420,15 @@ def test_package_collection_infinite_recursion(pytester: Pytester) -> None:
 
 
 def test_package_collection_init_given_as_argument(pytester: Pytester) -> None:
-    """Regression test for #3749"""
+    """Regression test for #3749, #8976, #9263, #9313.
+
+    Specifying an __init__.py file directly should collect only the __init__.py
+    Module, not the entire package.
+    """
     p = pytester.copy_example("collect/package_init_given_as_arg")
-    result = pytester.runpytest(p / "pkg" / "__init__.py")
-    result.stdout.fnmatch_lines(["*1 passed*"])
+    items, hookrecorder = pytester.inline_genitems(p / "pkg" / "__init__.py")
+    assert len(items) == 1
+    assert items[0].name == "test_init"
 
 
 def test_package_with_modules(pytester: Pytester) -> None:

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -114,7 +114,7 @@ class TestDoctests:
         reprec.assertoutcome(failed=1)
 
     def test_importmode(self, pytester: Pytester):
-        p = pytester.makepyfile(
+        pytester.makepyfile(
             **{
                 "namespacepkg/innerpkg/__init__.py": "",
                 "namespacepkg/innerpkg/a.py": """
@@ -132,7 +132,7 @@ class TestDoctests:
                 """,
             }
         )
-        reprec = pytester.inline_run(p, "--doctest-modules", "--import-mode=importlib")
+        reprec = pytester.inline_run("--doctest-modules", "--import-mode=importlib")
         reprec.assertoutcome(passed=1)
 
     def test_new_pattern(self, pytester: Pytester):

--- a/testing/test_nose.py
+++ b/testing/test_nose.py
@@ -504,7 +504,7 @@ def test_nose_setup_skipped_if_non_callable(pytester: Pytester) -> None:
             pass
         """,
     )
-    result = pytester.runpytest(p, "-p", "nose")
+    result = pytester.runpytest(p.parent, "-p", "nose")
     assert result.ret == 0
 
 


### PR DESCRIPTION
Previously it would collect the entire package, but this is not what users (including me) expect.

Refs #3749
Fixes #8976
Fixes #9263
Fixes #9313

---

Technically I'd say this is a bug fix, but I'm not entirely sure the previous behavior wasn't intentional (there are certainly several tests to the contrary). And it also has potential of breaking users who somehow rely on the previous behavior. Therefore I've marked this as `breaking`, and it should not be merged before we decide the next version will be a major. Still, acks would be good already :)