### PR TITLE
Improve duplicate values documentation

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1239,8 +1239,9 @@ class Metafunc:
         during the collection phase. If you need to setup expensive resources
         see about setting indirect to do it rather than at test setup time.
 
-        Can be called multiple times, in which case each call parametrizes all
-        previous parametrizations, e.g.
+        Can be called multiple times per test function (but only on different
+        argument names), in which case each call parametrizes all previous
+        parametrizations, e.g.
 
         ::
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1148,7 +1148,7 @@ class CallSpec2:
         arg2scope = self._arg2scope.copy()
         for arg, val in zip(argnames, valset):
             if arg in params or arg in funcargs:
-                raise ValueError(f"duplicate {arg!r}")
+                raise ValueError(f"duplicate parametrization of {arg!r}")
             valtype_for_arg = valtypes[arg]
             if valtype_for_arg == "params":
                 params[arg] = val


### PR DESCRIPTION
This would IMO fix the documentation-side of #11289.

As for the "feature-request-side" of it, if you see any chance to get allow `pytest_generate_tests` ever be used in an "overwriting" fashion, as can be done with fixture functions, I'd like to open a separate feature request issue on that.