### PR TITLE
Resolving Issue #11666

### DIFF
--- a/src/_pytest/_io/terminalwriter.py
+++ b/src/_pytest/_io/terminalwriter.py
@@ -215,13 +215,56 @@ class TerminalWriter:
             return source
         else:
             try:
-                from pygments.formatters.terminal256 import TerminalTrueColorFormatter
-                from pygments.formatters.terminal256 import Terminal256Formatter
+                from pygments.style import Style
+                from pygments.token import (
+                    Token,
+                    Comment,
+                    Keyword,
+                    Name,
+                    String,
+                    Error,
+                    Generic,
+                    Number,
+                    Operator,
+                )
 
+                from pygments.formatters.terminal256 import TerminalTrueColorFormatter
+
+                # Set the terminal formatter to better performing formatters is user environement allows for it
                 if os.environ.get('COLORTERM','') in ('truecolor', '24bit'):
                     terminal_formatter = TerminalTrueColorFormatter()
                 elif '256' in os.environ.get('TERM', ''):
-                    terminal_formatter = Terminal256Formatter()
+                    # Create new styling for 256 Formatter
+                    class Updated256Style(Style):
+                        # Set color values for the 256 Formatter
+                        styles = {
+                            Token: (""),
+                            Comment: ("ansigray"),
+                            Comment.Preproc: ("ansicyan"),
+                            Keyword: ("ansiblue"),
+                            Keyword.Type: ("ansicyan"),
+                            Operator.Word: ("ansimagenta"),
+                            Name.Builtin: ("ansicyan"),
+                            Name.Function: ("ansigreen"),
+                            Name.Namespace: ("ansicyan"),
+                            Name.Class: ("ansigreen"),
+                            Name.Exception: ("ansicyan"),
+                            Name.Decorator: ("ansibrightblack"),
+                            Name.Variable: ("ansired"),
+                            Name.Constant: ("ansired"),
+                            Name.Attribute: ("ansicyan"),
+                            Name.Tag: ("ansibrightblue"),
+                            String: ("ansiyellow"),
+                            Number: ("ansiblue"),
+                            Generic.Deleted: ("ansibrightred"),
+                            Generic.Inserted: ("ansigreen"),
+                            Generic.Subheading: ("ansimagenta"),
+                            Generic.Error: ("ansibrightred"),
+                            Error: ("ansibrightred"),
+                        }
+
+                    from pygments.formatters.terminal256 import Terminal256Formatter
+                    terminal_formatter = Terminal256Formatter(style=Updated256Style)
                 else:
                     terminal_formatter = TerminalFormatter(
                                             bg=os.getenv("PYTEST_THEME_MODE", "dark"),

--- a/src/_pytest/_io/terminalwriter.py
+++ b/src/_pytest/_io/terminalwriter.py
@@ -228,11 +228,39 @@ class TerminalWriter:
                     Operator,
                 )
 
-                from pygments.formatters.terminal256 import TerminalTrueColorFormatter
-
                 # Set the terminal formatter to better performing formatters is user environement allows for it
                 if os.environ.get('COLORTERM','') in ('truecolor', '24bit'):
