### PR TITLE
fixtures: more tweaks

### DIFF
--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -255,8 +255,8 @@ class DoctestItem(Item):
         self,
         name: str,
         parent: "Union[DoctestTextfile, DoctestModule]",
-        runner: Optional["doctest.DocTestRunner"] = None,
-        dtest: Optional["doctest.DocTest"] = None,
+        runner: "doctest.DocTestRunner",
+        dtest: "doctest.DocTest",
     ) -> None:
         super().__init__(name, parent)
         self.runner = runner
@@ -288,19 +288,13 @@ class DoctestItem(Item):
         self._request = TopRequest(self, _ispytest=True)  # type: ignore[arg-type]
 
     def setup(self) -> None:
-        if self.dtest is not None:
-            self._request._fillfixtures()
-
-            globs = dict(getfixture=self._request.getfixturevalue)
-            for name, value in self._request.getfixturevalue(
-                "doctest_namespace"
-            ).items():
-                globs[name] = value
-            self.dtest.globs.update(globs)
+        self._request._fillfixtures()
+        globs = dict(getfixture=self._request.getfixturevalue)
+        for name, value in self._request.getfixturevalue("doctest_namespace").items():
+            globs[name] = value
+        self.dtest.globs.update(globs)
 
     def runtest(self) -> None:
-        assert self.dtest is not None
-        assert self.runner is not None
         _check_all_skipped(self.dtest)
         self._disable_output_capturing_for_darwin()
         failures: List["doctest.DocTestFailure"] = []
@@ -387,7 +381,6 @@ class DoctestItem(Item):
         return ReprFailDoctest(reprlocation_lines)
 
     def reportinfo(self) -> Tuple[Union["os.PathLike[str]", str], Optional[int], str]:
-        assert self.dtest is not None
         return self.path, self.dtest.lineno, "[doctest] %s" % self.name
 
 

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -400,8 +400,8 @@ def _get_flag_lookup() -> Dict[str, int]:
     )
 
 
-def get_optionflags(parent):
-    optionflags_str = parent.config.getini("doctest_optionflags")
+def get_optionflags(config: Config) -> int:
+    optionflags_str = config.getini("doctest_optionflags")
     flag_lookup_table = _get_flag_lookup()
     flag_acc = 0
     for flag in optionflags_str:
@@ -409,8 +409,8 @@ def get_optionflags(parent):
     return flag_acc
 
 
-def _get_continue_on_failure(config):
-    continue_on_failure = config.getvalue("doctest_continue_on_failure")
+def _get_continue_on_failure(config: Config) -> bool:
+    continue_on_failure: bool = config.getvalue("doctest_continue_on_failure")
     if continue_on_failure:
         # We need to turn off this if we use pdb since we should stop at
         # the first failure.
@@ -433,7 +433,7 @@ class DoctestTextfile(Module):
         name = self.path.name
         globs = {"__name__": "__main__"}
 
