### PR TITLE
[7.4.x] Fix crash when passing a very long cmdline argument (#11404)

### DIFF
--- a/changelog/11394.bugfix.rst
+++ b/changelog/11394.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed crash when parsing long command line arguments that might be interpreted as files.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -57,6 +57,7 @@ from _pytest.pathlib import bestrelpath
 from _pytest.pathlib import import_path
 from _pytest.pathlib import ImportMode
 from _pytest.pathlib import resolve_package_path
+from _pytest.pathlib import safe_exists
 from _pytest.stash import Stash
 from _pytest.warning_types import PytestConfigWarning
 from _pytest.warning_types import warn_explicit_for
@@ -557,12 +558,8 @@ class PytestPluginManager(PluginManager):
             anchor = absolutepath(current / path)
 
             # Ensure we do not break if what appears to be an anchor
-            # is in fact a very long option (#10169).
-            try:
-                anchor_exists = anchor.exists()
-            except OSError:  # pragma: no cover
-                anchor_exists = False
-            if anchor_exists:
+            # is in fact a very long option (#10169, #11394).
+            if safe_exists(anchor):
                 self._try_load_conftest(anchor, importmode, rootpath)
                 foundanchor = True
         if not foundanchor:

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -16,6 +16,7 @@ from .exceptions import UsageError
 from _pytest.outcomes import fail
 from _pytest.pathlib import absolutepath
 from _pytest.pathlib import commonpath
+from _pytest.pathlib import safe_exists
 
 if TYPE_CHECKING:
     from . import Config
@@ -150,14 +151,6 @@ def get_dirs_from_args(args: Iterable[str]) -> List[Path]:
         if path.is_dir():
             return path
         return path.parent
-
-    def safe_exists(path: Path) -> bool:
-        # This can throw on paths that contain characters unrepresentable at the OS level,
-        # or with invalid syntax on Windows (https://bugs.python.org/issue35306)
-        try:
-            return path.exists()
-        except OSError:
-            return False
 
     # These look like paths but may not exist
     possible_paths = (

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -36,6 +36,7 @@ from _pytest.outcomes import exit
 from _pytest.pathlib import absolutepath
 from _pytest.pathlib import bestrelpath
 from _pytest.pathlib import fnmatch_ex
+from _pytest.pathlib import safe_exists
 from _pytest.pathlib import visit
 from _pytest.reports import CollectReport
 from _pytest.reports import TestReport
@@ -895,7 +896,7 @@ def resolve_collection_argument(
         strpath = search_pypath(strpath)
     fspath = invocation_path / strpath
     fspath = absolutepath(fspath)
-    if not fspath.exists():
+    if not safe_exists(fspath):
         msg = (
             "module or package not found: {arg} (missing __init__.py?)"
             if as_pypath

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -1,6 +1,5 @@
 import atexit
 import contextlib
-import errno
 import fnmatch
 import importlib.util
 import itertools
@@ -798,7 +797,7 @@ def safe_exists(p: Path) -> bool:
     """Like Path.exists(), but account for input arguments that might be too long (#11394)."""
     try:
         return p.exists()
-    except OSError as e:
-        if e.errno == errno.ENAMETOOLONG:
-            return False
-        raise
+    except (ValueError, OSError):
+        # ValueError: stat: path too long for Windows
+        # OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect
+        return False

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -1,5 +1,6 @@
 import atexit
 import contextlib
+import errno
 import fnmatch
 import importlib.util
 import itertools
@@ -791,3 +792,13 @@ def copytree(source: Path, target: Path) -> None:
             shutil.copyfile(x, newx)
         elif x.is_dir():
             newx.mkdir(exist_ok=True)
+
+
+def safe_exists(p: Path) -> bool:
+    """Like Path.exists(), but account for input arguments that might be too long (#11394)."""
+    try:
+        return p.exists()
+    except OSError as e:
+        if e.errno == errno.ENAMETOOLONG:
+            return False
+        raise

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -1,3 +1,4 @@
+import errno
 import os.path
 import pickle
 import sys
@@ -24,6 +25,7 @@ from _pytest.pathlib import insert_missing_modules
 from _pytest.pathlib import maybe_delete_a_numbered_dir
 from _pytest.pathlib import module_name_from_path
 from _pytest.pathlib import resolve_package_path
+from _pytest.pathlib import safe_exists
 from _pytest.pathlib import symlink_or_skip
 from _pytest.pathlib import visit
 from _pytest.tmpdir import TempPathFactory
@@ -660,3 +662,33 @@ class TestImportLibMode:
 
         mod = import_path(init, root=tmp_path, mode=ImportMode.importlib)
         assert len(mod.instance.INSTANCES) == 1
+
+
+def test_safe_exists(tmp_path: Path) -> None:
+    d = tmp_path.joinpath("some_dir")
+    d.mkdir()
+    assert safe_exists(d) is True
+
+    f = tmp_path.joinpath("some_file")
+    f.touch()
+    assert safe_exists(f) is True
+
+    # Use unittest.mock() as a context manager to have a very narrow
+    # patch lifetime.
+    p = tmp_path.joinpath("some long filename" * 100)
+    with unittest.mock.patch.object(
+        Path,
+        "exists",
+        autospec=True,
+        side_effect=OSError(errno.ENAMETOOLONG, "name too long"),
+    ):
+        assert safe_exists(p) is False
+
+    with unittest.mock.patch.object(
+        Path,
+        "exists",
+        autospec=True,
+        side_effect=OSError(errno.EIO, "another kind of error"),
+    ):
+        with pytest.raises(OSError):
+            _ = safe_exists(p)

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -688,7 +688,6 @@ def test_safe_exists(tmp_path: Path) -> None:
         Path,
         "exists",
         autospec=True,
-        side_effect=OSError(errno.EIO, "another kind of error"),
+        side_effect=ValueError("name too long"),
     ):
-        with pytest.raises(OSError):
-            _ = safe_exists(p)
+        assert safe_exists(p) is False


### PR DESCRIPTION
Fixes #11394

(cherry picked from commit 28ccf476b91be32ffda303f0d7a8b57e475b465b)
