### PR TITLE
Revert sys.platform verification to simple comparison

### DIFF
--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -289,7 +289,7 @@ def get_user_id() -> int | None:
     # mypy follows the version and platform checking expectation of PEP 484:
     # https://mypy.readthedocs.io/en/stable/common_issues.html?highlight=platform#python-version-and-system-platform-checks
     # Containment checks are too complex for mypy v1.5.0 and cause failure.
-    if sys.platform in {"win32", "emscripten"}:
+    if sys.platform == "win32" or sys.platform == "emscripten":  # noqa: PLR1714
         # win32 does not have a getuid() function.
         # Emscripten has a return 0 stub.
         return None


### PR DESCRIPTION
As the comment above it states, we need to keep the comparison simple so mypy can understand it, otherwise it will fail to properly handle this on Windows and will flag ``os.getuid()`` missing.
