### PR TITLE
Mark some xfails from #10042 as non-strict

### DIFF
--- a/testing/test_debugging.py
+++ b/testing/test_debugging.py
@@ -372,7 +372,7 @@ class TestPDB:
         result = pytester.runpytest_subprocess("--pdb", ".")
         result.stdout.fnmatch_lines(["-> import unknown"])
 
-    @pytest.mark.xfail(reason="#10042")
+    @pytest.mark.xfail(reason="#10042", strict=False)
     def test_pdb_interaction_capturing_simple(self, pytester: Pytester) -> None:
         p1 = pytester.makepyfile(
             """
@@ -541,7 +541,7 @@ class TestPDB:
         assert "BdbQuit" not in rest
         assert "UNEXPECTED EXCEPTION" not in rest
 
-    @pytest.mark.xfail(reason="#10042")
+    @pytest.mark.xfail(reason="#10042", strict=False)
     def test_pdb_interaction_capturing_twice(self, pytester: Pytester) -> None:
         p1 = pytester.makepyfile(
             """
@@ -577,7 +577,7 @@ class TestPDB:
         assert "1 failed" in rest
         self.flush(child)
 
-    @pytest.mark.xfail(reason="#10042")
+    @pytest.mark.xfail(reason="#10042", strict=False)
     def test_pdb_with_injected_do_debug(self, pytester: Pytester) -> None:
         """Simulates pdbpp, which injects Pdb into do_debug, and uses
         self.__class__ in do_continue.
@@ -1022,7 +1022,7 @@ class TestDebuggingBreakpoints:
         assert "reading from stdin while output" not in rest
         TestPDB.flush(child)
 
-    @pytest.mark.xfail(reason="#10042")
+    @pytest.mark.xfail(reason="#10042", strict=False)
     def test_pdb_not_altered(self, pytester: Pytester) -> None:
         p1 = pytester.makepyfile(
             """
@@ -1182,7 +1182,7 @@ def test_quit_with_swallowed_SystemExit(pytester: Pytester) -> None:
 
 
 @pytest.mark.parametrize("fixture", ("capfd", "capsys"))
-@pytest.mark.xfail(reason="#10042")
+@pytest.mark.xfail(reason="#10042", strict=False)
 def test_pdb_suspends_fixture_capturing(pytester: Pytester, fixture: str) -> None:
     """Using "-s" with pytest should suspend/resume fixture capturing."""
     p1 = pytester.makepyfile(


### PR DESCRIPTION
While debugging https://github.com/pytest-dev/pytest/pull/11825#issuecomment-1894094641 in hypothesis, I was sidetracked by some `xfail`s that unexpectedly passed. Based on https://github.com/pytest-dev/pytest/issues/10042#issuecomment-1237132867 and https://github.com/pytest-dev/pytest/issues/10042#issuecomment-1274655510 it looks like these particular ones should not fail the test suite if they unexpectedly pass.

This trivial change has no linked issue, and does not require a changelog entry or AUTHORS addition.


<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
