### PR TITLE
Escape skip reason in junitxml

### DIFF
--- a/changelog/11842.bugfix.rst
+++ b/changelog/11842.bugfix.rst
@@ -1,0 +1,1 @@
+Properly escape the ``reason`` of a :ref:`skipif <pytest.mark.skipif ref>` mark when writing JUnit XML files.

--- a/changelog/11842.bugfix.rst
+++ b/changelog/11842.bugfix.rst
@@ -1,1 +1,1 @@
-Properly escape the ``reason`` of a :ref:`skipif <pytest.mark.skipif ref>` mark when writing JUnit XML files.
+Properly escape the ``reason`` of a :ref:`skip <pytest.mark.skip ref>` mark when writing JUnit XML files.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -248,7 +248,9 @@ class _NodeReporter:
                 skipreason = skipreason[9:]
             details = f"{filename}:{lineno}: {skipreason}"
 
-            skipped = ET.Element("skipped", type="pytest.skip", message=bin_xml_escape(skipreason))
+            skipped = ET.Element(
+                "skipped", type="pytest.skip", message=bin_xml_escape(skipreason)
+            )
             skipped.text = bin_xml_escape(details)
             self.append(skipped)
             self.write_captured_output(report)

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -248,7 +248,7 @@ class _NodeReporter:
                 skipreason = skipreason[9:]
             details = f"{filename}:{lineno}: {skipreason}"
 
-            skipped = ET.Element("skipped", type="pytest.skip", message=skipreason)
+            skipped = ET.Element("skipped", type="pytest.skip", message=bin_xml_escape(skipreason))
             skipped.text = bin_xml_escape(details)
             self.append(skipped)
             self.write_captured_output(report)

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1654,6 +1654,7 @@ def test_escaped_skipreason_issue3533(
 
 
 def test_bin_escaped_skipreason(pytester: Pytester, run_and_parse: RunAndParse) -> None:
+    """Special characters are skipped from mark.skip reason (#11842)."""
     pytester.makepyfile(
         """
         import pytest

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1653,6 +1653,24 @@ def test_escaped_skipreason_issue3533(
     snode.assert_attr(message="1 <> 2")
 
 
+def test_bin_escaped_skipreason(
+    pytester: Pytester, run_and_parse: RunAndParse
+) -> None:
+    pytester.makepyfile(
+        """
+        import pytest
+        @pytest.mark.skip("\33[31;1red\33[0m")
+        def test_skip():
+            pass
+    """
+    )
+    _, dom = run_and_parse()
+    node = dom.find_first_by_tag("testcase")
+    snode = node.find_first_by_tag("skipped")
+    assert "#x1B[31;1mred#x1B[0m" in snode.text
+    snode.assert_attr(message="#x1B[31;1mred#x1B[0m")
+
+
 def test_escaped_setup_teardown_error(
     pytester: Pytester, run_and_parse: RunAndParse
 ) -> None:

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1653,9 +1653,7 @@ def test_escaped_skipreason_issue3533(
     snode.assert_attr(message="1 <> 2")
 
 
-def test_bin_escaped_skipreason(
-    pytester: Pytester, run_and_parse: RunAndParse
-) -> None:
+def test_bin_escaped_skipreason(pytester: Pytester, run_and_parse: RunAndParse) -> None:
     pytester.makepyfile(
         """
         import pytest

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1657,7 +1657,7 @@ def test_bin_escaped_skipreason(pytester: Pytester, run_and_parse: RunAndParse) 
     pytester.makepyfile(
         """
         import pytest
-        @pytest.mark.skip("\33[31;1red\33[0m")
+        @pytest.mark.skip("\33[31;1mred\33[0m")
         def test_skip():
             pass
     """

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1654,7 +1654,7 @@ def test_escaped_skipreason_issue3533(
 
 
 def test_bin_escaped_skipreason(pytester: Pytester, run_and_parse: RunAndParse) -> None:
-    """Special characters are skipped from mark.skip reason (#11842)."""
+    """Escape special characters from mark.skip reason (#11842)."""
     pytester.makepyfile(
         """
         import pytest


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Escape invalid characters in the skip message in junitxml.

Small repro:
```
import pytest

class TestA:
    @pytest.mark.skip("\33[31;1madsfsd\33[0m")
    def test_a(self):
        assert 2 == 2
```
Run the above via `pytest repro.py --junit-xml=repro.xml`
The result is (formatted for easier reading):
```
<?xml version="1.0" encoding="utf-8"?>
<testsuites>
    <testsuite name="pytest" errors="0" failures="0" skipped="1" tests="1" time="0.045"
        timestamp="2024-01-18T09:38:22.499385" hostname="csl-mbp">
        <testcase classname="repro.TestA" name="test_a" time="0.000">
            <skipped type="pytest.skip" message="[31;1mrandom colored skip reason[0m">/Users/csl/zzzzzzzz/random-testing/repro.py:4:
                #x1B[31;1mrandom colored skip reason#x1B[0m</skipped>
        </testcase>
    </testsuite>
</testsuites>
```
There's an invalid XML character (Unicode 0x1b) in the message that prevents me from parsing the XML.
The output after this change is:
```
<?xml version="1.0" encoding="utf-8"?>
<testsuites>
    <testsuite name="pytest" errors="0" failures="0" skipped="1" tests="1" time="0.037"
        timestamp="2024-01-18T09:39:55.805037" hostname="csl-mbp">
        <testcase classname="repro.TestA" name="test_a" time="0.000">
            <skipped type="pytest.skip" message="#x1B[31;1mrandom colored skip reason#x1B[0m">/Users/csl/zzzzzzzz/random-testing/repro.py:4:
                #x1B[31;1mrandom colored skip reason#x1B[0m</skipped>
        </testcase>
    </testsuite>
</testsuites>
```
