### PR TITLE
Add class docstring to NodeMeta

### DIFF
--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -127,6 +127,20 @@ _NodeType = TypeVar("_NodeType", bound="Node")
 
 
 class NodeMeta(type):
+    """Metaclass used by :class:`Node` to enforce that direct construction raises 
+    :class:`Failed`
+    
+    This behaviour supports the indirection introduced with :meth:`Node.from_parent`,
+    the named constructor to be used instead of direct construction. The design 
+    decision to enforce indirection with :class:`NodeMeta` was made as a 
+    temporary aid for refactoring the collection tree, which was diagnosed to 
+    have :class:`Node` objects whose creational patterns were overly entangled. 
+    Once the refactoring is complete, this metaclass can be removed. 
+    
+    See https://github.com/pytest-dev/pytest/projects/3 for an overview of the
+    progress on detangling the :class:`Node` classes.   
+    """  
+    
     def __call__(self, *k, **kw):
         msg = (
             "Direct construction of {name} has been deprecated, please use {name}.from_parent.\n"

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -127,20 +127,20 @@ _NodeType = TypeVar("_NodeType", bound="Node")
 
 
 class NodeMeta(type):
-    """Metaclass used by :class:`Node` to enforce that direct construction raises 
+    """Metaclass used by :class:`Node` to enforce that direct construction raises
     :class:`Failed`.
-    
+
     This behaviour supports the indirection introduced with :meth:`Node.from_parent`,
-    the named constructor to be used instead of direct construction. The design 
-    decision to enforce indirection with :class:`NodeMeta` was made as a 
-    temporary aid for refactoring the collection tree, which was diagnosed to 
-    have :class:`Node` objects whose creational patterns were overly entangled. 
-    Once the refactoring is complete, this metaclass can be removed. 
-    
+    the named constructor to be used instead of direct construction. The design
+    decision to enforce indirection with :class:`NodeMeta` was made as a
+    temporary aid for refactoring the collection tree, which was diagnosed to
+    have :class:`Node` objects whose creational patterns were overly entangled.
+    Once the refactoring is complete, this metaclass can be removed.
+
     See https://github.com/pytest-dev/pytest/projects/3 for an overview of the
-    progress on detangling the :class:`Node` classes.   
-    """  
-    
+    progress on detangling the :class:`Node` classes.
+    """
+
     def __call__(self, *k, **kw):
         msg = (
             "Direct construction of {name} has been deprecated, please use {name}.from_parent.\n"

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -128,7 +128,7 @@ _NodeType = TypeVar("_NodeType", bound="Node")
 
 class NodeMeta(type):
     """Metaclass used by :class:`Node` to enforce that direct construction raises 
-    :class:`Failed`
+    :class:`Failed`.
     
     This behaviour supports the indirection introduced with :meth:`Node.from_parent`,
     the named constructor to be used instead of direct construction. The design 


### PR DESCRIPTION
#### Overview
I attempt to add a docstring for `NodeMeta` that contains a helpful summary of what it does and the reason for its existence, as well as a link to a project board that contains more information. The intention was to make the docstring helpful to new and experienced contributors alike.

Note: I did a direct edit on the pytest repo but I am unsure if it came through. If the direct edit and this PR clash, then this PR is the authoritative contribution.

#### Areas of Concern
1) I am unsure whether my summary is accurate or current, so I'd be especially grateful if @RonnyPfannschmidt or others involved with detangling `Node` relationships could review this.

2) I don't have much experience with Sphinx documentation. I tried to use directives but I am unsure if linking to a project board should be handled in a particular way.

#### Housekeeping
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

