### PR TITLE
Color the full diff that pytest shows as a diff

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,6 +56,7 @@ Barney Gale
 Ben Gartner
 Ben Webb
 Benjamin Peterson
+Benjamin Schubert
 Bernard Pratz
 Bo Wu
 Bob Ippolito

--- a/changelog/11520.improvement.rst
+++ b/changelog/11520.improvement.rst
@@ -1,1 +1,1 @@
-* Improved very verbose diff output to color it as a diff instead of only red.
+Improved very verbose diff output to color it as a diff instead of only red.

--- a/changelog/11520.improvement.rst
+++ b/changelog/11520.improvement.rst
@@ -1,0 +1,1 @@
+* Improved very verbose diff output to color it as a diff instead of only red.

--- a/src/_pytest/_io/terminalwriter.py
+++ b/src/_pytest/_io/terminalwriter.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import sys
 from typing import final
+from typing import Literal
 from typing import Optional
 from typing import Sequence
 from typing import TextIO
@@ -193,15 +194,21 @@ class TerminalWriter:
         for indent, new_line in zip(indents, new_lines):
             self.line(indent + new_line)
 
-    def _highlight(self, source: str) -> str:
-        """Highlight the given source code if we have markup support."""
+    def _highlight(
+        self, source: str, lexer: Literal["diff", "python"] = "python"
+    ) -> str:
+        """Highlight the given source if we have markup support."""
         from _pytest.config.exceptions import UsageError
 
         if not self.hasmarkup or not self.code_highlight:
             return source
         try:
             from pygments.formatters.terminal import TerminalFormatter
-            from pygments.lexers.python import PythonLexer
+
+            if lexer == "python":
+                from pygments.lexers.python import PythonLexer as Lexer
+            elif lexer == "diff":
+                from pygments.lexers.diff import DiffLexer as Lexer
             from pygments import highlight
             import pygments.util
         except ImportError:
