### PR TITLE
fixtures: inline some functions to streamline the code

### DIFF
--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -569,18 +569,18 @@ class FixtureRequest(abc.ABC):
     def _get_active_fixturedef(
         self, argname: str
     ) -> Union["FixtureDef[object]", PseudoFixtureDef[object]]:
+        if argname == "request":
+            cached_result = (self, [0], None)
+            return PseudoFixtureDef(cached_result, Scope.Function)
+
+        # If we already finished computing a fixture by this name in this item,
+        # return it.
         fixturedef = self._fixture_defs.get(argname)
         if fixturedef is not None:
             self._check_scope(fixturedef, fixturedef._scope)
             return fixturedef
 
-        try:
-            fixturedef = self._getnextfixturedef(argname)
-        except FixtureLookupError:
-            if argname == "request":
-                cached_result = (self, [0], None)
-                return PseudoFixtureDef(cached_result, Scope.Function)
-            raise
+        fixturedef = self._getnextfixturedef(argname)
 
         # Prepare a SubRequest object for calling the fixture.
         funcitem = self._pyfuncitem


### PR DESCRIPTION
The `getfixturevalue` code is split over several functions, but I find it mostly obscures the flow of the logic. This PR inlines `_getnextfixturedef` and `_compute_fixture_value` into  `_get_active_fixturedef` which is now a single linear function, mostly. I did move some sanity checking code out of the function since it mostly distracts.