### PR TITLE
pytester: use `monkeypatch.chdir()` for dir changing

### DIFF
--- a/changelog/11315.trivial.rst
+++ b/changelog/11315.trivial.rst
@@ -1,0 +1,3 @@
+The :fixture:`pytester` fixture now uses the :fixture:`monkeypatch` fixture to manage the current working directory.
+If you use ``pytester`` in combination with :func:`monkeypatch.undo() <pytest.MonkeyPatch.undo>`, the CWD might get restored.
+Use :func:`monkeypatch.context() <pytest.MonkeyPatch.context>` instead.

--- a/testing/_py/test_local.py
+++ b/testing/_py/test_local.py
@@ -1080,14 +1080,14 @@ class TestImport:
         name = "pointsback123"
         ModuleType = type(os)
         p = tmpdir.ensure(name + ".py")
-        for ending in (".pyc", "$py.class", ".pyo"):
-            mod = ModuleType(name)
-            pseudopath = tmpdir.ensure(name + ending)
-            mod.__file__ = str(pseudopath)
-            monkeypatch.setitem(sys.modules, name, mod)
-            newmod = p.pyimport()
-            assert mod == newmod
-        monkeypatch.undo()
+        with monkeypatch.context() as mp:
+            for ending in (".pyc", "$py.class", ".pyo"):
+                mod = ModuleType(name)
+                pseudopath = tmpdir.ensure(name + ending)
+                mod.__file__ = str(pseudopath)
+                mp.setitem(sys.modules, name, mod)
+                newmod = p.pyimport()
+                assert mod == newmod
         mod = ModuleType(name)
         pseudopath = tmpdir.ensure(name + "123.py")
         mod.__file__ = str(pseudopath)

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -854,7 +854,11 @@ raise ValueError()
         reprtb = p.repr_traceback(excinfo)
         assert len(reprtb.reprentries) == 3
 
