### PR TITLE
Fix import_path for packages

### DIFF
--- a/changelog/11306.bugfix.rst
+++ b/changelog/11306.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug using ``--importmode=importlib`` which would cause package ``__init__.py`` files to be imported more than once in some cases.

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -623,6 +623,10 @@ def module_name_from_path(path: Path, root: Path) -> str:
         # Use the parts for the relative path to the root path.
         path_parts = relative_path.parts
 
+    # Module name for packages do not contain the __init__ file.
+    if path_parts[-1] == "__init__":
+        path_parts = path_parts[:-1]
+
     return ".".join(path_parts)
 
 


### PR DESCRIPTION
For packages, `import_path` receives the path to the package's `__init__.py` file, however module names (as they live in `sys.modules`) should not include the `__init__` part.

For example, `app/core/__init__.py` should be imported as `app.core`, not as `app.core.__init__`.

Fix #11306
