### PR TITLE
terminal: fix progress percentages not aligning correctly in xdist

### DIFF
--- a/changelog/7166.bugfix.rst
+++ b/changelog/7166.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed progress percentages (the ``[ 87%]`` at the edge of the screen) sometimes not aligning correctly when running with pytest-xdist ``-n``.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -432,7 +432,7 @@ class TerminalReporter:
         char = {"xfailed": "x", "skipped": "s"}.get(char, char)
         return char in self.reportchars
 
-    def write_fspath_result(self, nodeid: str, res, **markup: bool) -> None:
+    def write_fspath_result(self, nodeid: str, res: str, **markup: bool) -> None:
         fspath = self.config.rootpath / nodeid.split("::")[0]
         if self.currentfspath is None or fspath != self.currentfspath:
             if self.currentfspath is not None and self._show_progress_info:
@@ -565,10 +565,11 @@ class TerminalReporter:
     def pytest_runtest_logstart(
         self, nodeid: str, location: Tuple[str, Optional[int], str]
     ) -> None:
+        fspath, lineno, domain = location
         # Ensure that the path is printed before the
         # 1st test of a module starts running.
         if self.showlongtestinfo:
-            line = self._locationline(nodeid, *location)
+            line = self._locationline(nodeid, fspath, lineno, domain)
             self.write_ensure_prefix(line, "")
             self.flush()
         elif self.showfspath:
@@ -591,7 +592,6 @@ class TerminalReporter:
         if not letter and not word:
             # Probably passed setup/teardown.
             return
-        running_xdist = hasattr(rep, "node")
         if markup is None:
             was_xfail = hasattr(report, "wasxfail")
             if rep.passed and not was_xfail:
@@ -609,6 +609,7 @@ class TerminalReporter:
         else:
             self._progress_nodeids_reported.add(rep.nodeid)
             line = self._locationline(rep.nodeid, *rep.location)
+            running_xdist = hasattr(rep, "node")
             if not running_xdist:
                 self.write_ensure_prefix(line, word, **markup)
                 if rep.skipped or hasattr(report, "wasxfail"):
@@ -649,38 +650,26 @@ class TerminalReporter:
         return len(self._progress_nodeids_reported) == self._session.testscollected
 
     def pytest_runtest_logfinish(self, nodeid: str) -> None:
-        assert self._session
         if (
             self.config.get_verbosity(Config.VERBOSITY_TEST_CASES) <= 0
             and self._show_progress_info
         ):
-            if self._show_progress_info == "count":
-                num_tests = self._session.testscollected
-                progress_length = len(f" [{num_tests}/{num_tests}]")
-            else:
-                progress_length = len(" [100%]")
-
             self._progress_nodeids_reported.add(nodeid)
 
             if self._is_last_item:
                 self._write_progress_information_filling_space()
             else:
-                main_color, _ = self._get_main_color()
-                w = self._width_of_current_line
-                past_edge = w + progress_length + 1 >= self._screen_width
-                if past_edge:
-                    msg = self._get_progress_information_message()
-                    self._tw.write(msg + "\n", **{main_color: True})
+                self._write_progress_information_if_past_edge()
 
     def _get_progress_information_message(self) -> str:
         assert self._session
         collected = self._session.testscollected
         if self._show_progress_info == "count":
             if collected:
-                progress = self._progress_nodeids_reported
+                progress = len(self._progress_nodeids_reported)
                 counter_format = f"{{:{len(str(collected))}d}}"
                 format_string = f" [{counter_format}/{{}}]"
-                return format_string.format(len(progress), collected)
+                return format_string.format(progress, collected)
             return f" [ {collected} / {collected} ]"
         else:
             if collected:
@@ -688,6 +677,20 @@ class TerminalReporter:
                     f" [{len(self._progress_nodeids_reported) * 100 // collected:3d}%]"
                 )
             return " [100%]"
+
+    def _write_progress_information_if_past_edge(self) -> None:
+        w = self._width_of_current_line
+        if self._show_progress_info == "count":
+            assert self._session
+            num_tests = self._session.testscollected
+            progress_length = len(f" [{num_tests}/{num_tests}]")
+        else:
+            progress_length = len(" [100%]")
+        past_edge = w + progress_length + 1 >= self._screen_width
+        if past_edge:
+            main_color, _ = self._get_main_color()
+            msg = self._get_progress_information_message()
+            self._tw.write(msg + "\n", **{main_color: True})
 
     def _write_progress_information_filling_space(self) -> None:
         color, _ = self._get_main_color()
@@ -937,7 +940,7 @@ class TerminalReporter:
                 line += "[".join(values)
             return line
 
-        # collect_fspath comes from testid which has a "/"-normalized path.
+        # fspath comes from testid which has a "/"-normalized path.
         if fspath:
             res = mkrel(nodeid)
             if self.verbosity >= 2 and nodeid.split("::")[0] != fspath.replace(


### PR DESCRIPTION
Fix #7166.

The first commit is just preparation without logic changes. The second commit is the fix. After some consideration this is the least disruptive change I could come up with.

There is no test, because it's hard to come up with a deterministic test for this without manually orchestrating hook calls, which is too much effort for me. I manually tested scenarios I could think of.