### PR TITLE
Catch `OSError` from `getpass.getuser()`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -340,6 +340,7 @@ Ronny Pfannschmidt
 Ross Lawley
 Ruaridh Williamson
 Russel Winder
+Russell Martin
 Ryan Puddephatt
 Ryan Wooden
 Sadra Barikbin

--- a/changelog/11875.bugfix.rst
+++ b/changelog/11875.bugfix.rst
@@ -1,0 +1,1 @@
+Correctly handle errors from :func:`getpass.getuser` in Python 3.13.

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -204,7 +204,7 @@ def get_user() -> Optional[str]:
         import getpass
 
         return getpass.getuser()
-    except (ImportError, KeyError):
+    except (ImportError, OSError, KeyError):
         return None
 
 


### PR DESCRIPTION
- Previously, `getpass.getuser()` would leak an ImportError if the USERNAME environment variable was not set on Windows because the `pwd` module cannot be imported.
- Starting in Python 3.13.0a3, it only raises `OSError`.
- Closes #11874

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
