### PR TITLE
Reverse order on marks from MRO

### DIFF
--- a/changelog/10447.bugfix.rst
+++ b/changelog/10447.bugfix.rst
@@ -1,0 +1,1 @@
+When resolving marks from a class hierarchy MRO, reverse the order so that more basic classes' marks will be processed ahead of ancestral classes.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -372,9 +372,11 @@ def get_unpacked_marks(
     """
     if isinstance(obj, type):
         if not consider_mro:
-            mark_lists = [obj.__dict__.get("pytestmark", [])]
+            mark_lists: Iterable[Any] = [obj.__dict__.get("pytestmark", [])]
         else:
-            mark_lists = [x.__dict__.get("pytestmark", []) for x in obj.__mro__]
+            mark_lists = reversed(
+                [x.__dict__.get("pytestmark", []) for x in obj.__mro__]
+            )
         mark_list = []
         for item in mark_lists:
             if isinstance(item, list):


### PR DESCRIPTION
Fixes #10447

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
