### PR TITLE
fixtures: show test as skip location if skipped from an xunit setup function

### DIFF
--- a/changelog/11216.improvement.rst
+++ b/changelog/11216.improvement.rst
@@ -1,0 +1,1 @@
+If a test is skipped from inside an :ref:`xunit setup fixture <classic xunit>`, the test summary now shows the test location instead of the fixture location.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1162,9 +1162,10 @@ def pytest_fixture_setup(
     try:
         result = call_fixture_func(fixturefunc, request, kwargs)
     except TEST_OUTCOME as e:
-        if isinstance(e, skip.Exception) and not fixturefunc.__name__.startswith(
-            "xunit_setup"
-        ):
+        if isinstance(e, skip.Exception):
+            # The test requested a fixture which caused a skip.
+            # Don't show the fixture as the skip location, as then the user
+            # wouldn't know which test skipped.
             e._use_item_location = True
         fixturedef.cached_result = (None, my_cache_key, e)
         raise

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -989,33 +989,34 @@ def test_skipped_reasons_functional(pytester: Pytester) -> None:
     pytester.makepyfile(
         test_one="""
             import pytest
-            from conftest import doskip
+            from helpers import doskip
 
-            def setup_function(func):
-                doskip()
+            def setup_function(func):  # LINE 4
+                doskip("setup function")
 
             def test_func():
                 pass
 
-            class TestClass(object):
+            class TestClass:
                 def test_method(self):
-                    doskip()
+                    doskip("test method")
 
-                @pytest.mark.skip("via_decorator")
+                @pytest.mark.skip("via_decorator")  # LINE 14
                 def test_deco(self):
                     assert 0
         """,
-        conftest="""
+        helpers="""
             import pytest, sys
-            def doskip():
+            def doskip(reason):
                 assert sys._getframe().f_lineno == 3
-                pytest.skip('test')
+                pytest.skip(reason)  # LINE 4
         """,
     )
     result = pytester.runpytest("-rs")
     result.stdout.fnmatch_lines_random(
         [
-            "SKIPPED [[]2[]] conftest.py:4: test",
+            "SKIPPED [[]1[]] test_one.py:7: setup function",
+            "SKIPPED [[]1[]] helpers.py:4: test method",
             "SKIPPED [[]1[]] test_one.py:14: via_decorator",
         ]
     )


### PR DESCRIPTION
Fix #11216.