### PR TITLE
[junit] move properties handling to `finalize()`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -170,6 +170,7 @@ Ian Lesperance
 Ilya Konstantinov
 Ionuț Turturică
 Isaac Virshup
+Israel Fruchter
 Itxaso Aizpurua
 Iwan Briquemont
 Jaap Broekhuizen

--- a/changelog/11367.bugfix.rst
+++ b/changelog/11367.bugfix.rst
@@ -1,5 +1,4 @@
 [junit] move properties handling to :func:`finalize()`
 
-seem like not all the cases of calling finalize were adding the properties into the test case element, 
+seem like not all the cases of calling finalize were adding the properties into the test case element,
 which leads to some test cases missing the expected properties.
-

--- a/changelog/11367.bugfix.rst
+++ b/changelog/11367.bugfix.rst
@@ -1,0 +1,5 @@
+[junit] move properties handling to :func:`finalize()`
+
+seem like not all the cases of calling finalize were adding the properties into the test case element, 
+which leads to some test cases missing the expected properties.
+

--- a/changelog/11367.bugfix.rst
+++ b/changelog/11367.bugfix.rst
@@ -1,4 +1,1 @@
-[junit] move properties handling to :func:`finalize()`
-
-seem like not all the cases of calling finalize were adding the properties into the test case element,
-which leads to some test cases missing the expected properties.
+Fixed bug where `user_properties` where not being saved in the JUnit XML file if a fixture failed during teardown.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -502,6 +502,10 @@ class LogXML:
         # Local hack to handle xdist report order.
         workernode = getattr(report, "node", None)
         reporter = self.node_reporters.pop((nodeid, workernode))
+
+        for propname, propvalue in report.user_properties:
+            reporter.add_property(propname, str(propvalue))
+
         if reporter is not None:
             reporter.finalize()
 
@@ -598,9 +602,6 @@ class LogXML:
         if report.when == "teardown":
             reporter = self._opentestcase(report)
             reporter.write_captured_output(report)
-
-            for propname, propvalue in report.user_properties:
-                reporter.add_property(propname, str(propvalue))
 
             self.finalize(report)
             report_wid = getattr(report, "worker_id", None)


### PR DESCRIPTION
seem like not all the cases of calling `finalize` were adding the properties into the test case element, which leads to some test cases missing the expected properties.

Fixes: #11367

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
