### PR TITLE
Prefer using the invocation dir over CWD

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1179,8 +1179,8 @@ class Config:
             args, namespace=copy.copy(self.option)
         )
         rootpath, inipath, inicfg = determine_setup(
-            ns.inifilename,
-            ns.file_or_dir + unknown_args,
+            inifile=ns.inifilename,
+            args=ns.file_or_dir + unknown_args,
             rootdir_cmd_arg=ns.rootdir or None,
             invocation_dir=self.invocation_params.dir,
         )

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -541,6 +541,7 @@ class PytestPluginManager(PluginManager):
         noconftest: bool,
         rootpath: Path,
         confcutdir: Optional[Path],
+        invocation_dir: Path,
         importmode: Union[ImportMode, str],
     ) -> None:
         """Load initial conftest files given a preparsed "namespace".
@@ -550,8 +551,9 @@ class PytestPluginManager(PluginManager):
         All builtin and 3rd party plugins will have been loaded, however, so
         common options will not confuse our logic here.
         """
-        current = Path.cwd()
-        self._confcutdir = absolutepath(current / confcutdir) if confcutdir else None
+        self._confcutdir = (
+            absolutepath(invocation_dir / confcutdir) if confcutdir else None
+        )
         self._noconftest = noconftest
         self._using_pyargs = pyargs
         foundanchor = False
@@ -561,7 +563,7 @@ class PytestPluginManager(PluginManager):
             i = path.find("::")
             if i != -1:
                 path = path[:i]
-            anchor = absolutepath(current / path)
+            anchor = absolutepath(invocation_dir / path)
 
             # Ensure we do not break if what appears to be an anchor
             # is in fact a very long option (#10169, #11394).
@@ -569,7 +571,7 @@ class PytestPluginManager(PluginManager):
                 self._try_load_conftest(anchor, importmode, rootpath)
                 foundanchor = True
         if not foundanchor:
-            self._try_load_conftest(current, importmode, rootpath)
+            self._try_load_conftest(invocation_dir, importmode, rootpath)
 
     def _is_in_confcutdir(self, path: Path) -> bool:
         """Whether a path is within the confcutdir.
@@ -1168,6 +1170,7 @@ class Config:
             noconftest=early_config.known_args_namespace.noconftest,
             rootpath=early_config.rootpath,
             confcutdir=early_config.known_args_namespace.confcutdir,
+            invocation_dir=early_config.invocation_params.dir,
             importmode=early_config.known_args_namespace.importmode,
         )
 
@@ -1261,6 +1264,8 @@ class Config:
         """Decide the args (initial paths/nodeids) to use given the relevant inputs.
 
         :param warn: Whether can issue warnings.
+
+        :returns: The args and the args source. Guaranteed to be non-empty.
         """
         if args:
             source = Config.ArgsSource.ARGS

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -87,6 +87,7 @@ def load_config_dict_from_file(
 
 
 def locate_config(
+    invocation_dir: Path,
     args: Iterable[Path],
 ) -> Tuple[Optional[Path], Optional[Path], Dict[str, Union[str, List[str]]]]:
     """Search in the list of arguments for a valid ini-file for pytest,
@@ -100,7 +101,7 @@ def locate_config(
     ]
     args = [x for x in args if not str(x).startswith("-")]
     if not args:
-        args = [Path.cwd()]
+        args = [invocation_dir]
     for arg in args:
         argpath = absolutepath(arg)
         for base in (argpath, *argpath.parents):
