### PR TITLE
Adding a non regression test for #9765

### DIFF
--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -114,7 +114,7 @@ class TestPytestPluginInteractions:
         pytester.makepyfile(**{"tests/conftest.py": ""})
 
         conftest = pytester.path.joinpath("tests/conftest.py")
-        conftest_lower = type(conftest)("TESTS/CONFTEST.PY")
+        conftest_lower = pytester.path.joinpath("TESTS/conftest.py")
 
         mod = config.pluginmanager._importconftest(
             conftest, importmode="prepend", rootpath=pytester.path

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -129,6 +129,32 @@ class TestPytestPluginInteractions:
             conftest_lower, importmode="prepend", rootpath=pytester.path
         )
 
+    def test_conftestpath_no_normalization(self, pytester: Pytester) -> None:
+        """Non-regression test for https://github.com/pytest-dev/pytest/issues/9765
+
+        Ensures that the conftests are registered in the plugin dictionary with a key
+        that does not depend on the normalization of the input path.
+        """
+
+        config = pytester.parseconfig()
+        pytester.makepyfile(**{"tests/conftest.py": ""})
+
+        conftest = pytester.path.joinpath("tests/conftest.py")
+        contest_similar = pytester.path.joinpath("tests/../tests/conftest.py")
+
+        mod = config.pluginmanager._importconftest(
+            conftest, importmode="prepend", rootpath=pytester.path
+        )
+
+        # Those two calls should succeed because the conftest should be registered
+        # independently of the normalization of conftestpath.
+        assert mod is config.pluginmanager._importconftest(
+            conftest, importmode="prepend", rootpath=pytester.path
+        )
+        assert mod is config.pluginmanager._importconftest(
+            contest_similar, importmode="prepend", rootpath=pytester.path
+        )
+
     def test_hook_tracing(self, _config_for_test: Config) -> None:
         pytestpm = _config_for_test.pluginmanager  # fully initialized with plugins
         saveindent = []

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -114,7 +114,7 @@ class TestPytestPluginInteractions:
         pytester.makepyfile(**{"tests/conftest.py": ""})
 
         conftest = pytester.path.joinpath("tests/conftest.py")
-        conftest_lower = pytester.path.joinpath("TESTS/CONFTEST.PY")
+        conftest_lower = type(conftest)("TESTS/CONFTEST.PY")
 
         mod = config.pluginmanager._importconftest(
             conftest, importmode="prepend", rootpath=pytester.path


### PR DESCRIPTION
Non regression test for #9765

The test is expected to fail here, and to be fixed in https://github.com/pytest-dev/pytest/pull/11708 .

Note that the test does not reproduce directly the cause of #9765 but is a best effort at reproducing the mechanism. In #9765 we were surprised of the formatting of `mod.__file__` because it differs from `str(conftestpath)` although `str(conftestpath)` has not been altered.

Here we trigger an issue by submitting an altered `conftestpath` although `mod.__file__`  most likely would have the expected value. It does not reproduce the crash linked to double loading, but instead highlights that modules that should have been the same are in fact different.

I haven't found any documentation or PEP that says how `mod.__file__` can be expected to be formatted, so in fact we could expect it to have any weird formatting as long as it resolves to `str(conftestpath)` so I think it is correct to run `_importconftest` once more with the original input like proposed in this PR.