### PR TITLE
cacheprovider: fix file-skipping functionality across packages

### DIFF
--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -854,6 +854,33 @@ class TestLastFailed:
             ]
         )
 
+    def test_lastfailed_skip_collection_with_nesting(self, pytester: Pytester) -> None:
+        """Check that file skipping works even when the file with failures is
+        nested at a different level of the collection tree."""
+        pytester.makepyfile(
+            **{
+                "test_1.py": """
+                    def test_1(): pass
+                """,
+                "pkg/__init__.py": "",
+                "pkg/test_2.py": """
+                    def test_2(): assert False
+                """,
+            }
+        )
+        # first run
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines(["collected 2 items", "*1 failed*1 passed*"])
+        # second run - test_1.py is skipped.
+        result = pytester.runpytest("--lf")
+        result.stdout.fnmatch_lines(
+            [
+                "collected 1 item",
+                "run-last-failure: rerun previous 1 failure (skipped 1 file)",
+                "*= 1 failed in *",
+            ]
+        )
+
     def test_lastfailed_with_known_failures_not_being_selected(
         self, pytester: Pytester
     ) -> None:


### PR DESCRIPTION
Continuation of fc538c5766a1c67bfcd704288279ceac5e20070a. Fixes #11054 again.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
