### PR TITLE
[4.6.x] Add html_baseurl to sphinx conf.py (#12364)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -114,6 +114,7 @@ Ilya Konstantinov
 Ionuț Turturică
 Iwan Briquemont
 Jaap Broekhuizen
+James Frost
 Jan Balster
 Janne Vanhala
 Jason R. Coombs

--- a/changelog/12363.doc.rst
+++ b/changelog/12363.doc.rst
@@ -1,0 +1,1 @@
+The documentation webpages now links to a canonical version to reduce outdated documentation in search engine results.

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -218,6 +218,9 @@ html_show_sourcelink = False
 # Output file base name for HTML help builder.
 htmlhelp_basename = "pytestdoc"
 
+# The base URL which points to the root of the HTML documentation. It is used
+# to indicate the location of document using the canonical link relation (#12363).
+html_baseurl = "https://docs.pytest.org/en/stable/"
 
 # -- Options for LaTeX output --------------------------------------------------
 


### PR DESCRIPTION
Backport of PR https://github.com/pytest-dev/pytest/pull/12364 to 4.6.x branch. Needed on all currently published documentation branches to resolve the issue.