### PR TITLE
refactor: simplify bound method representation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -149,6 +149,7 @@ Evgeny Seliverstov
 Fabian Sturm
 Fabien Zarifian
 Fabio Zadrozny
+Farbod Ahmadian
 faph
 Felix Hofstätter
 Felix Nieuwenhuizen

--- a/changelog/389.improvement.rst
+++ b/changelog/389.improvement.rst
@@ -2,7 +2,7 @@ The readability of assertion introspection of bound methods has been enhanced
 -- by :user:`farbodahm`, :user:`webknjaz`, :user:`obestwalter`, :user:`flub`
 and :user:`glyphack`.
 
-Previously it was something like this:
+Earlier, it was like:
 
 .. code-block:: console
 

--- a/changelog/389.improvement.rst
+++ b/changelog/389.improvement.rst
@@ -1,0 +1,38 @@
+The readability of assertion introspection of bound methods has been enhanced
+-- by :user:`farbodahm`, :user:`webknjaz`, :user:`obestwalter`, :user:`flub`
+and :user:`glyphack`.
+
+Previously it was something like this:
+
+.. code-block:: console
+
+    =================================== FAILURES ===================================
+    _____________________________________ test _____________________________________
+
+        def test():
+    >       assert Help().fun() == 2
+    E       assert 1 == 2
+    E        +  where 1 = <bound method Help.fun of <example.Help instance at 0x256a830>>()
+    E        +    where <bound method Help.fun of <example.Help instance at 0x256a830>> = <example.Help instance at 0x256a830>.fun
+    E        +      where <example.Help instance at 0x256a830> = Help()
+
+    example.py:7: AssertionError
+    =========================== 1 failed in 0.03 seconds ===========================
+
+
+And now it's like:
+
+.. code-block:: console
+
+    =================================== FAILURES ===================================
+    _____________________________________ test _____________________________________
+
+        def test():
+    >       assert Help().fun() == 2
+    E       assert 1 == 2
+    E        +  where 1 = fun()
+    E        +    where fun = <test_local.Help object at 0x1074be230>.fun
+    E        +      where <test_local.Help object at 0x1074be230> = Help()
+
+    test_local.py:13: AssertionError
+    =========================== 1 failed in 0.03 seconds ===========================

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -59,7 +59,6 @@ class SafeRepr(reprlib.Repr):
             if self.use_ascii:
                 s = ascii(x)
             else:
-
                 s = super().repr(x)
         except (KeyboardInterrupt, SystemExit):
             raise

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pprint
 import reprlib
-from types import MethodType
 
 
 def _try_repr_or_str(obj: object) -> str:

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -64,13 +64,7 @@ class SafeRepr(reprlib.Repr):
                     # for bound methods, skip redundant <bound method ...> information
                     s = x.__name__
                 else:
-                    # if none of the mro classes have implemented __repr__
-                    # show class name
-                    mro_classes = x.__class__.mro()[:-1]
-                    if not any("__repr__" in cls.__dict__ for cls in mro_classes):
-                        s = x.__class__.__name__
-                    else:
-                        s = super().repr(x)
+                    s = super().repr(x)
 
         except (KeyboardInterrupt, SystemExit):
             raise

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -59,6 +59,7 @@ class SafeRepr(reprlib.Repr):
             if self.use_ascii:
                 s = ascii(x)
             else:
+
                 s = super().repr(x)
         except (KeyboardInterrupt, SystemExit):
             raise

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -60,12 +60,7 @@ class SafeRepr(reprlib.Repr):
             if self.use_ascii:
                 s = ascii(x)
             else:
-                if isinstance(x, MethodType):
-                    # for bound methods, skip redundant <bound method ...> information
-                    s = x.__name__
-                else:
-                    s = super().repr(x)
-
+                s = super().repr(x)
         except (KeyboardInterrupt, SystemExit):
             raise
         except BaseException as exc:

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -1018,7 +1018,9 @@ class AssertionRewriter(ast.NodeVisitor):
                     ]
                 ):
                     pytest_temp = self.variable()
-                    self.variables_overwrite[self.scope][v.left.target.id] = v.left  # type:ignore[assignment]
+                    self.variables_overwrite[self.scope][
+                        v.left.target.id
+                    ] = v.left  # type:ignore[assignment]
                     v.left.target.id = pytest_temp
             self.push_format_context()
             res, expl = self.visit(v)
