### PR TITLE
fix for ValueError raised in faulthandler teardown code

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -346,6 +346,7 @@ Serhii Mozghovyi
 Seth Junot
 Shantanu Jain
 Shubham Adep
+Simon Blanchard
 Simon Gomizelj
 Simon Holesch
 Simon Kerr

--- a/changelog/11439.bugfix.rst
+++ b/changelog/11439.bugfix.rst
@@ -1,0 +1,1 @@
+Fix for ValueError exception being raised in faulthandler teardown code.

--- a/changelog/11439.bugfix.rst
+++ b/changelog/11439.bugfix.rst
@@ -1,1 +1,1 @@
-Fix for ValueError exception being raised in faulthandler teardown code.
+Handle an edge case where :data:`sys.stderr` might already be closed when :ref:`faulthandler` is tearing down.

--- a/src/_pytest/faulthandler.py
+++ b/src/_pytest/faulthandler.py
@@ -1,4 +1,3 @@
-import io
 import os
 import sys
 from typing import Generator
@@ -51,7 +50,7 @@ def get_stderr_fileno() -> int:
         if fileno == -1:
             raise AttributeError()
         return fileno
-    except (AttributeError, io.UnsupportedOperation):
+    except (AttributeError, ValueError):
         # pytest-xdist monkeypatches sys.stderr with an object that is not an actual file.
         # https://docs.python.org/3/library/faulthandler.html#issue-with-file-descriptors
         # This is potentially dangerous, but the best we can do.


### PR DESCRIPTION
Closes #11439

Fix is to add ValueError to the caught exceptions in get_stderr_fileno().

The io.UnsupportedOperation exception inherits from ValueError so this has been removed.
