### PR TITLE
fixtures: fix non-working package-scope parametrization reordering

### DIFF
--- a/changelog/12328.bugfix.rst
+++ b/changelog/12328.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a regression in pytest 8.0.0 where package-scoped parameterized items were not correctly reordered to minimize setups/teardowns in some cases.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -187,7 +187,8 @@ def get_parametrized_fixture_keys(
         if scope is Scope.Session:
             scoped_item_path = None
         elif scope is Scope.Package:
-            scoped_item_path = item.path
+            # Package key = module's directory.
+            scoped_item_path = item.path.parent
         elif scope is Scope.Module:
             scoped_item_path = item.path
         elif scope is Scope.Class:


### PR DESCRIPTION
The `.parent` was incorrectly removed in
a21fb87a90974189c1b8b26189959507189bb3a1, but it was actually correct (well, it assumes that Module.path.parent == Package.path, which I'm not sure is always correct, but that's a different matter). Restore it.

Fix #12328.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
