### PR TITLE
Add OuputVerbosity and use it in assertions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -291,6 +291,7 @@ Ondřej Súkup
 Oscar Benjamin
 Parth Patel
 Patrick Hayes
+Patrick Lannigan
 Paul Müller
 Paul Reece
 Pauli Virtanen

--- a/changelog/11387.feature.rst
+++ b/changelog/11387.feature.rst
@@ -2,4 +2,4 @@ Added the new :confval:`verbosity_assertions` configuration option for fine-grai
 
 See :ref:`Fine-grained verbosity <pytest.fine_grained_verbosity>` for more details.
 
-For plugin authors, :attr:`config.output_verbosity <pytest.Config.output_verbosity>` can be used to retrieve the verbosity level for a specific :class:`pytest.VerbosityType`.
+For plugin authors, :attr:`config.output_verbosity <pytest.Config.get_verbosity>` can be used to retrieve the verbosity level for a specific verbosity type.

--- a/changelog/11387.feature.rst
+++ b/changelog/11387.feature.rst
@@ -1,4 +1,5 @@
-Added fine-grained verbosity support to override the application wide verbosity level.
-:class:`pytest.OutputVerbosity` can be used to retrieve the verbosity level for a specific :class:`pytest.VerbosityType`.
-:confval:`verbosity_assertions` option added to be able to control assertion output independent of the application wide
-verbosity level. See :ref:`Fine-grained verbosity <pytest.fine_grained_verbosity>`.
+Added the new :confval:`verbosity_assertions` configuration option for fine-grained control of failed assertions verbosity.
+
+See :ref:`Fine-grained verbosity <pytest.fine_grained_verbosity>` for more details.
+
+For plugin authors, :attr:`config.output_verbosity <pytest.Config.output_verbosity>` can be used to retrieve the verbosity level for a specific :class:`pytest.VerbosityType`.

--- a/changelog/11387.feature.rst
+++ b/changelog/11387.feature.rst
@@ -1,1 +1,4 @@
-:confval:`verbosity_assertions` option added to be able to control assertion output independent of the application wide verbosity level.
+Added fine-grained verbosity support to override the application wide verbosity level.
+:class:`pytest.OutputVerbosity` can be used to retrieve the verbosity level for a specific :class:`pytest.VerbosityType`.
+:confval:`verbosity_assertions` option added to be able to control assertion output independent of the application wide
+verbosity level. See :ref:`Fine-grained verbosity <pytest.fine_grained_verbosity>`.

--- a/changelog/11387.feature.rst
+++ b/changelog/11387.feature.rst
@@ -2,4 +2,4 @@ Added the new :confval:`verbosity_assertions` configuration option for fine-grai
 
 See :ref:`Fine-grained verbosity <pytest.fine_grained_verbosity>` for more details.
 
-For plugin authors, :attr:`config.output_verbosity <pytest.Config.get_verbosity>` can be used to retrieve the verbosity level for a specific verbosity type.
+For plugin authors, :attr:`config.get_verbosity <pytest.Config.get_verbosity>` can be used to retrieve the verbosity level for a specific verbosity type.

--- a/changelog/11387.feature.rst
+++ b/changelog/11387.feature.rst
@@ -1,0 +1,1 @@
+:confval:`verbosity_assertions` option added to be able to control assertion output independent of the application wide verbosity level.

--- a/doc/en/how-to/output.rst
+++ b/doc/en/how-to/output.rst
@@ -289,7 +289,7 @@ however some plugins might make use of higher verbosity.
 .. _`pytest.fine_grained_verbosity`:
 
 Fine-grained verbosity
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~
 
 In addition to specifying the application wide verbosity level, it is possible to control specific aspects independently.
 This is done by setting a verbosity level in the configuration file for the specific aspect of the output.

--- a/doc/en/how-to/output.rst
+++ b/doc/en/how-to/output.rst
@@ -270,16 +270,17 @@ situations, for example you are shown even fixtures that start with ``_`` if you
 Using higher verbosity levels (``-vvv``, ``-vvvv``, ...) is supported, but has no effect in pytest itself at the moment,
 however some plugins might make use of higher verbosity.
 
-Fine gain verbosity
+Fine-grained verbosity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In addition to specifying the application wide verbosity level, it is possible to control specific aspects independently.
 This is done by setting a verbosity level in the configuration file for the specific aspect of the output.
 
-``verbosity_assertions``: Controls how verbose the assertion output should be when pytest is executed. A value of ``2``
+:confval:`verbosity_assertions`: Controls how verbose the assertion output should be when pytest is executed. A value of ``2``
 would have the same output as the previous example, but each test inside the file is shown by a single character in the
 output.
 
+(Note: currently this is the only option available, but more might be added in the future).
 .. _`pytest.detailed_failed_tests_usage`:
 
 Producing a detailed summary report

--- a/doc/en/how-to/output.rst
+++ b/doc/en/how-to/output.rst
@@ -270,17 +270,20 @@ situations, for example you are shown even fixtures that start with ``_`` if you
 Using higher verbosity levels (``-vvv``, ``-vvvv``, ...) is supported, but has no effect in pytest itself at the moment,
 however some plugins might make use of higher verbosity.
 
+.. _`pytest.fine_grained_verbosity`:
+
 Fine-grained verbosity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In addition to specifying the application wide verbosity level, it is possible to control specific aspects independently.
 This is done by setting a verbosity level in the configuration file for the specific aspect of the output.
 
