### PR TITLE
Reintroduce default value for ignore_args argument of FixtureManager.getfixtureclosure

### DIFF
--- a/changelog/11868.bugfix.rst
+++ b/changelog/11868.bugfix.rst
@@ -1,1 +1,1 @@
-Reintroduced the default value for the ``ignore_args`` of internal ``FixtureManager.getfixtureclosure``: even though it is an internal API, it was changed by accident in 8.0.0 and this broken a number of plugins.
+Reintroduced the default value for the ``ignore_args`` of internal ``FixtureManager.getfixtureclosure``: it was changed in 8.0.0 and this has broken a number of plugins.

--- a/changelog/11868.bugfix.rst
+++ b/changelog/11868.bugfix.rst
@@ -1,0 +1,1 @@
+Reintroduced the default value for the ``ignore_args`` of internal ``FixtureManager.getfixtureclosure``: even though it is an internal API, it was changed by accident in 8.0.0 and this broken a number of plugins.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1524,7 +1524,7 @@ class FixtureManager:
         self,
         parentnode: nodes.Node,
         initialnames: Tuple[str, ...],
-        ignore_args: AbstractSet[str],
+        ignore_args: AbstractSet[str] = frozenset(),
     ) -> Tuple[List[str], Dict[str, Sequence[FixtureDef[Any]]]]:
         # Collect the closure of all fixtures, starting with the given
         # fixturenames as the initial set.  As we have to visit all


### PR DESCRIPTION
Fix #11868
