### PR TITLE
 python: fix instance handling in static and class method tests

### DIFF
--- a/changelog/12065.bugfix.rst
+++ b/changelog/12065.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed a regression in pytest 8.0.0 where test classes containing ``setup_method`` and tests using ``@staticmethod`` or ``@classmethod`` would crash with ``AttributeError: 'NoneType' object has no attribute 'setup_method'``.
+
+Now the :attr:`request.instance <pytest.FixtureRequest.instance>` attribute of tests using ``@staticmethod`` and ``@classmethod`` is no longer ``None``, but a fresh instance of the class, like in non-static methods.
+Previously it was ``None``, and all fixtures of such tests would share a single ``self``.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1096,7 +1096,7 @@ def resolve_fixture_function(
     fixturedef: FixtureDef[FixtureValue], request: FixtureRequest
 ) -> "_FixtureFunc[FixtureValue]":
     """Get the actual callable that can be called to obtain the fixture
-    value, dealing with unittest-specific instances and bound methods."""
+    value."""
     fixturefunc = fixturedef.func
     # The fixture function needs to be bound to the actual
     # request.instance so that code working with "fixturedef" behaves

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1101,17 +1101,18 @@ def resolve_fixture_function(
     # The fixture function needs to be bound to the actual
     # request.instance so that code working with "fixturedef" behaves
     # as expected.
-    if request.instance is not None:
+    instance = request.instance
+    if instance is not None:
         # Handle the case where fixture is defined not in a test class, but some other class
         # (for example a plugin class with a fixture), see #2270.
         if hasattr(fixturefunc, "__self__") and not isinstance(
-            request.instance,
+            instance,
             fixturefunc.__self__.__class__,  # type: ignore[union-attr]
         ):
             return fixturefunc
         fixturefunc = getimfunc(fixturedef.func)
         if fixturefunc != fixturedef.func:
-            fixturefunc = fixturefunc.__get__(request.instance)  # type: ignore[union-attr]
+            fixturefunc = fixturefunc.__get__(instance)  # type: ignore[union-attr]
     return fixturefunc
 
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -470,8 +470,9 @@ class FixtureRequest(abc.ABC):
     @property
     def instance(self):
         """Instance (can be None) on which test function was collected."""
-        function = getattr(self, "function", None)
-        return getattr(function, "__self__", None)
+        if self.scope != "function":
+            return None
+        return getattr(self._pyfuncitem, "instance", None)
 
     @property
     def module(self):

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -177,16 +177,15 @@ class TestCaseFunction(Function):
     nofuncargs = True
     _excinfo: Optional[List[_pytest._code.ExceptionInfo[BaseException]]] = None
 
-    def _getobj(self):
+    def _getinstance(self):
         assert isinstance(self.parent, UnitTestCase)
-        testcase = self.parent.obj(self.name)
-        return getattr(testcase, self.name)
+        return self.parent.obj(self.name)
 
     # Backward compat for pytest-django; can be removed after pytest-django
     # updates + some slack.
     @property
     def _testcase(self):
-        return self._obj.__self__
+        return self.instance
 
     def setup(self) -> None:
         # A bound method to be called during teardown() if set (see 'runtest()').
@@ -296,7 +295,8 @@ class TestCaseFunction(Function):
     def runtest(self) -> None:
         from _pytest.debugging import maybe_wrap_pytest_function_for_tracing
 
-        testcase = self.obj.__self__
+        testcase = self.instance
+        assert testcase is not None
 
         maybe_wrap_pytest_function_for_tracing(self)
 

--- a/testing/python/integration.py
+++ b/testing/python/integration.py
@@ -410,22 +410,37 @@ def test_function_instance(pytester: Pytester) -> None:
     items = pytester.getitems(
         """
         def test_func(): pass
+
         class TestIt:
             def test_method(self): pass
+
             @classmethod
             def test_class(cls): pass
+
             @staticmethod
             def test_static(): pass
         """
     )
     assert len(items) == 4
+
     assert isinstance(items[0], Function)
     assert items[0].name == "test_func"
     assert items[0].instance is None
+
     assert isinstance(items[1], Function)
     assert items[1].name == "test_method"
     assert items[1].instance is not None
     assert items[1].instance.__class__.__name__ == "TestIt"
+
+    # Even class and static methods get an instance!
+    # This is the instance used for bound fixture methods, which
+    # class/staticmethod tests are perfectly able to request.
+    assert isinstance(items[2], Function)
+    assert items[2].name == "test_class"
+    assert items[2].instance is not None
+
     assert isinstance(items[3], Function)
     assert items[3].name == "test_static"
-    assert items[3].instance is None
+    assert items[3].instance is not None
+
+    assert items[1].instance is not items[2].instance is not items[3].instance


### PR DESCRIPTION
and also fixes a regression in pytest 8.0.0 where `setup_method` crashes if the class has static or class method tests.

It is allowed to have a test class with static/class methods which request non-static/class method fixtures (including `setup_method` xunit-fixture). I take it as a given that we need to support this somewhat odd scenario (stdlib unittest also supports it).

This raises a question -- when a staticmethod test requests a bound fixture, what is that fixture's `self`?

stdlib unittest says - a fresh instance for the test.

Previously, pytest said - some instance that is shared by all static/class methods. This is definitely broken since it breaks test isolation.

Change pytest to behave like stdlib unittest here.

In practice, this means stopping to rely on `self.obj.__self__` to get to the instance from the test function's binding. This doesn't work because staticmethods are not bound to anything.

Instead, keep the instance explicitly and use that.

BTW, I think this will allow us to change `Class`'s fixture collection (`parsefactories`) to happen on the class itself instead of a class instance, allowing us to avoid one class instantiation. But needs more work.

Fixes https://github.com/pytest-dev/pytest/issues/12065.