### PR TITLE
Add hash comparison for pyc cache files

### DIFF
--- a/changelog/11418.improvement.rst
+++ b/changelog/11418.improvement.rst
@@ -1,0 +1,1 @@
+Added hash comparison for pyc cache files.

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -94,6 +94,7 @@ class AssertionState:
     def __init__(self, config: Config, mode) -> None:
         self.mode = mode
         self.trace = config.trace.root.get("assertion")
+        self.invalidation_mode = config.known_args_namespace.invalidationmode
         self.hook: Optional[rewrite.AssertionRewritingHook] = None
 
 

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -223,6 +223,14 @@ def pytest_addoption(parser: Parser) -> None:
         help="Prepend/append to sys.path when importing test modules and conftest "
         "files. Default: prepend.",
     )
+    group.addoption(
+        "--invalidation-mode",
+        default="timestamp",
+        choices=["timestamp", "checked-hash"],
+        dest="invalidationmode",
+        help="Pytest pyc cache invalidation mode. Default: timestamp.",
+    )
+
     parser.addini(
         "consider_namespace_packages",
         type="bool",


### PR DESCRIPTION
Compare pyc cache files by source hash.

Especially in CI environments, it's common for mtimes to be reset when restoring a cache. To work around that, fallback to a source hash comparison if both size and mtime didn't match.

Related:
- https://docs.python.org/3/reference/import.html#pyc-invalidation
- https://docs.python.org/3/library/importlib.html#importlib.util.source_hash
- https://github.com/psf/black/pull/3821