### PR TITLE
Ignore isort on _version.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,3 +178,6 @@ force-sort-within-sections = true
 order-by-type = false
 known-local-folder = ["pytest", "_pytest"]
 lines-after-imports = 2
+
+[tool.ruff.lint.per-file-ignores]
+"src/_pytest/_version.py" = ["I001"]


### PR DESCRIPTION
The file is generated. This makes `ruff src/` run cleanly (when not running through pre-commit).