### PR TITLE
Add typing to `from_parent` return values

### DIFF
--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -48,6 +48,7 @@ from _pytest.warning_types import PytestWarning
 
 if TYPE_CHECKING:
     import doctest
+    from typing import Self
 
 DOCTEST_REPORT_CHOICE_NONE = "none"
 DOCTEST_REPORT_CHOICE_CDIFF = "cdiff"
@@ -134,11 +135,9 @@ def pytest_collect_file(
         if config.option.doctestmodules and not any(
             (_is_setup_py(file_path), _is_main_py(file_path))
         ):
-            mod: DoctestModule = DoctestModule.from_parent(parent, path=file_path)
-            return mod
+            return DoctestModule.from_parent(parent, path=file_path)
     elif _is_doctest(config, file_path, parent):
-        txt: DoctestTextfile = DoctestTextfile.from_parent(parent, path=file_path)
-        return txt
+        return DoctestTextfile.from_parent(parent, path=file_path)
     return None
 
 
@@ -273,14 +272,14 @@ class DoctestItem(Item):
         self._initrequest()
 
     @classmethod
-    def from_parent(  # type: ignore
+    def from_parent(  # type: ignore[override]
         cls,
         parent: "Union[DoctestTextfile, DoctestModule]",
         *,
         name: str,
         runner: "doctest.DocTestRunner",
         dtest: "doctest.DocTest",
-    ):
+    ) -> "Self":
         # incompatible signature due to imposed limits on subclass
         """The public named constructor."""
         return super().from_parent(name=name, parent=parent, runner=runner, dtest=dtest)

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -21,6 +21,7 @@ from typing import Optional
 from typing import overload
 from typing import Sequence
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 import warnings
 
@@ -47,6 +48,10 @@ from _pytest.reports import TestReport
 from _pytest.runner import collect_one_node
 from _pytest.runner import SetupState
 from _pytest.warning_types import PytestWarning
+
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 def pytest_addoption(parser: Parser) -> None:
@@ -491,16 +496,16 @@ class Dir(nodes.Directory):
     @classmethod
     def from_parent(  # type: ignore[override]
         cls,
-        parent: nodes.Collector,  # type: ignore[override]
+        parent: nodes.Collector,
         *,
         path: Path,
-    ) -> "Dir":
+    ) -> "Self":
         """The public constructor.
 
         :param parent: The parent collector of this Dir.
         :param path: The directory's path.
         """
-        return super().from_parent(parent=parent, path=path)  # type: ignore[no-any-return]
+        return super().from_parent(parent=parent, path=path)
 
     def collect(self) -> Iterable[Union[nodes.Item, nodes.Collector]]:
         config = self.config

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -27,6 +27,7 @@ from typing import Pattern
 from typing import Sequence
 from typing import Set
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 import warnings
 
@@ -80,6 +81,10 @@ from _pytest.stash import StashKey
 from _pytest.warning_types import PytestCollectionWarning
 from _pytest.warning_types import PytestReturnNotNoneWarning
 from _pytest.warning_types import PytestUnhandledCoroutineWarning
+
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 _PYTEST_DIR = Path(_pytest.__file__).parent
@@ -205,8 +210,7 @@ def pytest_collect_directory(
 ) -> Optional[nodes.Collector]:
     pkginit = path / "__init__.py"
     if pkginit.is_file():
-        pkg: Package = Package.from_parent(parent, path=path)
-        return pkg
+        return Package.from_parent(parent, path=path)
     return None
 
 
@@ -231,8 +235,7 @@ def path_matches_patterns(path: Path, patterns: Iterable[str]) -> bool:
 
 
 def pytest_pycollect_makemodule(module_path: Path, parent) -> "Module":
-    mod: Module = Module.from_parent(parent, path=module_path)
-    return mod
+    return Module.from_parent(parent, path=module_path)
 
 
 @hookimpl(trylast=True)
@@ -243,8 +246,7 @@ def pytest_pycollect_makeitem(
     # Nothing was collected elsewhere, let's do it here.
     if safe_isclass(obj):
         if collector.istestclass(obj, name):
-            klass: Class = Class.from_parent(collector, name=name, obj=obj)
-            return klass
+            return Class.from_parent(collector, name=name, obj=obj)
     elif collector.istestfunction(obj, name):
         # mock seems to store unbound methods (issue473), normalize it.
         obj = getattr(obj, "__func__", obj)
@@ -263,7 +265,7 @@ def pytest_pycollect_makeitem(
             )
         elif getattr(obj, "__test__", True):
             if is_generator(obj):
-                res: Function = Function.from_parent(collector, name=name)
+                res = Function.from_parent(collector, name=name)
                 reason = (
                     f"yield tests were removed in pytest 4.0 - {name} will be ignored"
                 )
@@ -466,9 +468,7 @@ class PyCollector(PyobjMixin, nodes.Collector, abc.ABC):
         clscol = self.getparent(Class)
         cls = clscol and clscol.obj or None
 
-        definition: FunctionDefinition = FunctionDefinition.from_parent(
-            self, name=name, callobj=funcobj
-        )
+        definition = FunctionDefinition.from_parent(self, name=name, callobj=funcobj)
         fixtureinfo = definition._fixtureinfo
 
         # pytest_generate_tests impls call metafunc.parametrize() which fills
@@ -752,7 +752,7 @@ class Class(PyCollector):
     """Collector for test methods (and nested classes) in a Python class."""
 
     @classmethod
-    def from_parent(cls, parent, *, name, obj=None, **kw):
+    def from_parent(cls, parent, *, name, obj=None, **kw) -> "Self":  # type: ignore[override]
         """The public constructor."""
         return super().from_parent(name=name, parent=parent, **kw)
 
@@ -1732,8 +1732,9 @@ class Function(PyobjMixin, nodes.Item):
         self.fixturenames = fixtureinfo.names_closure
         self._initrequest()
 
+    # todo: determine sound type limitations
     @classmethod
-    def from_parent(cls, parent, **kw):  # todo: determine sound type limitations
+    def from_parent(cls, parent, **kw) -> "Self":
         """The public constructor."""
         return super().from_parent(parent=parent, **kw)
 

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -55,8 +55,7 @@ def pytest_pycollect_makeitem(
     except Exception:
         return None
     # Yes, so let's collect it.
-    item: UnitTestCase = UnitTestCase.from_parent(collector, name=name, obj=obj)
-    return item
+    return UnitTestCase.from_parent(collector, name=name, obj=obj)
 
 
 class UnitTestCase(Class):

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -1596,7 +1596,7 @@ def test_fscollector_from_parent(pytester: Pytester, request: FixtureRequest) ->
     assert collector.x == 10
 
 
-def test_class_from_parent(pytester: Pytester, request: FixtureRequest) -> None:
+def test_class_from_parent(request: FixtureRequest) -> None:
     """Ensure Class.from_parent can forward custom arguments to the constructor."""
 
     class MyCollector(pytest.Class):


### PR DESCRIPTION
Up to now the return values of `from_parent` were untyped, this is an attempt to make it work with `typing.Self`.