### PR TITLE
Use typing.Literal without TYPE_CHECKING checks

### DIFF
--- a/src/_pytest/_py/path.py
+++ b/src/_pytest/_py/path.py
@@ -25,13 +25,11 @@ from stat import S_ISREG
 from typing import Any
 from typing import Callable
 from typing import cast
+from typing import Literal
 from typing import overload
 from typing import TYPE_CHECKING
 
 from . import error
-
-if TYPE_CHECKING:
-    from typing import Literal
 
 # Moved from local.py.
 iswin32 = sys.platform == "win32" or (getattr(os, "_name", False) == "nt")

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -9,12 +9,12 @@ from typing import cast
 from typing import Dict
 from typing import final
 from typing import List
+from typing import Literal
 from typing import Mapping
 from typing import NoReturn
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
-from typing import TYPE_CHECKING
 from typing import Union
 
 import _pytest._io
@@ -23,9 +23,6 @@ from _pytest.deprecated import ARGUMENT_PERCENT_DEFAULT
 from _pytest.deprecated import ARGUMENT_TYPE_STR
 from _pytest.deprecated import ARGUMENT_TYPE_STR_CHOICE
 from _pytest.deprecated import check_ispytest
-
-if TYPE_CHECKING:
-    from typing_extensions import Literal
 
 FILE_OR_DIR = "file_or_dir"
 
@@ -177,7 +174,7 @@ class Parser:
         name: str,
         help: str,
         type: Optional[
-            "Literal['string', 'paths', 'pathlist', 'args', 'linelist', 'bool']"
+            Literal["string", "paths", "pathlist", "args", "linelist", "bool"]
         ] = None,
         default: Any = None,
     ) -> None:

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -60,6 +60,7 @@ from _pytest.outcomes import skip
 from _pytest.outcomes import TEST_OUTCOME
 from _pytest.pathlib import absolutepath
 from _pytest.pathlib import bestrelpath
+from _pytest.scope import _ScopeName
 from _pytest.scope import HIGH_SCOPES
 from _pytest.scope import Scope
 from _pytest.stash import StashKey
@@ -68,7 +69,6 @@ from _pytest.stash import StashKey
 if TYPE_CHECKING:
     from typing import Deque
 
-    from _pytest.scope import _ScopeName
     from _pytest.main import Session
     from _pytest.python import CallSpec2
     from _pytest.python import Function
@@ -444,7 +444,7 @@ class FixtureRequest:
         self.param: Any
 
     @property
-    def scope(self) -> "_ScopeName":
+    def scope(self) -> _ScopeName:
         """Scope string, one of "function", "class", "module", "package", "session"."""
         return self._scope.value
 
@@ -949,10 +949,10 @@ def _teardown_yield_fixture(fixturefunc, it) -> None:
 
 
 def _eval_scope_callable(
-    scope_callable: "Callable[[str, Config], _ScopeName]",
+    scope_callable: Callable[[str, Config], _ScopeName],
     fixture_name: str,
     config: Config,
-) -> "_ScopeName":
+) -> _ScopeName:
     try:
         # Type ignored because there is no typing mechanism to specify
         # keyword arguments, currently.
@@ -987,7 +987,7 @@ class FixtureDef(Generic[FixtureValue]):
         baseid: Optional[str],
         argname: str,
         func: "_FixtureFunc[FixtureValue]",
