### PR TITLE
Remove more unused pprint features

### DIFF
--- a/src/_pytest/_io/pprint.py
+++ b/src/_pytest/_io/pprint.py
@@ -78,8 +78,6 @@ class PrettyPrinter:
             The maximum depth to print out nested structures.
 
         """
-        indent = int(indent)
-        width = int(width)
         if indent < 0:
             raise ValueError("indent must be >= 0")
         if depth is not None and depth <= 0:

--- a/src/_pytest/_io/pprint.py
+++ b/src/_pytest/_io/pprint.py
@@ -486,12 +486,7 @@ class PrettyPrinter:
         write("\n" + " " * indent)
 
     def _repr(self, object: Any, context: Set[int], level: int) -> str:
-        return self.format(object, context.copy(), self._depth, level)
-
-    def format(
-        self, object: Any, context: Set[int], maxlevels: Optional[int], level: int
-    ) -> str:
-        return self._safe_repr(object, context, maxlevels, level)
+        return self._safe_repr(object, context.copy(), self._depth, level)
 
     def _pprint_default_dict(
         self,
@@ -639,8 +634,8 @@ class PrettyPrinter:
             else:
                 items = object.items()
             for k, v in items:
-                krepr = self.format(k, context, maxlevels, level)
-                vrepr = self.format(v, context, maxlevels, level)
+                krepr = self._safe_repr(k, context, maxlevels, level)
+                vrepr = self._safe_repr(v, context, maxlevels, level)
                 append(f"{krepr}: {vrepr}")
             context.remove(objid)
             return "{%s}" % ", ".join(components)
@@ -668,7 +663,7 @@ class PrettyPrinter:
             append = components.append
             level += 1
             for o in object:
-                orepr = self.format(o, context, maxlevels, level)
+                orepr = self._safe_repr(o, context, maxlevels, level)
                 append(orepr)
             context.remove(objid)
             return format % ", ".join(components)

--- a/src/_pytest/_io/pprint.py
+++ b/src/_pytest/_io/pprint.py
@@ -65,7 +65,6 @@ class PrettyPrinter:
         width: int = 80,
         depth: Optional[int] = None,
         *,
-        sort_dicts: bool = True,
         underscore_numbers: bool = False,
     ) -> None:
         """Handle pretty printing operations onto a stream using a set of
@@ -80,9 +79,6 @@ class PrettyPrinter:
         depth
             The maximum depth to print out nested structures.
 
-        sort_dicts
-            If true, dict keys are sorted.
-
         """
         indent = int(indent)
         width = int(width)
@@ -95,7 +91,6 @@ class PrettyPrinter:
         self._depth = depth
         self._indent_per_level = indent
         self._width = width
-        self._sort_dicts = sort_dicts
         self._underscore_numbers = underscore_numbers
 
     def pformat(self, object: Any) -> str:
@@ -174,10 +169,7 @@ class PrettyPrinter:
     ) -> None:
         write = stream.write
         write("{")
-        if self._sort_dicts:
-            items = sorted(object.items(), key=_safe_tuple)
-        else:
-            items = object.items()
+        items = sorted(object.items(), key=_safe_tuple)
         self._format_dict_items(items, stream, indent, allowance, context, level)
         write("}")
 
@@ -629,11 +621,7 @@ class PrettyPrinter:
             components: List[str] = []
             append = components.append
             level += 1
-            if self._sort_dicts:
-                items = sorted(object.items(), key=_safe_tuple)
-            else:
-                items = object.items()
-            for k, v in items:
+            for k, v in sorted(object.items(), key=_safe_tuple):
                 krepr = self._safe_repr(k, context, maxlevels, level)
                 vrepr = self._safe_repr(v, context, maxlevels, level)
                 append(f"{krepr}: {vrepr}")

--- a/src/_pytest/_io/pprint.py
+++ b/src/_pytest/_io/pprint.py
@@ -64,8 +64,6 @@ class PrettyPrinter:
         indent: int = 4,
         width: int = 80,
         depth: Optional[int] = None,
-        *,
-        underscore_numbers: bool = False,
     ) -> None:
         """Handle pretty printing operations onto a stream using a set of
         configured parameters.
@@ -91,7 +89,6 @@ class PrettyPrinter:
         self._depth = depth
         self._indent_per_level = indent
         self._width = width
-        self._underscore_numbers = underscore_numbers
 
     def pformat(self, object: Any) -> str:
         sio = _StringIO()
@@ -603,12 +600,6 @@ class PrettyPrinter:
 
         r = getattr(typ, "__repr__", None)
 
-        if issubclass(typ, int) and r is int.__repr__:
-            if self._underscore_numbers:
-                return f"{object:_d}"
-            else:
-                return repr(object)
-
         if issubclass(typ, dict) and r is dict.__repr__:
             if not object:
                 return "{}"
@@ -659,7 +650,9 @@ class PrettyPrinter:
         return repr(object)
 
 
-_builtin_scalars = frozenset({str, bytes, bytearray, float, complex, bool, type(None)})
+_builtin_scalars = frozenset(
+    {str, bytes, bytearray, float, complex, bool, type(None), int}
+)
 
 
 def _recursion(object: Any) -> str:


### PR DESCRIPTION
The vendored version of pprint doesn't use all those features, we can simplify and reduce the amount of code we have to handle.

Since the module has already quite diverged from upstream, it doesn't really make sense to keep those in