### PR TITLE
doc: Update trainings/events

### DIFF
--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -4,11 +4,10 @@
 
 .. sidebar:: **Next Open Trainings and Events**
 
-    - `Professional Testing with Python <https://python-academy.com/courses/python_course_testing.html>`_, via `Python Academy <https://www.python-academy.com/>`_ (3 day in-depth training):
-        * **June 11th to 13th 2024**, Remote
-        * **March 4th to 6th 2025**, Leipzig, Germany / Remote
-    - `pytest development sprint <https://github.com/pytest-dev/sprint>`_, **June 17th -- 22nd 2024**
-    - pytest tips and tricks for a better testsuite, `Europython 2024 <https://ep2024.europython.eu/>`_, **July 8th -- 14th 2024** (3h), Prague
+    - `pytest development sprint <https://github.com/pytest-dev/sprint>`_, **June 17th -- 22nd 2024**, Klaus (AT) / Remote
+    - `pytest tips and tricks for a better testsuite <https://ep2024.europython.eu/session/pytest-tips-and-tricks-for-a-better-testsuite>`_, at `Europython 2024 <https://ep2024.europython.eu/>`_, **July 8th -- 14th 2024** (3h), Prague (CZ)
+    - `pytest: Professionelles Testen (nicht nur) für Python <https://pretalx.com/workshoptage-2024/talk/9VUHYB/>`_, at `CH Open Workshoptage <https://workshoptage.ch/>`_, **September 2nd 2024**, HSLU Rotkreuz (CH)
+    - `Professional Testing with Python <https://python-academy.com/courses/python_course_testing.html>`_, via `Python Academy <https://www.python-academy.com/>`_ (3 day in-depth training), **March 4th -- 6th 2025**, Leipzig (DE) / Remote
 
     Also see :doc:`previous talks and blogposts <talks>`
 


### PR DESCRIPTION
- Remove upcoming Python Academy training (cancelled due to only 2 sign-ups)
- Add link for Europython training
- Add training [at Workshoptage](https://pretalx.com/workshoptage-2024/talk/9VUHYB/)
- More infos and consistent formatting