### PR TITLE
fix #11797: be more lenient on SequenceLike approx

### DIFF
--- a/changelog/11797.bugfix.rst
+++ b/changelog/11797.bugfix.rst
@@ -1,0 +1,1 @@
+:func:`pytest.approx` now correctly handles :class:`Sequence <collections.abc.Sequence>`-like objects.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -129,6 +129,8 @@ def _recursive_sequence_map(f, x):
     if isinstance(x, (list, tuple)):
         seq_type = type(x)
         return seq_type(_recursive_sequence_map(f, xi) for xi in x)
+    elif _is_sequence_like(x):
+        return [_recursive_sequence_map(f, xi) for xi in x]
     else:
         return f(x)
 
@@ -721,11 +723,7 @@ def approx(expected, rel=None, abs=None, nan_ok: bool = False) -> ApproxBase:
     elif _is_numpy_array(expected):
         expected = _as_numpy_array(expected)
         cls = ApproxNumpy
-    elif (
-        hasattr(expected, "__getitem__")
-        and isinstance(expected, Sized)
-        and not isinstance(expected, (str, bytes))
-    ):
+    elif _is_sequence_like(expected):
         cls = ApproxSequenceLike
     elif isinstance(expected, Collection) and not isinstance(expected, (str, bytes)):
         msg = f"pytest.approx() only supports ordered sequences, but got: {expected!r}"
@@ -734,6 +732,14 @@ def approx(expected, rel=None, abs=None, nan_ok: bool = False) -> ApproxBase:
         cls = ApproxScalar
 
     return cls(expected, rel, abs, nan_ok)
+
+
+def _is_sequence_like(expected: object) -> bool:
+    return (
+        hasattr(expected, "__getitem__")
+        and isinstance(expected, Sized)
+        and not isinstance(expected, (str, bytes))
+    )
 
 
 def _is_numpy_array(obj: object) -> bool:


### PR DESCRIPTION
this needs a validation as it allows partially implemented sequences

closes #11797 

this changes the recursive map of approx to accept all sequences (just like approx)
i would like to gather feedback form @nicoddemus and @Zac-HD on whether to accept the recursion in general,
or if we ought to limit it by changing the toplevel call in ApproxSequenceLike to a listcomp operating only on the elements of the sequence
