### PR TITLE
MAINT: adding back Python 3.13 classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,6 +314,7 @@ ignore = "W009"
 
 [tool.pyproject-fmt]
 indent = 4
+max_supported_python = "3.13"
 
 [tool.pytest.ini_options]
 minversion = "2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Testing",
     "Topic :: Utilities",


### PR DESCRIPTION
This adds back the classifier as it was removed by accident, and I also added the config to avoid pyproject-fmt from removing it again.

 See https://github.com/pytest-dev/pytest/pull/12321#issuecomment-2311805015 for context.