### PR TITLE
[7.4.x] Ensure the docstring is a string

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -376,6 +376,7 @@ Tomer Keren
 Tony Narlock
 Tor Colvin
 Trevor Bekolay
+Tushar Sadhwani
 Tyler Goodlet
 Tyler Smart
 Tzu-ping Chung

--- a/changelog/11140.bugfix.rst
+++ b/changelog/11140.bugfix.rst
@@ -1,0 +1,1 @@
+Fix non-string constants at the top of file being detected as docstrings on Python>=3.8.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -604,6 +604,13 @@ def _get_assertion_exprs(src: bytes) -> Dict[int, str]:
     return ret
 
 
+def _get_ast_constant_value(value: astStr) -> object:
+    if sys.version_info >= (3, 8):
+        return value.value
+    else:
+        return value.s
+
+
 class AssertionRewriter(ast.NodeVisitor):
     """Assertion rewriting implementation.
 
@@ -700,11 +707,10 @@ class AssertionRewriter(ast.NodeVisitor):
                 expect_docstring
                 and isinstance(item, ast.Expr)
                 and isinstance(item.value, astStr)
+                and isinstance(_get_ast_constant_value(item.value), str)
             ):
-                if sys.version_info >= (3, 8):
-                    doc = item.value.value
-                else:
-                    doc = item.value.s
+                doc = _get_ast_constant_value(item.value)
+                assert isinstance(doc, str)
                 if self.is_rewrite_disabled(doc):
                     return
                 expect_docstring = False

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -2077,3 +2077,17 @@ class TestReprSizeVerbosity:
         self.create_test_file(pytester, DEFAULT_REPR_MAX_SIZE * 10)
         result = pytester.runpytest("-vv")
         result.stdout.no_fnmatch_line("*xxx...xxx*")
+
+
+class TestIssue11140:
+    def test_constant_not_picked_as_module_docstring(self, pytester: Pytester) -> None:
+        pytester.makepyfile(
+            """\
+            0
+
+            def test_foo():
+                pass
+            """
+        )
+        result = pytester.runpytest()
+        assert result.ret == 0


### PR DESCRIPTION
(cherry picked from commit 084d756ae6a03bba7a257ebae3c83095b228988f)

[ran: adapted to 7.4.x, fixed changelog issue number]

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
