### PR TITLE
Change "Marks applied to fixtures" removal from 8 to 9

### DIFF
--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -12,6 +12,7 @@ from warnings import warn
 
 from _pytest.warning_types import PytestDeprecationWarning
 from _pytest.warning_types import PytestRemovedIn8Warning
+from _pytest.warning_types import PytestRemovedIn9Warning
 from _pytest.warning_types import UnformattedWarning
 
 # set of plugins which have been integrated into the core; we use this list to ignore
@@ -122,7 +123,7 @@ HOOK_LEGACY_MARKING = UnformattedWarning(
     "#configuring-hook-specs-impls-using-markers",
 )
 
-MARKED_FIXTURE = PytestRemovedIn8Warning(
+MARKED_FIXTURE = PytestRemovedIn9Warning(
     "Marks applied to fixtures have no effect\n"
     "See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function"
 )

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -290,7 +290,7 @@ def test_importing_instance_is_deprecated(pytester: Pytester) -> None:
 def test_fixture_disallow_on_marked_functions():
     """Test that applying @pytest.fixture to a marked function warns (#3364)."""
     with pytest.warns(
-        pytest.PytestRemovedIn8Warning,
+        pytest.PytestRemovedIn9Warning,
         match=r"Marks applied to fixtures have no effect",
     ) as record:
 
@@ -309,7 +309,7 @@ def test_fixture_disallow_on_marked_functions():
 def test_fixture_disallow_marks_on_fixtures():
     """Test that applying a mark to a fixture warns (#3364)."""
     with pytest.warns(
-        pytest.PytestRemovedIn8Warning,
+        pytest.PytestRemovedIn9Warning,
         match=r"Marks applied to fixtures have no effect",
     ) as record:
 
@@ -325,7 +325,7 @@ def test_fixture_disallow_marks_on_fixtures():
 def test_fixture_disallowed_between_marks():
     """Test that applying a mark to a fixture warns (#3364)."""
     with pytest.warns(
-        pytest.PytestRemovedIn8Warning,
+        pytest.PytestRemovedIn9Warning,
         match=r"Marks applied to fixtures have no effect",
     ) as record:
 


### PR DESCRIPTION
The deprecation has only been added in 8.0, so can't be removed in 8. That will have to wait for 9.