### PR TITLE
Add new filtering() context manager to LogCaptureFixture class

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -188,6 +188,7 @@ Javier Romero
 Jeff Rackauckas
 Jeff Widman
 Jenni Rinker
+Jens Tröger
 John Eddie Ayson
 John Litborn
 John Towler

--- a/changelog/11610.feature.rst
+++ b/changelog/11610.feature.rst
@@ -1,0 +1,2 @@
+Added :func:`LogCaptureFixture.filtering() <pytest.LogCaptureFixture.filtering>` context manager that
+adds a given :class:`logging.Filter` object to the caplog fixture.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -564,6 +564,22 @@ class LogCaptureFixture:
             self.handler.setLevel(handler_orig_level)
             logging.disable(original_disable_level)
 
+    @contextmanager
+    def filtering(self, filter_: logging.Filter) -> Generator[None, None, None]:
+        """Context manager that temporarily adds the given filter to the caplog's
+        :meth:`handler` for the 'with' statement block, and removes that filter at the
+        end of the block.
+
+        :param filter_: A custom :class:`logging.Filter` object.
+
+        .. versionadded:: 7.5
+        """
+        self.handler.addFilter(filter_)
+        try:
+            yield
+        finally:
+            self.handler.removeFilter(filter_)
+
 
 @fixture
 def caplog(request: FixtureRequest) -> Generator[LogCaptureFixture, None, None]:


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
Closes #11610 

Please note that I also added a `versionadded:: 7.5` to the method’s docstring, though I’m not exactly sure how you guys handle the version number.

Also, regarding typing of the fixture args please note the recent change https://github.com/python/typeshed/pull/11018 and how with Python 3.12 the return type of the filter has changed. I am not sure how you’d like to handle that, please advise.