### PR TITLE
📝 Add markup to the PR #12545 changelog entry

### DIFF
--- a/changelog/12544.improvement.rst
+++ b/changelog/12544.improvement.rst
@@ -1,4 +1,3 @@
-The _in_venv function now detects Python virtual environments by checking
-for a pyvenv.cfg file, ensuring reliable detection on various platforms.
-
--- by :user:`zachsnickers`.
+The ``_in_venv()`` function now detects Python virtual environments by
+checking for a :file:`pyvenv.cfg` file, ensuring reliable detection on
+various platforms -- by :user:`zachsnickers`.

--- a/changelog/12545.improvement.rst
+++ b/changelog/12545.improvement.rst
@@ -1,0 +1,1 @@
+12544.improvement.rst


### PR DESCRIPTION
The original change note didn't use RST in places with identifiers.
This patch corrects that and includes the byline into the sentence.

Preview: https://pytest--12559.org.readthedocs.build/en/12559/changelog.html#improvements-in-existing-functionality