### PR TITLE
Filter warnings from AssertionRewritingHook when exec'ing module

### DIFF
--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -29,6 +29,7 @@ from typing import Set
 from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import Union
+import warnings
 
 from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE
 from _pytest._io.saferepr import saferepr
@@ -175,7 +176,9 @@ class AssertionRewritingHook(importlib.abc.MetaPathFinder, importlib.abc.Loader)
                     self._writing_pyc = False
         else:
             state.trace(f"found cached rewritten pyc for {fn}")
-        exec(co, module.__dict__)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            exec(co, module.__dict__)
 
     def _early_rewrite_bailout(self, name: str, state: "AssertionState") -> bool:
         """A fast way to get out of rewriting modules.
@@ -859,8 +862,6 @@ class AssertionRewriter(ast.NodeVisitor):
         the expression is false.
         """
         if isinstance(assert_.test, ast.Tuple) and len(assert_.test.elts) >= 1:
-            import warnings
-
             from _pytest.warning_types import PytestAssertRewriteWarning
 
             # TODO: This assert should not be needed.


### PR DESCRIPTION
This method raises warnings from packages very early in the pytest collection process, way before configured filterwarnings can be set up. It's not interesting to raise anything here IMO, so let's filter and ignore them.

This should also prevent spurious issue reports for you, like https://github.com/pytest-dev/pytest/issues/11741 and https://github.com/pytest-dev/pytest/issues/9884