### PR TITLE
🧪 Unmeasure coverage in tests expected to fail

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -29,3 +29,5 @@ exclude_lines =
 
     ^\s*if TYPE_CHECKING:
     ^\s*@overload( |$)
+
+    ^\s*@pytest\.mark\.xfail

--- a/changelog/12531.contrib.rst
+++ b/changelog/12531.contrib.rst
@@ -1,0 +1,6 @@
+The coverage reporting configuration has been updated to exclude
+pytest's own tests marked as expected to fail from the coverage
+report. This has an effect of reducing the influence of flaky
+tests on the resulting number.
+
+-- by :user`webknjaz`


### PR DESCRIPTION
These tests are known to only be executed partially or not at all. So we always get incomplete, missing, and sometimes flaky, coverage in the test functions that are expected to fail.

This change updates the ``coverage.py`` config to prevent said tests from influencing the coverage level measurement.