### PR TITLE
Add back "Fix teardown error reporting when --maxfail=1 (#11721)"

### DIFF
--- a/changelog/11706.bugfix.rst
+++ b/changelog/11706.bugfix.rst
@@ -1,0 +1,4 @@
+Fix reporting of teardown errors in higher-scoped fixtures when using `--maxfail` or `--stepwise`.
+
+Originally added in pytest 8.0.0, but reverted in 8.0.2 due to a regression in pytest-xdist.
+This regression was fixed in pytest-xdist 3.6.1.

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -134,6 +134,10 @@ def runtestprotocol(
             show_test_item(item)
         if not item.config.getoption("setuponly", False):
             reports.append(call_and_report(item, "call", log))
+    # If the session is about to fail or stop, teardown everything - this is
+    # necessary to correctly report fixture teardown errors (see #11706)
+    if item.session.shouldfail or item.session.shouldstop:
+        nextitem = None
     reports.append(call_and_report(item, "teardown", log, nextitem=nextitem))
     # After all teardown hooks have been called
     # want funcargs and request info to go away.


### PR DESCRIPTION
Closes #11706.

Originally fixed in #11721, but then reverted in #12022 due to a regression in `pytest-xdist`.

The regression was fixed on the `pytest-xdist` side in https://github.com/pytest-dev/pytest-xdist/pull/1026.