### PR TITLE
Replaced `typing.Self` with `typing_extensions.Self`

### DIFF
--- a/changelog/12744.bugfix.rst
+++ b/changelog/12744.bugfix.rst
@@ -1,0 +1,1 @@
+Replaced `typing.Self` with `typing_extensions.Self` -- by :user:`Avasam`

--- a/changelog/12744.bugfix.rst
+++ b/changelog/12744.bugfix.rst
@@ -1,1 +1,1 @@
-Replaced `typing.Self` with `typing_extensions.Self` -- by :user:`Avasam`
+Fixed typing compatibility with Python 3.9 or less -- replaced `typing.Self` with `typing_extensions.Self` -- by :user:`Avasam`

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -44,7 +44,8 @@ from _pytest.warning_types import PytestWarning
 
 if TYPE_CHECKING:
     import doctest
-    from typing import Self
+
+    from typing_extensions import Self
 
 DOCTEST_REPORT_CHOICE_NONE = "none"
 DOCTEST_REPORT_CHOICE_CDIFF = "cdiff"

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -43,7 +43,7 @@ from _pytest.warning_types import PytestWarning
 
 
 if TYPE_CHECKING:
-    from typing import Self
+    from typing_extensions import Self
 
     # Imported here due to circular import.
     from _pytest.main import Session

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -78,7 +78,7 @@ from _pytest.warning_types import PytestUnhandledCoroutineWarning
 
 
 if TYPE_CHECKING:
-    from typing import Self
+    from typing_extensions import Self
 
 
 def pytest_addoption(parser: Parser) -> None:


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Fixes https://github.com/pytest-dev/pytest/pull/11916#issuecomment-2313758038

Importing `Self` from `typing` breaks the return type on Python 3.9 and under. You should be using `from typing_extension import Self` instead.

For example, the following code:
```py
def pytest_collect_file(file_path: pathlib.Path, parent: Node) -> CheckdocsItem | None:
    if file_path.name not in project_files:
        return None
    return CheckdocsItem.from_parent(parent, name='project')
```
Will error with `Returning Any from function declared to return "CheckdocsItem | None"  [no-any-return]` on 3.8 & 3.9, but pass on 3.10+ Which can only be worked around by disabling the error entirely in mypy, or doing:
```py
def pytest_collect_file(file_path: pathlib.Path, parent: Node) -> CheckdocsItem | None:
    if file_path.name not in project_files:
        return None
    if sys.version_info >= (3, 10):
        return CheckdocsItem.from_parent(parent, name='project')
    else:
        return cast(CheckdocsItem, CheckdocsItem.from_parent(parent, name='project'))
```
