### PR TITLE
Make use of `-I` in all Python invocations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,7 +79,7 @@ jobs:
 
     - name: Install tox
       run: |
-        python -m pip install --upgrade pip
+        python -Im pip install --upgrade pip
         pip install --upgrade tox
 
     - name: Publish GitHub release notes

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -Im pip install --upgrade pip
         pip install --upgrade setuptools tox
 
     - name: Prepare release PR (minor/patch release)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,7 +186,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -Im pip install --upgrade pip
         pip install tox coverage
 
     - name: Test without coverage
@@ -201,7 +201,7 @@ jobs:
 
     - name: Generate coverage report
       if: "matrix.use_coverage"
-      run: python -m coverage xml
+      run: python -Im coverage xml
 
     - name: Upload coverage to Codecov
       if: "matrix.use_coverage"

--- a/.github/workflows/update-plugin-list.yml
+++ b/.github/workflows/update-plugin-list.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -Im pip install --upgrade pip
           pip install packaging requests tabulate[widechars] tqdm requests-cache platformdirs
 
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -299,7 +299,7 @@ Here is a simple overview, with pytest-specific bits:
 #. If instead of using ``tox`` you prefer to run the tests directly, then we suggest to create a virtual environment and use
    an editable install with the ``testing`` extra::
 
-       $ python3 -m venv .venv
+       $ python3 -Im venv .venv
        $ source .venv/bin/activate  # Linux
        $ .venv/Scripts/activate.bat  # Windows
        $ pip install -e ".[testing]"

--- a/doc/en/explanation/goodpractices.rst
+++ b/doc/en/explanation/goodpractices.rst
@@ -137,7 +137,7 @@ which are better explained in this excellent `blog post`_ by Ionel Cristian Măr
     directory) you can rely on the fact that Python by default puts the current directory in ``sys.path`` to
     import your package and run ``python -m pytest`` to execute the tests against the local copy directly.
 
-    See :ref:`pytest vs python -m pytest` for more information about the difference between calling ``pytest`` and
+    See :ref:`pytest vs python -Im pytest` for more information about the difference between calling ``pytest`` and
     ``python -m pytest``.
 
 Tests as part of application code

--- a/doc/en/explanation/pythonpath.rst
+++ b/doc/en/explanation/pythonpath.rst
@@ -130,13 +130,13 @@ imported in the global import namespace.
 
 This is also discussed in details in :ref:`test discovery`.
 
-.. _`pytest vs python -m pytest`:
+.. _`pytest vs python -Im pytest`:
 
-Invoking ``pytest`` versus ``python -m pytest``
------------------------------------------------
+Invoking ``pytest`` versus ``python -Im pytest``
+------------------------------------------------
 
-Running pytest with ``pytest [...]`` instead of ``python -m pytest [...]`` yields nearly
-equivalent behaviour, except that the latter will add the current directory to ``sys.path``, which
-is standard ``python`` behavior.
+Running pytest with ``pytest [...]`` instead of ``python -Im pytest [...]`` yields nearly
+equivalent behaviour, except that the latter will add the current directory to ``sys.path``
+in case when ``-I`` is omitted, which is standard ``python`` behavior.
 
 See also :ref:`invoke-python`.

--- a/doc/en/how-to/usage.rst
+++ b/doc/en/how-to/usage.rst
@@ -158,17 +158,20 @@ Other ways of calling pytest
 
 .. _invoke-python:
 
-Calling pytest through ``python -m pytest``
+Calling pytest through ``python -Im pytest``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can invoke testing through the Python interpreter from the command line:
 
 .. code-block:: text
 
-    python -m pytest [...]
+    python -Im pytest [...]
 
