### PR TITLE
runner: add support for `sys.last_exc` for post-mortem debugging on Python>=3.12

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -128,6 +128,7 @@ Edison Gustavo Muenz
 Edoardo Batini
 Edson Tadeu M. Manoel
 Eduardo Schettino
+Edward Haigh
 Eero Vaher
 Eli Boyarski
 Elizaveta Shashkova

--- a/changelog/11850.improvement.rst
+++ b/changelog/11850.improvement.rst
@@ -1,0 +1,1 @@
+Added support for :data:`sys.last_exc` for post-mortem debugging on Python>=3.12.

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -164,6 +164,8 @@ def pytest_runtest_call(item: Item) -> None:
         del sys.last_type
         del sys.last_value
         del sys.last_traceback
+        if sys.version_info >= (3, 12, 0):
+            del sys.last_exc  # type: ignore[attr-defined]
     except AttributeError:
         pass
     try:
@@ -172,6 +174,8 @@ def pytest_runtest_call(item: Item) -> None:
         # Store trace info to allow postmortem debugging
         sys.last_type = type(e)
         sys.last_value = e
+        if sys.version_info >= (3, 12, 0):
+            sys.last_exc = e  # type: ignore[attr-defined]
         assert e.__traceback__ is not None
         # Skip *this* frame
         sys.last_traceback = e.__traceback__.tb_next

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -926,6 +926,9 @@ def test_store_except_info_on_error() -> None:
     # Check that exception info is stored on sys
     assert sys.last_type is IndexError
     assert isinstance(sys.last_value, IndexError)
+    if sys.version_info >= (3, 12, 0):
+        assert isinstance(sys.last_exc, IndexError)  # type: ignore[attr-defined]
+
     assert sys.last_value.args[0] == "TEST"
     assert sys.last_traceback
 
@@ -934,6 +937,8 @@ def test_store_except_info_on_error() -> None:
     runner.pytest_runtest_call(ItemMightRaise())  # type: ignore[arg-type]
     assert not hasattr(sys, "last_type")
     assert not hasattr(sys, "last_value")
+    if sys.version_info >= (3, 12, 0):
+        assert not hasattr(sys, "last_exc")
     assert not hasattr(sys, "last_traceback")
 
 


### PR DESCRIPTION
Fix #11850

This PR is same as #11934 by @robotherapist with the comments fixed, so we can include it pytest 8.1 (I can't update the original PR).

Reviewed by me.

Closes #11934