### PR TITLE
doc: fix broken code blocks

### DIFF
--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -983,6 +983,7 @@ def capsys(request: SubRequest) -> Generator[CaptureFixture[str], None, None]:
     Returns an instance of :class:`CaptureFixture[str] <pytest.CaptureFixture>`.
 
     Example:
+
     .. code-block:: python
 
         def test_output(capsys):
@@ -1010,6 +1011,7 @@ def capsysbinary(request: SubRequest) -> Generator[CaptureFixture[bytes], None, 
     Returns an instance of :class:`CaptureFixture[bytes] <pytest.CaptureFixture>`.
 
     Example:
+
     .. code-block:: python
 
         def test_output(capsysbinary):
@@ -1037,6 +1039,7 @@ def capfd(request: SubRequest) -> Generator[CaptureFixture[str], None, None]:
     Returns an instance of :class:`CaptureFixture[str] <pytest.CaptureFixture>`.
 
     Example:
+
     .. code-block:: python
 
         def test_system_echo(capfd):
@@ -1064,6 +1067,7 @@ def capfdbinary(request: SubRequest) -> Generator[CaptureFixture[bytes], None, N
     Returns an instance of :class:`CaptureFixture[bytes] <pytest.CaptureFixture>`.
 
     Example:
+
     .. code-block:: python
 
         def test_system_echo(capfdbinary):

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1735,6 +1735,7 @@ class Config:
         can be used to explicitly use the global verbosity level.
 
         Example:
+
         .. code-block:: ini
 
             # content of pytest.ini

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -142,6 +142,7 @@ class MonkeyPatch:
         which undoes any patching done inside the ``with`` block upon exit.
 
         Example:
+
         .. code-block:: python
 
             import functools

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -805,6 +805,7 @@ class Pytester:
             The first created file.
 
         Examples:
+
         .. code-block:: python
 
             pytester.makefile(".txt", "line1", "line2")
@@ -858,6 +859,7 @@ class Pytester:
         existing files.
 
         Examples:
+
         .. code-block:: python
 
             def test_something(pytester):
@@ -877,6 +879,7 @@ class Pytester:
         existing files.
 
         Examples:
+
         .. code-block:: python
 
             def test_something(pytester):


### PR DESCRIPTION
Caused by 4588653b2497ed25976b7aaff225b889fb476756. ~~I disabled the offending Ruff rule.~~

Fix #12437.