### PR TITLE
Add warning when testpaths is set but paths are not found by glob

### DIFF
--- a/changelog/11013.improvement.rst
+++ b/changelog/11013.improvement.rst
@@ -1,0 +1,1 @@
+Added warning when testpaths is set, but paths are not found by glob. In this case, pytest will search fall back to searching from current directory.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1382,6 +1382,14 @@ class Config:
                         args = []
                         for path in testpaths:
                             args.extend(sorted(glob.iglob(path, recursive=True)))
+                        if testpaths and not args:
+                            warning_text = (
+                                "testpaths defined but path not found, "
+                                "will search recursively from current directory instead"
+                            )
+                            self.issue_config_time_warning(
+                                PytestConfigWarning(warning_text), stacklevel=3
+                            )
                 if not args:
                     source = Config.ArgsSource.INCOVATION_DIR
                     args = [str(self.invocation_params.dir)]


### PR DESCRIPTION
Closes #11013

Used PytestConfigWarning and setting warning_text string for message to follow convention for some of the other warnings, and set stacklevel to 3 so it shows the warning thrown by parse function. Tried to make the message concise, but if unclear please let me know and I can change!

Tested against steps to reproduce from #11006 and warning is shown.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
