### PR TITLE
Fixed Bug Regarding Attribute Error in pytest.approx For Types Implicitly Convertible to Numpy Arrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,5 @@ language: python
 rvm:
  - "3.9"
 
-install:
-  - pip install --user pre-commit
-  - pip install tox
-
 script:
   - pytest testing/python/approx.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+
+rvm:
+ - "3.9"
+
+install:
+  - pip install --user pre-commit
+  - pip install tox
+
+script:
+  - pytest testing/python/approx.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: python
-
-rvm:
- - "3.9"
-
-script:
-  - pytest testing/python/approx.py

--- a/AUTHORS
+++ b/AUTHORS
@@ -321,6 +321,7 @@ Pierre Sassoulas
 Pieter Mulder
 Piotr Banaszkiewicz
 Piotr Helm
+Poulami Sau
 Prakhar Gurunani
 Prashant Anand
 Prashant Sharma

--- a/changelog/12114.bugfix.rst
+++ b/changelog/12114.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed attribute error in pytest.approx for types implicitly convertible to numpy arrays by converting other_side to a numpy array so that np_array_shape != other_side.shape can be properly checked.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -163,6 +163,9 @@ class ApproxNumpy(ApproxBase):
             self._approx_scalar, self.expected.tolist()
         )
 
+        # convert other_side to numpy array to ensure shape attribute is available
+        other_side = _as_numpy_array(other_side)
+
         if np_array_shape != other_side.shape:
             return [
                 "Impossible to compare arrays with different shapes.",

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -142,7 +142,7 @@ class ApproxNumpy(ApproxBase):
         )
         return f"approx({list_scalars!r})"
 
-    def _repr_compare(self, other_side: "ndarray") -> List[str]:
+    def _repr_compare(self, other_side: Union["ndarray", List[Any]]) -> List[str]:
         import itertools
         import math
 
@@ -164,12 +164,13 @@ class ApproxNumpy(ApproxBase):
         )
 
         # convert other_side to numpy array to ensure shape attribute is available
-        other_side = _as_numpy_array(other_side)
+        other_side_as_array = _as_numpy_array(other_side)
+        assert other_side_as_array is not None
 
-        if np_array_shape != other_side.shape:
+        if np_array_shape != other_side_as_array.shape:
             return [
                 "Impossible to compare arrays with different shapes.",
-                f"Shapes: {np_array_shape} and {other_side.shape}",
+                f"Shapes: {np_array_shape} and {other_side_as_array.shape}",
             ]
 
         number_of_elements = self.expected.size
@@ -178,7 +179,7 @@ class ApproxNumpy(ApproxBase):
         different_ids = []
         for index in itertools.product(*(range(i) for i in np_array_shape)):
             approx_value = get_value_from_nested_list(approx_side_as_seq, index)
-            other_value = get_value_from_nested_list(other_side, index)
+            other_value = get_value_from_nested_list(other_side_as_array, index)
             if approx_value != other_value:
                 abs_diff = abs(approx_value.expected - other_value)
                 max_abs_diff = max(max_abs_diff, abs_diff)
@@ -191,7 +192,7 @@ class ApproxNumpy(ApproxBase):
         message_data = [
             (
                 str(index),
-                str(get_value_from_nested_list(other_side, index)),
+                str(get_value_from_nested_list(other_side_as_array, index)),
                 str(get_value_from_nested_list(approx_side_as_seq, index)),
             )
             for index in different_ids

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -773,7 +773,6 @@ class TestApprox:
                 self.vals = vals
 
             def __array__(self, dtype=None, copy=None):
-                print("called __array__ in ImplicitArray")
                 return np.array(self.vals)
 
         vec1 = ImplicitArray([1.0, 2.0, 3.0])

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -773,10 +773,12 @@ class TestApprox:
                 self.vals = vals
 
             def __array__(self, dtype=None, copy=None):
+                print("called __array__ in ImplicitArray")
                 return np.array(self.vals)
 
         vec1 = ImplicitArray([1.0, 2.0, 3.0])
         vec2 = ImplicitArray([1.0, 2.0, 4.0])
+        # see issue #12114 for test case
         assert vec1 != approx(vec2)
 
     def test_numpy_array_protocol(self):

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -778,6 +778,7 @@ class TestApprox:
 
         vec1 = ImplicitArray([1.0, 2.0, 3.0])
         vec2 = ImplicitArray([1.0, 2.0, 4.0])
+        # see issue #12114 for test case
         assert vec1 != approx(vec2)
 
     def test_numpy_array_protocol(self):

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -773,12 +773,10 @@ class TestApprox:
                 self.vals = vals
 
             def __array__(self, dtype=None, copy=None):
-                print("called __array__ in ImplicitArray")
                 return np.array(self.vals)
 
         vec1 = ImplicitArray([1.0, 2.0, 3.0])
         vec2 = ImplicitArray([1.0, 2.0, 4.0])
-        # see issue #12114 for test case
         assert vec1 != approx(vec2)
 
     def test_numpy_array_protocol(self):

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -763,6 +763,23 @@ class TestApprox:
         assert a12 != approx(a21)
         assert a21 != approx(a12)
 
+    def test_numpy_array_implicit_conversion(self):
+        np = pytest.importorskip("numpy")
+
+        class ImplicitArray:
+            """Type which is implicitly convertible to a numpy array."""
+
+            def __init__(self, vals):
+                self.vals = vals
+
+            def __array__(self, dtype=None, copy=None):
+                print("called __array__ in ImplicitArray")
+                return np.array(self.vals)
+
+        vec1 = ImplicitArray([1.0, 2.0, 3.0])
+        vec2 = ImplicitArray([1.0, 2.0, 4.0])
+        assert vec1 != approx(vec2)
+
     def test_numpy_array_protocol(self):
         """
         array-like objects such as tensorflow's DeviceArray are handled like ndarray.


### PR DESCRIPTION
Fixed the bug for _repr_compare in the ApproxNumpy class located in pytest.approx to ensure that other_side is a numpy array before comparing np_array_shape != other_side.shape. I have verified that the provided test cases, along with the test case provided in #12114, have all passed using pytest testing/python/approx.py.