### PR TITLE
unittest: fix class instances no longer released on test teardown since pytest 8.2.0

### DIFF
--- a/changelog/12367.bugfix.rst
+++ b/changelog/12367.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a regression in pytest 8.2.0 where unittest class instances (a fresh one is created for each test) were not released promptly on test teardown but only on session teardown.

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -218,11 +218,12 @@ class TestCaseFunction(Function):
         super().setup()
 
     def teardown(self) -> None:
-        super().teardown()
         if self._explicit_tearDown is not None:
             self._explicit_tearDown()
             self._explicit_tearDown = None
         self._obj = None
+        self._instance = None
+        super().teardown()
 
     def startTest(self, testcase: "unittest.TestCase") -> None:
         pass


### PR DESCRIPTION
Fix #12367.