### PR TITLE
Improved the terminal colour formatting, Issue #11666

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -192,6 +192,7 @@ Jake VanderPlas
 Jakob van Santen
 Jakub Mitoraj
 James Bourbeau
+James Hutchins
 Jan Balster
 Janne Vanhala
 Jason R. Coombs

--- a/changelog/11666.improvement.rst
+++ b/changelog/11666.improvement.rst
@@ -1,0 +1,7 @@
+Improved the terminal writer to be able to use pygments Terminal256Formatter and TerminalTrueColorFormatter.
+
+These can be set by the user with the environmental variable PYTEST_THEME.
+
+There is also a default format set with both a light and dark mode which can be changed with the environmental variable PYTEST_THEME_MODE.
+
+If no environmental variables are set it defaults to dark mode.


### PR DESCRIPTION
Hello,

This PR resolves https://github.com/pytest-dev/pytest/issues/11666.

This is my first time contributing to an open source project so please excuse any beginner mistakes. 

I used the pull request https://github.com/pytest-dev/pytest/pull/11700 as an initial guide as they started to implement this issue but then stopped. 

I also know that there are errors with my pull request. I believe that they are all due to do the testing of the terminal output, which I have now changed. I am not sure how to change these tests properly, so have left it for now. 

### What I did ###
My goal was to implement the use of the pygment classes `TerminalTrueColorFormatter` and `Terminal256Formatter` to get richer colours in the terminal . 

To do this I used the same logic as pygments use to get the formatter that is appropriate for the users computer.
https://github.com/pygments/pygments/blob/861fb9131b13241d7ea700fba8f6a38cf6f97285/pygments/cmdline.py#L448-L453C57

I set up the formatter in a way that the users can add their own style by setting the environmental variable `PYTEST_THEME `.  I also added in default styles which will be used if `PYTEST_THEME ` is not set. 

Both `TerminalTrueColorFormatter` and `Terminal256Formatter` do not have _light mode_ or _dark mode_ options. I therefore created two default styles, one for each. I tried to create the styles as close as I could to the default style of `TerminalFormatter`. The environmental variable `PYTEST_THEME_MODE` sets if the _light mode_ or _dark mode_ default style is used. If `PYTEST_THEME_MODE` is not set dark mode is the default style. 


To create the default styles. I made classes at the end of the terminalwiter.py file. If this is the wrong spot for them I am sorry. 



Thanks,
James
