### PR TITLE
fix overridden/extended fixtures

### DIFF
--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1505,6 +1505,20 @@ class FixtureManager:
         # to re-discover fixturedefs again for each fixturename
         # (discovering matching fixtures for a given name/node is expensive).
 
+        def dependent_fixtures_argnames(
+            fixture_defs: Sequence[FixtureDef[Any]],
+        ) -> List[str]:
+            last_fixture = fixture_defs[-1]
+            # Initialize with the argnames of the last fixture
+            dependent_argnames = list(last_fixture.argnames)
+            for arg in fixture_defs:
+                if arg.argname in last_fixture.argnames:
+                    # Add new argument names maintaining order and avoiding duplicates
+                    for argname in arg.argnames:
+                        if argname not in dependent_argnames:
+                            dependent_argnames.append(argname)
+            return dependent_argnames
+
         fixturenames_closure = list(initialnames)
 
         arg2fixturedefs: Dict[str, Sequence[FixtureDef[Any]]] = {}
@@ -1519,7 +1533,8 @@ class FixtureManager:
                 fixturedefs = self.getfixturedefs(argname, parentnode)
                 if fixturedefs:
                     arg2fixturedefs[argname] = fixturedefs
-                    for arg in fixturedefs[-1].argnames:
+                    argnames = dependent_fixtures_argnames(fixturedefs)
+                    for arg in argnames:
                         if arg not in fixturenames_closure:
                             fixturenames_closure.append(arg)
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1508,15 +1508,18 @@ class FixtureManager:
         def dependent_fixtures_argnames(
             fixture_defs: Sequence[FixtureDef[Any]],
         ) -> List[str]:
-            last_fixture = fixture_defs[-1]
             # Initialize with the argnames of the last fixture
-            dependent_argnames = list(last_fixture.argnames)
-            for arg in fixture_defs:
-                if arg.argname in last_fixture.argnames:
-                    # Add new argument names maintaining order and avoiding duplicates
-                    for argname in arg.argnames:
+            dependent_argnames = list(fixture_defs[-1].argnames)
+            # Iterate over the list in reverse order, skipping the last element already processed.
+            for index, current_fixture in enumerate(
+                reversed(fixture_defs[:-1]), start=1
+            ):
+                if current_fixture.argname in fixture_defs[-index].argnames:
+                    for argname in current_fixture.argnames:
                         if argname not in dependent_argnames:
                             dependent_argnames.append(argname)
+                else:
+                    break
             return dependent_argnames
 
         fixturenames_closure = list(initialnames)

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1799,7 +1799,6 @@ class TestFixtureManagerParseFactories:
                 @pytest.fixture
                 def hello(self, hello):
                     return "class"
-
                 @pytest.mark.parametrize("param", ["foo"])
                 def test_hello(self, item, hello, fm):
                     print(item)

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1803,7 +1803,7 @@ class TestFixtureManagerParseFactories:
                 def test_hello(self, item, hello, fm):
                     print(item)
                     clousurelist, _ = fm.getfixtureclosure(item, ("hello",), {})
-                    assert clousurelist[0] == ["hello", "param", "request"]
+                    assert clousurelist == ["hello", "param", "request"]
             """
         )
         reprec = pytester.inline_run("-s")

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -449,6 +449,21 @@ def test_parametrized_with_kwargs(pytester: Pytester) -> None:
 
 def test_parametrize_overriden_extended_fixture(pytester: Pytester) -> None:
     """Overriden fixtures must pass over dependend fixtures for parameterization (#12091)"""
+    pytester.makeconftest(
+        """
+        import pytest
+
+        @pytest.fixture
+        def not_needed():
+            assert False, "Should not be called!"
+
+        @pytest.fixture
+        def main(foo):
+            assert False, "Should not be called!"
+
+    """
+    )
+
     py_file = pytester.makepyfile(
         """\
         import pytest

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -447,6 +447,35 @@ def test_parametrized_with_kwargs(pytester: Pytester) -> None:
     assert result.ret == 0
 
 
+def test_parametrize_overriden_extended_fixture(pytester: Pytester) -> None:
+    """Overriden fixtures must pass over dependend fixtures for parameterization (#12091)"""
+    py_file = pytester.makepyfile(
+        """\
+        import pytest
+
+        @pytest.fixture
+        def param() -> int:
+            return 1
+
+        @pytest.fixture
+        def main(param: int) -> int:
+            return sum(range(param + 1))
+
+
+        class TestFoo:
+            @pytest.fixture
+            def main(self, main: int) -> int:
+                return main
+
+            @pytest.mark.parametrize("param", [2])
+            def test_foo(self, main: int) -> None:
+                assert main == 3
+        """
+    )
+    result = pytester.runpytest(py_file)
+    assert result.ret == 0
+
+
 def test_parametrize_iterator(pytester: Pytester) -> None:
     """`parametrize` should work with generators (#5354)."""
     py_file = pytester.makepyfile(


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
This PR aims to solve this issue #12091. In the issue example shown below,  `fixturedefs` defined [here](https://github.com/pytest-dev/pytest/blob/14437788f07584fcf0578bdb952c720e0b9dd2ab/src/_pytest/fixtures.py#L1535)  was returning a tuple of the two versions of the overridden `main` fixture. The dependency on `param` was in the first element of the tuple, so doing `fixture_defs[-1]` would never find that dependency due to name duplication. The change is quite simple, checks in the tuple all fixturedefs whose `argname` is contained in `fixture_defs[-1].argnames`

```python
import pytest

@pytest.fixture
def param() -> int:
    return 1

@pytest.fixture
def main(param: int) -> int:
    return sum(range(param + 1))


class TestFoo:
    @pytest.fixture
    def main(self, main: int) -> int:
        return main

    @pytest.mark.parametrize("param", [2])
    def test_foo(self, main: int) -> None:
        assert main == 3
```




