### PR TITLE
config: use `pluginmanager.unblock` instead of accessing pluggy's internals

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
         additional_dependencies:
           - iniconfig>=1.1.0
           - attrs>=19.2.0
-          - pluggy
+          - pluggy>=1.4.0
           - packaging
           - tomli
           - types-pkg_resources

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ py_modules = py
 install_requires =
     iniconfig
     packaging
-    pluggy>=1.3.0,<2.0
+    pluggy>=1.4.0,<2.0
     colorama;sys_platform=="win32"
     exceptiongroup>=1.0.0rc8;python_version<"3.11"
     tomli>=1.0.0;python_version<"3.11"

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -745,13 +745,10 @@ class PytestPluginManager(PluginManager):
                 self.set_blocked("pytest_" + name)
         else:
             name = arg
-            # Unblock the plugin.  None indicates that it has been blocked.
-            # There is no interface with pluggy for this.
-            if self._name2plugin.get(name, -1) is None:
-                del self._name2plugin[name]
+            # Unblock the plugin.
+            self.unblock(name)
             if not name.startswith("pytest_"):
-                if self._name2plugin.get("pytest_" + name, -1) is None:
-                    del self._name2plugin["pytest_" + name]
+                self.unblock("pytest_" + name)
             self.import_plugin(arg, consider_entry_points=True)
 
     def consider_conftest(


### PR DESCRIPTION
The function was added in pluggy 1.4.0.