### PR TITLE
Use oldest supported Python in mypy pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
     -   id: mypy
         files: ^(src/|testing/|scripts/)
         args: []
+        language_version: "3.8"
         additional_dependencies:
           - iniconfig>=1.1.0
           - attrs>=19.2.0

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -49,7 +49,7 @@ from _pytest.warning_types import PytestWarning
 
 
 if TYPE_CHECKING:
-    from typing import Self
+    from typing_extensions import Self
 
     from _pytest.fixtures import FixtureManager
 

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -167,7 +167,7 @@ def pytest_runtest_call(item: Item) -> None:
         del sys.last_value
         del sys.last_traceback
         if sys.version_info >= (3, 12, 0):
-            del sys.last_exc
+            del sys.last_exc  # type:ignore[attr-defined]
     except AttributeError:
         pass
     try:
@@ -177,7 +177,7 @@ def pytest_runtest_call(item: Item) -> None:
         sys.last_type = type(e)
         sys.last_value = e
         if sys.version_info >= (3, 12, 0):
-            sys.last_exc = e
+            sys.last_exc = e  # type:ignore[attr-defined]
         assert e.__traceback__ is not None
         # Skip *this* frame
         sys.last_traceback = e.__traceback__.tb_next

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -1030,7 +1030,7 @@ def test_store_except_info_on_error() -> None:
     assert sys.last_type is IndexError
     assert isinstance(sys.last_value, IndexError)
     if sys.version_info >= (3, 12, 0):
-        assert isinstance(sys.last_exc, IndexError)
+        assert isinstance(sys.last_exc, IndexError)  # type:ignore[attr-defined]
 
     assert sys.last_value.args[0] == "TEST"
     assert sys.last_traceback


### PR DESCRIPTION
Follow up to #12744, this ensures type checking works at the oldest Python version supported by pytest.
