### PR TITLE
WIP: Rework fixture dependency graph calculation

### DIFF
--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -265,7 +265,7 @@ class DoctestItem(Item):
         # Stuff needed for fixture support.
         self.obj = None
         fm = self.session._fixturemanager
-        fixtureinfo = fm.getfixtureinfo(node=self, func=None, cls=None)
+        fixtureinfo = fm.getfixtureinfo2(node=self, func=None, cls=None)
         self._fixtureinfo = fixtureinfo
         self.fixturenames = fixtureinfo.names_closure
         self._initrequest()

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1898,7 +1898,12 @@ class FixtureManager:
                 else:
                     defs = retrieve(arg)
                     if not defs:
-                        # for now just skip if no definitions are found
+                        # for now just add a edge/node instead of reporting an error
+                        if parent_stack:
+                            with suppress(DuplicateDependency):
+                                info.add_dependency(parent_stack[-1], (arg, -1))
+                        else:
+                            info.add_node((arg, -1))
                         continue
                     if parent_stack:
                         parent = parent_stack[-1]

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -60,7 +60,7 @@ from _pytest.deprecated import INSTANCE_COLLECTOR
 from _pytest.deprecated import NOSE_SUPPORT_METHOD
 from _pytest.fixtures import FixtureDef
 from _pytest.fixtures import FixtureRequest
-from _pytest.fixtures import FuncFixtureInfo
+from _pytest.fixtures import FuncFixtureInfo2
 from _pytest.fixtures import get_scope_node
 from _pytest.main import Session
 from _pytest.mark import MARK_GEN
@@ -1199,7 +1199,7 @@ class Metafunc:
     def __init__(
         self,
         definition: "FunctionDefinition",
-        fixtureinfo: fixtures.FuncFixtureInfo,
+        fixtureinfo: fixtures.FuncFixtureInfo2,
         config: Config,
         cls=None,
         module=None,
@@ -1648,7 +1648,7 @@ def _show_fixtures_per_test(config: Config, session: Session) -> None:
 
     def write_item(item: nodes.Item) -> None:
         # Not all items have _fixtureinfo attribute.
-        info: Optional[FuncFixtureInfo] = getattr(item, "_fixtureinfo", None)
+        info: Optional[FuncFixtureInfo2] = getattr(item, "_fixtureinfo", None)
         if info is None or not info.name2fixturedefs:
             # This test item does not use any fixtures.
             return
@@ -1775,7 +1775,7 @@ class Function(PyobjMixin, nodes.Item):
         callobj=NOTSET,
         keywords: Optional[Mapping[str, Any]] = None,
         session: Optional[Session] = None,
-        fixtureinfo: Optional[FuncFixtureInfo] = None,
+        fixtureinfo: Optional[FuncFixtureInfo2] = None,
         originalname: Optional[str] = None,
     ) -> None:
         super().__init__(name, parent, config=config, session=session)
@@ -1811,8 +1811,8 @@ class Function(PyobjMixin, nodes.Item):
 
         if fixtureinfo is None:
             fm = self.session._fixturemanager
-            fixtureinfo = fm.getfixtureinfo(self, self.obj, self.cls)
-        self._fixtureinfo: FuncFixtureInfo = fixtureinfo
+            fixtureinfo = fm.getfixtureinfo2(self, self.obj, self.cls)
+        self._fixtureinfo: FuncFixtureInfo2 = fixtureinfo
         self.fixturenames = fixtureinfo.names_closure
         self._initrequest()
 


### PR DESCRIPTION
This PR is the central part of the _first_ point proposed in #11532. 
It adds the mechanisms to  shift from resolving fixtures strictly by name to building a proper fixture dependency graph.
All new objects and methods keep the interface of the objects/methods they are intended to eventually replace for now.

As mentioned  in the discusion thread I wish to get some feedback if this is a direction worth pursuing further and if it is how to implement proper error reporting during collection for cyclic dependencies errors and mis-scoped dependencies errors

~~*__NOTE:__*  _The new mechanism are not used yet. Replacing `FuncFixtureInfo` and `FixtureManager.getfixtureinfo` by `FuncFictureInfo2` and `FixtureManager.gefixtureinfo2` should mostly work but I have not tested it yet._~~

#### References:
David J. Pearce and Paul H. J. Kelly. 2007. A dynamic topological sort algorithm for directed acyclic graphs. ACM J. Exp. Algorithmics 11 (2006), 1.7–es. https://doi.org/10.1145/1187436.1210590