### PR TITLE
doc: Link pytest.main to how-to guide

### DIFF
--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -82,6 +82,8 @@ pytest.exit
 pytest.main
 ~~~~~~~~~~~
 
+**Tutorial**: :ref:`pytest.main-usage`
+
 .. autofunction:: pytest.main
 
 pytest.param


### PR DESCRIPTION
Links to here: [How to invoke pytest — pytest documentation](https://docs.pytest.org/en/7.4.x/how-to/usage.html#calling-pytest-from-python-code)