### PR TITLE
docs: changing some docs for last-failed-no-failures

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -336,6 +336,7 @@ Samuele Pedroni
 Sanket Duthade
 Sankt Petersbug
 Saravanan Padmanaban
+Sean Malloy
 Segev Finer
 Serhii Mozghovyi
 Seth Junot

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1892,8 +1892,9 @@ All the command-line flags can be obtained by running ``pytest --help``::
                             tests. Optional argument: glob (default: '*').
       --cache-clear         Remove all cache contents at start of test run
       --lfnf={all,none}, --last-failed-no-failures={all,none}
-                            Which tests to run with no previously (known)
-                            failures
+                            Determines whether to execute tests when there
+                            are no previously (known) failures or when no
+                            cached ``lastfailed`` data was found
       --sw, --stepwise      Exit on test failure and continue from last failing
                             test next time
       --sw-skip, --stepwise-skip

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -499,7 +499,8 @@ def pytest_addoption(parser: Parser) -> None:
         dest="last_failed_no_failures",
         choices=("all", "none"),
         default="all",
-        help="Which tests to run with no previously (known) failures",
+        help="Determines whether to execute tests when there are no previously (known)"
+        "failures or when no cached ``lastfailed`` data was found",
     )
 
 


### PR DESCRIPTION
* Made the functionality of last-failed-no-failures more clear within the docs

closes #11354 
Change is trivial/a small documentation fix, so no changes to changelog.