### PR TITLE
Improve CI workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,33 +1,38 @@
 name: deploy
 
 on:
-  push:
-    tags:
-      # These tags are protected, see:
-      # https://github.com/pytest-dev/pytest/settings/tag_protection
-      - "[0-9]+.[0-9]+.[0-9]+"
-      - "[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+        default: '1.2.3'
 
 
 # Set permissions at the job level.
 permissions: {}
 
 jobs:
-  build:
+  package:
     runs-on: ubuntu-latest
+    env:
+      SETUPTOOLS_SCM_PRETEND_VERSION: ${{ github.event.inputs.version }}
     timeout-minutes: 10
+
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
         persist-credentials: false
+
     - name: Build and Check Package
       uses: hynek/build-and-inspect-python-package@v1.5
 
   deploy:
     if: github.repository == 'pytest-dev/pytest'
-    needs: [build]
+    needs: [package]
     runs-on: ubuntu-latest
+    environment: deploy
     timeout-minutes: 30
     permissions:
       id-token: write
@@ -37,8 +42,16 @@ jobs:
       with:
         name: Packages
         path: dist
+
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@v1.8.8
+
+    - name: Push tag
+      run: |
+        git config user.name "pytest bot"
+        git config user.email "pytestbot@gmail.com"
+        git tag --annotate --message=v${{ github.event.inputs.version }} v${{ github.event.inputs.version }} ${{ github.sha }}
+        git push origin v${{ github.event.inputs.version }}
 
   release-notes:
 
@@ -55,11 +68,11 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: "3.11"
-
 
     - name: Install tox
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,19 @@ concurrency:
 permissions: {}
 
 jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    - name: Build and Check Package
+      uses: hynek/build-and-inspect-python-package@v1.5
+
   build:
+    needs: [package]
+
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     permissions:
@@ -58,7 +70,6 @@ jobs:
           "macos-py310",
           "macos-py312",
 
-          "docs",
           "doctesting",
           "plugins",
         ]
@@ -149,10 +160,6 @@ jobs:
             os: ubuntu-latest
             tox_env: "plugins"
 
-          - name: "docs"
-            python: "3.8"
-            os: ubuntu-latest
-            tox_env: "docs"
           - name: "doctesting"
             python: "3.8"
             os: ubuntu-latest
@@ -164,6 +171,12 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
+
+    - name: Download Package
+      uses: actions/download-artifact@v3
+      with:
+        name: Packages
+        path: dist
 
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v4
@@ -178,11 +191,13 @@ jobs:
 
     - name: Test without coverage
       if: "! matrix.use_coverage"
-      run: "tox -e ${{ matrix.tox_env }}"
+      shell: bash
+      run: tox run -e ${{ matrix.tox_env }} --installpkg `find dist/*.tar.gz`
 
     - name: Test with coverage
       if: "matrix.use_coverage"
-      run: "tox -e ${{ matrix.tox_env }}-coverage"
+      shell: bash
+      run: tox run -e ${{ matrix.tox_env }}-coverage --installpkg `find dist/*.tar.gz`
 
     - name: Generate coverage report
       if: "matrix.use_coverage"
@@ -196,10 +211,3 @@ jobs:
         fail_ci_if_error: true
         files: ./coverage.xml
         verbose: true
-
-  check-package:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build and Check Package
-      uses: hynek/build-and-inspect-python-package@v1.5

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -133,14 +133,11 @@ Releasing
 
 Both automatic and manual processes described above follow the same steps from this point onward.
 
-#. After all tests pass and the PR has been approved, tag the release commit
-   in the ``release-MAJOR.MINOR.PATCH`` branch and push it. This will publish to PyPI::
+#. After all tests pass and the PR has been approved, trigger the ``deploy`` job
+   in https://github.com/pytest-dev/pytest/actions/workflows/deploy.yml.
 
-     git fetch upstream
-     git tag MAJOR.MINOR.PATCH upstream/release-MAJOR.MINOR.PATCH
-     git push upstream MAJOR.MINOR.PATCH
-
-   Wait for the deploy to complete, then make sure it is `available on PyPI <https://pypi.org/project/pytest>`_.
+   This job will require approval from ``pytest-dev/core``, after which it will publish to PyPI
+   and tag the repository.
 
 #. Merge the PR. **Make sure it's not squash-merged**, so that the tagged commit ends up in the main branch.
 


### PR DESCRIPTION
* Build the package only once, and test on all platforms.
* Deploy is now triggered manually via an Action, which is then responsible for tagging the repository after the package has been uploaded successfully.
* Drop 'docs': we nowadays rely on readthedocs preview PR builds.

---

This is cherry-picked from #11377: realized that we need to have `deploy` in `main` in order to be able to trigger `workflow_dispatch`.