### PR TITLE
Fix for operation on closed file in faulthandler teardown

### DIFF
--- a/changelog/11572.bugfix.rst
+++ b/changelog/11572.bugfix.rst
@@ -1,0 +1,1 @@
+Handle an edge case where :data:`sys.stderr` and :data:`sys.__stderr__` might already be closed when :ref:`faulthandler` is tearing down.

--- a/src/_pytest/faulthandler.py
+++ b/src/_pytest/faulthandler.py
@@ -25,6 +25,9 @@ def pytest_addoption(parser: Parser) -> None:
 def pytest_configure(config: Config) -> None:
     import faulthandler
 
+    # stash original stderr fileno to be restored at the end of the test session
+    # sys.stderr and sys.__stderr__ may be closed or patched during the session
+    # so we can't rely on their values being good at that point
     stderr_fileno = get_stderr_fileno()
     config.stash[fault_handler_original_stderr_fd_key] = stderr_fileno
     config.stash[fault_handler_stderr_fd_key] = os.dup(stderr_fileno)

--- a/src/_pytest/faulthandler.py
+++ b/src/_pytest/faulthandler.py
@@ -25,9 +25,9 @@ def pytest_addoption(parser: Parser) -> None:
 def pytest_configure(config: Config) -> None:
     import faulthandler
 
-    # stash original stderr fileno to be restored at the end of the test session
+    # Stash original stderr fileno to be restored at the end of the test session
     # sys.stderr and sys.__stderr__ may be closed or patched during the session
-    # so we can't rely on their values being good at that point
+    # so we can't rely on their values being good at that point (#11572).
     stderr_fileno = get_stderr_fileno()
     config.stash[fault_handler_original_stderr_fd_key] = stderr_fileno
     config.stash[fault_handler_stderr_fd_key] = os.dup(stderr_fileno)


### PR DESCRIPTION
Closes #11572 

remember stderr fileno in config.stash to be restored on faulthandler teardown