### PR TITLE
Don't reregister subfixture finalizer in parent fixture if value is cached

### DIFF
--- a/changelog/12135.bugfix.rst
+++ b/changelog/12135.bugfix.rst
@@ -1,1 +1,1 @@
-Fix subfixtures adding their finalizer multiple times to parent fixtures, causing incorrect teardown ordering in some instances.
+Fix fixtures adding their finalizer multiple times to fixtures they request, causing unreliable and non-intuitive teardown ordering in some instances.

--- a/changelog/12135.bugfix.rst
+++ b/changelog/12135.bugfix.rst
@@ -1,0 +1,1 @@
+Fix subfixtures adding their finalizer multiple times to parent fixtures, causing incorrect teardown ordering in some instances.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1035,19 +1035,25 @@ class FixtureDef(Generic[FixtureValue]):
             raise BaseExceptionGroup(msg, exceptions[::-1])
 
     def execute(self, request: SubRequest) -> FixtureValue:
-        # Ensure arguments (parent fixtures) are loaded.
-        # If their cache has been invalidated it will finish itself and subfixtures,
-        # which will set our self.cached_result = None.
-        # If/when parent fixture parametrization is included in our cache key this
-        # can be moved after checking our cache key and not require saving in a list.
-        parent_fixtures_to_add_finalizer = []
+        """Return the value of this fixture, executing it if not cached."""
+        # Ensure dependent fixtures that this fixture requests are loaded.
+        # This needs to be done before checking if we have a cached value, since
+        # if a dependent fixture has their cache invalidated, e.g. due to
+        # parametrization, they finalize themselves and fixtures depending on it
+        # (which will likely include this fixture) setting `self.cached_result = None`.
+        # See #4871
+        requested_fixtures_that_should_finalize_us = []
         for argname in self.argnames:
             fixturedef = request._get_active_fixturedef(argname)
+            # Saves requested fixtures in a list so we later can add our finalizer
+            # to them, ensuring that if a requested fixture gets torn down we get torn
+            # down first. This is generally handled by SetupState, but still currently
+            # needed when this fixture is not parametrized but depends on a parametrized
+            # fixture.
             if not isinstance(fixturedef, PseudoFixtureDef):
-                # save fixture as one to add our finalizer to, if we're not cached
-                # resolves #12135
-                parent_fixtures_to_add_finalizer.append(fixturedef)
+                requested_fixtures_that_should_finalize_us.append(fixturedef)
 
+        # Check for (and return) cached value/exception.
         my_cache_key = self.cache_key(request)
         if self.cached_result is not None:
             cache_key = self.cached_result[1]
@@ -1065,9 +1071,11 @@ class FixtureDef(Generic[FixtureValue]):
             self.finish(request)
             assert self.cached_result is None
 
+        # Add finalizer to requested fixtures we saved previously.
+        # We make sure to do this after checking for cached value to avoid
+        # adding our finalizer multiple times. (#12135)
         finalizer = functools.partial(self.finish, request=request)
-        # add finalizer to parent fixtures
-        for parent_fixture in parent_fixtures_to_add_finalizer:
+        for parent_fixture in requested_fixtures_that_should_finalize_us:
             parent_fixture.addfinalizer(finalizer)
 
         ihook = request.node.ihook

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1036,7 +1036,7 @@ class FixtureDef(Generic[FixtureValue]):
 
     def execute(self, request: SubRequest) -> FixtureValue:
         """Return the value of this fixture, executing it if not cached."""
-        # Ensure dependent fixtures that this fixture requests are loaded.
+        # Ensure that the dependent fixtures requested by this fixture are loaded.
         # This needs to be done before checking if we have a cached value, since
         # if a dependent fixture has their cache invalidated, e.g. due to
         # parametrization, they finalize themselves and fixtures depending on it

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -4751,3 +4751,88 @@ def test_scoped_fixture_teardown_order(pytester: Pytester) -> None:
     )
     result = pytester.runpytest()
     assert result.ret == 0
