### PR TITLE
Allow Sphinx 7.x

### DIFF
--- a/doc/en/_templates/slim_searchbox.html
+++ b/doc/en/_templates/slim_searchbox.html
@@ -5,11 +5,10 @@
 <div id="searchbox" style="display: none" role="search">
   <div class="searchformwrapper">
     <form class="search" action="{{ pathto('search') }}" method="get">
-      <input type="text" name="q" aria-labelledby="searchlabel"
-        placeholder="Search"/>
+      <input type="text" name="q" aria-labelledby="searchlabel" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"/>
       <input type="submit" value="{{ _('Go') }}" />
     </form>
   </div>
 </div>
-<script type="text/javascript">$('#searchbox').show(0);</script>
+<script>document.getElementById('searchbox').style.display = "block"</script>
 {%- endif %}

--- a/doc/en/requirements.txt
+++ b/doc/en/requirements.txt
@@ -2,8 +2,7 @@ pallets-sphinx-themes
 pluggy>=1.2.0
 pygments-pytest>=2.3.0
 sphinx-removed-in>=0.2.0
-# In Sphinx 6 and 7, the search bar disappears; restrict this for now until we find a solution.
-sphinx>=5,<6
+sphinx>=7
 sphinxcontrib-trio
 sphinxcontrib-svg2pdfconverter
 # Pin packaging because it no longer handles 'latest' version, which


### PR DESCRIPTION
Thanks to https://github.com/pytest-dev/pytest/issues/11988#issuecomment-1950318888, the problem was our custom template.

The solution was to copy the template from Sphinx 7 and remove the header.
