### PR TITLE
Fix: pytest >=8.1.0 displays no diff for AssertionError with `--impor…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -412,6 +412,7 @@ Ted Xiao
 Terje Runde
 Thomas Grainger
 Thomas Hisch
+Tianyu Dongfang
 Tim Hoffmann
 Tim Strazny
 TJ Bruno

--- a/changelog/12659.bugfix.rst
+++ b/changelog/12659.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the issue of not displaying assertion failure differences when using the parameter ``--import-mode=importlib`` in pytest>=8.1.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -101,6 +101,16 @@ class AssertionRewritingHook(importlib.abc.MetaPathFinder, importlib.abc.Loader)
 
         # Type ignored because mypy is confused about the `self` binding here.
         spec = self._find_spec(name, path)  # type: ignore
+
+        if spec is None and path is not None:
+            # With --import-mode=importlib, PathFinder cannot find spec without modifying `sys.path`,
+            # causing inability to assert rewriting (#12659).
+            # At this point, try using the file path to find the module spec.
+            for _path_str in path:
+                spec = importlib.util.spec_from_file_location(name, _path_str)
+                if spec is not None:
+                    break
+
         if (
             # the import machinery could not find a file to import
             spec is None

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -621,7 +621,9 @@ def _import_module_using_spec(
     # Checking with sys.meta_path first in case one of its hooks can import this module,
     # such as our own assertion-rewrite hook.
     for meta_importer in sys.meta_path:
-        spec = meta_importer.find_spec(module_name, [str(module_location)])
+        spec = meta_importer.find_spec(
+            module_name, [str(module_location), str(module_path)]
+        )
         if spec_matches_module_path(spec, module_path):
             break
     else:

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -1372,6 +1372,42 @@ class TestNamespacePackages:
         )
         assert mod is mod2
 
+    def test_ns_multiple_levels_import_rewrite_assertions(
+        self,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
+        pytester: Pytester,
+    ) -> None:
+        """Check assert rewriting with `--import-mode=importlib` (#12659)."""
+        self.setup_directories(tmp_path, monkeypatch, pytester)
+        code = dedent("""
+        def test():
+            assert "four lights" == "five lights"
+        """)
+
+        # A case is in a subdirectory with an `__init__.py` file.
+        test_py = tmp_path / "src/dist2/com/company/calc/algo/test_demo.py"
+        test_py.write_text(code, encoding="UTF-8")
+
+        pkg_root, module_name = resolve_pkg_root_and_module_name(
+            test_py, consider_namespace_packages=True
+        )
+        assert (pkg_root, module_name) == (
+            tmp_path / "src/dist2",
+            "com.company.calc.algo.test_demo",
+        )
+
+        result = pytester.runpytest("--import-mode=importlib", test_py)
+
+        result.stdout.fnmatch_lines(
+            [
+                "E       AssertionError: assert 'four lights' == 'five lights'",
+                "E         *",
+                "E         - five lights*",
+                "E         + four lights",
+            ]
+        )
+
     @pytest.mark.parametrize("import_mode", ["prepend", "append", "importlib"])
     def test_incorrect_namespace_package(
         self,


### PR DESCRIPTION
closes #12659



<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
