### PR TITLE
module __file__ attribute is not the canonical path

### DIFF
--- a/src/_pytest/_py/os_path.py
+++ b/src/_pytest/_py/os_path.py
@@ -1,0 +1,20 @@
+import os
+from types import ModuleType
+from typing import Optional
+
+
+def module_casesensitivepath(module: ModuleType) -> Optional[str]:
+    """Return the canonical __file__ of the module without resolving symlinks."""
+    path = module.__file__
+    if path is None:
+        return None
+    return casesensitivepath(path)
+
+
+def casesensitivepath(path: str) -> str:
+    """Return the case-sensitive version of the path."""
+    resolved_path = os.path.realpath(path)
+    if resolved_path.lower() == path.lower():
+        return resolved_path
+    # Patch has one or more symlinks. Todo: find the correct path casing.
+    return path

--- a/src/_pytest/_py/path.py
+++ b/src/_pytest/_py/path.py
@@ -30,6 +30,7 @@ from typing import overload
 from typing import TYPE_CHECKING
 
 from . import error
+from . import os_path
 
 # Moved from local.py.
 iswin32 = sys.platform == "win32" or (getattr(os, "_name", False) == "nt")
@@ -1126,7 +1127,7 @@ class LocalPath:
             if self.basename == "__init__.py":
                 return mod  # we don't check anything as we might
                 # be in a namespace package ... too icky to check
-            modfile = mod.__file__
+            modfile = os_path.module_casesensitivepath(mod)
             assert modfile is not None
             if modfile[-4:] in (".pyc", ".pyo"):
                 modfile = modfile[:-1]

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -52,6 +52,7 @@ from .findpaths import determine_setup
 from _pytest._code import ExceptionInfo
 from _pytest._code import filter_traceback
 from _pytest._io import TerminalWriter
+from _pytest._py.os_path import module_casesensitivepath
 from _pytest.outcomes import fail
 from _pytest.outcomes import Skipped
 from _pytest.pathlib import absolutepath
@@ -631,8 +632,7 @@ class PytestPluginManager(PluginManager):
     def _importconftest(
         self, conftestpath: Path, importmode: Union[str, ImportMode], rootpath: Path
     ) -> types.ModuleType:
-        conftestpath_plugin_name = str(conftestpath)
-        existing = self.get_plugin(conftestpath_plugin_name)
+        existing = self.get_plugin(str(conftestpath))
         if existing is not None:
             return cast(types.ModuleType, existing)
 
@@ -668,7 +668,7 @@ class PytestPluginManager(PluginManager):
                         )
                     mods.append(mod)
         self.trace(f"loading conftestmodule {mod!r}")
