### PR TITLE
Load plugins referencing entry point name provided via config and env var

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -265,6 +265,7 @@ Mandeep Bhutani
 Manuel Krebber
 Marc Mueller
 Marc Schlaich
+Marcel Telka
 Marcelo Duarte Trevisani
 Marcin Bachry
 Marc Bresson

--- a/changelog/12624.improvement.rst
+++ b/changelog/12624.improvement.rst
@@ -1,0 +1,5 @@
+Plugins specified in the :globalvar:`pytest_plugins` config setting and
+:envvar:`PYTEST_PLUGINS` environment variable now allow using
+:ref:`entry points <pip-installable plugins>` names additionally to the
+importable definitions. Prior to this release, these identifiers used to only
+work with the ``-p`` CLI option -- by :user:`mtelka` and :user:`webknjaz`.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1166,7 +1166,9 @@ specified plugins will be loaded.
 
 .. envvar:: PYTEST_PLUGINS
 
-Contains comma-separated list of modules that should be loaded as plugins:
+Contains comma-separated list of :term:`importable modules <Module>`
+or :ref:`entry point names <pip-installable plugins>` that should be
+loaded as plugins:
 
 .. code-block:: bash
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -826,7 +826,7 @@ class PytestPluginManager(PluginManager):
     ) -> None:
         plugins = _get_plugin_specs_as_list(spec)
         for import_spec in plugins:
-            self.import_plugin(import_spec)
+            self.import_plugin(import_spec, consider_entry_points=True)
 
     def import_plugin(self, modname: str, consider_entry_points: bool = False) -> None:
         """Import a plugin with ``modname``.


### PR DESCRIPTION
This allows to load plugins via `PYTEST_PLUGINS` environment variable and `pytest_plugins` global variable using their names in installed package entry points.

Closes #12624.