### PR TITLE
doctest: remove special conftest handling

### DIFF
--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -558,24 +558,18 @@ class DoctestModule(Module):
             else:  # pragma: no cover
                 pass
 
-        if self.path.name == "conftest.py":
-            module = self.config.pluginmanager._importconftest(
+        try:
+            module = import_path(
                 self.path,
-                self.config.getoption("importmode"),
-                rootpath=self.config.rootpath,
+                root=self.config.rootpath,
+                mode=self.config.getoption("importmode"),
             )
-        else:
-            try:
-                module = import_path(
-                    self.path,
-                    root=self.config.rootpath,
-                    mode=self.config.getoption("importmode"),
-                )
-            except ImportError:
-                if self.config.getvalue("doctest_ignore_import_errors"):
-                    skip("unable to import module %r" % self.path)
-                else:
-                    raise
+        except ImportError:
+            if self.config.getvalue("doctest_ignore_import_errors"):
+                skip("unable to import module %r" % self.path)
+            else:
+                raise
+
         # Uses internal doctest module parsing mechanism.
         finder = MockAwareDocTestFinder()
         optionflags = get_optionflags(self.config)


### PR DESCRIPTION
(Diff better viewed ignoring whitespace)

Since e1c66ab0ad8eda13e5552dfc939e07d7290ecd39, conftest loading is handled at the directory level before sub-nodes are collected, so there is no need for the doctest plugin to handle it specially.

This was probably the case even before e1c66ab0ad8eda13e5552dfc939e07d7290ecd39, but I haven't verified this.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
