### PR TITLE
testresult: correctly apply verbose word markup and avoid crash

### DIFF
--- a/changelog/12472.bugfix.rst
+++ b/changelog/12472.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a crash when returning category ``"error"`` or ``"failed"`` with a custom test status from :hook:`pytest_report_teststatus` hook -- :user:`pbrezina`.

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -208,7 +208,7 @@ class BaseReport:
                 return word, markup
 
         fail(
-            "pytest_report_teststatus() hook (from a plugin) returned "
+            f"pytest_report_teststatus() hook (from a plugin) returned "
             "an invalid verbose value: {verbose!r}.\nExpected either a string "
             "or a tuple of (word, markup)."
         )

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -207,7 +207,7 @@ class BaseReport:
             if isinstance(word, str) and isinstance(markup, Mapping):
                 return word, markup
 
-        fail(
+        fail(  # pragma: no cover
             "pytest_report_teststatus() hook (from a plugin) returned "
             f"an invalid verbose value: {verbose!r}.\nExpected either a string "
             "or a tuple of (word, markup)."

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -209,7 +209,7 @@ class BaseReport:
 
         fail(
             "pytest_report_teststatus() hook (from a plugin) returned "
-            "an invalid verbose value: {verbose!r}.\nExpected either a string "
+            f"an invalid verbose value: {verbose!r}.\nExpected either a string "
             "or a tuple of (word, markup)."
         )
 

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -208,7 +208,7 @@ class BaseReport:
                 return word, markup
 
         fail(
-            f"pytest_report_teststatus() hook (from a plugin) returned "
+            "pytest_report_teststatus() hook (from a plugin) returned "
             "an invalid verbose value: {verbose!r}.\nExpected either a string "
             "or a tuple of (word, markup)."
         )

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1206,10 +1206,10 @@ class TerminalReporter:
         def show_xfailed(lines: list[str]) -> None:
             xfailed = self.stats.get("xfailed", [])
             for rep in xfailed:
-                verbose_word = rep._get_verbose_word(self.config)
-                markup_word = self._tw.markup(
-                    verbose_word, **{_color_for_type["warnings"]: True}
+                verbose_word, verbose_markup = rep._get_verbose_word_with_markup(
+                    self.config, {_color_for_type["warnings"]: True}
                 )
+                markup_word = self._tw.markup(verbose_word, **verbose_markup)
                 nodeid = _get_node_id_with_markup(self._tw, self.config, rep)
                 line = f"{markup_word} {nodeid}"
                 reason = rep.wasxfail
@@ -1221,10 +1221,10 @@ class TerminalReporter:
         def show_xpassed(lines: list[str]) -> None:
             xpassed = self.stats.get("xpassed", [])
             for rep in xpassed:
-                verbose_word = rep._get_verbose_word(self.config)
-                markup_word = self._tw.markup(
-                    verbose_word, **{_color_for_type["warnings"]: True}
+                verbose_word, verbose_markup = rep._get_verbose_word_with_markup(
+                    self.config, {_color_for_type["warnings"]: True}
                 )
+                markup_word = self._tw.markup(verbose_word, **verbose_markup)
                 nodeid = _get_node_id_with_markup(self._tw, self.config, rep)
                 line = f"{markup_word} {nodeid}"
                 reason = rep.wasxfail
@@ -1237,10 +1237,10 @@ class TerminalReporter:
             fskips = _folded_skips(self.startpath, skipped) if skipped else []
             if not fskips:
                 return
-            verbose_word = skipped[0]._get_verbose_word(self.config)
-            markup_word = self._tw.markup(
-                verbose_word, **{_color_for_type["warnings"]: True}
+            verbose_word, verbose_markup = skipped[0]._get_verbose_word_with_markup(
+                self.config, {_color_for_type["warnings"]: True}
             )
+            markup_word = self._tw.markup(verbose_word, **verbose_markup)
             prefix = "Skipped: "
             for num, fspath, lineno, reason in fskips:
                 if reason.startswith(prefix):
@@ -1421,8 +1421,10 @@ def _get_line_with_reprcrash_message(
     config: Config, rep: BaseReport, tw: TerminalWriter, word_markup: dict[str, bool]
 ) -> str:
     """Get summary line for a report, trying to add reprcrash message."""
-    verbose_word = rep._get_verbose_word(config)
-    word = tw.markup(verbose_word, **word_markup)
+    verbose_word, verbose_markup = rep._get_verbose_word_with_markup(
+        config, word_markup
+    )
+    word = tw.markup(verbose_word, **verbose_markup)
     node = _get_node_id_with_markup(tw, config, rep)
 
     line = f"{word} {node}"


### PR DESCRIPTION
The following snippet would have resulted in crash on multiple places since
`_get_verbose_word` expects only string, not a tuple.

```python
    @pytest.hookimpl(tryfirst=True)
    def pytest_report_teststatus(report: pytest.CollectReport | pytest.TestReport, config: pytest.Config):
        if report.when == "call":
            return ("error", "A",  ("AVC", {"bold": True, "red": True}))

        return None
```

```python-traceback
Traceback (most recent call last):
  File "/home/pbrezina/workspace/sssd/.venv/bin/pytest", line 8, in <module>
    sys.exit(console_main())
             ^^^^^^^^^^^^^^
  File "/home/pbrezina/workspace/pytest/src/_pytest/config/__init__.py", line 207, in console_main
    code = main()
           ^^^^^^
  File "/home/pbrezina/workspace/pytest/src/_pytest/config/__init__.py", line 179, in main
    ret: Union[ExitCode, int] = config.hook.pytest_cmdline_main(
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pbrezina/workspace/sssd/.venv/lib64/python3.11/site-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pbrezina/workspace/sssd/.venv/lib64/python3.11/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pbrezina/workspace/sssd/.venv/lib64/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/home/pbrezina/workspace/sssd/.venv/lib64/python3.11/site-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pbrezina/workspace/pytest/src/_pytest/main.py", line 333, in pytest_cmdline_main
    return wrap_session(config, _main)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pbrezina/workspace/pytest/src/_pytest/main.py", line 321, in wrap_session
    config.hook.pytest_sessionfinish(
  File "/home/pbrezina/workspace/sssd/.venv/lib64/python3.11/site-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pbrezina/workspace/sssd/.venv/lib64/python3.11/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pbrezina/workspace/sssd/.venv/lib64/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/home/pbrezina/workspace/sssd/.venv/lib64/python3.11/site-packages/pluggy/_callers.py", line 122, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pbrezina/workspace/pytest/src/_pytest/logging.py", line 872, in pytest_sessionfinish
    return (yield)
            ^^^^^
  File "/home/pbrezina/workspace/sssd/.venv/lib64/python3.11/site-packages/pluggy/_callers.py", line 124, in _multicall
    teardown.send(result)  # type: ignore[union-attr]
    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/pbrezina/workspace/pytest/src/_pytest/terminal.py", line 899, in pytest_sessionfinish
    self.config.hook.pytest_terminal_summary(
  File "/home/pbrezina/workspace/sssd/.venv/lib64/python3.11/site-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pbrezina/workspace/sssd/.venv/lib64/python3.11/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pbrezina/workspace/sssd/.venv/lib64/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/home/pbrezina/workspace/sssd/.venv/lib64/python3.11/site-packages/pluggy/_callers.py", line 124, in _multicall
    teardown.send(result)  # type: ignore[union-attr]
    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/pbrezina/workspace/pytest/src/_pytest/terminal.py", line 923, in pytest_terminal_summary
    self.short_test_summary()
  File "/home/pbrezina/workspace/pytest/src/_pytest/terminal.py", line 1272, in short_test_summary
    action(lines)
  File "/home/pbrezina/workspace/pytest/src/_pytest/terminal.py", line 1205, in show_simple
    line = _get_line_with_reprcrash_message(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pbrezina/workspace/pytest/src/_pytest/terminal.py", line 1429, in _get_line_with_reprcrash_message
    word = tw.markup(verbose_word, **word_markup)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pbrezina/workspace/pytest/src/_pytest/_io/terminalwriter.py", line 114, in markup
    text = "".join(f"\x1b[{cod}m" for cod in esc) + text + "\x1b[0m"
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
TypeError: can only concatenate str (not "tuple") to str
```



<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->