### PR TITLE
Fix crash using empty string for parametrized value more than once

### DIFF
--- a/changelog/11563.bugfix.rst
+++ b/changelog/11563.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed crash when using an empty string for the same parametrized value more than once.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1003,7 +1003,7 @@ class IdMaker:
             for index, id in enumerate(resolved_ids):
                 if id_counts[id] > 1:
                     suffix = ""
-                    if id[-1].isdigit():
+                    if id and id[-1].isdigit():
                         suffix = "_"
                     new_id = f"{id}{suffix}{id_suffixes[id]}"
                     while new_id in set(resolved_ids):

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -626,6 +626,13 @@ class TestMetafunc:
             ).make_unique_parameterset_ids()
             assert result == [expected]
 
+    def test_idmaker_duplicated_empty_str(self) -> None:
+        """Regression test for empty strings parametrized more than once (#11563)."""
+        result = IdMaker(
+            ("a",), [pytest.param(""), pytest.param("")], None, None, None, None, None
+        ).make_unique_parameterset_ids()
+        assert result == ["0", "1"]
+
     def test_parametrize_ids_exception(self, pytester: Pytester) -> None:
         """
         :param pytester: the instance of Pytester class, a temporary


### PR DESCRIPTION
Fixes #11563.
