### PR TITLE
🧪 Make a draft based plugin bump PR CI trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,11 @@ on:
     branches:
       - main
       - "[0-9]+.[0-9]+.x"
+    types:
+    - opened  # default
+    - synchronize  # default
+    - reopened  # default
+    - ready_for_review  # used in PRs created from the release workflow
 
 env:
   PYTEST_ADDOPTS: "--color=yes"

--- a/.github/workflows/update-plugin-list.yml
+++ b/.github/workflows/update-plugin-list.yml
@@ -46,6 +46,7 @@ jobs:
         run: python scripts/update-plugin-list.py
 
       - name: Create Pull Request
+        id: pr
         uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e
         with:
           commit-message: '[automated] Update plugin list'
@@ -55,3 +56,13 @@ jobs:
           branch-suffix: short-commit-hash
           title: '[automated] Update plugin list'
           body: '[automated] Update plugin list'
+          draft: true
+
+      - name: Instruct the maintainers to trigger CI by undrafting the PR
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh pr comment
+          --body 'Please mark the PR as ready for review to trigger PR checks.'
+          --repo '${{ github.repository }}'
+          '${{ steps.pr.outputs.pull-request-number }}'

--- a/changelog/12502.contrib.rst
+++ b/changelog/12502.contrib.rst
@@ -1,0 +1,7 @@
+The UX of the GitHub automation making pull requests to update the
+plugin list has been updated. Previously, the maintainers had to close
+the automatically created pull requests and re-open them to trigger the
+CI runs. From now on, they only need to click the `Ready for review`
+button instead.
+
+-- by :user:`webknjaz`.


### PR DESCRIPTION
Normally, PRs/commits published using the default GitHub Actions CI/CD API token are not propagated to any integrations. This patch marks the plugin update PR as a draft and leaves a comment asking the maintainers to mark it as ready for review in order to actually trigger a CI run.

This idea is found in GitHub's own repos:
* https://github.com/github/codeql-action/pull/2263#issuecomment-2078311173
* https://github.com/github/codeql-action/blob/4ebadbc7/.github/workflows/update-dependencies.yml#L38-L41
* https://github.com/github/codeql-action/pull/1868
* https://github.com/github/codeql-action/pull/679