### PR TITLE
Remove quotes from example tmp_path_retention_policy

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -351,6 +351,7 @@ Rafal Semik
 Raquel Alegre
 Ravi Chandra
 Reagan Lee
+Rob Arrow
 Robert Holt
 Roberto Aldera
 Roberto Polli

--- a/changelog/12678.doc.rst
+++ b/changelog/12678.doc.rst
@@ -1,0 +1,1 @@
+Remove erroneous quotes from `tmp_path_retention_policy` example in docs.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1873,7 +1873,7 @@ passed multiple times. The expected format is ``name=value``. For example::
    .. code-block:: ini
 
         [pytest]
-        tmp_path_retention_policy = "all"
+        tmp_path_retention_policy = all
 
    Default: ``all``
 


### PR DESCRIPTION
Previously the docs contained an example for `tmp_path_retention_policy` which included quotes around the value. If the configuration was actually set with this value. The following error would be encountered

`INTERNALERROR> ValueError: tmp_path_retention_policy must be either all, failed, none. Current input: "all".`

This is because the value of the field was not being unwrapped from the quotes when parsed.

This commit removes the quotes from the example so that if used in the configuration file, no error will occur.

closes #12678
