### PR TITLE
Clarify PytestPluginManager._is_in_confcutdir

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -578,12 +578,18 @@ class PytestPluginManager(PluginManager):
             self._try_load_conftest(invocation_dir, importmode, rootpath)
 
     def _is_in_confcutdir(self, path: Path) -> bool:
-        """Whether a path is within the confcutdir.
-
-        When false, should not load conftest.
-        """
+        """Whether consider the given path to load conftests from."""
         if self._confcutdir is None:
             return True
+        # The semantics here are literally:
+        #   Do not load a conftest if it is found upwards from confcut dir.
+        # But this is *not* the same as:
+        #   Load only conftests from confcutdir or below.
+        # At first glance they might seem the same thing, however we do support use cases where
+        # we want to load conftests that are not found in confcutdir or below, but are found
+        # in completely different directory hierarchies like packages installed
+        # in out-of-source trees.
+        # (see #9767 for a regression where the logic was inverted).
         return path not in self._confcutdir.parents
 
     def _try_load_conftest(
@@ -609,9 +615,6 @@ class PytestPluginManager(PluginManager):
         if directory in self._dirpath2confmods:
             return
 
-        # XXX these days we may rather want to use config.rootpath
-        # and allow users to opt into looking into the rootdir parent
-        # directories instead of requiring to specify confcutdir.
         clist = []
         for parent in reversed((directory, *directory.parents)):
             if self._is_in_confcutdir(parent):

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -578,7 +578,7 @@ class PytestPluginManager(PluginManager):
             self._try_load_conftest(invocation_dir, importmode, rootpath)
 
     def _is_in_confcutdir(self, path: Path) -> bool:
-        """Whether consider the given path to load conftests from."""
+        """Whether to consider the given path to load conftests from."""
         if self._confcutdir is None:
             return True
         # The semantics here are literally:


### PR DESCRIPTION
Follow up to #12006, let's put some comments clarifying `is_in_confcutdir` semantics, as this is not the first time someone misunderstands it.

Also removed an obsolete comment in `_loadconftestmodules`: we already set the `confcutdir` based on `rootdir`/`initfile` if not explicitly given.
