### PR TITLE
fixtures: remove unneeded optimization from `_getnextfixturedef`

### DIFF
--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -413,9 +413,7 @@ class FixtureRequest(abc.ABC):
             # We arrive here because of a dynamic call to
             # getfixturevalue(argname) usage which was naturally
             # not known at parsing/collection time.
-            parent = self._pyfuncitem.parent
-            assert parent is not None
-            fixturedefs = self._fixturemanager.getfixturedefs(argname, parent)
+            fixturedefs = self._fixturemanager.getfixturedefs(argname, self._pyfuncitem)
             if fixturedefs is not None:
                 self._arg2fixturedefs[argname] = fixturedefs
         # No fixtures defined with this name.


### PR DESCRIPTION
According to my understanding, this code, which handles obtaining the relevant fixturedefs when a dynamic `getfixturevalue` is used, has an optimization where it only grabs fixturedefs that are visible to the *parent* of the item, instead of the item itself, under the assumption that a fixturedef can't be visible to a single item, only to a collector.

Remove this optimization for the following reasons:
- It doesn't save much (one loop iteration in `matchfactories`)
- It slightly complicates the complex fixtures code
- If some plugin wants to make a fixture visible only to a single item, why not let it?
- In the static case (`getfixtureclosure`), this optimization is not done (despite the confusing name `parentnode`, it is *not* the parent node). This is inconsistent.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
