### PR TITLE
Add Python 3.11 compatibility to 4.6.x

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -222,6 +222,7 @@ Samuele Pedroni
 Sankt Petersbug
 Segev Finer
 Serhii Mozghovyi
+Shantanu Jain
 Simon Gomizelj
 Skylar Downes
 Srinivas Reddy Thatiparthy

--- a/changelog/8539.bugfix.rst
+++ b/changelog/8539.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed assertion rewriting on Python 3.10.

--- a/changelog/9163.bugfix.rst
+++ b/changelog/9163.bugfix.rst
@@ -1,0 +1,1 @@
+The end line number and end column offset are now properly set for rewritten assert statements.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -652,12 +652,9 @@ class AssertionRewriter(ast.NodeVisitor):
         if not mod.body:
             # Nothing to do.
             return
+
         # Insert some special imports at the top of the module but after any
         # docstrings and __future__ imports.
-        aliases = [
-            ast.alias(six.moves.builtins.__name__, "@py_builtins"),
-            ast.alias("_pytest.assertion.rewrite", "@pytest_ar"),
-        ]
         doc = getattr(mod, "docstring", None)
         expect_docstring = doc is None
         if doc is not None and self.is_rewrite_disabled(doc):
@@ -684,6 +681,19 @@ class AssertionRewriter(ast.NodeVisitor):
             pos += 1
         else:
             lineno = item.lineno
+        if sys.version_info >= (3, 10):
+            aliases = [
+                ast.alias(six.moves.builtins.__name__, "@py_builtins", lineno=lineno, col_offset=0),
+                ast.alias(
+                    "_pytest.assertion.rewrite", "@pytest_ar",
+                    lineno=lineno, col_offset=0
+                ),
+            ]
+        else:
+            aliases = [
+                ast.alias(six.moves.builtins.__name__, "@py_builtins"),
+                ast.alias("_pytest.assertion.rewrite", "@pytest_ar"),
+            ]
         imports = [
             ast.Import([alias], lineno=lineno, col_offset=0) for alias in aliases
         ]

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -111,6 +111,28 @@ class TestAssertionRewrite(object):
             assert imp.col_offset == 0
         assert isinstance(m.body[3], ast.Expr)
 
+    def test_location_is_set(self):
+        s = textwrap.dedent(
+            """
+
+        assert False, (
+
+            "Ouch"
+          )
+
+        """
+        )
+        m = rewrite(s)
+        for node in m.body:
+            if isinstance(node, ast.Import):
+                continue
+            for n in [node, *ast.iter_child_nodes(node)]:
+                assert n.lineno == 3
+                assert n.col_offset == 0
+                if sys.version_info >= (3, 8):
+                    assert n.end_lineno == 6
+                    assert n.end_col_offset == 3
+
     def test_dont_rewrite(self):
         s = """'PYTEST_DONT_REWRITE'\nassert 14"""
         m = rewrite(s)


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

This adds Python 3.11 compatibility to 2.7-compatible version.