### PR TITLE
testing: remove a no longer necessary skip

### DIFF
--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1959,16 +1959,6 @@ def test_invocation_args(pytester: Pytester) -> None:
     ],
 )
 def test_config_blocked_default_plugins(pytester: Pytester, plugin: str) -> None:
-    if plugin == "debugging":
-        # Fixed in xdist (after 1.27.0).
-        # https://github.com/pytest-dev/pytest-xdist/pull/422
-        try:
-            import xdist  # noqa: F401
-        except ImportError:
-            pass
-        else:
-            pytest.skip("does not work with xdist currently")
-
     p = pytester.makepyfile("def test(): pass")
     result = pytester.runpytest(str(p), "-pno:%s" % plugin)
 


### PR DESCRIPTION
pytest-xdist was released at 2019-02-15, seems enough time.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