-        self.consider_conftest(mod, registration_name=conftestpath_plugin_name)
+        self.consider_conftest(mod)
         return mod
 
     def _check_non_top_pytest_plugins(
@@ -748,11 +748,9 @@ class PytestPluginManager(PluginManager):
                     del self._name2plugin["pytest_" + name]
             self.import_plugin(arg, consider_entry_points=True)
 
-    def consider_conftest(
-        self, conftestmodule: types.ModuleType, registration_name: str
-    ) -> None:
+    def consider_conftest(self, conftestmodule: types.ModuleType) -> None:
         """:meta private:"""
-        self.register(conftestmodule, name=registration_name)
+        self.register(conftestmodule, name=module_casesensitivepath(conftestmodule))
 
     def consider_env(self) -> None:
         """:meta private:"""

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -8,6 +8,7 @@ from typing import Optional
 from typing import Union
 
 import pytest
+from _pytest._py.os_path import module_casesensitivepath
 from _pytest.config import Config
 from _pytest.config import ExitCode
 from _pytest.config import PrintHelp
@@ -265,7 +266,7 @@ def pytest_report_header(config: Config) -> List[str]:
         items = config.pluginmanager.list_name_plugin()
         for name, plugin in items:
             if hasattr(plugin, "__file__"):
-                r = plugin.__file__
+                r = module_casesensitivepath(plugin)
             else:
                 r = repr(plugin)
             lines.append(f"    {name:<20}: {r}")

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -35,6 +35,7 @@ from typing import Type
 from typing import TypeVar
 from typing import Union
 
+from _pytest._py.os_path import module_casesensitivepath
 from _pytest.compat import assert_never
 from _pytest.outcomes import skip
 from _pytest.warning_types import PytestWarning
@@ -572,7 +573,7 @@ def import_path(
 
     ignore = os.environ.get("PY_IGNORE_IMPORTMISMATCH", "")
     if ignore != "1":
-        module_file = mod.__file__
+        module_file = module_casesensitivepath(mod)
         if module_file is None:
             raise ImportPathMismatchError(module_name, module_file, path)
 

--- a/testing/test_os_utils.py
+++ b/testing/test_os_utils.py
@@ -1,0 +1,82 @@
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from _pytest._py import os_path
+
+_ON_CASEINSENSITIVE_OS = sys.platform.startswith("win")
+
+
+def test_casesensitivepath(tmp_path: Path) -> None:
+    dirname_with_caps = tmp_path / "Testdir"
+    dirname_with_caps.mkdir()
+    real_filename = dirname_with_caps / "_test_casesensitivepath.py"
+    with real_filename.open("wb"):
+        pass
+    real_linkname = dirname_with_caps / "_test_casesensitivepath_link.py"
+    real_linkname.symlink_to(real_filename)
+
+    # Test path resolving
+
+    original = str(real_filename)
+    expected = str(real_filename)
+    assert os_path.casesensitivepath(original) == expected
+
+    original = str(real_filename).lower()
+    if _ON_CASEINSENSITIVE_OS:
+        expected = str(real_filename)
+    else:
+        expected = str(real_filename).lower()
+    assert os_path.casesensitivepath(original) == expected
+
+    # Test symlink preservation
+
+    original = str(real_linkname)
+    expected = str(real_linkname)
+    assert os_path.casesensitivepath(original) == expected
+
+    original = str(real_linkname).lower()
+    expected = str(real_linkname).lower()
+    assert os_path.casesensitivepath(original) == expected
+
+
+def test_module_casesensitivepath(tmp_path: Path) -> None:
+    dirname_with_caps = tmp_path / "Testdir"
+    dirname_with_caps.mkdir()
+    real_filename = dirname_with_caps / "_test_module_casesensitivepath.py"
+    with real_filename.open("wb"):
+        pass
+    real_linkname = dirname_with_caps / "_test_module_casesensitivepath_link.py"
+    real_linkname.symlink_to(real_filename)
+
+    mod = ModuleType("dummy.name")
+
+    mod.__file__ = None
+    assert os_path.module_casesensitivepath(mod) is None
+
+    # Test path resolving
+
+    original = str(real_filename)
+    expected = str(real_filename)
+    mod.__file__ = original
+    assert os_path.module_casesensitivepath(mod) == expected
+
+    original = str(real_filename).lower()
+    if _ON_CASEINSENSITIVE_OS:
+        expected = str(real_filename)
+    else:
+        expected = str(real_filename).lower()
+    mod.__file__ = original
+    assert os_path.module_casesensitivepath(mod) == expected
+
+    # Test symlink preservation
+
+    original = str(real_linkname)
+    expected = str(real_linkname)
+    mod.__file__ = original
+    assert os_path.module_casesensitivepath(mod) == expected
+
+    original = str(real_linkname).lower()
+    expected = str(real_linkname).lower()
+    mod.__file__ = original
+    assert os_path.module_casesensitivepath(mod) == expected

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -118,17 +118,14 @@ class TestPytestPluginInteractions:
         plugin = config.pluginmanager.get_plugin(str(conftest))
         assert plugin is mod
 
-        mod_uppercase = config.pluginmanager._importconftest(
-            conftest_upper_case,
-            importmode="prepend",
-            rootpath=pytester.path,
-        )
+        with pytest.raises(ValueError, match="Plugin name already registered"):
+            config.pluginmanager._importconftest(
+                conftest_upper_case,
+                importmode="prepend",
+                rootpath=pytester.path,
+            )
         plugin_uppercase = config.pluginmanager.get_plugin(str(conftest_upper_case))
-        assert plugin_uppercase is mod_uppercase
-
-        # No str(conftestpath) normalization so conftest should be imported
-        # twice and modules should be different objects
-        assert mod is not mod_uppercase
+        assert plugin_uppercase is None
 
     def test_hook_tracing(self, _config_for_test: Config) -> None:
         pytestpm = _config_for_test.pluginmanager  # fully initialized with plugins
@@ -400,7 +397,7 @@ class TestPytestPluginManager:
             pytester.makepyfile("pytest_plugins='xyz'"), root=pytester.path
         )
         with pytest.raises(ImportError):
-            pytestpm.consider_conftest(mod, registration_name="unused")
+            pytestpm.consider_conftest(mod)
 
 
 class TestPytestPluginManagerBootstrapming:


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

closes #11816

# What

Undo https://github.com/pytest-dev/pytest/pull/11708 and replace it will a more general fix of `anymodule.__file__` not having the right casing.

This fails on Windows (python 3.8, pytest 8.0.0rc2):

```
python -m pip install "ewokscore==0.7.1" matplotlib ipykernel^
    git+https://github.com/pytest-dev/pytest.git@b0c7f923aa39f0765425c367a02f53b1d97915f6 --no-cache
python -m pytest -v --pyargs ewokscore.tests
```

This MR fixes it:

```
python -m pip install "ewokscore==0.7.1" matplotlib ipykernel^
    git+https://github.com/woutdenolf/pytest.git@module_file_resolve --no-cache
python -m pytest -v --pyargs ewokscore.tests
```

Test with the h5py CI that was broken by the issue: https://github.com/h5py/h5py/pull/2368

# Notes

* we need to use `realpath`, `abspath` is not enough: https://github.com/pytest-dev/pytest/pull/11821#issuecomment-1892792126
* it seems we need to preserve symlinks: https://github.com/pytest-dev/pytest/pull/6523
* the behavior of `TestPytestPluginInteractions.test_conftestpath_case_sensitivity` is expected to change (https://github.com/pytest-dev/pytest/pull/11708/files#r1447814841) but this MR changes it in a way that was not intended (`config.pluginmanager.get_plugin` returns `None` when the string case is not the real path case)
