### PR TITLE
Fix doctest collection of `functools.cached_property` objects.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -379,6 +379,7 @@ Tor Colvin
 Trevor Bekolay
 Tushar Sadhwani
 Tyler Goodlet
+Tyler Smart
 Tzu-ping Chung
 Vasily Kuznetsov
 Victor Maryama

--- a/changelog/11237.bugfix.rst
+++ b/changelog/11237.bugfix.rst
@@ -1,0 +1,1 @@
+Fix doctest collection of `functools.cached_property` objects.

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -537,14 +537,11 @@ class DoctestModule(Module):
                         tests, obj, name, module, source_lines, globs, seen
                     )
 
-        class CachedPropertyAwareDocTestFinder(MockAwareDocTestFinder):
             def _from_module(self, module, object):
-                """Doctest code does not take into account `@cached_property`,
-                this is a hackish way to fix it. https://github.com/python/cpython/issues/107995
-
-                Wrap Doctest finder so that when it calls `_from_module` for
-                a cached_property it uses the underlying function instead of the
-                wrapped cached_property object.
+                """`cached_property` objects will are never considered a part
+                of the 'current module'. As such they are skipped by doctest.
+                Here we override `_from_module` to check the underlying
+                function instead. https://github.com/python/cpython/issues/107995
                 """
                 if isinstance(object, functools.cached_property):
                     object = object.func
@@ -571,7 +568,7 @@ class DoctestModule(Module):
                 else:
                     raise
         # Uses internal doctest module parsing mechanism.
-        finder = CachedPropertyAwareDocTestFinder()
+        finder = MockAwareDocTestFinder()
         optionflags = get_optionflags(self)
         runner = _get_runner(
             verbose=False,

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -551,6 +551,9 @@ class DoctestModule(Module):
                     # Type ignored because this is a private function.
                     return super()._from_module(module, object)  # type: ignore[misc]
 
+            else:  # pragma: no cover
+                pass
+
         if self.path.name == "conftest.py":
             module = self.config.pluginmanager._importconftest(
                 self.path,

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -537,17 +537,19 @@ class DoctestModule(Module):
                         tests, obj, name, module, source_lines, globs, seen
                     )
 
-            def _from_module(self, module, object):
-                """`cached_property` objects will are never considered a part
-                of the 'current module'. As such they are skipped by doctest.
-                Here we override `_from_module` to check the underlying
-                function instead. https://github.com/python/cpython/issues/107995
-                """
-                if isinstance(object, functools.cached_property):
-                    object = object.func
+            if sys.version_info < (3, 13):
 
-                # Type ignored because this is a private function.
-                return super()._from_module(module, object)  # type: ignore[misc]
+                def _from_module(self, module, object):
+                    """`cached_property` objects are never considered a part
+                    of the 'current module'. As such they are skipped by doctest.
+                    Here we override `_from_module` to check the underlying
+                    function instead. https://github.com/python/cpython/issues/107995
+                    """
+                    if isinstance(object, functools.cached_property):
+                        object = object.func
+
+                    # Type ignored because this is a private function.
+                    return super()._from_module(module, object)  # type: ignore[misc]
 
         if self.path.name == "conftest.py":
             module = self.config.pluginmanager._importconftest(

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -482,6 +482,24 @@ class TestDoctests:
         reprec = pytester.inline_run(p, "--doctest-modules")
         reprec.assertoutcome(failed=1)
 
+    def test_doctest_cached_property(self, pytester: Pytester):
+        p = pytester.makepyfile(
+            """
+            import functools
+
+            class Foo:
+                @functools.cached_property
+                def foo(self):
+                    '''
+                    >>> assert False, "Tacos!"
+                    '''
+                    ...
+        """
+        )
+        result = pytester.runpytest(p, "--doctest-modules")
+        result.assert_outcomes(failed=1)
+        assert "Tacos!" in result.stdout.str()
+
     def test_doctestmodule_external_and_issue116(self, pytester: Pytester):
         p = pytester.mkpydir("hello")
         p.joinpath("__init__.py").write_text(


### PR DESCRIPTION
I'll be first to admit that the proposed solution is _very_ hacky but felt inspired by some adjacent code to do things this way. Suggestions for improvement are welcomed. 🙂

closes #11237
