### PR TITLE
[ast.Str] Use ast.Constant instead pending removal in python 3.14

### DIFF
--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -680,7 +680,7 @@ class AssertionRewriter(ast.NodeVisitor):
             if (
                 expect_docstring
                 and isinstance(item, ast.Expr)
-                and isinstance(item.value, ast.Str)
+                and isinstance(item.value, ast.Constant)
             ):
                 doc = item.value.s
                 if self.is_rewrite_disabled(doc):


### PR DESCRIPTION
Pytest start raising deprecation warning in its own code when launched with python 3.12:
```
  File "/home/runner/work/astroid/astroid/venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py", line 683, in run
    and isinstance(item.value, ast.Str)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.0-beta.1/x64/lib/python3.12/ast.py", line 555, in __instancecheck__
    warnings._deprecated(
  File "/opt/hostedtoolcache/Python/3.12.0-beta.1/x64/lib/python3.12/warnings.py", line 529, in _deprecated
    warn(msg, DeprecationWarning, stacklevel=3)
DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
```
See https://github.com/pylint-dev/astroid/actions/runs/5196979689/jobs/9371270546?pr=2199. I'm not sure if ``ast.Str`` and ``ast.Constant`` are really equivalent so I'm opening the PR to launch the CI and see.