### PR TITLE
Improve reporting from __iter__ exceptions

### DIFF
--- a/changelog/7966.bugfix.rst
+++ b/changelog/7966.bugfix.rst
@@ -1,0 +1,1 @@
+Assertion rewrite mechanism now gives a seperate, more detailed error message from failures within __iter__.

--- a/changelog/7966.bugfix.rst
+++ b/changelog/7966.bugfix.rst
@@ -1,0 +1,1 @@
+Removes unhelpful error message from assertion rewrite mechanism when exceptions raised in __iter__ methods, and instead treats them as un-iterable.

--- a/changelog/7966.bugfix.rst
+++ b/changelog/7966.bugfix.rst
@@ -1,1 +1,0 @@
-Assertion rewrite mechanism now gives a seperate, more detailed error message from failures within __iter__.

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -132,7 +132,7 @@ def isiterable(obj: Any) -> bool:
     try:
         iter(obj)
         return not istext(obj)
-    except TypeError:
+    except Exception:
         return False
 
 

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -134,13 +134,6 @@ def isiterable(obj: Any) -> bool:
         return not istext(obj)
     except TypeError:
         return False
-    except Exception as e:
-        raise ValueError(
-            [
-                f"pytest_assertion plugin: unexpected exception {e!r} while testing object {obj!r}",
-                ", probably from __iter__",
-            ]
-        )
 
 
 def has_default_eq(
@@ -202,20 +195,13 @@ def assertrepr_compare(
                 explanation = _notin_text(left, right, verbose)
     except outcomes.Exit:
         raise
-    except Exception as e:
-        if (
-            isinstance(e, ValueError)
-            and (len(e.args) == 1)
-            and ("__iter__" in str(e.args[0]))
-        ):
-            explanation = e.args[0]
-        else:
-            explanation = [
-                "(pytest_assertion plugin: representation of details failed: {}.".format(
-                    _pytest._code.ExceptionInfo.from_current()._getreprcrash()
-                ),
-                " Probably an object has a faulty __repr__.)",
-            ]
+    except Exception:
+        explanation = [
+            "(pytest_assertion plugin: representation of details failed: {}.".format(
+                _pytest._code.ExceptionInfo.from_current()._getreprcrash()
+            ),
+            " Probably an object has a faulty __repr__.)",
+        ]
 
     if not explanation:
         return None

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -136,7 +136,10 @@ def isiterable(obj: Any) -> bool:
         return False
     except Exception as e:
         raise ValueError(
-            f"Unexpected exception {e!r} while testing object {obj!r}. Probably an issue with __iter__"
+            [
+                f"pytest_assertion plugin: unexpected exception {e!r} while testing object {obj!r}",
+                ", probably from __iter__",
+            ]
         )
 
 
@@ -203,9 +206,9 @@ def assertrepr_compare(
         if (
             isinstance(e, ValueError)
             and (len(e.args) == 1)
-            and ("Unexpected exception" in str(e.args[0]))
+            and ("__iter__" in str(e.args[0]))
         ):
-            explanation = [e.args[0]]
+            explanation = e.args[0]
         else:
             explanation = [
                 "(pytest_assertion plugin: representation of details failed: {}.".format(

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -132,13 +132,9 @@ def isiterable(obj: Any) -> bool:
     try:
         iter(obj)
         return not istext(obj)
+    except TypeError:
+        return False
     except Exception as e:
-        if (
-            isinstance(e, TypeError)
-            and (len(e.args) == 1)
-            and "iter() returned non-iterator of type" in str(e.args[0])
-        ):
-            return False
         raise ValueError(f"Unexpected exception {e!r} while testing object {obj!r}")
 
 

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -135,7 +135,9 @@ def isiterable(obj: Any) -> bool:
     except TypeError:
         return False
     except Exception as e:
-        raise ValueError(f"Unexpected exception {e!r} while testing object {obj!r}")
+        raise ValueError(
+            f"Unexpected exception {e!r} while testing object {obj!r}. Probably an issue with __iter__"
+        )
 
 
 def has_default_eq(

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -698,7 +698,7 @@ class TestAssertionRewrite:
 
         msg = getmsg(f)
         assert msg is not None
-        assert "Unexpected exception" in msg
+        assert "__iter__" in msg and "__repr__" not in msg
 
     def test_formatchar(self) -> None:
         def f() -> None:

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -689,7 +689,7 @@ class TestAssertionRewrite:
         def f() -> None:
             class A:
                 def __iter__(self):
-                    raise ValueError()
+                    raise TypeError("user message")
 
                 def __eq__(self, o: object) -> bool:
                     return self is o
@@ -698,7 +698,7 @@ class TestAssertionRewrite:
 
         msg = getmsg(f)
         assert msg is not None
-        assert "__iter__" in msg and "__repr__" not in msg
+        assert "Unexpected exception" in msg
 
     def test_formatchar(self) -> None:
         def f() -> None:

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -685,6 +685,21 @@ class TestAssertionRewrite:
         assert msg is not None
         assert "<MY42 object> < 0" in msg
 
+    def test_assert_handling_raise_in__iter__(self) -> None:
+        def f() -> None:
+            class A:
+                def __iter__(self):
+                    raise TypeError("user message")
+
+                def __eq__(self, o: object) -> bool:
+                    return self is o
+
+            assert A() == A()
+
+        msg = getmsg(f)
+        assert msg is not None
+        assert "Unexpected exception" in msg
+
     def test_formatchar(self) -> None:
         def f() -> None:
             assert "%test" == "test"  # type: ignore[comparison-overlap]

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -689,16 +689,19 @@ class TestAssertionRewrite:
         def f() -> None:
             class A:
                 def __iter__(self):
-                    raise TypeError("user message")
+                    raise ValueError()
 
                 def __eq__(self, o: object) -> bool:
                     return self is o
+
+                def __repr__(self):
+                    return "<A object>"
 
             assert A() == A()
 
         msg = getmsg(f)
         assert msg is not None
-        assert "Unexpected exception" in msg
+        assert "<A object> == <A object>" in msg
 
     def test_formatchar(self) -> None:
         def f() -> None:

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -689,7 +689,7 @@ class TestAssertionRewrite:
         def f() -> None:
             class A:
                 def __iter__(self):
-                    raise TypeError("user message")
+                    raise ValueError()
 
                 def __eq__(self, o: object) -> bool:
                     return self is o

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -685,8 +685,9 @@ class TestAssertionRewrite:
         assert msg is not None
         assert "<MY42 object> < 0" in msg
 
-    def test_assert_handling_raise_in__iter__(self) -> None:
-        def f() -> None:
+    def test_assert_handling_raise_in__iter__(self, pytester: Pytester) -> None:
+        pytester.makepyfile(
+            """\
             class A:
                 def __iter__(self):
                     raise ValueError()
@@ -698,10 +699,10 @@ class TestAssertionRewrite:
                     return "<A object>"
 
             assert A() == A()
-
-        msg = getmsg(f)
-        assert msg is not None
-        assert "<A object> == <A object>" in msg
+            """
+        )
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines(["*E*assert <A object> == <A object>"])
 
     def test_formatchar(self) -> None:
         def f() -> None:


### PR DESCRIPTION
Fixes #7966

Previously, the assertion rewrite mechanism would fail to capture raised errors within ``__iter__`` and suggest the error is within ``__repr__``, which this new reporting now fixes.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
