### PR TITLE
[7.4.x] Fix user_properties not saved to XML if fixture errors during teardown

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -166,6 +166,8 @@ Ian Bicking
 Ian Lesperance
 Ilya Konstantinov
 Ionuț Turturică
+Isaac Virshup
+Israel Fruchter
 Itxaso Aizpurua
 Iwan Briquemont
 Jaap Broekhuizen

--- a/changelog/11367.bugfix.rst
+++ b/changelog/11367.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug where `user_properties` where not being saved in the JUnit XML file if a fixture failed during teardown.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -502,6 +502,10 @@ class LogXML:
         # Local hack to handle xdist report order.
         workernode = getattr(report, "node", None)
         reporter = self.node_reporters.pop((nodeid, workernode))
+
+        for propname, propvalue in report.user_properties:
+            reporter.add_property(propname, str(propvalue))
+
         if reporter is not None:
             reporter.finalize()
 
@@ -598,9 +602,6 @@ class LogXML:
         if report.when == "teardown":
             reporter = self._opentestcase(report)
             reporter.write_captured_output(report)
-
-            for propname, propvalue in report.user_properties:
-                reporter.add_property(propname, str(propvalue))
 
             self.finalize(report)
             report_wid = getattr(report, "worker_id", None)


### PR DESCRIPTION
Move handling of user_properties to `finalize()`.

Previously if a fixture failed during teardown, `pytest_runtest_logreport` would not be called with "teardown", resulting in the user properties not being saved on the JUnit XML file.

Fixes: #11367
(cherry picked from commit 917ce9aa0102c7f0ec8fdac118058c41ffb603e6)
