### PR TITLE
Obey verbosity level when printing 'msg' part of assertions

### DIFF
--- a/changelog/6682.bugfix.rst
+++ b/changelog/6682.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug where the verbosity levels where not being respected when printing the "msg" part of failed assertion (as in ``assert condition, msg``).

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -451,7 +451,7 @@ def _format_assertmsg(obj: object) -> str:
     # However in either case we want to preserve the newline.
     replaces = [("\n", "\n~"), ("%", "%%")]
     if not isinstance(obj, str):
-        obj = saferepr(obj)
+        obj = saferepr(obj, _get_maxsize_for_saferepr(util._config))
         replaces.append(("\\n", "\n~"))
 
     for r1, r2 in replaces:

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -341,6 +341,34 @@ class TestAssertionRewrite:
         assert result.ret == 1
         result.stdout.fnmatch_lines(["*AssertionError: b'ohai!'", "*assert False"])
 
+    def test_assertion_message_verbosity(self, pytester: Pytester) -> None:
+        """
+        Obey verbosity levels when printing the "message" part of assertions, when they are
+        non-strings (#6682).
+        """
+        pytester.makepyfile(
+            """
+            class LongRepr:
+
+                def __repr__(self):
+                    return "A" * 500
+
+            def test_assertion_verbosity():
+                assert False, LongRepr()
+            """
+        )
+        # Normal verbosity: assertion message gets abbreviated.
+        result = pytester.runpytest()
+        assert result.ret == 1
+        result.stdout.re_match_lines(
+            [r".*AssertionError: A+\.\.\.A+$", ".*assert False"]
+        )
+
+        # High-verbosity: do not abbreviate the assertion message.
+        result = pytester.runpytest("-vv")
+        assert result.ret == 1
+        result.stdout.re_match_lines([r".*AssertionError: A+$", ".*assert False"])
+
     def test_boolop(self) -> None:
         def f1() -> None:
             f = g = False


### PR DESCRIPTION
Seems like we just missed that case when more fine-grained verbosity levels were added.

Fixes #6682, #12307

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
