### PR TITLE
📝 Make "setuptools entrypoint" term generic

### DIFF
--- a/changelog/12469.doc.rst
+++ b/changelog/12469.doc.rst
@@ -1,0 +1,6 @@
+The external plugin mentions in the documentation now avoid mentioning
+:std:doc:`setuptools entry-points <setuptools:index>` as the concept is
+much more generic nowadays. Instead, the terminology of "external",
+"installed", or "third-party" plugins (or packages) replaces that.
+
+-- by :user:`webknjaz`

--- a/changelog/12469.improvement.rst
+++ b/changelog/12469.improvement.rst
@@ -1,0 +1,4 @@
+The console output now uses the "third-party plugins" terminology,
+replacing the previously established but confusing and outdated
+reference to :std:doc:`setuptools <setuptools:index>`
+-- by :user:`webknjaz`.

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -212,7 +212,7 @@ the command line arguments before they get processed:
 
 .. code-block:: python
 
-    # setuptools plugin
+    # installable external plugin
     import sys
 
 
@@ -1073,8 +1073,8 @@ Instead of freezing the pytest runner as a separate executable, you can make
 your frozen program work as the pytest runner by some clever
 argument handling during program startup. This allows you to
 have a single executable, which is usually more convenient.
-Please note that the mechanism for plugin discovery used by pytest
-(setuptools entry points) doesn't work with frozen executables so pytest
+Please note that the mechanism for plugin discovery used by pytest (:ref:`entry
+points <pip-installable plugins>`) doesn't work with frozen executables so pytest
 can't find any third party plugins automatically. To include third party plugins
 like ``pytest-timeout`` they must be imported explicitly and passed on to pytest.main.
 

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -1931,7 +1931,7 @@ The same applies for the test folder level obviously.
 Using fixtures from other projects
 ----------------------------------
 
-Usually projects that provide pytest support will use :ref:`entry points <setuptools entry points>`,
+Usually projects that provide pytest support will use :ref:`entry points <pip-installable plugins>`,
 so just installing those projects into an environment will make those fixtures available for use.
 
 In case you want to use fixtures from a project that does not use entry points, you can

--- a/doc/en/how-to/usage.rst
+++ b/doc/en/how-to/usage.rst
@@ -154,7 +154,7 @@ You can early-load plugins (internal and external) explicitly in the command-lin
 The option receives a ``name`` parameter, which can be:
 
 * A full module dotted name, for example ``myproject.plugins``. This dotted name must be importable.
-* The entry-point name of a plugin. This is the name passed to ``setuptools`` when the plugin is
+* The entry-point name of a plugin. This is the name passed to ``importlib`` when the plugin is
   registered. For example to early-load the :pypi:`pytest-cov` plugin you can use::
 
     pytest -p pytest_cov

--- a/doc/en/how-to/writing_plugins.rst
+++ b/doc/en/how-to/writing_plugins.rst
@@ -16,8 +16,8 @@ reporting by calling :ref:`well specified hooks <hook-reference>` of the followi
 
 * builtin plugins: loaded from pytest's internal ``_pytest`` directory.
 
-* :ref:`external plugins <extplugins>`: modules discovered through
-  `setuptools entry points`_
+* :ref:`external plugins <extplugins>`: installed third-party modules discovered
+  through :ref:`entry points <pip-installable plugins>` in their packaging metadata
 
 * `conftest.py plugins`_: modules auto-discovered in test directories
 
@@ -42,7 +42,8 @@ Plugin discovery order at tool startup
 3. by scanning the command line for the ``-p name`` option
    and loading the specified plugin. This happens before normal command-line parsing.
 
-4. by loading all plugins registered through `setuptools entry points`_.
+4. by loading all plugins registered through installed third-party package
+   :ref:`entry points <pip-installable plugins>`.
 
 5. by loading all plugins specified through the :envvar:`PYTEST_PLUGINS` environment variable.
 
@@ -142,7 +143,8 @@ Making your plugin installable by others
 If you want to make your plugin externally available, you
 may define a so-called entry point for your distribution so
 that ``pytest`` finds your plugin module. Entry points are
-a feature that is provided by :std:doc:`setuptools <setuptools:index>`.
+a feature that is provided by :std:doc:`packaging tools
+<packaging:specifications/entry-points>`.
 
 pytest looks up the ``pytest11`` entrypoint to discover its
 plugins, thus you can make your plugin available by defining
@@ -265,8 +267,9 @@ of the variable will also be loaded as plugins, and so on.
     tests root directory is deprecated, and will raise a warning.
 
 This mechanism makes it easy to share fixtures within applications or even
-external applications without the need to create external plugins using
-the ``setuptools``'s entry point technique.
+external applications without the need to create external plugins using the
+:std:doc:`entry point packaging metadata
+<packaging:guides/creating-and-discovering-plugins>` technique.
 
 Plugins imported by :globalvar:`pytest_plugins` will also automatically be marked
 for assertion rewriting (see :func:`pytest.register_assert_rewrite`).

--- a/doc/en/reference/customize.rst
+++ b/doc/en/reference/customize.rst
@@ -90,7 +90,7 @@ and can also be used to hold pytest configuration if they have a ``[pytest]`` se
 setup.cfg
 ~~~~~~~~~
 