-:confval:`verbosity_assertions`: Controls how verbose the assertion output should be when pytest is executed. A value of ``2``
-would have the same output as the previous example, but each test inside the file is shown by a single character in the
-output.
+:confval:`verbosity_assertions`: Controls how verbose the assertion output should be when pytest is executed. Running
+``pytest --no-header`` with a value of ``2`` would have the same output as the previous example, but each test inside
+the file is shown by a single character in the output.
 
 (Note: currently this is the only option available, but more might be added in the future).
+
 .. _`pytest.detailed_failed_tests_usage`:
 
 Producing a detailed summary report

--- a/doc/en/how-to/output.rst
+++ b/doc/en/how-to/output.rst
@@ -270,6 +270,16 @@ situations, for example you are shown even fixtures that start with ``_`` if you
 Using higher verbosity levels (``-vvv``, ``-vvvv``, ...) is supported, but has no effect in pytest itself at the moment,
 however some plugins might make use of higher verbosity.
 
+Fine gain verbosity
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In addition to specifying the application wide verbosity level, it is possible to control specific aspects independently.
+This is done by setting a verbosity level in the configuration file for the specific aspect of the output.
+
+``verbosity_assertions``: Controls how verbose the assertion output should be when pytest is executed. A value of ``2``
+would have the same output as the previous example, but each test inside the file is shown by a single character in the
+output.
+
 .. _`pytest.detailed_failed_tests_usage`:
 
 Producing a detailed summary report

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1826,13 +1826,13 @@ passed multiple times. The expected format is ``name=value``. For example::
 
     Set a verbosity level specifically for assertion related output, overriding the application wide level.
 
-
     .. code-block:: ini
 
         [pytest]
         verbosity_assertions = 2
 
-    Defaults to application wide verbosity level (via the ``-v`` command-line option).
+    Defaults to application wide verbosity level (via the ``-v`` command-line option). A special value of
+    "auto" can be used to explicitly use the global verbosity level.
 
 
 .. confval:: xfail_strict

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -999,6 +999,7 @@ Stash
     :show-inheritance:
     :members:
 
+
 Global Variables
 ----------------
 

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1819,6 +1819,19 @@ passed multiple times. The expected format is ``name=value``. For example::
             clean_db
 
 
+.. confval:: verbosity_assertions
+
+    Set a verbosity level specifically for assertion related output, overriding the application wide level.
+
+
+    .. code-block:: ini
+
+        [pytest]
+        verbosity_assertions = 2
+
+    Defaults to application wide verbosity level.
+
+
 .. confval:: xfail_strict
 
     If set to ``True``, tests marked with ``@pytest.mark.xfail`` that actually succeed will by default fail the

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -957,6 +957,15 @@ OptionGroup
 .. autoclass:: pytest.OptionGroup()
     :members:
 
+OutputVerbosity
+~~~~~~~~~~~~~~~
+
+.. autoclass:: pytest.OutputVerbosity()
+    :members:
+
+.. autoclass:: pytest.VerbosityType()
+    :members:
+
 PytestPluginManager
 ~~~~~~~~~~~~~~~~~~~
 
@@ -995,7 +1004,6 @@ Stash
 .. autoclass:: pytest.StashKey
     :show-inheritance:
     :members:
-
 
 Global Variables
 ----------------

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -961,15 +961,6 @@ OptionGroup
 .. autoclass:: pytest.OptionGroup()
     :members:
 
-OutputVerbosity
-~~~~~~~~~~~~~~~
-
-.. autoclass:: pytest.OutputVerbosity()
-    :members:
-
-.. autoclass:: pytest.VerbosityType()
-    :members:
-
 PytestPluginManager
 ~~~~~~~~~~~~~~~~~~~
 

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1841,7 +1841,7 @@ passed multiple times. The expected format is ``name=value``. For example::
         [pytest]
         verbosity_assertions = 2
 
-    Defaults to application wide verbosity level.
+    Defaults to application wide verbosity level (via the ``-v`` command-line option).
 
 
 .. confval:: xfail_strict

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -48,7 +48,7 @@ def pytest_addoption(parser: Parser) -> None:
         "assertions",
         help=(
             "Specify a verbosity level for assertions, overriding the main level. "
-            "Higher levels will provide more a more detailed explanation when an assertion fails."
+            "Higher levels will provide more detailed explanation when an assertion fails."
         ),
     )
 

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -12,8 +12,6 @@ from _pytest.assertion import util
 from _pytest.assertion.rewrite import assertstate_key
 from _pytest.config import Config
 from _pytest.config import hookimpl
-from _pytest.config import OutputVerbosity
-from _pytest.config import VerbosityType
 from _pytest.config.argparsing import Parser
 from _pytest.nodes import Item
 
@@ -44,9 +42,9 @@ def pytest_addoption(parser: Parser) -> None:
         help="Enables the pytest_assertion_pass hook. "
         "Make sure to delete any previously generated pyc cache files.",
     )
