### PR TITLE
``pytest.warns`` multiple argument handling

### DIFF
--- a/changelog/11906.bugfix.rst
+++ b/changelog/11906.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression with :func:`pytest.warns` using custom warning subclasses which have more than one parameter in their `__init__`.

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -42,11 +42,13 @@ def recwarn() -> Generator["WarningsRecorder", None, None]:
 @overload
 def deprecated_call(
     *, match: Optional[Union[str, Pattern[str]]] = ...
-) -> "WarningsRecorder": ...
+) -> "WarningsRecorder":
+    ...
 
 
 @overload
-def deprecated_call(func: Callable[..., T], *args: Any, **kwargs: Any) -> T: ...
+def deprecated_call(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+    ...
 
 
 def deprecated_call(
@@ -88,7 +90,8 @@ def warns(
     expected_warning: Union[Type[Warning], Tuple[Type[Warning], ...]] = ...,
     *,
     match: Optional[Union[str, Pattern[str]]] = ...,
-) -> "WarningsChecker": ...
+) -> "WarningsChecker":
+    ...
 
 
 @overload
@@ -97,7 +100,8 @@ def warns(
     func: Callable[..., T],
     *args: Any,
     **kwargs: Any,
-) -> T: ...
+) -> T:
+    ...
 
 
 def warns(

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -322,10 +322,10 @@ class WarningsChecker(WarningsRecorder):
             for w in self:
                 if not self.matches(w):
                     warnings.warn_explicit(
-                        str(w.message),
-                        w.message.__class__,  # type: ignore[arg-type]
-                        w.filename,
-                        w.lineno,
+                        message=w.message,
+                        category=w.category,
+                        filename=w.filename,
+                        lineno=w.lineno,
                         module=w.__module__,
                         source=w.source,
                     )

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -42,13 +42,11 @@ def recwarn() -> Generator["WarningsRecorder", None, None]:
 @overload
 def deprecated_call(
     *, match: Optional[Union[str, Pattern[str]]] = ...
-) -> "WarningsRecorder":
-    ...
+) -> "WarningsRecorder": ...
 
 
 @overload
-def deprecated_call(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
-    ...
+def deprecated_call(func: Callable[..., T], *args: Any, **kwargs: Any) -> T: ...
 
 
 def deprecated_call(
@@ -90,8 +88,7 @@ def warns(
     expected_warning: Union[Type[Warning], Tuple[Type[Warning], ...]] = ...,
     *,
     match: Optional[Union[str, Pattern[str]]] = ...,
-) -> "WarningsChecker":
-    ...
+) -> "WarningsChecker": ...
 
 
 @overload
@@ -100,8 +97,7 @@ def warns(
     func: Callable[..., T],
     *args: Any,
     **kwargs: Any,
-) -> T:
-    ...
+) -> T: ...
 
 
 def warns(
@@ -336,7 +332,9 @@ class WarningsChecker(WarningsRecorder):
 
     @staticmethod
     def _validate_message(wrn: Any) -> None:
-        if not isinstance(msg := wrn.message.args[0], str):
+        if type(wrn.message) is UserWarning and not isinstance(
+            msg := wrn.message.args[0], str
+        ):
             raise TypeError(
                 f"Warning message must be str, got {msg!r} (type {type(msg).__name__})"
             )

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -506,7 +506,7 @@ def test_raise_type_error_on_non_string_warning_cpython() -> None:
             warnings.warn(1)  # type: ignore
 
 
-def test_multiple_arg_custom_warning(self) -> None:
+def test_multiple_arg_custom_warning() -> None:
     """Test for issue #11906."""
 
     class CustomWarning(UserWarning):

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -480,6 +480,8 @@ class TestWarns:
                 raise ValueError("some exception")
 
     def test_multiple_arg_custom_warning(self) -> None:
+        """Test for issue #11906."""
+
         class CustomWarning(UserWarning):
             def __init__(self, a, b):
                 pass

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -479,28 +479,13 @@ class TestWarns:
                 warnings.warn("some warning", category=FutureWarning)
                 raise ValueError("some exception")
 
+    def test_multiple_arg_custom_warning(self) -> None:
+        class CustomWarning(UserWarning):
+            def __init__(self, a, b):
+                pass
 
-def test_raise_type_error_on_non_string_warning() -> None:
-    """Check pytest.warns validates warning messages are strings (#10865)."""
-    with pytest.raises(TypeError, match="Warning message must be str"):
-        with pytest.warns(UserWarning):
-            warnings.warn(1)  # type: ignore
-
-
-def test_no_raise_type_error_on_string_warning() -> None:
-    """Check pytest.warns validates warning messages are strings (#10865)."""
-    with pytest.warns(UserWarning):
-        warnings.warn("Warning")
-
-
-@pytest.mark.skipif(
-    hasattr(sys, "pypy_version_info"),
-    reason="Not for pypy",
-)
-def test_raise_type_error_on_non_string_warning_cpython() -> None:
-    # Check that we get the same behavior with the stdlib, at least if filtering
-    # (see https://github.com/python/cpython/issues/103577 for details)
-    with pytest.raises(TypeError):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", "test")
-            warnings.warn(1)  # type: ignore
+        with pytest.warns(CustomWarning):
+            with pytest.raises(pytest.fail.Exception, match="DID NOT WARN"):
+                with pytest.warns(CustomWarning, match="not gonna match"):
+                    a, b = 1, 2
+                    warnings.warn(CustomWarning(a, b))

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -479,15 +479,42 @@ class TestWarns:
                 warnings.warn("some warning", category=FutureWarning)
                 raise ValueError("some exception")
 
-    def test_multiple_arg_custom_warning(self) -> None:
-        """Test for issue #11906."""
 
-        class CustomWarning(UserWarning):
-            def __init__(self, a, b):
-                pass
+def test_raise_type_error_on_non_string_warning() -> None:
+    """Check pytest.warns validates warning messages are strings (#10865)."""
+    with pytest.raises(TypeError, match="Warning message must be str"):
+        with pytest.warns(UserWarning):
+            warnings.warn(1)  # type: ignore
 
-        with pytest.warns(CustomWarning):
-            with pytest.raises(pytest.fail.Exception, match="DID NOT WARN"):
-                with pytest.warns(CustomWarning, match="not gonna match"):
-                    a, b = 1, 2
-                    warnings.warn(CustomWarning(a, b))
+
+def test_no_raise_type_error_on_string_warning() -> None:
+    """Check pytest.warns validates warning messages are strings (#10865)."""
+    with pytest.warns(UserWarning):
+        warnings.warn("Warning")
+
+
+@pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info"),
+    reason="Not for pypy",
+)
+def test_raise_type_error_on_non_string_warning_cpython() -> None:
+    # Check that we get the same behavior with the stdlib, at least if filtering
+    # (see https://github.com/python/cpython/issues/103577 for details)
+    with pytest.raises(TypeError):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "test")
+            warnings.warn(1)  # type: ignore
+
+
+def test_multiple_arg_custom_warning(self) -> None:
+    """Test for issue #11906."""
+
+    class CustomWarning(UserWarning):
+        def __init__(self, a, b):
+            pass
+
+    with pytest.warns(CustomWarning):
+        with pytest.raises(pytest.fail.Exception, match="DID NOT WARN"):
+            with pytest.warns(CustomWarning, match="not gonna match"):
+                a, b = 1, 2
+                warnings.warn(CustomWarning(a, b))


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Fixes #11906