### PR TITLE
Disallow Sphinx 6 and 7

### DIFF
--- a/doc/en/requirements.txt
+++ b/doc/en/requirements.txt
@@ -2,7 +2,8 @@ pallets-sphinx-themes
 pluggy>=1.2.0
 pygments-pytest>=2.3.0
 sphinx-removed-in>=0.2.0
-sphinx>=5,<8
+# In Sphinx 6 and 7, the search bar disappears; restrict this for now until we find a solution.
+sphinx>=5,<6
 sphinxcontrib-trio
 sphinxcontrib-svg2pdfconverter
 # Pin packaging because it no longer handles 'latest' version, which


### PR DESCRIPTION
Using Sphinx 6.x and 7.x the search bar disappears. Restrict to Sphinx 5.x for now until we find a solution.

Reverts #11568
Fixes #11988
