### PR TITLE
docs: Revise `cache_dir` option section

### DIFF
--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1294,10 +1294,10 @@ passed multiple times. The expected format is ``name=value``. For example::
 
 .. confval:: cache_dir
 
-   Sets a directory where stores content of cache plugin. Default directory is
+   Sets the directory where the cache plugin's content is stored. Default directory is
    ``.pytest_cache`` which is created in :ref:`rootdir <rootdir>`. Directory may be
    relative or absolute path. If setting relative path, then directory is created
-   relative to :ref:`rootdir <rootdir>`. Additionally path may contain environment
+   relative to :ref:`rootdir <rootdir>`. Additionally, a path may contain environment
    variables, that will be expanded. For more information about cache plugin
    please refer to :ref:`cache_provider`.
 


### PR DESCRIPTION
## Description
I found myself pausing to decipher the following sentence in the pytest reference [docs](https://docs.pytest.org/en/8.3.x/reference/reference.html#confval-cache_dir), "Sets a directory where stores content of cache plugin.". With little context, the sentence is unclear and can easily interrupt a reader's _flow_. This PR introduces an update to revise the description for the `cache_dir` configuration options section to improve semantics and clarity.

### Decisions
> This section outlines notable considerations for developers/maintainers.
- This PRs branch is based on `pytest/main` from my forked checkout. Kindly advise me on how to cascade this change across all pytest doc versions (ie. `latest`, `stable`, `8.3.x`, etc).
- Alternative sentence **variations** to use to improve clarity:
  - Specifies the directory where the cache plugin's content is stored.
  - Sets a directory that stores the content of the cache plugin.
  - Sets the directory where the cache plugin's content will be stored.

## Testing
Tests run: `N/A`

## Additional

- **Here is a quick checklist that should be present in PRs.**

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

- ℹ**This change is trivial. Hence the following have been bypassed and left unchecked:**

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`.
- [ ] Add yourself to `AUTHORS` in alphabetical order.