### PR TITLE
nodes: fix tracebacks from collection errors are not getting pruned

### DIFF
--- a/changelog/11710.bugfix.rst
+++ b/changelog/11710.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed tracebacks from collection errors not getting pruned.

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -579,7 +579,7 @@ class Collector(Node, abc.ABC):
             ntraceback = traceback.cut(path=self.path)
             if ntraceback == traceback:
                 ntraceback = ntraceback.cut(excludepath=tracebackcutdir)
-            return excinfo.traceback.filter(excinfo)
+            return ntraceback.filter(excinfo)
         return excinfo.traceback
 
 

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -16,7 +16,6 @@ from _pytest.nodes import Item
 from _pytest.pathlib import symlink_or_skip
 from _pytest.pytester import HookRecorder
 from _pytest.pytester import Pytester
-from _pytest._code.code import ExceptionChainRepr, ReprTraceback
 
 
 def ensure_file(file_path: Path) -> Path:


### PR DESCRIPTION
Fix #11710.