### PR TITLE
[8.0.x] Merge pull request #11941 from bluetech/doctest-parsefactories

### DIFF
--- a/changelog/11929.bugfix.rst
+++ b/changelog/11929.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a regression in pytest 8.0.0 whereby autouse fixtures defined in a module get ignored by the doctests in the module.


### PR DESCRIPTION
doctest: fix autouse fixtures possibly not getting picked up (cherry picked from commit 6c0b6c2f92b68757988cdb11499cac750ba71862)

Note - the backport is not clean due to 06dbd3c21ccdf1ac76e8fa264048133cb4660842, but as argued in that commit we can just ignore the `conftest.py` branch. 