### PR TITLE
🚑🧪 Set the Codecov token directly in GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,6 +250,7 @@ jobs:
       with:
         fail_ci_if_error: false
         files: ./coverage.xml
+        token: 1eca3b1f-31a2-4fb8-a8c3-138b441b50a7 #repo token; cfg read fails
         verbose: true
 
   check:  # This job does nothing and is only used for the branch protection


### PR DESCRIPTION
It's necessary since it seems that the currently used Codecov uploader doesn't read the token from the config sometimes.

This is a follow-up for #12508 which wasn't enough.