### PR TITLE
[7.4.x] Fix assert rewriting with assignment expressions (#11414)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -231,6 +231,7 @@ Maho
 Maik Figura
 Mandeep Bhutani
 Manuel Krebber
+Marc Mueller
 Marc Schlaich
 Marcelo Duarte Trevisani
 Marcin Bachry

--- a/changelog/11239.bugfix.rst
+++ b/changelog/11239.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``:=`` in asserts impacting unrelated test cases.

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1531,6 +1531,27 @@ class TestIssue11028:
         result.stdout.fnmatch_lines(["*assert 4 > 5", "*where 5 = add_one(4)"])
 
 
+class TestIssue11239:
+    def test_assertion_walrus_different_test_cases(self, pytester: Pytester) -> None:
+        """Regression for (#11239)
+
+        Walrus operator rewriting would leak to separate test cases if they used the same variables.
+        """
+        pytester.makepyfile(
+            """
+            def test_1():
+                state = {"x": 2}.get("x")
+                assert state is not None
+
+            def test_2():
+                db = {"x": 2}
+                assert (state := db.get("x")) is not None
+        """
+        )
+        result = pytester.runpytest()
+        assert result.ret == 0
+
+
 @pytest.mark.skipif(
     sys.maxsize <= (2**31 - 1), reason="Causes OverflowError on 32bit systems"
 )

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1532,6 +1532,7 @@ class TestIssue11028:
 
 
 class TestIssue11239:
+    @pytest.mark.skipif(sys.version_info[:2] <= (3, 7), reason="Only Python 3.8+")
     def test_assertion_walrus_different_test_cases(self, pytester: Pytester) -> None:
         """Regression for (#11239)
 


### PR DESCRIPTION
Fixes #11239

(cherry picked from commit 7259e8db9844f6f973c1d0c0ce46cc68c8248abb)
