### PR TITLE
FIX key formating divergence when inspecting plugin dictionary.

### DIFF
--- a/changelog/9765.bugfix.rst
+++ b/changelog/9765.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a frustrating bug that afflicted some users with the only error being ``assert mod not in mods``. The issue was caused by the fact that ``str(Path(mod))`` and ``mod.__file__`` don't necessarily produce the same string, and was being erroneously used interchangably in some places in the code.
+
+This fix also broke the internal API of ``PytestPluginManager.consider_conftest`` by introducing a new parameter -- we mention this in case it is being used by external code, even if marked as *private*.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -634,7 +634,8 @@ class PytestPluginManager(PluginManager):
     def _importconftest(
         self, conftestpath: Path, importmode: Union[str, ImportMode], rootpath: Path
     ) -> types.ModuleType:
-        existing = self.get_plugin(str(conftestpath))
+        conftestpath_plugin_name = str(conftestpath)
+        existing = self.get_plugin(conftestpath_plugin_name)
         if existing is not None:
             return cast(types.ModuleType, existing)
 
@@ -666,7 +667,7 @@ class PytestPluginManager(PluginManager):
                     assert mod not in mods
                     mods.append(mod)
         self.trace(f"loading conftestmodule {mod!r}")
-        self.consider_conftest(mod)
+        self.consider_conftest(mod, registration_name=conftestpath_plugin_name)
         return mod
 
     def _check_non_top_pytest_plugins(
@@ -746,9 +747,11 @@ class PytestPluginManager(PluginManager):
                     del self._name2plugin["pytest_" + name]
             self.import_plugin(arg, consider_entry_points=True)
 
-    def consider_conftest(self, conftestmodule: types.ModuleType) -> None:
+    def consider_conftest(
+        self, conftestmodule: types.ModuleType, registration_name: str
+    ) -> None:
         """:meta private:"""
-        self.register(conftestmodule, name=conftestmodule.__file__)
+        self.register(conftestmodule, name=registration_name)
 
     def consider_env(self) -> None:
         """:meta private:"""


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/issues/9765

What happens is that `str(conftestpath)` is not necessarily equal to `mod.__file__`, which is the key that is really used in `self._name2plugin`. For instance I've noticed that on windows, the `module.__file__` string for some modules is sometimes small cased (`c:\\users...`), while `str(conftestpath)` is not (`C:\\Users...`). For my particular reproducer of https://github.com/pytest-dev/pytest/issues/9765, it causes some plugins loaded from conftest to be double loaded, since the preliminary lookup fails because the key is wrong. And double-loading leads to a crash.

This might not be a good fix if there are other direct calls to `self.register` in other areas of the code base that would risk to format the keys differently when it's crafted from paths to conftest files, but I've not found any evidences of that.
