### PR TITLE
Add a changelog entry about FixtureManager.getfixtureclosure losing a default argument

### DIFF
--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -266,8 +266,7 @@ These are breaking changes where deprecation was not possible.
   therefore fail on the newly-re-emitted warnings.
 
 
-- The internal ``FixtureManager.getfixtureclosure`` method introduced a breaking change (mostly by accident):
-  the ``ignore_args`` parameter was changed to an ``AbstractSet[str]`` and lost the default argument. Plugins
+- The internal ``FixtureManager.getfixtureclosure`` method has changed. Plugins which use this method or
   which subclass ``FixtureManager`` and overwrite that method will need to adapt to the change.
 
 

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -266,6 +266,11 @@ These are breaking changes where deprecation was not possible.
   therefore fail on the newly-re-emitted warnings.
 
 
+- The internal ``FixtureManager.getfixtureclosure`` method introduced a breaking change (mostly by accident):
+  the ``ignore_args`` parameter was changed to an ``AbstractSet[str]`` and lost the default argument. Plugins
+  which subclass ``FixtureManager`` and overwrite that method will need to adapt to the change.
+
+
 
 Deprecations
 ------------


### PR DESCRIPTION
As discussed in #11868.

