### PR TITLE
add nuts to plugin list

### DIFF
--- a/scripts/update-plugin-list.py
+++ b/scripts/update-plugin-list.py
@@ -44,6 +44,7 @@ DEVELOPMENT_STATUS_CLASSIFIERS = (
 )
 ADDITIONAL_PROJECTS = {  # set of additional projects to consider as plugins
     "logassert",
+    "nuts",
 }
 
 


### PR DESCRIPTION
Adding https://github.com/network-unit-testing-system/nuts to the plugin list.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
