### PR TITLE
code: fix `IndexError` crash in `getstatementrange_ast`

### DIFF
--- a/changelog/11953.bugfix.rst
+++ b/changelog/11953.bugfix.rst
@@ -1,0 +1,1 @@
+Fix an ``IndexError`` crash raising from ``getstatementrange_ast``.

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -197,7 +197,9 @@ def getstatementrange_ast(
         # by using the BlockFinder helper used which inspect.getsource() uses itself.
         block_finder = inspect.BlockFinder()
         # If we start with an indented line, put blockfinder to "started" mode.
-        block_finder.started = source.lines[start][0].isspace()
+        block_finder.started = (
+            bool(source.lines[start]) and source.lines[start][0].isspace()
+        )
         it = ((x + "\n") for x in source.lines[start:end])
         try:
             for tok in tokenize.generate_tokens(lambda: next(it)):


### PR DESCRIPTION
Fix #11953.

I haven't been able to reproduce (needs a multiline statement which starts with a blank line?), though I didn't try very hard. However the fix is pretty innocent so I think it's OK to merge without a regression test.