### PR TITLE
🚑🧪📝 Allow invoking git in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -85,8 +85,6 @@ basepython = python3
 usedevelop = True
 deps =
     -r{toxinidir}/doc/en/requirements.txt
-    # https://github.com/twisted/towncrier/issues/340
-    towncrier<21.3.0
 allowlist_externals =
   git
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -87,6 +87,8 @@ deps =
     -r{toxinidir}/doc/en/requirements.txt
     # https://github.com/twisted/towncrier/issues/340
     towncrier<21.3.0
+allowlist_externals =
+  git
 commands =
     # Retrieve possibly missing commits:
     -git fetch --unshallow


### PR DESCRIPTION
It is called when building the docs. Apparently, `tox -e docs` is not
invoked in CI, neither is it called in RTD, resulting in the
regression having been caught only in local development environments.

This is a follow-up for #12493.
