### PR TITLE
[pre-commit] Activate ruff checks and fix existing issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,6 @@ ignore = [
     # ruff ignore
     "RUF005", # Consider `(x, *y)` instead of concatenation
     "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
-    "RUF015", # Prefer `next(iter(x))` over single element slice
 ]
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,8 +158,6 @@ ignore = [
     "D404", # First word of the docstring should not be "This"
     "D415", # First line should end with a period, question mark, or exclamation point
     # ruff ignore
-    "RUF001", # String contains ambiguous character
-    "RUF003", # Comment contains ambiguous character
     "RUF005", # Consider `(x, *y)` instead of concatenation
     "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
     "RUF015", # Prefer `next(iter(x))` over single element slice

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ select = [
     "F",  # pyflakes
     "I",  # isort
     "UP", # pyupgrade
+    "RUF", # ruff
     "W",  # pycodestyle
 ]
 ignore = [
@@ -156,6 +157,12 @@ ignore = [
     "D402", # First line should not be the function's signature
     "D404", # First word of the docstring should not be "This"
     "D415", # First line should end with a period, question mark, or exclamation point
+    # ruff ignore
+    "RUF001", # String contains ambiguous character
+    "RUF003", # Comment contains ambiguous character
+    "RUF005", # Consider `(x, *y)` instead of concatenation
+    "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
+    "RUF015", # Prefer `next(iter(x))` over single element slice
 ]
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,6 @@ ignore = [
     "D404", # First word of the docstring should not be "This"
     "D415", # First line should end with a period, question mark, or exclamation point
     # ruff ignore
-    "RUF005", # Consider `(x, *y)` instead of concatenation
     "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
 ]
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -107,7 +107,7 @@ def pre_release(
 
 def changelog(version: str, write_out: bool = False) -> None:
     addopts = [] if write_out else ["--draft"]
-    check_call(["towncrier", "--yes", "--version", version] + addopts)
+    check_call(["towncrier", "--yes", "--version", version, *addopts])
 
 
 def main() -> None:

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -1018,7 +1018,7 @@ class FormattedExcinfo:
             extraline: Optional[str] = (
                 "!!! Recursion error detected, but an error occurred locating the origin of recursion.\n"
                 "  The following exception happened when comparing locals in the stack frame:\n"
-                f"    {type(e).__name__}: {str(e)}\n"
+                f"    {type(e).__name__}: {e!s}\n"
                 f"  Displaying first and last {max_frames} stack frames out of {len(traceback)}."
             )
             # Type ignored because adding two instances of a List subtype

--- a/src/_pytest/_py/path.py
+++ b/src/_pytest/_py/path.py
@@ -1105,9 +1105,7 @@ class LocalPath:
                 modname = self.purebasename
             spec = importlib.util.spec_from_file_location(modname, str(self))
             if spec is None or spec.loader is None:
-                raise ImportError(
-                    f"Can't find module {modname} at location {str(self)}"
-                )
+                raise ImportError(f"Can't find module {modname} at location {self!s}")
             mod = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(mod)
             return mod

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -925,7 +925,7 @@ class AssertionRewriter(ast.NodeVisitor):
             # If any hooks implement assert_pass hook
             hook_impl_test = ast.If(
                 self.helper("_check_if_assertion_pass_impl"),
-                self.expl_stmts + [hook_call_pass],
+                [*self.expl_stmts, hook_call_pass],
                 [],
             )
             statements_pass = [hook_impl_test]

--- a/src/_pytest/assertion/truncate.py
+++ b/src/_pytest/assertion/truncate.py
@@ -92,7 +92,8 @@ def _truncate_explanation(
     else:
         # Add proper ellipsis when we were able to fit a full line exactly
         truncated_explanation[-1] = "..."
-    return truncated_explanation + [
+    return [
+        *truncated_explanation,
         "",
         f"...Full output truncated ({truncated_line_count} line"
         f"{'' if truncated_line_count == 1 else 's'} hidden), {USAGE_MSG}",

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -233,8 +233,8 @@ def assertrepr_compare(
         return None
 
     if explanation[0] != "":
-        explanation = [""] + explanation
-    return [summary] + explanation
+        explanation = ["", *explanation]
+    return [summary, *explanation]
 
 
 def _compare_eq_any(

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -27,7 +27,7 @@ _S = TypeVar("_S")
 # https://www.python.org/dev/peps/pep-0484/#support-for-singleton-types-in-unions
 class NotSetType(enum.Enum):
     token = 0
-NOTSET: Final = NotSetType.token  # noqa: E305
+NOTSET: Final = NotSetType.token
 # fmt: on
 
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -671,7 +671,7 @@ class PytestPluginManager(PluginManager):
                 if dirpath in path.parents or path == dirpath:
                     if mod in mods:
                         raise AssertionError(
-                            f"While trying to load conftest path {str(conftestpath)}, "
+                            f"While trying to load conftest path {conftestpath!s}, "
                             f"found that the module {mod} is already loaded with path {mod.__file__}. "
                             "This is not supposed to happen. Please report this issue to pytest."
                         )

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -238,7 +238,8 @@ essential_plugins = (
     "helpconfig",  # Provides -p.
 )
 
-default_plugins = essential_plugins + (
+default_plugins = (
+    *essential_plugins,
     "python",
     "terminal",
     "debugging",

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -122,7 +122,7 @@ class Parser:
         from _pytest._argcomplete import filescompleter
 
         optparser = MyOptionParser(self, self.extra_info, prog=self.prog)
-        groups = self._groups + [self._anonymous]
+        groups = [*self._groups, self._anonymous]
         for group in groups:
             if group.options:
                 desc = group.description or group.name

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1225,7 +1225,7 @@ def fixture(
 
 
 @overload
-def fixture(  # noqa: F811
+def fixture(
     fixture_function: None = ...,
     *,
     scope: "Union[_ScopeName, Callable[[str, Config], _ScopeName]]" = ...,
@@ -1239,7 +1239,7 @@ def fixture(  # noqa: F811
     ...
 
 
-def fixture(  # noqa: F811
+def fixture(
     fixture_function: Optional[FixtureFunction] = None,
     *,
     scope: "Union[_ScopeName, Callable[[str, Config], _ScopeName]]" = "function",
@@ -1673,7 +1673,7 @@ class FixtureManager:
         raise NotImplementedError()
 
     @overload
-    def parsefactories(  # noqa: F811
+    def parsefactories(
         self,
         node_or_obj: object,
         nodeid: Optional[str],
@@ -1682,7 +1682,7 @@ class FixtureManager:
     ) -> None:
         raise NotImplementedError()
 
-    def parsefactories(  # noqa: F811
+    def parsefactories(
         self,
         node_or_obj: Union[nodes.Node, object],
         nodeid: Union[str, NotSetType, None] = NOTSET,

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -375,7 +375,7 @@ def record_testsuite_property(request: FixtureRequest) -> Callable[[str, object]
 
     xml = request.config.stash.get(xml_key, None)
     if xml is not None:
-        record_func = xml.add_global_property  # noqa
+        record_func = xml.add_global_property
     return record_func
 
 

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -726,12 +726,12 @@ class Session(nodes.Collector):
         ...
 
     @overload
-    def perform_collect(  # noqa: F811
+    def perform_collect(
         self, args: Optional[Sequence[str]] = ..., genitems: bool = ...
     ) -> Sequence[Union[nodes.Item, nodes.Collector]]:
         ...
 
-    def perform_collect(  # noqa: F811
+    def perform_collect(
         self, args: Optional[Sequence[str]] = None, genitems: bool = True
     ) -> Sequence[Union[nodes.Item, nodes.Collector]]:
         """Perform the collection phase for this session.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -406,7 +406,7 @@ def normalize_mark_list(
     for mark in mark_list:
         mark_obj = getattr(mark, "mark", mark)
         if not isinstance(mark_obj, Mark):
-            raise TypeError(f"got {repr(mark_obj)} instead of Mark")
+            raise TypeError(f"got {mark_obj!r} instead of Mark")
         yield mark_obj
 
 

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1061,7 +1061,7 @@ class Pytester:
         :param cmdlineargs: Any extra command line arguments to use.
         """
         p = self.makepyfile(source)
-        values = list(cmdlineargs) + [p]
+        values = [*list(cmdlineargs), p]
         return self.inline_run(*values)
 
     def inline_genitems(self, *args) -> Tuple[List[Item], HookRecorder]:
@@ -1491,10 +1491,10 @@ class Pytester:
         """
         __tracebackhide__ = True
         p = make_numbered_dir(root=self.path, prefix="runpytest-", mode=0o700)
-        args = ("--basetemp=%s" % p,) + args
+        args = ("--basetemp=%s" % p, *args)
         plugins = [x for x in self.plugins if isinstance(x, str)]
         if plugins:
-            args = ("-p", plugins[0]) + args
+            args = ("-p", plugins[0], *args)
         args = self._getpytestargs() + args
         return self.run(*args, timeout=timeout)
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -358,7 +358,7 @@ class PyobjMixin(nodes.Node):
 # hook is not called for them.
 # fmt: off
 class _EmptyClass: pass  # noqa: E701
-IGNORED_ATTRIBUTES = frozenset.union(  # noqa: E305
+IGNORED_ATTRIBUTES = frozenset.union(
     frozenset(),
     # Module.
     dir(types.ModuleType("empty_module")),

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -730,7 +730,7 @@ def approx(expected, rel=None, abs=None, nan_ok: bool = False) -> ApproxBase:
         # Type ignored because the error is wrong -- not unreachable.
         and not isinstance(expected, STRING_TYPES)  # type: ignore[unreachable]
     ):
-        msg = f"pytest.approx() only supports ordered sequences, but got: {repr(expected)}"
+        msg = f"pytest.approx() only supports ordered sequences, but got: {expected!r}"
         raise TypeError(msg)
     else:
         cls = ApproxScalar
@@ -780,7 +780,7 @@ def raises(
 
 
 @overload
-def raises(  # noqa: F811
+def raises(
     expected_exception: Union[Type[E], Tuple[Type[E], ...]],
     func: Callable[..., Any],
     *args: Any,
@@ -789,7 +789,7 @@ def raises(  # noqa: F811
     ...
 
 
-def raises(  # noqa: F811
+def raises(
     expected_exception: Union[Type[E], Tuple[Type[E], ...]], *args: Any, **kwargs: Any
 ) -> Union["RaisesContext[E]", _pytest._code.ExceptionInfo[E]]:
     r"""Assert that a code block/function call raises an exception type, or one of its subclasses.

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -47,13 +47,11 @@ def deprecated_call(
 
 
 @overload
-def deprecated_call(  # noqa: F811
-    func: Callable[..., T], *args: Any, **kwargs: Any
-) -> T:
+def deprecated_call(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
     ...
 
 
-def deprecated_call(  # noqa: F811
+def deprecated_call(
     func: Optional[Callable[..., Any]] = None, *args: Any, **kwargs: Any
 ) -> Union["WarningsRecorder", Any]:
     """Assert that code produces a ``DeprecationWarning`` or ``PendingDeprecationWarning`` or ``FutureWarning``.
@@ -97,7 +95,7 @@ def warns(
 
 
 @overload
-def warns(  # noqa: F811
+def warns(
     expected_warning: Union[Type[Warning], Tuple[Type[Warning], ...]],
     func: Callable[..., T],
     *args: Any,
@@ -106,7 +104,7 @@ def warns(  # noqa: F811
     ...
 
 
-def warns(  # noqa: F811
+def warns(
     expected_warning: Union[Type[Warning], Tuple[Type[Warning], ...]] = Warning,
     *args: Any,
     match: Optional[Union[str, Pattern[str]]] = None,

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -79,7 +79,7 @@ def deprecated_call(
     """
     __tracebackhide__ = True
     if func is not None:
-        args = (func,) + args
+        args = (func, *args)
     return warns(
         (DeprecationWarning, PendingDeprecationWarning, FutureWarning), *args, **kwargs
     )

--- a/testing/_py/test_local.py
+++ b/testing/_py/test_local.py
@@ -17,7 +17,7 @@ import pytest
 def ignore_encoding_warning():
     with warnings.catch_warnings():
         with contextlib.suppress(NameError):  # new in 3.10
-            warnings.simplefilter("ignore", EncodingWarning)  # type: ignore [name-defined]  # noqa: F821
+            warnings.simplefilter("ignore", EncodingWarning)  # type: ignore [name-defined]
         yield
 
 

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -1739,7 +1739,7 @@ def test_hidden_entries_of_chained_exceptions_are_not_shown(pytester: Pytester) 
 def add_note(err: BaseException, msg: str) -> None:
     """Adds a note to an exception inplace."""
     if sys.version_info < (3, 11):
-        err.__notes__ = getattr(err, "__notes__", []) + [msg]  # type: ignore[attr-defined]
+        err.__notes__ = [*getattr(err, "__notes__", []), msg]  # type: ignore[attr-defined]
     else:
         err.add_note(msg)
 

--- a/testing/freeze/create_executable.py
+++ b/testing/freeze/create_executable.py
@@ -9,5 +9,5 @@ if __name__ == "__main__":
     for x in pytest.freeze_includes():
         hidden.extend(["--hidden-import", x])
     hidden.extend(["--hidden-import", "distutils"])
-    args = ["pyinstaller", "--noconfirm"] + hidden + ["runtests_script.py"]
+    args = ["pyinstaller", "--noconfirm", *hidden, "runtests_script.py"]
     subprocess.check_call(" ".join(args), shell=True)

--- a/testing/io/test_wcwidth.py
+++ b/testing/io/test_wcwidth.py
@@ -15,7 +15,7 @@ import pytest
         ("\u1ABE", 0),
         ("\u0591", 0),
         ("🉐", 2),
-        ("＄", 2),
+        ("＄", 2),  # noqa: RUF001
     ],
 )
 def test_wcwidth(c: str, expected: int) -> None:

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -1032,7 +1032,7 @@ def test_log_set_path(pytester: Pytester) -> None:
             def pytest_runtest_setup(item):
                 config = item.config
                 logging_plugin = config.pluginmanager.get_plugin("logging-plugin")
-                report_file = os.path.join({repr(report_dir_base)}, item._request.node.name)
+                report_file = os.path.join({report_dir_base!r}, item._request.node.name)
                 logging_plugin.set_log_path(report_file)
                 return (yield)
         """

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -1209,7 +1209,7 @@ class TestReportInfo:
         classcol = pytester.collect_by_name(modcol, "TestClass")
         assert isinstance(classcol, Class)
         path, lineno, msg = classcol.reportinfo()
-        func = list(classcol.collect())[0]
+        func = next(iter(classcol.collect()))
         assert isinstance(func, Function)
         path, lineno, msg = func.reportinfo()
 

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -4536,5 +4536,5 @@ def test_yield_fixture_with_no_value(pytester: Pytester) -> None:
 def test_deduplicate_names() -> None:
     items = deduplicate_names("abacd")
     assert items == ("a", "b", "c", "d")
-    items = deduplicate_names(items + ("g", "f", "g", "e", "b"))
+    items = deduplicate_names((*items, "g", "f", "g", "e", "b"))
     assert items == ("a", "b", "c", "d", "g", "f", "e")

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -3086,7 +3086,7 @@ class TestFixtureMarker:
             def test_other():
                 pass
         """  # noqa: UP031 (python syntax issues)
-            % {"scope": scope}  # noqa: UP031 (python syntax issues)
+            % {"scope": scope}
         )
         reprec = pytester.inline_run("-lvs")
         reprec.assertoutcome(passed=3)

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -147,7 +147,7 @@ class TestRaises:
         try:
             pytest.raises(ValueError, int, "0")
         except pytest.fail.Exception as e:
-            assert e.msg == f"DID NOT RAISE {repr(ValueError)}"
+            assert e.msg == f"DID NOT RAISE {ValueError!r}"
         else:
             assert False, "Expected pytest.raises.Exception"
 
@@ -155,7 +155,7 @@ class TestRaises:
             with pytest.raises(ValueError):
                 pass
         except pytest.fail.Exception as e:
-            assert e.msg == f"DID NOT RAISE {repr(ValueError)}"
+            assert e.msg == f"DID NOT RAISE {ValueError!r}"
         else:
             assert False, "Expected pytest.raises.Exception"
 

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -914,16 +914,16 @@ class TestAssert_reprcompare:
         assert expl == [
             r"'hyv\xe4' == 'hyva\u0308'",
             "",
-            f"- {str(right)}",
-            f"+ {str(left)}",
+            f"- {right!s}",
+            f"+ {left!s}",
         ]
 
         expl = callequal(left, right, verbose=2)
         assert expl == [
             r"'hyv\xe4' == 'hyva\u0308'",
             "",
-            f"- {str(right)}",
-            f"+ {str(left)}",
+            f"- {right!s}",
+            f"+ {left!s}",
         ]
 
 

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1149,7 +1149,7 @@ class TestAssert_reprcompare_attrsclass:
     def test_attrs_with_auto_detect_and_custom_eq(self) -> None:
         @attr.s(
             auto_detect=True
-        )  # attr.s doesn’t ignore a custom eq if auto_detect=True
+        )  # attr.s doesn't ignore a custom eq if auto_detect=True
         class SimpleDataObject:
             field_a = attr.ib()
 

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -729,7 +729,7 @@ class TestDoctests:
                 >>> name = 'с' # not letter 'c' but instead Cyrillic 's'.
                 'anything'
                 """
-            '''
+            '''  # noqa: RUF001
         )
         result = pytester.runpytest("--doctest-modules")
         result.stdout.fnmatch_lines(["Got nothing", "* 1 failed in*"])

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -190,7 +190,7 @@ class TestDoctests:
         )
         doctest = f"""
             >>> "{test_string}"
-            {repr(test_string)}
+            {test_string!r}
         """
         fn = pytester.path / "test_encoding.txt"
         fn.write_text(doctest, encoding=encoding)

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -42,7 +42,7 @@ class RunAndParse:
         self, *args: Union[str, "os.PathLike[str]"], family: Optional[str] = "xunit1"
     ) -> Tuple[RunResult, "DomNode"]:
         if family:
-            args = ("-o", "junit_family=" + family) + args
+            args = ("-o", "junit_family=" + family, *args)
         xml_path = self.pytester.path.joinpath("junit.xml")
         result = self.pytester.runpytest("--junitxml=%s" % xml_path, *args)
         if family == "xunit2":

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -227,7 +227,7 @@ class TestInlineRunModulesCleanup:
 
     def spy_factory(self):
         class SysModulesSnapshotSpy:
-            instances: List["SysModulesSnapshotSpy"] = []  # noqa: F821
+            instances: List["SysModulesSnapshotSpy"] = []
 
             def __init__(self, preserve=None) -> None:
                 SysModulesSnapshotSpy.instances.append(self)
@@ -725,7 +725,7 @@ def test_run_result_repr() -> None:
     # known exit code
     r = pytester_mod.RunResult(1, outlines, errlines, duration=0.5)
     assert repr(r) == (
-        f"<RunResult ret={str(pytest.ExitCode.TESTS_FAILED)} len(stdout.lines)=3"
+        f"<RunResult ret={pytest.ExitCode.TESTS_FAILED!s} len(stdout.lines)=3"
         " len(stderr.lines)=4 duration=0.50s>"
     )
 

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -417,8 +417,8 @@ class TestTerminal:
 
         result = pytester.runpytest("-v")
         result.stdout.fnmatch_lines(
-            common_output
-            + [
+            [
+                *common_output,
                 "test_verbose_skip_reason.py::test_long_skip SKIPPED (1 cannot *...) *",
                 "test_verbose_skip_reason.py::test_long_xfail XFAIL (2 cannot *...) *",
             ]
@@ -426,17 +426,13 @@ class TestTerminal:
 
         result = pytester.runpytest("-vv")
         result.stdout.fnmatch_lines(
-            common_output
-            + [
-                (
-                    "test_verbose_skip_reason.py::test_long_skip SKIPPED"
-                    " (1 cannot do foobar"
-                ),
+            [
+                *common_output,
+                "test_verbose_skip_reason.py::test_long_skip SKIPPED"
+                " (1 cannot do foobar",
                 "because baz is missing due to I don't know what) *",
-                (
-                    "test_verbose_skip_reason.py::test_long_xfail XFAIL"
-                    " (2 cannot do foobar"
-                ),
+                "test_verbose_skip_reason.py::test_long_xfail XFAIL"
+                " (2 cannot do foobar",
                 "because baz is missing due to I don't know what) *",
             ]
         )


### PR DESCRIPTION
Follow-up to #11901, there's some nice fixes here I think, especially automated removal of useless noqa. I would consider adding flake8-bugbear next but let me know what you think. I suppose most of the ``f"{x!s}"`` are the default behavior in a f-string and we could replace them with ``f"{x}"`` but I'm not sure why this is not what ruff does when autofixing already.