### PR TITLE
config: split `_getconftestmodules` and `_loadconftestmodules`

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -581,26 +581,25 @@ class PytestPluginManager(PluginManager):
     def _try_load_conftest(
         self, anchor: Path, importmode: Union[str, ImportMode], rootpath: Path
     ) -> None:
-        self._getconftestmodules(anchor, importmode, rootpath)
+        self._loadconftestmodules(anchor, importmode, rootpath)
         # let's also consider test* subdirs
         if anchor.is_dir():
             for x in anchor.glob("test*"):
                 if x.is_dir():
-                    self._getconftestmodules(x, importmode, rootpath)
+                    self._loadconftestmodules(x, importmode, rootpath)
 
-    def _getconftestmodules(
+    def _loadconftestmodules(
         self, path: Path, importmode: Union[str, ImportMode], rootpath: Path
-    ) -> Sequence[types.ModuleType]:
+    ) -> None:
         if self._noconftest:
-            return []
+            return
 
         directory = self._get_directory(path)
 
         # Optimization: avoid repeated searches in the same directory.
         # Assumes always called with same importmode and rootpath.
-        existing_clist = self._dirpath2confmods.get(directory)
-        if existing_clist is not None:
-            return existing_clist
+        if directory in self._dirpath2confmods:
+            return
 
         # XXX these days we may rather want to use config.rootpath
         # and allow users to opt into looking into the rootdir parent
@@ -613,16 +612,17 @@ class PytestPluginManager(PluginManager):
                     mod = self._importconftest(conftestpath, importmode, rootpath)
                     clist.append(mod)
         self._dirpath2confmods[directory] = clist
-        return clist
+
+    def _getconftestmodules(self, path: Path) -> Sequence[types.ModuleType]:
+        directory = self._get_directory(path)
+        return self._dirpath2confmods.get(directory, ())
 
     def _rget_with_confmod(
         self,
         name: str,
         path: Path,
-        importmode: Union[str, ImportMode],
-        rootpath: Path,
     ) -> Tuple[types.ModuleType, Any]:
-        modules = self._getconftestmodules(path, importmode, rootpath=rootpath)
+        modules = self._getconftestmodules(path)
         for mod in reversed(modules):
             try:
                 return mod, getattr(mod, name)
@@ -1562,13 +1562,9 @@ class Config:
         else:
             return self._getini_unknown_type(name, type, value)
 
-    def _getconftest_pathlist(
-        self, name: str, path: Path, rootpath: Path
-    ) -> Optional[List[Path]]:
+    def _getconftest_pathlist(self, name: str, path: Path) -> Optional[List[Path]]:
         try:
-            mod, relroots = self.pluginmanager._rget_with_confmod(
-                name, path, self.getoption("importmode"), rootpath
-            )
+            mod, relroots = self.pluginmanager._rget_with_confmod(name, path)
         except KeyError:
             return None
         assert mod.__file__ is not None

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -376,7 +376,7 @@ def _in_venv(path: Path) -> bool:
 
 def pytest_ignore_collect(collection_path: Path, config: Config) -> Optional[bool]:
     ignore_paths = config._getconftest_pathlist(
-        "collect_ignore", path=collection_path.parent, rootpath=config.rootpath
+        "collect_ignore", path=collection_path.parent
     )
     ignore_paths = ignore_paths or []
     excludeopt = config.getoption("ignore")
@@ -387,7 +387,7 @@ def pytest_ignore_collect(collection_path: Path, config: Config) -> Optional[boo
         return True
 
     ignore_globs = config._getconftest_pathlist(
-        "collect_ignore_glob", path=collection_path.parent, rootpath=config.rootpath
+        "collect_ignore_glob", path=collection_path.parent
     )
     ignore_globs = ignore_globs or []
     excludeglobopt = config.getoption("ignore_glob")
@@ -551,11 +551,16 @@ class Session(nodes.FSCollector):
         pm = self.config.pluginmanager
         # Check if we have the common case of running
         # hooks with all conftest.py files.
-        my_conftestmodules = pm._getconftestmodules(
+        #
+        # TODO: pytest relies on this call to load non-initial conftests. This
+        # is incidental. It will be better to load conftests at a more
+        # well-defined place.
+        pm._loadconftestmodules(
             path,
             self.config.getoption("importmode"),
             rootpath=self.config.rootpath,
         )
+        my_conftestmodules = pm._getconftestmodules(path)
         remove_mods = pm._conftest_plugins.difference(my_conftestmodules)
         if remove_mods:
             # One or more conftests are not in use at this fspath.

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -2103,9 +2103,7 @@ class TestAutouseManagement:
         reprec = pytester.inline_run("-v", "-s", "--confcutdir", pytester.path)
         reprec.assertoutcome(passed=8)
         config = reprec.getcalls("pytest_unconfigure")[0].config
-        values = config.pluginmanager._getconftestmodules(
-            p, importmode="prepend", rootpath=pytester.path
-        )[0].values
+        values = config.pluginmanager._getconftestmodules(p)[0].values
         assert values == ["fin_a1", "fin_a2", "fin_b1", "fin_b2"] * 2
 
     def test_scope_ordering(self, pytester: Pytester) -> None:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -642,18 +642,11 @@ class TestConfigAPI:
         p = tmp_path.joinpath("conftest.py")
         p.write_text(f"mylist = {['.', str(somepath)]}", encoding="utf-8")
         config = pytester.parseconfigure(p)
-        assert (
-            config._getconftest_pathlist("notexist", path=tmp_path, rootpath=tmp_path)
-            is None
-        )
-        pl = (
-            config._getconftest_pathlist("mylist", path=tmp_path, rootpath=tmp_path)
-            or []
-        )
-        print(pl)
-        assert len(pl) == 2
-        assert pl[0] == tmp_path
-        assert pl[1] == somepath
+        assert config._getconftest_pathlist("notexist", path=tmp_path) is None
+        assert config._getconftest_pathlist("mylist", path=tmp_path) == [
+            tmp_path,
+            somepath,
+        ]
 
     @pytest.mark.parametrize("maybe_type", ["not passed", "None", '"string"'])
     def test_addini(self, pytester: Pytester, maybe_type: str) -> None:


### PR DESCRIPTION
Previously, the `_getconftestmodules` function was used both to load conftest modules for a path (during `pytest_load_initial_conftests`), and to retrieve conftest modules for a path (during hook dispatch and for fetching `collect_ignore`). This made things muddy - it is usually nicer to have clear separation between "command" and "query" functions, when they occur in separate phases.

So split into "load" and "get".

Currently, `gethookproxy` still loads conftest itself. I hope to change this in the future.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
