### PR TITLE
doc: Remove sold out training

### DIFF
--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -3,7 +3,6 @@
 .. sidebar:: Next Open Trainings and Events
 
    - `Professional Testing with Python <https://python-academy.com/courses/python_course_testing.html>`_, via `Python Academy <https://www.python-academy.com/>`_ (3 day in-depth training):
-      * **March 5th to 7th 2024**, Leipzig, Germany / Remote
       * **June 11th to 13th 2024**, Remote
       * **March 4th to 6th 2025**, Leipzig, Germany / Remote
    - `pytest development sprint <https://github.com/pytest-dev/pytest/discussions/11655>`_, June 2024 (`date poll <https://nuudel.digitalcourage.de/2tEsEpRcwMNcAXVO>`_)


### PR DESCRIPTION
Apologies for the PR churn - only now Python Academy told me they will remove the sold out training from their website, so it makes sense to remove it on pytest.org too :sweat_smile: 