### PR TITLE
doc: fix typos

### DIFF
--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -395,7 +395,7 @@ epub_copyright = "2013, holger krekel et alii"
 # The format is a list of tuples containing the path and title.
 # epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 # epub_post_files = []
 

--- a/doc/en/how-to/writing_hook_functions.rst
+++ b/doc/en/how-to/writing_hook_functions.rst
@@ -100,7 +100,7 @@ object, the wrapper may modify that result, but it's probably better to avoid it
 
 If the hook implementation failed with an exception, the wrapper can handle that
 exception using a ``try-catch-finally`` around the ``yield``, by propagating it,
-supressing it, or raising a different exception entirely.
+suppressing it, or raising a different exception entirely.
 
 For more information, consult the
 :ref:`pluggy documentation about hook wrappers <pluggy:hookwrappers>`.

--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -87,7 +87,7 @@ Features
 Documentation
 -------------
 
-* :ref:`Get started <get-started>` - install pytest and grasp its basics just twenty minutes
+* :ref:`Get started <get-started>` - install pytest and grasp its basics in just twenty minutes
 * :ref:`How-to guides <how-to>` - step-by-step guides, covering a vast range of use-cases and needs
 * :ref:`Reference guides <reference>` - includes the complete pytest API reference, lists of plugins and more
 * :ref:`Explanation <explanation>` - background, discussion of key topics, answers to higher-level questions


### PR DESCRIPTION
Added a missing word and fixed two codespell warnings in documentation.