### PR TITLE
cacheprovider: fix `.pytest_cache` not being world-readable

### DIFF
--- a/changelog/12308.bugfix.rst
+++ b/changelog/12308.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a regression in pytest 8.2.0 where the permissions of automatically-created ``.pytest_cache`` directories became ``rwx------`` instead of the expected ``rwxr-xr-x``.

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -213,6 +213,13 @@ class Cache:
             dir=self._cachedir.parent,
         ) as newpath:
             path = Path(newpath)
+
+            # Reset permissions to the default, see #12308.
+            # Note: there's no way to get the current umask atomically, eek.
+            umask = os.umask(0o022)
+            os.umask(umask)
+            path.chmod(0o777 - umask)
+
             with open(path.joinpath("README.md"), "xt", encoding="UTF-8") as f:
                 f.write(README_CONTENT)
             with open(path.joinpath(".gitignore"), "xt", encoding="UTF-8") as f:

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -31,6 +31,21 @@ class TestNewAPI:
         p = config.cache.mkdir("name")
         assert p.is_dir()
 
+    def test_cache_dir_permissions(self, pytester: Pytester) -> None:
+        """The .pytest_cache directory should have world-readable permissions
+        (depending on umask).
+
+        Regression test for #12308.
+        """
+        pytester.makeini("[pytest]")
+        config = pytester.parseconfigure()
+        assert config.cache is not None
+        p = config.cache.mkdir("name")
+        assert p.is_dir()
+        # Instead of messing with umask, make sure .pytest_cache has the same
+        # permissions as the default that `mkdir` gives `p`.
+        assert (p.parent.stat().st_mode & 0o777) == (p.stat().st_mode & 0o777)
+
     def test_config_cache_dataerror(self, pytester: Pytester) -> None:
         pytester.makeini("[pytest]")
         config = pytester.parseconfigure()


### PR DESCRIPTION
Fix #12308.