@@ -1062,7 +1064,9 @@ class AssertionRewriter(ast.NodeVisitor):
             if isinstance(arg, ast.Name) and arg.id in self.variables_overwrite.get(
                 self.scope, {}
             ):
-                arg = self.variables_overwrite[self.scope][arg.id]  # type:ignore[assignment]
+                arg = self.variables_overwrite[self.scope][
+                    arg.id
+                ]  # type:ignore[assignment]
             res, expl = self.visit(arg)
             arg_expls.append(expl)
             new_args.append(res)
@@ -1070,7 +1074,9 @@ class AssertionRewriter(ast.NodeVisitor):
             if isinstance(
                 keyword.value, ast.Name
             ) and keyword.value.id in self.variables_overwrite.get(self.scope, {}):
-                keyword.value = self.variables_overwrite[self.scope][keyword.value.id]  # type:ignore[assignment]
+                keyword.value = self.variables_overwrite[self.scope][
+                    keyword.value.id
+                ]  # type:ignore[assignment]
             res, expl = self.visit(keyword.value)
             new_kwargs.append(ast.keyword(keyword.arg, res))
             if keyword.arg:
@@ -1107,9 +1113,13 @@ class AssertionRewriter(ast.NodeVisitor):
         if isinstance(
             comp.left, ast.Name
         ) and comp.left.id in self.variables_overwrite.get(self.scope, {}):
-            comp.left = self.variables_overwrite[self.scope][comp.left.id]  # type:ignore[assignment]
+            comp.left = self.variables_overwrite[self.scope][
+                comp.left.id
+            ]  # type:ignore[assignment]
         if isinstance(comp.left, ast.NamedExpr):
-            self.variables_overwrite[self.scope][comp.left.target.id] = comp.left  # type:ignore[assignment]
+            self.variables_overwrite[self.scope][
+                comp.left.target.id
+            ] = comp.left  # type:ignore[assignment]
         left_res, left_expl = self.visit(comp.left)
         if isinstance(comp.left, (ast.Compare, ast.BoolOp)):
             left_expl = f"({left_expl})"
@@ -1127,7 +1137,9 @@ class AssertionRewriter(ast.NodeVisitor):
                 and next_operand.target.id == left_res.id
             ):
                 next_operand.target.id = self.variable()
-                self.variables_overwrite[self.scope][left_res.id] = next_operand  # type:ignore[assignment]
+                self.variables_overwrite[self.scope][
+                    left_res.id
+                ] = next_operand  # type:ignore[assignment]
             next_res, next_expl = self.visit(next_operand)
             if isinstance(next_operand, (ast.Compare, ast.BoolOp)):
                 next_expl = f"({next_expl})"

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -420,7 +420,7 @@ def _saferepr(obj: object) -> str:
     if isinstance(obj, types.MethodType):
         # for bound methods, skip redundant <bound method ...> information
         return obj.__name__
-    
+
     maxsize = _get_maxsize_for_saferepr(util._config)
     return saferepr(obj, maxsize=maxsize).replace("\n", "\\n")
 
@@ -1018,9 +1018,7 @@ class AssertionRewriter(ast.NodeVisitor):
                     ]
                 ):
                     pytest_temp = self.variable()
-                    self.variables_overwrite[self.scope][
-                        v.left.target.id
-                    ] = v.left  # type:ignore[assignment]
+                    self.variables_overwrite[self.scope][v.left.target.id] = v.left  # type:ignore[assignment]
                     v.left.target.id = pytest_temp
             self.push_format_context()
             res, expl = self.visit(v)
@@ -1064,9 +1062,7 @@ class AssertionRewriter(ast.NodeVisitor):
             if isinstance(arg, ast.Name) and arg.id in self.variables_overwrite.get(
                 self.scope, {}
             ):
-                arg = self.variables_overwrite[self.scope][
-                    arg.id
-                ]  # type:ignore[assignment]
+                arg = self.variables_overwrite[self.scope][arg.id]  # type:ignore[assignment]
             res, expl = self.visit(arg)
             arg_expls.append(expl)
             new_args.append(res)
@@ -1074,9 +1070,7 @@ class AssertionRewriter(ast.NodeVisitor):
             if isinstance(
                 keyword.value, ast.Name
             ) and keyword.value.id in self.variables_overwrite.get(self.scope, {}):
