### PR TITLE
unittest: fix assertion errors on unittest reruns

### DIFF
--- a/changelog/12424.bugfix.rst
+++ b/changelog/12424.bugfix.rst
@@ -1,0 +1,1 @@
+Fix crash with `assert testcase is not None` assertion failure when re-running unittest tests using plugins like pytest-rerunfailures. Regressed in 8.2.2.

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -222,7 +222,7 @@ class TestCaseFunction(Function):
             self._explicit_tearDown()
             self._explicit_tearDown = None
         self._obj = None
-        self._instance = None
+        del self._instance
         super().teardown()
 
     def startTest(self, testcase: "unittest.TestCase") -> None:

--- a/testing/plugins_integration/pytest_rerunfailures_integration.py
+++ b/testing/plugins_integration/pytest_rerunfailures_integration.py
@@ -1,0 +1,11 @@
+import unittest
+
+
+class MyTestCase(unittest.TestCase):
+    first_time = True
+
+    def test_fail_the_first_time(self) -> None:
+        """Regression test for issue #12424."""
+        if self.first_time:
+            type(self).first_time = False
+            self.fail()

--- a/tox.ini
+++ b/tox.ini
@@ -141,7 +141,7 @@ commands =
     pytest --cov=. simple_integration.py
     pytest --ds=django_settings simple_integration.py
     pytest --html=simple.html simple_integration.py
-    pytest --reruns 5 simple_integration.py
+    pytest --reruns 5 simple_integration.py pytest_rerunfailures_integration.py
     pytest pytest_anyio_integration.py
     pytest pytest_asyncio_integration.py
     pytest pytest_mock_integration.py


### PR DESCRIPTION
This fixes unittest test reruns when using plugins like pytest-rerunfailures.

The `instance` property uses AttributeError to check if the instance needs to be initialized, so `del` is the correct way to clear it, not setting to `None`.

Regressed in 8.2.2.

Fix #12424