### PR TITLE
📝 Replace GH/PyPI `extlinks` w/ `sphinx-issues`

### DIFF
--- a/changelog/12522.contrib.rst
+++ b/changelog/12522.contrib.rst
@@ -1,0 +1,4 @@
+The ``:pull:`` RST role has been replaced with a shorter
+``:pr:`` due to starting to use the implementation from
+the third-party :pypi:`sphinx-issues` Sphinx extension
+-- by :user:`webknjaz`.

--- a/doc/en/announce/release-2.9.0.rst
+++ b/doc/en/announce/release-2.9.0.rst
@@ -45,7 +45,7 @@ The py.test Development Team
 **New Features**
 
 * New ``pytest.mark.skip`` mark, which unconditionally skips marked tests.
-  Thanks :user:`MichaelAquilina` for the complete PR (:pull:`1040`).
+  Thanks :user:`MichaelAquilina` for the complete PR (:pr:`1040`).
 
 * ``--doctest-glob`` may now be passed multiple times in the command-line.
   Thanks :user:`jab` and :user:`nicoddemus` for the PR.

--- a/doc/en/announce/release-2.9.1.rst
+++ b/doc/en/announce/release-2.9.1.rst
@@ -44,7 +44,7 @@ The py.test Development Team
   Thanks :user:`nicoddemus` for the PR.
 
 * Fix (:issue:`469`): junit parses report.nodeid incorrectly, when params IDs
-  contain ``::``. Thanks :user:`tomviner` for the PR (:pull:`1431`).
+  contain ``::``. Thanks :user:`tomviner` for the PR (:pr:`1431`).
 
 * Fix (:issue:`578`): SyntaxErrors
   containing non-ascii lines at the point of failure generated an internal

--- a/doc/en/announce/release-2.9.2.rst
+++ b/doc/en/announce/release-2.9.2.rst
@@ -44,14 +44,14 @@ The py.test Development Team
 
 * Fix Xfail does not work with condition keyword argument.
   Thanks :user:`astraw38` for reporting the issue (:issue:`1496`) and :user:`tomviner`
-  for PR the (:pull:`1524`).
+  for PR the (:pr:`1524`).
 
 * Fix win32 path issue when putting custom config file with absolute path
   in ``pytest.main("-c your_absolute_path")``.
 
 * Fix maximum recursion depth detection when raised error class is not aware
   of unicode/encoded bytes.
-  Thanks :user:`prusse-martin` for the PR (:pull:`1506`).
+  Thanks :user:`prusse-martin` for the PR (:pr:`1506`).
 
 * Fix ``pytest.mark.skip`` mark when used in strict mode.
   Thanks :user:`pquentin` for the PR and :user:`RonnyPfannschmidt` for

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -268,7 +268,7 @@ Bug Fixes
 
 - `#11904 <https://github.com/pytest-dev/pytest/issues/11904>`_: Fixed a regression in pytest 8.0.0 that would cause test collection to fail due to permission errors when using ``--pyargs``.
 
-  This change improves the collection tree for tests specified using ``--pyargs``, see :pull:`12043` for a comparison with pytest 8.0 and <8.
+  This change improves the collection tree for tests specified using ``--pyargs``, see :pr:`12043` for a comparison with pytest 8.0 and <8.
 
 
 - `#12011 <https://github.com/pytest-dev/pytest/issues/12011>`_: Fixed a regression in 8.0.1 whereby ``setup_module`` xunit-style fixtures are not executed when ``--doctest-modules`` is passed.
@@ -1422,7 +1422,7 @@ Bug Fixes
       tests/link -> tests/real
 
   running ``pytest tests`` now imports the conftest twice, once as ``tests/real/conftest.py`` and once as ``tests/link/conftest.py``.
-  This is a fix to match a similar change made to test collection itself in pytest 6.0 (see :pull:`6523` for details).
+  This is a fix to match a similar change made to test collection itself in pytest 6.0 (see :pr:`6523` for details).
 
 
 - `#9626 <https://github.com/pytest-dev/pytest/issues/9626>`_: Fixed count of selected tests on terminal collection summary when there were errors or skipped modules.
