### PR TITLE
avoid using __file__ in pytest_plugin_registered as can be wrong on Windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,7 @@ repos:
         additional_dependencies:
           - iniconfig>=1.1.0
           - attrs>=19.2.0
+          - pluggy
           - packaging
           - tomli
           - types-pkg_resources

--- a/changelog/11825.improvement.rst
+++ b/changelog/11825.improvement.rst
@@ -1,0 +1,1 @@
+The :hook:`pytest_plugin_registered` hook has a new ``plugin_name`` parameter containing the name by which ``plugin`` is registered.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -490,15 +490,19 @@ class PytestPluginManager(PluginManager):
                 )
             )
             return None
-        ret: Optional[str] = super().register(plugin, name)
-        if ret:
+        plugin_name = super().register(plugin, name)
+        if plugin_name is not None:
             self.hook.pytest_plugin_registered.call_historic(
-                kwargs=dict(plugin=plugin, manager=self)
+                kwargs=dict(
+                    plugin=plugin,
+                    plugin_name=plugin_name,
+                    manager=self,
+                )
             )
 
             if isinstance(plugin, types.ModuleType):
                 self.consider_module(plugin)
-        return ret
+        return plugin_name
 
     def getplugin(self, name: str):
         # Support deprecated naming because plugins (xdist e.g.) use it.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1483,27 +1483,27 @@ class FixtureManager:
 
         return FuncFixtureInfo(argnames, initialnames, names_closure, arg2fixturedefs)
 
-    def pytest_plugin_registered(self, plugin: _PluggyPlugin) -> None:
-        nodeid = None
-        plugin_name = self.config.pluginmanager.get_name(plugin)
-
-        # Construct the base nodeid which is later used to check
-        # what fixtures are visible for particular tests (as denoted
-        # by their test id).
+    def pytest_plugin_registered(self, plugin: _PluggyPlugin, plugin_name: str) -> None:
+        # Fixtures defined in conftest plugins are only visible to within the
+        # conftest's directory. This is unlike fixtures in non-conftest plugins
+        # which have global visibility. So for conftests, construct the base
+        # nodeid from the plugin name (which is the conftest path).
         if plugin_name and plugin_name.endswith("conftest.py"):
-            # The plugin name is assumed to be equal to plugin.__file__
-            # for conftest plugins. The difference is that plugin_name
-            # has the correct capitalization on capital-insensitive
-            # systems (Windows).
-            p = absolutepath(plugin_name)
+            # Note: we explicitly do *not* use `plugin.__file__` here -- The
+            # difference is that plugin_name has the correct capitalization on
+            # case-insensitive systems (Windows) and other normalization issues
+            # (issue #11816).
+            conftestpath = absolutepath(plugin_name)
             try:
-                nodeid = str(p.parent.relative_to(self.config.rootpath))
+                nodeid = str(conftestpath.parent.relative_to(self.config.rootpath))
             except ValueError:
                 nodeid = ""
             if nodeid == ".":
                 nodeid = ""
             if os.sep != nodes.SEP:
                 nodeid = nodeid.replace(os.sep, nodes.SEP)
+        else:
+            nodeid = None
 
         self.parsefactories(plugin, nodeid)
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1485,23 +1485,25 @@ class FixtureManager:
 
     def pytest_plugin_registered(self, plugin: _PluggyPlugin) -> None:
         nodeid = None
-        try:
-            p = absolutepath(plugin.__file__)  # type: ignore[attr-defined]
-        except AttributeError:
-            pass
-        else:
-            # Construct the base nodeid which is later used to check
-            # what fixtures are visible for particular tests (as denoted
-            # by their test id).
-            if p.name == "conftest.py":
-                try:
-                    nodeid = str(p.parent.relative_to(self.config.rootpath))
-                except ValueError:
-                    nodeid = ""
-                if nodeid == ".":
-                    nodeid = ""
-                if os.sep != nodes.SEP:
-                    nodeid = nodeid.replace(os.sep, nodes.SEP)
+        plugin_name = self.config.pluginmanager.get_name(plugin)
+
+        # Construct the base nodeid which is later used to check
+        # what fixtures are visible for particular tests (as denoted
+        # by their test id).
+        if plugin_name and plugin_name.endswith("conftest.py"):
+            # The plugin name is assumed to be equal to plugin.__file__
+            # for conftest plugins. The difference is that plugin_name
+            # has the correct capitalization on capital-insensitive
+            # systems (Windows).
+            p = absolutepath(plugin_name)
+            try:
+                nodeid = str(p.parent.relative_to(self.config.rootpath))
+            except ValueError:
+                nodeid = ""
+            if nodeid == ".":
+                nodeid = ""
+            if os.sep != nodes.SEP:
+                nodeid = nodeid.replace(os.sep, nodes.SEP)
 
         self.parsefactories(plugin, nodeid)
 

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -63,12 +63,15 @@ def pytest_addhooks(pluginmanager: "PytestPluginManager") -> None:
 
 @hookspec(historic=True)
 def pytest_plugin_registered(
-    plugin: "_PluggyPlugin", manager: "PytestPluginManager"
+    plugin: "_PluggyPlugin",
+    plugin_name: str,
+    manager: "PytestPluginManager",
 ) -> None:
     """A new pytest plugin got registered.
 
     :param plugin: The plugin module or instance.
-    :param manager: pytest plugin manager.
+    :param plugin_name: The name by which the plugin is registered.
+    :param manager: The pytest plugin manager.
 
     .. note::
         This hook is incompatible with hook wrappers.


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

closes https://github.com/pytest-dev/pytest/issues/11816

Alternative fix to https://github.com/pytest-dev/pytest/pull/11821.

The plugin name is equal to the path for conftest plugins (suggested in https://github.com/pytest-dev/pytest/issues/11816#issuecomment-1893364761). Use that instead of `plugin.__file__`.

Test with the h5py CI that was broken by the issue: https://github.com/h5py/h5py/pull/2370

Another way of testing this MR:

```
python -m pip install "ewokscore==0.7.1" matplotlib ipykernel^
    git+https://github.com/woutdenolf/pytest.git@fix_missing_fixture_issue --no-cache
python -m pytest -v --pyargs ewokscore.tests
```