@@ -113,7 +114,10 @@ def locate_config(
     return None, None, {}
 
 
-def get_common_ancestor(paths: Iterable[Path]) -> Path:
+def get_common_ancestor(
+    invocation_dir: Path,
+    paths: Iterable[Path],
+) -> Path:
     common_ancestor: Optional[Path] = None
     for path in paths:
         if not path.exists():
@@ -130,7 +134,7 @@ def get_common_ancestor(paths: Iterable[Path]) -> Path:
                 if shared is not None:
                     common_ancestor = shared
     if common_ancestor is None:
-        common_ancestor = Path.cwd()
+        common_ancestor = invocation_dir
     elif common_ancestor.is_file():
         common_ancestor = common_ancestor.parent
     return common_ancestor
@@ -162,10 +166,11 @@ CFG_PYTEST_SECTION = "[pytest] section in {filename} files is no longer supporte
 
 
 def determine_setup(
+    *,
     inifile: Optional[str],
     args: Sequence[str],
-    rootdir_cmd_arg: Optional[str] = None,
-    invocation_dir: Optional[Path] = None,
+    rootdir_cmd_arg: Optional[str],
+    invocation_dir: Path,
 ) -> Tuple[Path, Optional[Path], Dict[str, Union[str, List[str]]]]:
     """Determine the rootdir, inifile and ini configuration values from the
     command line arguments.
@@ -177,8 +182,7 @@ def determine_setup(
     :param rootdir_cmd_arg:
         The `--rootdir` command line argument, if given.
     :param invocation_dir:
-        The working directory when pytest was invoked, if known.
-        If not known, the current working directory is used.
+        The working directory when pytest was invoked.
     """
     rootdir = None
     dirs = get_dirs_from_args(args)
@@ -189,8 +193,8 @@ def determine_setup(
         if rootdir_cmd_arg is None:
             rootdir = inipath_.parent
     else:
-        ancestor = get_common_ancestor(dirs)
-        rootdir, inipath, inicfg = locate_config([ancestor])
+        ancestor = get_common_ancestor(invocation_dir, dirs)
+        rootdir, inipath, inicfg = locate_config(invocation_dir, [ancestor])
         if rootdir is None and rootdir_cmd_arg is None:
             for possible_rootdir in (ancestor, *ancestor.parents):
                 if (possible_rootdir / "setup.py").is_file():
@@ -198,13 +202,11 @@ def determine_setup(
                     break
             else:
                 if dirs != [ancestor]:
-                    rootdir, inipath, inicfg = locate_config(dirs)
+                    rootdir, inipath, inicfg = locate_config(invocation_dir, dirs)
                 if rootdir is None:
-                    if invocation_dir is not None:
-                        cwd = invocation_dir
-                    else:
-                        cwd = Path.cwd()
-                    rootdir = get_common_ancestor([cwd, ancestor])
+                    rootdir = get_common_ancestor(
+                        invocation_dir, [invocation_dir, ancestor]
+                    )
                     if is_fs_root(rootdir):
                         rootdir = ancestor
     if rootdir_cmd_arg:

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -109,10 +109,11 @@ def pytest_cmdline_parse() -> Generator[None, Config, Config]:
         debugfile = open(path, "w", encoding="utf-8")
         debugfile.write(
             "versions pytest-%s, "
-            "python-%s\ncwd=%s\nargs=%s\n\n"
+            "python-%s\ninvocation_dir=%s\ncwd=%s\nargs=%s\n\n"
             % (
                 pytest.__version__,
                 ".".join(map(str, sys.version_info)),
+                config.invocation_params.dir,
                 os.getcwd(),
                 config.invocation_params.args,
             )

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -35,6 +35,7 @@ def conftest_setinitial(
         noconftest=False,
         rootpath=Path(args[0]),
         confcutdir=confcutdir,
+        invocation_dir=Path.cwd(),
         importmode="prepend",
     )
 

--- a/testing/test_findpaths.py
+++ b/testing/test_findpaths.py
@@ -109,18 +109,19 @@ class TestCommonAncestor:
         fn2 = tmp_path / "foo" / "zaz" / "test_2.py"
         fn2.parent.mkdir(parents=True)
         fn2.touch()
-        assert get_common_ancestor([fn1, fn2]) == tmp_path / "foo"
-        assert get_common_ancestor([fn1.parent, fn2]) == tmp_path / "foo"
-        assert get_common_ancestor([fn1.parent, fn2.parent]) == tmp_path / "foo"
-        assert get_common_ancestor([fn1, fn2.parent]) == tmp_path / "foo"
+        cwd = Path.cwd()
+        assert get_common_ancestor(cwd, [fn1, fn2]) == tmp_path / "foo"
+        assert get_common_ancestor(cwd, [fn1.parent, fn2]) == tmp_path / "foo"
+        assert get_common_ancestor(cwd, [fn1.parent, fn2.parent]) == tmp_path / "foo"
+        assert get_common_ancestor(cwd, [fn1, fn2.parent]) == tmp_path / "foo"
 
     def test_single_dir(self, tmp_path: Path) -> None:
-        assert get_common_ancestor([tmp_path]) == tmp_path
+        assert get_common_ancestor(Path.cwd(), [tmp_path]) == tmp_path
 
     def test_single_file(self, tmp_path: Path) -> None:
         fn = tmp_path / "foo.py"
         fn.touch()
-        assert get_common_ancestor([fn]) == tmp_path
+        assert get_common_ancestor(Path.cwd(), [fn]) == tmp_path
 
 
 def test_get_dirs_from_args(tmp_path):


### PR DESCRIPTION
We should aim to remove all `cwd()` calls except one (for the invocation dir), otherwise things will go bad if the working directory changes. Use the invocation dir instead.