### PR TITLE
Remove Anthony from Tidelift participants

### DIFF
--- a/TIDELIFT.rst
+++ b/TIDELIFT.rst
@@ -23,7 +23,6 @@ members of the `contributors team`_ interested in receiving funding.
 
 The current list of contributors receiving funding are:
 
-* `@asottile`_
 * `@nicoddemus`_
 * `@The-Compiler`_
 
@@ -55,6 +54,5 @@ funds. Just drop a line to one of the `@pytest-dev/tidelift-admins`_ or use the 
 .. _`@pytest-dev/tidelift-admins`: https://github.com/orgs/pytest-dev/teams/tidelift-admins/members
 .. _`agreement`: https://tidelift.com/docs/lifting/agreement
 
-.. _`@asottile`: https://github.com/asottile
 .. _`@nicoddemus`: https://github.com/nicoddemus
 .. _`@The-Compiler`: https://github.com/The-Compiler


### PR DESCRIPTION
As discussed in the core development channels, `@asottile` asked to no longer be a Tidelift participant, at least for the time being.
