### PR TITLE
Pin back pytest-asyncio to 8.0.0 compatible release

### DIFF
--- a/testing/plugins_integration/requirements.txt
+++ b/testing/plugins_integration/requirements.txt
@@ -1,6 +1,6 @@
 anyio[curio,trio]==4.2.0
 django==5.0
-pytest-asyncio==0.23.4
+pytest-asyncio==0.23.3
 # Temporarily not installed until pytest-bdd is fixed:
 # https://github.com/pytest-dev/pytest/pull/11785
 # pytest-bdd==7.0.1


### PR DESCRIPTION
The current version (0.23.4) explicitly does not support pytest 8 yet, so we fallback to the previous release in the hope that at least our integration tests pass.
