### PR TITLE
Closes #11314. Use log_format as default for log_file_format

### DIFF
--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -637,7 +637,7 @@ class LoggingPlugin:
         # File logging.
         self.log_file_level = get_log_level_for_setting(
             config, "log_file_level", "log_level"
-            )
+        )
         log_file = get_option_ini(config, "log_file") or os.devnull
         if log_file != os.devnull:
             directory = os.path.dirname(os.path.abspath(log_file))

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -303,13 +303,13 @@ def pytest_addoption(parser: Parser) -> None:
     add_option_ini(
         "--log-file-format",
         dest="log_file_format",
-        default=DEFAULT_LOG_FORMAT,
+        default=None,
         help="Log format used by the logging module",
     )
     add_option_ini(
         "--log-file-date-format",
         dest="log_file_date_format",
-        default=DEFAULT_LOG_DATE_FORMAT,
+        default=None,
         help="Log date format used by the logging module",
     )
     add_option_ini(
@@ -635,7 +635,9 @@ class LoggingPlugin:
         self.report_handler.setFormatter(self.formatter)
 
         # File logging.
-        self.log_file_level = get_log_level_for_setting(config, "log_file_level")
+        self.log_file_level = get_log_level_for_setting(
+            config, "log_file_level", "log_level"
+            )
         log_file = get_option_ini(config, "log_file") or os.devnull
         if log_file != os.devnull:
             directory = os.path.dirname(os.path.abspath(log_file))


### PR DESCRIPTION
The change fixes to use log_format if log_file_format is not provided.
Also fixes to use log_date_format if log_file_date_format is not provided.
Also fixes to use log_level if log_file_level is not provided. 
This is also the existing behavior in case of log_cli too. 
Hence, this fix makes the behavior standard for log_file and log_cli (format, date format and log level)

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