-                keyword.value = self.variables_overwrite[self.scope][
-                    keyword.value.id
-                ]  # type:ignore[assignment]
+                keyword.value = self.variables_overwrite[self.scope][keyword.value.id]  # type:ignore[assignment]
             res, expl = self.visit(keyword.value)
             new_kwargs.append(ast.keyword(keyword.arg, res))
             if keyword.arg:
@@ -1113,13 +1107,9 @@ class AssertionRewriter(ast.NodeVisitor):
         if isinstance(
             comp.left, ast.Name
         ) and comp.left.id in self.variables_overwrite.get(self.scope, {}):
-            comp.left = self.variables_overwrite[self.scope][
-                comp.left.id
-            ]  # type:ignore[assignment]
+            comp.left = self.variables_overwrite[self.scope][comp.left.id]  # type:ignore[assignment]
         if isinstance(comp.left, ast.NamedExpr):
-            self.variables_overwrite[self.scope][
-                comp.left.target.id
-            ] = comp.left  # type:ignore[assignment]
+            self.variables_overwrite[self.scope][comp.left.target.id] = comp.left  # type:ignore[assignment]
         left_res, left_expl = self.visit(comp.left)
         if isinstance(comp.left, (ast.Compare, ast.BoolOp)):
             left_expl = f"({left_expl})"
@@ -1137,9 +1127,7 @@ class AssertionRewriter(ast.NodeVisitor):
                 and next_operand.target.id == left_res.id
             ):
                 next_operand.target.id = self.variable()
-                self.variables_overwrite[self.scope][
-                    left_res.id
-                ] = next_operand  # type:ignore[assignment]
+                self.variables_overwrite[self.scope][left_res.id] = next_operand  # type:ignore[assignment]
             next_res, next_expl = self.visit(next_operand)
             if isinstance(next_operand, (ast.Compare, ast.BoolOp)):
                 next_expl = f"({next_expl})"

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -1018,9 +1018,7 @@ class AssertionRewriter(ast.NodeVisitor):
                     ]
                 ):
                     pytest_temp = self.variable()
-                    self.variables_overwrite[self.scope][
-                        v.left.target.id
-                    ] = v.left  # type:ignore[assignment]
+                    self.variables_overwrite[self.scope][v.left.target.id] = v.left  # type:ignore[assignment]
                     v.left.target.id = pytest_temp
             self.push_format_context()
             res, expl = self.visit(v)
@@ -1064,9 +1062,7 @@ class AssertionRewriter(ast.NodeVisitor):
             if isinstance(arg, ast.Name) and arg.id in self.variables_overwrite.get(
                 self.scope, {}
             ):
-                arg = self.variables_overwrite[self.scope][
-                    arg.id
-                ]  # type:ignore[assignment]
+                arg = self.variables_overwrite[self.scope][arg.id]  # type:ignore[assignment]
             res, expl = self.visit(arg)
             arg_expls.append(expl)
             new_args.append(res)
@@ -1074,9 +1070,7 @@ class AssertionRewriter(ast.NodeVisitor):
             if isinstance(
                 keyword.value, ast.Name
             ) and keyword.value.id in self.variables_overwrite.get(self.scope, {}):
-                keyword.value = self.variables_overwrite[self.scope][
-                    keyword.value.id
-                ]  # type:ignore[assignment]
+                keyword.value = self.variables_overwrite[self.scope][keyword.value.id]  # type:ignore[assignment]
             res, expl = self.visit(keyword.value)
             new_kwargs.append(ast.keyword(keyword.arg, res))
             if keyword.arg:
@@ -1113,13 +1107,9 @@ class AssertionRewriter(ast.NodeVisitor):
         if isinstance(
             comp.left, ast.Name
         ) and comp.left.id in self.variables_overwrite.get(self.scope, {}):
-            comp.left = self.variables_overwrite[self.scope][
-                comp.left.id
-            ]  # type:ignore[assignment]
+            comp.left = self.variables_overwrite[self.scope][comp.left.id]  # type:ignore[assignment]
         if isinstance(comp.left, ast.NamedExpr):
-            self.variables_overwrite[self.scope][
-                comp.left.target.id
-            ] = comp.left  # type:ignore[assignment]
+            self.variables_overwrite[self.scope][comp.left.target.id] = comp.left  # type:ignore[assignment]
         left_res, left_expl = self.visit(comp.left)
         if isinstance(comp.left, (ast.Compare, ast.BoolOp)):
             left_expl = f"({left_expl})"
