### PR TITLE
Fix caching of parameterized fixtures

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -302,6 +302,7 @@ Nicholas Devenish
 Nicholas Murphy
 Niclas Olofsson
 Nicolas Delaby
+Nicolas Simonds
 Nico Vidal
 Nikolay Kondratyev
 Nipunn Koorapati

--- a/changelog/6962.bugfix.rst
+++ b/changelog/6962.bugfix.rst
@@ -1,0 +1,2 @@
+Parametrization parameters are now compared using `==` instead of `is` (`is` is still used as a fallback if the parameter does not support `==`).
+This fixes use of parameters such as lists, which have a different `id` but compare equal, causing fixtures to be re-computed instead of being cached.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1042,12 +1042,18 @@ class FixtureDef(Generic[FixtureValue]):
                 requested_fixtures_that_should_finalize_us.append(fixturedef)
 
         # Check for (and return) cached value/exception.
-        my_cache_key = self.cache_key(request)
         if self.cached_result is not None:
+            request_cache_key = self.cache_key(request)
             cache_key = self.cached_result[1]
-            # note: comparison with `==` can fail (or be expensive) for e.g.
-            # numpy arrays (#6497).
-            if my_cache_key is cache_key:
+            try:
+                # Attempt to make a normal == check: this might fail for objects
+                # which do not implement the standard comparison (like numpy arrays -- #6497).
+                cache_hit = bool(request_cache_key == cache_key)
+            except (ValueError, RuntimeError):
+                # If the comparison raises, use 'is' as fallback.
+                cache_hit = request_cache_key is cache_key
+
+            if cache_hit:
                 if self.cached_result[2] is not None:
                     exc = self.cached_result[2]
                     raise exc


### PR DESCRIPTION
The fix for Issue #6541 caused regression where cache hits became cache misses, unexpectedly.

Backport of commit d489247505a953885a156e61d4473497cbc167ea

Fixes #6962

---------

Co-authored-by: Nicolas Simonds <nisimond@cisco.com>
Co-authored-by: Bruno Oliveira <bruno@pytest.org>
Co-authored-by: Ran Benita <ran@unusedvar.com>