### PR TITLE
Fix handling empty values of NO_COLOR and FORCE_COLOR

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -266,6 +266,7 @@ Michael Goerz
 Michael Krebs
 Michael Seifert
 Michal Wajszczuk
+Michał Górny
 Michał Zięba
 Mickey Pashov
 Mihai Capotă

--- a/changelog/11712.bugfix.rst
+++ b/changelog/11712.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed handling ``NO_COLOR`` and ``FORCE_COLOR`` to ignore an empty value.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1146,13 +1146,13 @@ When set to ``0``, pytest will not use color.
 
 .. envvar:: NO_COLOR
 
-When set (regardless of value), pytest will not use color in terminal output.
+When set to a non-empty string (regardless of value), pytest will not use color in terminal output.
 ``PY_COLORS`` takes precedence over ``NO_COLOR``, which takes precedence over ``FORCE_COLOR``.
 See `no-color.org <https://no-color.org/>`__ for other libraries supporting this community standard.
 
 .. envvar:: FORCE_COLOR
 
-When set (regardless of value), pytest will use color in terminal output.
+When set to a non-empty string (regardless of value), pytest will use color in terminal output.
 ``PY_COLORS`` and ``NO_COLOR`` take precedence over ``FORCE_COLOR``.
 
 Exceptions

--- a/src/_pytest/_io/terminalwriter.py
+++ b/src/_pytest/_io/terminalwriter.py
@@ -29,9 +29,9 @@ def should_do_markup(file: TextIO) -> bool:
         return True
     if os.environ.get("PY_COLORS") == "0":
         return False
-    if "NO_COLOR" in os.environ:
+    if os.environ.get("NO_COLOR"):
         return False
-    if "FORCE_COLOR" in os.environ:
+    if os.environ.get("FORCE_COLOR"):
         return True
     return (
         hasattr(file, "isatty") and file.isatty() and os.environ.get("TERM") != "dumb"

--- a/testing/io/test_terminalwriter.py
+++ b/testing/io/test_terminalwriter.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 from pathlib import Path
 from typing import Generator
+from typing import Optional
 from unittest import mock
 
 import pytest
@@ -164,59 +165,67 @@ def test_attr_hasmarkup() -> None:
     assert "\x1b[0m" in s
 
 
-def assert_color_set():
+def assert_color(expected: bool, default: Optional[bool] = None) -> None:
     file = io.StringIO()
-    tw = terminalwriter.TerminalWriter(file)
-    assert tw.hasmarkup
+    if default is None:
+        default = not expected
+    file.isatty = lambda: default  # type: ignore
+    tw = terminalwriter.TerminalWriter(file=file)
+    assert tw.hasmarkup is expected
     tw.line("hello", bold=True)
     s = file.getvalue()
-    assert len(s) > len("hello\n")
-    assert "\x1b[1m" in s
-    assert "\x1b[0m" in s
-
-
-def assert_color_not_set():
-    f = io.StringIO()
-    f.isatty = lambda: True  # type: ignore
-    tw = terminalwriter.TerminalWriter(file=f)
-    assert not tw.hasmarkup
-    tw.line("hello", bold=True)
-    s = f.getvalue()
-    assert s == "hello\n"
+    if expected:
+        assert len(s) > len("hello\n")
+        assert "\x1b[1m" in s
+        assert "\x1b[0m" in s
+    else:
+        assert s == "hello\n"
 
 
 def test_should_do_markup_PY_COLORS_eq_1(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setitem(os.environ, "PY_COLORS", "1")
-    assert_color_set()
+    assert_color(True)
 
 
 def test_should_not_do_markup_PY_COLORS_eq_0(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setitem(os.environ, "PY_COLORS", "0")
-    assert_color_not_set()
+    assert_color(False)
 
 
 def test_should_not_do_markup_NO_COLOR(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setitem(os.environ, "NO_COLOR", "1")
-    assert_color_not_set()
+    assert_color(False)
 
 
 def test_should_do_markup_FORCE_COLOR(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setitem(os.environ, "FORCE_COLOR", "1")
-    assert_color_set()
+    assert_color(True)
 
 
-def test_should_not_do_markup_NO_COLOR_and_FORCE_COLOR(
+@pytest.mark.parametrize(
+    ["NO_COLOR", "FORCE_COLOR", "expected"],
+    [
+        ("1", "1", False),
+        ("", "1", True),
+        ("1", "", False),
+    ],
+)
+def test_NO_COLOR_and_FORCE_COLOR(
     monkeypatch: MonkeyPatch,
+    NO_COLOR: str,
+    FORCE_COLOR: str,
+    expected: bool,
 ) -> None:
-    monkeypatch.setitem(os.environ, "NO_COLOR", "1")
-    monkeypatch.setitem(os.environ, "FORCE_COLOR", "1")
-    assert_color_not_set()
+    monkeypatch.setitem(os.environ, "NO_COLOR", NO_COLOR)
+    monkeypatch.setitem(os.environ, "FORCE_COLOR", FORCE_COLOR)
+    assert_color(expected)
 
 
-def test_empty_NO_COLOR_ignored(monkeypatch: MonkeyPatch) -> None:
+def test_empty_NO_COLOR_and_FORCE_COLOR_ignored(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setitem(os.environ, "NO_COLOR", "")
-    monkeypatch.setitem(os.environ, "FORCE_COLOR", "1")
-    assert_color_set()
+    monkeypatch.setitem(os.environ, "FORCE_COLOR", "")
+    assert_color(True, True)
+    assert_color(False, False)
 
 
 class TestTerminalWriterLineWidth:

--- a/testing/io/test_terminalwriter.py
+++ b/testing/io/test_terminalwriter.py
@@ -213,6 +213,12 @@ def test_should_not_do_markup_NO_COLOR_and_FORCE_COLOR(
     assert_color_not_set()
 
 
+def test_empty_NO_COLOR_ignored(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setitem(os.environ, "NO_COLOR", "")
+    monkeypatch.setitem(os.environ, "FORCE_COLOR", "1")
+    assert_color_set()
+
+
 class TestTerminalWriterLineWidth:
     def test_init(self) -> None:
         tw = terminalwriter.TerminalWriter()


### PR DESCRIPTION
Fix handling NO_COLOR and FORCE_COLOR environment variables to correctly be ignored when they are set to an empty value, as defined in the specification:

> Command-line software which adds ANSI color to its output by default
> should check for a NO_COLOR environment variable that, when present
> *and not an empty string* (regardless of its value), prevents
> the addition of ANSI color.

(emphasis mine, https://no-color.org/)

The same is true of FORCE_COLOR, https://force-color.org/.

----

- [ ] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