@@ -210,7 +217,7 @@ class TerminalWriter:
             try:
                 highlighted: str = highlight(
                     source,
-                    PythonLexer(),
+                    Lexer(),
                     TerminalFormatter(
                         bg=os.getenv("PYTEST_THEME_MODE", "dark"),
                         style=os.getenv("PYTEST_THEME"),

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -197,7 +197,7 @@ def assertrepr_compare(
     try:
         if op == "==":
             writer = config.get_terminal_writer()
-            explanation = _compare_eq_any(left, right, writer, verbose)
+            explanation = _compare_eq_any(left, right, writer._highlight, verbose)
         elif op == "not in":
             if istext(left) and istext(right):
                 explanation = _notin_text(left, right, verbose)

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -160,6 +160,9 @@ def color_mapping():
             "red": "\x1b[31m",
             "green": "\x1b[32m",
             "yellow": "\x1b[33m",
+            "light-gray": "\x1b[90m",
+            "light-red": "\x1b[91m",
+            "light-green": "\x1b[92m",
             "bold": "\x1b[1m",
             "reset": "\x1b[0m",
             "kw": "\x1b[94m",
@@ -171,6 +174,7 @@ def color_mapping():
             "endline": "\x1b[90m\x1b[39;49;00m",
         }
         RE_COLORS = {k: re.escape(v) for k, v in COLORS.items()}
+        NO_COLORS = {k: "" for k in COLORS.keys()}
 
         @classmethod
         def format(cls, lines: List[str]) -> List[str]:
@@ -186,6 +190,11 @@ def color_mapping():
         def format_for_rematch(cls, lines: List[str]) -> List[str]:
             """Replace color names for use with LineMatcher.re_match_lines"""
             return [line.format(**cls.RE_COLORS) for line in lines]
+
+        @classmethod
+        def strip_colors(cls, lines: List[str]) -> List[str]:
+            """Entirely remove every color code"""
+            return [line.format(**cls.NO_COLORS) for line in lines]
 
     return ColorMapping
 

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -1,5 +1,6 @@
 # mypy: disable-error-code="attr-defined"
 import logging
+from typing import Iterator
 
 import pytest
 from _pytest.logging import caplog_records_key
@@ -9,8 +10,8 @@ logger = logging.getLogger(__name__)
 sublogger = logging.getLogger(__name__ + ".baz")
 
 
-@pytest.fixture
-def cleanup_disabled_logging():
+@pytest.fixture(autouse=True)
+def cleanup_disabled_logging() -> Iterator[None]:
     """Simple fixture that ensures that a test doesn't disable logging.
 
     This is necessary because ``logging.disable()`` is global, so a test disabling logging
@@ -42,7 +43,7 @@ def test_change_level(caplog):
     assert "CRITICAL" in caplog.text
 
 
-def test_change_level_logging_disabled(caplog, cleanup_disabled_logging):
+def test_change_level_logging_disabled(caplog):
     logging.disable(logging.CRITICAL)
     assert logging.root.manager.disable == logging.CRITICAL
     caplog.set_level(logging.WARNING)
@@ -85,9 +86,7 @@ def test_change_level_undo(pytester: Pytester) -> None:
     result.stdout.no_fnmatch_line("*log from test2*")
 
 
-def test_change_disabled_level_undo(
-    pytester: Pytester, cleanup_disabled_logging
-) -> None:
+def test_change_disabled_level_undo(pytester: Pytester) -> None:
     """Ensure that '_force_enable_logging' in 'set_level' is undone after the end of the test.
 
     Tests the logging output themselves (affected by disabled logging level).
@@ -159,7 +158,7 @@ def test_with_statement(caplog):
     assert "CRITICAL" in caplog.text
 
 
-def test_with_statement_logging_disabled(caplog, cleanup_disabled_logging):
+def test_with_statement_logging_disabled(caplog):
     logging.disable(logging.CRITICAL)
     assert logging.root.manager.disable == logging.CRITICAL
     with caplog.at_level(logging.WARNING):
@@ -197,9 +196,7 @@ def test_with_statement_logging_disabled(caplog, cleanup_disabled_logging):
         ("NOTVALIDLEVEL", logging.NOTSET),
     ],
 )
