### PR TITLE
ci: Use Python 3.8 to test latest pluggy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,17 +38,17 @@ jobs:
       matrix:
         name: [
           "windows-py37",
-          "windows-py37-pluggy",
           "windows-py38",
+          "windows-py38-pluggy",
           "windows-py39",
           "windows-py310",
           "windows-py311",
           "windows-py312",
 
           "ubuntu-py37",
-          "ubuntu-py37-pluggy",
           "ubuntu-py37-freeze",
           "ubuntu-py38",
+          "ubuntu-py38-pluggy",
           "ubuntu-py39",
           "ubuntu-py310",
           "ubuntu-py311",
@@ -70,15 +70,15 @@ jobs:
             python: "3.7"
             os: windows-latest
             tox_env: "py37-numpy"
-          - name: "windows-py37-pluggy"
-            python: "3.7"
-            os: windows-latest
-            tox_env: "py37-pluggymain-pylib-xdist"
           - name: "windows-py38"
             python: "3.8"
             os: windows-latest
             tox_env: "py38-unittestextras"
             use_coverage: true
+          - name: "windows-py38-pluggy"
+            python: "3.8"
+            os: windows-latest
+            tox_env: "py38-pluggymain-pylib-xdist"
           - name: "windows-py39"
             python: "3.9"
             os: windows-latest
@@ -101,10 +101,6 @@ jobs:
             os: ubuntu-latest
             tox_env: "py37-lsof-numpy-pexpect"
             use_coverage: true
-          - name: "ubuntu-py37-pluggy"
-            python: "3.7"
-            os: ubuntu-latest
-            tox_env: "py37-pluggymain-pylib-xdist"
           - name: "ubuntu-py37-freeze"
             python: "3.7"
             os: ubuntu-latest
@@ -113,6 +109,10 @@ jobs:
             python: "3.8"
             os: ubuntu-latest
             tox_env: "py38-xdist"
+          - name: "ubuntu-py38-pluggy"
+            python: "3.8"
+            os: ubuntu-latest
+            tox_env: "py38-pluggymain-pylib-xdist"
           - name: "ubuntu-py39"
             python: "3.9"
             os: ubuntu-latest


### PR DESCRIPTION
Pluggy dropped Python 3.7 support.
Also see 165fbbd12a74ab639d61ce1f28dfef1511a2c2e2

Fixes #11293