### PR TITLE
Resolving Issue #11457

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -347,6 +347,7 @@ Sanket Duthade
 Sankt Petersbug
 Saravanan Padmanaban
 Sean Malloy
+Sean Pourgoutzidis
 Segev Finer
 Serhii Mozghovyi
 Seth Junot


### PR DESCRIPTION
Hello,

This PR resolves #11457.

## Description:

Essentially, the issue is that when the user calls .fail() and the test case has an internal error, they will receive the reason for failing passed to .fail() as well as the internal error context. The figure below was the test given to produce this behaviour:

![TestToReplicateIssue](https://github.com/pytest-dev/pytest/assets/112140775/6a66ef6b-701e-49d8-9f75-32176865b8f7)

And the following figure is the behaviour itself:

![ErroneousResult](https://github.com/pytest-dev/pytest/assets/112140775/9fcc93b9-3840-413f-90ca-15f4d516a61b)

## Solution:

This was described as unfavourable, so to prevent this behaviour, I added a suppress context parameter to the .fail() function to allow users to choose whether they want to internal error context to be printed. Now, with running the same test, we choose to suppress the context:

![TestWithNewFunctionality](https://github.com/pytest-dev/pytest/assets/112140775/4c429c8a-3eec-4fe4-b498-7aae42d7ff8e)

This gives us the following result:


![UpdatedResult](https://github.com/pytest-dev/pytest/assets/112140775/36805f25-1a66-49c4-9b3e-ad53841b35cb)


I believe this is an apt fix as suppress_context is set to False by default, meaning that it would not change the default behaviour, but gives the user more overall control of their text outputs.


## Information

Head-fork: seanpourgoutzidis/pytest
compare: issue11457

base-fork: pytest-dev/pytest
base: main

Thanks,
Sean