-        scope: Union[Scope, "_ScopeName", Callable[[str, Config], "_ScopeName"], None],
+        scope: Union[Scope, _ScopeName, Callable[[str, Config], _ScopeName], None],
         params: Optional[Sequence[object]],
         unittest: bool = False,
         ids: Optional[
@@ -1048,7 +1048,7 @@ class FixtureDef(Generic[FixtureValue]):
         self._finalizers: Final[List[Callable[[], object]]] = []
 
     @property
-    def scope(self) -> "_ScopeName":
+    def scope(self) -> _ScopeName:
         """Scope string, one of "function", "class", "module", "package", "session"."""
         return self._scope.value
 

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -18,7 +18,7 @@ from _pytest.deprecated import WARNING_CMDLINE_PREPARSE_HOOK
 if TYPE_CHECKING:
     import pdb
     import warnings
-    from typing_extensions import Literal
+    from typing import Literal
 
     from _pytest._code.code import ExceptionRepr
     from _pytest._code.code import ExceptionInfo

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -16,6 +16,7 @@ from typing import Dict
 from typing import final
 from typing import Generator
 from typing import List
+from typing import Literal
 from typing import Mapping
 from typing import Optional
 from typing import Tuple
@@ -41,8 +42,6 @@ from _pytest.terminal import TerminalReporter
 
 if TYPE_CHECKING:
     logging_StreamHandler = logging.StreamHandler[StringIO]
-
-    from typing_extensions import Literal
 else:
     logging_StreamHandler = logging.StreamHandler
 

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -13,13 +13,13 @@ from typing import final
 from typing import FrozenSet
 from typing import Iterator
 from typing import List
+from typing import Literal
 from typing import Optional
 from typing import overload
 from typing import Sequence
 from typing import Set
 from typing import Tuple
 from typing import Type
-from typing import TYPE_CHECKING
 from typing import Union
 
 import _pytest._code
@@ -41,10 +41,6 @@ from _pytest.reports import CollectReport
 from _pytest.reports import TestReport
 from _pytest.runner import collect_one_node
 from _pytest.runner import SetupState
-
-
-if TYPE_CHECKING:
-    from typing_extensions import Literal
 
 
 def pytest_addoption(parser: Parser) -> None:

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -20,13 +20,13 @@ from typing import Generator
 from typing import Iterable
 from typing import Iterator
 from typing import List
+from typing import Literal
 from typing import Mapping
 from typing import Optional
 from typing import Pattern
 from typing import Sequence
 from typing import Set
 from typing import Tuple
-from typing import TYPE_CHECKING
 from typing import Union
 
 import _pytest
@@ -75,15 +75,11 @@ from _pytest.pathlib import import_path
 from _pytest.pathlib import ImportPathMismatchError
 from _pytest.pathlib import parts
 from _pytest.pathlib import visit
+from _pytest.scope import _ScopeName
 from _pytest.scope import Scope
 from _pytest.warning_types import PytestCollectionWarning
 from _pytest.warning_types import PytestReturnNotNoneWarning
 from _pytest.warning_types import PytestUnhandledCoroutineWarning
-
-if TYPE_CHECKING:
-    from typing_extensions import Literal
-
-    from _pytest.scope import _ScopeName
 
 
 _PYTEST_DIR = Path(_pytest.__file__).parent
@@ -1236,7 +1232,7 @@ class Metafunc:
         ids: Optional[
             Union[Iterable[Optional[object]], Callable[[Any], Optional[object]]]
         ] = None,
-        scope: "Optional[_ScopeName]" = None,
+        scope: Optional[_ScopeName] = None,
         *,
         _param_mark: Optional[Mark] = None,
     ) -> None:

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -9,6 +9,7 @@ from typing import final
 from typing import Iterable
 from typing import Iterator
 from typing import List
+from typing import Literal
 from typing import Mapping
 from typing import NoReturn
 from typing import Optional
@@ -36,8 +37,6 @@ from _pytest.nodes import Item
 from _pytest.outcomes import skip
 
 if TYPE_CHECKING:
-    from typing_extensions import Literal
-
     from _pytest.runner import CallInfo
 
 
@@ -64,7 +63,7 @@ class BaseReport:
     ]
     sections: List[Tuple[str, str]]
     nodeid: str
-    outcome: "Literal['passed', 'failed', 'skipped']"
+    outcome: Literal["passed", "failed", "skipped"]
 
     def __init__(self, **kw: Any) -> None:
         self.__dict__.update(kw)
