### PR TITLE
Fixed color test when TERM=dumb

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -383,6 +383,7 @@ Reza Mousavi
 Raquel Alegre
 Ravi Chandra
 Reagan Lee
+Reilly Brogan
 Rob Arrow
 Robert Holt
 Roberto Aldera

--- a/changelog/12244.contrib.rst
+++ b/changelog/12244.contrib.rst
@@ -1,0 +1,1 @@
+Fixed self-test failures when `TERM=dumb`.

--- a/testing/io/test_terminalwriter.py
+++ b/testing/io/test_terminalwriter.py
@@ -224,6 +224,7 @@ def test_NO_COLOR_and_FORCE_COLOR(
 
 
 def test_empty_NO_COLOR_and_FORCE_COLOR_ignored(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("TERM", "xterm-256color")
     monkeypatch.setitem(os.environ, "NO_COLOR", "")
     monkeypatch.setitem(os.environ, "FORCE_COLOR", "")
     assert_color(True, True)


### PR DESCRIPTION
Dumb terminals are incapable of handling color, so this test would fail when ran in such an environment. We encountered this on the Solus build infrastructure which uses such a headless terminal.
