### PR TITLE
refactor: use division operator to join paths.

### DIFF
--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -680,7 +680,7 @@ def resolve_package_path(path: Path) -> Optional[Path]:
     result = None
     for parent in itertools.chain((path,), path.parents):
         if parent.is_dir():
-            if not parent.joinpath("__init__.py").is_file():
+            if not (parent / "__init__.py").is_file():
                 break
             if not parent.name.isidentifier():
                 break

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -345,18 +345,18 @@ def test_resolve_package_path(tmp_path: Path) -> None:
     (pkg / "subdir").mkdir()
     (pkg / "subdir/__init__.py").touch()
     assert resolve_package_path(pkg) == pkg
-    assert resolve_package_path(pkg.joinpath("subdir", "__init__.py")) == pkg
+    assert resolve_package_path(pkg / "subdir/__init__.py") == pkg
 
 
 def test_package_unimportable(tmp_path: Path) -> None:
     pkg = tmp_path / "pkg1-1"
     pkg.mkdir()
     pkg.joinpath("__init__.py").touch()
-    subdir = pkg.joinpath("subdir")
+    subdir = pkg / "subdir"
     subdir.mkdir()
-    pkg.joinpath("subdir/__init__.py").touch()
+    (pkg / "subdir/__init__.py").touch()
     assert resolve_package_path(subdir) == subdir
-    xyz = subdir.joinpath("xyz.py")
+    xyz = subdir / "xyz.py"
     xyz.touch()
     assert resolve_package_path(xyz) == subdir
     assert not resolve_package_path(pkg)


### PR DESCRIPTION
Starting with `resolve_package_path()` and its associated tests, this refactoring seeks to make path concatenation more readable and consistent.

To be consistent, all uses of `.joinpath()` need to be replaced with the `/` operator or the other way around. I have chosen to standardise the use of the `/` operator across `resolve_package_path()` and its tests because
   1) it is already used in the tests
   2) it is more succinct and readable
   3) casual profiling with `%timeit` didn't reveal a performance loss
           `/` operator: 273 µs ± 86.6 µs
                    `.joinpath()`: 269 µs ± 99.4 µs

Eventual consistency within and across all files is the ultimate goal. This is achievable. There are currently 428 uses of `.joinpath()` across 45 files. Counting assignment expressions only, there are 111 uses of the `/` operator across 23 files. However, even if there is a usage pattern of 4:1 against the `/` operator, I do not think that makes standardising it an unwise choice. There
are gains in readability.

#### Profiling

##### `/` operator
```python
#operator_profiling.ipynb

from pathlib import Path
from tempfile import TemporaryDirectory

with TemporaryDirectory() as tmp_dir:
    tmp_dir = Path(tmp_dir)
    (tmp_dir / '__init__.py').touch()
    print("operator approach:")
    %timeit (tmp_dir / "something/__init__.py").is_file()
```
##### `joinpath()`
```python
#joinpath_profiling.ipynb

from pathlib import Path
from tempfile import TemporaryDirectory

with TemporaryDirectory() as tmp_dir:
    tmp_dir = Path(tmp_dir)
    (tmp_dir / '__init__.py').touch()
    print(".joinpath approach:")
    %timeit tmp_dir.joinpath("something/__init__.py").is_file()

```

#### Housekeeping

- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
