### PR TITLE
Bump PyPy runtime to v3.9 @ GHA 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
             tox_env: "py313"
             use_coverage: true
           - name: "ubuntu-pypy3"
-            python: "pypy-3.8"
+            python: "pypy-3.9"
             os: ubuntu-latest
             tox_env: "pypy3-xdist"
 

--- a/changelog/11771.contrib.rst
+++ b/changelog/11771.contrib.rst
@@ -1,0 +1,5 @@
+The PyPy runtime version has been updated to 3.9 from 3.8 that introduced
+a flaky bug at the garbage collector which was not expected to fix there
+as the V3.8 is EoL.
+
+-- by :user:`x612skm`

--- a/changelog/12557.contrib.rst
+++ b/changelog/12557.contrib.rst
@@ -1,0 +1,1 @@
+11771.contrib.rst

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -1140,8 +1140,8 @@ def test_errors_in_xfail_skip_expressions(pytester: Pytester) -> None:
     result = pytester.runpytest()
     markline = "            ^"
     pypy_version_info = getattr(sys, "pypy_version_info", None)
-    if pypy_version_info is not None and pypy_version_info < (6,):
-        markline = markline[1:]
+    if pypy_version_info is not None:
+        markline = markline[7:]
 
     if sys.version_info >= (3, 10):
         expected = [


### PR DESCRIPTION
As we were encountering this - 

```python-traceback
 __________________ ERROR collecting testing/_py/test_local.py __________________
/opt/hostedtoolcache/PyPy/3.8.16/x64/lib/pypy3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1023: in _gcd_import
    ???
<frozen importlib._bootstrap>:1000: in _find_and_load
    ???
<frozen importlib._bootstrap>:984: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:680: in _load_unlocked
    ???
.tox/pypy3-xdist/lib/pypy3.8/site-packages/_pytest/assertion/rewrite.py:166: in exec_module
    source_stat, co = _rewrite_test(fn, self.config)
.tox/pypy3-xdist/lib/pypy3.8/site-packages/_pytest/assertion/rewrite.py:350: in _rewrite_test
    co = compile(tree, strfn, "exec", dont_inherit=True)
E   TypeError: expected some sort of stmt, but got <_ast.Store object at 0x0000000002142880>
```

Due to the PyPy version 3.8 which has a bug at its garbage collector and its EoL. Hence bumping the PyPy version to resolve the issue.

Closes #11771 