@@ -2591,7 +2591,7 @@ Breaking Changes
   Resolving symlinks for the current directory and during collection was introduced as a bugfix in 3.9.0, but it actually is a new feature which had unfortunate consequences in Windows and surprising results in other platforms.
 
   The team decided to step back on resolving symlinks at all, planning to review this in the future with a more solid solution (see discussion in
-  :pull:`6523` for details).
+  :pr:`6523` for details).
 
   This might break test suites which made use of this feature; the fix is to create a symlink
   for the entire test tree, and not only to partial files/tress as it was possible previously.
@@ -2874,7 +2874,7 @@ Bug Fixes
 - :issue:`6871`: Fix crash with captured output when using :fixture:`capsysbinary`.
 
 
-- :issue:`6909`: Revert the change introduced by :pull:`6330`, which required all arguments to ``@pytest.mark.parametrize`` to be explicitly defined in the function signature.
+- :issue:`6909`: Revert the change introduced by :pr:`6330`, which required all arguments to ``@pytest.mark.parametrize`` to be explicitly defined in the function signature.
 
   The intention of the original change was to remove what was expected to be an unintended/surprising behavior, but it turns out many people relied on it, so the restriction has been reverted.
 
@@ -3044,7 +3044,7 @@ pytest 5.4.1 (2020-03-13)
 Bug Fixes
 ---------
 
-- :issue:`6909`: Revert the change introduced by :pull:`6330`, which required all arguments to ``@pytest.mark.parametrize`` to be explicitly defined in the function signature.
+- :issue:`6909`: Revert the change introduced by :pr:`6330`, which required all arguments to ``@pytest.mark.parametrize`` to be explicitly defined in the function signature.
 
   The intention of the original change was to remove what was expected to be an unintended/surprising behavior, but it turns out many people relied on it, so the restriction has been reverted.
 
@@ -4067,7 +4067,7 @@ Bug Fixes
   (``--collect-only``) when ``--log-cli-level`` is used.
 
 
-- :issue:`5389`: Fix regressions of :pull:`5063` for ``importlib_metadata.PathDistribution`` which have their ``files`` attribute being ``None``.
+- :issue:`5389`: Fix regressions of :pr:`5063` for ``importlib_metadata.PathDistribution`` which have their ``files`` attribute being ``None``.
 
 
 - :issue:`5390`: Fix regression where the ``obj`` attribute of ``TestCase`` items was no longer bound to methods.
@@ -4268,7 +4268,7 @@ Bug Fixes
   (``--collect-only``) when ``--log-cli-level`` is used.
 
 
-- :issue:`5389`: Fix regressions of :pull:`5063` for ``importlib_metadata.PathDistribution`` which have their ``files`` attribute being ``None``.
+- :issue:`5389`: Fix regressions of :pr:`5063` for ``importlib_metadata.PathDistribution`` which have their ``files`` attribute being ``None``.
 
 
 - :issue:`5390`: Fix regression where the ``obj`` attribute of ``TestCase`` items was no longer bound to methods.
@@ -7229,10 +7229,10 @@ New Features
 * Added ``junit_suite_name`` ini option to specify root ``<testsuite>`` name for JUnit XML reports (:issue:`533`).
 
 * Added an ini option ``doctest_encoding`` to specify which encoding to use for doctest files.
-  Thanks :user:`wheerd` for the PR (:pull:`2101`).
+  Thanks :user:`wheerd` for the PR (:pr:`2101`).
 
 * ``pytest.warns`` now checks for subclass relationship rather than
-  class equality. Thanks :user:`lesteve` for the PR (:pull:`2166`)
+  class equality. Thanks :user:`lesteve` for the PR (:pr:`2166`)
 
 * ``pytest.raises`` now asserts that the error message matches a text or regex
   with the ``match`` keyword argument. Thanks :user:`Kriechi` for the PR.
@@ -7260,7 +7260,7 @@ Changes
   the failure. (:issue:`2228`) Thanks to :user:`kkoukiou` for the PR.
 
 * Testcase reports with a ``url`` attribute will now properly write this to junitxml.
-  Thanks :user:`fushi` for the PR (:pull:`1874`).
+  Thanks :user:`fushi` for the PR (:pr:`1874`).
 
 * Remove common items from dict comparison output when verbosity=1. Also update
   the truncation message to make it clearer that pytest truncates all
