### PR TITLE
ENH: Improve warning stacklevel

### DIFF
--- a/changelog/12014.bugfix.rst
+++ b/changelog/12014.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the ``stacklevel`` used when warning about marks used on fixtures.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -410,7 +410,7 @@ def normalize_mark_list(
         yield mark_obj
 
 
-def store_mark(obj, mark: Mark, *, stacklevel: int=2) -> None:
+def store_mark(obj, mark: Mark, *, stacklevel: int = 2) -> None:
     """Store a Mark on an object.
 
     This is used to implement the Mark declarations/decorators correctly.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -355,7 +355,7 @@ class MarkDecorator:
             func = args[0]
             is_class = inspect.isclass(func)
             if len(args) == 1 and (istestfunc(func) or is_class):
-                store_mark(func, self.mark)
+                store_mark(func, self.mark, stacklevel=3)
                 return func
         return self.with_args(*args, **kwargs)
 
@@ -410,7 +410,7 @@ def normalize_mark_list(
         yield mark_obj
 
 
-def store_mark(obj, mark: Mark) -> None:
+def store_mark(obj, mark: Mark, *, stacklevel: int=2) -> None:
     """Store a Mark on an object.
 
     This is used to implement the Mark declarations/decorators correctly.
@@ -420,7 +420,7 @@ def store_mark(obj, mark: Mark) -> None:
     from ..fixtures import getfixturemarker
 
     if getfixturemarker(obj) is not None:
-        warnings.warn(MARKED_FIXTURE, stacklevel=2)
+        warnings.warn(MARKED_FIXTURE, stacklevel=stacklevel)
 
     # Always reassign name to avoid updating pytestmark in a reference that
     # was only borrowed.

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -118,6 +118,8 @@ def test_fixture_disallow_marks_on_fixtures():
             raise NotImplementedError()
 
     assert len(record) == 2  # one for each mark decorator
+    # should point to this file
+    assert all(rec.filename == __file__ for rec in record)
 
 
 def test_fixture_disallowed_between_marks():


### PR DESCRIPTION
- [ ] ~~Include documentation when adding new features.~~
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [x] Add yourself to `AUTHORS` in alphabetical order.

This is really proposal-by-PR (because the PR is pretty trivial). In MNE-Python at least it takes this warning on 8.0.1:
```
================================================================================= warnings summary =================================================================================
../pytest/src/_pytest/mark/structures.py:357
  /home/larsoner/python/pytest/src/_pytest/mark/structures.py:357: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
    store_mark(func, self.mark)
```
and puts it on the correct line needed to fix the warning
```
================================================================================= warnings summary =================================================================================
mne/conftest.py:1125
  /home/larsoner/python/mne-python/mne/conftest.py:1125: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
    @pytest.mark.filterwarnings("ignore:.*Extraction of measurement.*:")
```
Happy to add to some test if people think this is a good idea and will work in the general case. Happy to explore if it will work in some cases (esp. if someone can point me to the right place to add a test!).

Can also rebase and re-target for `main` but on my machine at least I get a cryptic error when I try to use latest `main` with MNE-Python so haven't done that for now.