### PR TITLE
config: fallback confcutdir to rootpath if inipath is not set

### DIFF
--- a/changelog/11043.improvement.rst
+++ b/changelog/11043.improvement.rst
@@ -1,0 +1,3 @@
+When `--confcutdir` is not specified, and there is no config file present, the conftest cutoff directory (`--confcutdir`) is now set to the :ref:`rootdir`.
+Previously in such cases, `conftest.py` files would be probed all the way to the root directory of the filesystem.
+If you are badly affected by this change, consider adding an empty config file to your desired cutoff directory, or explicitly set `--confcutdir`.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1261,8 +1261,11 @@ class Config:
                 _pytest.deprecated.STRICT_OPTION, stacklevel=2
             )
 
-        if self.known_args_namespace.confcutdir is None and self.inipath is not None:
-            confcutdir = str(self.inipath.parent)
+        if self.known_args_namespace.confcutdir is None:
+            if self.inipath is not None:
+                confcutdir = str(self.inipath.parent)
+            else:
+                confcutdir = str(self.rootpath)
             self.known_args_namespace.confcutdir = confcutdir
         try:
             self.hook.pytest_load_initial_conftests(

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -179,6 +179,23 @@ class TestParseIni:
         assert result.ret != 0
         result.stderr.fnmatch_lines("ERROR: *pyproject.toml: Invalid statement*")
 
+    def test_confcutdir_default_without_configfile(self, pytester: Pytester) -> None:
+        # If --confcutdir is not specified, and there is no configfile, default
+        # to the roothpath.
+        sub = pytester.mkdir("sub")
+        os.chdir(sub)
+        config = pytester.parseconfigure()
+        assert config.pluginmanager._confcutdir == sub
+
+    def test_confcutdir_default_with_configfile(self, pytester: Pytester) -> None:
+        # If --confcutdir is not specified, and there is a configfile, default
+        # to the configfile's directory.
+        pytester.makeini("[pytest]")
+        sub = pytester.mkdir("sub")
+        os.chdir(sub)
+        config = pytester.parseconfigure()
+        assert config.pluginmanager._confcutdir == pytester.path
+
     @pytest.mark.xfail(reason="probably not needed")
     def test_confcutdir(self, pytester: Pytester) -> None:
         sub = pytester.mkdir("sub")

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -594,7 +594,13 @@ class TestConftestVisibility:
         print("pytestarg        : %s" % testarg)
         print("expected pass    : %s" % expect_ntests_passed)
         os.chdir(dirs[chdir])
-        reprec = pytester.inline_run(testarg, "-q", "--traceconfig")
+        reprec = pytester.inline_run(
+            testarg,
+            "-q",
+            "--traceconfig",
+            "--confcutdir",
+            pytester.path,
+        )
         reprec.assertoutcome(passed=expect_ntests_passed)
 
 


### PR DESCRIPTION
Currently, if `--confcutdir` is not set, `inipath.parent` is used, and if `initpath` is not set, then `confcutdir` is None, which means there is no cutoff.

Having no cutoff is not great, it means we potentially start probing stuff all the way up to the filesystem root directory. So let's add another fallback, to `rootpath`, which is always something reasonable.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
