### PR TITLE
fixtures: stop using `request.param_index` in fixture cache key

### DIFF
--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1072,7 +1072,7 @@ class FixtureDef(Generic[FixtureValue]):
         return result
 
     def cache_key(self, request: SubRequest) -> object:
-        return request.param_index if not hasattr(request, "param") else request.param
+        return getattr(request, "param", None)
 
     def __repr__(self) -> str:
         return f"<FixtureDef argname={self.argname!r} scope={self.scope!r} baseid={self.baseid!r}>"


### PR DESCRIPTION
When `param` is not defined, `param_index` is always 0 (see [`_compute_fixture_value`](https://github.com/pytest-dev/pytest/blob/c650e3a94fb7e64001ada05ed9b0855d65693395/src/_pytest/fixtures.py#L606-L614)), so no point in using it besides adding some confusion.