### PR TITLE
fix: closes #11343's [attr-defined] type errors

### DIFF
--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -314,15 +314,20 @@ def safe_isclass(obj: object) -> bool:
 
 
 def get_user_id() -> int | None:
-    """Return the current user id, or None if we cannot get it reliably on the current platform."""
-    # win32 does not have a getuid() function.
-    # On Emscripten, getuid() is a stub that always returns 0.
-    if sys.platform in ("win32", "emscripten"):
+    """Return the current user id, or None if we cannot get it reliably on
+    the current platform."""
+    # mypy follows the version and platform checking expectation of PEP 484:
+    # https://mypy.readthedocs.io/en/stable/common_issues.html?highlight=platform#python-version-and-system-platform-checks
+    # Containment checks are too complex for mypy v1.5.0 and cause failure.
+    if sys.platform == "win32" or sys.platform == "emscripten":
+        # win32 does not have a getuid() function.
+        # Emscripten has a return 0 stub.
         return None
-    # getuid shouldn't fail, but cpython defines such a case.
+    # getuid shouldn't fail but cpython defines such a case.
     # Let's hope for the best.
-    uid = os.getuid()  # type: ignore[attr-defined]
-    return uid if uid != -1 else None
+    else:
+        uid = os.getuid()
+        return uid if uid != -1 else None
 
 
 # Perform exhaustiveness checking.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -321,7 +321,7 @@ def get_user_id() -> int | None:
         return None
     # getuid shouldn't fail, but cpython defines such a case.
     # Let's hope for the best.
-    uid = os.getuid()
+    uid = os.getuid()  # type: ignore[attr-defined]
     return uid if uid != -1 else None
 
 

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -313,9 +313,16 @@ def safe_isclass(obj: object) -> bool:
         return False
 
 
-def get_user_id() -> int | None:
+def get_user_id(*, UNRELIABLE: int = -1) -> int | None:
     """Return the current user id, or None if we cannot get it reliably on
-    the current platform."""
+    the current platform.
+
+    :param UNRELIABLE:
+        The platform-specific constant which indicates that the retrieved uid
+        is unreliable. The default value, -1, is a common unreliability
+        indicator on UNIX-like systems.
+    :return: The user id or None
+    """
     # mypy follows the version and platform checking expectation of PEP 484:
     # https://mypy.readthedocs.io/en/stable/common_issues.html?highlight=platform#python-version-and-system-platform-checks
     # Containment checks are too complex for mypy v1.5.0 and cause failure.
@@ -323,11 +330,9 @@ def get_user_id() -> int | None:
         # win32 does not have a getuid() function.
         # Emscripten has a return 0 stub.
         return None
-    # getuid shouldn't fail but cpython defines such a case.
-    # Let's hope for the best.
     else:
         uid = os.getuid()
-        return uid if uid != -1 else None
+        return uid if uid != UNRELIABLE else None
 
 
 # Perform exhaustiveness checking.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -314,7 +314,7 @@ def safe_isclass(obj: object) -> bool:
 
 
 def get_user_id() -> int | None:
-    """Return the current process's real user id or None if it cannot be
+    """Return the current process's real user id or None if it could not be
     determined.
 
     :return: The user id or None if it could not be determined.
@@ -328,7 +328,7 @@ def get_user_id() -> int | None:
         return None
     else:
         # On other platforms, a return value of -1 is assumed to indicate that
-        # the current process's real user id cannot be determined.
+        # the current process's real user id could not be determined.
         ERROR = -1
         uid = os.getuid()
         return uid if uid != ERROR else None

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -329,9 +329,9 @@ def get_user_id() -> int | None:
     else:
         # On other platforms, a return value of -1 is assumed to indicate that
         # the current process's real user id cannot be determined.
-        UNRELIABLE = -1
+        ERROR = -1
         uid = os.getuid()
-        return uid if uid != UNRELIABLE else None
+        return uid if uid != ERROR else None
 
 
 # Perform exhaustiveness checking.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -313,14 +313,10 @@ def safe_isclass(obj: object) -> bool:
         return False
 
 
-def get_user_id(*, UNRELIABLE: int = -1) -> int | None:
-    """Return the current user id, or None if we cannot get it reliably on
-    the current platform.
+def get_user_id() -> int | None:
+    """Return the current process's real user id or None if it cannot be
+    retrieved reliably.
 
-    :param UNRELIABLE:
-        The platform-specific constant which indicates that the retrieved uid
-        is unreliable. The default value, -1, is a common unreliability
-        indicator on UNIX-like systems.
     :return: The user id or None
     """
     # mypy follows the version and platform checking expectation of PEP 484:
@@ -331,6 +327,9 @@ def get_user_id(*, UNRELIABLE: int = -1) -> int | None:
         # Emscripten has a return 0 stub.
         return None
     else:
+        # On other platforms, a return value of -1 is assumed to indicate that
+        # the current process's real user id cannot be retrieved reliably.
+        UNRELIABLE = -1
         uid = os.getuid()
         return uid if uid != UNRELIABLE else None
 

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -315,9 +315,9 @@ def safe_isclass(obj: object) -> bool:
 
 def get_user_id() -> int | None:
     """Return the current process's real user id or None if it cannot be
-    retrieved reliably.
+    determined.
 
-    :return: The user id or None
+    :return: The user id or None if it could not be determined.
     """
     # mypy follows the version and platform checking expectation of PEP 484:
     # https://mypy.readthedocs.io/en/stable/common_issues.html?highlight=platform#python-version-and-system-platform-checks
@@ -328,7 +328,7 @@ def get_user_id() -> int | None:
         return None
     else:
         # On other platforms, a return value of -1 is assumed to indicate that
-        # the current process's real user id cannot be retrieved reliably.
+        # the current process's real user id cannot be determined.
         UNRELIABLE = -1
         uid = os.getuid()
         return uid if uid != UNRELIABLE else None

--- a/testing/test_parseopt.py
+++ b/testing/test_parseopt.py
@@ -291,7 +291,8 @@ class TestParser:
 
 def test_argcomplete(pytester: Pytester, monkeypatch: MonkeyPatch) -> None:
     try:
-        encoding = locale.getencoding()  # New in Python 3.11, ignores utf-8 mode
+        # New in Python 3.11, ignores utf-8 mode
+        encoding = locale.getencoding()  # type: ignore[attr-defined]
     except AttributeError:
         encoding = locale.getpreferredencoding(False)
     try:


### PR DESCRIPTION
On Windows 10.0.19045, the mypy hook is failing on pre-commit because of two `[attr-defined]` errors, which prevents me from staging changes. The problem was first reported in #11343. This PR applies a fix by adding `type: ignore` comments to the erroring lines:

```
src\_pytest\compat.py:324: error: Module has no attribute "getuid"; maybe "getpid" or "getppid"?  [attr-defined]
testing\test_parseopt.py:294: error: Module has no attribute "getencoding"  [attr-defined]
```