### PR TITLE
Migration from ``setup.cfg`` to ``pyproject.toml``

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,6 @@ repos:
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==24.1.1]
--   repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.5.0
-    hooks:
-    -   id: setup-cfg-fmt
-        args: ["--max-py-version=3.12", "--include-version-classifiers"]
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,6 @@
 [project]
-
 name = "pytest"
-dynamic = [
-    "version",
-    "optional-dependencies",
-    "dependencies",
-    "scripts",
-    "requires-python"
-]
+dynamic = ["version"]
 description = "pytest: simple powerful testing with Python"
 authors = [
     {name = "Holger Krekel"},
@@ -40,6 +33,32 @@ classifiers = [
     "Topic :: Software Development :: Testing",
     "Topic :: Utilities",
 ]
+
+dependencies = [
+    "colorama;sys_platform=='win32'",
+    "exceptiongroup>=1.0.0rc8;python_version<'3.11'",
+    "iniconfig",
+    "packaging",
+    "pluggy>=1.4.0,<2.0",
+    "tomli>=1.0.0;python_version<'3.11'",
+]
+requires-python = ">=3.8"
+
+[project.optional-dependencies]
+testing = [
+    "argcomplete",
+    "attrs>=19.2.0",
+    "hypothesis>=3.56",
+    "mock",
+    "pygments>=2.7.2",
+    "requests",
+    "setuptools",
+    "xmlschema",
+]
+
+[project.scripts]
+"py.test" = "pytest:console_main"
+pytest = "pytest:console_main"
 
 [project.urls]
 Homepage = "https://docs.pytest.org/en/latest/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,10 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.package-data]
+"_pytest" = ["py.typed"]
+"pytest" = ["py.typed"]
+
 [tool.setuptools_scm]
 write_to = "src/_pytest/_version.py"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,53 @@
+[project]
+
+name = "pytest"
+dynamic = [
+    "version",
+    "optional-dependencies",
+    "dependencies",
+    "scripts",
+    "requires-python"
+]
+description = "pytest: simple powerful testing with Python"
+authors = [
+    {name = "Holger Krekel"},
+    {name = "Bruno Oliveira"},
+    {name = "Ronny Pfannschmidt"},
+    {name = "Floris Bruynooghe"},
+    {name = "Brianna Laugher"},
+    {name = "Florian Bruhin"},
+    {name = "Others (See AUTHORS)"},
+]
+readme = "README.rst"
+license = {text = "MIT"}
+keywords = ["test", "unittest"]
+classifiers = [
+    "Development Status :: 6 - Mature",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: Unix",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Testing",
+    "Topic :: Utilities",
+]
+
+[project.urls]
+Homepage = "https://docs.pytest.org/en/latest/"
+Changelog = "https://docs.pytest.org/en/stable/changelog.html"
+Twitter = "https://twitter.com/pytestdotorg"
+Source = "https://github.com/pytest-dev/pytest"
+Tracker = "https://github.com/pytest-dev/pytest/issues"
+
 [build-system]
 requires = [
   "setuptools>=45.0",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,33 +1,9 @@
 [options]
-install_requires =
-    iniconfig
-    packaging
-    pluggy>=1.4.0,<2.0
-    colorama;sys_platform=="win32"
-    exceptiongroup>=1.0.0rc8;python_version<"3.11"
-    tomli>=1.0.0;python_version<"3.11"
-python_requires = >=3.8
 package_dir =
     =src
 setup_requires =
     setuptools
     setuptools-scm>=6.0
-
-[options.entry_points]
-console_scripts =
-    pytest=pytest:console_main
-    py.test=pytest:console_main
-
-[options.extras_require]
-testing =
-    argcomplete
-    attrs>=19.2.0
-    hypothesis>=3.56
-    mock
-    pygments>=2.7.2
-    requests
-    setuptools
-    xmlschema
 
 [options.package_data]
 _pytest = py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,3 @@
-[options]
-package_dir =
-    =src
-setup_requires =
-    setuptools
-    setuptools-scm>=6.0
-
 [options.package_data]
 _pytest = py.typed
 pytest = py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[metadata]
-platforms = unix, linux, osx, cygwin, win32
-
 [options]
 install_requires =
     iniconfig

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[options.package_data]
-_pytest = py.typed
-pytest = py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,36 +1,5 @@
 [metadata]
-name = pytest
-description = pytest: simple powerful testing with Python
-long_description = file: README.rst
-long_description_content_type = text/x-rst
-url = https://docs.pytest.org/en/latest/
-author = Holger Krekel, Bruno Oliveira, Ronny Pfannschmidt, Floris Bruynooghe, Brianna Laugher, Florian Bruhin and others
-license = MIT
-license_files = LICENSE
 platforms = unix, linux, osx, cygwin, win32
-classifiers =
-    Development Status :: 6 - Mature
-    Intended Audience :: Developers
-    License :: OSI Approved :: MIT License
-    Operating System :: MacOS :: MacOS X
-    Operating System :: Microsoft :: Windows
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Topic :: Software Development :: Libraries
-    Topic :: Software Development :: Testing
-    Topic :: Utilities
-keywords = test, unittest
-project_urls =
-    Changelog=https://docs.pytest.org/en/stable/changelog.html
-    Twitter=https://twitter.com/pytestdotorg
-    Source=https://github.com/pytest-dev/pytest
-    Tracker=https://github.com/pytest-dev/pytest/issues
 
 [options]
 install_requires =


### PR DESCRIPTION
This is a follow-up to https://github.com/pytest-dev/pytest/pull/11928. Diff between what is generated on main and what is generated on last commit of this branch using ``python -m build`` is as follow:
```diff
diff --git a/pytest-8.1.0.dev153+gaaa9ca732/.pre-commit-config.yaml b/pytest-8.1.0.dev153+gaaa9ca732/.pre-commit-config.yaml
index 032fe8c4d..ca3b41d58 100644
--- a/pytest-8.1.0.dev153+gaaa9ca732/.pre-commit-config.yaml
+++ b/pytest-8.1.0.dev153+gaaa9ca732/.pre-commit-config.yaml
@@ -21,11 +21,6 @@ repos:
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==24.1.1]
--   repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.5.0
-    hooks:
-    -   id: setup-cfg-fmt
-        args: ["--max-py-version=3.12", "--include-version-classifiers"]
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
diff --git a/pytest-8.1.0.dev153+gaaa9ca732/PKG-INFO b/pytest-8.1.0.dev153+gaaa9ca732/PKG-INFO
index 8691affe6..27e62a6c4 100644
--- a/pytest-8.1.0.dev153+gaaa9ca732/PKG-INFO
+++ b/pytest-8.1.0.dev153+gaaa9ca732/PKG-INFO
@@ -1,44 +1,42 @@
 Metadata-Version: 2.1
 Name: pytest
-Version: 8.1.0.dev153+gaaa9ca732
+Version: 8.1.0.dev159+g2f7ee5dde.d20240205
 Summary: pytest: simple powerful testing with Python
-Home-page: https://docs.pytest.org/en/latest/
-Author: Holger Krekel, Bruno Oliveira, Ronny Pfannschmidt, Floris Bruynooghe, Brianna Laugher, Florian Bruhin and others
+Author: Holger Krekel
+Maintainer: Bruno Oliveira, Ronny Pfannschmidt, Floris Bruynooghe, Brianna Laugher, Florian Bruhin and others, Others (See AUTHORS)
 License: MIT
+Project-URL: Homepage, https://docs.pytest.org/en/latest/
 Project-URL: Changelog, https://docs.pytest.org/en/stable/changelog.html
 Project-URL: Twitter, https://twitter.com/pytestdotorg
 Project-URL: Source, https://github.com/pytest-dev/pytest
 Project-URL: Tracker, https://github.com/pytest-dev/pytest/issues
 Keywords: test,unittest
-Platform: unix
-Platform: linux
-Platform: osx
-Platform: cygwin
-Platform: win32
 Classifier: Development Status :: 6 - Mature
 Classifier: Intended Audience :: Developers
 Classifier: License :: OSI Approved :: MIT License
-Classifier: Operating System :: MacOS :: MacOS X
+Classifier: Operating System :: Unix
+Classifier: Operating System :: MacOS
 Classifier: Operating System :: Microsoft :: Windows
 Classifier: Operating System :: POSIX
 Classifier: Programming Language :: Python :: 3
 Classifier: Programming Language :: Python :: 3 :: Only
-Classifier: Programming Language :: Python :: 3.8
-Classifier: Programming Language :: Python :: 3.9
 Classifier: Programming Language :: Python :: 3.10
 Classifier: Programming Language :: Python :: 3.11
 Classifier: Programming Language :: Python :: 3.12
+Classifier: Programming Language :: Python :: 3.8
+Classifier: Programming Language :: Python :: 3.9
 Classifier: Topic :: Software Development :: Libraries
 Classifier: Topic :: Software Development :: Testing
 Classifier: Topic :: Utilities
 Requires-Python: >=3.8
 Description-Content-Type: text/x-rst
 License-File: LICENSE
+License-File: AUTHORS
+Requires-Dist: colorama; sys_platform == "win32"
+Requires-Dist: exceptiongroup>=1.0.0rc8; python_version < "3.11"
 Requires-Dist: iniconfig
 Requires-Dist: packaging
 Requires-Dist: pluggy<2.0,>=1.4.0
-Requires-Dist: colorama; sys_platform == "win32"
-Requires-Dist: exceptiongroup>=1.0.0rc8; python_version < "3.11"
 Requires-Dist: tomli>=1.0.0; python_version < "3.11"
 Provides-Extra: testing
 Requires-Dist: argcomplete; extra == "testing"
@@ -49,6 +47,13 @@ Requires-Dist: pygments>=2.7.2; extra == "testing"
 Requires-Dist: requests; extra == "testing"
 Requires-Dist: setuptools; extra == "testing"
 Requires-Dist: xmlschema; extra == "testing"
+Provides-Extra: release
+Requires-Dist: pypandoc; extra == "release"
+Requires-Dist: colorama; extra == "release"
+Requires-Dist: github3.py; extra == "release"
+Requires-Dist: pre-commit>=2.9.3; extra == "release"
+Requires-Dist: wheel; extra == "release"
+Requires-Dist: towncrier<21.3.0; extra == "release"
 
 .. image:: https://github.com/pytest-dev/pytest/raw/main/doc/en/img/pytest_logo_curves.svg
    :target: https://docs.pytest.org/en/stable/
diff --git a/pytest-8.1.0.dev153+gaaa9ca732/pyproject.toml b/pytest-8.1.0.dev153+gaaa9ca732/pyproject.toml
index 15a855ce6..8c1b3fff0 100644
--- a/pytest-8.1.0.dev153+gaaa9ca732/pyproject.toml
+++ b/pytest-8.1.0.dev153+gaaa9ca732/pyproject.toml
@@ -1,3 +1,83 @@
+[project]
+name = "pytest"
+dynamic = ["version"]
+description = "pytest: simple powerful testing with Python"
+authors = [
+    {name = "Holger Krekel"},
+]
+maintainers = [
+    {name = "Bruno Oliveira"},
+    {name = "Ronny Pfannschmidt"},
+    {name = "Floris Bruynooghe"},
+    {name = "Brianna Laugher"},
+    {name = "Florian Bruhin and others"},
+    {name = "Others (See AUTHORS)"},
+]
+readme = "README.rst"
+license = {text = "MIT"}
+keywords = ["test", "unittest"]
+classifiers = [
+    "Development Status :: 6 - Mature",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Testing",
+    "Topic :: Utilities",
+]
+
+dependencies = [
+    "colorama;sys_platform=='win32'",
+    "exceptiongroup>=1.0.0rc8;python_version<'3.11'",
+    "iniconfig",
+    "packaging",
+    "pluggy>=1.4.0,<2.0",
+    "tomli>=1.0.0;python_version<'3.11'",
+]
+requires-python = ">=3.8"
+
+[project.optional-dependencies]
+testing = [
+    "argcomplete",
+    "attrs>=19.2.0",
+    "hypothesis>=3.56",
+    "mock",
+    "pygments>=2.7.2",
+    "requests",
+    "setuptools",
+    "xmlschema",
+]
+release = [
+    "pypandoc",
+    "colorama",
+    "github3.py",
+    "pre-commit>=2.9.3",
+    "wheel",
+    # https://github.com/twisted/towncrier/issues/340
+    "towncrier<21.3.0",
+]
+
+[project.scripts]
+"py.test" = "pytest:console_main"
+pytest = "pytest:console_main"
+
+[project.urls]
+Homepage = "https://docs.pytest.org/en/latest/"
+Changelog = "https://docs.pytest.org/en/stable/changelog.html"
+Twitter = "https://twitter.com/pytestdotorg"
+Source = "https://github.com/pytest-dev/pytest"
+Tracker = "https://github.com/pytest-dev/pytest/issues"
+
 [build-system]
 requires = [
   "setuptools>=45.0",
@@ -5,6 +85,10 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.package-data]
+"_pytest" = ["py.typed"]
+"pytest" = ["py.typed"]
+
 [tool.setuptools_scm]
 write_to = "src/_pytest/_version.py"
 
diff --git a/pytest-8.1.0.dev153+gaaa9ca732/setup.cfg b/pytest-8.1.0.dev153+gaaa9ca732/setup.cfg
index 71d7ed980..8bfd5a12f 100644
--- a/pytest-8.1.0.dev153+gaaa9ca732/setup.cfg
+++ b/pytest-8.1.0.dev153+gaaa9ca732/setup.cfg
@@ -1,72 +1,3 @@
-[metadata]
-name = pytest
-description = pytest: simple powerful testing with Python
-long_description = file: README.rst
-long_description_content_type = text/x-rst
-url = https://docs.pytest.org/en/latest/
-author = Holger Krekel, Bruno Oliveira, Ronny Pfannschmidt, Floris Bruynooghe, Brianna Laugher, Florian Bruhin and others
-license = MIT
-license_files = LICENSE
-platforms = unix, linux, osx, cygwin, win32
-classifiers = 
-	Development Status :: 6 - Mature
-	Intended Audience :: Developers
-	License :: OSI Approved :: MIT License
-	Operating System :: MacOS :: MacOS X
-	Operating System :: Microsoft :: Windows
-	Operating System :: POSIX
-	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3 :: Only
-	Programming Language :: Python :: 3.8
-	Programming Language :: Python :: 3.9
-	Programming Language :: Python :: 3.10
-	Programming Language :: Python :: 3.11
-	Programming Language :: Python :: 3.12
-	Topic :: Software Development :: Libraries
-	Topic :: Software Development :: Testing
-	Topic :: Utilities
-keywords = test, unittest
-project_urls = 
-	Changelog=https://docs.pytest.org/en/stable/changelog.html
-	Twitter=https://twitter.com/pytestdotorg
-	Source=https://github.com/pytest-dev/pytest
-	Tracker=https://github.com/pytest-dev/pytest/issues
-
-[options]
-install_requires = 
-	iniconfig
-	packaging
-	pluggy>=1.4.0,<2.0
-	colorama;sys_platform=="win32"
-	exceptiongroup>=1.0.0rc8;python_version<"3.11"
-	tomli>=1.0.0;python_version<"3.11"
-python_requires = >=3.8
-package_dir = 
-	=src
-setup_requires = 
-	setuptools
-	setuptools-scm>=6.0
-
-[options.entry_points]
-console_scripts = 
-	pytest=pytest:console_main
-	py.test=pytest:console_main
-
-[options.extras_require]
-testing = 
-	argcomplete
-	attrs>=19.2.0
-	hypothesis>=3.56
-	mock
-	pygments>=2.7.2
-	requests
-	setuptools
-	xmlschema
-
-[options.package_data]
-_pytest = py.typed
-pytest = py.typed
-
 [egg_info]
 tag_build = 
 tag_date = 0
diff --git a/pytest-8.1.0.dev153+gaaa9ca732/tox.ini b/pytest-8.1.0.dev153+gaaa9ca732/tox.ini
index 0ac2ff2dd..c335601fe 100644
--- a/pytest-8.1.0.dev153+gaaa9ca732/tox.ini
+++ b/pytest-8.1.0.dev153+gaaa9ca732/tox.ini
@@ -22,8 +22,6 @@ envlist =
     # not included in CI.
     py311-exceptiongroup
 
-
-
 [testenv]
 commands =
     {env:_PYTEST_TOX_COVERAGE_RUN:} pytest {posargs:{env:_PYTEST_TOX_DEFAULT_POSARGS:}}
@@ -163,26 +161,19 @@ description = do a release, required posarg of the version number
 basepython = python3
 usedevelop = True
 passenv = *
-deps =
-    colorama
-    github3.py
-    pre-commit>=2.9.3
-    wheel
-    # https://github.com/twisted/towncrier/issues/340
-    towncrier<21.3.0
+extras = release
 commands = python scripts/release.py {posargs}
 
 [testenv:prepare-release-pr]
 description = prepare a release PR from a manual trigger in GitHub actions
 usedevelop = {[testenv:release]usedevelop}
 passenv = {[testenv:release]passenv}
-deps = {[testenv:release]deps}
+extras = {[testenv:release]extras}
 commands = python scripts/prepare-release-pr.py {posargs}
 
 [testenv:generate-gh-release-notes]
 description = generate release notes that can be published as GitHub Release
 basepython = python3
-usedevelop = True
-deps =
-    pypandoc
+usedevelop = {[testenv:release]usedevelop}
+extras = {[testenv:release]extras}
 commands = python scripts/generate-gh-release-notes.py {posargs}
```

(It look like we're packaging our pre-commit configuration and other things that are not strictly necessary to use pytest, or maybe I didn't package properly.)