@@ -7269,7 +7269,7 @@ Changes
 
 * ``--pdbcls`` no longer implies ``--pdb``. This makes it possible to use
   ``addopts=--pdbcls=module.SomeClass`` on ``pytest.ini``. Thanks :user:`davidszotten` for
-  the PR (:pull:`1952`).
+  the PR (:pr:`1952`).
 
 * fix :issue:`2013`: turn RecordedWarning into ``namedtuple``,
   to give it a comprehensible repr while preventing unwarranted modification.
@@ -7523,7 +7523,7 @@ Bug Fixes
   a sequence of strings) when modules are considered for assertion rewriting.
   Due to this bug, much more modules were being rewritten than necessary
   if a test suite uses ``pytest_plugins`` to load internal plugins (:issue:`1888`).
-  Thanks :user:`jaraco` for the report and :user:`nicoddemus` for the PR (:pull:`1891`).
+  Thanks :user:`jaraco` for the report and :user:`nicoddemus` for the PR (:pr:`1891`).
 
 * Do not call tearDown and cleanups when running tests from
   ``unittest.TestCase`` subclasses with ``--pdb``
@@ -7578,12 +7578,12 @@ time or change existing behaviors in order to make them less surprising/more use
   * ``--nomagic``: use ``--assert=plain`` instead;
   * ``--report``: use ``-r`` instead;
 
-  Thanks to :user:`RedBeardCode` for the PR (:pull:`1664`).
+  Thanks to :user:`RedBeardCode` for the PR (:pr:`1664`).
 
 * ImportErrors in plugins now are a fatal error instead of issuing a
   pytest warning (:issue:`1479`). Thanks to :user:`The-Compiler` for the PR.
 
-* Removed support code for Python 3 versions < 3.3 (:pull:`1627`).
+* Removed support code for Python 3 versions < 3.3 (:pr:`1627`).
 
 * Removed all ``py.test-X*`` entry points. The versioned, suffixed entry points
   were never documented and a leftover from a pre-virtualenv era. These entry
@@ -7594,19 +7594,19 @@ time or change existing behaviors in order to make them less surprising/more use
 * ``pytest.skip()`` now raises an error when used to decorate a test function,
   as opposed to its original intent (to imperatively skip a test inside a test function). Previously
   this usage would cause the entire module to be skipped (:issue:`607`).
-  Thanks :user:`omarkohl` for the complete PR (:pull:`1519`).
+  Thanks :user:`omarkohl` for the complete PR (:pr:`1519`).
 
 * Exit tests if a collection error occurs. A poll indicated most users will hit CTRL-C
   anyway as soon as they see collection errors, so pytest might as well make that the default behavior (:issue:`1421`).
   A ``--continue-on-collection-errors`` option has been added to restore the previous behaviour.
-  Thanks :user:`olegpidsadnyi` and :user:`omarkohl` for the complete PR (:pull:`1628`).
+  Thanks :user:`olegpidsadnyi` and :user:`omarkohl` for the complete PR (:pr:`1628`).
 
 * Renamed the pytest ``pdb`` module (plugin) into ``debugging`` to avoid clashes with the builtin ``pdb`` module.
 
 * Raise a helpful failure message when requesting a parametrized fixture at runtime,
   e.g. with ``request.getfixturevalue``. Previously these parameters were simply
   never defined, so a fixture decorated like ``@pytest.fixture(params=[0, 1, 2])``
-  only ran once (:pull:`460`).
+  only ran once (:pr:`460`).
   Thanks to :user:`nikratio` for the bug report, :user:`RedBeardCode` and :user:`tomviner` for the PR.
 
 * ``_pytest.monkeypatch.monkeypatch`` class has been renamed to ``_pytest.monkeypatch.MonkeyPatch``
@@ -7624,7 +7624,7 @@ time or change existing behaviors in order to make them less surprising/more use
 
 * New ``doctest_namespace`` fixture for injecting names into the
   namespace in which doctests run.
-  Thanks :user:`milliams` for the complete PR (:pull:`1428`).
+  Thanks :user:`milliams` for the complete PR (:pr:`1428`).
 
 * New ``--doctest-report`` option available to change the output format of diffs
   when running (failing) doctests (implements :issue:`1749`).
