### PR TITLE
Add new `ExceptionInfo.group_contains` assertion helper method

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -266,6 +266,7 @@ Michal Wajszczuk
 Michał Zięba
 Mickey Pashov
 Mihai Capotă
+Mihail Milushev
 Mike Hoyle (hoylemd)
 Mike Lundy
 Milan Lesnek

--- a/changelog/10441.feature.rst
+++ b/changelog/10441.feature.rst
@@ -1,0 +1,2 @@
+Added :func:`ExceptionInfo.group_contains() <pytest.ExceptionInfo.group_contains>`, an assertion
+helper that tests if an `ExceptionGroup` contains a matching exception.

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -97,6 +97,30 @@ Use the :ref:`raises <assertraises>` helper to assert that some code raises an e
         with pytest.raises(SystemExit):
             f()
 
+You can also use the context provided by :ref:`raises <assertraises>` to
+assert that an expected exception is part of a raised ``ExceptionGroup``:
+
+.. code-block:: python
+
+    # content of test_exceptiongroup.py
+    import pytest
+
+
+    def f():
+        raise ExceptionGroup(
+            "Group message",
+            [
+                RuntimeError(),
+            ],
+        )
+
+
+    def test_exception_in_group():
+        with pytest.raises(ExceptionGroup) as excinfo:
+            f()
+        assert excinfo.group_contains(RuntimeError)
+        assert not excinfo.group_contains(TypeError)
+
 Execute the test function with “quiet” reporting mode:
 
 .. code-block:: pytest

--- a/doc/en/how-to/assert.rst
+++ b/doc/en/how-to/assert.rst
@@ -119,6 +119,52 @@ The regexp parameter of the ``match`` method is matched with the ``re.search``
 function, so in the above example ``match='123'`` would have worked as
 well.
 
+You can also use the :func:`excinfo.group_contains() <pytest.ExceptionInfo.group_contains>`
+method to test for exceptions returned as part of an ``ExceptionGroup``:
+
+.. code-block:: python
+
+    def test_exception_in_group():
+        with pytest.raises(RuntimeError) as excinfo:
+            raise ExceptionGroup(
+                "Group message",
+                [
+                    RuntimeError("Exception 123 raised"),
+                ],
+            )
+        assert excinfo.group_contains(RuntimeError, match=r".* 123 .*")
+        assert not excinfo.group_contains(TypeError)
+
+The optional ``match`` keyword parameter works the same way as for
+:func:`pytest.raises`.
+
+By default ``group_contains()`` will recursively search for a matching
+exception at any level of nested ``ExceptionGroup`` instances. You can
+specify a ``depth`` keyword parameter if you only want to match an
+exception at a specific level; exceptions contained directly in the top
+``ExceptionGroup`` would match ``depth=1``.
+
+.. code-block:: python
+
+    def test_exception_in_group_at_given_depth():
+        with pytest.raises(RuntimeError) as excinfo:
+            raise ExceptionGroup(
+                "Group message",
+                [
+                    RuntimeError(),
+                    ExceptionGroup(
+                        "Nested group",
+                        [
+                            TypeError(),
+                        ],
+                    ),
+                ],
+            )
+        assert excinfo.group_contains(RuntimeError, depth=1)
+        assert excinfo.group_contains(TypeError, depth=2)
+        assert not excinfo.group_contains(RuntimeError, depth=2)
+        assert not excinfo.group_contains(TypeError, depth=1)
+
 There's an alternate form of the :func:`pytest.raises` function where you pass
 a function that will be executed with the given ``*args`` and ``**kwargs`` and
 assert that the given exception is raised:

--- a/doc/en/how-to/assert.rst
+++ b/doc/en/how-to/assert.rst
@@ -115,7 +115,7 @@ that a regular expression matches on the string representation of an exception
         with pytest.raises(ValueError, match=r".* 123 .*"):
             myfunc()
 
-The regexp parameter of the ``match`` method is matched with the ``re.search``
+The regexp parameter of the ``match`` parameter is matched with the ``re.search``
 function, so in the above example ``match='123'`` would have worked as
 well.
 

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -697,6 +697,14 @@ class ExceptionInfo(Generic[E]):
         )
         return fmt.repr_excinfo(self)
 
+    def _stringify_exception(self, exc: BaseException) -> str:
+        return "\n".join(
+            [
+                str(exc),
+                *getattr(exc, "__notes__", []),
+            ]
+        )
+
     def match(self, regexp: Union[str, Pattern[str]]) -> "Literal[True]":
         """Check whether the regular expression `regexp` matches the string
         representation of the exception using :func:`python:re.search`.
@@ -704,18 +712,63 @@ class ExceptionInfo(Generic[E]):
         If it matches `True` is returned, otherwise an `AssertionError` is raised.
         """
         __tracebackhide__ = True
-        value = "\n".join(
-            [
-                str(self.value),
-                *getattr(self.value, "__notes__", []),
-            ]
-        )
+        value = self._stringify_exception(self.value)
         msg = f"Regex pattern did not match.\n Regex: {regexp!r}\n Input: {value!r}"
         if regexp == value:
             msg += "\n Did you mean to `re.escape()` the regex?"
         assert re.search(regexp, value), msg
         # Return True to allow for "assert excinfo.match()".
         return True
