### PR TITLE
[8.2.x] fixtures: fix catastrophic performance problem in `reorder_items`

### DIFF
--- a/changelog/12355.bugfix.rst
+++ b/changelog/12355.bugfix.rst
@@ -1,0 +1,1 @@
+Fix possible catastrophic performance slowdown on a certain parametrization pattern involving many higher-scoped parameters.

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -2219,6 +2219,25 @@ class TestAutouseManagement:
         reprec = pytester.inline_run("-s")
         reprec.assertoutcome(passed=2)
 
+    def test_reordering_catastrophic_performance(self, pytester: Pytester) -> None:
+        """Check that a certain high-scope parametrization pattern doesn't cause
+        a catasrophic slowdown.
+
+        Regression test for #12355.
+        """
+        pytester.makepyfile("""
+            import pytest
+
+            params = tuple("abcdefghijklmnopqrstuvwxyz")
+            @pytest.mark.parametrize(params, [range(len(params))] * 3, scope="module")
+            def test_parametrize(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z):
+                pass
+        """)
+
+        result = pytester.runpytest()
+
+        result.assert_outcomes(passed=3)
+
 
 class TestFixtureMarker:
     def test_parametrize(self, pytester: Pytester) -> None:


### PR DESCRIPTION
Manual minimal backport from commit e89d23b24741c001e8651a77303992cfa41c1664.