@@ -258,11 +257,11 @@ class TestReport(BaseReport):
         nodeid: str,
         location: Tuple[str, Optional[int], str],
         keywords: Mapping[str, Any],
-        outcome: "Literal['passed', 'failed', 'skipped']",
+        outcome: Literal["passed", "failed", "skipped"],
         longrepr: Union[
             None, ExceptionInfo[BaseException], Tuple[str, int, str], str, TerminalRepr
         ],
-        when: "Literal['setup', 'call', 'teardown']",
+        when: Literal["setup", "call", "teardown"],
         sections: Iterable[Tuple[str, str]] = (),
         duration: float = 0,
         start: float = 0,

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -9,6 +9,7 @@ from typing import Dict
 from typing import final
 from typing import Generic
 from typing import List
+from typing import Literal
 from typing import Optional
 from typing import Tuple
 from typing import Type
@@ -38,8 +39,6 @@ if sys.version_info[:2] < (3, 11):
     from exceptiongroup import BaseExceptionGroup
 
 if TYPE_CHECKING:
-    from typing_extensions import Literal
-
     from _pytest.main import Session
     from _pytest.terminal import TerminalReporter
 
@@ -184,7 +183,7 @@ def pytest_runtest_teardown(item: Item, nextitem: Optional[Item]) -> None:
 
 
 def _update_current_test_var(
-    item: Item, when: Optional["Literal['setup', 'call', 'teardown']"]
+    item: Item, when: Optional[Literal["setup", "call", "teardown"]]
 ) -> None:
     """Update :envvar:`PYTEST_CURRENT_TEST` to reflect the current item and stage.
 
@@ -217,7 +216,7 @@ def pytest_report_teststatus(report: BaseReport) -> Optional[Tuple[str, str, str
 
 
 def call_and_report(
-    item: Item, when: "Literal['setup', 'call', 'teardown']", log: bool = True, **kwds
+    item: Item, when: Literal["setup", "call", "teardown"], log: bool = True, **kwds
 ) -> TestReport:
     call = call_runtest_hook(item, when, **kwds)
     hook = item.ihook
@@ -245,7 +244,7 @@ def check_interactive_exception(call: "CallInfo[object]", report: BaseReport) ->
 
 
 def call_runtest_hook(
-    item: Item, when: "Literal['setup', 'call', 'teardown']", **kwds
+    item: Item, when: Literal["setup", "call", "teardown"], **kwds
 ) -> "CallInfo[None]":
     if when == "setup":
         ihook: Callable[..., None] = item.ihook.pytest_runtest_setup
@@ -281,7 +280,7 @@ class CallInfo(Generic[TResult]):
     #: The call duration, in seconds.
     duration: float
     #: The context of invocation: "collect", "setup", "call" or "teardown".
-    when: "Literal['collect', 'setup', 'call', 'teardown']"
+    when: Literal["collect", "setup", "call", "teardown"]
 
     def __init__(
         self,
@@ -290,7 +289,7 @@ class CallInfo(Generic[TResult]):
         start: float,
         stop: float,
         duration: float,
-        when: "Literal['collect', 'setup', 'call', 'teardown']",
+        when: Literal["collect", "setup", "call", "teardown"],
         *,
         _ispytest: bool = False,
     ) -> None:
@@ -319,7 +318,7 @@ class CallInfo(Generic[TResult]):
     def from_call(
         cls,
         func: "Callable[[], TResult]",
-        when: "Literal['collect', 'setup', 'call', 'teardown']",
+        when: Literal["collect", "setup", "call", "teardown"],
         reraise: Optional[
             Union[Type[BaseException], Tuple[Type[BaseException], ...]]
         ] = None,

--- a/src/_pytest/scope.py
+++ b/src/_pytest/scope.py
@@ -9,13 +9,11 @@ Also this makes the module light to import, as it should.
 """
 from enum import Enum
 from functools import total_ordering
