### PR TITLE
nodes: rename `iterparents()` -> `iter_parents()`

### DIFF
--- a/changelog/11801.improvement.rst
+++ b/changelog/11801.improvement.rst
@@ -1,2 +1,2 @@
-Added the :func:`iterparents() <_pytest.nodes.Node.iterparents>` helper method on nodes.
+Added the :func:`iter_parents() <_pytest.nodes.Node.iter_parents>` helper method on nodes.
 It is similar to :func:`listchain <_pytest.nodes.Node.listchain>`, but goes from bottom to top, and returns an iterator, not a list.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -119,7 +119,7 @@ def get_scope_package(
 ) -> Optional[nodes.Node]:
     from _pytest.python import Package
 
-    for parent in node.iterparents():
+    for parent in node.iter_parents():
         if isinstance(parent, Package) and parent.nodeid == fixturedef.baseid:
             return parent
     return node.session
@@ -1775,7 +1775,7 @@ class FixtureManager:
     def _matchfactories(
         self, fixturedefs: Iterable[FixtureDef[Any]], node: nodes.Node
     ) -> Iterator[FixtureDef[Any]]:
-        parentnodeids = {n.nodeid for n in node.iterparents()}
+        parentnodeids = {n.nodeid for n in node.iter_parents()}
         for fixturedef in fixturedefs:
             if fixturedef.baseid in parentnodeids:
                 yield fixturedef

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -256,7 +256,7 @@ class Node(abc.ABC, metaclass=NodeMeta):
     def teardown(self) -> None:
         pass
 
-    def iterparents(self) -> Iterator["Node"]:
+    def iter_parents(self) -> Iterator["Node"]:
         """Iterate over all parent collectors starting from and including self
         up to the root of the collection tree.
 
@@ -318,7 +318,7 @@ class Node(abc.ABC, metaclass=NodeMeta):
         :param name: If given, filter the results by the name attribute.
         :returns: An iterator of (node, mark) tuples.
         """
-        for node in self.iterparents():
+        for node in self.iter_parents():
             for mark in node.own_markers:
                 if name is None or getattr(mark, "name", None) == name:
                     yield node, mark
@@ -368,7 +368,7 @@ class Node(abc.ABC, metaclass=NodeMeta):
         :param cls: The node class to search for.
         :returns: The node, if found.
         """
-        for node in self.iterparents():
+        for node in self.iter_parents():
             if isinstance(node, cls):
                 return node
         return None

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -333,7 +333,7 @@ class PyobjMixin(nodes.Node):
     def getmodpath(self, stopatmodule: bool = True, includemodule: bool = False) -> str:
         """Return Python path relative to the containing module."""
         parts = []
-        for node in self.iterparents():
+        for node in self.iter_parents():
             name = node.name
             if isinstance(node, Module):
                 name = os.path.splitext(name)[0]


### PR DESCRIPTION
After the fact I remembered that there is `node.iter_markers()`, so let's be consistent with that rather than with `listchain()`.