@@ -1137,9 +1127,7 @@ class AssertionRewriter(ast.NodeVisitor):
                 and next_operand.target.id == left_res.id
             ):
                 next_operand.target.id = self.variable()
-                self.variables_overwrite[self.scope][
-                    left_res.id
-                ] = next_operand  # type:ignore[assignment]
+                self.variables_overwrite[self.scope][left_res.id] = next_operand  # type:ignore[assignment]
             next_res, next_expl = self.visit(next_operand)
             if isinstance(next_operand, (ast.Compare, ast.BoolOp)):
                 next_expl = f"({next_expl})"

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -417,6 +417,10 @@ def _saferepr(obj: object) -> str:
     sequences, especially '\n{' and '\n}' are likely to be present in
     JSON reprs.
     """
+    if isinstance(obj, types.MethodType):
+        # for bound methods, skip redundant <bound method ...> information
+        return obj.__name__
+    
     maxsize = _get_maxsize_for_saferepr(util._config)
     return saferepr(obj, maxsize=maxsize).replace("\n", "\\n")
 
@@ -1014,7 +1018,9 @@ class AssertionRewriter(ast.NodeVisitor):
                     ]
                 ):
                     pytest_temp = self.variable()
-                    self.variables_overwrite[self.scope][v.left.target.id] = v.left  # type:ignore[assignment]
+                    self.variables_overwrite[self.scope][
+                        v.left.target.id
+                    ] = v.left  # type:ignore[assignment]
                     v.left.target.id = pytest_temp
             self.push_format_context()
             res, expl = self.visit(v)
@@ -1058,7 +1064,9 @@ class AssertionRewriter(ast.NodeVisitor):
             if isinstance(arg, ast.Name) and arg.id in self.variables_overwrite.get(
                 self.scope, {}
             ):
-                arg = self.variables_overwrite[self.scope][arg.id]  # type:ignore[assignment]
+                arg = self.variables_overwrite[self.scope][
+                    arg.id
+                ]  # type:ignore[assignment]
             res, expl = self.visit(arg)
             arg_expls.append(expl)
             new_args.append(res)
@@ -1066,7 +1074,9 @@ class AssertionRewriter(ast.NodeVisitor):
             if isinstance(
                 keyword.value, ast.Name
             ) and keyword.value.id in self.variables_overwrite.get(self.scope, {}):
-                keyword.value = self.variables_overwrite[self.scope][keyword.value.id]  # type:ignore[assignment]
+                keyword.value = self.variables_overwrite[self.scope][
+                    keyword.value.id
+                ]  # type:ignore[assignment]
             res, expl = self.visit(keyword.value)
             new_kwargs.append(ast.keyword(keyword.arg, res))
             if keyword.arg:
@@ -1103,9 +1113,13 @@ class AssertionRewriter(ast.NodeVisitor):
         if isinstance(
             comp.left, ast.Name
         ) and comp.left.id in self.variables_overwrite.get(self.scope, {}):
-            comp.left = self.variables_overwrite[self.scope][comp.left.id]  # type:ignore[assignment]
+            comp.left = self.variables_overwrite[self.scope][
+                comp.left.id
+            ]  # type:ignore[assignment]
         if isinstance(comp.left, ast.NamedExpr):
-            self.variables_overwrite[self.scope][comp.left.target.id] = comp.left  # type:ignore[assignment]
+            self.variables_overwrite[self.scope][
+                comp.left.target.id
+            ] = comp.left  # type:ignore[assignment]
         left_res, left_expl = self.visit(comp.left)
         if isinstance(comp.left, (ast.Compare, ast.BoolOp)):
             left_expl = f"({left_expl})"
@@ -1123,7 +1137,9 @@ class AssertionRewriter(ast.NodeVisitor):
                 and next_operand.target.id == left_res.id
             ):
                 next_operand.target.id = self.variable()
-                self.variables_overwrite[self.scope][left_res.id] = next_operand  # type:ignore[assignment]
+                self.variables_overwrite[self.scope][
+                    left_res.id
+                ] = next_operand  # type:ignore[assignment]
             next_res, next_expl = self.visit(next_operand)
             if isinstance(next_operand, (ast.Compare, ast.BoolOp)):
                 next_expl = f"({next_expl})"

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -1,11 +1,11 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
+import re
 
 from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE
 from _pytest._io.saferepr import saferepr
 from _pytest._io.saferepr import saferepr_unlimited
 import pytest
-import re
 
 
 def test_simple_repr():

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
+
 import re
 
 from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -196,22 +196,20 @@ def test_saferepr_unlimited_exc():
 
 class TestSafereprUnbounded:
     class Help:
-        def __init__(self, i):
-            self.i = i
-
         def bound_method(self):
-            return self.i
+            pass
 
     def test_saferepr_bound_method(self):
         """saferepr() of a bound method should show only the method name"""
-        assert saferepr(self.Help(10).bound_method) == "bound_method"
+        assert saferepr(self.Help().bound_method) == "bound_method"
 
     def test_saferepr_unbounded(self):
         """saferepr() of an unbound method should still show the full information"""
-        obj = self.Help(10)
+        obj = self.Help()
+        obj_id = f"{id(obj) :x}".lstrip("0").lower()
         assert (
             saferepr(obj)
-            == f"<test_saferepr.{self.__class__.__name__}.Help object at 0x{id(obj):x}>"
+            == f"<test_saferepr.{self.__class__.__name__}.Help object at 0x{obj_id !s}>"
         )
         assert (
             saferepr(self.Help)

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -1,8 +1,6 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
-import re
-
 from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE
 from _pytest._io.saferepr import saferepr
 from _pytest._io.saferepr import saferepr_unlimited

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -194,26 +194,3 @@ def test_saferepr_unlimited_exc():
     assert saferepr_unlimited(A()).startswith(
         "<[ValueError(42) raised in repr()] A object at 0x"
     )
-
-
-class TestSafereprUnbounded:
-    class Help:
-        def bound_method(self):  # pragma: no cover
-            pass
-
-    def test_saferepr_bound_method(self):
-        """saferepr() of a bound method should show only the method name"""
-        assert saferepr(self.Help().bound_method) == "bound_method"
-
-    def test_saferepr_unbounded(self):
-        """saferepr() of an unbound method should still show the full information"""
-        obj = self.Help()
-        # using id() to fetch memory address fails on different platforms
-        pattern = re.compile(
-            r"<test_saferepr.TestSafereprUnbounded.Help object at 0x[0-9a-fA-F]*>",
-        )
-        assert pattern.match(saferepr(obj))
-        assert (
-            saferepr(self.Help)
-            == f"<class 'test_saferepr.{self.__class__.__name__}.Help'>"
-        )

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -5,6 +5,7 @@ from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE
 from _pytest._io.saferepr import saferepr
 from _pytest._io.saferepr import saferepr_unlimited
 import pytest
+import re
 
 
 def test_simple_repr():
@@ -206,7 +207,9 @@ class TestSafereprUnbounded:
     def test_saferepr_unbounded(self):
         """saferepr() of an unbound method should still show the full information"""
         obj = self.Help()
-        obj_id = f"{id(obj) :x}".lstrip("0").lower()
+        # On windows, id adds leading zeros
+        obj_id = re.sub(r"^0+", "", f"{id(obj):x}").lower()
+
         assert (
             saferepr(obj)
             == f"<test_saferepr.{self.__class__.__name__}.Help object at 0x{obj_id !s}>"

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -6,6 +6,7 @@ from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE
 from _pytest._io.saferepr import saferepr
 from _pytest._io.saferepr import saferepr_unlimited
 import pytest
+import re
 
 
 def test_simple_repr():
@@ -197,7 +198,7 @@ def test_saferepr_unlimited_exc():
 
 class TestSafereprUnbounded:
     class Help:
-        def bound_method(self):
+        def bound_method(self):  # pragma: no cover
             pass
 
     def test_saferepr_bound_method(self):

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -192,3 +192,28 @@ def test_saferepr_unlimited_exc():
     assert saferepr_unlimited(A()).startswith(
         "<[ValueError(42) raised in repr()] A object at 0x"
     )
+
+
+class TestSafereprUnbounded:
+    class Help:
+        def __init__(self, i):
+            self.i = i
+
+        def bound_method(self):
+            return self.i
+
+    def test_saferepr_bound_method(self):
+        """saferepr() of a bound method should show only the method name"""
+        assert saferepr(self.Help(10).bound_method) == "bound_method"
+
+    def test_saferepr_unbounded(self):
+        """saferepr() of an unbound method should still show the full information"""
+        obj = self.Help(10)
+        assert (
+            saferepr(obj)
+            == f"<test_saferepr.{self.__class__.__name__}.Help object at 0x{id(obj):x}>"
+        )
+        assert (
+            saferepr(self.Help)
+            == f"<class 'test_saferepr.{self.__class__.__name__}.Help'>"
+        )

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -6,7 +6,6 @@ from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE
 from _pytest._io.saferepr import saferepr
 from _pytest._io.saferepr import saferepr_unlimited
 import pytest
-import re
 
 
 def test_simple_repr():

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -6,6 +6,7 @@ from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE
 from _pytest._io.saferepr import saferepr
 from _pytest._io.saferepr import saferepr_unlimited
 import pytest
+import re
 
 
 def test_simple_repr():
@@ -207,13 +208,11 @@ class TestSafereprUnbounded:
     def test_saferepr_unbounded(self):
         """saferepr() of an unbound method should still show the full information"""
         obj = self.Help()
-        # On windows, id adds leading zeros
-        obj_id = re.sub(r"^0+", "", f"{id(obj):x}").lower()
-
-        assert (
-            saferepr(obj)
-            == f"<test_saferepr.{self.__class__.__name__}.Help object at 0x{obj_id !s}>"
+        # using id() to fetch memory address fails on different platforms
+        pattern = re.compile(
+            r"<test_saferepr.TestSafereprUnbounded.Help object at 0x[0-9a-fA-F]*>",
         )
+        assert pattern.match(saferepr(obj))
         assert (
             saferepr(self.Help)
             == f"<class 'test_saferepr.{self.__class__.__name__}.Help'>"

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -19,7 +19,6 @@ from typing import Generator
 from typing import Mapping
 from unittest import mock
 import zipfile
-import re
 
 import _pytest._code
 from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE
@@ -36,7 +35,6 @@ from _pytest.config import Config
 from _pytest.config import ExitCode
 from _pytest.pathlib import make_numbered_dir
 from _pytest.pytester import Pytester
-from _pytest.assertion.rewrite import _saferepr
 import pytest
 
 

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -10,6 +10,7 @@ import marshal
 import os
 from pathlib import Path
 import py_compile
+import re
 import stat
 import sys
 import textwrap
@@ -18,13 +19,13 @@ from typing import Generator
 from typing import Mapping
 from unittest import mock
 import zipfile
-import re
 
 import _pytest._code
 from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE
 from _pytest.assertion import util
 from _pytest.assertion.rewrite import _get_assertion_exprs
 from _pytest.assertion.rewrite import _get_maxsize_for_saferepr
+from _pytest.assertion.rewrite import _saferepr
 from _pytest.assertion.rewrite import AssertionRewritingHook
 from _pytest.assertion.rewrite import get_cache_dir
 from _pytest.assertion.rewrite import PYC_TAIL
@@ -34,7 +35,6 @@ from _pytest.config import Config
 from _pytest.config import ExitCode
 from _pytest.pathlib import make_numbered_dir
 from _pytest.pytester import Pytester
-from _pytest.assertion.rewrite import _saferepr
 import pytest
 
 

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -19,6 +19,7 @@ from typing import Generator
 from typing import Mapping
 from unittest import mock
 import zipfile
+import re
 
 import _pytest._code
 from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE
@@ -35,6 +36,7 @@ from _pytest.config import Config
 from _pytest.config import ExitCode
 from _pytest.pathlib import make_numbered_dir
 from _pytest.pytester import Pytester
+from _pytest.assertion.rewrite import _saferepr
 import pytest
 
 


### PR DESCRIPTION
Closes #389

With the help of @flub and @obestwalter, we were able to find an easy way to simplify the output of assertion failures to something like this, while keeping the old behavior same as before for unbounded objects:

```
=================================== FAILURES ===================================
_____________________________________ test _____________________________________

    def test():
>       assert Help().fun() == 2
E       assert 1 == 2
E        +  where 1 = fun()
E        +    where fun = <test_local.Help object at 0x1074be230>.fun
E        +      where <test_local.Help object at 0x1074be230> = Help()

test_local.py:13: AssertionError
=========================== 1 failed in 0.03 seconds ===========================
```

However, I opened an issue (#12499) to refactor the data structure of assertions AST (in `rewerite.py`) from string to something more flexible.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
