### PR TITLE
testing: add `.*` to `norecursedirs`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,12 @@ python_classes = ["Test", "Acceptance"]
 python_functions = ["test"]
 # NOTE: "doc" is not included here, but gets tested explicitly via "doctesting".
 testpaths = ["testing"]
-norecursedirs = ["testing/example_scripts"]
+norecursedirs = [
+  "testing/example_scripts",
+  ".*",
+  "build",
+  "dist",
+]
 xfail_strict = true
 filterwarnings = [
     "error",


### PR DESCRIPTION
Setting `norecursedirs` overrides the default, so we end up scanning dot-directories and such which slows down collection unnecessarily (by 150ms on my working directory for a noop).