### PR TITLE
[pylint] Fixes all ``use-maxplit-args``, ``consider-using-enumerate``

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,6 +228,7 @@ disable = [
     "pointless-exception-statement",
     "pointless-statement",
     "pointless-string-statement",
+    "possibly-used-before-assignment",
     "protected-access",
     "raise-missing-from",
     "redefined-argument-from-local",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,6 @@ disable = [
     "comparison-with-itself",
     "condition-evals-to-constant",
     "consider-using-dict-items",
-    "consider-using-enumerate",
     "consider-using-from-import",
     "consider-using-f-string",
     "consider-using-in",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,7 +276,6 @@ disable = [
     "useless-else-on-loop",
     "useless-import-alias",
     "useless-return",
-    "use-maxsplit-arg",
     "using-constant-test",
     "wrong-import-order",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ disable = [
     "bad-mcs-method-argument",
     "broad-exception-caught",
     "broad-exception-raised",
-    "cell-var-from-loop",
+    "cell-var-from-loop",                     # B023 from ruff / flake8-bugbear
     "comparison-of-constants",
     "comparison-with-callable",
     "comparison-with-itself",
@@ -194,7 +194,7 @@ disable = [
     "consider-using-ternary",
     "consider-using-with",
     "cyclic-import",
-    "disallowed-name",
+    "disallowed-name",                        # foo / bar are used often in tests
     "duplicate-code",
     "eval-used",
     "exec-used",

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1821,7 +1821,10 @@ def _show_fixtures_per_test(config: Config, session: "Session") -> None:
         fixture_doc = inspect.getdoc(fixture_def.func)
         if fixture_doc:
             write_docstring(
-                tw, fixture_doc.split("\n\n")[0] if verbose <= 0 else fixture_doc
+                tw,
+                fixture_doc.split("\n\n", maxsplit=1)[0]
+                if verbose <= 0
+                else fixture_doc,
             )
         else:
             tw.line("    no docstring available", red=True)
@@ -1903,7 +1906,9 @@ def _showfixtures_main(config: Config, session: "Session") -> None:
         tw.write("\n")
         doc = inspect.getdoc(fixturedef.func)
         if doc:
-            write_docstring(tw, doc.split("\n\n")[0] if verbose <= 0 else doc)
+            write_docstring(
+                tw, doc.split("\n\n", maxsplit=1)[0] if verbose <= 0 else doc
+            )
         else:
             tw.line("    no docstring available", red=True)
         tw.line()

--- a/testing/test_reports.py
+++ b/testing/test_reports.py
@@ -100,14 +100,13 @@ class TestReportSerialization:
 
         rep_entries = rep.longrepr.reprtraceback.reprentries
         a_entries = a.longrepr.reprtraceback.reprentries
-        for i in range(len(a_entries)):
-            rep_entry = rep_entries[i]
+        assert len(rep_entries) == len(a_entries)  # python < 3.10 zip(strict=True)
+        for a_entry, rep_entry in zip(a_entries, rep_entries):
             assert isinstance(rep_entry, ReprEntry)
             assert rep_entry.reprfileloc is not None
             assert rep_entry.reprfuncargs is not None
             assert rep_entry.reprlocals is not None
 
-            a_entry = a_entries[i]
             assert isinstance(a_entry, ReprEntry)
             assert a_entry.reprfileloc is not None
             assert a_entry.reprfuncargs is not None
@@ -146,9 +145,10 @@ class TestReportSerialization:
 
         rep_entries = rep.longrepr.reprtraceback.reprentries
         a_entries = a.longrepr.reprtraceback.reprentries
-        for i in range(len(a_entries)):
-            assert isinstance(rep_entries[i], ReprEntryNative)
-            assert rep_entries[i].lines == a_entries[i].lines
+        assert len(rep_entries) == len(a_entries)  # python < 3.10 zip(strict=True)
+        for rep_entry, a_entry in zip(rep_entries, a_entries):
+            assert isinstance(rep_entry, ReprEntryNative)
+            assert rep_entry.lines == a_entry.lines
 
     def test_itemreport_outcomes(self, pytester: Pytester) -> None:
         # This test came originally from test_remote.py in xdist (ca03269).

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -280,10 +280,8 @@ def test_warning_recorded_hook(pytester: Pytester) -> None:
         ("call warning", "runtest", "test_warning_recorded_hook.py::test_func"),
         ("teardown warning", "runtest", "test_warning_recorded_hook.py::test_func"),
     ]
-    for index in range(len(expected)):
-        collected_result = collected[index]
-        expected_result = expected[index]
-
+    assert len(collected) == len(expected)  # python < 3.10 zip(strict=True)
+    for collected_result, expected_result in zip(collected, expected):
         assert collected_result[0] == expected_result[0], str(collected)
         assert collected_result[1] == expected_result[1], str(collected)
         assert collected_result[2] == expected_result[2], str(collected)


### PR DESCRIPTION
Using `` maxsplit=1`` from ``use-maxplit-args`` will make splits slightly faster and is the important one that will improve performances.

The other fix are about readability / style.