### PR TITLE
testing: fix isolation issue in `tr` fixture

### DIFF
--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1802,7 +1802,7 @@ def test_terminal_no_summary_warnings_header_once(pytester: Pytester) -> None:
 
 @pytest.fixture(scope="session")
 def tr() -> TerminalReporter:
-    config = _pytest.config._prepareconfig()
+    config = _pytest.config._prepareconfig([])
     return TerminalReporter(config)
 
 


### PR DESCRIPTION
The default for `_prepareconfig` is to use `sys.argv`, which in this case are the flags passed to (top-level) `pytest`. This is not the intention, the tests themselves should not be affected by it.