### PR TITLE
python: remove support for nose's `compat_co_firstlineno`

### DIFF
--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -387,6 +387,13 @@ Will also need to be ported to a supported pytest style. One way to do it is usi
 .. _`with-setup-nose`: https://nose.readthedocs.io/en/latest/testing_tools.html?highlight=with_setup#nose.tools.with_setup
 
 
+The ``compat_co_firstlineno`` attribute
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Nose inspects this attribute on function objects to allow overriding the function's inferred line number.
+Pytest no longer respects this attribute.
+
+
 
 Passing ``msg=`` to ``pytest.skip``, ``pytest.fail`` or ``pytest.exit``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -6,7 +6,6 @@ import fnmatch
 import inspect
 import itertools
 import os
-import sys
 import types
 import warnings
 from collections import Counter
@@ -350,20 +349,8 @@ class PyobjMixin(nodes.Node):
 
     def reportinfo(self) -> Tuple[Union["os.PathLike[str]", str], Optional[int], str]:
         # XXX caching?
-        obj = self.obj
-        compat_co_firstlineno = getattr(obj, "compat_co_firstlineno", None)
-        if isinstance(compat_co_firstlineno, int):
-            # nose compatibility
-            file_path = sys.modules[obj.__module__].__file__
-            assert file_path is not None
-            if file_path.endswith(".pyc"):
-                file_path = file_path[:-1]
-            path: Union["os.PathLike[str]", str] = file_path
-            lineno = compat_co_firstlineno
-        else:
-            path, lineno = getfslineno(obj)
+        path, lineno = getfslineno(self.obj)
         modpath = self.getmodpath()
-        assert isinstance(lineno, int)
         return path, lineno, modpath
 
 


### PR DESCRIPTION
Since we're removing nose support, let's also drop support for this attribute.

From doing a code search on github, this seems completely unused outside of nose, except for some projects which used to use it, but no longer do.