### PR TITLE
doc/example/parametrize: a few fixes/improvements

### DIFF
--- a/doc/en/example/multipython.py
+++ b/doc/en/example/multipython.py
@@ -1,14 +1,13 @@
-"""
-module containing a parametrized tests testing cross-python
-serialization via the pickle module.
-"""
+"""Module containing a parametrized tests testing cross-python serialization
+via the pickle module."""
 import shutil
 import subprocess
 import textwrap
 
 import pytest
 
-pythonlist = ["python3.5", "python3.6", "python3.7"]
+
+pythonlist = ["python3.9", "python3.10", "python3.11"]
 
 
 @pytest.fixture(params=pythonlist)
@@ -43,7 +42,7 @@ class Python:
                 )
             )
         )
-        subprocess.check_call((self.pythonpath, str(dumpfile)))
+        subprocess.run((self.pythonpath, str(dumpfile)), check=True)
 
     def load_and_is_true(self, expression):
         loadfile = self.picklefile.with_name("load.py")
@@ -63,7 +62,7 @@ class Python:
             )
         )
         print(loadfile)
-        subprocess.check_call((self.pythonpath, str(loadfile)))
+        subprocess.run((self.pythonpath, str(loadfile)), check=True)
 
 
 @pytest.mark.parametrize("obj", [42, {}, {1: 3}])

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -483,8 +483,8 @@ argument sets to use for each test function.  Let's run it:
     FAILED test_parametrize.py::TestClass::test_equals[1-2] - assert 1 == 2
     1 failed, 2 passed in 0.12s
 
-Indirect parametrization with multiple fixtures
---------------------------------------------------------------
+Parametrization with multiple fixtures
+--------------------------------------
 
 Here is a stripped down real-life example of using parametrized
 testing for testing serialization of objects between different python
@@ -509,8 +509,8 @@ Running it results in some skips if we don't have all the python interpreters in
    SKIPPED [9] multipython.py:69: 'python3.7' not found
    27 skipped in 0.12s
 
-Indirect parametrization of optional implementations/imports
---------------------------------------------------------------------
+Parametrization of optional implementations/imports
+---------------------------------------------------
 
 If you want to compare the outcomes of several implementations of a given
 API, you can write test functions that receive the already imported implementations


### PR DESCRIPTION
Remove "Indirect" from a few section names -- not actually indirect.

Also few minor updates to the related multipython.py example.
