### PR TITLE
[doc] Fix minor typo in example/parametrize.rst

### DIFF
--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -686,5 +686,5 @@ For example:
             assert (6 / example_input) == e
 
 In the example above, the first three test cases should run without any
-exceptions, while the fourth should raise a``ZeroDivisionError`` exception,
+exceptions, while the fourth should raise a ``ZeroDivisionError`` exception,
 which is expected by pytest.


### PR DESCRIPTION
A space is needed for ``ZeroDivisionError`` to render as teletype.

I don't have 3.12 on this computer so I did not build the docs locally to test.  However, compare renderings of `ZeroDivisionError` with current main

https://github.com/pytest-dev/pytest/blob/main/doc/en/example/parametrize.rst#parametrizing-conditional-raising

and this pr

https://github.com/svenevs/pytest/blob/fix/docs-example-parametrize-minor-typo/doc/en/example/parametrize.rst#parametrizing-conditional-raising

Thanks for the docs, I definitely want to start adding some test id's for what I'm working on (current output = chaos xD).  Was easy to find in the docs! :slightly_smiling_face:


