### PR TITLE
mypy: disallow untyped defs by default

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -94,6 +94,7 @@ formats = sdist.tgz,bdist_wheel
 mypy_path = src
 check_untyped_defs = True
 disallow_any_generics = True
+disallow_untyped_defs = True
 ignore_missing_imports = True
 show_error_codes = True
 strict_equality = True

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import ast
 import dataclasses
 import inspect

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import ast
 import inspect
 import textwrap

--- a/src/_pytest/_io/pprint.py
+++ b/src/_pytest/_io/pprint.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 # This module was imported from the cpython standard library
 # (https://github.com/python/cpython/) at commit
 # c5140945c723ae6c4b7ee81ff720ac8ea4b52cfd (python3.12).

--- a/src/_pytest/_py/path.py
+++ b/src/_pytest/_py/path.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """local path implementation."""
 from __future__ import annotations
 

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Support for presenting detailed information in failing assertions."""
 import sys
 from typing import Any

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Utilities for assertion debugging."""
 import collections.abc
 import os

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Implementation of the cache provider."""
 # This plugin was not named "cache" to avoid conflicts with the external
 # pytest-cache version.

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Per-test stdout/stderr capturing mechanism."""
 import abc
 import collections

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Python version compatibility code."""
 from __future__ import annotations
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Command line options, ini-file and conftest.py processing."""
 import argparse
 import collections.abc

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import argparse
 import os
 import sys

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Interactive debugging with PDB, the Python Debugger."""
 import argparse
 import functools

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Discover and run doctests in modules and test files."""
 import bdb
 import functools

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import abc
 import dataclasses
 import functools

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Version info, help messages, tracing configuration."""
 import os
 import sys

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Hook specifications for pytest plugins which are invoked by pytest itself
 and by builtin plugins."""
 from pathlib import Path

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Report test results in JUnit-XML format, for use with Jenkins and build
 integration servers.
 

--- a/src/_pytest/legacypath.py
+++ b/src/_pytest/legacypath.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Add backward compatibility support for the legacy py path type."""
 import dataclasses
 import os

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Access and control log capturing."""
 import io
 import logging

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import collections.abc
 import dataclasses
 import inspect

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Monkeypatching and mocking functionality."""
 import os
 import re

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import abc
 import os
 import warnings

--- a/src/_pytest/pastebin.py
+++ b/src/_pytest/pastebin.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Submit failure or test session information to a pastebin service."""
 import tempfile
 from io import StringIO

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import atexit
 import contextlib
 import fnmatch

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """(Disabled by default) support for testing pytest and pytest plugins.
 
 PYTEST_DONT_REWRITE

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Python test discovery, setup and run of test functions."""
 import abc
 import dataclasses

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import math
 import pprint
 from collections.abc import Collection

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Record warnings during test function execution."""
 import re
 import warnings

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import dataclasses
 import os
 from io import StringIO

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Basic collect and runtest protocol implementations."""
 import bdb
 import dataclasses

--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Support for skip/xfail functions and markers."""
 import dataclasses
 import os

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Terminal reporting of the full testing process.
 
 This is a good source for looking at the various reporting hooks.

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Support for providing temporary directories to test functions."""
 import dataclasses
 import os

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Discover and run std-library "unittest" style tests."""
 import sys
 import traceback

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import sys
 import warnings
 from contextlib import contextmanager

--- a/testing/_py/test_local.py
+++ b/testing/_py/test_local.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import contextlib
 import multiprocessing
 import os

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import dataclasses
 import importlib.metadata
 import os

--- a/testing/code/test_code.py
+++ b/testing/code/test_code.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import re
 import sys
 from types import FrameType

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 from __future__ import annotations
 
 import importlib

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 # flake8: noqa
 # disable flake check on this file because some constructs are strange
 # or redundant on purpose and can't be disable on a line-by-line basis

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import dataclasses
 import re
 import sys

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 from _pytest import deprecated
 from _pytest.pytester import Pytester

--- a/testing/example_scripts/acceptance/fixture_mock_integration.py
+++ b/testing/example_scripts/acceptance/fixture_mock_integration.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Reproduces issue #3774"""
 from unittest import mock
 

--- a/testing/example_scripts/collect/collect_init_tests/tests/__init__.py
+++ b/testing/example_scripts/collect/collect_init_tests/tests/__init__.py
@@ -1,2 +1,3 @@
+# mypy: allow-untyped-defs
 def test_init():
     pass

--- a/testing/example_scripts/collect/collect_init_tests/tests/test_foo.py
+++ b/testing/example_scripts/collect/collect_init_tests/tests/test_foo.py
@@ -1,2 +1,3 @@
+# mypy: allow-untyped-defs
 def test_foo():
     pass

--- a/testing/example_scripts/collect/package_infinite_recursion/conftest.py
+++ b/testing/example_scripts/collect/package_infinite_recursion/conftest.py
@@ -1,2 +1,3 @@
+# mypy: allow-untyped-defs
 def pytest_ignore_collect(collection_path):
     return False

--- a/testing/example_scripts/collect/package_infinite_recursion/tests/test_basic.py
+++ b/testing/example_scripts/collect/package_infinite_recursion/tests/test_basic.py
@@ -1,2 +1,3 @@
+# mypy: allow-untyped-defs
 def test():
     pass

--- a/testing/example_scripts/collect/package_init_given_as_arg/pkg/__init__.py
+++ b/testing/example_scripts/collect/package_init_given_as_arg/pkg/__init__.py
@@ -1,2 +1,3 @@
+# mypy: allow-untyped-defs
 def test_init():
     pass

--- a/testing/example_scripts/collect/package_init_given_as_arg/pkg/test_foo.py
+++ b/testing/example_scripts/collect/package_init_given_as_arg/pkg/test_foo.py
@@ -1,2 +1,3 @@
+# mypy: allow-untyped-defs
 def test_foo():
     pass

--- a/testing/example_scripts/config/collect_pytest_prefix/test_foo.py
+++ b/testing/example_scripts/config/collect_pytest_prefix/test_foo.py
@@ -1,2 +1,3 @@
+# mypy: allow-untyped-defs
 def test_foo():
     pass

--- a/testing/example_scripts/conftest_usageerror/conftest.py
+++ b/testing/example_scripts/conftest_usageerror/conftest.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 def pytest_configure(config):
     import pytest
 

--- a/testing/example_scripts/customdirectory/conftest.py
+++ b/testing/example_scripts/customdirectory/conftest.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 # content of conftest.py
 import json
 

--- a/testing/example_scripts/customdirectory/tests/test_first.py
+++ b/testing/example_scripts/customdirectory/tests/test_first.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 # content of test_first.py
 def test_1():
     pass

--- a/testing/example_scripts/customdirectory/tests/test_second.py
+++ b/testing/example_scripts/customdirectory/tests/test_second.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 # content of test_second.py
 def test_2():
     pass

--- a/testing/example_scripts/customdirectory/tests/test_third.py
+++ b/testing/example_scripts/customdirectory/tests/test_third.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 # content of test_third.py
 def test_3():
     pass

--- a/testing/example_scripts/dataclasses/test_compare_initvar.py
+++ b/testing/example_scripts/dataclasses/test_compare_initvar.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 from dataclasses import dataclass
 from dataclasses import InitVar
 

--- a/testing/example_scripts/dataclasses/test_compare_recursive_dataclasses.py
+++ b/testing/example_scripts/dataclasses/test_compare_recursive_dataclasses.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 from dataclasses import dataclass
 
 

--- a/testing/example_scripts/doctest/main_py/__main__.py
+++ b/testing/example_scripts/doctest/main_py/__main__.py
@@ -1,2 +1,3 @@
+# mypy: allow-untyped-defs
 def test_this_is_ignored():
     assert True

--- a/testing/example_scripts/doctest/main_py/test_normal_module.py
+++ b/testing/example_scripts/doctest/main_py/test_normal_module.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 def test_doc():
     """
     >>> 10 > 5

--- a/testing/example_scripts/fixtures/custom_item/conftest.py
+++ b/testing/example_scripts/fixtures/custom_item/conftest.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/fixtures/custom_item/foo/test_foo.py
+++ b/testing/example_scripts/fixtures/custom_item/foo/test_foo.py
@@ -1,2 +1,3 @@
+# mypy: allow-untyped-defs
 def test():
     pass

--- a/testing/example_scripts/fixtures/fill_fixtures/test_conftest_funcargs_only_available_in_subdir/sub1/conftest.py
+++ b/testing/example_scripts/fixtures/fill_fixtures/test_conftest_funcargs_only_available_in_subdir/sub1/conftest.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/fixtures/fill_fixtures/test_conftest_funcargs_only_available_in_subdir/sub1/test_in_sub1.py
+++ b/testing/example_scripts/fixtures/fill_fixtures/test_conftest_funcargs_only_available_in_subdir/sub1/test_in_sub1.py
@@ -1,2 +1,3 @@
+# mypy: allow-untyped-defs
 def test_1(arg1):
     pass

--- a/testing/example_scripts/fixtures/fill_fixtures/test_conftest_funcargs_only_available_in_subdir/sub2/conftest.py
+++ b/testing/example_scripts/fixtures/fill_fixtures/test_conftest_funcargs_only_available_in_subdir/sub2/conftest.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/fixtures/fill_fixtures/test_conftest_funcargs_only_available_in_subdir/sub2/test_in_sub2.py
+++ b/testing/example_scripts/fixtures/fill_fixtures/test_conftest_funcargs_only_available_in_subdir/sub2/test_in_sub2.py
@@ -1,2 +1,3 @@
+# mypy: allow-untyped-defs
 def test_2(arg2):
     pass

--- a/testing/example_scripts/fixtures/fill_fixtures/test_detect_recursive_dependency_error.py
+++ b/testing/example_scripts/fixtures/fill_fixtures/test_detect_recursive_dependency_error.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/fixtures/fill_fixtures/test_extend_fixture_conftest_conftest/conftest.py
+++ b/testing/example_scripts/fixtures/fill_fixtures/test_extend_fixture_conftest_conftest/conftest.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/fixtures/fill_fixtures/test_extend_fixture_conftest_conftest/pkg/conftest.py
+++ b/testing/example_scripts/fixtures/fill_fixtures/test_extend_fixture_conftest_conftest/pkg/conftest.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/fixtures/fill_fixtures/test_extend_fixture_conftest_conftest/pkg/test_spam.py
+++ b/testing/example_scripts/fixtures/fill_fixtures/test_extend_fixture_conftest_conftest/pkg/test_spam.py
@@ -1,2 +1,3 @@
+# mypy: allow-untyped-defs
 def test_spam(spam):
     assert spam == "spamspam"

--- a/testing/example_scripts/fixtures/fill_fixtures/test_extend_fixture_conftest_module/conftest.py
+++ b/testing/example_scripts/fixtures/fill_fixtures/test_extend_fixture_conftest_module/conftest.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/fixtures/fill_fixtures/test_extend_fixture_conftest_module/test_extend_fixture_conftest_module.py
+++ b/testing/example_scripts/fixtures/fill_fixtures/test_extend_fixture_conftest_module/test_extend_fixture_conftest_module.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/fixtures/fill_fixtures/test_extend_fixture_module_class.py
+++ b/testing/example_scripts/fixtures/fill_fixtures/test_extend_fixture_module_class.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/fixtures/fill_fixtures/test_funcarg_basic.py
+++ b/testing/example_scripts/fixtures/fill_fixtures/test_funcarg_basic.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/fixtures/fill_fixtures/test_funcarg_lookup_classlevel.py
+++ b/testing/example_scripts/fixtures/fill_fixtures/test_funcarg_lookup_classlevel.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/fixtures/fill_fixtures/test_funcarg_lookup_modulelevel.py
+++ b/testing/example_scripts/fixtures/fill_fixtures/test_funcarg_lookup_modulelevel.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/fixtures/fill_fixtures/test_funcarg_lookupfails.py
+++ b/testing/example_scripts/fixtures/fill_fixtures/test_funcarg_lookupfails.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/fixtures/test_fixture_named_request.py
+++ b/testing/example_scripts/fixtures/test_fixture_named_request.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/fixtures/test_getfixturevalue_dynamic.py
+++ b/testing/example_scripts/fixtures/test_getfixturevalue_dynamic.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/issue88_initial_file_multinodes/conftest.py
+++ b/testing/example_scripts/issue88_initial_file_multinodes/conftest.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/issue88_initial_file_multinodes/test_hello.py
+++ b/testing/example_scripts/issue88_initial_file_multinodes/test_hello.py
@@ -1,2 +1,3 @@
+# mypy: allow-untyped-defs
 def test_hello():
     pass

--- a/testing/example_scripts/issue_519.py
+++ b/testing/example_scripts/issue_519.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pprint
 from typing import List
 from typing import Tuple

--- a/testing/example_scripts/marks/marks_considered_keywords/test_marks_as_keywords.py
+++ b/testing/example_scripts/marks/marks_considered_keywords/test_marks_as_keywords.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/perf_examples/collect_stats/generate_folders.py
+++ b/testing/example_scripts/perf_examples/collect_stats/generate_folders.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import argparse
 import pathlib
 

--- a/testing/example_scripts/perf_examples/collect_stats/template_test.py
+++ b/testing/example_scripts/perf_examples/collect_stats/template_test.py
@@ -1,2 +1,3 @@
+# mypy: allow-untyped-defs
 def test_x():
     pass

--- a/testing/example_scripts/tmpdir/tmp_path_fixture.py
+++ b/testing/example_scripts/tmpdir/tmp_path_fixture.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/example_scripts/unittest/test_parametrized_fixture_error_message.py
+++ b/testing/example_scripts/unittest/test_parametrized_fixture_error_message.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import unittest
 
 import pytest

--- a/testing/example_scripts/unittest/test_setup_skip.py
+++ b/testing/example_scripts/unittest/test_setup_skip.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Skipping an entire subclass with unittest.skip() should *not* call setUp from a base class."""
 import unittest
 

--- a/testing/example_scripts/unittest/test_setup_skip_class.py
+++ b/testing/example_scripts/unittest/test_setup_skip_class.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Skipping an entire subclass with unittest.skip() should *not* call setUpClass from a base class."""
 import unittest
 

--- a/testing/example_scripts/unittest/test_setup_skip_module.py
+++ b/testing/example_scripts/unittest/test_setup_skip_module.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """setUpModule is always called, even if all tests in the module are skipped"""
 import unittest
 

--- a/testing/example_scripts/unittest/test_unittest_asyncio.py
+++ b/testing/example_scripts/unittest/test_unittest_asyncio.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 from typing import List
 from unittest import IsolatedAsyncioTestCase
 

--- a/testing/example_scripts/unittest/test_unittest_asynctest.py
+++ b/testing/example_scripts/unittest/test_unittest_asynctest.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Issue #7110"""
 import asyncio
 from typing import List

--- a/testing/example_scripts/unittest/test_unittest_plain_async.py
+++ b/testing/example_scripts/unittest/test_unittest_plain_async.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import unittest
 
 

--- a/testing/example_scripts/warnings/test_group_warnings_by_message.py
+++ b/testing/example_scripts/warnings/test_group_warnings_by_message.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import warnings
 
 import pytest

--- a/testing/example_scripts/warnings/test_group_warnings_by_message_summary/test_1.py
+++ b/testing/example_scripts/warnings/test_group_warnings_by_message_summary/test_1.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import warnings
 
 import pytest

--- a/testing/example_scripts/warnings/test_group_warnings_by_message_summary/test_2.py
+++ b/testing/example_scripts/warnings/test_group_warnings_by_message_summary/test_2.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 from test_1 import func
 
 

--- a/testing/freeze/tests/test_trivial.py
+++ b/testing/freeze/tests/test_trivial.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 def test_upper():
     assert "foo".upper() == "FOO"
 

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE
 from _pytest._io.saferepr import saferepr

--- a/testing/io/test_terminalwriter.py
+++ b/testing/io/test_terminalwriter.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import io
 import os
 import re

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import io
 import os
 import re

--- a/testing/plugins_integration/bdd_wallet.py
+++ b/testing/plugins_integration/bdd_wallet.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 from pytest_bdd import given
 from pytest_bdd import scenario
 from pytest_bdd import then

--- a/testing/plugins_integration/pytest_anyio_integration.py
+++ b/testing/plugins_integration/pytest_anyio_integration.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import anyio
 
 import pytest

--- a/testing/plugins_integration/pytest_asyncio_integration.py
+++ b/testing/plugins_integration/pytest_asyncio_integration.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import asyncio
 
 import pytest

--- a/testing/plugins_integration/pytest_mock_integration.py
+++ b/testing/plugins_integration/pytest_mock_integration.py
@@ -1,2 +1,3 @@
+# mypy: allow-untyped-defs
 def test_mocker(mocker):
     mocker.MagicMock()

--- a/testing/plugins_integration/pytest_trio_integration.py
+++ b/testing/plugins_integration/pytest_trio_integration.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import trio
 
 import pytest

--- a/testing/plugins_integration/pytest_twisted_integration.py
+++ b/testing/plugins_integration/pytest_twisted_integration.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest_twisted
 from twisted.internet.task import deferLater
 

--- a/testing/plugins_integration/simple_integration.py
+++ b/testing/plugins_integration/simple_integration.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 
 

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import operator
 from contextlib import contextmanager
 from decimal import Decimal

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import os
 import sys
 import textwrap

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import os
 import sys
 import textwrap
@@ -4403,7 +4404,7 @@ def test_fixture_named_request(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(
         [
             "*'request' is a reserved word for fixtures, use another name:",
-            "  *test_fixture_named_request.py:5",
+            "  *test_fixture_named_request.py:6",
         ]
     )
 

--- a/testing/python/integration.py
+++ b/testing/python/integration.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 from _pytest._code import getfslineno
 from _pytest.fixtures import getfixturemarker

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import dataclasses
 import itertools
 import re

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import re
 import sys
 

--- a/testing/test_argcomplete.py
+++ b/testing/test_argcomplete.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import subprocess
 import sys
 from pathlib import Path

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import collections
 import sys
 import textwrap

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import ast
 import errno
 import glob

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import os
 import shutil
 from pathlib import Path

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import contextlib
 import io
 import os

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import os
 import pprint
 import shutil

--- a/testing/test_compat.py
+++ b/testing/test_compat.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import enum
 import sys
 from functools import cached_property

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import dataclasses
 import importlib.metadata
 import os

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import os
 import textwrap
 from pathlib import Path

--- a/testing/test_debugging.py
+++ b/testing/test_debugging.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import os
 import sys
 from typing import List

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import inspect
 import sys
 import textwrap

--- a/testing/test_entry_points.py
+++ b/testing/test_entry_points.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import importlib.metadata
 
 

--- a/testing/test_faulthandler.py
+++ b/testing/test_faulthandler.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import io
 import sys
 

--- a/testing/test_findpaths.py
+++ b/testing/test_findpaths.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import os
 from pathlib import Path
 from textwrap import dedent

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 from _pytest.config import ExitCode
 from _pytest.pytester import Pytester

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import os
 import platform
 from datetime import datetime

--- a/testing/test_legacypath.py
+++ b/testing/test_legacypath.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 from pathlib import Path
 
 import pytest

--- a/testing/test_link_resolve.py
+++ b/testing/test_link_resolve.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import os.path
 import subprocess
 import sys

--- a/testing/test_main.py
+++ b/testing/test_main.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import argparse
 import os
 import re

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import os
 import sys
 from typing import List

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import os
 import re
 import sys

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import re
 import warnings
 from pathlib import Path

--- a/testing/test_parseopt.py
+++ b/testing/test_parseopt.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import argparse
 import locale
 import os

--- a/testing/test_pastebin.py
+++ b/testing/test_pastebin.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import email.message
 import io
 from typing import List

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import errno
 import os.path
 import pickle

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import os
 import shutil
 import sys

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import os
 import subprocess
 import sys

--- a/testing/test_python_path.py
+++ b/testing/test_python_path.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import sys
 from textwrap import dedent
 from typing import Generator

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import warnings
 from typing import List
 from typing import Optional

--- a/testing/test_reports.py
+++ b/testing/test_reports.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 from typing import Sequence
 from typing import Union
 

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import inspect
 import os
 import sys

--- a/testing/test_runner_xunit.py
+++ b/testing/test_runner_xunit.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Test correct setup/teardowns at module, class, and instance level."""
 from typing import List
 

--- a/testing/test_session.py
+++ b/testing/test_session.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import pytest
 from _pytest.config import ExitCode
 from _pytest.monkeypatch import MonkeyPatch

--- a/testing/test_setuponly.py
+++ b/testing/test_setuponly.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import sys
 
 import pytest

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import sys
 import textwrap
 

--- a/testing/test_stepwise.py
+++ b/testing/test_stepwise.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 from pathlib import Path
 
 import pytest

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """Terminal reporting of the full testing process."""
 import collections
 import os

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import dataclasses
 import os
 import stat

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import gc
 import sys
 from typing import List

--- a/testing/test_warning_types.py
+++ b/testing/test_warning_types.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import inspect
 
 import pytest

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import os
 import sys
 import warnings
@@ -623,11 +624,11 @@ def test_group_warnings_by_message_summary(pytester: Pytester) -> None:
             "*== %s ==*" % WARNINGS_SUMMARY_HEADER,
             "test_1.py: 21 warnings",
             "test_2.py: 1 warning",
-            "  */test_1.py:7: UserWarning: foo",
+            "  */test_1.py:8: UserWarning: foo",
             "    warnings.warn(UserWarning(msg))",
             "",
             "test_1.py: 20 warnings",
-            "  */test_1.py:7: UserWarning: bar",
+            "  */test_1.py:8: UserWarning: bar",
             "    warnings.warn(UserWarning(msg))",
             "",
             "-- Docs: *",

--- a/testing/typing_checks.py
+++ b/testing/typing_checks.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 """File for checking typing issues.
 
 This file is not executed, it is only checked by mypy to ensure that


### PR DESCRIPTION
Change our mypy configuration to disallow untyped defs by default, which ensures *new* files added to the code base are fully typed.

To avoid having to type-annotate everything now, add `# mypy: allow-untyped-defs` to files which are not fully type annotated yet. 

As we fully type annotate those modules, we can then just remove that directive from the top.