### PR TITLE
Rename 'testing' extra to 'dev'

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -297,12 +297,12 @@ Here is a simple overview, with pytest-specific bits:
    When committing, ``pre-commit`` will re-format the files if necessary.
 
 #. If instead of using ``tox`` you prefer to run the tests directly, then we suggest to create a virtual environment and use
-   an editable install with the ``testing`` extra::
+   an editable install with the ``dev`` extra::
 
        $ python3 -m venv .venv
        $ source .venv/bin/activate  # Linux
        $ .venv/Scripts/activate.bat  # Windows
-       $ pip install -e ".[testing]"
+       $ pip install -e ".[dev]"
 
    Afterwards, you can edit the files and run pytest normally::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     'tomli>=1; python_version < "3.11"',
 ]
 [project.optional-dependencies]
-testing = [
+dev = [
     "argcomplete",
     "attrs>=19.2",
     "hypothesis>=3.56",

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ setenv =
     lsof: _PYTEST_TOX_POSARGS_LSOF=--lsof
 
     xdist: _PYTEST_TOX_POSARGS_XDIST=-n auto
-extras = testing
+extras = dev
 deps =
     doctesting: PyYAML
     exceptiongroup: exceptiongroup>=1.0.0rc8


### PR DESCRIPTION
Minor, but seems `dev` is more standard for the development extras than `testing`, being the default for tools like `poetry`.