-    def test_traceback_short_no_source(self, importasmod, monkeypatch) -> None:
+    def test_traceback_short_no_source(
+        self,
+        importasmod,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         mod = importasmod(
             """
             def func1():
@@ -866,14 +870,14 @@ raise ValueError()
         excinfo = pytest.raises(ValueError, mod.entry)
         from _pytest._code.code import Code
 
-        monkeypatch.setattr(Code, "path", "bogus")
-        p = FormattedExcinfo(style="short")
-        reprtb = p.repr_traceback_entry(excinfo.traceback[-2])
-        lines = reprtb.lines
-        last_p = FormattedExcinfo(style="short")
-        last_reprtb = last_p.repr_traceback_entry(excinfo.traceback[-1], excinfo)
-        last_lines = last_reprtb.lines
-        monkeypatch.undo()
+        with monkeypatch.context() as mp:
+            mp.setattr(Code, "path", "bogus")
+            p = FormattedExcinfo(style="short")
+            reprtb = p.repr_traceback_entry(excinfo.traceback[-2])
+            lines = reprtb.lines
+            last_p = FormattedExcinfo(style="short")
+            last_reprtb = last_p.repr_traceback_entry(excinfo.traceback[-1], excinfo)
+            last_lines = last_reprtb.lines
         assert lines[0] == "    func1()"
 
         assert last_lines[0] == '    raise ValueError("hello")'

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -895,7 +895,11 @@ def test_rewritten():
         )
 
     @pytest.mark.skipif('"__pypy__" in sys.modules')
-    def test_pyc_vs_pyo(self, pytester: Pytester, monkeypatch) -> None:
+    def test_pyc_vs_pyo(
+        self,
+        pytester: Pytester,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         pytester.makepyfile(
             """
             import pytest
@@ -905,13 +909,13 @@ def test_rewritten():
         )
         p = make_numbered_dir(root=Path(pytester.path), prefix="runpytest-")
         tmp = "--basetemp=%s" % p
-        monkeypatch.setenv("PYTHONOPTIMIZE", "2")
-        monkeypatch.delenv("PYTHONDONTWRITEBYTECODE", raising=False)
-        monkeypatch.delenv("PYTHONPYCACHEPREFIX", raising=False)
-        assert pytester.runpytest_subprocess(tmp).ret == 0
-        tagged = "test_pyc_vs_pyo." + PYTEST_TAG
-        assert tagged + ".pyo" in os.listdir("__pycache__")
-        monkeypatch.undo()
+        with monkeypatch.context() as mp:
+            mp.setenv("PYTHONOPTIMIZE", "2")
+            mp.delenv("PYTHONDONTWRITEBYTECODE", raising=False)
+            mp.delenv("PYTHONPYCACHEPREFIX", raising=False)
+            assert pytester.runpytest_subprocess(tmp).ret == 0
+            tagged = "test_pyc_vs_pyo." + PYTEST_TAG
+            assert tagged + ".pyo" in os.listdir("__pycache__")
         monkeypatch.delenv("PYTHONDONTWRITEBYTECODE", raising=False)
         monkeypatch.delenv("PYTHONPYCACHEPREFIX", raising=False)
         assert pytester.runpytest_subprocess(tmp).ret == 1

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -236,15 +236,15 @@ class TestImportPath:
         name = "pointsback123"
         p = tmp_path.joinpath(name + ".py")
         p.touch()
-        for ending in (".pyc", ".pyo"):
-            mod = ModuleType(name)
-            pseudopath = tmp_path.joinpath(name + ending)
-            pseudopath.touch()
-            mod.__file__ = str(pseudopath)
-            monkeypatch.setitem(sys.modules, name, mod)
-            newmod = import_path(p, root=tmp_path)
-            assert mod == newmod
-        monkeypatch.undo()
+        with monkeypatch.context() as mp:
+            for ending in (".pyc", ".pyo"):
+                mod = ModuleType(name)
+                pseudopath = tmp_path.joinpath(name + ending)
+                pseudopath.touch()
+                mod.__file__ = str(pseudopath)
+                mp.setitem(sys.modules, name, mod)
+                newmod = import_path(p, root=tmp_path)
+                assert mod == newmod
         mod = ModuleType(name)
         pseudopath = tmp_path.joinpath(name + "123.py")
         pseudopath.touch()

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import sys
 import time
-from pathlib import Path
 from types import ModuleType
 from typing import List
 
@@ -11,7 +10,6 @@ import pytest
 from _pytest.config import ExitCode
 from _pytest.config import PytestPluginManager
 from _pytest.monkeypatch import MonkeyPatch
-from _pytest.pytester import CwdSnapshot
 from _pytest.pytester import HookRecorder
 from _pytest.pytester import LineMatcher
 from _pytest.pytester import Pytester
@@ -299,17 +297,6 @@ def test_assert_outcomes_after_pytest_error(pytester: Pytester) -> None:
     result = pytester.runpytest("--unexpected-argument")
     with pytest.raises(ValueError, match="Pytest terminal summary report not found"):
         result.assert_outcomes(passed=0)
-
-
-def test_cwd_snapshot(pytester: Pytester) -> None:
-    foo = pytester.mkdir("foo")
-    bar = pytester.mkdir("bar")
-    os.chdir(foo)
-    snapshot = CwdSnapshot()
-    os.chdir(bar)
-    assert Path().absolute() == bar
-    snapshot.restore()
-    assert Path().absolute() == foo
 
 
 class TestSysModulesSnapshot:


### PR DESCRIPTION
The current method as the following problem, described by @sadra-barikbin in https://github.com/pytest-dev/pytest/pull/11236#issuecomment-1666851689:

The tests that request both `pytester` and `monkeypatch` and use `monkeypatch.chdir` without context, relying on `monkeypatch`'s teardown to restore cwd. This doesn't work because the following sequence of actions take place:

- `monkeypatch` is set up.
- `pytester` is set up. It saves the original cwd and changes it to a new one dedicated to the test function.
- Test function calls `monkeypatch.chdir()` without context. `monkeypatch` saves cwd, which is not the original one, before changing it.
- `pytester` is torn down. It restores the cwd to the original one.
- `monkeypatch` is torn down. It restores cwd to what it has saved.

The solution here is to have pytester use `monkeypatch.chdir()` itself, then everything is handled correctly.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