@@ -7632,23 +7632,23 @@ time or change existing behaviors in order to make them less surprising/more use
 
 * New ``name`` argument to ``pytest.fixture`` decorator which allows a custom name
   for a fixture (to solve the funcarg-shadowing-fixture problem).
-  Thanks :user:`novas0x2a` for the complete PR (:pull:`1444`).
+  Thanks :user:`novas0x2a` for the complete PR (:pr:`1444`).
 
 * New ``approx()`` function for easily comparing floating-point numbers in
   tests.
-  Thanks :user:`kalekundert` for the complete PR (:pull:`1441`).
+  Thanks :user:`kalekundert` for the complete PR (:pr:`1441`).
 
 * Ability to add global properties in the final xunit output file by accessing
   the internal ``junitxml`` plugin (experimental).
-  Thanks :user:`tareqalayan` for the complete PR :pull:`1454`).
+  Thanks :user:`tareqalayan` for the complete PR :pr:`1454`).
 
 * New ``ExceptionInfo.match()`` method to match a regular expression on the
   string representation of an exception (:issue:`372`).
-  Thanks :user:`omarkohl` for the complete PR (:pull:`1502`).
+  Thanks :user:`omarkohl` for the complete PR (:pr:`1502`).
 
 * ``__tracebackhide__`` can now also be set to a callable which then can decide
   whether to filter the traceback based on the ``ExceptionInfo`` object passed
-  to it. Thanks :user:`The-Compiler` for the complete PR (:pull:`1526`).
+  to it. Thanks :user:`The-Compiler` for the complete PR (:pr:`1526`).
 
 * New ``pytest_make_parametrize_id(config, val)`` hook which can be used by plugins to provide
   friendly strings for custom types.
@@ -7666,7 +7666,7 @@ time or change existing behaviors in order to make them less surprising/more use
 * Introduce ``pytest`` command as recommended entry point. Note that ``py.test``
   still works and is not scheduled for removal. Closes proposal
   :issue:`1629`. Thanks :user:`obestwalter` and :user:`davehunt` for the complete PR
-  (:pull:`1633`).
+  (:pr:`1633`).
 
 * New cli flags:
 
@@ -7710,19 +7710,19 @@ time or change existing behaviors in order to make them less surprising/more use
 
 * Change ``report.outcome`` for ``xpassed`` tests to ``"passed"`` in non-strict
   mode and ``"failed"`` in strict mode. Thanks to :user:`hackebrot` for the PR
-  (:pull:`1795`) and :user:`gprasad84` for report (:issue:`1546`).
+  (:pr:`1795`) and :user:`gprasad84` for report (:issue:`1546`).
 
 * Tests marked with ``xfail(strict=False)`` (the default) now appear in
   JUnitXML reports as passing tests instead of skipped.
-  Thanks to :user:`hackebrot` for the PR (:pull:`1795`).
+  Thanks to :user:`hackebrot` for the PR (:pr:`1795`).
 
 * Highlight path of the file location in the error report to make it easier to copy/paste.
-  Thanks :user:`suzaku` for the PR (:pull:`1778`).
+  Thanks :user:`suzaku` for the PR (:pr:`1778`).
 
 * Fixtures marked with ``@pytest.fixture`` can now use ``yield`` statements exactly like
   those marked with the ``@pytest.yield_fixture`` decorator. This change renders
   ``@pytest.yield_fixture`` deprecated and makes ``@pytest.fixture`` with ``yield`` statements
-  the preferred way to write teardown code (:pull:`1461`).
+  the preferred way to write teardown code (:pr:`1461`).
   Thanks :user:`csaftoiu` for bringing this to attention and :user:`nicoddemus` for the PR.
 
 * Explicitly passed parametrize ids do not get escaped to ascii (:issue:`1351`).
@@ -7733,11 +7733,11 @@ time or change existing behaviors in order to make them less surprising/more use
   Thanks :user:`nicoddemus` for the PR.
 
 * ``pytest_terminal_summary`` hook now receives the ``exitstatus``
-  of the test session as argument. Thanks :user:`blueyed` for the PR (:pull:`1809`).
+  of the test session as argument. Thanks :user:`blueyed` for the PR (:pr:`1809`).
 
 * Parametrize ids can accept ``None`` as specific test id, in which case the
   automatically generated id for that argument will be used.