+
+
+def test_subfixture_not_queue_multiple_finalizers(pytester: Pytester) -> None:
+    """Make sure subfixtures don't needlessly requeue their finalizer multiple times in
+    parent fixture.
+
+    Regression test for #12135
+    """
+    pytester.makepyfile(
+        """
+        import pytest
+
+        def _assert_len(request):
+            assert len(request._get_active_fixturedef('fixture_1')._finalizers) == 1
+
+
+        @pytest.fixture(scope="module")
+        def fixture_1():
+            ...
+
+        @pytest.fixture(scope="module")
+        def fixture_2(request, fixture_1):
+            yield
+
+        def test_1(request, fixture_2):
+            _assert_len(request)
+
+        def test_2(request, fixture_2):
+            _assert_len(request)
+        """
+    )
+    result = pytester.runpytest()
+    assert result.ret == 0
+
+
+def test_subfixture_teardown_order(pytester: Pytester) -> None:
+    """
+    Make sure fixtures don't re-register their finalization in parent fixtures multiple
+    times, causing ordering failure in their teardowns.
+
+    Regression test for #12135
+    """
+    pytester.makepyfile(
+        """
+        import pytest
+
+        execution_order = []
+
+        @pytest.fixture(scope="class")
+        def fixture_1():
+            ...
+
+        @pytest.fixture(scope="class")
+        def fixture_2(fixture_1):
+            execution_order.append("setup 2")
+            yield
+            execution_order.append("teardown 2")
+
+        @pytest.fixture(scope="class")
+        def fixture_3(fixture_1):
+            execution_order.append("setup 3")
+            yield
+            execution_order.append("teardown 3")
+
+        class TestFoo:
+            def test_initialize_fixtures(self, fixture_2, fixture_3):
+                ...
+
+            # This would previously reschedule fixture_2's finalizer in the parent fixture,
+            # causing it to be torn down before fixture 3.
+            def test_reschedule_fixture_2(self, fixture_2):
+                ...
+
+            # Force finalization directly on fixture_1
+            # Otherwise the cleanup would sequence 3&2 before 1 as normal.
+            @pytest.mark.parametrize("fixture_1", [None], indirect=["fixture_1"])
+            def test_finalize_fixture_1(self, fixture_1):
+                ...
+
+        def test_result():
+            assert execution_order == ["setup 2", "setup 3", "teardown 3", "teardown 2"]
+        """
+    )
+    result = pytester.runpytest()
+    assert result.ret == 0

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -4753,39 +4753,6 @@ def test_scoped_fixture_teardown_order(pytester: Pytester) -> None:
     assert result.ret == 0
 
 
-def test_subfixture_not_queue_multiple_finalizers(pytester: Pytester) -> None:
-    """Make sure subfixtures don't needlessly requeue their finalizer multiple times in
-    parent fixture.
-
-    Regression test for #12135
-    """
-    pytester.makepyfile(
-        """
-        import pytest
-
-        def _assert_len(request):
-            assert len(request._get_active_fixturedef('fixture_1')._finalizers) == 1
-
-
-        @pytest.fixture(scope="module")
-        def fixture_1():
-            ...
-
-        @pytest.fixture(scope="module")
-        def fixture_2(request, fixture_1):
-            yield
-
-        def test_1(request, fixture_2):
-            _assert_len(request)
-
-        def test_2(request, fixture_2):
-            _assert_len(request)
-        """
-    )
-    result = pytester.runpytest()
-    assert result.ret == 0
-
-
 def test_subfixture_teardown_order(pytester: Pytester) -> None:
     """
     Make sure fixtures don't re-register their finalization in parent fixtures multiple


### PR DESCRIPTION
Fixes #12135

> When getting the value of a fixture, it will always add its finalizer to parent fixtures, regardless of if it's cached or not. When we have several subfixtures, this leads to unpredictable ordering between them when they're torn down (if triggered by the parent fixture being torn down). It is also an obvious inefficiency, where a long-lived parent fixture could rack up tons of irrelevant fixtures.

Adds two regression tests: one that checks the ordering failure, and one that checks the number of finalizers.

The implementation would be slightly cleaner if parent fixture parametrization was included in the cache key, as discussed in https://github.com/pytest-dev/pytest/issues/4871#issuecomment-2002622725