### PR TITLE
BUG: Fix warning stacklevel

### DIFF
--- a/changelog/12564.bugfix.rst
+++ b/changelog/12564.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the ``stacklevel`` used when warning about marks used on fixtures.

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -97,7 +97,7 @@ def check_ispytest(ispytest: bool) -> None:
 
 def _warn_auto_stacklevel(message: Warning | str, category: Any = UserWarning) -> None:
     """Emit a warning with trace outside the pytest namespace."""
-    root_dir = Path(__file__).parents[1]
+    root_dir = Path(__file__).parent
     frame = inspect.currentframe()
     fname, lineno = "unknown", 0
     while frame:

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import inspect
 from pathlib import Path
+from typing import Any
 from warnings import warn
 from warnings import warn_explicit
 
@@ -94,7 +95,7 @@ def check_ispytest(ispytest: bool) -> None:
         warn(PRIVATE, stacklevel=3)
 
 
-def _warn_auto_stacklevel(message, category=UserWarning):
+def _warn_auto_stacklevel(message: Warning | str, category: Any = UserWarning) -> None:
     """Emit a warning with trace outside the pytest namespace."""
     root_dir = Path(__file__).parents[1]
     frame = inspect.currentframe()

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1192,7 +1192,7 @@ class FixtureFunctionMarker:
             )
 
         if hasattr(function, "pytestmark"):
-            warnings.warn(MARKED_FIXTURE, stacklevel=2)
+            warnings.warn(MARKED_FIXTURE, stacklevel=4)
 
         function = wrap_function_to_error_out_if_called_directly(function, self)
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -60,6 +60,7 @@ from _pytest.config.argparsing import Parser
 from _pytest.deprecated import check_ispytest
 from _pytest.deprecated import MARKED_FIXTURE
 from _pytest.deprecated import YIELD_FIXTURE
+from _pytest.deprecated import _warn_auto_stacklevel
 from _pytest.main import Session
 from _pytest.mark import Mark
 from _pytest.mark import ParameterSet
@@ -1192,7 +1193,7 @@ class FixtureFunctionMarker:
             )
 
         if hasattr(function, "pytestmark"):
-            warnings.warn(MARKED_FIXTURE, stacklevel=4)
+            _warn_auto_stacklevel(MARKED_FIXTURE)
 
         function = wrap_function_to_error_out_if_called_directly(function, self)
 
@@ -1322,7 +1323,7 @@ def yield_fixture(
     .. deprecated:: 3.0
         Use :py:func:`pytest.fixture` directly instead.
     """
-    warnings.warn(YIELD_FIXTURE, stacklevel=2)
+    _warn_auto_stacklevel(YIELD_FIXTURE)
     return fixture(
         fixture_function,
         *args,

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -33,7 +33,6 @@ from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
-import warnings
 
 import _pytest
 from _pytest import nodes
@@ -57,10 +56,10 @@ from _pytest.config import _PluggyPlugin
 from _pytest.config import Config
 from _pytest.config import ExitCode
 from _pytest.config.argparsing import Parser
+from _pytest.deprecated import _warn_auto_stacklevel
 from _pytest.deprecated import check_ispytest
 from _pytest.deprecated import MARKED_FIXTURE
 from _pytest.deprecated import YIELD_FIXTURE
-from _pytest.deprecated import _warn_auto_stacklevel
 from _pytest.main import Session
 from _pytest.mark import Mark
 from _pytest.mark import ParameterSet

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -24,9 +24,9 @@ from ..compat import ascii_escaped
 from ..compat import NOTSET
 from ..compat import NotSetType
 from _pytest.config import Config
+from _pytest.deprecated import _warn_auto_stacklevel
 from _pytest.deprecated import check_ispytest
 from _pytest.deprecated import MARKED_FIXTURE
-from _pytest.deprecated import _warn_auto_stacklevel
 from _pytest.outcomes import fail
 from _pytest.scope import _ScopeName
 from _pytest.warning_types import PytestUnknownMarkWarning

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -193,10 +193,12 @@ def test_fixture_disallow_on_marked_functions():
         pytest.PytestRemovedIn9Warning,
         match=r"Marks applied to fixtures have no effect",
     ) as record:
+
         @pytest.mark.parametrize("example", ["hello"])
         @pytest.fixture
         def foo():
             raise NotImplementedError()
+
     assert len(record) == 1
     assert record[0].filename == __file__
 

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -196,7 +196,7 @@ def test_fixture_disallow_on_marked_functions():
 
         @pytest.mark.parametrize("example", ["hello"])
         @pytest.fixture
-        def foo():
+        def bar():
             raise NotImplementedError()
 
     assert len(record) == 1

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -59,7 +59,7 @@ def test_hookimpl_via_function_attributes_are_deprecated():
 
     with pytest.warns(
         PytestDeprecationWarning,
-        match=r"Please use the pytest.hookimpl\(tryfirst=True\)",
+        match=r"Please use the pytest\.hookimpl\(tryfirst=True\)",
     ) as recorder:
         pm.register(DeprecatedMarkImplPlugin())
     (record,) = recorder
@@ -186,6 +186,18 @@ def test_fixture_disallow_on_marked_functions():
     # ValueError("fixture is being applied more than once to the same function")
     assert len(record) == 1
     # should point to this file
+    assert record[0].filename == __file__
+
+    # Same with a different order
+    with pytest.warns(
+        pytest.PytestRemovedIn9Warning,
+        match=r"Marks applied to fixtures have no effect",
+    ) as record:
+        @pytest.mark.parametrize("example", ["hello"])
+        @pytest.fixture
+        def foo():
+            raise NotImplementedError()
+    assert len(record) == 1
     assert record[0].filename == __file__
 
 

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -185,6 +185,8 @@ def test_fixture_disallow_on_marked_functions():
     # from applying @fixture twice
     # ValueError("fixture is being applied more than once to the same function")
     assert len(record) == 1
+    # should point to this file
+    assert record[0].filename == __file__
 
 
 def test_fixture_disallow_marks_on_fixtures():


### PR DESCRIPTION
Similar to #12014, improves this warning:
```
  /home/larsoner/python/virtualenvs/base/lib/python3.12/site-packages/_pytest/fixtures.py:1303: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
```
to become:
```
  /home/larsoner/python/mne-nirs/mne_nirs/conftest.py:133: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
```