### PR TITLE
capture warning when exception is raised (fix #9036)

### DIFF
--- a/changelog/9036.bugfix.rst
+++ b/changelog/9036.bugfix.rst
@@ -1,0 +1,1 @@
+``pytest.warns`` and similar functions now capture warnings when an exception is raised inside a ``with`` block.

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -298,11 +298,6 @@ class WarningsChecker(WarningsRecorder):
             # nothing to do in this deprecated case, see WARNS_NONE_ARG above
             return
 
-        if not (exc_type is None and exc_val is None and exc_tb is None):
-            # We currently ignore missing warnings if an exception is active.
-            # TODO: fix this, because it means things are surprisingly order-sensitive.
-            return
-
         def found_str():
             return pformat([record.message for record in self], indent=2)
 


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

continue PR #10208 by @eltimen

Fixes #9036 and #11032 (same issue)

When a warning is being warned while an exception is raised, `pytest.warns` should still capture the warning if not matched.

CC @Zac-HD 
