### PR TITLE
fix #10701 - warnings recorder pop match also subclass

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -263,6 +263,7 @@ Mickey Pashov
 Mihai Capotă
 Mike Hoyle (hoylemd)
 Mike Lundy
+Milan Lesnek
 Miro Hrončok
 Nathaniel Compton
 Nathaniel Waisbrot

--- a/changelog/10701.bugfix.rst
+++ b/changelog/10701.bugfix.rst
@@ -1,0 +1,1 @@
+``pytest.WarningsRecorder.pop`` now also pop most recent subclass of warning.

--- a/changelog/10701.bugfix.rst
+++ b/changelog/10701.bugfix.rst
@@ -1,1 +1,2 @@
-``pytest.WarningsRecorder.pop`` now also pop most recent subclass of warning.
+:meth:`pytest.WarningsRecorder.pop` will return the most-closely-matched warning in the list,
+rather than the first warning which is an instance of the requested type.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 write_to = "src/_pytest/_version.py"
 
 [tool.pytest.ini_options]
-#minversion = "2.0"
+minversion = "2.0"
 addopts = "-rfEX -p pytester --strict-markers"
 python_files = ["test_*.py", "*_test.py", "testing/python/*.py"]
 python_classes = ["Test", "Acceptance"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 write_to = "src/_pytest/_version.py"
 
 [tool.pytest.ini_options]
-minversion = "2.0"
+#minversion = "2.0"
 addopts = "-rfEX -p pytester --strict-markers"
 python_files = ["test_*.py", "*_test.py", "testing/python/*.py"]
 python_classes = ["Test", "Acceptance"]

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -206,12 +206,18 @@ class WarningsRecorder(warnings.catch_warnings):  # type:ignore[type-arg]
         return len(self._list)
 
     def pop(self, cls: Type[Warning] = Warning) -> "warnings.WarningMessage":
-        """Pop the first recorded warning, raise exception if not exists."""
+        """Pop the first recorded warning (or subclass of warning), raise exception if not exists."""
+        matches = []
         for i, w in enumerate(self._list):
-            if issubclass(w.category, cls):
+            if w.category == cls:
                 return self._list.pop(i)
-        __tracebackhide__ = True
-        raise AssertionError(f"{cls!r} not found in warning list")
+            if issubclass(w.category, cls):
+                matches.append((i, w))
+        if not matches:
+            __tracebackhide__ = True
+            raise AssertionError(f"{cls!r} not found in warning list")
+        (idx, best), *rest = matches
+        return self._list.pop(idx)
 
     def clear(self) -> None:
         """Clear the list of recorded warnings."""

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -206,23 +206,26 @@ class WarningsRecorder(warnings.catch_warnings):  # type:ignore[type-arg]
         return len(self._list)
 
     def pop(self, cls: Type[Warning] = Warning) -> "warnings.WarningMessage":
-        """Pop the first recorded warning (or subclass of warning), raise exception if not exists."""
-        matches = []
+        """Pop the first recorded warning which is an instance of ``cls``.
+
+        But not an instance of a child class of any other match.
+        Raises ``AssertionError`` if there is no match.
+
+        """
+
+        best_idx = None
         for i, w in enumerate(self._list):
             if w.category == cls:
-                return self._list.pop(i)
-            if issubclass(w.category, cls):
-                matches.append((i, w))
-        if not matches:
-            __tracebackhide__ = True
-            raise AssertionError(f"{cls!r} not found in warning list")
-        (idx, best), *rest = matches
-        for i, w in rest:
-            if issubclass(w.category, best.category) and not issubclass(
-                best.category, w.category
+                return self._list.pop(i)  # exact match, stop looking
+            if issubclass(w.category, cls) and (
+                best_idx is None
+                or not issubclass(w.category, self._list[best_idx].category)  # type: ignore[unreachable]
             ):
-                idx, best = i, w
-        return self._list.pop(idx)
+                best_idx = i
+        if best_idx is not None:
+            return self._list.pop(best_idx)
+        __tracebackhide__ = True
+        raise AssertionError(f"{cls!r} not found in warning list")
 
     def clear(self) -> None:
         """Clear the list of recorded warnings."""

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -217,6 +217,11 @@ class WarningsRecorder(warnings.catch_warnings):  # type:ignore[type-arg]
             __tracebackhide__ = True
             raise AssertionError(f"{cls!r} not found in warning list")
         (idx, best), *rest = matches
+        for i, w in rest:
+            if issubclass(w.category, best.category) and not issubclass(
+                best.category, w.category
+            ):
+                idx, best = i, w
         return self._list.pop(idx)
 
     def clear(self) -> None:

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -206,20 +206,17 @@ class WarningsRecorder(warnings.catch_warnings):  # type:ignore[type-arg]
         return len(self._list)
 
     def pop(self, cls: Type[Warning] = Warning) -> "warnings.WarningMessage":
-        """Pop the first recorded warning which is an instance of ``cls``.
-
-        But not an instance of a child class of any other match.
+        """Pop the first recorded warning which is an instance of ``cls``,
+        but not an instance of a child class of any other match.
         Raises ``AssertionError`` if there is no match.
-
         """
-
-        best_idx = None
+        best_idx: Optional[int] = None
         for i, w in enumerate(self._list):
             if w.category == cls:
                 return self._list.pop(i)  # exact match, stop looking
             if issubclass(w.category, cls) and (
                 best_idx is None
-                or not issubclass(w.category, self._list[best_idx].category)  # type: ignore[unreachable]
+                or not issubclass(w.category, self._list[best_idx].category)
             ):
                 best_idx = i
         if best_idx is not None:

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -72,10 +72,12 @@ class TestSubclassWarningPop:
 
     def test_pop_most_recent(self):
         with pytest.warns(self.ParentWarning) as record:
-            self.raise_warnings_from_list([self.ChildWarning, self.ChildOfChildWarning])
+            self.raise_warnings_from_list(
+                [self.ChildOfChildWarning, self.ChildWarning, self.ChildOfChildWarning]
+            )
 
         _warn = record.pop(self.ParentWarning)
-        assert _warn.category is self.ChildOfChildWarning
+        assert _warn.category is self.ChildWarning
 
 
 class TestWarningsRecorderChecker:

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -54,7 +54,7 @@ class TestSubclassWarningPop:
         for warn in _warnings:
             warnings.warn(f"Warning {warn().__repr__()}", warn)
 
-    def test_pop(self):
+    def test_pop_finds_exact_match(self):
         with pytest.warns((self.ParentWarning, self.ChildWarning)) as record:
             self.raise_warnings_from_list(
                 [self.ChildWarning, self.ParentWarning, self.ChildOfChildWarning]
@@ -64,13 +64,13 @@ class TestSubclassWarningPop:
         _warn = record.pop(self.ParentWarning)
         assert _warn.category is self.ParentWarning
 
-    def test_pop_raises(self):
+    def test_pop_raises_if_no_match(self):
         with pytest.raises(AssertionError):
             with pytest.warns(self.ParentWarning) as record:
                 self.raise_warnings_from_list([self.ParentWarning])
             record.pop(self.ChildOfChildWarning)
 
-    def test_pop_most_recent(self):
+    def test_pop_finds_best_inexact_match(self):
         with pytest.warns(self.ParentWarning) as record:
             self.raise_warnings_from_list(
                 [self.ChildOfChildWarning, self.ChildWarning, self.ChildOfChildWarning]

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -37,6 +37,26 @@ def test_recwarn_captures_deprecation_warning(recwarn: WarningsRecorder) -> None
     assert recwarn.pop(DeprecationWarning)
 
 
+class TestSubclassWarningPop:
+    class ParentWarning(Warning):
+        pass
+
+    class ChildWarning(ParentWarning):
+        pass
+
+    def raise_warnings(self):
+        warnings.warn("Warning Child", self.ChildWarning)
+        warnings.warn("Warning Parent", self.ParentWarning)
+
+    def test_pop(self):
+        with pytest.warns((self.ParentWarning, self.ChildWarning)) as record:
+            self.raise_warnings()
+
+        assert len(record) == 2
+        _warn = record.pop(self.ParentWarning)
+        assert _warn.category is self.ParentWarning
+
+
 class TestWarningsRecorderChecker:
     def test_recording(self) -> None:
         rec = WarningsRecorder(_ispytest=True)

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -44,7 +44,11 @@ class TestSubclassWarningPop:
     class ChildWarning(ParentWarning):
         pass
 
+    class RandomWarning(Warning):
+        pass
+
     def raise_warnings(self):
+        warnings.warn("Warning Random", self.RandomWarning)
         warnings.warn("Warning Child", self.ChildWarning)
         warnings.warn("Warning Parent", self.ParentWarning)
 


### PR DESCRIPTION
closes #10701 
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
