### PR TITLE
main: move norecursedir check to main's pytest_ignore_collect

### DIFF
--- a/changelog/11081.improvement.rst
+++ b/changelog/11081.improvement.rst
@@ -1,0 +1,1 @@
+The :confval:`norecursedir` check is now performed in a :hook:`pytest_ignore_collect` implementation, so plugins can affect it.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -400,6 +400,12 @@ def pytest_ignore_collect(collection_path: Path, config: Config) -> Optional[boo
     allow_in_venv = config.getoption("collect_in_virtualenv")
     if not allow_in_venv and _in_venv(collection_path):
         return True
+
+    if collection_path.is_dir():
+        norecursepatterns = config.getini("norecursedirs")
+        if any(fnmatch_ex(pat, collection_path) for pat in norecursepatterns):
+            return True
+
     return None
 
 
@@ -562,9 +568,6 @@ class Session(nodes.FSCollector):
         fspath = Path(direntry.path)
         ihook = self.gethookproxy(fspath.parent)
         if ihook.pytest_ignore_collect(collection_path=fspath, config=self.config):
-            return False
-        norecursepatterns = self.config.getini("norecursedirs")
-        if any(fnmatch_ex(pat, fspath) for pat in norecursepatterns):
             return False
         return True
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -706,9 +706,6 @@ class Package(Module):
         ihook = self.session.gethookproxy(fspath.parent)
         if ihook.pytest_ignore_collect(collection_path=fspath, config=self.config):
             return False
-        norecursepatterns = self.config.getini("norecursedirs")
-        if any(fnmatch_ex(pat, fspath) for pat in norecursepatterns):
-            return False
         return True
 
     def _collectfile(


### PR DESCRIPTION
Fix #11081