### PR TITLE
Add more set assertion rewrites e.g. ``>=``

### DIFF
--- a/changelog/10617.feature.rst
+++ b/changelog/10617.feature.rst
@@ -1,0 +1,3 @@
+This change resolves :issue:`10617`` and adds more powerful set assertion rewrites for comparisons
+other than equality ``==``. Previously, only ``==`` was supported for sets. Now, the additional
+following operations are supported: ``!=``, ``<=``, ``>=``, ``<``, and ``>``.

--- a/changelog/10617.feature.rst
+++ b/changelog/10617.feature.rst
@@ -1,3 +1,2 @@
-This change resolves :issue:`10617`` and adds more powerful set assertion rewrites for comparisons
-other than equality ``==``. Previously, only ``==`` was supported for sets. Now, the additional
-following operations are supported: ``!=``, ``<=``, ``>=``, ``<``, and ``>``.
+Added more comprehensive set assertion rewrites for comparisons other than equality ``==``, with
+the following operations now providing better failure messages: ``!=``, ``<=``, ``>=``, ``<``, and ``>``.

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -193,6 +193,22 @@ def assertrepr_compare(
         elif op == "not in":
             if istext(left) and istext(right):
                 explanation = _notin_text(left, right, verbose)
+        elif op == "!=":
+            if isset(left) and isset(right):
+                explanation = ["Both sets are equal"]
+        elif op == ">=":
+            if isset(left) and isset(right):
+                explanation = _compare_gte_set(left, right, verbose)
+        elif op == "<=":
+            if isset(left) and isset(right):
+                explanation = _compare_lte_set(left, right, verbose)
+        elif op == ">":
+            if isset(left) and isset(right):
+                explanation = _compare_gt_set(left, right, verbose)
+        elif op == "<":
+            if isset(left) and isset(right):
+                explanation = _compare_lt_set(left, right, verbose)
+
     except outcomes.Exit:
         raise
     except Exception:
@@ -392,15 +408,75 @@ def _compare_eq_set(
     left: AbstractSet[Any], right: AbstractSet[Any], verbose: int = 0
 ) -> List[str]:
     explanation = []
-    diff_left = left - right
-    diff_right = right - left
-    if diff_left:
-        explanation.append("Extra items in the left set:")
-        for item in diff_left:
-            explanation.append(saferepr(item))
-    if diff_right:
-        explanation.append("Extra items in the right set:")
-        for item in diff_right:
+    # diff_left = _set_one_sided_diff("left", left, right)
+    # diff_right = _set_one_sided_diff("right", right, left)
+    # if diff_left:
+    explanation.extend(_set_one_sided_diff("left", left, right))
+    # if diff_right:
+    explanation.extend(_set_one_sided_diff("right", right, left))
+    return explanation
+    # explanation = []
+    # diff_left = left - right
+    # diff_right = right - left
+    # if diff_left:
+    #     explanation.append("Extra items in the left set:")
+    #     for item in diff_left:
+    #         explanation.append(saferepr(item))
+    # if diff_right:
+    #     explanation.append("Extra items in the right set:")
+    #     for item in diff_right:
+    #         explanation.append(saferepr(item))
+    # return explanation
+
+
+def _compare_gt_set(
+    left: AbstractSet[Any], right: AbstractSet[Any], verbose: int = 0
+) -> List[str]:
+    # explanation = []
+    explanation = _compare_gte_set(left, right, verbose)
+    if not explanation:
+        return ["Both sets are equal"]
+    return explanation
+
+
+def _compare_lt_set(
+    left: AbstractSet[Any], right: AbstractSet[Any], verbose: int = 0
+) -> List[str]:
+    # explanation = []
+    explanation = _compare_lte_set(left, right, verbose)
+    if not explanation:
+        return ["Both sets are equal"]
+    return explanation
+
+
+def _compare_gte_set(
+    left: AbstractSet[Any], right: AbstractSet[Any], verbose: int = 0
+) -> List[str]:
+    explanation = []
+    # diff_right = _set_one_sided_diff("right", right, left)
+    # if diff_right:
+    explanation.extend(_set_one_sided_diff("right", right, left))
+    return explanation
+
+
+def _compare_lte_set(
+    left: AbstractSet[Any], right: AbstractSet[Any], verbose: int = 0
+) -> List[str]:
+    explanation = []
+    # diff_left = _set_one_sided_diff("left", left, right)
+    # if diff_left:
+    explanation.extend(_set_one_sided_diff("left", left, right))
+    return explanation
+
+
+def _set_one_sided_diff(
+    posn: str, set1: AbstractSet[Any], set2: AbstractSet[Any]
+) -> List[str]:
+    explanation = []
+    diff = set1 - set2
+    if diff:
+        explanation.append(f"Extra items in the {posn} set:")
+        for item in diff:
             explanation.append(saferepr(item))
     return explanation
 

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -408,31 +408,14 @@ def _compare_eq_set(
     left: AbstractSet[Any], right: AbstractSet[Any], verbose: int = 0
 ) -> List[str]:
     explanation = []
-    # diff_left = _set_one_sided_diff("left", left, right)
-    # diff_right = _set_one_sided_diff("right", right, left)
-    # if diff_left:
     explanation.extend(_set_one_sided_diff("left", left, right))
-    # if diff_right:
     explanation.extend(_set_one_sided_diff("right", right, left))
     return explanation
-    # explanation = []
-    # diff_left = left - right
-    # diff_right = right - left
-    # if diff_left:
-    #     explanation.append("Extra items in the left set:")
-    #     for item in diff_left:
-    #         explanation.append(saferepr(item))
-    # if diff_right:
-    #     explanation.append("Extra items in the right set:")
-    #     for item in diff_right:
-    #         explanation.append(saferepr(item))
-    # return explanation
 
 
 def _compare_gt_set(
     left: AbstractSet[Any], right: AbstractSet[Any], verbose: int = 0
 ) -> List[str]:
-    # explanation = []
     explanation = _compare_gte_set(left, right, verbose)
     if not explanation:
         return ["Both sets are equal"]
@@ -442,7 +425,6 @@ def _compare_gt_set(
 def _compare_lt_set(
     left: AbstractSet[Any], right: AbstractSet[Any], verbose: int = 0
 ) -> List[str]:
-    # explanation = []
     explanation = _compare_lte_set(left, right, verbose)
     if not explanation:
         return ["Both sets are equal"]
@@ -452,21 +434,13 @@ def _compare_lt_set(
 def _compare_gte_set(
     left: AbstractSet[Any], right: AbstractSet[Any], verbose: int = 0
 ) -> List[str]:
-    explanation = []
-    # diff_right = _set_one_sided_diff("right", right, left)
-    # if diff_right:
-    explanation.extend(_set_one_sided_diff("right", right, left))
-    return explanation
+    return _set_one_sided_diff("right", right, left)
 
 
 def _compare_lte_set(
     left: AbstractSet[Any], right: AbstractSet[Any], verbose: int = 0
 ) -> List[str]:
-    explanation = []
-    # diff_left = _set_one_sided_diff("left", left, right)
-    # if diff_left:
-    explanation.extend(_set_one_sided_diff("left", left, right))
-    return explanation
+    return _set_one_sided_diff("left", left, right)
 
 
 def _set_one_sided_diff(

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1345,48 +1345,98 @@ def test_reprcompare_whitespaces() -> None:
     ]
 
 
-def test_pytest_assertrepr_compare_integration(pytester: Pytester) -> None:
+@pytest.mark.parametrize("op", [">=", "<="])
+def test_operators_not_set_for_full_coverage(op, pytester: Pytester) -> None:
     pytester.makepyfile(
-        """
+        f"""
         def test_hello():
-            x = set(range(100))
-            y = x.copy()
-            y.remove(50)
-            assert x == y
+            x = ["hello x"]
+            y = ["hello y"]
+            assert x {op} y
     """
     )
+
     result = pytester.runpytest()
-    result.stdout.fnmatch_lines(
-        [
-            "*def test_hello():*",
-            "*assert x == y*",
-            "*E*Extra items*left*",
-            "*E*50*",
-            "*= 1 failed in*",
-        ]
-    )
+    result.stdout.no_fnmatch_line(f"assert x {op} y")
 
 
-def test_sequence_comparison_uses_repr(pytester: Pytester) -> None:
-    pytester.makepyfile(
+class TestSetAssertions:
+    @pytest.mark.parametrize("op", [">=", ">", "<=", "<", "=="])
+    def test_set_extra_item(self, op, pytester: Pytester) -> None:
+        pytester.makepyfile(
+            f"""
+            def test_hello():
+                x = set("hello x")
+                y = set("hello y")
+                assert x {op} y
         """
-        def test_hello():
-            x = set("hello x")
-            y = set("hello y")
-            assert x == y
-    """
-    )
-    result = pytester.runpytest()
-    result.stdout.fnmatch_lines(
-        [
-            "*def test_hello():*",
-            "*assert x == y*",
-            "*E*Extra items*left*",
-            "*E*'x'*",
-            "*E*Extra items*right*",
-            "*E*'y'*",
-        ]
-    )
+        )
+
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines(
+            [
+                "*def test_hello():*",
+                f"*assert x {op} y*",
+            ]
+        )
+        if op in [">=", ">", "=="]:
+            result.stdout.fnmatch_lines(
+                [
+                    "*E*Extra items in the right set:*",
+                    "*E*'y'",
+                ]
+            )
+        if op in ["<=", "<", "=="]:
+            result.stdout.fnmatch_lines(
+                [
+                    "*E*Extra items in the left set:*",
+                    "*E*'x'",
+                    # "*E*50*",
+                ]
+            )
+        assert True  # only reached if no error above
+
+    @pytest.mark.parametrize("op", [">", "<", "!="])
+    def test_set_proper_superset_equal(self, pytester: Pytester, op) -> None:
+        pytester.makepyfile(
+            f"""
+            def test_hello():
+                x = set([1, 2, 3])
+                y = x.copy()
+                assert x {op} y
+        """
+        )
+
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines(
+            [
+                "*def test_hello():*",
+                f"*assert x {op} y*",
+                "*E*Both sets are equal*",
+            ]
+        )
+        assert True  # only reached if no error above
+
+    def test_pytest_assertrepr_compare_integration(self, pytester: Pytester) -> None:
+        pytester.makepyfile(
+            """
+            def test_hello():
+                x = set(range(100))
+                y = x.copy()
+                y.remove(50)
+                assert x == y
+        """
+        )
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines(
+            [
+                "*def test_hello():*",
+                "*assert x == y*",
+                "*E*Extra items*left*",
+                "*E*50*",
+                "*= 1 failed in*",
+            ]
+        )
 
 
 def test_assertrepr_loaded_per_dir(pytester: Pytester) -> None:

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1345,21 +1345,6 @@ def test_reprcompare_whitespaces() -> None:
     ]
 
 
-@pytest.mark.parametrize("op", [">=", "<="])
-def test_operators_not_set_for_full_coverage(op, pytester: Pytester) -> None:
-    pytester.makepyfile(
-        f"""
-        def test_hello():
-            x = ["hello x"]
-            y = ["hello y"]
-            assert x {op} y
-    """
-    )
-
-    result = pytester.runpytest()
-    result.stdout.no_fnmatch_line(f"assert x {op} y")
-
-
 class TestSetAssertions:
     @pytest.mark.parametrize("op", [">=", ">", "<=", "<", "=="])
     def test_set_extra_item(self, op, pytester: Pytester) -> None:

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1391,10 +1391,8 @@ class TestSetAssertions:
                 [
                     "*E*Extra items in the left set:*",
                     "*E*'x'",
-                    # "*E*50*",
                 ]
             )
-        assert True  # only reached if no error above
 
     @pytest.mark.parametrize("op", [">", "<", "!="])
     def test_set_proper_superset_equal(self, pytester: Pytester, op) -> None:
@@ -1415,7 +1413,6 @@ class TestSetAssertions:
                 "*E*Both sets are equal*",
             ]
         )
-        assert True  # only reached if no error above
 
     def test_pytest_assertrepr_compare_integration(self, pytester: Pytester) -> None:
         pytester.makepyfile(


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
This resolves #10617 and adds more powerful set assertion rewrites for comparisons other than equality ``==``. Previously, only ``==`` was supported for sets. Now, the additional following operations are supported: ``!=``, ``<=``, ``>=``, ``<``, and ``>``.
