### PR TITLE
Add doctesting-coverage to envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ envlist =
     pypy3
     py38-{pexpect,xdist,unittestextras,numpy,pluggymain,pylib}
     doctesting
+    doctesting-coverage
     plugins
     py38-freeze
     docs


### PR DESCRIPTION
Explicitly add `doctest-coverage` to the `envlist` in `tox.ini` to fix failing CI, for example here: https://github.com/pytest-dev/pytest/actions/runs/5912812576/job/16036585548?pr=11317

_More details:_

Latest tox version enforces allowed tox environments to be explicitly in the tox `envlist` (https://github.com/tox-dev/tox/pull/3089).

Note there is some follow up work to relax these rules: https://github.com/tox-dev/tox/pull/3099