### PR TITLE
examples: be more precise about TestReport outcome

### DIFF
--- a/changelog/12535.doc.rst
+++ b/changelog/12535.doc.rst
@@ -1,0 +1,4 @@
+`This
+example`<https://docs.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures>
+showed ``print`` statements that do not exactly reflect what the
+different branches actually do.  The fix makes the example more precise.

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -904,7 +904,9 @@ here is a little example implemented via a local plugin:
         # "function" scope
         report = request.node.stash[phase_report_key]
         if report["setup"].failed:
-            print("setting up a test failed or skipped", request.node.nodeid)
+            print("setting up a test failed", request.node.nodeid)
+        elif report["setup"].skipped:
+            print("setting up a test skipped", request.node.nodeid)
         elif ("call" not in report) or report["call"].failed:
             print("executing test failed or skipped", request.node.nodeid)
 


### PR DESCRIPTION
Current state deals with the setup outcome only:
* testing only for "failed" should not be reported as "or skipped"
* test for "skipped" explicitly instead

I'm unclear what to do about the test call outcome, as I don't see in which case "call" would not be in report, while setup was "passed" (was this intended for the case where setup was indeed "skipped"?  would't that be unintuitive?).
