### PR TITLE
Feed a test only with initialnames, not the whole fixture closure

### DIFF
--- a/changelog/11284.deprecation.rst
+++ b/changelog/11284.deprecation.rst
@@ -1,0 +1,3 @@
+Accessing ``item.funcargs`` with fixture names other than the direct ones, i.e. the direct args, the ones with ``autouse`` and the ones with ``usefixtures`` issues a warning.
+
+This will become an error in pytest 9.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -280,18 +280,15 @@ The accompanying ``py.path.local`` based paths have been deprecated: plugins whi
 
 .. _item-funcargs-deprecation:
 
-Accessing ``item.funcargs`` with not directly requested fixture names
+Accessing ``item.funcargs`` with non-directly requested fixture names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. deprecated:: 8.0
-.. versionremoved:: 9.0
+.. versionremoved:: 8.1
 
-Accessing ``item.funcargs`` with not directly requested fixture names issues warning and
-will be erroneous starting from pytest 9. Directly requested fixtures are the direct args
-to the test, the ``usefixtures`` fixtures and the ``autouse`` ones.
+Accessing ``item.funcargs`` with non-directly requested fixture names issues a warning and will be erroneous starting from pytest 9.
+Directly requested fixtures are the direct arguments to the test, ``usefixtures`` fixtures and ``autouse`` fixtures.
 
-To request fixtures other than the directly requested ones, user could use
-``request.getfixturevalue`` instead.
+To request a fixture other than the directly requested ones, use :func:`request.getfixturevalue <pytest.FixtureRequest.getfixturevalue>` instead.
 
 .. _nose-deprecation:
 

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -278,6 +278,20 @@ The accompanying ``py.path.local`` based paths have been deprecated: plugins whi
     resolved in future versions as we slowly get rid of the :pypi:`py`
     dependency (see :issue:`9283` for a longer discussion).
 
+.. _item-funcargs-deprecation:
+
+Accessing ``item.funcargs`` with not directly requested fixture names
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 8.0
+.. versionremoved:: 9.0
+
+Accessing ``item.funcargs`` with not directly requested fixture names issues warning and
+will be erroneous starting from pytest 9. Directly requested fixtures are the direct args
+to the test, the ``usefixtures`` fixtures and the ``autouse`` ones.
+
+To request fixtures other than the directly requested ones, user could use
+``request.getfixturevalue`` instead.
 
 .. _nose-deprecation:
 

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -819,7 +819,7 @@ case we just write some information out to a ``failures`` file:
             with open("failures", mode, encoding="utf-8") as f:
                 # let's also access a fixture for the fun of it
                 if "tmp_path" in item.fixturenames:
-                    extra = " ({})".format(item.funcargs["tmp_path"])
+                    extra = " ({})".format(item._request.getfixturevalue("tmp_path"))
                 else:
                     extra = ""
 

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -818,8 +818,8 @@ case we just write some information out to a ``failures`` file:
             mode = "a" if os.path.exists("failures") else "w"
             with open("failures", mode, encoding="utf-8") as f:
                 # let's also access a fixture for the fun of it
-                if "tmp_path" in item.fixturenames:
-                    extra = " ({})".format(item._request.getfixturevalue("tmp_path"))
+                if "tmp_path" in item.funcargs:
+                    extra = " ({})".format(item.funcargs["tmp_path"])
                 else:
                     extra = ""
 

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -17,6 +17,7 @@ from collections import defaultdict
 from pathlib import Path
 from pathlib import PurePath
 from typing import Callable
+from typing import DefaultDict
 from typing import Dict
 from typing import IO
 from typing import Iterable
@@ -668,9 +669,9 @@ class AssertionRewriter(ast.NodeVisitor):
         else:
             self.enable_assertion_pass_hook = False
         self.source = source
