### PR TITLE
Added `logot` to the plugin list

### DIFF
--- a/scripts/update-plugin-list.py
+++ b/scripts/update-plugin-list.py
@@ -61,6 +61,7 @@ DEVELOPMENT_STATUS_CLASSIFIERS = (
 )
 ADDITIONAL_PROJECTS = {  # set of additional projects to consider as plugins
     "logassert",
+    "logot",
     "nuts",
     "flask_fixture",
 }


### PR DESCRIPTION
I've just released [`logot`](https://github.com/etianen/logot), a log testing library that includes a [`pytest` plugin](https://logot.readthedocs.io/latest/using-pytest.html). Although it works with other testing frameworks, the `pytest` integration is showcased everywhere in the docs, and generally expected to be _the way to use it_.

Because the library is not named `pytest-XXX`, it needs to be added to the manual plugin list. 🙇 

Here's a quick example of how it looks:

``` py
from logot import Logot, logged

def test_something(logot: Logot) -> None:
   do_something()
   logot.assert_logged(logged.info("Something was done"))
```

`logot`'s most interesting feature is its ability to test highly-concurrent [threaded](https://logot.readthedocs.io/latest/index.html#testing-threaded-code) or [async](https://logot.readthedocs.io/latest/index.html#testing-asynchronous-code) code by asserting on captured logs. It's also useful in "normal" synchronous code as a higher-level `caplog` replacement.