-                    terminal_formatter = TerminalTrueColorFormatter()
+                    # Create new styling for True Color Formatter
+                    class UpdatedTrueStyle(Style):
+                        # Set color values for the True Color Formatter
+                        styles = {
+                            Token: (""),
+                            Comment: ("ansigray"),
+                            Comment.Preproc: ("ansicyan"),
+                            Keyword: ("ansiblue"),
+                            Keyword.Type: ("ansicyan"),
+                            Operator.Word: ("ansimagenta"),
+                            Name.Builtin: ("ansicyan"),
+                            Name.Function: ("ansigreen"),
+                            Name.Namespace: ("ansicyan"),
+                            Name.Class: ("ansigreen"),
+                            Name.Exception: ("ansicyan"),
+                            Name.Decorator: ("ansibrightblack"),
+                            Name.Variable: ("ansired"),
+                            Name.Constant: ("ansired"),
+                            Name.Attribute: ("ansicyan"),
+                            Name.Tag: ("ansibrightblue"),
+                            String: ("ansiyellow"),
+                            Number: ("ansiblue"),
+                            Generic.Deleted: ("ansibrightred"),
+                            Generic.Inserted: ("ansigreen"),
+                            Generic.Subheading: ("ansimagenta"),
+                            Generic.Error: ("ansibrightred"),
+                            Error: ("ansibrightblue"),
+                        }
+
+                    from pygments.formatters.terminal256 import TerminalTrueColorFormatter
+                    terminal_formatter = TerminalTrueColorFormatter(style=UpdatedTrueStyle)
                 elif '256' in os.environ.get('TERM', ''):
                     # Create new styling for 256 Formatter
                     class Updated256Style(Style):

--- a/src/_pytest/_io/terminalwriter.py
+++ b/src/_pytest/_io/terminalwriter.py
@@ -229,7 +229,7 @@ class TerminalWriter:
                 )
 
                 # Set the terminal formatter to better performing formatters is user environement allows for it
-                if os.environ.get('COLORTERM','') in ('truecolor', '24bit'):
+                if os.environ.get("COLORTERM", "") in ("truecolor", "24bit"):
                     # Create new styling for True Color Formatter
                     class UpdatedTrueStyle(Style):
                         # Set color values for the True Color Formatter
@@ -259,9 +259,14 @@ class TerminalWriter:
                             Error: ("ansibrightblue"),
                         }
 
-                    from pygments.formatters.terminal256 import TerminalTrueColorFormatter
-                    terminal_formatter = TerminalTrueColorFormatter(style=UpdatedTrueStyle)
-                elif '256' in os.environ.get('TERM', ''):
+                    from pygments.formatters.terminal256 import (
+                        TerminalTrueColorFormatter,
+                    )
+
+                    terminal_formatter = TerminalTrueColorFormatter(
+                        style=UpdatedTrueStyle
+                    )
+                elif "256" in os.environ.get("TERM", ""):
                     # Create new styling for 256 Formatter
                     class Updated256Style(Style):
                         # Set color values for the 256 Formatter
@@ -292,12 +297,13 @@ class TerminalWriter:
                         }
 
                     from pygments.formatters.terminal256 import Terminal256Formatter
