### PR TITLE
Pin towncrier due to incompatibility with sphinxcontrib-towncrier

### DIFF
--- a/doc/en/broken-dep-constraints.txt
+++ b/doc/en/broken-dep-constraints.txt
@@ -1,0 +1,6 @@
+# This file contains transitive dependencies that need to be pinned for some reason.
+# Eventually this file will be empty, but in this case keep it around for future use.
+
+# Pin towncrier temporarily due to incompatibility with sphinxcontrib-towncrier:
+# https://github.com/sphinx-contrib/sphinxcontrib-towncrier/issues/92
+towncrier!=24.7.0,!=24.7.1

--- a/doc/en/requirements.txt
+++ b/doc/en/requirements.txt
@@ -5,10 +5,6 @@ sphinx-removed-in>=0.2.0
 sphinx>=7
 sphinxcontrib-trio
 sphinxcontrib-svg2pdfconverter
-# Pin packaging because it no longer handles 'latest' version, which
-# is the version that is assigned to the docs.
-# See https://github.com/pytest-dev/pytest/pull/10578#issuecomment-1348249045.
-packaging
 furo
 sphinxcontrib-towncrier
 sphinx-issues

--- a/doc/en/requirements.txt
+++ b/doc/en/requirements.txt
@@ -1,3 +1,4 @@
+-c broken-dep-constraints.txt
 pluggy>=1.5.0
 pygments-pytest>=2.3.0
 sphinx-removed-in>=0.2.0


### PR DESCRIPTION
Pin `towncrier` until we find a solution to https://github.com/sphinx-contrib/sphinxcontrib-towncrier/issues/92.

The 2nd commit just removes an obsolete comment and explicit dependency (see commit message).