-This is almost equivalent to invoking the command line script ``pytest [...]``
-directly, except that calling via ``python`` will also add the current directory to ``sys.path``.
+This is equivalent to invoking the command line script ``pytest [...]``
+directly, for as long as ``-I`` is used. Dropping it will also add the current
+directory to ``sys.path``, which may have a side effect of not `testing your
+project as installed
+<https://blog.ganssle.io/articles/2019/08/test-as-installed.html>`__.
 
 
 .. _`pytest.main-usage`:

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -97,7 +97,7 @@ def pytest_addoption(parser: Parser) -> None:
         choices=("inprocess", "subprocess"),
         help=(
             "Run pytest sub runs in tests using an 'inprocess' "
-            "or 'subprocess' (python -m main) method"
+            "or 'subprocess' (python -Im main) method"
         ),
     )
 

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -589,17 +589,17 @@ class TestInvocationVariants:
 
     def test_python_minus_m_invocation_ok(self, pytester: Pytester) -> None:
         p1 = pytester.makepyfile("def test_hello(): pass")
-        res = pytester.run(sys.executable, "-m", "pytest", str(p1))
+        res = pytester.run(sys.executable, "-Im", "pytest", str(p1))
         assert res.ret == 0
 
     def test_python_minus_m_invocation_fail(self, pytester: Pytester) -> None:
         p1 = pytester.makepyfile("def test_fail(): 0/0")
-        res = pytester.run(sys.executable, "-m", "pytest", str(p1))
+        res = pytester.run(sys.executable, "-Im", "pytest", str(p1))
         assert res.ret == 1
 
     def test_python_pytest_package(self, pytester: Pytester) -> None:
         p1 = pytester.makepyfile("def test_pass(): pass")
-        res = pytester.run(sys.executable, "-m", "pytest", str(p1))
+        res = pytester.run(sys.executable, "-Im", "pytest", str(p1))
         assert res.ret == 0
         res.stdout.fnmatch_lines(["*1 passed*"])
 

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1702,18 +1702,18 @@ def test_exception_handling_no_traceback(pytester: Pytester) -> None:
     "cmdline_args, warning_output",
     [
         (
-            ["-OO", "-m", "pytest", "-h"],
+            ["-OO", "-Im", "pytest", "-h"],
             ["warning :*PytestConfigWarning:*assert statements are not executed*"],
         ),
         (
-            ["-OO", "-m", "pytest"],
+            ["-OO", "-Im", "pytest"],
             [
                 "=*= warnings summary =*=",
                 "*PytestConfigWarning:*assert statements are not executed*",
             ],
         ),
         (
-            ["-OO", "-m", "pytest", "--assert=plain"],
+            ["-OO", "-Im", "pytest", "--assert=plain"],
             [
                 "=*= warnings summary =*=",
                 "*PytestConfigWarning: ASSERTIONS ARE NOT EXECUTED and FAILING TESTS WILL PASS.  "

--- a/testing/test_parseopt.py
+++ b/testing/test_parseopt.py
@@ -317,7 +317,7 @@ def test_argcomplete(pytester: Pytester, monkeypatch: MonkeyPatch) -> None:
         # http://stackoverflow.com/q/12589419/1307905
         # so we use bash
         fp.write(
-            'COMP_WORDBREAKS="$COMP_WORDBREAKS" {} -m pytest 8>&1 9>&2'.format(
+            'COMP_WORDBREAKS="$COMP_WORDBREAKS" {} -Im pytest 8>&1 9>&2'.format(
                 shlex.quote(sys.executable)
             )
         )

--- a/testing/test_setuponly.py
+++ b/testing/test_setuponly.py
@@ -313,6 +313,6 @@ def test_show_fixture_action_with_bytes(pytester: Pytester) -> None:
         """
     )
     result = pytester.run(
-        sys.executable, "-bb", "-m", "pytest", "--setup-show", str(test_file)
+        sys.executable, "-bb", "-Im", "pytest", "--setup-show", str(test_file)
     )
     assert result.ret == 0

--- a/tox.ini
+++ b/tox.ini
@@ -129,7 +129,7 @@ setenv =
 pip_pre=true
 # use latest pip to get new dependency resolver (#7783)
 download=true
-install_command=python -m pip install {opts} {packages}
+install_command=python -Im pip install {opts} {packages}
 changedir = testing/plugins_integration
 deps = -rtesting/plugins_integration/requirements.txt
 setenv =


### PR DESCRIPTION
This helps prevent testing the non-installed source. Additionally, the patch updates the docs to demonstrate a more predictable runpy-style invocation method.