-  Thanks :user:`palaviv` for the complete PR (:pull:`1468`).
+  Thanks :user:`palaviv` for the complete PR (:pr:`1468`).
 
 * The parameter to xunit-style setup/teardown methods (``setup_method``,
   ``setup_module``, etc.) is now optional and may be omitted.
@@ -7745,32 +7745,32 @@ time or change existing behaviors in order to make them less surprising/more use
 
 * Improved automatic id generation selection in case of duplicate ids in
   parametrize.
-  Thanks :user:`palaviv` for the complete PR (:pull:`1474`).
+  Thanks :user:`palaviv` for the complete PR (:pr:`1474`).
 
 * Now pytest warnings summary is shown up by default. Added a new flag
   ``--disable-pytest-warnings`` to explicitly disable the warnings summary (:issue:`1668`).
 
 * Make ImportError during collection more explicit by reminding
   the user to check the name of the test module/package(s) (:issue:`1426`).
-  Thanks :user:`omarkohl` for the complete PR (:pull:`1520`).
+  Thanks :user:`omarkohl` for the complete PR (:pr:`1520`).
 
 * Add ``build/`` and ``dist/`` to the default ``--norecursedirs`` list. Thanks
   :user:`mikofski` for the report and :user:`tomviner` for the PR (:issue:`1544`).
 
 * ``pytest.raises`` in the context manager form accepts a custom
   ``message`` to raise when no exception occurred.
-  Thanks :user:`palaviv` for the complete PR (:pull:`1616`).
+  Thanks :user:`palaviv` for the complete PR (:pr:`1616`).
 
 * ``conftest.py`` files now benefit from assertion rewriting; previously it
   was only available for test modules. Thanks :user:`flub`, :user:`sober7` and
   :user:`nicoddemus` for the PR (:issue:`1619`).
 
 * Text documents without any doctests no longer appear as "skipped".
-  Thanks :user:`graingert` for reporting and providing a full PR (:pull:`1580`).
+  Thanks :user:`graingert` for reporting and providing a full PR (:pr:`1580`).
 
 * Ensure that a module within a namespace package can be found when it
   is specified on the command line together with the ``--pyargs``
-  option.  Thanks to :user:`taschini` for the PR (:pull:`1597`).
+  option.  Thanks to :user:`taschini` for the PR (:pr:`1597`).
 
 * Always include full assertion explanation during assertion rewriting. The previous behaviour was hiding
   sub-expressions that happened to be ``False``, assuming this was redundant information.
@@ -7786,20 +7786,20 @@ time or change existing behaviors in order to make them less surprising/more use
   Thanks :user:`nicoddemus` for the PR.
 
 * ``[pytest]`` sections in ``setup.cfg`` files should now be named ``[tool:pytest]``
-  to avoid conflicts with other distutils commands (see :pull:`567`). ``[pytest]`` sections in
+  to avoid conflicts with other distutils commands (see :pr:`567`). ``[pytest]`` sections in
   ``pytest.ini`` or ``tox.ini`` files are supported and unchanged.
   Thanks :user:`nicoddemus` for the PR.
 
 * Using ``pytest_funcarg__`` prefix to declare fixtures is considered deprecated and will be
-  removed in pytest-4.0 (:pull:`1684`).
+  removed in pytest-4.0 (:pr:`1684`).
   Thanks :user:`nicoddemus` for the PR.
 
 * Passing a command-line string to ``pytest.main()`` is considered deprecated and scheduled
-  for removal in pytest-4.0. It is recommended to pass a list of arguments instead (:pull:`1723`).
+  for removal in pytest-4.0. It is recommended to pass a list of arguments instead (:pr:`1723`).
 
 * Rename ``getfuncargvalue`` to ``getfixturevalue``. ``getfuncargvalue`` is
   still present but is now considered deprecated. Thanks to :user:`RedBeardCode` and :user:`tomviner`
-  for the PR (:pull:`1626`).
+  for the PR (:pr:`1626`).
 
 * ``optparse`` type usage now triggers DeprecationWarnings (:issue:`1740`).
 
