### PR TITLE
Improve documentation & other kinks of marker keyword expression PR #12500

### DIFF
--- a/doc/en/example/markers.rst
+++ b/doc/en/example/markers.rst
@@ -80,7 +80,7 @@ keyword arguments, e.g. to run only tests marked with ``device`` and the specifi
 
 .. code-block:: pytest
 
-    $ pytest -v -m 'device(serial="123")'
+    $ pytest -v -m "device(serial='123')"
     =========================== test session starts ============================
     platform linux -- Python 3.x.y, pytest-8.x.y, pluggy-1.x.y -- $PYTHON_PREFIX/bin/python
     cachedir: .pytest_cache

--- a/doc/en/how-to/usage.rst
+++ b/doc/en/how-to/usage.rst
@@ -88,7 +88,7 @@ with the ``phase`` keyword argument set to ``1``:
 
 .. code-block:: bash
 
-    pytest -m slow(phase=1)
+    pytest -m "slow(phase=1)"
 
 For more information see :ref:`marks <mark>`.
 

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -5,7 +5,7 @@ The grammar is:
 expression: expr? EOF
 expr:       and_expr ('or' and_expr)*
 and_expr:   not_expr ('and' not_expr)*
-not_expr:   'not' not_expr | '(' expr ')' | ident ( '(' name '=' value ( ', ' name '=' value )*  ')')*
+not_expr:   'not' not_expr | '(' expr ')' | ident ('(' name '=' value ( ', ' name '=' value )*  ')')?
 
 ident:      (\w|:|\+|-|\.|\[|\]|\\|/)+
 

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -5,9 +5,10 @@ The grammar is:
 expression: expr? EOF
 expr:       and_expr ('or' and_expr)*
 and_expr:   not_expr ('and' not_expr)*
-not_expr:   'not' not_expr | '(' expr ')' | ident ('(' name '=' value ( ', ' name '=' value )*  ')')?
+not_expr:   'not' not_expr | '(' expr ')' | ident kwargs?
 
 ident:      (\w|:|\+|-|\.|\[|\]|\\|/)+
+kwargs:     ('(' name '=' value ( ', ' name '=' value )*  ')')
 name:       a valid ident, but not a reserved keyword
 value:      (unescaped) string literal | (-)?[0-9]+ | 'False' | 'True' | 'None'
 

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -12,7 +12,7 @@ ident:      (\w|:|\+|-|\.|\[|\]|\\|/)+
 The semantics are:
 
 - Empty expression evaluates to False.
-- ident evaluates to True of False according to a provided matcher function.
+- ident evaluates to True or False according to a provided matcher function.
 - or/and/not evaluate according to the usual boolean semantics.
 """
 

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -8,12 +8,15 @@ and_expr:   not_expr ('and' not_expr)*
 not_expr:   'not' not_expr | '(' expr ')' | ident ('(' name '=' value ( ', ' name '=' value )*  ')')?
 
 ident:      (\w|:|\+|-|\.|\[|\]|\\|/)+
+name:       a valid ident, but not a reserved keyword
+value:      (unescaped) string literal | (-)?[0-9]+ | 'False' | 'True' | 'None'
 
 The semantics are:
 
 - Empty expression evaluates to False.
 - ident evaluates to True or False according to a provided matcher function.
 - or/and/not evaluate according to the usual boolean semantics.
+- ident with parentheses and keyword arguments evaluates to True or False according to a provided matcher function.
 """
 
 from __future__ import annotations

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -51,7 +51,7 @@ class TokenType(enum.Enum):
     IDENT = "identifier"
     EOF = "end of input"
     EQUAL = "="
-    STRING = "str"
+    STRING = "string literal"
     COMMA = ","
 
 

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -235,7 +235,7 @@ def test_mark_option(
 
 @pytest.mark.parametrize(
     ("expr", "expected_passed"),
-    [  # TODO: improve/sort out
+    [
         ("car(color='red')", ["test_one"]),
         ("car(color='red') or car(color='blue')", ["test_one", "test_two"]),
         ("car and not car(temp=5)", ["test_one", "test_three"]),

--- a/testing/test_mark_expression.py
+++ b/testing/test_mark_expression.py
@@ -228,6 +228,7 @@ def test_invalid_idents(ident: str) -> None:
             r'escaping with "\\" not supported in marker expression',
         ),
         ("mark(empty_list=[])", r'unexpected character/s "\[\]"'),
+        ("'str'", "expected not OR left parenthesis OR identifier; got string literal"),
     ),
 )
 def test_invalid_kwarg_name_or_value(  # TODO: move to `test_syntax_errors` ?

--- a/testing/test_mark_expression.py
+++ b/testing/test_mark_expression.py
@@ -231,7 +231,7 @@ def test_invalid_idents(ident: str) -> None:
         ("'str'", "expected not OR left parenthesis OR identifier; got string literal"),
     ),
 )
-def test_invalid_kwarg_name_or_value(  # TODO: move to `test_syntax_errors` ?
+def test_invalid_kwarg_name_or_value(
     expr: str, expected_error_msg: str, mark_matcher: MarkMatcher
 ) -> None:
     with pytest.raises(ParseError, match=expected_error_msg):
@@ -290,7 +290,7 @@ def test_keyword_expressions_with_numbers(
         ("builtin_matchers_mark(z=1)", False),
     ),
 )
-def test_builtin_matchers_keyword_expressions(  # TODO: naming when decided
+def test_builtin_matchers_keyword_expressions(
     expr: str, expected: bool, mark_matcher: MarkMatcher
 ) -> None:
     assert evaluate(expr, mark_matcher) is expected


### PR DESCRIPTION
Follow up to #12500 

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
