### PR TITLE
feat: add --fold-skipped=yes|no cli option

### DIFF
--- a/changelog/12567.feature.rst
+++ b/changelog/12567.feature.rst
@@ -1,0 +1,7 @@
+Added ``--no-fold-skipped`` command line option
+
+If this option is set, then skipped tests in short summary are no longer grouped
+by reason but all tests are printed individually with correct nodeid in the same
+way as other statuses.
+
+-- by :user:`pbrezina`

--- a/doc/en/how-to/output.rst
+++ b/doc/en/how-to/output.rst
@@ -552,6 +552,11 @@ captured output:
     PASSED test_example.py::test_ok
     == 1 failed, 1 passed, 1 skipped, 1 xfailed, 1 xpassed, 1 error in 0.12s ===
 
+.. note::
+
+    By default, parametrized variants of skipped tests are grouped together if
+    they share the same skip reason. You can use ``--no-fold-skipped`` to print each skipped test separately.
+
 Creating resultlog format files
 --------------------------------------------------
 


### PR DESCRIPTION
This controlls how the skipped tests are displayed in the short summary.

- yes (default): keeps the current behavior that folds the skipped tests
  together
- no: each skipped test is on its own line, display as any other status

Resolves: https://github.com/pytest-dev/pytest/issues/9876


<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->