### PR TITLE
Fix collection failures due to permission errors when using `--pyargs`

### DIFF
--- a/changelog/11904.bugfix.rst
+++ b/changelog/11904.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a regression in pytest 8.0.0 that would cause test collection to fail due to permission errors when using ``--pyargs``.
+
+This change improves the collection tree for tests specified using ``--pyargs``, see :pull:`12043` for a comparison with pytest 8.0 and <8.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -5,6 +5,7 @@ import dataclasses
 import fnmatch
 import functools
 import importlib
+import importlib.util
 import os
 from pathlib import Path
 import sys

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -851,13 +851,14 @@ class Session(nodes.Collector):
             if argpath.is_dir():
                 assert not names, f"invalid arg {(argpath, names)!r}"
 
-            # Match the argpath from the root, e.g.
+            paths = [argpath]
+            # Add relevant parents of the path, from the root, e.g.
             #   /a/b/c.py -> [/, /a, /a/b, /a/b/c.py]
-            paths = [*reversed(argpath.parents), argpath]
-            # Paths outside of the confcutdir should not be considered, unless
-            # it's the argpath itself.
-            while len(paths) > 1 and not pm._is_in_confcutdir(paths[0]):
-                paths = paths[1:]
+            # Paths outside of the confcutdir should not be considered.
+            for path in argpath.parents:
+                if not pm._is_in_confcutdir(path):
+                    break
+                paths.insert(0, path)
 
             # Start going over the parts from the root, collecting each level
             # and discarding all nodes which don't match the level's part.

--- a/testing/test_main.py
+++ b/testing/test_main.py
@@ -139,24 +139,28 @@ class TestResolveCollectionArgument:
         ) == CollectionArgument(
             path=invocation_path / "src/pkg/test.py",
             parts=[],
+            module_name=None,
         )
         assert resolve_collection_argument(
             invocation_path, "src/pkg/test.py::"
         ) == CollectionArgument(
             path=invocation_path / "src/pkg/test.py",
             parts=[""],
+            module_name=None,
         )
         assert resolve_collection_argument(
             invocation_path, "src/pkg/test.py::foo::bar"
         ) == CollectionArgument(
             path=invocation_path / "src/pkg/test.py",
             parts=["foo", "bar"],
+            module_name=None,
         )
         assert resolve_collection_argument(
             invocation_path, "src/pkg/test.py::foo::bar::"
         ) == CollectionArgument(
             path=invocation_path / "src/pkg/test.py",
             parts=["foo", "bar", ""],
+            module_name=None,
         )
 
     def test_dir(self, invocation_path: Path) -> None:
@@ -166,6 +170,7 @@ class TestResolveCollectionArgument:
         ) == CollectionArgument(
             path=invocation_path / "src/pkg",
             parts=[],
+            module_name=None,
         )
 
         with pytest.raises(
@@ -185,18 +190,21 @@ class TestResolveCollectionArgument:
         ) == CollectionArgument(
             path=invocation_path / "src/pkg/test.py",
             parts=[],
+            module_name="pkg.test",
         )
         assert resolve_collection_argument(
             invocation_path, "pkg.test::foo::bar", as_pypath=True
         ) == CollectionArgument(
             path=invocation_path / "src/pkg/test.py",
             parts=["foo", "bar"],
+            module_name="pkg.test",
         )
         assert resolve_collection_argument(
             invocation_path, "pkg", as_pypath=True
         ) == CollectionArgument(
             path=invocation_path / "src/pkg",
             parts=[],
+            module_name="pkg",
         )
 
         with pytest.raises(
@@ -212,6 +220,7 @@ class TestResolveCollectionArgument:
         ) == CollectionArgument(
             path=invocation_path / "src/pkg/test.py",
             parts=["test[a::b]"],
+            module_name=None,
         )
 
     def test_does_not_exist(self, invocation_path: Path) -> None:
@@ -237,6 +246,7 @@ class TestResolveCollectionArgument:
         ) == CollectionArgument(
             path=Path(os.path.abspath("src")),
             parts=[],
+            module_name=None,
         )
 
         # ensure full paths given in the command-line without the drive letter resolve
@@ -247,6 +257,7 @@ class TestResolveCollectionArgument:
         ) == CollectionArgument(
             path=Path(os.path.abspath("src")),
             parts=[],
+            module_name=None,
         )
 
 

--- a/testing/test_main.py
+++ b/testing/test_main.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from _pytest.config import ExitCode
 from _pytest.config import UsageError
+from _pytest.main import CollectionArgument
 from _pytest.main import resolve_collection_argument
 from _pytest.main import validate_basetemp
 from _pytest.pytester import Pytester
@@ -133,26 +134,38 @@ class TestResolveCollectionArgument:
 
     def test_file(self, invocation_path: Path) -> None:
         """File and parts."""
-        assert resolve_collection_argument(invocation_path, "src/pkg/test.py") == (
-            invocation_path / "src/pkg/test.py",
-            [],
+        assert resolve_collection_argument(
+            invocation_path, "src/pkg/test.py"
+        ) == CollectionArgument(
+            path=invocation_path / "src/pkg/test.py",
+            parts=[],
         )
-        assert resolve_collection_argument(invocation_path, "src/pkg/test.py::") == (
-            invocation_path / "src/pkg/test.py",
-            [""],
+        assert resolve_collection_argument(
+            invocation_path, "src/pkg/test.py::"
+        ) == CollectionArgument(
+            path=invocation_path / "src/pkg/test.py",
+            parts=[""],
         )
         assert resolve_collection_argument(
             invocation_path, "src/pkg/test.py::foo::bar"
-        ) == (invocation_path / "src/pkg/test.py", ["foo", "bar"])
+        ) == CollectionArgument(
+            path=invocation_path / "src/pkg/test.py",
+            parts=["foo", "bar"],
+        )
         assert resolve_collection_argument(
             invocation_path, "src/pkg/test.py::foo::bar::"
-        ) == (invocation_path / "src/pkg/test.py", ["foo", "bar", ""])
+        ) == CollectionArgument(
+            path=invocation_path / "src/pkg/test.py",
+            parts=["foo", "bar", ""],
+        )
 
     def test_dir(self, invocation_path: Path) -> None:
         """Directory and parts."""
