### PR TITLE
cacheprovider: fix file-skipping feature for files in packages

### DIFF
--- a/changelog/11054.bugfix.rst
+++ b/changelog/11054.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``--last-failed``'s "(skipped N files)" functionality for files inside of packages (directories with `__init__.py` files).

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -219,7 +219,7 @@ class LFPluginCollWrapper:
 
     @hookimpl(hookwrapper=True)
     def pytest_make_collect_report(self, collector: nodes.Collector):
-        if isinstance(collector, Session):
+        if isinstance(collector, (Session, Package)):
             out = yield
             res: CollectReport = out.get_result()
 

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -420,7 +420,13 @@ class TestLastFailed:
         result = pytester.runpytest()
         result.stdout.fnmatch_lines(["*1 failed in*"])
 
-    def test_terminal_report_lastfailed(self, pytester: Pytester) -> None:
+    @pytest.mark.parametrize("parent", ("session", "package"))
+    def test_terminal_report_lastfailed(self, pytester: Pytester, parent: str) -> None:
+        if parent == "package":
+            pytester.makepyfile(
+                __init__="",
+            )
+
         test_a = pytester.makepyfile(
             test_a="""
             def test_a1(): pass


### PR DESCRIPTION
`--lf` has a feature where if a certain `Module` (python file) does not contain any failed tests, it is skipped entirely at the collector level instead of being collected and each item skipped individually. When this happens the collection summary looks like this:

    run-last-failure: rerun previous 1 failure (skipped 1 file)

However, this feature didn't work for `Module`s inside of `Package`s, only for those directly beneath the `Session`.

Fix #11054.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
