### PR TITLE
EAFP check on if file is accessible.

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -203,7 +203,11 @@ def pytest_collect_directory(
     path: Path, parent: nodes.Collector
 ) -> Optional[nodes.Collector]:
     pkginit = path / "__init__.py"
-    if pkginit.is_file():
+    try:
+        is_accessible_file = pkginit.is_file()
+    except PermissionError:
+        is_accessible_file = False
+    if is_accessible_file:
         pkg: Package = Package.from_parent(parent, path=path)
         return pkg
     return None


### PR DESCRIPTION
closes #11902.
`os.access` suggests EAFP rather than checking access then accessing.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
