### PR TITLE
Accept `None` in `_XfailMarkDecorator`'s `condition`param and expose default value

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -338,6 +338,7 @@ Saiprasad Kale
 Samuel Colvin
 Samuel Dion-Girardeau
 Samuel Searles-Bryant
+Samuel Therrien (Avasam)
 Samuele Pedroni
 Sanket Duthade
 Sankt Petersbug

--- a/changelog/10094#issuecomment-1774215699.improvement.rst
+++ b/changelog/10094#issuecomment-1774215699.improvement.rst
@@ -1,0 +1,1 @@
+Improved the documentation and type signature for :func:`pytest.mark.xfail <pytest.mark.xfail>`'s ``condition`` param to support ``None``.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -239,11 +239,10 @@ Marks a test function as *expected to fail*.
 
 .. py:function:: pytest.mark.xfail(condition=None, *, reason=None, raises=None, run=True, strict=xfail_strict)
 
-    :type condition: bool or str
-    :param condition:
-        Condition for marking the test function as xfail (``True/False`` or a
-        :ref:`condition string <string conditions>`). If a bool, you also have
-        to specify ``reason`` (see :ref:`condition string <string conditions>`).
+    :keyword Optional[Union[bool, str]] condition: 
+        Condition for marking the test function as xfail (``True/False/None`` or a
+        :ref:`condition string <string conditions>`). If a bool or None, you also have
+        to specify ``reason`` (see :ref:`condition string <string conditions>`). ``None`` is the same as ``False``.
     :keyword str reason:
         Reason why the test function is marked as xfail.
     :keyword Type[Exception] raises:

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -239,7 +239,7 @@ Marks a test function as *expected to fail*.
 
 .. py:function:: pytest.mark.xfail(condition=None, *, reason=None, raises=None, run=True, strict=xfail_strict)
 
-    :keyword Optional[Union[bool, str]] condition: 
+    :keyword Optional[Union[bool, str]] condition:
         Condition for marking the test function as xfail (``True/False/None`` or a
         :ref:`condition string <string conditions>`). If a bool or None, you also have
         to specify ``reason`` (see :ref:`condition string <string conditions>`). ``None`` is the same as ``False``.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -457,8 +457,8 @@ if TYPE_CHECKING:
         @overload
         def __call__(
             self,
-            condition: Union[str, bool] = ...,
-            *conditions: Union[str, bool],
+            condition: Optional[Union[str, bool]] = None,
+            *conditions: Optional[Union[str, bool]],
             reason: str = ...,
             run: bool = ...,
             raises: Union[


### PR DESCRIPTION
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [x] Include documentation when adding new features.
- [N/A] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Fixes comments https://github.com/pypa/setuptools/pull/3979#discussion_r1367963793 and https://github.com/pytest-dev/pytest/issues/10094#issuecomment-1774215699  
Should not conflict with #11501

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