-        self.scope: tuple[ast.AST, ...] = ()
-        self.variables_overwrite: defaultdict[
-            tuple[ast.AST, ...], Dict[str, str]
+        self.scope: Tuple[ast.AST, ...] = ()
+        self.variables_overwrite: DefaultDict[
+            Tuple[ast.AST, ...], Dict[str, str]
         ] = defaultdict(dict)
 
     def run(self, mod: ast.Module) -> None:

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -11,6 +11,7 @@ in case of warnings which need to format their messages.
 from warnings import warn
 
 from _pytest.warning_types import PytestDeprecationWarning
+from _pytest.warning_types import PytestRemovedIn8Warning
 from _pytest.warning_types import PytestRemovedIn9Warning
 from _pytest.warning_types import UnformattedWarning
 
@@ -46,6 +47,13 @@ HOOK_LEGACY_MARKING = UnformattedWarning(
 MARKED_FIXTURE = PytestRemovedIn9Warning(
     "Marks applied to fixtures have no effect\n"
     "See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function"
+)
+
+ITEM_FUNCARGS_MEMBERS = PytestRemovedIn9Warning(
+    "Access to names other than initialnames i.e., direct args,"
+    " the ones with `usefixture` or the ones with `autouse` through "
+    "`item.funcargs` is deprecated and will raise `KeyError` from "
+    "pytest 9. Please use `request.getfixturevalue` instead."
 )
 
 # You want to make some `__init__` or function "private".

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -11,7 +11,6 @@ in case of warnings which need to format their messages.
 from warnings import warn
 
 from _pytest.warning_types import PytestDeprecationWarning
-from _pytest.warning_types import PytestRemovedIn8Warning
 from _pytest.warning_types import PytestRemovedIn9Warning
 from _pytest.warning_types import UnformattedWarning
 

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -50,10 +50,10 @@ MARKED_FIXTURE = PytestRemovedIn9Warning(
 )
 
 ITEM_FUNCARGS_MEMBERS = PytestRemovedIn9Warning(
-    "Access to names other than initialnames i.e., direct args,"
-    " the ones with `usefixture` or the ones with `autouse` through "
-    "`item.funcargs` is deprecated and will raise `KeyError` from "
-    "pytest 9. Please use `request.getfixturevalue` instead."
+    "Accessing `item.funcargs` with a fixture name not directly requested"
+    " by the item, through a direct argument, `usefixtures` marker or"
+    " an `autouse` fixture, is deprecated and will raise KeyError starting"
+    " from pytest 9. Please use request.getfixturevalue instead."
 )
 
 # You want to make some `__init__` or function "private".

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -40,6 +40,7 @@ from _pytest.outcomes import OutcomeException
 from _pytest.outcomes import skip
 from _pytest.pathlib import fnmatch_ex
 from _pytest.pathlib import import_path
+from _pytest.python import DeprecatingFuncArgs
 from _pytest.python import Module
 from _pytest.python_api import approx
 from _pytest.warning_types import PytestWarning
@@ -284,7 +285,9 @@ class DoctestItem(Item):
         return super().from_parent(name=name, parent=parent, runner=runner, dtest=dtest)
 
     def _initrequest(self) -> None:
-        self.funcargs: Dict[str, object] = {}
+        self.funcargs: Dict[str, object] = DeprecatingFuncArgs(
+            self._fixtureinfo.initialnames
+        )
         self._request = TopRequest(self, _ispytest=True)  # type: ignore[arg-type]
 
     def setup(self) -> None:

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -683,11 +683,9 @@ class TopRequest(FixtureRequest):
     def _fillfixtures(self) -> None:
         item = self._pyfuncitem
         fixturenames = getattr(item, "fixturenames", self.fixturenames)
-        initialnames = item._fixtureinfo.initialnames
         for argname in fixturenames:
-            value = self.getfixturevalue(argname)
-            if argname not in item.funcargs and argname in initialnames:
-                item.funcargs[argname] = value
+            if argname not in item.funcargs:
+                item.funcargs[argname] = self.getfixturevalue(argname)
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         self.node.addfinalizer(finalizer)

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -682,9 +682,12 @@ class TopRequest(FixtureRequest):
 
     def _fillfixtures(self) -> None:
         item = self._pyfuncitem
-        for argname in item.fixturenames:
-            if argname not in item.funcargs:
-                item.funcargs[argname] = self.getfixturevalue(argname)
+        fixturenames = getattr(item, "fixturenames", self.fixturenames)
+        initialnames = item._fixtureinfo.initialnames
+        for argname in fixturenames:
+            value = self.getfixturevalue(argname)
+            if argname not in item.funcargs and argname in initialnames:
+                item.funcargs[argname] = value
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         self.node.addfinalizer(finalizer)

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 from typing import Callable
 from typing import Dict
+from typing import Final
 from typing import final
 from typing import Generator
 from typing import Iterable
@@ -55,6 +56,7 @@ from _pytest.config import ExitCode
 from _pytest.config import hookimpl
 from _pytest.config.argparsing import Parser
 from _pytest.deprecated import check_ispytest
+from _pytest.deprecated import ITEM_FUNCARGS_MEMBERS
 from _pytest.fixtures import FixtureDef
 from _pytest.fixtures import FixtureRequest
 from _pytest.fixtures import FuncFixtureInfo
@@ -1660,19 +1662,13 @@ def write_docstring(tw: TerminalWriter, doc: str, indent: str = "    ") -> None:
 
 
 class DeprecatingFuncArgs(Dict[str, object]):
-    def __init__(self, initialnames):
-        self.initialnames = initialnames
+    def __init__(self, initialnames: Sequence[str]) -> None:
         super().__init__()
+        self.initialnames: Final = initialnames
 
     def __getitem__(self, key: str) -> object:
         if key not in self.initialnames:
-            warnings.warn(
-                "Accessing to names other than initialnames i.e., direct args,"
-                " the ones with `usefixture` or the ones with `autouse` through "
-                "`item.funcargs` is deprecated and will raise `KeyError` from "
-                "pytest 9. Please use `request.getfixturevalue` instead.",
-                DeprecationWarning,
-            )
+            warnings.warn(ITEM_FUNCARGS_MEMBERS)
         return super().__getitem__(key)
 
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1668,7 +1668,7 @@ class DeprecatingFuncArgs(Dict[str, object]):
 
     def __getitem__(self, key: str) -> object:
         if key not in self.initialnames:
-            warnings.warn(ITEM_FUNCARGS_MEMBERS)
+            warnings.warn(ITEM_FUNCARGS_MEMBERS, stacklevel=2)
         return super().__getitem__(key)
 
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1664,10 +1664,12 @@ def write_docstring(tw: TerminalWriter, doc: str, indent: str = "    ") -> None:
 class DeprecatingFuncArgs(Dict[str, object]):
     def __init__(self, initialnames: Sequence[str]) -> None:
         super().__init__()
+        self.warned: bool = False
         self.initialnames: Final = initialnames
 
     def __getitem__(self, key: str) -> object:
-        if key not in self.initialnames:
+        if not self.warned and key not in self.initialnames:
+            self.warned = True
             warnings.warn(ITEM_FUNCARGS_MEMBERS, stacklevel=2)
         return super().__getitem__(key)
 

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -217,7 +217,7 @@ def test_deprecated_access_to_item_funcargs(pytester: Pytester) -> None:
     test.setup()
     with pytest.warns(
         pytest.PytestRemovedIn9Warning,
-        match=r"Access to names other than initialnames",
+        match=r"Accessing `item.funcargs` with a fixture",
     ) as record:
         test.funcargs["fixture1"]
         assert len(record) == 1

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -135,65 +135,6 @@ def test_fixture_disallowed_between_marks():
     assert len(record) == 2  # one for each mark decorator
 
 
-@pytest.mark.filterwarnings("default")
-def test_nose_deprecated_with_setup(pytester: Pytester) -> None:
-    pytest.importorskip("nose")
-    pytester.makepyfile(
-        """
-        from nose.tools import with_setup
-
-        def setup_fn_no_op():
-            ...
-
-        def teardown_fn_no_op():
-            ...
-
-        @with_setup(setup_fn_no_op, teardown_fn_no_op)
-        def test_omits_warnings():
-            ...
-        """
-    )
-    output = pytester.runpytest("-Wdefault::pytest.PytestRemovedIn8Warning")
-    message = [
-        "*PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.",
-        "*test_nose_deprecated_with_setup.py::test_omits_warnings is using nose method: `setup_fn_no_op` (setup)",
-        "*PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.",
-        "*test_nose_deprecated_with_setup.py::test_omits_warnings is using nose method: `teardown_fn_no_op` (teardown)",
-    ]
-    output.stdout.fnmatch_lines(message)
-    output.assert_outcomes(passed=1)
-
-
-@pytest.mark.filterwarnings("default")
-def test_nose_deprecated_setup_teardown(pytester: Pytester) -> None:
-    pytest.importorskip("nose")
-    pytester.makepyfile(
-        """
-        class Test:
-
-            def setup(self):
-                ...
-
-            def teardown(self):
-                ...
-
-            def test(self):
-                ...
-        """
-    )
-    output = pytester.runpytest("-Wdefault::pytest.PytestRemovedIn8Warning")
-    message = [
-        "*PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.",
-        "*test_nose_deprecated_setup_teardown.py::Test::test is using nose-specific method: `setup(self)`",
-        "*To remove this warning, rename it to `setup_method(self)`",
-        "*PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.",
-        "*test_nose_deprecated_setup_teardown.py::Test::test is using nose-specific method: `teardown(self)`",
-        "*To remove this warning, rename it to `teardown_method(self)`",
-    ]
-    output.stdout.fnmatch_lines(message)
-    output.assert_outcomes(passed=1)
-
-
 def test_deprecated_access_to_item_funcargs(pytester: Pytester) -> None:
     pytester.makepyfile(
         """

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -133,3 +133,93 @@ def test_fixture_disallowed_between_marks():
             raise NotImplementedError()
 
     assert len(record) == 2  # one for each mark decorator
+
+
+@pytest.mark.filterwarnings("default")
+def test_nose_deprecated_with_setup(pytester: Pytester) -> None:
+    pytest.importorskip("nose")
+    pytester.makepyfile(
+        """
+        from nose.tools import with_setup
+
+        def setup_fn_no_op():
+            ...
+
+        def teardown_fn_no_op():
+            ...
+
+        @with_setup(setup_fn_no_op, teardown_fn_no_op)
+        def test_omits_warnings():
+            ...
+        """
+    )
+    output = pytester.runpytest("-Wdefault::pytest.PytestRemovedIn8Warning")
+    message = [
+        "*PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.",
+        "*test_nose_deprecated_with_setup.py::test_omits_warnings is using nose method: `setup_fn_no_op` (setup)",
+        "*PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.",
+        "*test_nose_deprecated_with_setup.py::test_omits_warnings is using nose method: `teardown_fn_no_op` (teardown)",
+    ]
+    output.stdout.fnmatch_lines(message)
+    output.assert_outcomes(passed=1)
+
+
+@pytest.mark.filterwarnings("default")
+def test_nose_deprecated_setup_teardown(pytester: Pytester) -> None:
+    pytest.importorskip("nose")
+    pytester.makepyfile(
+        """
+        class Test:
+
+            def setup(self):
+                ...
+
+            def teardown(self):
+                ...
+
+            def test(self):
+                ...
+        """
+    )
+    output = pytester.runpytest("-Wdefault::pytest.PytestRemovedIn8Warning")
+    message = [
+        "*PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.",
+        "*test_nose_deprecated_setup_teardown.py::Test::test is using nose-specific method: `setup(self)`",
+        "*To remove this warning, rename it to `setup_method(self)`",
+        "*PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.",
+        "*test_nose_deprecated_setup_teardown.py::Test::test is using nose-specific method: `teardown(self)`",
+        "*To remove this warning, rename it to `teardown_method(self)`",
+    ]
+    output.stdout.fnmatch_lines(message)
+    output.assert_outcomes(passed=1)
+
+
+def test_deprecated_access_to_item_funcargs(pytester: Pytester) -> None:
+    module = pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture
+        def fixture1():
+            return None
+
+        @pytest.fixture
+        def fixture2(fixture1):
+            return None
+
+        def test(fixture2):
+            pass
+        """
+    )
+    test = pytester.genitems((pytester.getmodulecol(module),))[0]
+    assert isinstance(test, pytest.Function)
+    test.session._setupstate.setup(test)
+    test.setup()
+    with pytest.warns(
+        pytest.PytestRemovedIn9Warning,
+        match=r"Access to names other than initialnames",
+    ) as record:
+        test.funcargs["fixture1"]
+        assert len(record) == 1
+        test.funcargs["fixture2"]
+        assert len(record) == 1

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -9,7 +9,6 @@ from _pytest.config import ExitCode
 from _pytest.fixtures import deduplicate_names
 from _pytest.fixtures import TopRequest
 from _pytest.monkeypatch import MonkeyPatch
-from _pytest.pytester import get_public_names
 from _pytest.pytester import Pytester
 from _pytest.python import Function
 
@@ -128,8 +127,7 @@ class TestFillFixtures:
         assert isinstance(item, Function)
         # Execute's item's setup, which fills fixtures.
         item.session._setupstate.setup(item)
-        del item.funcargs["request"]
-        assert len(get_public_names(item.funcargs)) == 2
+        assert len(item.funcargs) == 2
         assert item.funcargs["some"] == "test_func"
         assert item.funcargs["other"] == 42
 
@@ -841,8 +839,7 @@ class TestRequestBasic:
         val2 = req.getfixturevalue("other")  # see about caching
         assert val2 == 2
         assert item.funcargs["something"] == 1
-        assert len(get_public_names(item.funcargs)) == 2
-        assert "request" in item.funcargs
+        assert len(item.funcargs) == 1
 
     def test_request_addfinalizer(self, pytester: Pytester) -> None:
         item = pytester.getitem(

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -122,20 +122,16 @@ class TestFillFixtures:
             ["*recursive dependency involving fixture 'fix1' detected*"]
         )
 
-    def test_funcarg_basic(self, recwarn, pytester: Pytester) -> None:
+    def test_funcarg_basic(self, pytester: Pytester) -> None:
         pytester.copy_example()
         item = pytester.getitem(Path("test_funcarg_basic.py"))
         assert isinstance(item, Function)
         # Execute's item's setup, which fills fixtures.
         item.session._setupstate.setup(item)
-        assert len(recwarn) == 0
-        item.funcargs["request"]
-        assert len(recwarn) == 1 and recwarn[0].category is DeprecationWarning
         del item.funcargs["request"]
         assert len(get_public_names(item.funcargs)) == 2
         assert item.funcargs["some"] == "test_func"
         assert item.funcargs["other"] == 42
-        assert len(recwarn) == 1
 
     def test_funcarg_lookup_modulelevel(self, pytester: Pytester) -> None:
         pytester.copy_example()


### PR DESCRIPTION
To feed a test func only with its `_fixtureinfo.initialnames` which contains its argnames, `usefixtures` marks and autouse fixtures, not the whole fixture closure which might seem unexpected to the user.
