### PR TITLE
Configure ReadTheDocs to fail on warnings

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,10 @@ python:
        path: .
      - requirements: doc/en/requirements.txt
 
+sphinx:
+  configuration: doc/en/conf.py
+  fail_on_warning: true
+
 build:
   os: ubuntu-20.04
   tools:

--- a/doc/en/reference/customize.rst
+++ b/doc/en/reference/customize.rst
@@ -90,7 +90,7 @@ and can also be used to hold pytest configuration if they have a ``[pytest]`` se
 setup.cfg
 ~~~~~~~~~
 
-``setup.cfg`` files are general purpose configuration files, used originally by :doc:`distutils <python:distutils/configfile>`, and can also be used to hold pytest configuration
+``setup.cfg`` files are general purpose configuration files, used originally by ``distutils`` (now deprecated) and `setuptools <https://setuptools.pypa.io/en/latest/userguide/declarative_config.html>`__, and can also be used to hold pytest configuration
 if they have a ``[tool:pytest]`` section.
 
 .. code-block:: ini


### PR DESCRIPTION
Important to catch broken links and references.