### PR TITLE
Fix a tiny bug in `python.py::_find_parametrized_scope`

### DIFF
--- a/changelog/11234.bugfix.rst
+++ b/changelog/11234.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed the case that when there are multiple fixturedefs for a param, _find_parametrized_scope picks the farthest one, while it should pick the nearest one.

--- a/changelog/11234.bugfix.rst
+++ b/changelog/11234.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the case that when there are multiple fixturedefs for a param, _find_parametrized_scope picks the farthest one, while it should pick the nearest one.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -239,11 +239,17 @@ def getfixturemarker(obj: object) -> Optional["FixtureFunctionMarker"]:
     )
 
 
-# Parametrized fixture key, helper alias for code below.
-_Key = Tuple[object, ...]
+@dataclasses.dataclass(frozen=True)
+class FixtureArgKey:
+    argname: str
+    param_index: int
+    scoped_item_path: Optional[Path]
+    item_cls: Optional[type]
 
 
-def get_parametrized_fixture_keys(item: nodes.Item, scope: Scope) -> Iterator[_Key]:
+def get_parametrized_fixture_keys(
+    item: nodes.Item, scope: Scope
+) -> Iterator[FixtureArgKey]:
     """Return list of keys for all parametrized arguments which match
     the specified scope."""
     assert scope is not Scope.Function