+from typing import Literal
 from typing import Optional
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from typing_extensions import Literal
 
-    _ScopeName = Literal["session", "package", "module", "class", "function"]
+_ScopeName = Literal["session", "package", "module", "class", "function"]
 
 
 @total_ordering
@@ -33,11 +31,11 @@ class Scope(Enum):
     """
 
     # Scopes need to be listed from lower to higher.
-    Function: "_ScopeName" = "function"
-    Class: "_ScopeName" = "class"
-    Module: "_ScopeName" = "module"
-    Package: "_ScopeName" = "package"
-    Session: "_ScopeName" = "session"
+    Function: _ScopeName = "function"
+    Class: _ScopeName = "class"
+    Module: _ScopeName = "module"
+    Package: _ScopeName = "package"
+    Session: _ScopeName = "session"
 
     def next_lower(self) -> "Scope":
         """Return the next lower scope."""
@@ -60,7 +58,7 @@ class Scope(Enum):
 
     @classmethod
     def from_user(
-        cls, scope_name: "_ScopeName", descr: str, where: Optional[str] = None
+        cls, scope_name: _ScopeName, descr: str, where: Optional[str] = None
     ) -> "Scope":
         """
         Given a scope name from the user, return the equivalent Scope enum. Should be used

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -20,6 +20,7 @@ from typing import Dict
 from typing import final
 from typing import Generator
 from typing import List
+from typing import Literal
 from typing import Mapping
 from typing import NamedTuple
 from typing import Optional
@@ -54,8 +55,6 @@ from _pytest.reports import CollectReport
 from _pytest.reports import TestReport
 
 if TYPE_CHECKING:
-    from typing_extensions import Literal
-
     from _pytest.main import Session
 
 
@@ -366,7 +365,7 @@ class TerminalReporter:
         self._already_displayed_warnings: Optional[int] = None
         self._keyboardinterrupt_memo: Optional[ExceptionRepr] = None
 
-    def _determine_show_progress_info(self) -> "Literal['progress', 'count', False]":
+    def _determine_show_progress_info(self) -> Literal["progress", "count", False]:
         """Return whether we should display progress information based on the current config."""
         # do not show progress if we are not capturing output (#3038) unless explicitly
         # overridden by progress-even-when-capture-no

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -48,13 +48,13 @@ class TempPathFactory:
     _trace: Any
     _basetemp: Optional[Path]
     _retention_count: int
-    _retention_policy: "RetentionType"
+    _retention_policy: RetentionType
 
     def __init__(
         self,
         given_basetemp: Optional[Path],
         retention_count: int,
-        retention_policy: "RetentionType",
+        retention_policy: RetentionType,
         trace,
         basetemp: Optional[Path] = None,
         *,

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -2,8 +2,8 @@ import sys
 import warnings
 from contextlib import contextmanager
 from typing import Generator
+from typing import Literal
 from typing import Optional
-from typing import TYPE_CHECKING
 
 import pytest
 from _pytest.config import apply_warning_filters
@@ -12,9 +12,6 @@ from _pytest.config import parse_warning_filter
 from _pytest.main import Session
 from _pytest.nodes import Item
 from _pytest.terminal import TerminalReporter
-
-if TYPE_CHECKING:
-    from typing_extensions import Literal
 
 
 def pytest_configure(config: Config) -> None:
@@ -29,7 +26,7 @@ def pytest_configure(config: Config) -> None:
 def catch_warnings_for_item(
     config: Config,
     ihook,
-    when: "Literal['config', 'collect', 'runtest']",
+    when: Literal["config", "collect", "runtest"],
     item: Optional[Item],
 ) -> Generator[None, None, None]:
     """Context manager that catches warnings generated in the contained execution block.


### PR DESCRIPTION
Literal was added in Python 3.8 which we now require so can use it freely.