### PR TITLE
Emit Unregistered Mark Warning in Command Line Usage

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -267,6 +267,7 @@ Matt Bachmann
 Matt Duck
 Matt Williams
 Matthias Hafner
+Max Berkowitz
 Maxim Filipenko
 Maximilian Cosmo Sitter
 mbyt

--- a/changelog/10514.improvement.rst
+++ b/changelog/10514.improvement.rst
@@ -1,0 +1,1 @@
+Emit a warning when unregistered marks are used with the command line option -m.

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -236,7 +236,7 @@ def deselect_by_mark(items: "List[Item]", config: Config) -> None:
     if not matchexpr:
         return
 
-    expr = _parse_expression(matchexpr, "Wrong expression passed to '-m'")
+    expr = _parse_expression(matchexpr, "Wrong expression passed to '-m'", True)
     remaining: List[Item] = []
     deselected: List[Item] = []
     for item in items:
@@ -249,9 +249,9 @@ def deselect_by_mark(items: "List[Item]", config: Config) -> None:
         items[:] = remaining
 
 
-def _parse_expression(expr: str, exc_message: str) -> Expression:
+def _parse_expression(expr: str, exc_message: str, mark: bool = False) -> Expression:
     try:
-        return Expression.compile(expr)
+        return Expression.compile(expr, mark)
     except ParseError as e:
         raise UsageError(f"{exc_message}: {expr}: {e}") from None
 

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -98,7 +98,6 @@ class Scanner:
                     elif value == "not":
                         yield Token(TokenType.NOT, value, pos)
                     else:
-                        MARK_GEN.verify_mark(value)
                         yield Token(TokenType.IDENT, value, pos)
                     pos += len(value)
                 else:

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -206,13 +206,13 @@ class Expression:
         :param input: The input expression - one line.
         """
         astexpr = expression(Scanner(input))
-        
+
         if mark:
             for node in ast.walk(astexpr):
-                #if the node is an identifier, i.e. a mark name
-                if isinstance(node, ast.Name): 
-                    MARK_GEN.verify_mark(node.id[len(IDENT_PREFIX):])
-                    
+                # if the node is an identifier, i.e. a mark name
+                if isinstance(node, ast.Name):
+                    MARK_GEN.verify_mark(node.id[len(IDENT_PREFIX) :])
+
         code: types.CodeType = compile(
             astexpr,
             filename="<pytest match expression>",

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -26,6 +26,7 @@ from typing import Mapping
 from typing import NoReturn
 from typing import Optional
 from typing import Sequence
+from .structures import MARK_GEN
 
 
 __all__ = [
@@ -96,6 +97,7 @@ class Scanner:
                     elif value == "not":
                         yield Token(TokenType.NOT, value, pos)
                     else:
+                        MARK_GEN.verify_mark(value)
                         yield Token(TokenType.IDENT, value, pos)
                     pos += len(value)
                 else:

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -200,12 +200,19 @@ class Expression:
         self.code = code
 
     @classmethod
-    def compile(self, input: str) -> "Expression":
+    def compile(self, input: str, mark: bool = False) -> "Expression":
         """Compile a match expression.
 
         :param input: The input expression - one line.
         """
         astexpr = expression(Scanner(input))
+        
+        if mark:
+            for node in ast.walk(astexpr):
+                #if the node is an identifier, i.e. a mark name
+                if isinstance(node, ast.Name): 
+                    MARK_GEN.verify_mark(node.id[len(IDENT_PREFIX):])
+                    
         code: types.CodeType = compile(
             astexpr,
             filename="<pytest match expression>",

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -26,6 +26,7 @@ from typing import Mapping
 from typing import NoReturn
 from typing import Optional
 from typing import Sequence
+
 from .structures import MARK_GEN
 
 

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -520,11 +520,7 @@ class MarkGenerator:
         self._config: Optional[Config] = None
         self._markers: Set[str] = set()
 
-    def __getattr__(self, name: str) -> MarkDecorator:
-        """Generate a new :class:`MarkDecorator` with the given name."""
-        if name[0] == "_":
-            raise AttributeError("Marker name must NOT start with underscore")
-
+    def verify_mark(self, name: str) -> None:
         if self._config is not None:
             # We store a set of markers as a performance optimisation - if a mark
             # name is in the set we definitely know it, but a mark may be known and
@@ -556,8 +552,15 @@ class MarkGenerator:
                     "custom marks to avoid this warning - for details, see "
                     "https://docs.pytest.org/en/stable/how-to/mark.html" % name,
                     PytestUnknownMarkWarning,
-                    2,
+                    3,
                 )
+
+    def __getattr__(self, name: str) -> MarkDecorator:
+        """Generate a new :class:`MarkDecorator` with the given name."""
+        if name[0] == "_":
+            raise AttributeError("Marker name must NOT start with underscore")
+
+        self.verify_mark(name)
 
         return MarkDecorator(Mark(name, (), {}, _ispytest=True), _ispytest=True)
 

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -678,13 +678,6 @@ class TestAssert_reprcompare:
         assert expl is not None
         assert len(expl) > 1
 
-    def test_dict_truncate(self) -> None:
-        dict1 = {"asdf": [1, 1, 1, 1, 1, 1, 1, 1]}
-        dict2 = {"asdf": [1, 1, 1, 1, 1, 1, 1, 2]}
-        expl = callequal(dict1, dict2)
-        print(expl)
-        assert False
-
     def test_dict_omitting(self) -> None:
         lines = callequal({"a": 0, "b": 1}, {"a": 1, "b": 1})
         assert lines is not None

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -678,6 +678,13 @@ class TestAssert_reprcompare:
         assert expl is not None
         assert len(expl) > 1
 
+    def test_dict_truncate(self) -> None:
+        dict1 = {"asdf": [1, 1, 1, 1, 1, 1, 1, 1]}
+        dict2 = {"asdf": [1, 1, 1, 1, 1, 1, 1, 2]}
+        expl = callequal(dict1, dict2)
+        print(expl)
+        assert False
+
     def test_dict_omitting(self) -> None:
         lines = callequal({"a": 0, "b": 1}, {"a": 1, "b": 1})
         assert lines is not None


### PR DESCRIPTION
<!-
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Closes #10514 
Emit a warning when -m is used with unregistered marks

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.
- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
