### PR TITLE
terminalwriter: fix crash trying to highlight empty source

### DIFF
--- a/changelog/11758.bugfix.rst
+++ b/changelog/11758.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``IndexError: string index out of range`` crash in ``if highlighted[-1] == "\n" and source[-1] != "\n"``.
+This bug was introduced in pytest 8.0.0rc1.

--- a/src/_pytest/_io/terminalwriter.py
+++ b/src/_pytest/_io/terminalwriter.py
@@ -200,8 +200,9 @@ class TerminalWriter:
         """Highlight the given source if we have markup support."""
         from _pytest.config.exceptions import UsageError
 
-        if not self.hasmarkup or not self.code_highlight:
+        if not source or not self.hasmarkup or not self.code_highlight:
             return source
+
         try:
             from pygments.formatters.terminal import TerminalFormatter
 

--- a/testing/io/test_terminalwriter.py
+++ b/testing/io/test_terminalwriter.py
@@ -306,3 +306,17 @@ def test_code_highlight(has_markup, code_highlight, expected, color_mapping):
         match=re.escape("indents size (2) should have same size as lines (1)"),
     ):
         tw._write_source(["assert 0"], [" ", " "])
+
+
+def test_highlight_empty_source() -> None:
+    """Don't crash trying to highlight empty source code.
+
+    Issue #11758.
+    """
+    f = io.StringIO()
+    tw = terminalwriter.TerminalWriter(f)
+    tw.hasmarkup = True
+    tw.code_highlight = True
+    tw._write_source([])
+
+    assert f.getvalue() == ""


### PR DESCRIPTION
For quick checking I don't know how we can reach here with an empty source, so test just checks the function directly.

Fix #11758.