### PR TITLE
markers: support new ident '|'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -156,6 +156,7 @@ Florian Bruhin
 Florian Dahlitz
 Floris Bruynooghe
 Fraser Stark
+Fu Hanxi
 Gabriel Landau
 Gabriel Reis
 Garvit Shubham

--- a/changelog/12277.improvement.rst
+++ b/changelog/12277.improvement.rst
@@ -1,0 +1,1 @@
+Supported vertical bar ``|`` inside a marker.

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -6,7 +6,7 @@ expression: expr? EOF
 expr:       and_expr ('or' and_expr)*
 and_expr:   not_expr ('and' not_expr)*
 not_expr:   'not' not_expr | '(' expr ')' | ident
-ident:      (\w|:|\+|-|\.|\[|\]|\\|/)+
+ident:      (\w|:|\+|-|\.|\[|\]|\\|/|\|)+
 
 The semantics are:
 
@@ -86,7 +86,7 @@ class Scanner:
                 yield Token(TokenType.RPAREN, ")", pos)
                 pos += 1
             else:
-                match = re.match(r"(:?\w|:|\+|-|\.|\[|\]|\\|/)+", input[pos:])
+                match = re.match(r"(:?\w|:|\+|-|\.|\[|\]|\\|/|\|)+", input[pos:])
                 if match:
                     value = match.group(0)
                     if value == "or":


### PR DESCRIPTION
Hi pytest team!

While I'm developing a new feature to the [pytest-embedded](https://github.com/espressif/pytest-embedded) plugin, I realize that `|` is not allowed in pytest markers. (Inside the pytest-embedded plugin, I'm using `|` as a separator.)

```
ERROR: Wrong expression passed to '-m': esp32|esp32p4: at column 6: unexpected character "|"
```

I'm wondering the reason behind this. so I'm opening this PR.

Thanks!
Hanxi

**EDIT**

actually use `|` is better than `:` (which is supported now)

I didn't find a way to define a marker with `:` inside, since everything past after the first `:` will be considered as a optional description.

so `pytest -m "a:b"` will try to search a marker called `a:b`, but if I put

```
[pytest]
  a:b: test
```

only marker `a` will be added

if we support `|`, we could define with

```
[pytest]
  a|b: test
```

(tested with --strict-marker)

