### PR TITLE
[8.0.x] recwarn: let base exceptions propagate through `pytest.warns` again

### DIFF
--- a/changelog/11907.bugfix.rst
+++ b/changelog/11907.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a regression in pytest 8.0.0 whereby calling :func:`pytest.skip` and similar control-flow exceptions within a :func:`pytest.warns()` block would get suppressed instead of propagating.

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -21,6 +21,7 @@ import warnings
 from _pytest.deprecated import check_ispytest
 from _pytest.deprecated import WARNS_NONE_ARG
 from _pytest.fixtures import fixture
+from _pytest.outcomes import Exit
 from _pytest.outcomes import fail
 
 
@@ -310,6 +311,17 @@ class WarningsChecker(WarningsRecorder):
 
         if self.expected_warning is None:
             # nothing to do in this deprecated case, see WARNS_NONE_ARG above
+            return
+
+        # BaseExceptions like pytest.{skip,fail,xfail,exit} or Ctrl-C within
+        # pytest.warns should *not* trigger "DID NOT WARN" and get suppressed
+        # when the warning doesn't happen. Control-flow exceptions should always
+        # propagate.
+        if exc_val is not None and (
+            not isinstance(exc_val, Exception)
+            # Exit is an Exception, not a BaseException, for some reason.
+            or isinstance(exc_val, Exit)
+        ):
             return
 
         def found_str():


### PR DESCRIPTION
(cherry picked from commit 718cd400152d64e6e6d47dc96f61bf1e6c06011a)