### PR TITLE
Remove `prune_dependency_tree` and reuse `getfixtureclosure` logic

### DIFF
--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -55,6 +55,7 @@ class TestMetafunc:
         fixtureinfo: Any = FuncFixtureInfoMock(names)
         definition: Any = DefinitionMock._create(obj=func, _nodeid="mock::nodeid")
         definition._fixtureinfo = fixtureinfo
+        definition.config = config
         definition.session = SessionMock(FixtureManagerMock({}))
         return python.Metafunc(definition, fixtureinfo, config, _ispytest=True)
 


### PR DESCRIPTION
- To reuse `getfixtureclosure` in pruning dependency tree. In pytest, fixture closure of a test is computed twice if it's parametrized. The second computation takes place in `prune_dependency_tree`. They are the same except that the second one should also ignore dynamically-introduced parametrise args, besides the ones in `ignore_args`. The motivation behind unifying these two was that the code for computing the closure got larger in the 7th improvement of #11234 so the duplicate code between these two had become significant. **Maybe the bad news is that now I figured out that I need `is_pseudo` concept for unifying the two, to do the additional objective of the second computation.**

- To prune dependency tree only if dynamic parametrization has taken place. Currently for each parametrized test , directly or indirectly, dynamically or non-dynamically(using `@pytest.mark.parametrize`), computing fixture closure takes place twice. Once in `FixtureManager::getfixtureclosure` upon creating `FuncFixtureInfo` and once in `prunc_dependency_tree` after calling `pytest_generate_tests` hook. The second one is only necessary if **direct dynamic parametrization** has occurred for the test because this is the only parametrization that might shadow  some fixtures in the fixture closure computed in the first call. Note that as differentiating between direct and indirect dynamic parametrization requires a dirty hack, the second fixture closure computation in this PR is done in the latter case as well.
