### PR TITLE
fixtures: use exception group when multiple finalizers raise in fixture teardown

### DIFF
--- a/changelog/12047.improvement.rst
+++ b/changelog/12047.improvement.rst
@@ -1,0 +1,2 @@
+When multiple finalizers of a fixture raise an exception, now all exceptions are reported as an exception group.
+Previously, only the first exception was reported.


### PR DESCRIPTION
Fix #12047.

Previously, if more than one fixture finalizer raised, only the first was reported, and the other errors were lost.

Use an exception group to report them all. This is similar to the change we made in node teardowns (in `SetupState`).