### PR TITLE
Fix new typing issues in AST code

### DIFF
--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -959,7 +959,9 @@ class AssertionRewriter(ast.NodeVisitor):
 
         # Clear temporary variables by setting them to None.
         if self.variables:
-            variables: List[ast.expr] = [ast.Name(name, ast.Store()) for name in self.variables]
+            variables: List[ast.expr] = [
+                ast.Name(name, ast.Store()) for name in self.variables
+            ]
             clear = ast.Assign(variables, ast.Constant(None))
             self.statements.append(clear)
         # Fix locations (line numbers/column offsets).

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -835,7 +835,7 @@ class AssertionRewriter(ast.NodeVisitor):
         current = self.stack.pop()
         if self.stack:
             self.explanation_specifiers = self.stack[-1]
-        keys = [ast.Constant(key) for key in current.keys()]
+        keys: List[ast.expr] = [ast.Constant(key) for key in current.keys()]
         format_dict = ast.Dict(keys, list(current.values()))
         form = ast.BinOp(expl_expr, ast.Mod(), format_dict)
         name = "@py_format" + str(next(self.variable_counter))
@@ -926,13 +926,13 @@ class AssertionRewriter(ast.NodeVisitor):
                 [*self.expl_stmts, hook_call_pass],
                 [],
             )
-            statements_pass = [hook_impl_test]
+            statements_pass: List[ast.stmt] = [hook_impl_test]
 
             # Test for assertion condition
             main_test = ast.If(negation, statements_fail, statements_pass)
             self.statements.append(main_test)
             if self.format_variables:
-                variables = [
+                variables: List[ast.expr] = [
                     ast.Name(name, ast.Store()) for name in self.format_variables
                 ]
                 clear_format = ast.Assign(variables, ast.Constant(None))
@@ -959,7 +959,7 @@ class AssertionRewriter(ast.NodeVisitor):
 
         # Clear temporary variables by setting them to None.
         if self.variables:
-            variables = [ast.Name(name, ast.Store()) for name in self.variables]
+            variables: List[ast.expr] = [ast.Name(name, ast.Store()) for name in self.variables]
             clear = ast.Assign(variables, ast.Constant(None))
             self.statements.append(clear)
         # Fix locations (line numbers/column offsets).
@@ -1114,11 +1114,11 @@ class AssertionRewriter(ast.NodeVisitor):
         if isinstance(comp.left, (ast.Compare, ast.BoolOp)):
             left_expl = f"({left_expl})"
         res_variables = [self.variable() for i in range(len(comp.ops))]
-        load_names = [ast.Name(v, ast.Load()) for v in res_variables]
+        load_names: List[ast.expr] = [ast.Name(v, ast.Load()) for v in res_variables]
         store_names = [ast.Name(v, ast.Store()) for v in res_variables]
         it = zip(range(len(comp.ops)), comp.ops, comp.comparators)
-        expls = []
-        syms = []
+        expls: List[ast.expr] = []
+        syms: List[ast.expr] = []
         results = [left_res]
         for i, op, next_operand in it:
             if (

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -835,7 +835,7 @@ class AssertionRewriter(ast.NodeVisitor):
         current = self.stack.pop()
         if self.stack:
             self.explanation_specifiers = self.stack[-1]
-        keys: List[ast.expr] = [ast.Constant(key) for key in current.keys()]
+        keys: List[Optional[ast.expr]] = [ast.Constant(key) for key in current.keys()]
         format_dict = ast.Dict(keys, list(current.values()))
         form = ast.BinOp(expl_expr, ast.Mod(), format_dict)
         name = "@py_format" + str(next(self.variable_counter))
@@ -959,9 +959,7 @@ class AssertionRewriter(ast.NodeVisitor):
 
         # Clear temporary variables by setting them to None.
         if self.variables:
-            variables: List[ast.expr] = [
-                ast.Name(name, ast.Store()) for name in self.variables
-            ]
+            variables = [ast.Name(name, ast.Store()) for name in self.variables]
             clear = ast.Assign(variables, ast.Constant(None))
             self.statements.append(clear)
         # Fix locations (line numbers/column offsets).

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -130,6 +130,7 @@ class TestAssertionRewrite:
             if isinstance(node, ast.Import):
                 continue
             for n in [node, *ast.iter_child_nodes(node)]:
+                assert isinstance(n, (ast.stmt, ast.expr))
                 assert n.lineno == 3
                 assert n.col_offset == 0
                 assert n.end_lineno == 6


### PR DESCRIPTION
python/typeshed#11880 adds more precise types for AST nodes. I'm submitting some changes to adapt pytest to these changes.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