@@ -7857,11 +7857,11 @@ time or change existing behaviors in order to make them less surprising/more use
   :user:`tomviner` for the PR.
 
 * ``ConftestImportFailure`` now shows the traceback making it easier to
-  identify bugs in ``conftest.py`` files (:pull:`1516`). Thanks :user:`txomon` for
+  identify bugs in ``conftest.py`` files (:pr:`1516`). Thanks :user:`txomon` for
   the PR.
 
 * Text documents without any doctests no longer appear as "skipped".
-  Thanks :user:`graingert` for reporting and providing a full PR (:pull:`1580`).
+  Thanks :user:`graingert` for reporting and providing a full PR (:pr:`1580`).
 
 * Fixed collection of classes with custom ``__new__`` method.
   Fixes :issue:`1579`. Thanks to :user:`Stranger6667` for the PR.
@@ -7869,7 +7869,7 @@ time or change existing behaviors in order to make them less surprising/more use
 * Fixed scope overriding inside metafunc.parametrize (:issue:`634`).
   Thanks to :user:`Stranger6667` for the PR.
 
-* Fixed the total tests tally in junit xml output (:pull:`1798`).
+* Fixed the total tests tally in junit xml output (:pr:`1798`).
   Thanks to :user:`cboelsen` for the PR.
 
 * Fixed off-by-one error with lines from ``request.node.warn``.
@@ -7886,14 +7886,14 @@ time or change existing behaviors in order to make them less surprising/more use
 
 * Fix Xfail does not work with condition keyword argument.
   Thanks :user:`astraw38` for reporting the issue (:issue:`1496`) and :user:`tomviner`
-  for PR the (:pull:`1524`).
+  for PR the (:pr:`1524`).
 
 * Fix win32 path issue when putting custom config file with absolute path
   in ``pytest.main("-c your_absolute_path")``.
 
 * Fix maximum recursion depth detection when raised error class is not aware
   of unicode/encoded bytes.
-  Thanks :user:`prusse-martin` for the PR (:pull:`1506`).
+  Thanks :user:`prusse-martin` for the PR (:pr:`1506`).
 
 * Fix ``pytest.mark.skip`` mark when used in strict mode.
   Thanks :user:`pquentin` for the PR and :user:`RonnyPfannschmidt` for
@@ -7920,7 +7920,7 @@ time or change existing behaviors in order to make them less surprising/more use
   Thanks :user:`nicoddemus` for the PR.
 
 * Fix (:issue:`469`): junit parses report.nodeid incorrectly, when params IDs
-  contain ``::``. Thanks :user:`tomviner` for the PR (:pull:`1431`).
+  contain ``::``. Thanks :user:`tomviner` for the PR (:pr:`1431`).
 
 * Fix (:issue:`578`): SyntaxErrors
   containing non-ascii lines at the point of failure generated an internal
@@ -7941,7 +7941,7 @@ time or change existing behaviors in order to make them less surprising/more use
 **New Features**
 
 * New ``pytest.mark.skip`` mark, which unconditionally skips marked tests.
-  Thanks :user:`MichaelAquilina` for the complete PR (:pull:`1040`).
+  Thanks :user:`MichaelAquilina` for the complete PR (:pr:`1040`).
 
 * ``--doctest-glob`` may now be passed multiple times in the command-line.
   Thanks :user:`jab` and :user:`nicoddemus` for the PR.
@@ -7952,14 +7952,14 @@ time or change existing behaviors in order to make them less surprising/more use
 * ``pytest.mark.xfail`` now has a ``strict`` option, which makes ``XPASS``
   tests to fail the test suite (defaulting to ``False``). There's also a
   ``xfail_strict`` ini option that can be used to configure it project-wise.
-  Thanks :user:`rabbbit` for the request and :user:`nicoddemus` for the PR (:pull:`1355`).
+  Thanks :user:`rabbbit` for the request and :user:`nicoddemus` for the PR (:pr:`1355`).
 
 * ``Parser.addini`` now supports options of type ``bool``.
   Thanks :user:`nicoddemus` for the PR.
 
 * New ``ALLOW_BYTES`` doctest option. This strips ``b`` prefixes from byte strings
   in doctest output (similar to ``ALLOW_UNICODE``).
