### PR TITLE
🔥 Get rid of `setuptools` dev runtime dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ optional-dependencies.dev = [
     "mock",
     "pygments>=2.7.2",
     "requests",
-    "setuptools",
     "xmlschema",
 ]
 urls.Changelog = "https://docs.pytest.org/en/stable/changelog.html"

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1464,7 +1464,7 @@ def test_issue_9765(pytester: Pytester) -> None:
         }
     )
 
-    subprocess.run([sys.executable, "setup.py", "develop"], check=True)
+    subprocess.run([sys.executable, "-Im", "pip", "install", "-e", "."], check=True)
     try:
         # We are using subprocess.run rather than pytester.run on purpose.
         # pytester.run is adding the current directory to PYTHONPATH which avoids

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1471,7 +1471,11 @@ def test_issue_9765(pytester: Pytester) -> None:
         # the bug. We also use pytest rather than python -m pytest for the same
         # PYTHONPATH reason.
         subprocess.run(
-            ["pytest", "my_package"], capture_output=True, check=True, text=True
+            ["pytest", "my_package"],
+            capture_output=True,
+            check=True,
+            encoding="utf-8",
+            text=True,
         )
     except subprocess.CalledProcessError as exc:
         raise AssertionError(


### PR DESCRIPTION
Said dependency was being listed as needed for development. However,
it was only called via the deprecated `setup.py` CLI interface in the
tests once. This patch replaces the invocation with `pip install` and
pulls it from the list of the development runtime dependencies.