### PR TITLE
[pylint/ruff] Activate PLR / PLC messages in ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,9 @@ lint.select = [
     "I",       # isort
     "PGH004",  # pygrep-hooks - Use specific rule codes when using noqa
     "PIE",     # flake8-pie
+    "PLC",     # pylint convention
     "PLE",     # pylint error
+    "PLR",     # pylint refactor
     "PLR1714", # Consider merging multiple comparisons
     "PLW",     # pylint warning
     "PYI",     # flake8-pyi
@@ -139,6 +141,17 @@ lint.ignore = [
     # what we're doing when we use type(..) is ...
     "E721", # Do not compare types, use `isinstance()`
     # pylint ignore
+    "PLC0105", # `TypeVar` name "E" does not reflect its covariance;
+    "PLC0414", # Import alias does not rename original package
+    "PLR0124", # Name compared with itself
+    "PLR0133", # Two constants compared in a comparison (lots of those in tests)
+    "PLR0402", # Use `from x.y import z` in lieu of alias
+    "PLR0911", # Too many return statements
+    "PLR0912", # Too many branches
+    "PLR0913", # Too many arguments in function definition
+    "PLR0915", # Too many statements
+    "PLR2004", # Magic value used in comparison
+    "PLR2044", # Line with empty comment
     "PLR5501", # Use `elif` instead of `else` then `if`
     "PLW0120", # remove the else and dedent its contents
     "PLW0603", # Using the global statement
@@ -191,9 +204,9 @@ disable = [
     "broad-exception-caught",
     "broad-exception-raised",
     "cell-var-from-loop",                     # B023 from ruff / flake8-bugbear
-    "comparison-of-constants",
+    "comparison-of-constants",                # disabled in ruff (PLR0133)
     "comparison-with-callable",
-    "comparison-with-itself",
+    "comparison-with-itself",                 # PLR0124 from ruff
     "condition-evals-to-constant",
     "consider-using-dict-items",
     "consider-using-from-import",
@@ -201,14 +214,17 @@ disable = [
     "consider-using-in",
     "consider-using-ternary",
     "consider-using-with",
+    "consider-using-from-import",             # not activated by default, PLR0402 disabled in ruff
     "cyclic-import",
     "disallowed-name",                        # foo / bar are used often in tests
     "duplicate-code",
+    "else-if-used",                           # not activated by default, PLR5501 disabled in ruff
+    "empty-comment",                          # not activated by default, PLR2044 disabled in ruff
     "eval-used",
     "exec-used",
     "expression-not-assigned",
     "fixme",
-    "global-statement",
+    "global-statement",                       # PLW0603 disabled in ruff
     "import-error",
     "import-outside-toplevel",
     "inconsistent-return-statements",
@@ -218,6 +234,7 @@ disable = [
     "invalid-str-returned",
     "keyword-arg-before-vararg",
     "line-too-long",
+    "magic-value-comparison",                 # not activated by default, PLR2004 disabled in ruff
     "method-hidden",
     "missing-docstring",
     "missing-timeout",
@@ -232,14 +249,15 @@ disable = [
     "no-self-argument",
     "not-an-iterable",
     "not-callable",
-    "pointless-exception-statement",
-    "pointless-statement",
-    "pointless-string-statement",
+    "pointless-exception-statement",          # https://github.com/pytest-dev/pytest/pull/12379
+    "pointless-statement",                    # https://github.com/pytest-dev/pytest/pull/12379
+    "pointless-string-statement",             # https://github.com/pytest-dev/pytest/pull/12379
     "possibly-used-before-assignment",
     "protected-access",
     "raise-missing-from",
     "redefined-argument-from-local",
     "redefined-builtin",
+    "redefined-loop-name",                    # PLW2901 disabled in ruff
     "redefined-outer-name",
     "reimported",
     "simplifiable-condition",
@@ -249,18 +267,18 @@ disable = [
     "super-init-not-called",
     "too-few-public-methods",
     "too-many-ancestors",
-    "too-many-arguments",
-    "too-many-branches",
+    "too-many-arguments",                     # disabled in ruff
+    "too-many-branches",                      # disabled in ruff
     "too-many-function-args",
     "too-many-instance-attributes",
     "too-many-lines",
     "too-many-locals",
     "too-many-nested-blocks",
     "too-many-public-methods",
-    "too-many-return-statements",
-    "too-many-statements",
+    "too-many-return-statements",             # disabled in ruff
+    "too-many-statements",                    # disabled in ruff
     "try-except-raise",
-    "typevar-name-incorrect-variance",
+    "typevar-name-incorrect-variance",        # PLC0105 disabled in ruff
     "unbalanced-tuple-unpacking",
     "undefined-loop-variable",
     "undefined-variable",
@@ -280,7 +298,7 @@ disable = [
     "use-dict-literal",
     "use-implicit-booleaness-not-comparison",
     "use-implicit-booleaness-not-len",
-    "useless-else-on-loop",
+    "useless-else-on-loop",                   # PLC0414 disabled in ruff
     "useless-import-alias",
     "useless-return",
     "using-constant-test",

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -18,8 +18,8 @@ def _format_repr_exception(exc: BaseException, obj: object) -> str:
         exc_info = _try_repr_or_str(exc)
     except (KeyboardInterrupt, SystemExit):
         raise
-    except BaseException as exc:
-        exc_info = f"unpresentable exception ({_try_repr_or_str(exc)})"
+    except BaseException as inner_exc:
+        exc_info = f"unpresentable exception ({_try_repr_or_str(inner_exc)})"
     return (
         f"<[{exc_info} raised in repr()] {type(obj).__name__} object at 0x{id(obj):x}>"
     )

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -238,7 +238,6 @@ def showhelp(config: Config) -> None:
 
     for warningreport in reporter.stats.get("warnings", []):
         tw.line("warning : " + warningreport.message, red=True)
-    return
 
 
 conftest_options = [("pytest_plugins", "list of plugin names to load")]


### PR DESCRIPTION
Activate the PLR/PLC messages from ruff, and disable most of them. Also add some comments on existing pylint disables that are deactivated in ruff, so it's easy to see that the disable is voluntary and not because there's too much to fix.