### PR TITLE
Makes sure PYTEST_VERSION env variable is cleaned up after the running test_pytest_version_env_var ut

### DIFF
--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -1097,7 +1097,7 @@ def test_outcome_exception_bad_msg() -> None:
 
 
 def test_pytest_version_env_var(pytester: Pytester, monkeypatch: MonkeyPatch) -> None:
-    os.environ["PYTEST_VERSION"] = "old version"
+    monkeypatch.setenv("PYTEST_VERSION", "old version")
     pytester.makepyfile(
         """
         import pytest


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/pull/12190#discussion_r1570666814