### PR TITLE
doc: `import pytest` in `conftest.py` example in `doctest.rst`

### DIFF
--- a/doc/en/how-to/doctest.rst
+++ b/doc/en/how-to/doctest.rst
@@ -227,6 +227,7 @@ place the objects you want to appear in the doctest namespace:
     import pytest
     import numpy
 
+
     @pytest.fixture(autouse=True)
     def add_np(doctest_namespace):
         doctest_namespace["np"] = numpy

--- a/doc/en/how-to/doctest.rst
+++ b/doc/en/how-to/doctest.rst
@@ -224,8 +224,8 @@ place the objects you want to appear in the doctest namespace:
 .. code-block:: python
 
     # content of conftest.py
+    import pytest
     import numpy
-
 
     @pytest.fixture(autouse=True)
     def add_np(doctest_namespace):


### PR DESCRIPTION
- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Change is trivial or a small documentation fix (e.g., a typo or reword of a small section).

The `conftest.py` example does not work without the `import pytest`, which leads to the following error:

```
py310: commands[0]> pytest --doctest-modules --doctest-continue-on-failure --pyargs src
ImportError while loading conftest '[...]/mooplot/python/src/conftest.py'.
src/conftest.py:4: in <module>
    @pytest.fixture(autouse=True)
E   NameError: name 'pytest' is not defined
```