-  Thanks :user:`jaraco` for the request and :user:`nicoddemus` for the PR (:pull:`1287`).
+  Thanks :user:`jaraco` for the request and :user:`nicoddemus` for the PR (:pr:`1287`).
 
 * Give a hint on ``KeyboardInterrupt`` to use the ``--fulltrace`` option to show the errors.
   Fixes :issue:`1366`.
@@ -7991,7 +7991,7 @@ time or change existing behaviors in order to make them less surprising/more use
 
 * Removed code and documentation for Python 2.5 or lower versions,
   including removal of the obsolete ``_pytest.assertion.oldinterpret`` module.
-  Thanks :user:`nicoddemus` for the PR (:pull:`1226`).
+  Thanks :user:`nicoddemus` for the PR (:pr:`1226`).
 
 * Comparisons now always show up in full when ``CI`` or ``BUILD_NUMBER`` is
   found in the environment, even when ``-vv`` isn't used.

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -450,8 +450,6 @@ towncrier_draft_config_path = "pyproject.toml"  # relative to cwd
 # -- Options for sphinx_issues extension -----------------------------------
 
 issues_github_path = "pytest-dev/pytest"
-issues_prefix = "issue #"
-issues_pr_prefix = "pull request #"
 
 
 intersphinx_mapping = {

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -175,7 +175,7 @@ extlinks = {
     "bpo": ("https://bugs.python.org/issue%s", "bpo-%s"),
     "pypi": ("https://pypi.org/project/%s/", "%s"),
     "issue": (f"{_repo}/issues/%s", "issue #%s"),
-    "pull": (f"{_repo}/pull/%s", "pull request #%s"),
+    "pr": (f"{_repo}/pull/%s", "pull request #%s"),
     "user": ("https://github.com/%s", "@%s"),
 }
 

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -89,6 +89,7 @@ extensions = [
     "sphinx_removed_in",
     "sphinxcontrib_trio",
     "sphinxcontrib.towncrier.ext",  # provides `towncrier-draft-entries` directive
+    "sphinx_issues",  # implements `:issue:`, `:pr:` and other GH-related roles
 ]
 
 # Building PDF docs on readthedocs requires inkscape for svg to pdf
@@ -170,13 +171,8 @@ linkcheck_ignore = [
 linkcheck_workers = 5
 
 
-_repo = "https://github.com/pytest-dev/pytest"
 extlinks = {
     "bpo": ("https://bugs.python.org/issue%s", "bpo-%s"),
-    "pypi": ("https://pypi.org/project/%s/", "%s"),
-    "issue": (f"{_repo}/issues/%s", "issue #%s"),
-    "pr": (f"{_repo}/pull/%s", "pull request #%s"),
-    "user": ("https://github.com/%s", "@%s"),
 }
 
 
@@ -449,6 +445,13 @@ towncrier_draft_autoversion_mode = "draft"  # or: 'sphinx-version', 'sphinx-rele
 towncrier_draft_include_empty = True
 towncrier_draft_working_directory = PROJECT_ROOT_DIR
 towncrier_draft_config_path = "pyproject.toml"  # relative to cwd
+
+
+# -- Options for sphinx_issues extension -----------------------------------
+
+issues_github_path = "pytest-dev/pytest"
+issues_prefix = "issue #"
+issues_pr_prefix = "pull request #"
 
 
 intersphinx_mapping = {

--- a/doc/en/historical-notes.rst
+++ b/doc/en/historical-notes.rst
@@ -107,7 +107,7 @@ Here is a non-exhaustive list of issues fixed by the new implementation:
 
 * Marker transfer incompatible with inheritance (:issue:`535`).
 
-More details can be found in the :pull:`original PR <3317>`.
+More details can be found in the :pr:`original PR <3317>`.
 
 .. note::
 

--- a/doc/en/requirements.txt
+++ b/doc/en/requirements.txt
@@ -10,3 +10,4 @@ sphinxcontrib-svg2pdfconverter
 packaging
 furo
 sphinxcontrib-towncrier
+sphinx-issues


### PR DESCRIPTION
This Sphinx extension implements more generic roles that can also be used
more flexibly. Relying on an external extension allows us to stop
maintaining an in-repo copy of the commonly used behavior.

As a part of the change, the `:pull:` RST role is being replaced with `:pr:`.