### PR TITLE
Attest package provenance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,11 @@ jobs:
     env:
       SETUPTOOLS_SCM_PRETEND_VERSION: ${{ github.event.inputs.version }}
     timeout-minutes: 10
+    
+    # Required by attest-build-provenance-github.
+    permissions:
+      id-token: write
+      attestations: write
 
     steps:
     - uses: actions/checkout@v4
@@ -26,7 +31,9 @@ jobs:
         persist-credentials: false
 
     - name: Build and Check Package
-      uses: hynek/build-and-inspect-python-package@v2.4.0
+      uses: hynek/build-and-inspect-python-package@v2.5.0
+      with:
+        attest-build-provenance-github: 'true'
 
   deploy:
     if: github.repository == 'pytest-dev/pytest'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       SETUPTOOLS_SCM_PRETEND_VERSION: ${{ github.event.inputs.version }}
     timeout-minutes: 10
-    
+
     # Required by attest-build-provenance-github.
     permissions:
       id-token: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,19 +29,13 @@ permissions: {}
 jobs:
   package:
     runs-on: ubuntu-latest
-    # Required by attest-build-provenance-github.
-    permissions:
-      id-token: write
-      attestations: write
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         persist-credentials: false
     - name: Build and Check Package
-      uses: hynek/build-and-inspect-python-package@v2.5.0
-      with:
-        attest-build-provenance-github: 'true'
+      uses: hynek/build-and-inspect-python-package@v2.4.0
 
   build:
     needs: [package]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,13 +29,19 @@ permissions: {}
 jobs:
   package:
     runs-on: ubuntu-latest
+    # Required by attest-build-provenance-github.
+    permissions:
+      id-token: write
+      attestations: write
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         persist-credentials: false
     - name: Build and Check Package
-      uses: hynek/build-and-inspect-python-package@v2.4.0
+      uses: hynek/build-and-inspect-python-package@v2.5.0
+      with:
+        attest-build-provenance-github: 'true'
 
   build:
     needs: [package]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
     - name: Build and Check Package
-      uses: hynek/build-and-inspect-python-package@v2.4.0
+      uses: hynek/build-and-inspect-python-package@v2.5.0
 
   build:
     needs: [package]

--- a/changelog/12333.trivial.rst
+++ b/changelog/12333.trivial.rst
@@ -1,0 +1,1 @@
+pytest releases are now attested using the recent `Artifact Attestation <https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/>` support from GitHub, allowing users to attest the package provenance.

--- a/changelog/12333.trivial.rst
+++ b/changelog/12333.trivial.rst
@@ -1,1 +1,1 @@
-pytest releases are now attested using the recent `Artifact Attestation <https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/>` support from GitHub, allowing users to attest the package provenance.
+pytest releases are now attested using the recent `Artifact Attestation <https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/>` support from GitHub, allowing users to verify the provenance of pytest's sdist and wheel artifacts.


### PR DESCRIPTION
This uses the new build provenance support added in [build-and-inspect-python-package 2.5.0](https://github.com/hynek/build-and-inspect-python-package/blob/main/CHANGELOG.md#250---2024-05-13).

More information: https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/

Tested also in https://github.com/pytest-dev/pytest-mock/pull/431.

Note: even though it is technically necessary only for the `deploy` workflow, as the `test` workflow does not publish its packages, decided to always attest the provenance in both cases to avoid any surprises related to this (say a misconfiguration) when deploying.
