### PR TITLE
📝🔥 Remove the `:bpo:` RST role declaration

### DIFF
--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -3360,7 +3360,9 @@ Bug Fixes
 - :issue:`5914`: pytester: fix :py:func:`~pytest.LineMatcher.no_fnmatch_line` when used after positive matching.
 
 
-- :issue:`6082`: Fix line detection for doctest samples inside :py:class:`python:property` docstrings, as a workaround to :bpo:`17446`.
+- :issue:`6082`: Fix line detection for doctest samples inside
+  :py:class:`python:property` docstrings, as a workaround to
+  :issue:`python/cpython#61648`.
 
 
 - :issue:`6254`: Fix compatibility with pytest-parallel (regression in pytest 5.3.0).

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -82,7 +82,6 @@ extensions = [
     "pygments_pytest",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
-    "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
@@ -169,11 +168,6 @@ linkcheck_ignore = [
 
 # The number of worker threads to use when checking links (default=5).
 linkcheck_workers = 5
-
-
-extlinks = {
-    "bpo": ("https://bugs.python.org/issue%s", "bpo-%s"),
-}
 
 
 nitpicky = True


### PR DESCRIPTION
BPO is in read-only mode and all issues have been migrated to GitHub. This patch replaces the use of that role with `:issue:`, recently integrated via #12522. It also disables the built-in `extlinks` Sphinx extension, as it's no longer in use.