### PR TITLE
terminal: include markers in `--collect-only` output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -387,6 +387,7 @@ Terje Runde
 Thomas Grainger
 Thomas Hisch
 Tim Hoffmann
+Tim Sampson
 Tim Strazny
 TJ Bruno
 Tobias Diez

--- a/changelog/1509.improvement.rst
+++ b/changelog/1509.improvement.rst
@@ -1,0 +1,1 @@
+A comma-separated list of markers for each test will be included in the output of `--collect-only` when called with `--verbosity=-1`.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -826,7 +826,13 @@ class TerminalReporter:
                     self._tw.line("%s: %d" % (name, count))
             else:
                 for item in items:
-                    self._tw.line(item.nodeid)
+                    marks = {
+                        m.name
+                        for m in item.iter_markers()
+                        if m.name not in ["usefixtures", "parametrize"]
+                    }
+                    marks_str = f" marks: {','.join(marks)}"
+                    self._tw.line(f"{item.nodeid}{marks_str}")
             return
         stack: List[Node] = []
         indent = ""

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -1154,9 +1154,9 @@ class TestNewFirst:
         result = pytester.runpytest("--nf", "--collect-only", "-q")
         result.stdout.fnmatch_lines(
             [
-                "test_1/test_1.py::test_2",
-                "test_2/test_2.py::test_1",
-                "test_1/test_1.py::test_1",
+                "test_1/test_1.py::test_2 marks: ",
+                "test_2/test_2.py::test_1 marks: ",
+                "test_1/test_1.py::test_1 marks: ",
             ]
         )
 
@@ -1173,9 +1173,9 @@ class TestNewFirst:
         result.stdout.fnmatch_lines(
             [
                 "new_items: *test_1.py*test_1.py*test_2.py*",
-                "test_1/test_1.py::test_2",
-                "test_2/test_2.py::test_1",
-                "test_1/test_1.py::test_1",
+                "test_1/test_1.py::test_2 marks: ",
+                "test_2/test_2.py::test_1 marks: ",
+                "test_1/test_1.py::test_1 marks: ",
             ]
         )
 


### PR DESCRIPTION
Closes #1509

Note that I haven't done these yet:

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable. (I've updated the tests so that they should pass but new tests should be added)

As I have a few questions about how this should work and intend this PR to be a jumping off point for a conversation (as per @RonnyPfannschmidt 's suggestion in #1509).

My questions are:

- currently this will only display when `--verbosity=-1`. On one hand this feels reasonable as that outputs one test per line and for grepping purposes that makes most sense. However it feels then a bit weird that it's not included in more verbose levels of `collect-only`. Though having the marks in an output format where each test is multiple lines makes is kinda annoying from the POV of grepping... Maybe a new flag could be added (e.g. `--collect-only-include-markers`)? This seems a little clunky TBH though. Ultimately if we want to consume the output of `--collect-only` programmatically then I think some formal structured data output makes most sense (e.g. json) but that's quite a bit more work than what I did here.
- currently I guess this could be considered a breaking change as it changes output (but I suppose many people aren't relying on that?). I anyway included this as an improvement in the changelog for the time being.
