### PR TITLE
Revert "🚑🧪 Set the Codecov token directly in GHA"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,7 +250,6 @@ jobs:
       with:
         fail_ci_if_error: false
         files: ./coverage.xml
-        token: 1eca3b1f-31a2-4fb8-a8c3-138b441b50a7 #repo token; cfg read fails
         verbose: true
 
   check:  # This job does nothing and is only used for the branch protection


### PR DESCRIPTION
Reverts pytest-dev/pytest#12516.

https://github.com/codecov/codecov-cli/pull/464 has been released in codecov-cli v0.7.2 so this hack should no longer be necessary.