### PR TITLE
importlib: set children as attribute of parent modules

### DIFF
--- a/changelog/12194.bugfix.rst
+++ b/changelog/12194.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with ``--importmode=importlib`` and ``--doctest-modules`` where child modules did not appear as attributes in parent modules.

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -635,26 +635,28 @@ def _import_module_using_spec(
         # Attempt to import the parent module, seems is our responsibility:
         # https://github.com/python/cpython/blob/73906d5c908c1e0b73c5436faeff7d93698fc074/Lib/importlib/_bootstrap.py#L1308-L1311
         parent_module_name, _, name = module_name.rpartition(".")
-        parent_module: Optional[ModuleType] = sys.modules.get(parent_module_name)
-        if parent_module is None and parent_module_name:
-            # Find the directory of this module's parent.
-            parent_dir = (
-                module_path.parent.parent
-                if module_path.name == "__init__.py"
-                else module_path.parent
-            )
-            # Consider the parent module path as its __init__.py file, if it has one.
-            parent_module_path = (
-                parent_dir / "__init__.py"
-                if (parent_dir / "__init__.py").is_file()
-                else parent_dir
-            )
-            parent_module = _import_module_using_spec(
-                parent_module_name,
-                parent_module_path,
-                parent_dir,
-                insert_modules=insert_modules,
-            )
+        parent_module: Optional[ModuleType] = None
+        if parent_module_name:
+            parent_module = sys.modules.get(parent_module_name)
+            if parent_module is None:
+                # Find the directory of this module's parent.
+                parent_dir = (
+                    module_path.parent.parent
+                    if module_path.name == "__init__.py"
+                    else module_path.parent
+                )
+                # Consider the parent module path as its __init__.py file, if it has one.
+                parent_module_path = (
+                    parent_dir / "__init__.py"
+                    if (parent_dir / "__init__.py").is_file()
+                    else parent_dir
+                )
+                parent_module = _import_module_using_spec(
+                    parent_module_name,
+                    parent_module_path,
+                    parent_dir,
+                    insert_modules=insert_modules,
+                )
 
         # Find spec and import this module.
         mod = importlib.util.module_from_spec(spec)

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -620,10 +620,6 @@ def _import_module_using_spec(
     :param insert_modules:
         If True, will call insert_missing_modules to create empty intermediate modules
         for made-up module names (when importing test files not reachable from sys.path).
-        Note: we can probably drop insert_missing_modules altogether: instead of
-        generating module names such as "src.tests.test_foo", which require intermediate
-        empty modules, we might just as well generate unique module names like
-        "src_tests_test_foo".
     """
     # Checking with sys.meta_path first in case one of its hooks can import this module,
     # such as our own assertion-rewrite hook.

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -641,8 +641,24 @@ def _import_module_using_spec(
         parent_module_name, _, name = module_name.rpartition(".")
         parent_module: Optional[ModuleType] = sys.modules.get(parent_module_name)
         if parent_module is None and parent_module_name:
-            with contextlib.suppress(ModuleNotFoundError, ImportWarning):
-                parent_module = importlib.import_module(parent_module_name)
+            # Find the directory of this module's parent.
+            parent_dir = (
+                module_path.parent.parent
+                if module_path.name == "__init__.py"
+                else module_path.parent
+            )
+            # Consider the parent module path as its __init__.py file, if it has one.
+            parent_module_path = (
+                parent_dir / "__init__.py"
+                if (parent_dir / "__init__.py").is_file()
+                else parent_dir
+            )
+            parent_module = _import_module_using_spec(
+                parent_module_name,
+                parent_module_path,
+                parent_dir,
+                insert_modules=insert_modules,
+            )
 
         # Find spec and import this module.
         mod = importlib.util.module_from_spec(spec)

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -1127,6 +1127,41 @@ def test_safe_exists(tmp_path: Path) -> None:
 
 
 def test_import_sets_module_as_attribute(pytester: Pytester) -> None:
+    """Unittest test for #12194."""
+    pytester.path.joinpath("foo/bar/baz").mkdir(parents=True)
+    pytester.path.joinpath("foo/__init__.py").touch()
+    pytester.path.joinpath("foo/bar/__init__.py").touch()
+    pytester.path.joinpath("foo/bar/baz/__init__.py").touch()
+    pytester.syspathinsert()
+
+    # Import foo.bar.baz and ensure parent modules also ended up imported.
+    baz = import_path(
+        pytester.path.joinpath("foo/bar/baz/__init__.py"),
+        mode=ImportMode.importlib,
+        root=pytester.path,
+        consider_namespace_packages=False,
+    )
+    assert baz.__name__ == "foo.bar.baz"
+    foo = sys.modules["foo"]
+    assert foo.__name__ == "foo"
+    bar = sys.modules["foo.bar"]
+    assert bar.__name__ == "foo.bar"
+
+    # Check parent modules have an attribute pointing to their children.
+    assert bar.baz is baz
+    assert foo.bar is bar
+
+    # Ensure we returned the "foo.bar" module cached in sys.modules.
+    bar_2 = import_path(
+        pytester.path.joinpath("foo/bar/__init__.py"),
+        mode=ImportMode.importlib,
+        root=pytester.path,
+        consider_namespace_packages=False,
+    )
+    assert bar_2 is bar
+
+
+def test_import_sets_module_as_attribute_regression(pytester: Pytester) -> None:
     """Regression test for #12194."""
     pytester.path.joinpath("foo/bar/baz").mkdir(parents=True)
     pytester.path.joinpath("foo/__init__.py").touch()


### PR DESCRIPTION
Now `importlib` mode will correctly set the imported modules as an attribute of their parent modules.

As helpfully posted on #12194, that's how the Python import module works so we should follow suit.

In addition, we also try to import the parent modules as part of the process of importing a child module, again mirroring how Python importing works.

Because of the latter, I think it is more prudent to *not* backport this and release this in the next minor release: I fear importing the parent module like we are doing here might trigger some side effect in test suites in the wild, which would count as a change in behavior.

Fix #12194
