### PR TITLE
cacheprovider: make file-skipping work with any File, not just Modules

### DIFF
--- a/changelog/11068.bugfix.rst
+++ b/changelog/11068.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the ``--last-failed`` whole-file skipping functionality ("skipped N files") for :ref:`non-python test files <non-python tests>`.

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -27,7 +27,7 @@ from _pytest.deprecated import check_ispytest
 from _pytest.fixtures import fixture
 from _pytest.fixtures import FixtureRequest
 from _pytest.main import Session
-from _pytest.python import Module
+from _pytest.nodes import File
 from _pytest.python import Package
 from _pytest.reports import TestReport
 
@@ -242,7 +242,7 @@ class LFPluginCollWrapper:
             )
             return
 
-        elif isinstance(collector, Module):
+        elif isinstance(collector, File):
             if collector.path in self.lfplugin._last_failed_paths:
                 out = yield
                 res = out.get_result()
@@ -280,9 +280,9 @@ class LFPluginCollSkipfiles:
     def pytest_make_collect_report(
         self, collector: nodes.Collector
     ) -> Optional[CollectReport]:
-        # Packages are Modules, but we only want to skip test-bearing Modules,
+        # Packages are Files, but we only want to skip test-bearing Files,
         # so don't filter Packages.
-        if isinstance(collector, Module) and not isinstance(collector, Package):
+        if isinstance(collector, File) and not isinstance(collector, Package):
             if collector.path not in self.lfplugin._last_failed_paths:
                 self.lfplugin._skipped_files += 1
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -105,7 +105,7 @@ def tw_mock():
 
 
 @pytest.fixture
-def dummy_yaml_custom_test(pytester: Pytester):
+def dummy_yaml_custom_test(pytester: Pytester) -> None:
     """Writes a conftest file that collects and executes a dummy yaml test.
 
     Taken from the docs, but stripped down to the bare minimum, useful for

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -1085,6 +1085,28 @@ class TestLastFailed:
         result = pytester.runpytest("--lf")
         result.assert_outcomes(failed=3)
 
+    def test_non_python_file_skipped(
+        self,
+        pytester: Pytester,
+        dummy_yaml_custom_test: None,
+    ) -> None:
+        pytester.makepyfile(
+            **{
+                "test_bad.py": """def test_bad(): assert False""",
+            },
+        )
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines(["collected 2 items", "* 1 failed, 1 passed in *"])
+
+        result = pytester.runpytest("--lf")
+        result.stdout.fnmatch_lines(
+            [
+                "collected 1 item",
+                "run-last-failure: rerun previous 1 failure (skipped 1 file)",
+                "* 1 failed in *",
+            ]
+        )
+
 
 class TestNewFirst:
     def test_newfirst_usecase(self, pytester: Pytester) -> None:


### PR DESCRIPTION
~~NOTE: Includes #11059, will rebase after it's merged.~~

No reason for `--lf`'s whole-file-skipping feature to not for for non-Python files.

Fix #11068.