### PR TITLE
doc: allow Sphinx 6.x and 7.x

### DIFF
--- a/doc/en/requirements.txt
+++ b/doc/en/requirements.txt
@@ -2,7 +2,7 @@ pallets-sphinx-themes
 pluggy>=1.2.0
 pygments-pytest>=2.3.0
 sphinx-removed-in>=0.2.0
-sphinx>=5,<6
+sphinx>=5,<8
 sphinxcontrib-trio
 sphinxcontrib-svg2pdfconverter
 # Pin packaging because it no longer handles 'latest' version, which


### PR DESCRIPTION
They seem to work fine, let's allow them.