### PR TITLE
Fix heading level on index.rst

### DIFF
--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -124,7 +124,7 @@ Save time, reduce risk, and improve code health, while paying the maintainers of
 `Learn more. <https://tidelift.com/subscription/pkg/pypi-pytest?utm_source=pypi-pytest&utm_medium=referral&utm_campaign=enterprise&utm_term=repo>`_
 
 Security
-~~~~~~~~
+--------
 
 pytest has never been associated with a security vulnerability, but in any case, to report a
 security vulnerability please use the `Tidelift security contact <https://tidelift.com/security>`_.


### PR DESCRIPTION
"Security" was marked with a different heading level than all other entries on that page, effectively making it a subsection of "pytest for enterprise". This seems like an oversight. Security is not just for enterprises and should be on the same level as all other sections.
