### PR TITLE
Clarify docs for pytest.main default behavior

### DIFF
--- a/doc/en/how-to/usage.rst
+++ b/doc/en/how-to/usage.rst
@@ -173,7 +173,9 @@ You can invoke ``pytest`` from Python code directly:
 
 this acts as if you would call "pytest" from the command line.
 It will not raise :class:`SystemExit` but return the :ref:`exit code <exit-codes>` instead.
-You can pass in options and arguments:
+Be careful though, by default (when ``None`` is passed) ``main`` will read arguments
+from the command line, which may not be desirable.
+You can pass in options and arguments explicitly:
 
 .. code-block:: python
 

--- a/doc/en/how-to/usage.rst
+++ b/doc/en/how-to/usage.rst
@@ -173,8 +173,7 @@ You can invoke ``pytest`` from Python code directly:
 
 this acts as if you would call "pytest" from the command line.
 It will not raise :class:`SystemExit` but return the :ref:`exit code <exit-codes>` instead.
-Be careful though, by default (when ``None`` is passed) ``main`` will read arguments
-from the command line, which may not be desirable.
+If you don't pass it any arguments, ``main`` reads the arguments from the command line arguments of the process (:data:`sys.argv`), which may be undesirable.
 You can pass in options and arguments explicitly:
 
 .. code-block:: python

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -137,7 +137,9 @@ def main(
 ) -> Union[int, ExitCode]:
     """Perform an in-process test run.
 
-    :param args: List of command line arguments.
+    :param args:
+        List of command line arguments. If `None` or not given, defaults to reading
+        arguments directly from the command line.
     :param plugins: List of plugin objects to be auto-registered during initialization.
 
     :returns: An exit code.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -139,7 +139,7 @@ def main(
 
     :param args:
         List of command line arguments. If `None` or not given, defaults to reading
-        arguments directly from the command line.
+        arguments directly from the process command line (:data:`sys.argv`).
     :param plugins: List of plugin objects to be auto-registered during initialization.
 
     :returns: An exit code.


### PR DESCRIPTION
Add explicit mentions of the somewhat confusing default behavior (discussed in #11183) to both API reference and how-to section about ways to invoke pytest.