### PR TITLE
Fix ruff deprecation warning + enable few more rules

### DIFF
--- a/bench/bench.py
+++ b/bench/bench.py
@@ -5,7 +5,7 @@ if __name__ == "__main__":
     import cProfile
     import pstats
 
-    import pytest  # NOQA
+    import pytest  # noqa: F401
 
     script = sys.argv[1:] if len(sys.argv) > 1 else ["empty.py"]
     cProfile.run("pytest.cmdline.main(%r)" % script, "prof")

--- a/doc/en/example/assertion/failure_demo.py
+++ b/doc/en/example/assertion/failure_demo.py
@@ -172,7 +172,7 @@ class TestRaises:
         raise ValueError("demo error")
 
     def test_tupleerror(self):
-        a, b = [1]  # NOQA
+        a, b = [1]  # noqa: F841
 
     def test_reinterpret_fails_with_print_for_the_fun_of_it(self):
         items = [1, 2, 3]
@@ -180,7 +180,7 @@ class TestRaises:
         a, b = items.pop()
 
     def test_some_error(self):
-        if namenotexi:  # NOQA
+        if namenotexi:  # noqa: F821
             pass
 
     def func1(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ select = [
     "UP", # pyupgrade
     "RUF", # ruff
     "W",  # pycodestyle
+    "PIE", # flake8-pie
 ]
 ignore = [
     # bugbear ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ select = [
     "RUF", # ruff
     "W",  # pycodestyle
     "PIE", # flake8-pie
+    "PGH004", # pygrep-hooks - Use specific rule codes when using noqa
 ]
 ignore = [
     # bugbear ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,11 @@ target-version = ['py38']
 [tool.ruff]
 src = ["src"]
 line-length = 88
+
+[tool.ruff.format]
+docstring-code-format = true
+
+[tool.ruff.lint]
 select = [
     "B",  # bugbear
     "D",  # pydocstyle
@@ -129,9 +134,6 @@ ignore = [
     # ruff ignore
     "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
 ]
-
-[tool.ruff.format]
-docstring-code-format = true
 
 [tool.ruff.lint.pycodestyle]
 # In order to be able to format for 88 char in ruff format

--- a/src/_pytest/_py/path.py
+++ b/src/_pytest/_py/path.py
@@ -452,7 +452,7 @@ class LocalPath:
 
     def ensure_dir(self, *args):
         """Ensure the path joined with args is a directory."""
-        return self.ensure(*args, **{"dir": True})
+        return self.ensure(*args, dir=True)
 
     def bestrelpath(self, dest):
         """Return a string which is a relative path from self

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -1006,7 +1006,7 @@ class AssertionRewriter(ast.NodeVisitor):
             if i:
                 fail_inner: List[ast.stmt] = []
                 # cond is set in a prior loop iteration below
-                self.expl_stmts.append(ast.If(cond, fail_inner, []))  # noqa
+                self.expl_stmts.append(ast.If(cond, fail_inner, []))  # noqa: F821
                 self.expl_stmts = fail_inner
                 # Check if the left operand is a ast.NamedExpr and the value has already been visited
                 if (

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -712,7 +712,7 @@ class TestRequestBasic:
     )
     def test_request_garbage(self, pytester: Pytester) -> None:
         try:
-            import xdist  # noqa
+            import xdist  # noqa: F401
         except ImportError:
             pass
         else:

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -601,7 +601,7 @@ class TestAssert_reprcompare:
 
     def test_list_dont_wrap_strings(self) -> None:
         long_a = "a" * 10
-        l1 = ["a"] + [long_a for _ in range(0, 7)]
+        l1 = ["a"] + [long_a for _ in range(7)]
         l2 = ["should not get wrapped"]
         diff = callequal(l1, l2, verbose=True)
         assert diff == [

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -200,7 +200,7 @@ class TestAssertionRewrite:
         assert getmsg(f2) == "assert False"
 
         def f3() -> None:
-            assert a_global  # type: ignore[name-defined] # noqa
+            assert a_global  # type: ignore[name-defined] # noqa: F821
 
         assert getmsg(f3, {"a_global": False}) == "assert False"
 

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -535,7 +535,7 @@ class TestSession:
         newid = item.nodeid
         assert newid == id
         pprint.pprint(hookrec.calls)
-        topdir = pytester.path  # noqa
+        topdir = pytester.path  # noqa: F841
         hookrec.assert_contains(
             [
                 ("pytest_collectstart", "collector.path == topdir"),

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1231,8 +1231,7 @@ def test_plugin_loading_order(pytester: Pytester) -> None:
             import myplugin
             assert myplugin.terminal_plugin == [False, True]
         """,
-        **{
-            "myplugin": """
+        myplugin="""
             terminal_plugin = []
 
             def pytest_configure(config):
@@ -1241,8 +1240,7 @@ def test_plugin_loading_order(pytester: Pytester) -> None:
             def pytest_sessionstart(session):
                 config = session.config
                 terminal_plugin.append(bool(config.pluginmanager.get_plugin("terminalreporter")))
-            """
-        },
+            """,
     )
     pytester.syspathinsert()
     result = pytester.runpytest("-p", "myplugin", str(p1))

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -74,7 +74,7 @@ class TestEvaluation:
             """@pytest.mark.skipif("not hasattr(os, 'murks')")""",
             """@pytest.mark.skipif(condition="hasattr(os, 'murks')")""",
         ]
-        for i in range(0, 2):
+        for i in range(2):
             item = pytester.getitem(
                 f"""
                 import pytest

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -794,7 +794,7 @@ def test_resource_warning(pytester: Pytester, monkeypatch: pytest.MonkeyPatch) -
     # available, using `importorskip("tracemalloc")` for example,
     # because we want to ensure the same code path does not break in those platforms.
     try:
-        import tracemalloc  # noqa
+        import tracemalloc  # noqa: F401
 
         has_tracemalloc = True
     except ImportError:


### PR DESCRIPTION
Fix the following warning:

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
```

Enable https://docs.astral.sh/ruff/rules/#flake8-pie-pie
Enable https://docs.astral.sh/ruff/rules/blanket-noqa/