-def test_force_enable_logging_level_string(
-    caplog, cleanup_disabled_logging, level_str, expected_disable_level
-):
+def test_force_enable_logging_level_string(caplog, level_str, expected_disable_level):
     """Test _force_enable_logging using a level string.
 
     ``expected_disable_level`` is one level below ``level_str`` because the disabled log level

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1803,13 +1803,8 @@ def test_reprcompare_verbose_long() -> None:
                 assert [0, 1] == [0, 2]
             """,
             [
-                "{bold}{red}E       assert [0, 1] == [0, 2]{reset}",
-                "{bold}{red}E         At index 1 diff: 1 != 2{reset}",
-                "{bold}{red}E         Full diff:{reset}",
                 "{bold}{red}E         {light-red}- [0, 2]{hl-reset}{endline}{reset}",
-                "{bold}{red}E         ?     ^{endline}{reset}",
                 "{bold}{red}E         {light-green}+ [0, 1]{hl-reset}{endline}{reset}",
-                "{bold}{red}E         ?     ^{endline}{reset}",
             ],
         ),
         (
@@ -1820,30 +1815,9 @@ def test_reprcompare_verbose_long() -> None:
                 }
             """,
             [
-                (
-                    "{bold}{red}E       AssertionError: assert "
-                    "{{'number-is-1': 1, 'number-is-2': 2, 'number-is-3': 3, 'number-is-4': 4, 'number-is-5': 5}}"
-                    " == {{'number-is-0': 0, 'number-is-1': 1, 'number-is-2': 2, 'number-is-3': 3, 'number-is-4': 4}}"
-                    "{reset}"
-                ),
-                "{bold}{red}E         Common items:{reset}",
-                (
-                    "{bold}{red}E         "
-                    "{{'number-is-1': 1, 'number-is-2': 2, 'number-is-3': 3, 'number-is-4': 4}}{reset}"
-                ),
-                "{bold}{red}E         Left contains 1 more item:{reset}",
-                "{bold}{red}E         {{'number-is-5': 5}}{reset}",
-                "{bold}{red}E         Right contains 1 more item:{reset}",
-                "{bold}{red}E         {{'number-is-0': 0}}{reset}",
-                "{bold}{red}E         Full diff:{reset}",
                 "{bold}{red}E         {light-gray} {hl-reset} {{{endline}{reset}",
-                "{bold}{red}E         {light-red}-  'number-is-0': 0,{hl-reset}{endline}{reset}",
                 "{bold}{red}E         {light-gray} {hl-reset}  'number-is-1': 1,{endline}{reset}",
-                "{bold}{red}E         {light-gray} {hl-reset}  'number-is-2': 2,{endline}{reset}",
-                "{bold}{red}E         {light-gray} {hl-reset}  'number-is-3': 3,{endline}{reset}",
-                "{bold}{red}E         {light-gray} {hl-reset}  'number-is-4': 4,{endline}{reset}",
                 "{bold}{red}E         {light-green}+  'number-is-5': 5,{hl-reset}{endline}{reset}",
-                "{bold}{red}E         {light-gray} {hl-reset} }}{endline}{reset}",
             ],
         ),
     ),
@@ -1861,4 +1835,4 @@ def test_comparisons_handle_colors(
         else color_mapping.strip_colors
     )
 
-    result.stdout.fnmatch_lines(formatter(expected_lines))
+    result.stdout.fnmatch_lines(formatter(expected_lines), consecutive=False)

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1795,7 +1795,7 @@ def test_reprcompare_verbose_long() -> None:
 
 @pytest.mark.parametrize("enable_colors", [True, False])
 @pytest.mark.parametrize(
-    ("code", "expected_lines"),
+    ("test_code", "expected_lines"),
     (
         (
             """
@@ -1823,9 +1823,9 @@ def test_reprcompare_verbose_long() -> None:
     ),
 )
 def test_comparisons_handle_colors(
-    pytester: Pytester, color_mapping, enable_colors, code, expected_lines
+    pytester: Pytester, color_mapping, enable_colors, test_code, expected_lines
 ) -> None:
-    p = pytester.makepyfile(code)
+    p = pytester.makepyfile(test_code)
     result = pytester.runpytest(
         f"--color={'yes' if enable_colors else 'no'}", "-vv", str(p)
     )

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -18,11 +18,18 @@ from _pytest.pytester import Pytester
 
 
 def mock_config(verbose=0):
+    class TerminalWriter:
+        def _highlight(self, source, lexer):
+            return source
+
     class Config:
         def getoption(self, name):
             if name == "verbose":
                 return verbose
             raise KeyError("Not mocked out: %s" % name)
+
+        def get_terminal_writer(self):
+            return TerminalWriter()
 
     return Config()
 
@@ -1784,3 +1791,74 @@ def test_reprcompare_verbose_long() -> None:
         "{'v0': 0, 'v1': 1, 'v2': 12, 'v3': 3, 'v4': 4, 'v5': 5, "
         "'v6': 6, 'v7': 7, 'v8': 8, 'v9': 9, 'v10': 10}"
     )
