### PR TITLE
Adding stdio option for show-capture

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -173,6 +173,7 @@ Ilya Konstantinov
 Ionuț Turturică
 Isaac Virshup
 Israel Fruchter
+Itamar Hindi
 Itxaso Aizpurua
 Iwan Briquemont
 Jaap Broekhuizen
@@ -347,6 +348,7 @@ Sanket Duthade
 Sankt Petersbug
 Saravanan Padmanaban
 Sean Malloy
+Sebin (Eichel) Choi
 Segev Finer
 Serhii Mozghovyi
 Seth Junot

--- a/changelog/11037.feature.rst
+++ b/changelog/11037.feature.rst
@@ -1,0 +1,1 @@
+Added stdio as option for --show-capture to have both stderr and stdout output together.

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -352,7 +352,13 @@ def _enter_pdb(
         ("stderr", rep.capstderr),
         ("log", rep.caplog),
     ):
-        if showcapture in (sectionname, "all") and content:
+        if (
+            showcapture in (sectionname, "all")
+            or (
+                showcapture == "stdio"
+                and ("stdout" in sectionname or "stderr" in sectionname)
+            )
+        ) and content:
             tw.sep(">", "captured " + sectionname)
             if content[-1:] == "\n":
                 content = content[:-1]

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -217,9 +217,9 @@ def pytest_addoption(parser: Parser) -> None:
         "--show-capture",
         action="store",
         dest="showcapture",
-        choices=["no", "stdout", "stderr", "log", "all"],
+        choices=["no", "stdout", "stderr", "log", "stdio", "all"],
         default="all",
-        help="Controls how captured stdout/stderr/log is shown on failed tests. "
+        help="Controls how captured stdout/stderr/log is shown on failed tests. stdio displays both stdout and stderr. "
         "Default: all.",
     )
     group._addoption(
@@ -1039,7 +1039,14 @@ class TerminalReporter:
         if showcapture == "no":
             return
         for secname, content in rep.sections:
-            if showcapture != "all" and showcapture not in secname:
+            if (
+                showcapture != "all"
+                and showcapture not in secname
+                and (
+                    showcapture != "stdio"
+                    or ("stderr" not in secname and "stdout" not in secname)
+                )
+            ):
                 continue
             if "teardown" in secname:
                 self._tw.sep("-", secname)
@@ -1085,7 +1092,14 @@ class TerminalReporter:
         if showcapture == "no":
             return
         for secname, content in rep.sections:
-            if showcapture != "all" and showcapture not in secname:
+            if (
+                showcapture != "all"
+                and showcapture not in secname
+                and (
+                    showcapture != "stdio"
+                    or ("stderr" not in secname and "stdout" not in secname)
+                )
+            ):
                 continue
             self._tw.sep("-", secname)
             if content[-1:] == "\n":

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1620,6 +1620,11 @@ def pytest_report_header(config, start_path):
         assert "!This is stderr!" not in stdout
         assert "!This is a warning log msg!" in stdout
 
+        stdout = pytester.runpytest("--show-capture=stdio", "--tb=short").stdout.str()
+        assert "!This is stdout!" in stdout
+        assert "!This is stderr!" in stdout
+        assert "!This is a warning log msg!" not in stdout
+
         stdout = pytester.runpytest("--show-capture=no", "--tb=short").stdout.str()
         assert "!This is stdout!" not in stdout
         assert "!This is stderr!" not in stdout

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1665,6 +1665,11 @@ def pytest_report_header(config, start_path):
         assert "!stderr!" not in result
         assert "!log!" in result
 
+        result = pytester.runpytest("--show-capture=stdio", "--tb=short").stdout.str()
+        assert "!stdout!" in result
+        assert "!stderr!" in result
+        assert "!log!" not in result
+
         result = pytester.runpytest("--show-capture=no", "--tb=short").stdout.str()
         assert "!stdout!" not in result
         assert "!stderr!" not in result


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
Closes #11037

This issue resolves the inability to output stderr and stdout without log messages. We added a new choice called stdio which follows similar formatting to the other options and does what was requested in #11037. We added conditionals in the functions and confirmed with testing cases that showed no errors.