@@ -253,24 +259,28 @@ def get_parametrized_fixture_keys(item: nodes.Item, scope: Scope) -> Iterator[_K
         pass
     else:
         cs: CallSpec2 = callspec
-        # cs.indices.items() is random order of argnames.  Need to
+        # cs.indices is random order of argnames.  Need to
         # sort this so that different calls to
         # get_parametrized_fixture_keys will be deterministic.
-        for argname, param_index in sorted(cs.indices.items()):
+        for argname in sorted(cs.indices):
             if cs._arg2scope[argname] != scope:
                 continue
+
+            item_cls = None
             if scope is Scope.Session:
-                key: _Key = (argname, param_index)
+                scoped_item_path = None
             elif scope is Scope.Package:
-                key = (argname, param_index, item.path)
+                scoped_item_path = item.path
             elif scope is Scope.Module:
-                key = (argname, param_index, item.path)
+                scoped_item_path = item.path
             elif scope is Scope.Class:
+                scoped_item_path = item.path
                 item_cls = item.cls  # type: ignore[attr-defined]
-                key = (argname, param_index, item.path, item_cls)
             else:
                 assert_never(scope)
-            yield key
+
+            param_index = cs.indices[argname]
+            yield FixtureArgKey(argname, param_index, scoped_item_path, item_cls)
 
 
 # Algorithm for sorting on a per-parametrized resource setup basis.
@@ -280,12 +290,12 @@ def get_parametrized_fixture_keys(item: nodes.Item, scope: Scope) -> Iterator[_K
 
 
 def reorder_items(items: Sequence[nodes.Item]) -> List[nodes.Item]:
-    argkeys_cache: Dict[Scope, Dict[nodes.Item, Dict[_Key, None]]] = {}
-    items_by_argkey: Dict[Scope, Dict[_Key, Deque[nodes.Item]]] = {}
+    argkeys_cache: Dict[Scope, Dict[nodes.Item, Dict[FixtureArgKey, None]]] = {}
+    items_by_argkey: Dict[Scope, Dict[FixtureArgKey, Deque[nodes.Item]]] = {}
     for scope in HIGH_SCOPES:
-        d: Dict[nodes.Item, Dict[_Key, None]] = {}
+        d: Dict[nodes.Item, Dict[FixtureArgKey, None]] = {}
         argkeys_cache[scope] = d
-        item_d: Dict[_Key, Deque[nodes.Item]] = defaultdict(deque)
+        item_d: Dict[FixtureArgKey, Deque[nodes.Item]] = defaultdict(deque)
         items_by_argkey[scope] = item_d
         for item in items:
             keys = dict.fromkeys(get_parametrized_fixture_keys(item, scope), None)
@@ -301,8 +311,8 @@ def reorder_items(items: Sequence[nodes.Item]) -> List[nodes.Item]:
 
 def fix_cache_order(
     item: nodes.Item,
-    argkeys_cache: Dict[Scope, Dict[nodes.Item, Dict[_Key, None]]],
-    items_by_argkey: Dict[Scope, Dict[_Key, "Deque[nodes.Item]"]],
+    argkeys_cache: Dict[Scope, Dict[nodes.Item, Dict[FixtureArgKey, None]]],
+    items_by_argkey: Dict[Scope, Dict[FixtureArgKey, "Deque[nodes.Item]"]],
 ) -> None:
     for scope in HIGH_SCOPES:
         for key in argkeys_cache[scope].get(item, []):
@@ -311,13 +321,13 @@ def fix_cache_order(
 
 def reorder_items_atscope(
     items: Dict[nodes.Item, None],
-    argkeys_cache: Dict[Scope, Dict[nodes.Item, Dict[_Key, None]]],
-    items_by_argkey: Dict[Scope, Dict[_Key, "Deque[nodes.Item]"]],
+    argkeys_cache: Dict[Scope, Dict[nodes.Item, Dict[FixtureArgKey, None]]],
+    items_by_argkey: Dict[Scope, Dict[FixtureArgKey, "Deque[nodes.Item]"]],
     scope: Scope,
 ) -> Dict[nodes.Item, None]:
     if scope is Scope.Function or len(items) < 3:
         return items
-    ignore: Set[Optional[_Key]] = set()
+    ignore: Set[Optional[FixtureArgKey]] = set()
     items_deque = deque(items)
     items_done: Dict[nodes.Item, None] = {}
     scoped_items_by_argkey = items_by_argkey[scope]

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -492,7 +492,7 @@ class FixtureRequest:
             node: Optional[Union[nodes.Item, nodes.Collector]] = self._pyfuncitem
         elif scope is Scope.Package:
             # FIXME: _fixturedef is not defined on FixtureRequest (this class),
-            # but on FixtureRequest (a subclass).
+            # but on SubRequest (a subclass).
             node = get_scope_package(self._pyfuncitem, self._fixturedef)  # type: ignore[attr-defined]
         else:
             node = get_scope_node(self._pyfuncitem, scope)

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1682,7 +1682,7 @@ class Function(PyobjMixin, nodes.Item):
     :param config:
         The pytest Config object.
     :param callspec:
-        If given, this is function has been parametrized and the callspec contains
+        If given, this function has been parametrized and the callspec contains
         meta information about the parametrization.
     :param callobj:
         If given, the object which will be called when the Function is invoked,

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1516,7 +1516,7 @@ def _find_parametrized_scope(
     if all_arguments_are_fixtures:
         fixturedefs = arg2fixturedefs or {}
         used_scopes = [
-            fixturedef[0]._scope
+            fixturedef[-1]._scope
             for name, fixturedef in fixturedefs.items()
             if name in argnames
         ]

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1546,7 +1546,7 @@ class TestMetafuncFunctional:
 
             class Test:
                 @pytest.fixture(scope="class")
-                def fixture(self):
+                def fixture(self, fixture):
                     pass
 
                 @pytest.mark.parametrize("fixture", [0], indirect=True)

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1505,6 +1505,66 @@ class TestMetafuncFunctional:
         result = pytester.runpytest()
         assert result.ret == 0
 
+    def test_reordering_with_scopeless_and_just_indirect_parametrization(
+        self, pytester: Pytester
+    ) -> None:
+        pytester.makeconftest(
+            """
+            import pytest
+
+            @pytest.fixture(scope="package")
+            def fixture1():
+                pass
+            """
+        )
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.fixture(scope="module")
+            def fixture0():
+                pass
+
+            @pytest.fixture(scope="module")
+            def fixture1(fixture0):
+                pass
+
+            @pytest.mark.parametrize("fixture1", [0], indirect=True)
+            def test_0(fixture1):
+                pass
+
+            @pytest.fixture(scope="module")
+            def fixture():
+                pass
+
+            @pytest.mark.parametrize("fixture", [0], indirect=True)
+            def test_1(fixture):
+                pass
+
+            def test_2():
+                pass
+
+            class Test:
+                @pytest.fixture(scope="class")
+                def fixture(self):
+                    pass
+
+                @pytest.mark.parametrize("fixture", [0], indirect=True)
+                def test_3(self, fixture):
+                    pass
+            """
+        )
+        result = pytester.runpytest("-v")
+        assert result.ret == 0
+        result.stdout.fnmatch_lines(
+            [
+                "*test_0*",
+                "*test_1*",
+                "*test_2*",
+                "*test_3*",
+            ]
+        )
+
 
 class TestMetafuncFunctionalAuto:
     """Tests related to automatically find out the correct scope for

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -151,6 +151,7 @@ class TestMetafunc:
                 module_fix=[DummyFixtureDef(Scope.Module)],
                 class_fix=[DummyFixtureDef(Scope.Class)],
                 func_fix=[DummyFixtureDef(Scope.Function)],
+                mixed_fix=[DummyFixtureDef(Scope.Module), DummyFixtureDef(Scope.Class)],
             ),
         )
 
@@ -187,6 +188,7 @@ class TestMetafunc:
             )
             == Scope.Module
         )
+        assert find_scope(["mixed_fix"], indirect=True) == Scope.Class
 
     def test_parametrize_and_id(self) -> None:
         def func(x, y):


### PR DESCRIPTION
Currently, when there are multiple fixturedefs for a param, `_find_parametrized_scope` picks the farthest one, while it should pick the nearest one.
