### PR TITLE
Properly attach packages to the GH release notes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,12 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
 
+    - name: Download Package
+      uses: actions/download-artifact@v4
+      with:
+        name: Packages
+        path: dist
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
Follow up to https://github.com/pytest-dev/pytest/pull/11754, noticed that the latest GitHub release does not contain the attached files.

[Output log](https://github.com/pytest-dev/pytest/actions/runs/7562055008/job/20591844192) from the action:

```
🤔 Pattern 'dist/*' does not match any files.
```
