### PR TITLE
[8.0.x] recwarn: fix pytest.warns handling of Warnings with multiple arguments

### DIFF
--- a/changelog/11906.bugfix.rst
+++ b/changelog/11906.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression with :func:`pytest.warns` using custom warning subclasses which have more than one parameter in their `__init__`.

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -344,10 +344,10 @@ class WarningsChecker(WarningsRecorder):
             for w in self:
                 if not self.matches(w):
                     warnings.warn_explicit(
-                        str(w.message),
-                        w.message.__class__,  # type: ignore[arg-type]
-                        w.filename,
-                        w.lineno,
+                        message=w.message,
+                        category=w.category,
+                        filename=w.filename,
+                        lineno=w.lineno,
                         module=w.__module__,
                         source=w.source,
                     )

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -550,3 +550,17 @@ class TestWarns:
         result = pytester.runpytest_subprocess()
         assert result.ret == ExitCode.INTERRUPTED
         result.assert_outcomes()
+
+
+def test_multiple_arg_custom_warning() -> None:
+    """Test for issue #11906."""
+
+    class CustomWarning(UserWarning):
+        def __init__(self, a, b):
+            pass
+
+    with pytest.warns(CustomWarning):
+        with pytest.raises(pytest.fail.Exception, match="DID NOT WARN"):
+            with pytest.warns(CustomWarning, match="not gonna match"):
+                a, b = 1, 2
+                warnings.warn(CustomWarning(a, b))


### PR DESCRIPTION
(cherry picked from commit fbe18fc7a9a44982bedc81c1d25f63e6d20fffab)
