### PR TITLE
python: change `Package` to no longer be a `Module`/`File`

### DIFF
--- a/changelog/11137.breaking.rst
+++ b/changelog/11137.breaking.rst
@@ -1,0 +1,11 @@
+:class:`pytest.Package` is no longer a :class:`pytest.Module` or :class:`pytest.File`.
+
+The ``Package`` collector node designates a Python package, that is, a directory with an `__init__.py` file.
+Previously ``Package`` was a subtype of ``pytest.Module`` (which represents a single Python module),
+the module being the `__init__.py` file.
+This has been deemed a design mistake (see :issue:`11137` and :issue:`7777` for details).
+
+The ``path`` property of ``Package`` nodes now points to the package directory instead of the ``__init__.py`` file.
+
+Note that a ``Module`` node for ``__init__.py`` (which is not a ``Package``) may still exist,
+if it is picked up during collection (e.g. if you configured :confval:`python_files` to include ``__init__.py`` files).

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -495,6 +495,22 @@ an appropriate period of deprecation has passed.
 Some breaking changes which could not be deprecated are also listed.
 
 
+:class:`pytest.Package` is no longer a :class:`pytest.Module` or :class:`pytest.File`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionchanged:: 8.0
+
+The ``Package`` collector node designates a Python package, that is, a directory with an `__init__.py` file.
+Previously ``Package`` was a subtype of ``pytest.Module`` (which represents a single Python module),
+the module being the `__init__.py` file.
+This has been deemed a design mistake (see :issue:`11137` and :issue:`7777` for details).
+
+The ``path`` property of ``Package`` nodes now points to the package directory instead of the ``__init__.py`` file.
+
+Note that a ``Module`` node for ``__init__.py`` (which is not a ``Package``) may still exist,
+if it is picked up during collection (e.g. if you configured :confval:`python_files` to include ``__init__.py`` files).
+
+
 Collecting ``__init__.py`` files no longer collects package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -228,12 +228,7 @@ class LFPluginCollWrapper:
 
             # Use stable sort to priorize last failed.
             def sort_key(node: Union[nodes.Item, nodes.Collector]) -> bool:
-                # Package.path is the __init__.py file, we need the directory.
-                if isinstance(node, Package):
-                    path = node.path.parent
-                else:
-                    path = node.path
-                return path in lf_paths
+                return node.path in lf_paths
 
             res.result = sorted(
                 res.result,
@@ -277,9 +272,7 @@ class LFPluginCollSkipfiles:
     def pytest_make_collect_report(
         self, collector: nodes.Collector
     ) -> Optional[CollectReport]:
-        # Packages are Files, but we only want to skip test-bearing Files,
-        # so don't filter Packages.
-        if isinstance(collector, File) and not isinstance(collector, Package):
+        if isinstance(collector, File):
             if collector.path not in self.lfplugin._last_failed_paths:
                 self.lfplugin._skipped_files += 1
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -119,9 +119,8 @@ def get_scope_package(
     from _pytest.python import Package
 
     current: Optional[Union[nodes.Item, nodes.Collector]] = node
-    fixture_package_name = "{}/{}".format(fixturedef.baseid, "__init__.py")
     while current and (
-        not isinstance(current, Package) or fixture_package_name != current.nodeid
+        not isinstance(current, Package) or current.nodeid != fixturedef.baseid
     ):
         current = current.parent  # type: ignore[assignment]
     if current is None:
@@ -263,7 +262,7 @@ def get_parametrized_fixture_keys(item: nodes.Item, scope: Scope) -> Iterator[_K
             if scope is Scope.Session:
                 key: _Key = (argname, param_index)
             elif scope is Scope.Package:
-                key = (argname, param_index, item.path.parent)
+                key = (argname, param_index, item.path)
             elif scope is Scope.Module:
                 key = (argname, param_index, item.path)
             elif scope is Scope.Class:


### PR DESCRIPTION
Fix #11137.

I'll leave detailed notes on the changes below to hopefully make them easier to understand.