### PR TITLE
🧪 Make required CI jobs match branch protection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,6 +182,26 @@ jobs:
             tox_env: "doctesting"
             use_coverage: true
 
+    continue-on-error: >-
+      ${{
+        contains(
+          fromJSON(
+            '[
+              "windows-py38-pluggy",
+              "windows-py313",
+              "ubuntu-py38-pluggy",
+              "ubuntu-py38-freeze",
+              "ubuntu-py313",
+              "macos-py38",
+              "macos-py313"
+            ]'
+          ),
+          matrix.name
+        )
+        && true
+        || false
+      }}
+
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
The original PR required all the matrix jobs to pass. This patch corrects that, allowing some of them to fail according to how the branch protection is set up now.