### PR TITLE
explicitly detect conda envs - fixes #12652

### DIFF
--- a/changelog/12652.bugfix.rst
+++ b/changelog/12652.bugfix.rst
@@ -1,0 +1,4 @@
+Resolve the regression in conda environment detection by
+explicitly expanding virtualenv detection to conda environents
+
+-- by :user:`RonnyPfannschmidt`

--- a/changelog/12652.bugfix.rst
+++ b/changelog/12652.bugfix.rst
@@ -1,4 +1,3 @@
-Resolve the regression in conda environment detection by
-explicitly expanding virtualenv detection to conda environents
+Resolve regression `conda` environments where no longer being automatically detected.
 
 -- by :user:`RonnyPfannschmidt`

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -373,8 +373,10 @@ def _in_venv(path: Path) -> bool:
 
     [https://peps.python.org/pep-0405/]
 
-    for regression protection we also check for conda environments that do not include pyenv.cfg yet
-    https://github.com/conda/conda/issues/13337 is the conda issue tracking adding pyenv.cfg
+    For regression protection we also check for conda environments that do not include pyenv.cfg yet -- 
+    https://github.com/conda/conda/issues/13337 is the conda issue tracking adding pyenv.cfg.
+    
+    Checking for the `conda-meta/history` file per https://github.com/pytest-dev/pytest/issues/12652#issuecomment-2246336902.
 
     """
     try:

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -373,9 +373,9 @@ def _in_venv(path: Path) -> bool:
 
     [https://peps.python.org/pep-0405/]
 
-    For regression protection we also check for conda environments that do not include pyenv.cfg yet -- 
+    For regression protection we also check for conda environments that do not include pyenv.cfg yet --
     https://github.com/conda/conda/issues/13337 is the conda issue tracking adding pyenv.cfg.
-    
+
     Checking for the `conda-meta/history` file per https://github.com/pytest-dev/pytest/issues/12652#issuecomment-2246336902.
 
     """

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -370,9 +370,18 @@ def pytest_runtestloop(session: Session) -> bool:
 def _in_venv(path: Path) -> bool:
     """Attempt to detect if ``path`` is the root of a Virtual Environment by
     checking for the existence of the pyvenv.cfg file.
-    [https://peps.python.org/pep-0405/]"""
+
+    [https://peps.python.org/pep-0405/]
+
+    for regression protection we also check for conda environments that do not include pyenv.cfg yet
+    https://github.com/conda/conda/issues/13337 is the conda issue tracking adding pyenv.cfg
+
+    """
     try:
-        return path.joinpath("pyvenv.cfg").is_file()
+        return (
+            path.joinpath("pyvenv.cfg").is_file()
+            or path.joinpath("conda-meta", "history").is_file()
+        )
     except OSError:
         return False
 


### PR DESCRIPTION
initially we accidentially detected conda environmnts by just testing too many files
after steamlining we no longer detected conda environments
now we explicitly detect conda environments and test for support

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
-->

@jezdez - i believe this should solve it more future-proof, thanks for the input

Closes #12652 