### PR TITLE
fixtures: fix crash when `parametrize(scope="package")` is used without a Package

### DIFF
--- a/changelog/11255.bugfix.rst
+++ b/changelog/11255.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed crash on `parametrize(..., scope="package")` without a package present.

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1486,6 +1486,23 @@ class TestMetafuncFunctional:
             ]
         )
 
+    @pytest.mark.parametrize("scope", ["class", "package"])
+    def test_parametrize_missing_scope_doesnt_crash(
+        self, pytester: Pytester, scope: str
+    ) -> None:
+        """Doesn't crash when parametrize(scope=<scope>) is used without a
+        corresponding <scope> node."""
+        pytester.makepyfile(
+            f"""
+            import pytest
+
+            @pytest.mark.parametrize("x", [0], scope="{scope}")
+            def test_it(x): pass
+            """
+        )
+        result = pytester.runpytest()
+        assert result.ret == 0
+
 
 class TestMetafuncFunctionalAuto:
     """Tests related to automatically find out the correct scope for


### PR DESCRIPTION
There is handling for `scope="class"` without a class, but not for `scope="package"` without a package. It would fail the assert.