-        assert resolve_collection_argument(invocation_path, "src/pkg") == (
-            invocation_path / "src/pkg",
-            [],
+        assert resolve_collection_argument(
+            invocation_path, "src/pkg"
+        ) == CollectionArgument(
+            path=invocation_path / "src/pkg",
+            parts=[],
         )
 
         with pytest.raises(
@@ -169,13 +182,21 @@ class TestResolveCollectionArgument:
         """Dotted name and parts."""
         assert resolve_collection_argument(
             invocation_path, "pkg.test", as_pypath=True
-        ) == (invocation_path / "src/pkg/test.py", [])
+        ) == CollectionArgument(
+            path=invocation_path / "src/pkg/test.py",
+            parts=[],
+        )
         assert resolve_collection_argument(
             invocation_path, "pkg.test::foo::bar", as_pypath=True
-        ) == (invocation_path / "src/pkg/test.py", ["foo", "bar"])
-        assert resolve_collection_argument(invocation_path, "pkg", as_pypath=True) == (
-            invocation_path / "src/pkg",
-            [],
+        ) == CollectionArgument(
+            path=invocation_path / "src/pkg/test.py",
+            parts=["foo", "bar"],
+        )
+        assert resolve_collection_argument(
+            invocation_path, "pkg", as_pypath=True
+        ) == CollectionArgument(
+            path=invocation_path / "src/pkg",
+            parts=[],
         )
 
         with pytest.raises(
@@ -186,10 +207,12 @@ class TestResolveCollectionArgument:
             )
 
     def test_parametrized_name_with_colons(self, invocation_path: Path) -> None:
-        ret = resolve_collection_argument(
+        assert resolve_collection_argument(
             invocation_path, "src/pkg/test.py::test[a::b]"
+        ) == CollectionArgument(
+            path=invocation_path / "src/pkg/test.py",
+            parts=["test[a::b]"],
         )
-        assert ret == (invocation_path / "src/pkg/test.py", ["test[a::b]"])
 
     def test_does_not_exist(self, invocation_path: Path) -> None:
         """Given a file/module that does not exist raises UsageError."""
@@ -209,9 +232,11 @@ class TestResolveCollectionArgument:
     def test_absolute_paths_are_resolved_correctly(self, invocation_path: Path) -> None:
         """Absolute paths resolve back to absolute paths."""
         full_path = str(invocation_path / "src")
-        assert resolve_collection_argument(invocation_path, full_path) == (
-            Path(os.path.abspath("src")),
-            [],
+        assert resolve_collection_argument(
+            invocation_path, full_path
+        ) == CollectionArgument(
+            path=Path(os.path.abspath("src")),
+            parts=[],
         )
 
         # ensure full paths given in the command-line without the drive letter resolve
@@ -219,7 +244,10 @@ class TestResolveCollectionArgument:
         drive, full_path_without_drive = os.path.splitdrive(full_path)
         assert resolve_collection_argument(
             invocation_path, full_path_without_drive
-        ) == (Path(os.path.abspath("src")), [])
+        ) == CollectionArgument(
+            path=Path(os.path.abspath("src")),
+            parts=[],
+        )
 
 
 def test_module_full_path_without_drive(pytester: Pytester) -> None:


### PR DESCRIPTION
This should fix #11904. It does *not* fix all permission error situations that popped up with pytest 8.0.0 but most complaints were about `--pyargs` and others are mostly misconfigurations as far I could tell, so let's start with this to unblock pytest 8.1.0 and see about the others as the come.

The PR has some preparatory commits, here is the description of the main change (last commit):

In pytest<8, the collection tree for `pyargs` arguments in an invocation like this:

    pytest --collect-only --pyargs pyflakes.test.test_undefined_names

looked like this:

```xml
<Package test>
  <Module test_undefined_names.py>
    <UnitTestCase Test>
      <TestCaseFunction test_annotationUndefined>
      ... snipped ...
```

The pytest 8 collection improvements changed it to this:

```xml
<Dir pytest>
  <Dir .tox>
    <Dir venv>
      <Dir lib>
        <Dir python3.11>
          <Dir site-packages>
            <Package pyflakes>
              <Package test>
                <Module test_undefined_names.py>
                  <UnitTestCase Test>
                    <TestCaseFunction test_annotationUndefined>
                    ... snipped ...
```

Besides being egregious (and potentially even worse than the above, going all the way to the root, for system-installed packages, as is apparently common in CI), this also caused permission errors when trying to probe some of those intermediate directories.

This change makes `--pyargs` arguments no longer try to add parent directories to the collection tree according to the `--confcutdir` like they're regular arguments. Instead, only add the parents that are in the import path. This now looks like this:

```xml
<Package .tox/venv/lib/python3.11/site-packages/pyflakes>
  <Package test>
    <Module test_undefined_names.py>
      <UnitTestCase Test>
        <TestCaseFunction test_annotationUndefined>
        ... snipped ...
```