### PR TITLE
Improve assert mod not in mods error message

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -664,7 +664,12 @@ class PytestPluginManager(PluginManager):
         if dirpath in self._dirpath2confmods:
             for path, mods in self._dirpath2confmods.items():
                 if dirpath in path.parents or path == dirpath:
-                    assert mod not in mods
+                    if mod in mods:
+                        raise AssertionError(
+                            f"While trying to load conftest path {str(conftestpath)}, "
+                            f"found that the module {mod} is already loaded with path {mod.__file__}. "
+                            "This is not supposed to happen. Please report this issue to pytest."
+                        )
                     mods.append(mod)
         self.trace(f"loading conftestmodule {mod!r}")
         self.consider_conftest(mod, registration_name=conftestpath_plugin_name)


### PR DESCRIPTION
Related to #9765, add a better error message than `assert mod not in mods`. This would have been super useful to figure out from the error message the difference from `conftestpath` and `mod.__file__`. Hopefully the #11708 will be merged and this error is less likely to occur, but at least if a variation of the issue occurs again there will be a better error message.

Here is the error on my reproducer https://github.com/lesteve/pytest-issue-9765-reproducer:
```
AssertionError: str(conftestpath)='C:\\msys64\\home\\lesteve\\dev\\pytest-issue-9765-reproducer\\project\\conftest.py'
has already been loaded as the module mod=<module 'project.conftest' from 'c:\\msys64\\home\\lesteve\\dev\\pytest-issue
-9765-reproducer\\project\\conftest.py'>
```

For now I keep an `AssertionError` but let me know if you think another kind of error is more appropriate.

It does not seem that easy to add a test for this ...

Let me know if you think this is worth adding a changelog for this or not!

Depending on how #11708 goes, this may need to be tweaked since a discrepancy between `mod.__file__` and `str(contestpath)` is likely not how this problem will show up. It could even lead to red-herring, since it will be potentially fine that `mod.__file__` and `str(conftestpath)` are not the consistent and people may be misled by reading comments like https://github.com/pytest-dev/pytest/issues/9765#issuecomment-1880768441  ...