+
+    def _group_contains(
+        self,
+        exc_group: BaseExceptionGroup[BaseException],
+        expected_exception: Union[Type[BaseException], Tuple[Type[BaseException], ...]],
+        match: Union[str, Pattern[str], None],
+        recursive: bool = False,
+    ) -> bool:
+        """Return `True` if a `BaseExceptionGroup` contains a matching exception."""
+        for exc in exc_group.exceptions:
+            if recursive and isinstance(exc, BaseExceptionGroup):
+                if self._group_contains(exc, expected_exception, match, recursive):
+                    return True
+            if not isinstance(exc, expected_exception):
+                continue
+            if match is not None:
+                value = self._stringify_exception(exc)
+                if not re.search(match, value):
+                    continue
+            return True
+        return False
+
+    def group_contains(
+        self,
+        expected_exception: Union[Type[BaseException], Tuple[Type[BaseException], ...]],
+        match: Union[str, Pattern[str], None] = None,
+        recursive: bool = False,
+    ) -> bool:
+        """Check whether a captured exception group contains a matching exception.
+
+        :param Type[BaseException] | Tuple[Type[BaseException]] expected_exception:
+            The expected exception type, or a tuple if one of multiple possible
+            exception types are expected.
+
+        :param str | Pattern[str] | None match:
+            If specified, a string containing a regular expression,
+            or a regular expression object, that is tested against the string
+            representation of the exception and its `PEP-678 <https://peps.python.org/pep-0678/>` `__notes__`
+            using :func:`re.search`.
+
+            To match a literal string that may contain :ref:`special characters
+            <re-syntax>`, the pattern can first be escaped with :func:`re.escape`.
+
+        :param bool recursive:
+            If `True`, search will descend recursively into any nested exception groups.
+            If `False`, only the top exception group will be searched.
+        """
+        msg = "Captured exception is not an instance of `BaseExceptionGroup`"
+        assert isinstance(self.value, BaseExceptionGroup), msg
+        return self._group_contains(self.value, expected_exception, match, recursive)
 
 
 @dataclasses.dataclass

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -472,35 +472,65 @@ class TestGroupContains:
             raise exc_group
         assert not exc_info.group_contains(RuntimeError, match=r"^exception message$")
 
-    def test_contains_exception_type_recursive(self) -> None:
+    def test_contains_exception_type_unlimited_depth(self) -> None:
         exc_group = ExceptionGroup("", [ExceptionGroup("", [RuntimeError()])])
         with pytest.raises(ExceptionGroup) as exc_info:
             raise exc_group
-        assert exc_info.group_contains(RuntimeError, recursive=True)
+        assert exc_info.group_contains(RuntimeError)
 
-    def test_doesnt_contain_exception_type_nonrecursive(self) -> None:
+    def test_contains_exception_type_at_depth_1(self) -> None:
+        exc_group = ExceptionGroup("", [RuntimeError()])
+        with pytest.raises(ExceptionGroup) as exc_info:
+            raise exc_group
+        assert exc_info.group_contains(RuntimeError, depth=1)
+
+    def test_doesnt_contain_exception_type_past_depth(self) -> None:
         exc_group = ExceptionGroup("", [ExceptionGroup("", [RuntimeError()])])
         with pytest.raises(ExceptionGroup) as exc_info:
             raise exc_group
-        assert not exc_info.group_contains(RuntimeError)
+        assert not exc_info.group_contains(RuntimeError, depth=1)
 
-    def test_contains_exception_match_recursive(self) -> None:
+    def test_contains_exception_type_specific_depth(self) -> None:
+        exc_group = ExceptionGroup("", [ExceptionGroup("", [RuntimeError()])])
+        with pytest.raises(ExceptionGroup) as exc_info:
+            raise exc_group
+        assert exc_info.group_contains(RuntimeError, depth=2)
+
+    def test_contains_exception_match_unlimited_depth(self) -> None:
+        exc_group = ExceptionGroup(
+            "", [ExceptionGroup("", [RuntimeError("exception message")])]
+        )
+        with pytest.raises(ExceptionGroup) as exc_info:
+            raise exc_group
+        assert exc_info.group_contains(RuntimeError, match=r"^exception message$")
+
+    def test_contains_exception_match_at_depth_1(self) -> None:
+        exc_group = ExceptionGroup("", [RuntimeError("exception message")])
+        with pytest.raises(ExceptionGroup) as exc_info:
+            raise exc_group
+        assert exc_info.group_contains(
+            RuntimeError, match=r"^exception message$", depth=1
+        )
+
+    def test_doesnt_contain_exception_match_past_depth(self) -> None:
+        exc_group = ExceptionGroup(
+            "", [ExceptionGroup("", [RuntimeError("exception message")])]
+        )
+        with pytest.raises(ExceptionGroup) as exc_info:
+            raise exc_group
+        assert not exc_info.group_contains(
+            RuntimeError, match=r"^exception message$", depth=1
+        )
+
+    def test_contains_exception_match_specific_depth(self) -> None:
         exc_group = ExceptionGroup(
             "", [ExceptionGroup("", [RuntimeError("exception message")])]
         )
         with pytest.raises(ExceptionGroup) as exc_info:
             raise exc_group
         assert exc_info.group_contains(
-            RuntimeError, match=r"^exception message$", recursive=True
+            RuntimeError, match=r"^exception message$", depth=2
         )
-
-    def test_doesnt_contain_exception_match_nonrecursive(self) -> None:
-        exc_group = ExceptionGroup(
-            "", [ExceptionGroup("", [RuntimeError("message that will not match")])]
-        )
-        with pytest.raises(ExceptionGroup) as exc_info:
-            raise exc_group
-        assert not exc_info.group_contains(RuntimeError, match=r"^exception message$")
 
 
 class TestFormattedExcinfo:


### PR DESCRIPTION
Tests if a captured exception group contains an expected exception. Will raise `AssertionError` if the wrapped exception is not an exception group. Supports recursive search into nested exception groups.

(edit by Zac) Fixes #10441.