### PR TITLE
🧪🚑 Pass a Codecov config to the action @ GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,9 +247,8 @@ jobs:
     - name: Upload coverage to Codecov
       if: "matrix.use_coverage"
       uses: codecov/codecov-action@v4
-      continue-on-error: true
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         files: ./coverage.xml
         verbose: true
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,9 @@
 # reference: https://docs.codecov.io/docs/codecovyml-reference
+---
+
+codecov:
+  token: 1eca3b1f-31a2-4fb8-a8c3-138b441b50a7 #repo token
+
 coverage:
   status:
     patch: true


### PR DESCRIPTION
The #11921 update broke uploading coverage of the `main` branch (or any in-repo pushes for that matter) to Codecov 4 months ago. Version 4 requires an upload token to be provided and since there was no configuration for it, the upload was failing. But the step itself was showing up as successful due to `fail_ci_if_error: true` being set. The error is visible in the console output, though.

This patch flips the setting to `fail_ci_if_error: false` and sets the Codecov upload token in the config in clear text. The non-secret part allows the PRs uploads to be more stable.