-        optionflags = get_optionflags(self)
+        optionflags = get_optionflags(self.config)
 
         runner = _get_runner(
             verbose=False,
@@ -578,7 +578,7 @@ class DoctestModule(Module):
                     raise
         # Uses internal doctest module parsing mechanism.
         finder = MockAwareDocTestFinder()
-        optionflags = get_optionflags(self)
+        optionflags = get_optionflags(self.config)
         runner = _get_runner(
             verbose=False,
             optionflags=optionflags,

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -592,14 +592,9 @@ class DoctestModule(Module):
 def _setup_fixtures(doctest_item: DoctestItem) -> TopRequest:
     """Used by DoctestTextfile and DoctestItem to setup fixture information."""
 
-    def func() -> None:
-        pass
-
     doctest_item.funcargs = {}  # type: ignore[attr-defined]
     fm = doctest_item.session._fixturemanager
-    fixtureinfo = fm.getfixtureinfo(
-        node=doctest_item, func=func, cls=None, funcargs=False
-    )
+    fixtureinfo = fm.getfixtureinfo(node=doctest_item, func=None, cls=None)
     doctest_item._fixtureinfo = fixtureinfo  # type: ignore[attr-defined]
     doctest_item.fixturenames = fixtureinfo.names_closure  # type: ignore[attr-defined]
     fixture_request = TopRequest(doctest_item, _ispytest=True)  # type: ignore[arg-type]

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from collections import deque
 from contextlib import suppress
 from pathlib import Path
+from typing import AbstractSet
 from typing import Any
 from typing import Callable
 from typing import cast
@@ -1382,7 +1383,7 @@ def pytest_addoption(parser: Parser) -> None:
     )
 
 
-def _get_direct_parametrize_args(node: nodes.Node) -> List[str]:
+def _get_direct_parametrize_args(node: nodes.Node) -> Set[str]:
     """Return all direct parametrization arguments of a node, so we don't
     mistake them for fixtures.
 
@@ -1391,14 +1392,13 @@ def _get_direct_parametrize_args(node: nodes.Node) -> List[str]:
     These things are done later as well when dealing with parametrization
     so this could be improved.
     """
-    parametrize_argnames: List[str] = []
+    parametrize_argnames: Set[str] = set()
     for marker in node.iter_markers(name="parametrize"):
         if not marker.kwargs.get("indirect", False):
             p_argnames, _ = ParameterSet._parse_parametrize_args(
                 *marker.args, **marker.kwargs
             )
-            parametrize_argnames.extend(p_argnames)
-
+            parametrize_argnames.update(p_argnames)
     return parametrize_argnames
 
 
@@ -1519,7 +1519,7 @@ class FixtureManager:
         self,
         fixturenames: Tuple[str, ...],
         parentnode: nodes.Node,
-        ignore_args: Sequence[str] = (),
+        ignore_args: AbstractSet[str],
     ) -> Tuple[Tuple[str, ...], List[str], Dict[str, Sequence[FixtureDef[Any]]]]:
         # Collect the closure of all fixtures, starting with the given
         # fixturenames as the initial set.  As we have to visit all

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1460,13 +1460,12 @@ class FixtureManager:
     def getfixtureinfo(
         self,
         node: nodes.Item,
-        func: Callable[..., object],
+        func: Optional[Callable[..., object]],
         cls: Optional[type],
-        funcargs: bool = True,
     ) -> FuncFixtureInfo:
         """Calculate the :class:`FuncFixtureInfo` for an item.
 
-        If ``funcargs`` is false, or if the item sets an attribute
+        If ``func`` is None, or if the item sets an attribute
         ``nofuncargs = True``, then ``func`` is not examined at all.
 
         :param node:
@@ -1475,10 +1474,8 @@ class FixtureManager:
             The item's function.
         :param cls:
             If the function is a method, the method's class.
-        :param funcargs:
-            Whether to look into func's parameters as fixture requests.
         """
-        if funcargs and not getattr(node, "nofuncargs", False):
+        if func is not None and not getattr(node, "nofuncargs", False):
             argnames = getfuncargnames(func, name=node.name, cls=cls)
         else:
             argnames = ()

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1800,9 +1800,8 @@ class Function(PyobjMixin, nodes.Item):
             self.keywords.update(keywords)
 
         if fixtureinfo is None:
-            fixtureinfo = self.session._fixturemanager.getfixtureinfo(
-                self, self.obj, self.cls, funcargs=True
-            )
+            fm = self.session._fixturemanager
+            fixtureinfo = fm.getfixtureinfo(self, self.obj, self.cls)
         self._fixtureinfo: FuncFixtureInfo = fixtureinfo
         self.fixturenames = fixtureinfo.names_closure
         self._initrequest()

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from _pytest.compat import getfuncargnames
 from _pytest.config import ExitCode
+from _pytest.fixtures import deduplicate_names
 from _pytest.fixtures import TopRequest
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pytester import get_public_names
@@ -4531,3 +4532,10 @@ def test_yield_fixture_with_no_value(pytester: Pytester) -> None:
     result.assert_outcomes(errors=1)
     result.stdout.fnmatch_lines([expected])
     assert result.ret == ExitCode.TESTS_FAILED
+
+
+def test_deduplicate_names() -> None:
+    items = deduplicate_names("abacd")
+    assert items == ("a", "b", "c", "d")
+    items = deduplicate_names(items + ("g", "f", "g", "e", "b"))
+    assert items == ("a", "b", "c", "d", "g", "f", "e")


### PR DESCRIPTION
A few more small fixture cleanups/improvements from looking at #11243.

The second commit is picked from #11243 authored by @sadra-barikbin. The idea is to make #11243 a bit smaller after it's rebased on top of this (which I'll be happy to do if @sadra-barikbin prefers).

The last commits are some doctest cleanups after checking its fixture handling. If we ever want to provide a proper interface for (non-`Function`) items to support fixtures, `DoctestItem` can be our model case.