### PR TITLE
fixtures: remove a no longer needed sort

### DIFF
--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -169,33 +169,31 @@ def get_parametrized_fixture_keys(
     the specified scope."""
     assert scope is not Scope.Function
     try:
-        callspec = item.callspec  # type: ignore[attr-defined]
+        callspec: CallSpec2 = item.callspec  # type: ignore[attr-defined]
     except AttributeError:
-        pass
-    else:
-        cs: CallSpec2 = callspec
-        # cs.indices is random order of argnames.  Need to
-        # sort this so that different calls to
-        # get_parametrized_fixture_keys will be deterministic.
-        for argname in sorted(cs.indices):
-            if cs._arg2scope[argname] != scope:
-                continue
+        return
+    # cs.indices is random order of argnames.  Need to
+    # sort this so that different calls to
+    # get_parametrized_fixture_keys will be deterministic.
+    for argname in sorted(callspec.indices):
+        if callspec._arg2scope[argname] != scope:
+            continue
 
-            item_cls = None
-            if scope is Scope.Session:
-                scoped_item_path = None
-            elif scope is Scope.Package:
-                scoped_item_path = item.path
-            elif scope is Scope.Module:
-                scoped_item_path = item.path
-            elif scope is Scope.Class:
-                scoped_item_path = item.path
-                item_cls = item.cls  # type: ignore[attr-defined]
-            else:
-                assert_never(scope)
+        item_cls = None
+        if scope is Scope.Session:
+            scoped_item_path = None
+        elif scope is Scope.Package:
+            scoped_item_path = item.path
+        elif scope is Scope.Module:
+            scoped_item_path = item.path
+        elif scope is Scope.Class:
+            scoped_item_path = item.path
+            item_cls = item.cls  # type: ignore[attr-defined]
+        else:
+            assert_never(scope)
 
-            param_index = cs.indices[argname]
-            yield FixtureArgKey(argname, param_index, scoped_item_path, item_cls)
+        param_index = callspec.indices[argname]
+        yield FixtureArgKey(argname, param_index, scoped_item_path, item_cls)
 
 
 # Algorithm for sorting on a per-parametrized resource setup basis.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -172,10 +172,7 @@ def get_parametrized_fixture_keys(
         callspec: CallSpec2 = item.callspec  # type: ignore[attr-defined]
     except AttributeError:
         return
-    # cs.indices is random order of argnames.  Need to
-    # sort this so that different calls to
-    # get_parametrized_fixture_keys will be deterministic.
-    for argname in sorted(callspec.indices):
+    for argname in callspec.indices:
         if callspec._arg2scope[argname] != scope:
             continue
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1267,7 +1267,6 @@ class Metafunc:
         # Add funcargs as fixturedefs to fixtureinfo.arg2fixturedefs by registering
         # artificial "pseudo" FixtureDef's so that later at test execution time we can
         # rely on a proper FixtureDef to exist for fixture setup.
-        arg2fixturedefs = self._arg2fixturedefs
         node = None
         # If we have a scope that is higher than function, we need
         # to make sure we only ever create an according fixturedef on
@@ -1281,7 +1280,7 @@ class Metafunc:
                 # If used class scope and there is no class, use module-level
                 # collector (for now).
                 if scope_ is Scope.Class:
-                    assert isinstance(collector, _pytest.python.Module)
+                    assert isinstance(collector, Module)
                     node = collector
                 # If used package scope and there is no package, use session
                 # (for now).
@@ -1316,7 +1315,7 @@ class Metafunc:
                 )
                 if name2pseudofixturedef is not None:
                     name2pseudofixturedef[argname] = fixturedef
-            arg2fixturedefs[argname] = [fixturedef]
+            self._arg2fixturedefs[argname] = [fixturedef]
 
         # Create the new calls: if we are parametrize() multiple times (by applying the decorator
         # more than once) then we accumulate those calls generating the cartesian product

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -2730,12 +2730,12 @@ class TestFixtureMarker:
             """
             test_dynamic_parametrized_ordering.py::test[flavor1-vxlan] PASSED
             test_dynamic_parametrized_ordering.py::test2[flavor1-vxlan] PASSED
-            test_dynamic_parametrized_ordering.py::test[flavor2-vxlan] PASSED
-            test_dynamic_parametrized_ordering.py::test2[flavor2-vxlan] PASSED
-            test_dynamic_parametrized_ordering.py::test[flavor2-vlan] PASSED
-            test_dynamic_parametrized_ordering.py::test2[flavor2-vlan] PASSED
             test_dynamic_parametrized_ordering.py::test[flavor1-vlan] PASSED
             test_dynamic_parametrized_ordering.py::test2[flavor1-vlan] PASSED
+            test_dynamic_parametrized_ordering.py::test[flavor2-vlan] PASSED
+            test_dynamic_parametrized_ordering.py::test2[flavor2-vlan] PASSED
+            test_dynamic_parametrized_ordering.py::test[flavor2-vxlan] PASSED
+            test_dynamic_parametrized_ordering.py::test2[flavor2-vxlan] PASSED
         """
         )
 


### PR DESCRIPTION
First 2 commits are simple code cleanups, the 3rd commit is described below. I saw it when looking into #12008 but it's unrelated to it.

---

Dicts these days preserve order, so the sort is no longer needed to achieve determinism.

As shown by the `test_dynamic_parametrized_ordering` test, this can change the ordering of items, but only in equivalent ways (same number of setups/teardowns per scope), it will just respect the user's given ordering better (hence `vxlan` items now ordered before `vlan` items compared to the previous ordering).