### PR TITLE
Resolving Issue #10825

### DIFF
--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -340,6 +340,12 @@ class TestReport(BaseReport):
                 str,
                 TerminalRepr,
             ] = None
+        elif call.excinfo and when in ("setup", "teardown"):
+            outcome = "passed"
+            longrepr = excinfo
+            TerminalWriter().write(
+                msg=f"<Warning! You are using '{when}' file in your code>", Yellow=True
+            )
         else:
             if not isinstance(excinfo, ExceptionInfo):
                 outcome = "failed"

--- a/testing/test_setup.py
+++ b/testing/test_setup.py
@@ -1,0 +1,15 @@
+def foo():
+    """
+    >>> foo()
+    'bar'
+    """
+    return "bar"
+
+
+def setup():
+    # """
+    # >>> setup()
+    # 'ban'
+    # """
+    # return "ban"
+    raise RuntimeError("Setup called!!! Oh No")


### PR DESCRIPTION
Hello,

This PR resolves #10825 issue. It is related to the new versions of PyTest and not reproducible on the main branch.

# Description #
If the user adds doctest to a test file, if there is a function in the code `setup()` or `teardown()` that is not used for test, they would be automatically called. This would basically cause a very long error message which is not even related to the actual test:
![Screenshot from 2023-12-07 00-17-52](https://github.com/pytest-dev/pytest/assets/79033602/dcc62b49-ee71-452c-a48c-2f0dd81c13d2)

# Solution #
To avoid this long error message, I have added code for this edge case to basically ignore the error caused by it. A warning message is also added to inform the user about using a function name (setup or teardown) that might cause problem. Here is the new outcome for the same test:
![Screenshot from 2023-12-07 00-12-38](https://github.com/pytest-dev/pytest/assets/79033602/e802b302-bb71-4598-a7cd-5c0e137e47e8)
This would make the API report only the actual test which is the other function, have a much cleaner output and inform the user about possible bugs that having a function in the specific name might have.

I hope it would come in handy.

Thanks,
Ardavan
