### PR TITLE
Move show-fixtures code from python.py to fixtures.py

### DIFF
--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -51,6 +51,7 @@ from _pytest.compat import NotSetType
 from _pytest.compat import safe_getattr
 from _pytest.config import _PluggyPlugin
 from _pytest.config import Config
+from _pytest.config import ExitCode
 from _pytest.config.argparsing import Parser
 from _pytest.deprecated import check_ispytest
 from _pytest.deprecated import MARKED_FIXTURE
@@ -1365,6 +1366,33 @@ def pytest_addoption(parser: Parser) -> None:
         default=[],
         help="List of default fixtures to be used with this project",
     )
+    group = parser.getgroup("general")
+    group.addoption(
+        "--fixtures",
+        "--funcargs",
+        action="store_true",
+        dest="showfixtures",
+        default=False,
+        help="Show available fixtures, sorted by plugin appearance "
+        "(fixtures with leading '_' are only shown with '-v')",
+    )
+    group.addoption(
+        "--fixtures-per-test",
+        action="store_true",
+        dest="show_fixtures_per_test",
+        default=False,
+        help="Show fixtures per test",
+    )
+
+
+def pytest_cmdline_main(config: Config) -> Optional[Union[int, ExitCode]]:
+    if config.option.showfixtures:
+        showfixtures(config)
+        return 0
+    if config.option.show_fixtures_per_test:
+        show_fixtures_per_test(config)
+        return 0
+    return None
 
 
 def _get_direct_parametrize_args(node: nodes.Node) -> Set[str]:
@@ -1761,3 +1789,137 @@ class FixtureManager:
         for fixturedef in fixturedefs:
             if fixturedef.baseid in parentnodeids:
                 yield fixturedef
+
+
+def show_fixtures_per_test(config: Config) -> Union[int, ExitCode]:
+    from _pytest.main import wrap_session
+
+    return wrap_session(config, _show_fixtures_per_test)
+
+
+_PYTEST_DIR = Path(_pytest.__file__).parent
+
+
+def _pretty_fixture_path(invocation_dir: Path, func) -> str:
+    loc = Path(getlocation(func, invocation_dir))
+    prefix = Path("...", "_pytest")
+    try:
+        return str(prefix / loc.relative_to(_PYTEST_DIR))
+    except ValueError:
+        return bestrelpath(invocation_dir, loc)
+
+
+def _show_fixtures_per_test(config: Config, session: "Session") -> None:
+    import _pytest.config
+
+    session.perform_collect()
+    invocation_dir = config.invocation_params.dir
+    tw = _pytest.config.create_terminal_writer(config)
+    verbose = config.getvalue("verbose")
+
+    def get_best_relpath(func) -> str:
+        loc = getlocation(func, invocation_dir)
+        return bestrelpath(invocation_dir, Path(loc))
+
+    def write_fixture(fixture_def: FixtureDef[object]) -> None:
+        argname = fixture_def.argname
+        if verbose <= 0 and argname.startswith("_"):
+            return
+        prettypath = _pretty_fixture_path(invocation_dir, fixture_def.func)
+        tw.write(f"{argname}", green=True)
+        tw.write(f" -- {prettypath}", yellow=True)
+        tw.write("\n")
+        fixture_doc = inspect.getdoc(fixture_def.func)
+        if fixture_doc:
+            write_docstring(
+                tw, fixture_doc.split("\n\n")[0] if verbose <= 0 else fixture_doc
+            )
+        else:
+            tw.line("    no docstring available", red=True)
+
+    def write_item(item: nodes.Item) -> None:
+        # Not all items have _fixtureinfo attribute.
+        info: Optional[FuncFixtureInfo] = getattr(item, "_fixtureinfo", None)
+        if info is None or not info.name2fixturedefs:
+            # This test item does not use any fixtures.
+            return
+        tw.line()
+        tw.sep("-", f"fixtures used by {item.name}")
+        # TODO: Fix this type ignore.
+        tw.sep("-", f"({get_best_relpath(item.function)})")  # type: ignore[attr-defined]
+        # dict key not used in loop but needed for sorting.
+        for _, fixturedefs in sorted(info.name2fixturedefs.items()):
+            assert fixturedefs is not None
+            if not fixturedefs:
+                continue
+            # Last item is expected to be the one used by the test item.
+            write_fixture(fixturedefs[-1])
+
+    for session_item in session.items:
+        write_item(session_item)
+
+
+def showfixtures(config: Config) -> Union[int, ExitCode]:
+    from _pytest.main import wrap_session
+
+    return wrap_session(config, _showfixtures_main)
+
+
+def _showfixtures_main(config: Config, session: "Session") -> None:
+    import _pytest.config
+
+    session.perform_collect()
+    invocation_dir = config.invocation_params.dir
+    tw = _pytest.config.create_terminal_writer(config)
+    verbose = config.getvalue("verbose")
+
+    fm = session._fixturemanager
+
+    available = []
+    seen: Set[Tuple[str, str]] = set()
+
+    for argname, fixturedefs in fm._arg2fixturedefs.items():
+        assert fixturedefs is not None
+        if not fixturedefs:
+            continue
+        for fixturedef in fixturedefs:
+            loc = getlocation(fixturedef.func, invocation_dir)
+            if (fixturedef.argname, loc) in seen:
+                continue
+            seen.add((fixturedef.argname, loc))
+            available.append(
+                (
+                    len(fixturedef.baseid),
+                    fixturedef.func.__module__,
+                    _pretty_fixture_path(invocation_dir, fixturedef.func),
+                    fixturedef.argname,
+                    fixturedef,
+                )
+            )
+
+    available.sort()
+    currentmodule = None
+    for baseid, module, prettypath, argname, fixturedef in available:
+        if currentmodule != module:
+            if not module.startswith("_pytest."):
+                tw.line()
+                tw.sep("-", f"fixtures defined from {module}")
+                currentmodule = module
+        if verbose <= 0 and argname.startswith("_"):
+            continue
+        tw.write(f"{argname}", green=True)
+        if fixturedef.scope != "function":
+            tw.write(" [%s scope]" % fixturedef.scope, cyan=True)
+        tw.write(f" -- {prettypath}", yellow=True)
+        tw.write("\n")
+        doc = inspect.getdoc(fixturedef.func)
+        if doc:
+            write_docstring(tw, doc.split("\n\n")[0] if verbose <= 0 else doc)
+        else:
+            tw.line("    no docstring available", red=True)
+        tw.line()
+
+
+def write_docstring(tw: TerminalWriter, doc: str, indent: str = "    ") -> None:
+    for line in doc.split("\n"):
+        tw.line(indent + line)


### PR DESCRIPTION
It makes more sense, also, we have a long term idea of generalizing fixture support to items defined by other plugins, not just python, in which case `--fixtures` would definitely not be python-plugin specific.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
