### PR TITLE
Use pytestconfig instead of request.config in cache example

### DIFF
--- a/changelog/11065.doc.rst
+++ b/changelog/11065.doc.rst
@@ -1,0 +1,3 @@
+Use pytestconfig instead of request.config in cache example
+
+to be consistent with the API documentation.

--- a/doc/en/how-to/cache.rst
+++ b/doc/en/how-to/cache.rst
@@ -213,12 +213,12 @@ across pytest invocations:
 
 
     @pytest.fixture
-    def mydata(request):
-        val = request.config.cache.get("example/value", None)
+    def mydata(pytestconfig):
+        val = pytestconfig.cache.get("example/value", None)
         if val is None:
             expensive_computation()
             val = 42
-            request.config.cache.set("example/value", val)
+            pytestconfig.cache.set("example/value", val)
         return val
 
 


### PR DESCRIPTION
to be consistent with the API documentation.

Closes #11065 

