### PR TITLE
fix: improved caching of parameterized fixtures

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -306,6 +306,7 @@ Nicholas Devenish
 Nicholas Murphy
 Niclas Olofsson
 Nicolas Delaby
+Nicolas Simonds
 Nico Vidal
 Nikolay Kondratyev
 Nipunn Koorapati

--- a/changelog/6962.bugfix.rst
+++ b/changelog/6962.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug where parametrized fixtures were not being cached correctly, being recreated every time.

--- a/changelog/6962.bugfix.rst
+++ b/changelog/6962.bugfix.rst
@@ -1,1 +1,2 @@
-Fixed bug where parametrized fixtures were not being cached correctly, being recreated every time.
+Parametrization parameters are now compared using `==` instead of `is` (`is` is still used as a fallback if the parameter does not support `==`).
+This fixes use of parameters such as lists, which have a different `id` but compare equal, causing fixtures to be re-computed instead of being cached.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1057,9 +1057,8 @@ class FixtureDef(Generic[FixtureValue]):
         if self.cached_result is not None:
             cache_key = self.cached_result[1]
 
-            # note: `__eq__` is not required to return a bool, and sometimes
-            # doesn't, e.g., numpy arrays (#6497).  Coerce the comparison
-            # into a bool, and if that fails, fall back to an identity check.
+            # Coerce the comparison into a bool (#12600), and if that fails, fall back to an identity check:
+            # `__eq__` is not required to return a bool, and sometimes doesn't, e.g., numpy arrays (#6497).
             try:
                 cache_hit = bool(my_cache_key == cache_key)
             except (ValueError, RuntimeError):

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1057,12 +1057,14 @@ class FixtureDef(Generic[FixtureValue]):
         if self.cached_result is not None:
             cache_key = self.cached_result[1]
 
-            # Coerce the comparison into a bool (#12600), and if that fails, fall back to an identity check:
-            # `__eq__` is not required to return a bool, and sometimes doesn't, e.g., numpy arrays (#6497).
-            try:
-                cache_hit = bool(my_cache_key == cache_key)
-            except (ValueError, RuntimeError):
-                cache_hit = my_cache_key is cache_key
+            # First attempt to use 'is' for performance reasons (for example numpy arrays (#6497)).
+            cache_hit = my_cache_key is cache_key
+            if not cache_hit:
+                # If they are not the same, fallback to a bool comparison (#12600).
+                try:
+                    cache_hit = bool(my_cache_key == cache_key)
+                except (ValueError, RuntimeError):
+                    cache_hit = False
 
             if cache_hit:
                 if self.cached_result[2] is not None:

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1558,6 +1558,7 @@ class TestFixtureUsages:
         result.stdout.fnmatch_lines(["* 2 passed in *"])
 
     def test_parameterized_fixture_caching(self, pytester: Pytester) -> None:
+        """Regression test for #12600."""
         pytester.makepyfile(
             """
             import pytest

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1568,9 +1568,9 @@ class TestFixtureUsages:
 
             def pytest_generate_tests(metafunc):
                 if "my_fixture" in metafunc.fixturenames:
-                    param = "d%s" % "1"
-                    print("param id=%d" % id(param), flush=True)
-                    metafunc.parametrize("my_fixture", [param, "d2"], indirect=True)
+                    # Use unique objects for parametrization (as opposed to small strings
+                    # and small integers which are singletons).
+                    metafunc.parametrize("my_fixture", [[1], [2]], indirect=True)
 
             @pytest.fixture(scope='session')
             def my_fixture(request):


### PR DESCRIPTION
The fix for Issue #6541 caused a regression where cache hits unexpectedly became cache misses.  Attempt to restore the previous behavior, while also retaining the fix for the bug.

Fixes: Issue #6962