### PR TITLE
doc/reference: fix sidebar TOC depth

### DIFF
--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1,3 +1,5 @@
+:tocdepth: 3
+
 .. _`api-reference`:
 
 API Reference


### PR DESCRIPTION
Previously, the sidebar TOC had unlimited depth, making it useless and interfering with the content. This seems to have regressed in pytest 7.2.x going by the RTD version selector.