### PR TITLE
Docs: Fix custom styling, restore bullets

### DIFF
--- a/doc/en/_static/pytest.css
+++ b/doc/en/_static/pytest.css
@@ -1,0 +1,8 @@
+/* Hide list bullets and top-level indent in TOC sidebar */
+.sidebar-scroll ul {list-style: none;}
+.sidebar-scroll > ul {padding-left: 0;}
+.sidebar-scroll li {margin: 0.4em 0;}
+/* Widen the events sidebar on the front page */
+@media (min-width: 46em) {
+    #features {width: 50%;}
+}

--- a/doc/en/_static/pytest.css
+++ b/doc/en/_static/pytest.css
@@ -4,5 +4,8 @@
 .sidebar-scroll li {margin: 0.4em 0;}
 /* Widen the events sidebar on the front page */
 @media (min-width: 46em) {
-    #features {width: 50%;}
+    #features {
+        width: 50%;
+        margin-bottom: 1em;
+    }
 }

--- a/doc/en/_templates/style.html
+++ b/doc/en/_templates/style.html
@@ -1,7 +1,0 @@
-<style>
-    ul {list-style: none;}
-    li {margin: 0.4em 0;}
-    @media (min-width: 46em) {
-        #features {width: 50%;}
-    }
-</style>

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -251,7 +251,7 @@ html_favicon = "img/favicon.png"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
@@ -274,7 +274,6 @@ html_sidebars = {
         "globaltoc.html",
         "links.html",
         "sidebar/scroll-end.html",
-        "style.html",
     ],
     "**": [
         "sidebar/brand.html",
@@ -284,9 +283,12 @@ html_sidebars = {
         "relations.html",
         "links.html",
         "sidebar/scroll-end.html",
-        "style.html",
     ],
 }
+
+html_css_files = [
+    "pytest.css",
+]
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -251,7 +251,7 @@ html_favicon = "img/favicon.png"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
- Move the custom CSS to a dedicated `pytest.css` file in `_static/`, and reference it from the configuraton's `html_css_files` list.
- Update the list-customization styling to only affect `.sidebar-scroll` (the navigation sidebar), so that bullets are visible in the rest of the documentation.
- Remove the list indent from the navigation sidebar, but only at the top level, so that navigation is still nested with visible indents.

Fixes #12573
Fixes #12576 
Closes #12575
Updates #12290 
Updates #12326

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

### Before

![image](https://github.com/pytest-dev/pytest/assets/538020/432021a0-b21f-40ca-93b2-7374e1f5c541)


### After

![image](https://github.com/pytest-dev/pytest/assets/538020/af89272f-eb3c-46f4-bf69-a9dbeac410ab)
