### PR TITLE
Add summary for xfails with -rxX option

### DIFF
--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -878,8 +878,10 @@ class TerminalReporter:
     def pytest_terminal_summary(self) -> Generator[None, None, None]:
         self.summary_errors()
         self.summary_failures()
+        self.summary_xfailures()
         self.summary_warnings()
         self.summary_passes()
+        self.summary_xpasses()
         try:
             return (yield)
         finally:
@@ -1022,6 +1024,20 @@ class TerminalReporter:
                         self._outrep_summary(rep)
                     self._handle_teardown_sections(rep.nodeid)
 
+    def summary_xpasses(self) -> None:
+        if self.config.option.tbstyle != "no":
+            if self.hasopt("X"):
+                reports: List[TestReport] = self.getreports("xpassed")
+                if not reports:
+                    return
+                self.write_sep("=", "XPASSES")
+                for rep in reports:
+                    if rep.sections:
+                        msg = self._getfailureheadline(rep)
+                        self.write_sep("_", msg, green=True, bold=True)
+                        self._outrep_summary(rep)
+                    self._handle_teardown_sections(rep.nodeid)
+
     def _get_teardown_reports(self, nodeid: str) -> List[TestReport]:
         reports = self.getreports("")
         return [
@@ -1063,6 +1079,25 @@ class TerminalReporter:
                     self.write_sep("_", msg, red=True, bold=True)
                     self._outrep_summary(rep)
                     self._handle_teardown_sections(rep.nodeid)
+
+    def summary_xfailures(self) -> None:
+        if self.config.option.tbstyle != "no":
+            if self.hasopt("x"):
+                reports: List[BaseReport] = self.getreports("xfailed")
+                if not reports:
+                    return
+                self.write_sep("=", "XFAILURES")
+                if self.config.option.tbstyle == "line":
+                    for rep in reports:
+                        line = self._getcrashline(rep)
+                        self.write_line(line)
+                else:
+                    for rep in reports:
+                        msg = self._getfailureheadline(rep)
+                        self.write_sep("_", msg, red=True, bold=True)
+                        self._outrep_summary(rep)
+                        self._handle_teardown_sections(rep.nodeid)
+
 
     def summary_errors(self) -> None:
         if self.config.option.tbstyle != "no":


### PR DESCRIPTION
This is an early implementation which closes #11233.

It duplicates the code of the passes and failures summary implementation right now but I didn't want to refactor it before I know if something like this could be accepted.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
