### PR TITLE
Allow using `warnings.warn()` with a `Warning`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -127,6 +127,7 @@ Edison Gustavo Muenz
 Edoardo Batini
 Edson Tadeu M. Manoel
 Eduardo Schettino
+Eero Vaher
 Eli Boyarski
 Elizaveta Shashkova
 Éloi Rivard

--- a/changelog/10865.improvement.rst
+++ b/changelog/10865.improvement.rst
@@ -1,2 +1,3 @@
-:func:`pytest.warns` now validates that warning object's ``message`` is of type  `str` -- currently in Python it is possible to pass other types than `str` when creating `Warning` instances, however this causes an exception when :func:`warnings.filterwarnings` is used to filter those warnings. See `CPython #103577 <https://github.com/python/cpython/issues/103577>`__ for a discussion.
+:func:`pytest.warns` now validates that :func:`warnings.warn` was called with a `str` or a `Warning`.
+Currently in Python it is possible to use other types, however this causes an exception when :func:`warnings.filterwarnings` is used to filter those warnings (see `CPython #103577 <https://github.com/python/cpython/issues/103577>`__ for a discussion).
 While this can be considered a bug in CPython, we decided to put guards in pytest as the error message produced without this check in place is confusing.

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -314,7 +314,7 @@ class WarningsChecker(WarningsRecorder):
         ):
             return
 
-        def found_str():
+        def found_str() -> str:
             return pformat([record.message for record in self], indent=2)
 
         try:
@@ -341,14 +341,19 @@ class WarningsChecker(WarningsRecorder):
                         module=w.__module__,
                         source=w.source,
                     )
-            # Check warnings has valid argument type (#10865).
-            wrn: warnings.WarningMessage
-            for wrn in self:
-                self._validate_message(wrn)
 
-    @staticmethod
-    def _validate_message(wrn: Any) -> None:
-        if not isinstance(msg := wrn.message.args[0], str):
-            raise TypeError(
-                f"Warning message must be str, got {msg!r} (type {type(msg).__name__})"
-            )
+            # Currently in Python it is possible to pass other types than an
+            # `str` message when creating `Warning` instances, however this
+            # causes an exception when :func:`warnings.filterwarnings` is used
+            # to filter those warnings. See
+            # https://github.com/python/cpython/issues/103577 for a discussion.
+            # While this can be considered a bug in CPython, we put guards in
+            # pytest as the error message produced without this check in place
+            # is confusing (#10865).
+            for w in self:
+                msg = w.message.args[0]  # type: ignore[union-attr]
+                if isinstance(msg, str):
+                    continue
+                raise TypeError(
+                    f"Warning message must be str, got {msg!r} (type {type(msg).__name__})"
+                )


### PR DESCRIPTION
[`warnigns.warn()` expects its first argument to be a `str` or a `Warning`](https://docs.python.org/3/library/warnings.html#available-functions) (see also [`WarningMessage` in typeshed](https://github.com/python/typeshed/blob/9d90eeb29646f88937bcee38e4dd954a6a769ed2/stdlib/warnings.pyi#L43-L44)) and using a different type can cause difficult to diagnose errors (as was reported in #10865):
```python
>>> import warnings
>>> with warnings.catch_warnings():
...     warnings.filterwarnings("ignore", "test")
...     warnings.warn("Warning!")
...     warnings.warn(RuntimeWarning())
...     warnings.warn(0)
... 
<stdin>:3: UserWarning: Warning!
<stdin>:4: RuntimeWarning: 
Traceback (most recent call last):
  File "<stdin>", line 5, in <module>
TypeError: expected string or bytes-like object
```
Recently #11804 tried to help address this problem by making `pytest.warns()` check the type that was passed to `warnings.warn()`, but the checks are now too strict:
```python
>>> import warnings
>>> import pytest
>>> with pytest.warns(Warning):
...     warnings.warn(RuntimeWarning(["warning", "context"]))
... 
Traceback (most recent call last):
    ...
    raise TypeError(
TypeError: Warning message must be str, got ['warning', 'context'] (type list)
>>> with pytest.warns(Warning):
...     warnings.warn(RuntimeWarning())
... 
Traceback (most recent call last):
    ...
IndexError: tuple index out of range
```
Both uses are explicitly permitted by Python. Furthermore, in the second case the `IndexError` is completely unexpected.

With my patch `pytest.warns()` allows `warnings.warn()` to be used with a `Warning` instance, except if a `UserWarning` is created by passing it arguments and the first argument is not a `str`. This is because if an invalid type was used in `warnings.warn()` then Python creates a `UserWarning` anyways and it becomes impossible for `pytest` to figure out if that was done automatically or not. However, even with that shortcoming `pytest.warns()` still behaves much better than it does right now.

Closes #11954

Here is a quick checklist that should be present in PRs.

- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [ ] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.