### PR TITLE
[7.4.x] Adjustments to the release process (#11410)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,8 +36,10 @@ jobs:
     timeout-minutes: 30
     permissions:
       id-token: write
+      contents: write
     steps:
     - uses: actions/checkout@v3
+
     - name: Download Package
       uses: actions/download-artifact@v3
       with:

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -134,7 +134,8 @@ Releasing
 Both automatic and manual processes described above follow the same steps from this point onward.
 
 #. After all tests pass and the PR has been approved, trigger the ``deploy`` job
-   in https://github.com/pytest-dev/pytest/actions/workflows/deploy.yml.
+   in https://github.com/pytest-dev/pytest/actions/workflows/deploy.yml, using the ``release-MAJOR.MINOR.PATCH`` branch
+   as source.
 
    This job will require approval from ``pytest-dev/core``, after which it will publish to PyPI
    and tag the repository.

--- a/scripts/prepare-release-pr.py
+++ b/scripts/prepare-release-pr.py
@@ -31,10 +31,16 @@ class InvalidFeatureRelease(Exception):
 SLUG = "pytest-dev/pytest"
 
 PR_BODY = """\
-Created automatically from manual trigger.
+Created by the [prepare release pr](https://github.com/pytest-dev/pytest/actions/workflows/prepare-release-pr.yml)
+workflow.
 
-Once all builds pass and it has been **approved** by one or more maintainers, the build
-can be released by pushing a tag `{version}` to this repository.
+Once all builds pass and it has been **approved** by one or more maintainers,
+start the [deploy](https://github.com/pytest-dev/pytest/actions/workflows/deploy.yml) workflow, using these parameters:
+
+* `Use workflow from`: `release-{version}`.
+* `Release version`: `{version}`.
+
+After the `deploy` workflow has been approved by a core maintainer, the package will be uploaded to PyPI automatically.
 """
 
 


### PR DESCRIPTION
As discussed in #11408:

* Improve documentation for the release process.
* Fix the description for the PRs created by the `prepare release pr` workflow.
* Fix pushing tag in the `deploy` workflow.

(cherry picked from commit e5c81fa41aa437261009d2dcbed5f05bb2b86647)