+
                     terminal_formatter = Terminal256Formatter(style=Updated256Style)
                 else:
                     terminal_formatter = TerminalFormatter(
-                                            bg=os.getenv("PYTEST_THEME_MODE", "dark"),
-                                            style=os.getenv("PYTEST_THEME"),
-                                            )
+                        bg=os.getenv("PYTEST_THEME_MODE", "dark"),
+                        style=os.getenv("PYTEST_THEME"),
+                    )
                 highlighted: str = highlight(
                     source,
                     Lexer(),

--- a/src/_pytest/_io/terminalwriter.py
+++ b/src/_pytest/_io/terminalwriter.py
@@ -215,13 +215,22 @@ class TerminalWriter:
             return source
         else:
             try:
+                from pygments.formatters.terminal256 import TerminalTrueColorFormatter
+                from pygments.formatters.terminal256 import Terminal256Formatter
+
+                if os.environ.get('COLORTERM','') in ('truecolor', '24bit'):
+                    terminal_formatter = TerminalTrueColorFormatter()
+                elif '256' in os.environ.get('TERM', ''):
+                    terminal_formatter = Terminal256Formatter()
+                else:
+                    terminal_formatter = TerminalFormatter(
+                                            bg=os.getenv("PYTEST_THEME_MODE", "dark"),
+                                            style=os.getenv("PYTEST_THEME"),
+                                            )
                 highlighted: str = highlight(
                     source,
                     Lexer(),
-                    TerminalFormatter(
-                        bg=os.getenv("PYTEST_THEME_MODE", "dark"),
-                        style=os.getenv("PYTEST_THEME"),
-                    ),
+                    terminal_formatter,
                 )
                 return highlighted
             except pygments.util.ClassNotFound:

--- a/test_terminalwriter_styling.py
+++ b/test_terminalwriter_styling.py
@@ -1,0 +1,88 @@
+from typing import Any
+import pytest
+import warnings
+
+@pytest.fixture()
+def test_terminal_formatter_styling_one():
+    # Check assert with message
+    assert 1 + 1 == 2 
+    assert 2 + 2 == 5, "This assertion has a failure message"
+    
+@pytest.fixture()
+def test_terminal_formatter_styling_two():
+    # Check fail with message
+    pytest.fail("Test fails with pytest.fail()")  
+    
+@pytest.fixture()
+def test_terminal_formatter_styling_three():  
+    # Check xfail with message  
+    pytest.xfail("Test is expected to fail with pytest.xfail()")  
+    
+@pytest.fixture()
+def test_terminal_formatter_styling_four(): 
+    # Check skip with message   
+    pytest.skip("Test skipped with pytest.skip()") 
+
+@pytest.fixture()
+def test_terminal_formatter_styling_five():
+    # Check raise with message
+    with pytest.raises(ValueError, match="Custom error message"):
+        raise ValueError("Custom error message")
+
+@pytest.fixture()
+def test_terminal_formatter_styling_six():
+    # Check warning with message
+    with pytest.warns(UserWarning, match="Custom warning message"):
+        warnings.warn("Custom warning message", UserWarning)
+
+@pytest.fixture()
+def test_terminal_formatter_styling_seven():
+    @pytest.mark.custom_mark
+    def test_custom_mark():
+        pass
+
+    # Check for the custom mark
+    config = pytest.config
+    if hasattr(config, 'getini'):
+        config.getini("markers")  
+
+    # Check ouput with message
+    captured_output = "This should be captured"
+    with pytest.raises(AssertionError, match=captured_output):
+        assert captured_output == "This should not be captured"
+
+@pytest.fixture
+def test_terminal_formatter_styling_eight():
+    # Check printing of function
+    @pytest.mark.parametrize("input, expected", [("input1", "expected1"), ("input2", "expected2")])
+    def test_parameterized(input, expected):
+        assert input == expected
+
+    # Guarantee fail and output
+    assert False, "This test should fail for styling demonstration purposes"
+
+# Call all tests
+def test_one(test_terminal_formatter_styling_one):
+    ...
+
+def test_two(test_terminal_formatter_styling_two):
+    ...
+
+def test_three(test_terminal_formatter_styling_three):
+    ...
+
+def test_four(test_terminal_formatter_styling_four):
+    ...
+
+def test_five(test_terminal_formatter_styling_five):
+    ...
+
+def test_six(test_terminal_formatter_styling_six):
+    ...
+
+def test_seven(test_terminal_formatter_styling_seven):
+    ...
+
+def test_eight(test_terminal_formatter_styling_eight):
+    ...
+    

--- a/test_terminalwriter_styling.py
+++ b/test_terminalwriter_styling.py
@@ -1,27 +1,32 @@
-from typing import Any
-import pytest
 import warnings
+
+import pytest
+
 
 @pytest.fixture()
 def test_terminal_formatter_styling_one():
     # Check assert with message
-    assert 1 + 1 == 2 
+    assert 1 + 1 == 2
     assert 2 + 2 == 5, "This assertion has a failure message"
-    
+
+
 @pytest.fixture()
 def test_terminal_formatter_styling_two():
     # Check fail with message
-    pytest.fail("Test fails with pytest.fail()")  
-    
+    pytest.fail("Test fails with pytest.fail()")
+
+
 @pytest.fixture()
-def test_terminal_formatter_styling_three():  
-    # Check xfail with message  
-    pytest.xfail("Test is expected to fail with pytest.xfail()")  
-    
+def test_terminal_formatter_styling_three():
+    # Check xfail with message
+    pytest.xfail("Test is expected to fail with pytest.xfail()")
+
+
 @pytest.fixture()
-def test_terminal_formatter_styling_four(): 
-    # Check skip with message   
-    pytest.skip("Test skipped with pytest.skip()") 
+def test_terminal_formatter_styling_four():
+    # Check skip with message
+    pytest.skip("Test skipped with pytest.skip()")
+
 
 @pytest.fixture()
 def test_terminal_formatter_styling_five():
@@ -29,11 +34,13 @@ def test_terminal_formatter_styling_five():
     with pytest.raises(ValueError, match="Custom error message"):
         raise ValueError("Custom error message")
 
+
 @pytest.fixture()
 def test_terminal_formatter_styling_six():
     # Check warning with message
     with pytest.warns(UserWarning, match="Custom warning message"):
         warnings.warn("Custom warning message", UserWarning)
+
 
 @pytest.fixture()
 def test_terminal_formatter_styling_seven():
@@ -43,46 +50,56 @@ def test_terminal_formatter_styling_seven():
 
     # Check for the custom mark
     config = pytest.config
-    if hasattr(config, 'getini'):
-        config.getini("markers")  
+    if hasattr(config, "getini"):
+        config.getini("markers")
 
     # Check ouput with message
     captured_output = "This should be captured"
     with pytest.raises(AssertionError, match=captured_output):
         assert captured_output == "This should not be captured"
 
+
 @pytest.fixture
 def test_terminal_formatter_styling_eight():
     # Check printing of function
-    @pytest.mark.parametrize("input, expected", [("input1", "expected1"), ("input2", "expected2")])
+    @pytest.mark.parametrize(
+        "input, expected", [("input1", "expected1"), ("input2", "expected2")]
+    )
     def test_parameterized(input, expected):
         assert input == expected
 
     # Guarantee fail and output
     assert False, "This test should fail for styling demonstration purposes"
 
+
 # Call all tests
 def test_one(test_terminal_formatter_styling_one):
     ...
 
+
 def test_two(test_terminal_formatter_styling_two):
     ...
+
 
 def test_three(test_terminal_formatter_styling_three):
     ...
 
+
 def test_four(test_terminal_formatter_styling_four):
     ...
+
 
 def test_five(test_terminal_formatter_styling_five):
     ...
 
+
 def test_six(test_terminal_formatter_styling_six):
     ...
+
 
 def test_seven(test_terminal_formatter_styling_seven):
     ...
 
+
 def test_eight(test_terminal_formatter_styling_eight):
     ...
-    


### PR DESCRIPTION
Hello,

This PR resolves https://github.com/pytest-dev/pytest/issues/11666.

<h1>Description: </h1>
Pytest is currently using the TerminalFormatter class from the Pygments library as the application’s universal terminal formatter. This issue focuses on using newer terminal formatters from Pygments which would improve the richness of color and the styling quality. 

<h1>Solution:</h1>
We addressed the issue by implementing the Terminal256Formatter and the TerminalTrueColorFormatter classes, and selected one of the three formatters based on the user’s operating system capabilities.

![image](https://github.com/pytest-dev/pytest/assets/117669511/74f69093-162e-41dd-a758-9f6bb1f5041d)

Since the dark styling used in the TerminalFormatter class is not an option for either of the new formatters, we also created a new styling to closely match the dark Pytest design. 

![image](https://github.com/pytest-dev/pytest/assets/117669511/8902fd7b-5596-4e11-afc6-f68e4f6096ff)

This gives us the following results:

![image](https://github.com/pytest-dev/pytest/assets/117669511/d1585c78-1681-4c32-b1ac-34beb9c6d25c)
![image](https://github.com/pytest-dev/pytest/assets/117669511/e84dbb8e-2bbe-44fc-b49e-31eab3f05b01)

<h1>Information</h1>
Head-fork: tyyan03/pytest
compare: issue11666

base-fork: pytest-dev/pytest
base: main

Thanks,
Tyler and Rowan