### PR TITLE
Updated docs: Documented two ways to detect if a code is running from within a pytest run

### DIFF
--- a/changelog/12153.doc.rst
+++ b/changelog/12153.doc.rst
@@ -1,1 +1,1 @@
-Updated docs: Documented new way to detect if a code is running from within a pytest run
+Documented using :envvar:`PYTEST_VERSION` to detect if code is running from within a pytest run.

--- a/changelog/12153.doc.rst
+++ b/changelog/12153.doc.rst
@@ -1,0 +1,1 @@
+Updated docs: Documented new way to detect if a code is running from within a pytest run

--- a/changelog/12153.doc.rst
+++ b/changelog/12153.doc.rst
@@ -1,1 +1,1 @@
-Updated docs: Documented a better way to detect if a code is running from within a pytest run.
+Updated docs: Documented two ways to detect if a code is running from within a pytest run.

--- a/changelog/12153.doc.rst
+++ b/changelog/12153.doc.rst
@@ -1,0 +1,1 @@
+Updated docs: Documented a better way to detect if a code is running from within a pytest run.

--- a/changelog/12153.doc.rst
+++ b/changelog/12153.doc.rst
@@ -1,1 +1,0 @@
-Updated docs: Documented two ways to detect if a code is running from within a pytest run.

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -413,10 +413,10 @@ running from a test you can do this:
 
 
     if os.environ.get("PYTEST_VERSION") is not None:
-        # things you want to to do if your code is called by pytest
+        # Things you want to to do if your code is called by pytest.
         ...
     else:
-        # things you want to to do if your code is not called by pytest
+        # Things you want to to do if your code is not called by pytest.
         ...
 
 

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -405,49 +405,14 @@ Detect if running from within a pytest run
 Usually it is a bad idea to make application code
 behave differently if called from a test.  But if you
 absolutely must find out if your application code is
-running from a test, you can follow one of the two ways listed below.
-
-This is a simple way to do it:
-
-.. code-block:: python
-
-    import sys
-
-
-    _called_from_test_by_pytest = "pytest" in sys.modules
-
-    if _called_from_test_by_pytest:
-        # called from within a test run by pytest
-        ...
-    else:
-        # called "normally"
-        ...
-
-This works great, but you should be aware that there is an issue with it. If there is a pytest import anywhere
-in your code flow, ``"pytest" in sys.modules`` will return True even if your code is not actually running from within a pytest run.
-
-.. code-block:: python
-
-    import sys
-
-    import pytest  # unused anywhere in your code
-
-
-    def is_called_from_test_by_pytest():
-        return "pytest" in sys.modules
-
-
-    # This method above will return True even if your code is not actually running from within a pytest run
-    # as there is a pytest import in your code flow
-
-This is a bit long but a robust way to do it:
+running from a test you can do something like this:
 
 .. code-block:: python
 
     # content of your_module.py
 
 
-    _called_from_test_by_pytest = False
+    _called_from_test = False
 
 .. code-block:: python
 
@@ -455,13 +420,13 @@ This is a bit long but a robust way to do it:
 
 
     def pytest_configure(config):
-        your_module._called_from_test_by_pytest = True
+        your_module._called_from_test = True
 
-and then check for the ``your_module._called_from_test_by_pytest`` flag:
+and then check for the ``your_module._called_from_test`` flag:
 
 .. code-block:: python
 
-    if your_module._called_from_test_by_pytest:
+    if your_module._called_from_test:
         # called from within a test run
         ...
     else:

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -405,35 +405,20 @@ Detect if running from within a pytest run
 Usually it is a bad idea to make application code
 behave differently if called from a test.  But if you
 absolutely must find out if your application code is
-running from a test you can do something like this:
+running from a test you can do this:
 
 .. code-block:: python
 
-    # content of your_module.py
+    import os
 
 
-    _called_from_test = False
-
-.. code-block:: python
-
-    # content of conftest.py
-
-
-    def pytest_configure(config):
-        your_module._called_from_test = True
-
-and then check for the ``your_module._called_from_test`` flag:
-
-.. code-block:: python
-
-    if your_module._called_from_test:
-        # called from within a test run
+    if os.environ.get("PYTEST_VERSION") is not None:
+        # things you want to to do if your code is called by pytest
         ...
     else:
-        # called "normally"
+        # things you want to to do if your code is not called by pytest
         ...
 
-accordingly in your application.
 
 Adding info to test report header
 --------------------------------------------------------------

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -409,25 +409,13 @@ running from a test you can do something like this:
 
 .. code-block:: python
 
-    # content of your_module.py
+    import sys
 
 
-    _called_from_test = False
+    _called_from_test_by_pytest = "pytest" in sys.modules
 
-.. code-block:: python
-
-    # content of conftest.py
-
-
-    def pytest_configure(config):
-        your_module._called_from_test = True
-
-and then check for the ``your_module._called_from_test`` flag:
-
-.. code-block:: python
-
-    if your_module._called_from_test:
-        # called from within a test run
+    if _called_from_test_by_pytest:
+        # called from within a test run by pytest
         ...
     else:
         # called "normally"


### PR DESCRIPTION
Add a better way to detect if a code is running from within a pytest run.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
