### PR TITLE
Consider pyproject.toml files for config if no other config files were found

### DIFF
--- a/changelog/11962.improvement.rst
+++ b/changelog/11962.improvement.rst
@@ -1,0 +1,1 @@
+In case no other suitable candidates for configuration file are found, a ``pyproject.toml`` (even without a ``[tool.pytest.ini_options]`` table) will be considered as the configuration file and define the ``rootdir``.

--- a/doc/en/reference/customize.rst
+++ b/doc/en/reference/customize.rst
@@ -183,10 +183,14 @@ even if it does not contain a ``[tool.pytest.ini_options]`` table (this was adde
 The files are considered in the order above. Options from multiple ``configfiles`` candidates
 are never merged - the first match wins.
 
+The configuration file also determines the value of the ``rootpath``.
+
 The :class:`Config <pytest.Config>` object (accessible via hooks or through the :fixture:`pytestconfig` fixture)
 will subsequently carry these attributes:
 
-- :attr:`config.rootpath <pytest.Config.rootpath>`: the determined root directory, guaranteed to exist.
+- :attr:`config.rootpath <pytest.Config.rootpath>`: the determined root directory, guaranteed to exist. It is used as
+  a reference directory for constructing test addresses ("nodeids") and can be used also by plugins for storing
+  per-testrun information.
 
 - :attr:`config.inipath <pytest.Config.inipath>`: the determined ``configfile``, may be ``None``
   (it is named ``inipath`` for historical reasons).
@@ -196,9 +200,7 @@ will subsequently carry these attributes:
     versions of the older ``config.rootdir`` and ``config.inifile``, which have type
     ``py.path.local``, and still exist for backward compatibility.
 
-The ``rootdir`` is used as a reference directory for constructing test
-addresses ("nodeids") and can be used also by plugins for storing
-per-testrun information.
+
 
 Example:
 

--- a/doc/en/reference/customize.rst
+++ b/doc/en/reference/customize.rst
@@ -177,6 +177,9 @@ Files will only be matched for configuration if:
 * ``tox.ini``: contains a ``[pytest]`` section.
 * ``setup.cfg``: contains a ``[tool:pytest]`` section.
 
+Finally, a ``pyproject.toml`` file will be considered the ``configfile`` if no other match was found, in this case
+even if it does not contain a ``[tool.pytest.ini_options]`` table (this was added in ``8.1``).
+
 The files are considered in the order above. Options from multiple ``configfiles`` candidates
 are never merged - the first match wins.
 

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -101,15 +101,20 @@ def locate_config(
     args = [x for x in args if not str(x).startswith("-")]
     if not args:
         args = [invocation_dir]
+    found_pyproject_toml: Optional[Path] = None
     for arg in args:
         argpath = absolutepath(arg)
         for base in (argpath, *argpath.parents):
             for config_name in config_names:
                 p = base / config_name
                 if p.is_file():
+                    if p.name == "pyproject.toml" and found_pyproject_toml is None:
+                        found_pyproject_toml = p
                     ini_config = load_config_dict_from_file(p)
                     if ini_config is not None:
                         return base, p, ini_config
+    if found_pyproject_toml is not None:
+        return found_pyproject_toml.parent, found_pyproject_toml, {}
     return None, None, {}
 
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -135,14 +135,44 @@ class TestParseIni:
         assert config.getini("minversion") == "3.36"
 
     def test_pyproject_toml(self, pytester: Pytester) -> None:
-        pytester.makepyprojecttoml(
+        pyproject_toml = pytester.makepyprojecttoml(
             """
             [tool.pytest.ini_options]
             minversion = "1.0"
         """
         )
         config = pytester.parseconfig()
+        assert config.inipath == pyproject_toml
         assert config.getini("minversion") == "1.0"
+
+    def test_empty_pyproject_toml(self, pytester: Pytester) -> None:
+        """An empty pyproject.toml is considered as config if no other option is found."""
+        pyproject_toml = pytester.makepyprojecttoml("")
+        config = pytester.parseconfig()
+        assert config.inipath == pyproject_toml
+
+    def test_empty_pyproject_toml_found_many(self, pytester: Pytester) -> None:
+        """
+        In case we find multiple pyproject.toml files in our search, without a [tool.pytest.ini_options]
+        table and without finding other candidates, the closest to where we started wins.
+        """
+        pytester.makefile(
+            ".toml",
+            **{
+                "pyproject": "",
+                "foo/pyproject": "",
+                "foo/bar/pyproject": "",
+            },
+        )
+        config = pytester.parseconfig(pytester.path / "foo/bar")
+        assert config.inipath == pytester.path / "foo/bar/pyproject.toml"
+
+    def test_pytest_ini_trumps_pyproject_toml(self, pytester: Pytester) -> None:
+        """An empty pyproject.toml is considered as config if no other option is found."""
+        pytester.makepyprojecttoml("[tool.pytest.ini_options]")
+        pytest_ini = pytester.makefile(".ini", pytest="")
+        config = pytester.parseconfig()
+        assert config.inipath == pytest_ini
 
     def test_toxini_before_lower_pytestini(self, pytester: Pytester) -> None:
         sub = pytester.mkdir("sub")

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -168,7 +168,7 @@ class TestParseIni:
         assert config.inipath == pytester.path / "foo/bar/pyproject.toml"
 
     def test_pytest_ini_trumps_pyproject_toml(self, pytester: Pytester) -> None:
-        """An empty pyproject.toml is considered as config if no other option is found."""
+        """A pytest.ini always take precedence over a pyproject.toml file."""
         pytester.makepyprojecttoml("[tool.pytest.ini_options]")
         pytest_ini = pytester.makefile(".ini", pytest="")
         config = pytester.parseconfig()


### PR DESCRIPTION
Today `pyproject.toml` is the standard for declaring a Python project root, so seems reasonable to consider it for the ini configuration (and specially `rootdir`) in case we do not find other suitable candidates.

Related to #11311