### PR TITLE
Modernize the skipped `test_issue_9765` regression test

### DIFF
--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1471,7 +1471,11 @@ def test_issue_9765(pytester: Pytester) -> None:
         # the bug. We also use pytest rather than python -m pytest for the same
         # PYTHONPATH reason.
         subprocess.run(
-            ["pytest", "my_package"], capture_output=True, check=True, text=True
+            ["pytest", "my_package"],
+            capture_output=True,
+            check=True,
+            encoding="utf-8",
+            text=True,
         )
     except subprocess.CalledProcessError as exc:
         raise AssertionError(

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1464,7 +1464,10 @@ def test_issue_9765(pytester: Pytester) -> None:
         }
     )
 
-    subprocess.run([sys.executable, "setup.py", "develop"], check=True)
+    subprocess.run(
+        [sys.executable, "-Im", "pip", "install", "-e", "."],
+        check=True,
+    )
     try:
         # We are using subprocess.run rather than pytester.run on purpose.
         # pytester.run is adding the current directory to PYTHONPATH which avoids


### PR DESCRIPTION
The `subprocess.run()` invocation is present in the `test_issue_9765` regression test
that is always skipped unconditionally, resulting in the
`EncodingWarning` never manifesting itself in CI or development
environments of the contributors. This patch corrects the problem by passing the encoding value.

This patch also replaces the `setup.py` call w/ `pip install` in the same test.
Using this CLI interface has been deprecated in `setuptools` [[1]].

[1]: https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html