### PR TITLE
Fixes crashing under a squashfuse_ll read-only mount

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -441,6 +441,7 @@ Yao Xiao
 Yoav Caspi
 Yuliang Shao
 Yusuke Kadowaki
+Yutian Li
 Yuval Shimon
 Zac Hatfield-Dodds
 Zachary Kneupper

--- a/changelog/12300.bugfix.rst
+++ b/changelog/12300.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed handling of 'Function not implemented' error under squashfuse_ll, which is a different way to say that the mountpoint is read-only.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -1171,7 +1171,10 @@ def try_makedirs(cache_dir: Path) -> bool:
         return False
     except OSError as e:
         # as of now, EROFS doesn't have an equivalent OSError-subclass
-        if e.errno == errno.EROFS:
+        #
+        # squashfuse_ll returns ENOSYS "OSError: [Errno 38] Function not
+        # implemented" for a read-only error
+        if e.errno in {errno.EROFS, errno.ENOSYS}:
             return False
         raise
     return True

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1972,6 +1972,11 @@ def test_try_makedirs(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(os, "makedirs", partial(fake_mkdir, exc=err))
     assert not try_makedirs(p)
 
+    err = OSError()
+    err.errno = errno.ENOSYS
+    monkeypatch.setattr(os, "makedirs", partial(fake_mkdir, exc=err))
+    assert not try_makedirs(p)
+
     # unhandled OSError should raise
     err = OSError()
     err.errno = errno.ECHILD


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->

As described in #12300 , pytest crashes with `OSError: [Errno 38] Function not implemented` when it's run under a squashfuse_ll mountpoint. the exception comes from within
```
_pytest/assertion/rewrite.py:1102: in try_makedirs
    os.makedirs(cache_dir, exist_ok=True)
```
this is because squashfuse_ll returns `ENOSYS` instead of `EROFS` for a read-only filesystem, which pytest doesn't know how to handle.  This change adds handling of the error code.



closes #12300 