### PR TITLE
Add html_baseurl to sphinx conf.py

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -192,6 +192,7 @@ Jake VanderPlas
 Jakob van Santen
 Jakub Mitoraj
 James Bourbeau
+James Frost
 Jan Balster
 Janne Vanhala
 Jason R. Coombs

--- a/changelog/12363.doc.rst
+++ b/changelog/12363.doc.rst
@@ -1,0 +1,1 @@
+The documentation webpages now links to a canonical version to reduce outdated documentation in search engine results.

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -313,7 +313,7 @@ html_show_sourcelink = False
 htmlhelp_basename = "pytestdoc"
 
 # The base URL which points to the root of the HTML documentation. It is used
-# to indicate the location of document using the canonical link relation.
+# to indicate the location of document using the canonical link relation (#12363).
 html_baseurl = "https://docs.pytest.org/en/stable/"
 
 # -- Options for LaTeX output --------------------------------------------------

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -312,6 +312,9 @@ html_show_sourcelink = False
 # Output file base name for HTML help builder.
 htmlhelp_basename = "pytestdoc"
 
+# The base URL which points to the root of the HTML documentation. It is used
+# to indicate the location of document using the canonical link relation.
+html_baseurl = "https://docs.pytest.org/en/stable/"
 
 # -- Options for LaTeX output --------------------------------------------------
 


### PR DESCRIPTION
This is used to set the <link rel="canonical" href="X"> tag that points to the canonical version of the webpage. Including this indicates to search engines which version to include in their indexes, and should prevent older versions showing up.

Fixes https://github.com/pytest-dev/pytest/issues/12363

It would be worth checking the ReadTheDocs admin settings first, which I don't have access to. But if the domain is already set correctly as the canonical one, then this PR should manually add in the required HTML tag.

This change will also have to be backported to old versions of the documentation to have the desired effect on search engine indexes.