### PR TITLE
python: add workaround for permission error crashes from non-selected directories

### DIFF
--- a/changelog/12120.bugfix.rst
+++ b/changelog/12120.bugfix.rst
@@ -1,0 +1,1 @@
+Fix `PermissionError` crashes arising from directories which are not selected on the command-line.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -176,7 +176,12 @@ def pytest_collect_directory(
     path: Path, parent: nodes.Collector
 ) -> Optional[nodes.Collector]:
     pkginit = path / "__init__.py"
-    if pkginit.is_file():
+    try:
+        has_pkginit = pkginit.is_file()
+    except PermissionError:
+        # See https://github.com/pytest-dev/pytest/issues/12120#issuecomment-2106349096.
+        return None
+    if has_pkginit:
         return Package.from_parent(parent, path=path)
     return None
 

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -285,6 +285,23 @@ class TestCollectFS:
             items, reprec = pytester.inline_genitems()
             assert [x.name for x in items] == [f"test_{dirname}"]
 
+    def test_missing_permissions_on_unselected_directory_doesnt_crash(
+        self, pytester: Pytester
+    ) -> None:
+        """Regression test for #12120."""
+        test = pytester.makepyfile(test="def test(): pass")
+        bad = pytester.mkdir("bad")
+        try:
+            bad.chmod(0)
+
+            result = pytester.runpytest(test)
+        finally:
+            bad.chmod(750)
+            bad.rmdir()
+
+        assert result.ret == ExitCode.OK
+        result.assert_outcomes(passed=1)
+
 
 class TestCollectPluginHookRelay:
     def test_pytest_collect_file(self, pytester: Pytester) -> None:


### PR DESCRIPTION
Fix #12120.