### PR TITLE
nodes: add `Node.iterchain()` function

### DIFF
--- a/changelog/11801.improvement.rst
+++ b/changelog/11801.improvement.rst
@@ -1,0 +1,2 @@
+Added the :func:`iterparents() <_pytest.nodes.Node.iterparents>` helper method on nodes.
+It is similar to :func:`listchain <_pytest.nodes.Node.listchain>`, but goes from bottom to top, and returns an iterator, not a list.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -333,10 +333,8 @@ class PyobjMixin(nodes.Node):
 
     def getmodpath(self, stopatmodule: bool = True, includemodule: bool = False) -> str:
         """Return Python path relative to the containing module."""
-        chain = self.listchain()
-        chain.reverse()
         parts = []
-        for node in chain:
+        for node in self.iterparents():
             name = node.name
             if isinstance(node, Module):
                 name = os.path.splitext(name)[0]


### PR DESCRIPTION
This is a useful addition to the existing `listchain`. While `listchain` returns top-to-bottom, `iterchain` is bottom-to-top and doesn't require an internal full iteration + `reverse`.

Follow up on https://github.com/pytest-dev/pytest/pull/11785#discussion_r1444663550