### PR TITLE
Mention -q and -s in the docs

### DIFF
--- a/changelog/11507.doc.rst
+++ b/changelog/11507.doc.rst
@@ -1,0 +1,1 @@
+Added documentation lines for command line options -q (--quiet ).

--- a/changelog/11507.doc.rst
+++ b/changelog/11507.doc.rst
@@ -1,1 +1,0 @@
-Added documentation lines for command line options -q (--quiet ).

--- a/doc/en/how-to/output.rst
+++ b/doc/en/how-to/output.rst
@@ -15,15 +15,12 @@ Examples for modifying traceback printing:
     pytest --showlocals     # show local variables in tracebacks
     pytest -l               # show local variables (shortcut)
     pytest --no-showlocals  # hide local variables (if addopts enables them)
-    pytest --quiet          # quiet - less verbose - mode
-    pytest -q               # quiet - less verbose - mode (shortcut)
 
     pytest --capture=fd  # default, capture at the file descriptor level
     pytest --capture=sys # capture at the sys level
     pytest --capture=no  # don't capture
     pytest -s            # don't capture (shortcut)
     pytest --capture=tee-sys # capture to logs but also output to sys level streams
-
 
     pytest --tb=auto    # (default) 'long' tracebacks for the first and last
                          # entry, but 'short' style for the other entries
@@ -44,6 +41,13 @@ option you make sure a trace is shown.
 
 Verbosity
 --------------------------------------------------
+
+Examples for modifying printing verbosity:
+
+.. code-block:: bash
+
+    pytest --quiet          # quiet - less verbose - mode
+    pytest -q               # quiet - less verbose - mode (shortcut)
 
 The ``-v`` flag controls the verbosity of pytest output in various aspects: test session progress, assertion
 details when tests fail, fixtures details with ``--fixtures``, etc.

--- a/doc/en/how-to/output.rst
+++ b/doc/en/how-to/output.rst
@@ -18,6 +18,13 @@ Examples for modifying traceback printing:
     pytest --quiet          # quiet - less verbose - mode
     pytest -q               # quiet - less verbose - mode (shortcut)
 
+    pytest --capture=fd  # default, capture at the file descriptor level
+    pytest --capture=sys # capture at the sys level
+    pytest --capture=no  # don't capture
+    pytest -s            # don't capture (shortcut)
+    pytest --capture=tee-sys # capture to logs but also output to sys level streams
+
+
     pytest --tb=auto    # (default) 'long' tracebacks for the first and last
                          # entry, but 'short' style for the other entries
     pytest --tb=long    # exhaustive, informative traceback formatting

--- a/doc/en/how-to/output.rst
+++ b/doc/en/how-to/output.rst
@@ -48,6 +48,9 @@ Examples for modifying printing verbosity:
 
     pytest --quiet          # quiet - less verbose - mode
     pytest -q               # quiet - less verbose - mode (shortcut)
+    pytest -v               # increase verbosity, display individual test names
+    pytest -vv              # more verbose, display more details from the test output
+    pytest -vvv             # not a standard , but may be used for even more detail in certain setups
 
 The ``-v`` flag controls the verbosity of pytest output in various aspects: test session progress, assertion
 details when tests fail, fixtures details with ``--fixtures``, etc.

--- a/doc/en/how-to/output.rst
+++ b/doc/en/how-to/output.rst
@@ -15,6 +15,8 @@ Examples for modifying traceback printing:
     pytest --showlocals     # show local variables in tracebacks
     pytest -l               # show local variables (shortcut)
     pytest --no-showlocals  # hide local variables (if addopts enables them)
+    pytest --quiet          # quiet - less verbose - mode
+    pytest -q               # quiet - less verbose - mode (shortcut)
 
     pytest --tb=auto    # (default) 'long' tracebacks for the first and last
                          # entry, but 'short' style for the other entries


### PR DESCRIPTION
- Closes #11507.
- Added references to command line options `-q (--quiet )` ,`--capture` and `-s (--capture)` in the output documentation.
