### PR TITLE
use `if not TYPE_CHECKING` on `pytest.__getattr__` to prevent type checkers from using it

### DIFF
--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -1,5 +1,7 @@
 # PYTHON_ARGCOMPLETE_OK
 """pytest: unit and functional testing with Python."""
+from typing import TYPE_CHECKING
+
 from _pytest import __version__
 from _pytest import version_tuple
 from _pytest._code import ExceptionInfo
@@ -165,11 +167,12 @@ __all__ = [
     "yield_fixture",
 ]
 
+if not TYPE_CHECKING:
 
-def __getattr__(name: str) -> object:
-    if name == "Instance":
-        # The import emits a deprecation warning.
-        from _pytest.python import Instance
-
-        return Instance
-    raise AttributeError(f"module {__name__} has no attribute {name}")
+    def __getattr__(name: str) -> object:
+        if name == "Instance":
+            # The import emits a deprecation warning.
+            from _pytest.python import Instance
+    
+            return Instance
+        raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -173,6 +173,6 @@ if not TYPE_CHECKING:
         if name == "Instance":
             # The import emits a deprecation warning.
             from _pytest.python import Instance
-    
+
             return Instance
         raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -272,7 +272,7 @@ def test_importing_instance_is_deprecated(pytester: Pytester) -> None:
         pytest.PytestDeprecationWarning,
         match=re.escape("The pytest.Instance collector type is deprecated"),
     ):
-        pytest.Instance
+        pytest.Instance  # type:ignore[attr-defined]
 
     with pytest.warns(
         pytest.PytestDeprecationWarning,


### PR DESCRIPTION
fixes #11325