### PR TITLE
Handle microseconds with custom logging.Formatter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -131,6 +131,7 @@ Eric Siegerman
 Erik Aronesty
 Erik M. Bray
 Evan Kepner
+Evgeny Seliverstov
 Fabien Zarifian
 Fabio Zadrozny
 Felix Hofstätter

--- a/changelog/10991.improvement.rst
+++ b/changelog/10991.improvement.rst
@@ -1,2 +1,1 @@
 Added handling of ``%f`` directive to print microseconds in log format options, such as ``log-date-format``.
-Added helper :class:`pytest.logging.DatetimeFormatter <_pytest.logging.DatetimeFormatter>` which overrides :class:`logging.Formatter` behaviour to print log records with a microsecond-aware function :func:`datetime.strftime` instead of :func:`time.strftime`.

--- a/changelog/10991.improvement.rst
+++ b/changelog/10991.improvement.rst
@@ -1,0 +1,2 @@
+Added handling of ``%f`` directive to print microseconds in log format options, such as ``log-date-format``.
+Added helper :class:`pytest.logging.DatetimeFormatter <_pytest.logging.DatetimeFormatter>` which overrides :class:`logging.Formatter` behaviour to print log records with a microsecond-aware function :func:`datetime.strftime` instead of :func:`time.strftime`.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -63,8 +63,6 @@ class DatetimeFormatter(logging.Formatter):
     :func:`time.strftime` in case of microseconds in format string.
     """
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
 
     def formatTime(self, record: LogRecord, datefmt=None) -> str:
         if datefmt and "%f" in datefmt:

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -63,7 +63,6 @@ class DatetimeFormatter(logging.Formatter):
     :func:`time.strftime` in case of microseconds in format string.
     """
 
-
     def formatTime(self, record: LogRecord, datefmt=None) -> str:
         if datefmt and "%f" in datefmt:
             ct = self.converter(record.created)

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1234,3 +1234,100 @@ def test_log_disabling_works_with_log_cli(pytester: Pytester) -> None:
         "WARNING  disabled:test_log_disabling_works_with_log_cli.py:7 This string will be suppressed."
     )
     assert not result.stderr.lines
+
+
+def test_without_date_format_log(pytester: Pytester) -> None:
+    """Check that date is not printed by default."""
+    pytester.makepyfile(
+        """
+        import logging
+
+        logger = logging.getLogger(__name__)
+
+        def test_foo():
+            logger.warning('text')
+            assert False
+        """
+    )
+    result = pytester.runpytest()
+    assert result.ret == 1
+    result.stdout.fnmatch_lines(
+        ["WARNING  test_without_date_format_log:test_without_date_format_log.py:6 text"]
+    )
+
+
+def test_date_format_log(pytester: Pytester) -> None:
+    """Check that log_date_format affects output."""
+    pytester.makepyfile(
+        """
+        import logging
+
+        logger = logging.getLogger(__name__)
+
+        def test_foo():
+            logger.warning('text')
+            assert False
+        """
+    )
+    pytester.makeini(
+        """
+        [pytest]
+        log_format=%(asctime)s; %(levelname)s; %(message)s
+        log_date_format=%Y-%m-%d %H:%M:%S
+    """
+    )
+    result = pytester.runpytest()
+    assert result.ret == 1
+    result.stdout.re_match_lines([r"^[0-9-]{10} [0-9:]{8}; WARNING; text"])
+
+
+def test_date_format_percentf_log(pytester: Pytester) -> None:
+    """Make sure that microseconds are printed in log."""
+    pytester.makepyfile(
+        """
+        import logging
+
+        logger = logging.getLogger(__name__)
+
+        def test_foo():
+            logger.warning('text')
+            assert False
+        """
+    )
+    pytester.makeini(
+        """
+        [pytest]
+        log_format=%(asctime)s; %(levelname)s; %(message)s
+        log_date_format=%Y-%m-%d %H:%M:%S.%f
+    """
+    )
+    result = pytester.runpytest()
+    assert result.ret == 1
+    result.stdout.re_match_lines([r"^[0-9-]{10} [0-9:]{8}.[0-9]{6}; WARNING; text"])
+
+
+def test_date_format_percentf_tz_log(pytester: Pytester) -> None:
+    """Make sure that timezone and microseconds are properly formatted together."""
+    pytester.makepyfile(
+        """
+        import logging
+
+        logger = logging.getLogger(__name__)
+
+        def test_foo():
+            logger.warning('text')
+            assert False
+        """
+    )
+    pytester.makeini(
+        """
+        [pytest]
+        log_format=%(asctime)s; %(levelname)s; %(message)s
+        log_date_format=%Y-%m-%d %H:%M:%S.%f%z
+    """
+    )
+    result = pytester.runpytest()
+    assert result.ret == 1
+    result.stdout.re_match_lines(
+        [r"^[0-9-]{10} [0-9:]{8}.[0-9]{6}[+-][0-9\.]+; WARNING; text"]
+    )


### PR DESCRIPTION
Added handling of ``%f`` directive to print microseconds in log format options, such as ``log-date-format``. It is impossible to do with a standard `logging.Formatter` because it uses `time.strftime` which doesn't know about milliseconds and ``%f``. In this PR I added a custom Formatter which converts `LogRecord` to a `datetime.datetime` object and formats it with ``%f`` flag. This behaviour is enabled only if a microsecond flag is specified in a format string.

Also added a few tests to check the standard and changed behaviour.

Closes #10991.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
-->
