### PR TITLE
docs: clarify `pytest_deselected`/`pytest_collection_modifyitems` usage

### DIFF
--- a/changelog/12663.doc.rst
+++ b/changelog/12663.doc.rst
@@ -1,0 +1,1 @@
+Clarify that the `pytest_deselected` hook should be called from `pytest_collection_modifyitems` hook implementations when items are deselected.

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -274,6 +274,12 @@ def pytest_collection_modifyitems(
     """Called after collection has been performed. May filter or re-order
     the items in-place.
 
+    When items are deselected (filtered out from ``items``),
+    the hook :hook:`pytest_deselected` must be called explicitly
+    providing the deselected items
+    (e.g. with ``config.hook.pytest_deselected(deselected_items)``)
+    to properly notify other plugins.
+
     :param session: The pytest session object.
     :param config: The pytest config object.
     :param items: List of item objects.
@@ -453,6 +459,11 @@ def pytest_collectreport(report: CollectReport) -> None:
 
 def pytest_deselected(items: Sequence[Item]) -> None:
     """Called for deselected test items, e.g. by keyword.
+
+    Note that this hook exposes two integration aspects to plugins:
+    - it can be *implemented* to be notified of deselected items
+    - it must to be *called* from :hook:`pytest_collection_modifyitems`
+      implementations when items are deselected (to properly notify other plugins).
 
     May be called multiple times.
 

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -276,9 +276,8 @@ def pytest_collection_modifyitems(
 
     When items are deselected (filtered out from ``items``),
     the hook :hook:`pytest_deselected` must be called explicitly
-    providing the deselected items
-    (e.g. with ``config.hook.pytest_deselected(deselected_items)``)
-    to properly notify other plugins.
+    with the deselected items to properly notify other plugins,
+    e.g. with ``config.hook.pytest_deselected(deselected_items)``.
 
     :param session: The pytest session object.
     :param config: The pytest config object.
@@ -460,9 +459,10 @@ def pytest_collectreport(report: CollectReport) -> None:
 def pytest_deselected(items: Sequence[Item]) -> None:
     """Called for deselected test items, e.g. by keyword.
 
-    Note that this hook exposes two integration aspects to plugins:
+    Note that this hook has two integration aspects for plugins:
+
     - it can be *implemented* to be notified of deselected items
-    - it must to be *called* from :hook:`pytest_collection_modifyitems`
+    - it must be *called* from :hook:`pytest_collection_modifyitems`
       implementations when items are deselected (to properly notify other plugins).
 
     May be called multiple times.


### PR DESCRIPTION
Addresses confusion around `pytest_deselected` usage flagged in #12663

- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.
- [x] Add yourself to `AUTHORS` in alphabetical order.
