### PR TITLE
Update contact channels

### DIFF
--- a/doc/en/contact.rst
+++ b/doc/en/contact.rst
@@ -3,45 +3,51 @@
 .. _`contact`:
 
 Contact channels
-===================================
+================
 
-- `pytest issue tracker`_ to report bugs or suggest features (for version
-  2.0 and above).
-- `pytest discussions`_ at github for general questions.
-- `pytest discord server <https://discord.com/invite/pytest-dev>`_
-  for pytest development visibility and general assistance.
+Web
+---
+
+- `pytest issue tracker`_ to report bugs or suggest features.
+- `pytest discussions`_ at GitHub for general questions.
 - `pytest on stackoverflow.com <http://stackoverflow.com/search?q=pytest>`_
-  to post precise questions with the tag ``pytest``.  New Questions will usually
+  to post precise questions with the tag ``pytest``.  New questions will usually
   be seen by pytest users or developers and answered quickly.
 
-- `Testing In Python`_: a mailing list for Python testing tools and discussion.
+Chat
+----
 
-- `pytest-dev at python.org (mailing list)`_ pytest specific announcements and discussions.
-
-- :doc:`contribution guide <contributing>` for help on submitting pull
-  requests to GitHub.
-
+- `pytest discord server <https://discord.com/invite/pytest-dev>`_
+  for pytest development visibility and general assistance.
 - ``#pytest`` `on irc.libera.chat <ircs://irc.libera.chat:6697/#pytest>`_ IRC
   channel for random questions (using an IRC client, or `via webchat
-  <https://web.libera.chat/#pytest>`)
-- ``#pytest`` `on Matrix https://matrix.to/#/#pytest:matrix.org>`.
+  <https://web.libera.chat/#pytest>`_)
+- ``#pytest`` `on Matrix <https://matrix.to/#/#pytest:matrix.org>`_.
 
+Mail
+----
+
+- `Testing In Python`_: a mailing list for Python testing tools and discussion.
+- `pytest-dev at python.org`_ a mailing list for pytest specific announcements and discussions.
+- Mail to `core@pytest.org <mailto:core@pytest.org>`_ for topics that cannot be
+  discussed in public. Mails sent there will be distributed among the members
+  in the pytest core team, who can also be contacted individually:
+
+  * Ronny Pfannschmidt (:user:`RonnyPfannschmidt`, `ronny@pytest.org <mailto:ronny@pytest.org>`_)
+  * Florian Bruhin (:user:`The-Compiler`, `florian@pytest.org <mailto:florian@pytest.org>`_)
+  * Bruno Oliveira (:user:`nicoddemus`, `bruno@pytest.org <mailto:bruno@pytest.org>`_)
+  * Ran Benita (:user:`bluetech`, `ran@pytest.org <mailto:ran@pytest.org>`_)
+  * Zac Hatfield-Dodds (:user:`Zac-HD`, `zac@pytest.org <mailto:zac@pytest.org>`_)
+
+Other
+-----
+
+- The :doc:`contribution guide <contributing>` for help on submitting pull
+  requests to GitHub.
+- Florian Bruhin (:user:`The-Compiler`) offers pytest professional teaching and
+  consulting via `Bruhin Software <https://bruhin.software>`_.
 
 .. _`pytest issue tracker`: https://github.com/pytest-dev/pytest/issues
-.. _`old issue tracker`: https://bitbucket.org/hpk42/py-trunk/issues/
-
 .. _`pytest discussions`: https://github.com/pytest-dev/pytest/discussions
-
-.. _`get an account`:
-
-.. _tetamap: https://tetamap.wordpress.com/
-
-.. _`@pylibcommit`: https://twitter.com/pylibcommit
-
-
 .. _`Testing in Python`: http://lists.idyll.org/listinfo/testing-in-python
-.. _FOAF: https://en.wikipedia.org/wiki/FOAF
-.. _`py-dev`:
-.. _`development mailing list`:
-.. _`pytest-dev at python.org (mailing list)`: http://mail.python.org/mailman/listinfo/pytest-dev
-.. _`pytest-commit at python.org (mailing list)`: http://mail.python.org/mailman/listinfo/pytest-commit
+.. _`pytest-dev at python.org`: http://mail.python.org/mailman/listinfo/pytest-dev


### PR DESCRIPTION
Follow-up to #12427 plus some more cleanups:

- Mention `core@pytest.org` as mail point of contact ~~(not live yet, hence why this is a draft PR)~~
- Also add a list of core maintainers receiving such mails. Unfortunately the [GitHub Team page](https://github.com/orgs/pytest-dev/teams/core) is not public, so we can't just link to it. Still I feel like it's important to have a public-facing list of people that actually are in the core team, and I suppose this will be the right place?
- Mention Bruhin Software for trainings/consulting. Let me know if you'd rather not have me do that, but given that Merlinux was mentioned there and I pretty much took those things over from Holger, I suppose it should be fine?
- Remove dead link references
- Restructure channels into different groups for more readability
- Fix broken links from #12455
- Other minor edits