+
+
+@pytest.mark.parametrize("enable_colors", [True, False])
+@pytest.mark.parametrize(
+    ("code", "expected_lines"),
+    (
+        (
+            """
+            def test():
+                assert [0, 1] == [0, 2]
+            """,
+            [
+                "{bold}{red}E       assert [0, 1] == [0, 2]{reset}",
+                "{bold}{red}E         At index 1 diff: 1 != 2{reset}",
+                "{bold}{red}E         Full diff:{reset}",
+                "{bold}{red}E         {light-red}- [0, 2]{hl-reset}{endline}{reset}",
+                "{bold}{red}E         ?     ^{endline}{reset}",
+                "{bold}{red}E         {light-green}+ [0, 1]{hl-reset}{endline}{reset}",
+                "{bold}{red}E         ?     ^{endline}{reset}",
+            ],
+        ),
+        (
+            """
+            def test():
+                assert {f"number-is-{i}": i for i in range(1, 6)} == {
+                    f"number-is-{i}": i for i in range(5)
+                }
+            """,
+            [
+                (
+                    "{bold}{red}E       AssertionError: assert "
+                    "{{'number-is-1': 1, 'number-is-2': 2, 'number-is-3': 3, 'number-is-4': 4, 'number-is-5': 5}}"
+                    " == {{'number-is-0': 0, 'number-is-1': 1, 'number-is-2': 2, 'number-is-3': 3, 'number-is-4': 4}}"
+                    "{reset}"
+                ),
+                "{bold}{red}E         Common items:{reset}",
+                (
+                    "{bold}{red}E         "
+                    "{{'number-is-1': 1, 'number-is-2': 2, 'number-is-3': 3, 'number-is-4': 4}}{reset}"
+                ),
+                "{bold}{red}E         Left contains 1 more item:{reset}",
+                "{bold}{red}E         {{'number-is-5': 5}}{reset}",
+                "{bold}{red}E         Right contains 1 more item:{reset}",
+                "{bold}{red}E         {{'number-is-0': 0}}{reset}",
+                "{bold}{red}E         Full diff:{reset}",
+                "{bold}{red}E         {light-gray} {hl-reset} {{{endline}{reset}",
+                "{bold}{red}E         {light-red}-  'number-is-0': 0,{hl-reset}{endline}{reset}",
+                "{bold}{red}E         {light-gray} {hl-reset}  'number-is-1': 1,{endline}{reset}",
+                "{bold}{red}E         {light-gray} {hl-reset}  'number-is-2': 2,{endline}{reset}",
+                "{bold}{red}E         {light-gray} {hl-reset}  'number-is-3': 3,{endline}{reset}",
+                "{bold}{red}E         {light-gray} {hl-reset}  'number-is-4': 4,{endline}{reset}",
+                "{bold}{red}E         {light-green}+  'number-is-5': 5,{hl-reset}{endline}{reset}",
+                "{bold}{red}E         {light-gray} {hl-reset} }}{endline}{reset}",
+            ],
+        ),
+    ),
+)
+def test_comparisons_handle_colors(
+    pytester: Pytester, color_mapping, enable_colors, code, expected_lines
+) -> None:
+    p = pytester.makepyfile(code)
+    result = pytester.runpytest(
+        f"--color={'yes' if enable_colors else 'no'}", "-vv", str(p)
+    )
+    formatter = (
+        color_mapping.format_for_fnmatch
+        if enable_colors
+        else color_mapping.strip_colors
+    )
+
+    result.stdout.fnmatch_lines(formatter(expected_lines))


### PR DESCRIPTION
## Overview

Previously, it would get printed all in red, which makes it hard to read and actually understand.

However, the diffs shown are standard and have a supported lexer in Pygments. As such, use this to color the output when pygments is available.

This is a step towards #11520 but does not address all the discussion points yet.

## Visual changes

### Previously

![image](https://github.com/pytest-dev/pytest/assets/1672192/91ac0f75-86b3-4cef-b8f8-f67852a4bde6)

### With this change

![image](https://github.com/pytest-dev/pytest/assets/1672192/90c8dc7d-4cbb-4a8e-96c8-cf9ab8d9acc5)

## Questions

I am unsure about two things here:

- How we expose the lexers on the terminal writer. Having to pass a string and hoping it will do the right thing is not ideal, I believe it is slightly better than providing one when doing the call as, that way, only the terminalwriter has to handle whether pygments is available or not
- The testing might be a bit clunky and prone to breaking. If needed we could reduce the strictness of checks, let me know what you prefer