### PR TITLE
Resolving Issue #11666 - Using Richer Color Terminal Formatters

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -308,6 +308,7 @@ Omar Kohl
 Omer Hadari
 Ondřej Súkup
 Oscar Benjamin
+Pandula Gajadeera
 Parth Patel
 Patrick Hayes
 Patrick Lannigan

--- a/changelog/11666.improvement.rst
+++ b/changelog/11666.improvement.rst
@@ -1,0 +1,5 @@
+Improved the terminal writer to be able to use Terminal256Formatter and TerminalTrueColorFormatter.
+
+These are newer versions of TerminalFormmater from the pygments library that is currently in use.
+
+These style of these formatters are set by the users through the environmental variable PYTEST_THEME.

--- a/src/_pytest/_io/terminalwriter.py
+++ b/src/_pytest/_io/terminalwriter.py
@@ -218,13 +218,24 @@ class TerminalWriter:
             return source
         else:
             try:
+                # Import new more rich color formatters from the pygments library
+                from pygments.formatters.terminal256 import TerminalTrueColorFormatter
+                from pygments.formatters.terminal256 import Terminal256Formatter
+
+                # Use terminal formatters depending on user environment variables
+                if os.environ.get('COLORTERM','') in ('truecolor', '24bit'):
+                    # Style determined by user set environment variable, if none then use default style
+                    terminal_formatter = TerminalTrueColorFormatter(style=os.getenv("PYTEST_THEME","default"))
+                elif '256' in os.environ.get('TERM', ''):
+                    terminal_formatter = Terminal256Formatter(style=os.getenv("PYTEST_THEME","default"))
+                else:
+                    terminal_formatter = TerminalFormatter(
+                                            bg=os.getenv("PYTEST_THEME_MODE", "dark"),
+                                            style=os.getenv("PYTEST_THEME"),
+                                            )
                 highlighted: str = highlight(
                     source,
                     Lexer(),
-                    TerminalFormatter(
-                        bg=os.getenv("PYTEST_THEME_MODE", "dark"),
-                        style=os.getenv("PYTEST_THEME"),
-                    ),
                 )
                 # pygments terminal formatter may add a newline when there wasn't one.
                 # We don't want this, remove.


### PR DESCRIPTION
Hi,
This pull request attempts to resolve issue #11666 by implementing richer color terminal formatters from the pygments library.

## Description 
Many of the changes made were by referring to the previously closed pull request #11700 .The author of that pull request made several changes such as importing the ``Terminal256Formatter`` and ``TerminalTrueColorFormatter`` alongside the previously used ``TerminalFormatter``. User environment variables were taken to decide which formatter would be used. However, the author of the issue stated that user configuration of the style used by the formatters is preffered (by using the environment variable ``PYTEST_THEME``). The contributor attempted this but had errors due to ``PYTEST_THEME`` returning 'None'.

## Changes 
``Terminal256Formatter``, ``TerminalTrueColorFormatter`` and ``TerminalFormatter`` are used depending on environment variables.

Style of ``Terminal256Formatter`` and ``TerminalTrueColorFormatter`` is determined by the ``PYTEST_THEME`` environment variable.

In the case ``PYTEST_THEME`` returns 'None', the default style is used instead.

This is my first attempt at contributing to an open source project so any feedback or criticisms are welcome.

Thank you,
Pandula