-``setup.cfg`` files are general purpose configuration files, used originally by ``distutils`` (now deprecated) and `setuptools <https://setuptools.pypa.io/en/latest/userguide/declarative_config.html>`__, and can also be used to hold pytest configuration
+``setup.cfg`` files are general purpose configuration files, used originally by ``distutils`` (now deprecated) and :std:doc:`setuptools <setuptools:userguide/declarative_config>`, and can also be used to hold pytest configuration
 if they have a ``[tool:pytest]`` section.
 
 .. code-block:: ini

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -650,7 +650,7 @@ Reference to all hooks which can be implemented by :ref:`conftest.py files <loca
 Bootstrapping hooks
 ~~~~~~~~~~~~~~~~~~~
 
-Bootstrapping hooks called for plugins registered early enough (internal and setuptools plugins).
+Bootstrapping hooks called for plugins registered early enough (internal and third-party plugins).
 
 .. hook:: pytest_load_initial_conftests
 .. autofunction:: pytest_load_initial_conftests
@@ -1147,8 +1147,9 @@ When set, pytest will print tracing and debug information.
 
 .. envvar:: PYTEST_DISABLE_PLUGIN_AUTOLOAD
 
-When set, disables plugin auto-loading through setuptools entrypoints. Only explicitly specified plugins will be
-loaded.
+When set, disables plugin auto-loading through :std:doc:`entry point packaging
+metadata <packaging:guides/creating-and-discovering-plugins>`. Only explicitly
+specified plugins will be loaded.
 
 .. envvar:: PYTEST_PLUGINS
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1290,7 +1290,8 @@ class Config:
         self.pluginmanager.rewrite_hook = hook
 
         if os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
-            # We don't autoload from setuptools entry points, no need to continue.
+            # We don't autoload from distribution package entry points,
+            # no need to continue.
             return
 
         package_files = (
@@ -1381,8 +1382,8 @@ class Config:
         self._consider_importhook(args)
         self.pluginmanager.consider_preparse(args, exclude_only=False)
         if not os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
-            # Don't autoload from setuptools entry point. Only explicitly specified
-            # plugins are going to be loaded.
+            # Don't autoload from distribution package entry point. Only
+            # explicitly specified plugins are going to be loaded.
             self.pluginmanager.load_setuptools_entrypoints("pytest11")
         self.pluginmanager.consider_env()
 

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -243,7 +243,7 @@ def getpluginversioninfo(config: Config) -> List[str]:
     lines = []
     plugininfo = config.pluginmanager.list_plugin_distinfo()
     if plugininfo:
-        lines.append("setuptools registered plugins:")
+        lines.append("registered third-party plugins:")
         for plugin, dist in plugininfo:
             loc = getattr(plugin, "__file__", repr(plugin))
             content = f"{dist.project_name}-{dist.version} at {loc}"

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -223,7 +223,7 @@ class TestImportHookInstallation:
     ) -> None:
         monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
         # Make sure the hook is installed early enough so that plugins
-        # installed via setuptools are rewritten.
+        # installed via distribution package are rewritten.
         pytester.mkdir("hampkg")
         contents = {
             "hampkg/__init__.py": """\

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -10,7 +10,7 @@ def test_version_verbose(pytester: Pytester, pytestconfig, monkeypatch) -> None:
     assert result.ret == 0
     result.stdout.fnmatch_lines([f"*pytest*{pytest.__version__}*imported from*"])
     if pytestconfig.pluginmanager.list_plugin_distinfo():
-        result.stdout.fnmatch_lines(["*setuptools registered plugins:", "*at*"])
+        result.stdout.fnmatch_lines(["*registered third-party plugins:", "*at*"])
 
 
 def test_version_less_verbose(pytester: Pytester, pytestconfig, monkeypatch) -> None:


### PR DESCRIPTION
This feature grew out of `setuptools` but the modern interface for extracting this information from the distribution package metadata is `importlib.metadata`. So the patch attempts to reflect this in the documentation messaging.

Refs:
* https://docs.python.org/3/library/importlib.metadata.html#entry-points
* https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata
* https://packaging.python.org/en/latest/specifications/entry-points/#entry-points

Docs previews:
* https://pytest--12469.org.readthedocs.build/en/12469/example/simple.html#dynamically-adding-command-line-options
* https://pytest--12469.org.readthedocs.build/en/12469/example/simple.html#freezing-pytest
* https://pytest--12469.org.readthedocs.build/en/12469/how-to/fixtures.html#using-fixtures-from-other-projects
* https://pytest--12469.org.readthedocs.build/en/12469/how-to/usage.html#early-loading-plugins
* https://pytest--12469.org.readthedocs.build/en/12469/how-to/writing_plugins.html#writing-plugins
* https://pytest--12469.org.readthedocs.build/en/12469/how-to/writing_plugins.html#plugin-discovery-order-at-tool-startup
* https://pytest--12469.org.readthedocs.build/en/12469/how-to/writing_plugins.html#making-your-plugin-installable-by-others
* https://pytest--12469.org.readthedocs.build/en/12469/how-to/writing_plugins.html#requiring-loading-plugins-in-a-test-module-or-conftest-file
* https://pytest--12469.org.readthedocs.build/en/12469/reference/customize.html#setup-cfg
* https://pytest--12469.org.readthedocs.build/en/12469/reference/reference.html#bootstrapping-hooks
* https://pytest--12469.org.readthedocs.build/en/12469/reference/reference.html#envvar-PYTEST_DISABLE_PLUGIN_AUTOLOAD