### PR TITLE
Support venv detection on Windows with mingw Python

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -454,6 +454,7 @@ Yusuke Kadowaki
 Yutian Li
 Yuval Shimon
 Zac Hatfield-Dodds
+Zach Snicker
 Zachary Kneupper
 Zachary OBrien
 Zhouxin Qiu

--- a/changelog/12544.improvement.rst
+++ b/changelog/12544.improvement.rst
@@ -1,0 +1,4 @@
+The _in_venv function now detects Python virtual environments by checking
+for a pyvenv.cfg file, ensuring reliable detection on various platforms.
+
+-- by :user:`zachsnickers`.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1702,13 +1702,13 @@ passed multiple times. The expected format is ``name=value``. For example::
    This would tell ``pytest`` to not look into typical subversion or
    sphinx-build directories or into any ``tmp`` prefixed directory.
 
-   Additionally, ``pytest`` will attempt to intelligently identify and ignore a
-   virtualenv by the presence of an activation script.  Any directory deemed to
-   be the root of a virtual environment will not be considered during test
-   collection unless ``--collect-in-virtualenv`` is given.  Note also that
-   ``norecursedirs`` takes precedence over ``--collect-in-virtualenv``; e.g. if
-   you intend to run tests in a virtualenv with a base directory that matches
-   ``'.*'`` you *must* override ``norecursedirs`` in addition to using the
+   Additionally, ``pytest`` will attempt to intelligently identify and ignore
+   a virtualenv.  Any directory deemed to be the root of a virtual environment
+   will not be considered during test collection unless
+   ``--collect-in-virtualenv`` is given.  Note also that ``norecursedirs``
+   takes precedence over ``--collect-in-virtualenv``; e.g. if you intend to
+   run tests in a virtualenv with a base directory that matches ``'.*'`` you
+   *must* override ``norecursedirs`` in addition to using the
    ``--collect-in-virtualenv`` flag.
 
 

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -371,7 +371,7 @@ def _in_venv(path: Path) -> bool:
     """Attempt to detect if ``path`` is the root of a Virtual Environment by
     checking for the existence of the pyvenv.cfg file."""
     try:
-        return path.joinpath("pyvenv.cfg").exists()
+        return path.joinpath("pyvenv.cfg").is_file()
     except OSError:
         return False
 

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -369,7 +369,8 @@ def pytest_runtestloop(session: Session) -> bool:
 
 def _in_venv(path: Path) -> bool:
     """Attempt to detect if ``path`` is the root of a Virtual Environment by
-    checking for the existence of the pyvenv.cfg file."""
+    checking for the existence of the pyvenv.cfg file.
+    [https://peps.python.org/pep-0405/]"""
     try:
         return path.joinpath("pyvenv.cfg").is_file()
     except OSError:

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -369,22 +369,11 @@ def pytest_runtestloop(session: Session) -> bool:
 
 def _in_venv(path: Path) -> bool:
     """Attempt to detect if ``path`` is the root of a Virtual Environment by
-    checking for the existence of the appropriate activate script."""
-    bindir = path.joinpath("Scripts" if sys.platform.startswith("win") else "bin")
+    checking for the existence of the pyvenv.cfg file."""
     try:
-        if not bindir.is_dir():
-            return False
+        return path.joinpath("pyvenv.cfg").exists()
     except OSError:
         return False
-    activates = (
-        "activate",
-        "activate.csh",
-        "activate.fish",
-        "Activate",
-        "Activate.bat",
-        "Activate.ps1",
-    )
-    return any(fname.name in activates for fname in bindir.iterdir())
 
 
 def pytest_ignore_collect(collection_path: Path, config: Config) -> bool | None:

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -152,20 +152,8 @@ class TestCollectFS:
         assert "test_notfound" not in s
         assert "test_found" in s
 
-    @pytest.mark.parametrize(
-        "fname",
-        (
-            "activate",
-            "activate.csh",
-            "activate.fish",
-            "Activate",
-            "Activate.bat",
-            "Activate.ps1",
-        ),
-    )
-    def test_ignored_virtualenvs(self, pytester: Pytester, fname: str) -> None:
-        bindir = "Scripts" if sys.platform.startswith("win") else "bin"
-        ensure_file(pytester.path / "virtual" / bindir / fname)
+    def test_ignored_virtualenvs(self, pytester: Pytester) -> None:
+        ensure_file(pytester.path / "virtual" / "pyvenv.cfg")
         testfile = ensure_file(pytester.path / "virtual" / "test_invenv.py")
         testfile.write_text("def test_hello(): pass", encoding="utf-8")
 
@@ -179,23 +167,11 @@ class TestCollectFS:
         result = pytester.runpytest("virtual")
         assert "test_invenv" in result.stdout.str()
 
-    @pytest.mark.parametrize(
-        "fname",
-        (
-            "activate",
-            "activate.csh",
-            "activate.fish",
-            "Activate",
-            "Activate.bat",
-            "Activate.ps1",
-        ),
-    )
     def test_ignored_virtualenvs_norecursedirs_precedence(
-        self, pytester: Pytester, fname: str
+        self, pytester: Pytester
     ) -> None:
-        bindir = "Scripts" if sys.platform.startswith("win") else "bin"
         # norecursedirs takes priority
-        ensure_file(pytester.path / ".virtual" / bindir / fname)
+        ensure_file(pytester.path / ".virtual" / "pyvenv.cfg")
         testfile = ensure_file(pytester.path / ".virtual" / "test_invenv.py")
         testfile.write_text("def test_hello(): pass", encoding="utf-8")
         result = pytester.runpytest("--collect-in-virtualenv")
@@ -204,27 +180,13 @@ class TestCollectFS:
         result = pytester.runpytest("--collect-in-virtualenv", ".virtual")
         assert "test_invenv" in result.stdout.str()
 
-    @pytest.mark.parametrize(
-        "fname",
-        (
-            "activate",
-            "activate.csh",
-            "activate.fish",
-            "Activate",
-            "Activate.bat",
-            "Activate.ps1",
-        ),
-    )
-    def test__in_venv(self, pytester: Pytester, fname: str) -> None:
+    def test__in_venv(self, pytester: Pytester) -> None:
         """Directly test the virtual env detection function"""
-        bindir = "Scripts" if sys.platform.startswith("win") else "bin"
-        # no bin/activate, not a virtualenv
+        # no pyvenv.cfg, not a virtualenv
         base_path = pytester.mkdir("venv")
         assert _in_venv(base_path) is False
-        # with bin/activate, totally a virtualenv
-        bin_path = base_path.joinpath(bindir)
-        bin_path.mkdir()
-        bin_path.joinpath(fname).touch()
+        # with pyvenv.cfg, totally a virtualenv
+        base_path.joinpath("pyvenv.cfg").touch()
         assert _in_venv(base_path) is True
 
     def test_custom_norecursedirs(self, pytester: Pytester) -> None:


### PR DESCRIPTION
closes #12544

- Updated the `_in_venv` function in `src/_pytest/main.py` to correctly detect Python virtual environments.
- Updated the test cases in `testing/test_collection.py` to validate the new behavior.
- Created a changelog fragment to document this improvement.
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] closes #12544

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