-    OutputVerbosity._add_ini(
+    Config._add_ini(
         parser,
-        VerbosityType.Assertions,
+        Config.VERBOSITY_ASSERTIONS,
         help=(
             "Specify a verbosity level for assertions, overriding the main level. "
             "Higher levels will provide more detailed explanation when an assertion fails."

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -13,6 +13,7 @@ from _pytest.assertion.rewrite import assertstate_key
 from _pytest.config import Config
 from _pytest.config import hookimpl
 from _pytest.config import OutputVerbosity
+from _pytest.config import VerbosityType
 from _pytest.config.argparsing import Parser
 from _pytest.nodes import Item
 
@@ -43,9 +44,9 @@ def pytest_addoption(parser: Parser) -> None:
         help="Enables the pytest_assertion_pass hook. "
         "Make sure to delete any previously generated pyc cache files.",
     )
-    OutputVerbosity.add_ini(
+    OutputVerbosity._add_ini(
         parser,
-        "assertions",
+        VerbosityType.Assertions,
         help=(
             "Specify a verbosity level for assertions, overriding the main level. "
             "Higher levels will provide more detailed explanation when an assertion fails."

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -42,7 +42,7 @@ def pytest_addoption(parser: Parser) -> None:
         help="Enables the pytest_assertion_pass hook. "
         "Make sure to delete any previously generated pyc cache files.",
     )
-    Config._add_ini(
+    Config._add_verbosity_ini(
         parser,
         Config.VERBOSITY_ASSERTIONS,
         help=(

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -12,6 +12,7 @@ from _pytest.assertion import util
 from _pytest.assertion.rewrite import assertstate_key
 from _pytest.config import Config
 from _pytest.config import hookimpl
+from _pytest.config import OutputVerbosity
 from _pytest.config.argparsing import Parser
 from _pytest.nodes import Item
 
@@ -41,6 +42,14 @@ def pytest_addoption(parser: Parser) -> None:
         default=False,
         help="Enables the pytest_assertion_pass hook. "
         "Make sure to delete any previously generated pyc cache files.",
+    )
+    OutputVerbosity.add_ini(
+        parser,
+        "assertions",
+        help=(
+            "Specify a verbosity level for assertions, overriding the main level. "
+            "Higher levels will provide more a more detailed explanation when an assertion fails."
+        ),
     )
 
 

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -426,7 +426,10 @@ def _saferepr(obj: object) -> str:
 
 def _get_maxsize_for_saferepr(config: Optional[Config]) -> Optional[int]:
     """Get `maxsize` configuration for saferepr based on the given config object."""
-    verbosity = config.getoption("verbose") if config is not None else 0
+    if config is None:
+        verbosity = 0
+    else:
+        verbosity = config.get_verbosity(Config.VERBOSITY_ASSERTIONS)
     if verbosity >= 2:
         return None
     if verbosity >= 1:

--- a/src/_pytest/assertion/truncate.py
+++ b/src/_pytest/assertion/truncate.py
@@ -1,7 +1,7 @@
 """Utilities for truncating assertion output.
 
 Current default behaviour is to truncate assertion explanations at
-~8 terminal lines, unless running in "-vv" mode or running on CI.
+terminal lines, unless running with a verbosity level of at least 2 or running on CI.
 """
 from typing import List
 from typing import Optional
@@ -26,7 +26,7 @@ def truncate_if_required(
 
 def _should_truncate_item(item: Item) -> bool:
     """Whether or not this test item is eligible for truncation."""
-    verbose = item.config.option.verbose
+    verbose = item.config.output_verbosity.verbosity_for("assertions")
     return verbose < 2 and not util.running_on_ci()
 
 

--- a/src/_pytest/assertion/truncate.py
+++ b/src/_pytest/assertion/truncate.py
@@ -10,6 +10,7 @@ from _pytest.assertion import util
 from _pytest.config import Config
 from _pytest.nodes import Item
 
+
 DEFAULT_MAX_LINES = 8
 DEFAULT_MAX_CHARS = 8 * 80
 USAGE_MSG = "use '-vv' to show"

--- a/src/_pytest/assertion/truncate.py
+++ b/src/_pytest/assertion/truncate.py
@@ -7,7 +7,7 @@ from typing import List
 from typing import Optional
 
 from _pytest.assertion import util
-from _pytest.config import VerbosityType
+from _pytest.config import Config
 from _pytest.nodes import Item
 
 DEFAULT_MAX_LINES = 8
@@ -26,7 +26,7 @@ def truncate_if_required(
 
 def _should_truncate_item(item: Item) -> bool:
     """Whether or not this test item is eligible for truncation."""
-    verbose = item.config.output_verbosity.get(VerbosityType.Assertions)
+    verbose = item.config.get_verbosity(Config.VERBOSITY_ASSERTIONS)
     return verbose < 2 and not util.running_on_ci()
 
 

--- a/src/_pytest/assertion/truncate.py
+++ b/src/_pytest/assertion/truncate.py
@@ -1,7 +1,7 @@
 """Utilities for truncating assertion output.
 
 Current default behaviour is to truncate assertion explanations at
-terminal lines, unless running with a verbosity level of at least 2 or running on CI.
+terminal lines, unless running with an assertions verbosity level of at least 2 or running on CI.
 """
 from typing import List
 from typing import Optional

--- a/src/_pytest/assertion/truncate.py
+++ b/src/_pytest/assertion/truncate.py
@@ -7,8 +7,8 @@ from typing import List
 from typing import Optional
 
 from _pytest.assertion import util
+from _pytest.config import VerbosityType
 from _pytest.nodes import Item
-
 
 DEFAULT_MAX_LINES = 8
 DEFAULT_MAX_CHARS = 8 * 80
@@ -26,7 +26,7 @@ def truncate_if_required(
 
 def _should_truncate_item(item: Item) -> bool:
     """Whether or not this test item is eligible for truncation."""
-    verbose = item.config.output_verbosity.verbosity_for("assertions")
+    verbose = item.config.output_verbosity.get(VerbosityType.Assertions)
     return verbose < 2 and not util.running_on_ci()
 
 

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -18,6 +18,7 @@ from _pytest._io.saferepr import _pformat_dispatch
 from _pytest._io.saferepr import saferepr
 from _pytest._io.saferepr import saferepr_unlimited
 from _pytest.config import Config
+from _pytest.config import VerbosityType
 
 # The _reprcompare attribute on the util module is used by the new assertion
 # interpretation code and assertion rewriter to detect this plugin was
@@ -161,7 +162,7 @@ def assertrepr_compare(
     config, op: str, left: Any, right: Any, use_ascii: bool = False
 ) -> Optional[List[str]]:
     """Return specialised explanations for some operators/operands."""
-    verbose = config.output_verbosity.verbosity_for("assertions")
+    verbose = config.output_verbosity.get(VerbosityType.Assertions)
 
     # Strings which normalize equal are often hard to distinguish when printed; use ascii() to make this easier.
     # See issue #3246.

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -161,7 +161,7 @@ def assertrepr_compare(
     config, op: str, left: Any, right: Any, use_ascii: bool = False
 ) -> Optional[List[str]]:
     """Return specialised explanations for some operators/operands."""
-    verbose = config.getoption("verbose")
+    verbose = config.output_verbosity.verbosity_for("assertions")
 
     # Strings which normalize equal are often hard to distinguish when printed; use ascii() to make this easier.
     # See issue #3246.

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -20,7 +20,6 @@ from _pytest._io.saferepr import _pformat_dispatch
 from _pytest._io.saferepr import saferepr
 from _pytest._io.saferepr import saferepr_unlimited
 from _pytest.config import Config
-from _pytest.config import VerbosityType
 
 # The _reprcompare attribute on the util module is used by the new assertion
 # interpretation code and assertion rewriter to detect this plugin was
@@ -169,7 +168,7 @@ def assertrepr_compare(
     config, op: str, left: Any, right: Any, use_ascii: bool = False
 ) -> Optional[List[str]]:
     """Return specialised explanations for some operators/operands."""
-    verbose = config.output_verbosity.get(VerbosityType.Assertions)
+    verbose = config.get_verbosity(Config.VERBOSITY_ASSERTIONS)
 
     # Strings which normalize equal are often hard to distinguish when printed; use ascii() to make this easier.
     # See issue #3246.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1682,7 +1682,7 @@ class Config:
         ):
             return global_level
 
-        level = self.getini(Config._ini_name(verbosity_type))
+        level = self.getini(Config._verbosity_ini_name(verbosity_type))
 
         if level == Config._VERBOSITY_INI_DEFAULT:
             return global_level
@@ -1690,11 +1690,11 @@ class Config:
         return int(level)
 
     @staticmethod
-    def _ini_name(verbosity_type: str) -> str:
+    def _verbosity_ini_name(verbosity_type: str) -> str:
         return f"verbosity_{verbosity_type}"
 
     @staticmethod
-    def _add_ini(parser: "Parser", verbosity_type: str, help: str) -> None:
+    def _add_verbosity_ini(parser: "Parser", verbosity_type: str, help: str) -> None:
         """Add a output verbosity configuration option for the given output type.
 
         :param parser: Parser for command line arguments and ini-file values.
@@ -1705,7 +1705,7 @@ class Config:
         :py:func:`config.get_verbosity(type) <pytest.Config.get_verbosity>`.
         """
         parser.addini(
-            Config._ini_name(verbosity_type),
+            Config._verbosity_ini_name(verbosity_type),
             help=help,
             type="string",
             default=Config._VERBOSITY_INI_DEFAULT,

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1681,7 +1681,8 @@ class OutputVerbosity:
     @property
     def verbose(self) -> int:
         """Application wide verbosity level."""
-        return cast(int, self._config.option.verbose)
+        assert isinstance(self._config.option.verbose, int)
+        return self._config.option.verbose
 
     def get(self, verbosity_type: VerbosityType = VerbosityType.Global) -> int:
         """Return verbosity level for the given output type.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1654,7 +1654,7 @@ class Config:
     #: Verbosity type for failed assertions (see :confval:`verbosity_assertions`).
     VERBOSITY_ASSERTIONS: Final = "assertions"
     _KNOWN_VERBOSITY_TYPES: Final = {VERBOSITY_ASSERTIONS}
-    _VERBOSITY_INI_DEFAULT = "auto"
+    _VERBOSITY_INI_DEFAULT: Final = "auto"
 
     def get_verbosity(self, verbosity_type: Optional[str] = None) -> int:
         r"""Retrieve the verbosity level for a fine-grained verbosity type.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1701,7 +1701,6 @@ class OutputVerbosity:
     """
 
     DEFAULT = "auto"
-    _option_name_fmt = "verbosity_{}"
 
     def __init__(self, config: Config) -> None:
         self._config = config

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1667,11 +1667,30 @@ class Config:
 class VerbosityType(Enum):
     """Fine-grained verbosity categories."""
 
+    #: Application wide (default)
     Global = "global"
     Assertions = "assertions"
 
 
 class OutputVerbosity:
+    r"""Access to fine-grained verbosity levels.
+
+    .. code-block:: ini
+
+        # content of pytest.ini
+        [pytest]
+        verbosity_assertions = 2
+
+    .. code-block:: bash
+
+        pytest -v
+
+    .. code-block:: python
+
+        print(config.output_verbosity.get())  # 1
+        print(config.output_verbosity.get(VerbosityType.Assertions))  # 2
+    """
+
     DEFAULT = "auto"
     _option_name_fmt = "verbosity_{}"
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1651,13 +1651,26 @@ class Config:
         """Deprecated, use getoption(skip=True) instead."""
         return self.getoption(name, skip=True)
 
-    #: Verbosity for failed assertions (see :confval:`verbosity_assertions`).
+    #: Verbosity type for failed assertions (see :confval:`verbosity_assertions`).
     VERBOSITY_ASSERTIONS: Final = "assertions"
     _KNOWN_VERBOSITY_TYPES: Final = {VERBOSITY_ASSERTIONS}
     _VERBOSITY_INI_DEFAULT = "auto"
 
     def get_verbosity(self, verbosity_type: Optional[str] = None) -> int:
-        r"""Access to fine-grained verbosity levels.
+        r"""Retrieve the verbosity level for a fine-grained verbosity type.
+
+        :param verbosity_type: Verbosity type to get level for. If a level is
+            configured for the given type, that value will be returned. If the
+            given type is not a known verbosity type, the global verbosity
+            level will be returned. If the given type is None (default), the
+            global verbosity level will be returned.
+
+        To configure a level for a fine-grained verbosity type, the
+        configuration file should have a setting for the configuration name
+        and a numeric value for the verbosity level. A special value of "auto"
+        can be used to explicitly use the global verbosity level.
+
+        Example:
 
         .. code-block:: ini
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1021,7 +1021,12 @@ class Config:
         )
         self.args_source = Config.ArgsSource.ARGS
         self.args: List[str] = []
+
         self.output_verbosity = OutputVerbosity(self)
+        """Access to output verbosity configuration.
+
+        :type: OutputVerbosity
+        """
 
         if TYPE_CHECKING:
             from _pytest.cacheprovider import Cache
@@ -1667,13 +1672,17 @@ class Config:
 class VerbosityType(Enum):
     """Fine-grained verbosity categories."""
 
-    #: Application wide (default)
+    #: Application wide, controlled by ``-v``/``-q``.
     Global = "global"
+
+    #: Verbosity for failed assertions (see :confval:`verbosity_assertions`).
     Assertions = "assertions"
 
 
 class OutputVerbosity:
     r"""Access to fine-grained verbosity levels.
+
+    Access via :attr:`config.output_verbosity <pytest.Config.output_verbosity>`.
 
     .. code-block:: ini
 
@@ -1681,7 +1690,7 @@ class OutputVerbosity:
         [pytest]
         verbosity_assertions = 2
 
-    .. code-block:: bash
+    .. code-block:: console
 
         pytest -v
 
@@ -1699,7 +1708,11 @@ class OutputVerbosity:
 
     @property
     def verbose(self) -> int:
-        """Application wide verbosity level."""
+        """
+        Application wide verbosity level.
+
+        Same as the traditional ``config.getoption("verbose")``.
+        """
         assert isinstance(self._config.option.verbose, int)
         return self._config.option.verbose
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1653,7 +1653,6 @@ class Config:
 
     #: Verbosity type for failed assertions (see :confval:`verbosity_assertions`).
     VERBOSITY_ASSERTIONS: Final = "assertions"
-    _KNOWN_VERBOSITY_TYPES: Final = {VERBOSITY_ASSERTIONS}
     _VERBOSITY_INI_DEFAULT: Final = "auto"
 
     def get_verbosity(self, verbosity_type: Optional[str] = None) -> int:
@@ -1689,14 +1688,14 @@ class Config:
         """
         global_level = self.option.verbose
         assert isinstance(global_level, int)
-        if (
-            verbosity_type is None
-            or verbosity_type not in Config._KNOWN_VERBOSITY_TYPES
-        ):
+        if verbosity_type is None:
             return global_level
 
-        level = self.getini(Config._verbosity_ini_name(verbosity_type))
+        ini_name = Config._verbosity_ini_name(verbosity_type)
+        if ini_name not in self._parser._inidict:
+            return global_level
 
+        level = self.getini(ini_name)
         if level == Config._VERBOSITY_INI_DEFAULT:
             return global_level
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1705,16 +1705,6 @@ class OutputVerbosity:
     def __init__(self, config: Config) -> None:
         self._config = config
 
-    @property
-    def verbose(self) -> int:
-        """
-        Application wide verbosity level.
-
-        Same as the traditional ``config.getoption("verbose")``.
-        """
-        assert isinstance(self._config.option.verbose, int)
-        return self._config.option.verbose
-
     def get(self, verbosity_type: VerbosityType = VerbosityType.Global) -> int:
         """Return verbosity level for the given output type.
 
@@ -1725,7 +1715,9 @@ class OutputVerbosity:
         level = self._config.getini(OutputVerbosity._ini_name(verbosity_type))
 
         if level == OutputVerbosity.DEFAULT:
-            return self.verbose
+            assert isinstance(self._config.option.verbose, int)
+            return self._config.option.verbose
+
         return int(level)
 
     @staticmethod

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -18,6 +18,7 @@ from _pytest.config import main
 from _pytest.config import OutputVerbosity
 from _pytest.config import PytestPluginManager
 from _pytest.config import UsageError
+from _pytest.config import VerbosityType
 from _pytest.config.argparsing import OptionGroup
 from _pytest.config.argparsing import Parser
 from _pytest.debugging import pytestPDB as __pytestPDB
@@ -163,6 +164,7 @@ __all__ = [
     "TestReport",
     "TestShortLogReport",
     "UsageError",
+    "VerbosityType",
     "WarningsRecorder",
     "warns",
     "xfail",

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -15,6 +15,7 @@ from _pytest.config import ExitCode
 from _pytest.config import hookimpl
 from _pytest.config import hookspec
 from _pytest.config import main
+from _pytest.config import OutputVerbosity
 from _pytest.config import PytestPluginManager
 from _pytest.config import UsageError
 from _pytest.config.argparsing import OptionGroup
@@ -126,6 +127,7 @@ __all__ = [
     "Module",
     "MonkeyPatch",
     "OptionGroup",
+    "OutputVerbosity",
     "Package",
     "param",
     "Parser",

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -15,10 +15,8 @@ from _pytest.config import ExitCode
 from _pytest.config import hookimpl
 from _pytest.config import hookspec
 from _pytest.config import main
-from _pytest.config import OutputVerbosity
 from _pytest.config import PytestPluginManager
 from _pytest.config import UsageError
-from _pytest.config import VerbosityType
 from _pytest.config.argparsing import OptionGroup
 from _pytest.config.argparsing import Parser
 from _pytest.debugging import pytestPDB as __pytestPDB
@@ -128,7 +126,6 @@ __all__ = [
     "Module",
     "MonkeyPatch",
     "OptionGroup",
-    "OutputVerbosity",
     "Package",
     "param",
     "Parser",
@@ -164,7 +161,6 @@ __all__ = [
     "TestReport",
     "TestShortLogReport",
     "UsageError",
-    "VerbosityType",
     "WarningsRecorder",
     "warns",
     "xfail",

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -38,6 +38,41 @@ def mock_config(verbose: int = 0, assertion_override: Optional[int] = None):
     return Config()
 
 
+class TestMockConfig:
+    SOME_VERBOSITY_LEVEL = 3
+    SOME_OTHER_VERBOSITY_LEVEL = 10
+
+    def test_verbose_exposes_value(self):
+        config = mock_config(verbose=TestMockConfig.SOME_VERBOSITY_LEVEL)
+
+        assert config.output_verbosity.verbose == TestMockConfig.SOME_VERBOSITY_LEVEL
+
+    def test_verbosity_for_assertion_override_not_set_verbose_value(self):
+        config = mock_config(verbose=TestMockConfig.SOME_VERBOSITY_LEVEL)
+
+        assert (
+            config.output_verbosity.verbosity_for("assertions")
+            == TestMockConfig.SOME_VERBOSITY_LEVEL
+        )
+
+    def test_verbosity_for_assertion_override_set_custom_value(self):
+        config = mock_config(
+            verbose=TestMockConfig.SOME_VERBOSITY_LEVEL,
+            assertion_override=TestMockConfig.SOME_OTHER_VERBOSITY_LEVEL,
+        )
+
+        assert (
+            config.output_verbosity.verbosity_for("assertions")
+            == TestMockConfig.SOME_OTHER_VERBOSITY_LEVEL
+        )
+
+    def test_verbosity_for_unsupported_type_error(self):
+        config = mock_config(verbose=TestMockConfig.SOME_VERBOSITY_LEVEL)
+
+        with pytest.raises(KeyError):
+            config.output_verbosity.verbosity_for("NOT CONFIGURED NAME")
+
+
 class TestImportHookInstallation:
     @pytest.mark.parametrize("initial_conftest", [True, False])
     @pytest.mark.parametrize("mode", ["plain", "rewrite"])

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1905,12 +1905,12 @@ def test_fine_grained_assertion_verbosity(pytester: Pytester):
         """
     )
     pytester.makeini(
-        f"""
+        """
         [pytest]
-        {_Config._verbosity_ini_name(_Config.VERBOSITY_ASSERTIONS)} = 2
+        verbosity_assertions = 2
         """
     )
-    result = pytester.runpytest(str(p))
+    result = pytester.runpytest(p)
 
     result.stdout.fnmatch_lines(
         [

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1907,7 +1907,7 @@ def test_fine_grained_assertion_verbosity(pytester: Pytester):
     pytester.makeini(
         f"""
         [pytest]
-        {_Config._ini_name(_Config.VERBOSITY_ASSERTIONS)} = 2
+        {_Config._verbosity_ini_name(_Config.VERBOSITY_ASSERTIONS)} = 2
         """
     )
     result = pytester.runpytest(str(p))

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -17,12 +17,23 @@ from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pytester import Pytester
 
 
-def mock_config(verbose=0):
-    class Config:
-        def getoption(self, name):
-            if name == "verbose":
+def mock_config(verbose: int = 0, assertion_override: Optional[int] = None):
+    class OutputVerbosity:
+        @property
+        def verbose(self) -> int:
+            return verbose
+
+        def verbosity_for(self, output_type: str) -> int:
+            if output_type == "assertions":
+                if assertion_override is not None:
+                    return assertion_override
                 return verbose
-            raise KeyError("Not mocked out: %s" % name)
+
+            raise KeyError("Not mocked out: %s" % output_type)
+
+    class Config:
+        def __init__(self) -> None:
+            self.output_verbosity = OutputVerbosity()
 
     return Config()
 

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -2056,12 +2056,14 @@ class TestReprSizeVerbosity:
     )
     def test_get_maxsize_for_saferepr(self, verbose: int, expected_size) -> None:
         class FakeConfig:
-            def getoption(self, name: str) -> int:
-                assert name == "verbose"
+            def get_verbosity(self, verbosity_type: Optional[str] = None) -> int:
                 return verbose
 
         config = FakeConfig()
         assert _get_maxsize_for_saferepr(cast(Config, config)) == expected_size
+
+    def test_get_maxsize_for_saferepr_no_config(self) -> None:
+        assert _get_maxsize_for_saferepr(None) == DEFAULT_REPR_MAX_SIZE
 
     def create_test_file(self, pytester: Pytester, size: int) -> None:
         pytester.makepyfile(

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -2212,7 +2212,7 @@ class TestOutputVerbosity:
 
         assert config.option.verbose == config.output_verbosity.verbose
 
-    def test_level_matches_verbost_when_not_specified(
+    def test_level_matches_verbose_when_not_specified(
         self, pytester: Pytester, tmp_path: Path
     ) -> None:
         tmp_path.joinpath("pytest.ini").write_text(

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -2254,7 +2254,7 @@ class TestVerbosity:
 
     class VerbosityIni:
         def pytest_addoption(self, parser: Parser) -> None:
-            Config._add_ini(
+            Config._add_verbosity_ini(
                 parser, TestVerbosity.SOME_OUTPUT_TYPE, help="some help text"
             )
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -2279,6 +2279,24 @@ class TestVerbosity:
             == config.option.verbose
         )
 
+    def test_level_matches_verbose_when_not_known_type(
+        self, pytester: Pytester, tmp_path: Path
+    ) -> None:
+        tmp_path.joinpath("pytest.ini").write_text(
+            textwrap.dedent(
+                """\
+                [pytest]
+                addopts = --verbose
+                """
+            ),
+            encoding="utf-8",
+        )
+        pytester.plugins = [TestVerbosity.VerbosityIni()]
+
+        config = pytester.parseconfig(tmp_path)
+
+        assert config.get_verbosity("some fake verbosity type") == config.option.verbose
+
     def test_level_matches_specified_override(
         self, pytester: Pytester, tmp_path: Path
     ) -> None:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -2196,23 +2196,6 @@ class TestOutputVerbosity:
                 parser, TestOutputVerbosity.SOME_OUTPUT_TYPE, help="some help text"
             )
 
-    def test_verbose_matches_option_verbose(
-        self, pytester: Pytester, tmp_path: Path
-    ) -> None:
-        tmp_path.joinpath("pytest.ini").write_text(
-            textwrap.dedent(
-                """\
-                [pytest]
-                addopts = --verbose
-                """
-            ),
-            encoding="utf-8",
-        )
-
-        config = pytester.parseconfig(tmp_path)
-
-        assert config.option.verbose == config.output_verbosity.verbose
-
     def test_level_matches_verbose_when_not_specified(
         self, pytester: Pytester, tmp_path: Path
     ) -> None:
@@ -2231,7 +2214,7 @@ class TestOutputVerbosity:
 
         assert (
             config.output_verbosity.get(TestOutputVerbosity.SOME_OUTPUT_TYPE)
-            == config.output_verbosity.verbose
+            == config.option.verbose
         )
 
     def test_level_matches_specified_override(

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -22,6 +22,7 @@ from _pytest.config import ConftestImportFailure
 from _pytest.config import ExitCode
 from _pytest.config import OutputVerbosity
 from _pytest.config import parse_warning_filter
+from _pytest.config import VerbosityType
 from _pytest.config.argparsing import Parser
 from _pytest.config.exceptions import UsageError
 from _pytest.config.findpaths import determine_setup
@@ -2186,12 +2187,12 @@ class TestDebugOptions:
 
 
 class TestOutputVerbosity:
-    SOME_OUTPUT_TYPE = "foo"
+    SOME_OUTPUT_TYPE = VerbosityType.Assertions
     SOME_OUTPUT_VERBOSITY_LEVEL = 5
 
     class VerbosityIni:
         def pytest_addoption(self, parser: Parser) -> None:
-            OutputVerbosity.add_ini(
+            OutputVerbosity._add_ini(
                 parser, TestOutputVerbosity.SOME_OUTPUT_TYPE, help="some help text"
             )
 
@@ -2229,19 +2230,20 @@ class TestOutputVerbosity:
         config = pytester.parseconfig(tmp_path)
 
         assert (
-            config.output_verbosity.verbosity_for(TestOutputVerbosity.SOME_OUTPUT_TYPE)
+            config.output_verbosity.get(TestOutputVerbosity.SOME_OUTPUT_TYPE)
             == config.output_verbosity.verbose
         )
 
     def test_level_matches_specified_override(
         self, pytester: Pytester, tmp_path: Path
     ) -> None:
+        setting_name = f"verbosity_{TestOutputVerbosity.SOME_OUTPUT_TYPE.value}"
         tmp_path.joinpath("pytest.ini").write_text(
             textwrap.dedent(
                 f"""\
                 [pytest]
                 addopts = --verbose
-                verbosity_{TestOutputVerbosity.SOME_OUTPUT_TYPE} = {TestOutputVerbosity.SOME_OUTPUT_VERBOSITY_LEVEL}
+                {setting_name} = {TestOutputVerbosity.SOME_OUTPUT_VERBOSITY_LEVEL}
                 """
             ),
             encoding="utf-8",
@@ -2251,6 +2253,6 @@ class TestOutputVerbosity:
         config = pytester.parseconfig(tmp_path)
 
         assert (
-            config.output_verbosity.verbosity_for(TestOutputVerbosity.SOME_OUTPUT_TYPE)
+            config.output_verbosity.get(TestOutputVerbosity.SOME_OUTPUT_TYPE)
             == TestOutputVerbosity.SOME_OUTPUT_VERBOSITY_LEVEL
         )

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -20,7 +20,9 @@ from _pytest.config import _strtobool
 from _pytest.config import Config
 from _pytest.config import ConftestImportFailure
 from _pytest.config import ExitCode
+from _pytest.config import OutputVerbosity
 from _pytest.config import parse_warning_filter
+from _pytest.config.argparsing import Parser
 from _pytest.config.exceptions import UsageError
 from _pytest.config.findpaths import determine_setup
 from _pytest.config.findpaths import get_common_ancestor
@@ -2180,4 +2182,75 @@ class TestDebugOptions:
                 "*file. This file is opened with 'w' and truncated as a*",
                 "*Default: pytestdebug.log.",
             ]
+        )
+
+
+class TestOutputVerbosity:
+    SOME_OUTPUT_TYPE = "foo"
+    SOME_OUTPUT_VERBOSITY_LEVEL = 5
+
+    class VerbosityIni:
+        def pytest_addoption(self, parser: Parser) -> None:
+            OutputVerbosity.add_ini(
+                parser, TestOutputVerbosity.SOME_OUTPUT_TYPE, help="some help text"
+            )
+
+    def test_verbose_matches_option_verbose(
+        self, pytester: Pytester, tmp_path: Path
+    ) -> None:
+        tmp_path.joinpath("pytest.ini").write_text(
+            textwrap.dedent(
+                """\
+                [pytest]
+                addopts = --verbose
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        config = pytester.parseconfig(tmp_path)
+
+        assert config.option.verbose == config.output_verbosity.verbose
+
+    def test_level_matches_verbost_when_not_specified(
+        self, pytester: Pytester, tmp_path: Path
+    ) -> None:
+        tmp_path.joinpath("pytest.ini").write_text(
+            textwrap.dedent(
+                """\
+                [pytest]
+                addopts = --verbose
+                """
+            ),
+            encoding="utf-8",
+        )
+        pytester.plugins = [TestOutputVerbosity.VerbosityIni()]
+
+        config = pytester.parseconfig(tmp_path)
+
+        assert (
+            config.output_verbosity.verbosity_for(TestOutputVerbosity.SOME_OUTPUT_TYPE)
+            == config.output_verbosity.verbose
+        )
+
+    def test_level_matches_specified_override(
+        self, pytester: Pytester, tmp_path: Path
+    ) -> None:
+        tmp_path.joinpath("pytest.ini").write_text(
+            textwrap.dedent(
+                f"""\
+                [pytest]
+                addopts = --verbose
+                verbosity_{TestOutputVerbosity.SOME_OUTPUT_TYPE} = {TestOutputVerbosity.SOME_OUTPUT_VERBOSITY_LEVEL}
+                """
+            ),
+            encoding="utf-8",
+        )
+        pytester.plugins = [TestOutputVerbosity.VerbosityIni()]
+
+        config = pytester.parseconfig(tmp_path)
+
+        assert (
+            config.output_verbosity.verbosity_for(TestOutputVerbosity.SOME_OUTPUT_TYPE)
+            == TestOutputVerbosity.SOME_OUTPUT_VERBOSITY_LEVEL
         )

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -20,9 +20,7 @@ from _pytest.config import _strtobool
 from _pytest.config import Config
 from _pytest.config import ConftestImportFailure
 from _pytest.config import ExitCode
-from _pytest.config import OutputVerbosity
 from _pytest.config import parse_warning_filter
-from _pytest.config import VerbosityType
 from _pytest.config.argparsing import Parser
 from _pytest.config.exceptions import UsageError
 from _pytest.config.findpaths import determine_setup
@@ -2186,14 +2184,14 @@ class TestDebugOptions:
         )
 
 
-class TestOutputVerbosity:
-    SOME_OUTPUT_TYPE = VerbosityType.Assertions
+class TestVerbosity:
+    SOME_OUTPUT_TYPE = Config.VERBOSITY_ASSERTIONS
     SOME_OUTPUT_VERBOSITY_LEVEL = 5
 
     class VerbosityIni:
         def pytest_addoption(self, parser: Parser) -> None:
-            OutputVerbosity._add_ini(
-                parser, TestOutputVerbosity.SOME_OUTPUT_TYPE, help="some help text"
+            Config._add_ini(
+                parser, TestVerbosity.SOME_OUTPUT_TYPE, help="some help text"
             )
 
     def test_level_matches_verbose_when_not_specified(
@@ -2208,34 +2206,34 @@ class TestOutputVerbosity:
             ),
             encoding="utf-8",
         )
-        pytester.plugins = [TestOutputVerbosity.VerbosityIni()]
+        pytester.plugins = [TestVerbosity.VerbosityIni()]
 
         config = pytester.parseconfig(tmp_path)
 
         assert (
-            config.output_verbosity.get(TestOutputVerbosity.SOME_OUTPUT_TYPE)
+            config.get_verbosity(TestVerbosity.SOME_OUTPUT_TYPE)
             == config.option.verbose
         )
 
     def test_level_matches_specified_override(
         self, pytester: Pytester, tmp_path: Path
     ) -> None:
-        setting_name = f"verbosity_{TestOutputVerbosity.SOME_OUTPUT_TYPE.value}"
+        setting_name = f"verbosity_{TestVerbosity.SOME_OUTPUT_TYPE}"
         tmp_path.joinpath("pytest.ini").write_text(
             textwrap.dedent(
                 f"""\
                 [pytest]
                 addopts = --verbose
-                {setting_name} = {TestOutputVerbosity.SOME_OUTPUT_VERBOSITY_LEVEL}
+                {setting_name} = {TestVerbosity.SOME_OUTPUT_VERBOSITY_LEVEL}
                 """
             ),
             encoding="utf-8",
         )
-        pytester.plugins = [TestOutputVerbosity.VerbosityIni()]
+        pytester.plugins = [TestVerbosity.VerbosityIni()]
 
         config = pytester.parseconfig(tmp_path)
 
         assert (
-            config.output_verbosity.get(TestOutputVerbosity.SOME_OUTPUT_TYPE)
-            == TestOutputVerbosity.SOME_OUTPUT_VERBOSITY_LEVEL
+            config.get_verbosity(TestVerbosity.SOME_OUTPUT_TYPE)
+            == TestVerbosity.SOME_OUTPUT_VERBOSITY_LEVEL
         )


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->

`OuputVerbosity` is a new class that allows for retrieving a verbosity level for a specific output type. If nothing is specifically configured, the application wide verbose value is used.

The first use of this functionality is `verbosity_assertions` which can be used to make the assertion reports output at the most verbose level while still showing a single character for each test case when progress is being reported.


Addresses #11387

