### PR TITLE
🧪 Lint for typos in `:user:` RST role

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,6 +102,14 @@ repos:
             )
           $
         files: ^changelog/
+    -   id: changelogs-user-role
+        name: Changelog files should use a non-broken :user:`name` role
+        language: pygrep
+        entry: :user:([^`]+`?|`[^`]+[\s,])
+        pass_filenames: true
+        types:
+          - file
+          - rst
     -   id: py-deprecated
         name: py library is deprecated
         language: pygrep

--- a/changelog/12562.contrib.rst
+++ b/changelog/12562.contrib.rst
@@ -1,0 +1,2 @@
+Possible typos in using the ``:user:`` RST role is now being linted
+through the pre-commit tool integration -- by :user:`webknjaz`.


### PR DESCRIPTION
It is easy to forget backticks in change note bylines. It's happened in #12531 already, requiring a hotfix in #12560.

The pre-commit based check idea is coming from the Tox project and have been battle-tested in aiohttp, CherryPy, and other ecosystems.