### PR TITLE
Have pytest.raises match against exception `__notes__`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -168,6 +168,7 @@ Ian Bicking
 Ian Lesperance
 Ilya Konstantinov
 Ionuț Turturică
+Isaac Virshup
 Itxaso Aizpurua
 Iwan Briquemont
 Jaap Broekhuizen

--- a/changelog/11227.improvement.rst
+++ b/changelog/11227.improvement.rst
@@ -1,0 +1,1 @@
+Allow :func:`pytest.raises` ``match`` argument to match against `PEP-678 <https://peps.python.org/pep-0678/>` ``__notes__``.

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -704,7 +704,12 @@ class ExceptionInfo(Generic[E]):
         If it matches `True` is returned, otherwise an `AssertionError` is raised.
         """
         __tracebackhide__ = True
-        value = str(self.value)
+        value = "\n".join(
+            [
+                str(self.value),
+                *getattr(self.value, "__notes__", []),
+            ]
+        )
         msg = f"Regex pattern did not match.\n Regex: {regexp!r}\n Input: {value!r}"
         if regexp == value:
             msg += "\n Did you mean to `re.escape()` the regex?"

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -843,7 +843,8 @@ def raises(  # noqa: F811
         >>> with pytest.raises(ValueError, match=r'must be \d+$'):
         ...     raise ValueError("value must be 42")
 
-    The ``match`` argument searches the formatted exception string, which includes any ``__notes__``:
+    The ``match`` argument searches the formatted exception string, which includes any
+    `PEP-678 <https://peps.python.org/pep-0678/>` ``__notes__``:
 
         >>> with pytest.raises(ValueError, match=r'had a note added'):  # doctest: +SKIP
         ...    e = ValueError("value must be 42")

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -843,6 +843,13 @@ def raises(  # noqa: F811
         >>> with pytest.raises(ValueError, match=r'must be \d+$'):
         ...     raise ValueError("value must be 42")
 
+    The ``match`` argument searches the formatted exception string, which includes any ``__notes__``:
+
+        >>> with pytest.raises(ValueError, match=r'had a note added'):  # doctest: +SKIP
+        ...    e = ValueError("value must be 42")
+        ...    e.add_note("had a note added")
+        ...    raise e
+
     The context manager produces an :class:`ExceptionInfo` object which can be used to inspect the
     details of the captured exception::
 

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import io
 import operator
@@ -7,10 +9,7 @@ import sys
 import textwrap
 from pathlib import Path
 from typing import Any
-from typing import Dict
-from typing import Tuple
 from typing import TYPE_CHECKING
-from typing import Union
 
 import _pytest._code
 import pytest
@@ -802,7 +801,7 @@ raise ValueError()
         )
         excinfo = pytest.raises(ValueError, mod.entry)
 
-        styles: Tuple[_TracebackStyle, ...] = ("long", "short")
+        styles: tuple[_TracebackStyle, ...] = ("long", "short")
         for style in styles:
             p = FormattedExcinfo(style=style)
             reprtb = p.repr_traceback(excinfo)
@@ -929,7 +928,7 @@ raise ValueError()
         )
         excinfo = pytest.raises(ValueError, mod.entry)
 
-        styles: Tuple[_TracebackStyle, ...] = ("short", "long", "no")
+        styles: tuple[_TracebackStyle, ...] = ("short", "long", "no")
         for style in styles:
             for showlocals in (True, False):
                 repr = excinfo.getrepr(style=style, showlocals=showlocals)
@@ -1091,7 +1090,7 @@ raise ValueError()
             for funcargs in (True, False)
         ],
     )
-    def test_format_excinfo(self, reproptions: Dict[str, Any]) -> None:
+    def test_format_excinfo(self, reproptions: dict[str, Any]) -> None:
         def bar():
             assert False, "some error"
 
@@ -1399,7 +1398,7 @@ raise ValueError()
 @pytest.mark.parametrize("encoding", [None, "utf8", "utf16"])
 def test_repr_traceback_with_unicode(style, encoding):
     if encoding is None:
-        msg: Union[str, bytes] = "☹"
+        msg: str | bytes = "☹"
     else:
         msg = "☹".encode(encoding)
     try:

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -1648,3 +1648,38 @@ def test_hidden_entries_of_chained_exceptions_are_not_shown(pytester: Pytester) 
         ],
         consecutive=True,
     )
+
+
+@pytest.mark.skip("sys.version_info < (3,11)")
+@pytest.mark.parametrize(
+    "error,notes,match",
+    [
+        (Exception("test"), [], "test"),
+        (AssertionError("foo"), ["bar"], "bar"),
+        (AssertionError("foo"), ["bar", "baz"], "bar"),
+        (AssertionError("foo"), ["bar", "baz"], "baz"),
+    ],
+)
+def test_check_error_notes_success(error, notes, match):
+    for note in notes:
+        error.add_note(note)
+
+    with pytest.raises(Exception, match=match):
+        raise error
+
+
+@pytest.mark.skip("sys.version_info < (3,11)")
+@pytest.mark.parametrize(
+    "error, notes, match",
+    [
+        (Exception("test"), [], "foo"),
+        (AssertionError("foo"), ["bar"], "baz"),
+    ],
+)
+def test_check_error_notes_failure(error, notes, match):
+    for note in notes:
+        error.add_note(note)
+
+    with pytest.raises(AssertionError):
+        with pytest.raises(type(error), match=match):
+            raise error

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -2,6 +2,7 @@ import importlib
 import io
 import operator
 import queue
+import re
 import sys
 import textwrap
 from pathlib import Path
@@ -1665,6 +1666,8 @@ def add_note(err: BaseException, msg: str) -> None:
         (AssertionError("foo"), ["bar"], "bar"),
         (AssertionError("foo"), ["bar", "baz"], "bar"),
         (AssertionError("foo"), ["bar", "baz"], "baz"),
+        (ValueError("foo"), ["bar", "baz"], re.compile(r"bar\nbaz", re.MULTILINE)),
+        (ValueError("foo"), ["bar", "baz"], re.compile(r"BAZ", re.IGNORECASE)),
     ],
 )
 def test_check_error_notes_success(

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -1667,7 +1667,7 @@ def add_note(err: BaseException, msg: str) -> None:
         (AssertionError("foo"), ["bar", "baz"], "baz"),
     ],
 )
-def test_check_error_notes_success(error, notes, match):
+def test_check_error_notes_success(error: Exception, notes: list[str], match: str) -> None:
     for note in notes:
         add_note(error, note)
 
@@ -1683,7 +1683,7 @@ def test_check_error_notes_success(error, notes, match):
         (AssertionError("foo"), ["bar"], "foo\nbaz"),
     ],
 )
-def test_check_error_notes_failure(error, notes, match):
+def test_check_error_notes_failure(error: Exception, notes: list[str], match: str) -> None:
     for note in notes:
         add_note(error, note)
 


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Closes #11223

Adds support for matching against `__notes__` added to an exception within `pytest.raises`. See issue for discussion/ design.

### Notes

* The doctest is skipped because `add_note` is only available in 3.11+
  * An alternative could be to add a backport of this feature to `exceptiongroup`: https://github.com/agronholm/exceptiongroup/issues/31

### TODO

- [x] Add yourself to `AUTHORS` in alphabetical 
- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`.