### PR TITLE
tox: turn off PYTHONWARNDEFAULTENCODING for pre-commit, sphinx etc.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -74,6 +74,9 @@ skip_install = True
 basepython = python3
 deps = pre-commit>=2.9.3
 commands = pre-commit run --all-files --show-diff-on-failure {posargs:}
+setenv =
+    # pre-commit and tools it launches are not clean of this warning.
+    PYTHONWARNDEFAULTENCODING=
 
 [testenv:docs]
 basepython = python3
@@ -88,6 +91,9 @@ commands =
     # changelog in the docs; this does not happen on ReadTheDocs because it uses
     # the standard sphinx command so the 'changelog_towncrier_draft' is never set there
     sphinx-build -W --keep-going -b html doc/en doc/en/_build/html -t changelog_towncrier_draft {posargs:}
+setenv =
+    # Sphinx is not clean of this warning.
+    PYTHONWARNDEFAULTENCODING=
 
 [testenv:docs-checklinks]
 basepython = python3
@@ -96,6 +102,9 @@ changedir = doc/en
 deps = -r{toxinidir}/doc/en/requirements.txt
 commands =
     sphinx-build -W -q --keep-going -b linkcheck . _build
+setenv =
+    # Sphinx is not clean of this warning.
+    PYTHONWARNDEFAULTENCODING=
 
 [testenv:regen]
 changedir = doc/en
@@ -110,6 +119,9 @@ allowlist_externals =
     make
 commands =
     make regen
+setenv =
+    # We don't want this warning to reach regen output.
+    PYTHONWARNDEFAULTENCODING=
 
 [testenv:plugins]
 # use latest versions of all plugins, including pre-releases


### PR DESCRIPTION
Fix #11157.