### PR TITLE
fix: avoid rounding microsecond to `1_000_000`

### DIFF
--- a/changelog/11861.bugfix.rst
+++ b/changelog/11861.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid microsecond exceeds ``1_000_000`` when using ``log-date-format`` with ``%f`` specifier, which might cause the test suite to crash.

--- a/changelog/11861.trivial.rst
+++ b/changelog/11861.trivial.rst
@@ -1,0 +1,1 @@
+Avoid microsecond exceeds ``1_000_000`` when using ``log-date-format`` with ``%f`` specifier.

--- a/changelog/11861.trivial.rst
+++ b/changelog/11861.trivial.rst
@@ -1,1 +1,0 @@
-Avoid microsecond exceeds ``1_000_000`` when using ``log-date-format`` with ``%f`` specifier.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -71,7 +71,8 @@ class DatetimeFormatter(logging.Formatter):
             tz = timezone(timedelta(seconds=ct.tm_gmtoff), ct.tm_zone)
             # Construct `datetime.datetime` object from `struct_time`
             # and msecs information from `record`
-            dt = datetime(*ct[0:6], microsecond=round(record.msecs * 1000), tzinfo=tz)
+            # Using int() instead of round() to avoid it exceeding 1_000_000 and causing a ValueError (#11861).
+            dt = datetime(*ct[0:6], microsecond=int(record.msecs * 1000), tzinfo=tz)
             return dt.strftime(datefmt)
         # Use `logging.Formatter` for non-microsecond formats
         return super().formatTime(record, datefmt)


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

I'm using pytest with python 3.9, and my `log-date-format` is enabled for microseconds. However, my testsuite occasionally fails with the message below:
```
ValueError: microsecond must be in 0..999999
```
I'm pretty sure the issue occurred because we're rounding up microsecond here, which make it exceeds 999999.
https://github.com/pytest-dev/pytest/blob/ac2cd72e5fb00257ef1f6e17b2c16336362c6234/src/_pytest/logging.py#L72-L75

As we can see `msecs` can take more than 4 digits after decimal points, hence it can be rounded up to `1_000_000` after multiplying with `1_000`. (in python 3.9)
```python
>>> import logging
>>> r = logging.makeLogRecord({'msg': 'Message'})
>>> r.msecs
696.0451602935791
```

This is "fixed" in python 3.10 and 3.11 https://github.com/python/cpython/issues/89047
They floored `msecs` so it will always never be rounded to `1_000_000`.
```python
>>> import logging
>>> r = logging.makeLogRecord({'msg': 'Message'})
>>> r.msecs
459.0
```

However, since we also support 3.8 and 3.9, I think we should fix this by flooring microsecond as well.
(I don't know how to write test for this case without mocking `time.time()`)