### PR TITLE
Added mention of Databricks fixture plugin for PyTest

### DIFF
--- a/scripts/update-plugin-list.py
+++ b/scripts/update-plugin-list.py
@@ -66,6 +66,7 @@ ADDITIONAL_PROJECTS = {  # set of additional projects to consider as plugins
     "logot",
     "nuts",
     "flask_fixture",
+    "databricks-labs-pytester",
 }
 
 


### PR DESCRIPTION
Adding it as a `ADDITIONAL_PROJECTS`, because our naming conventions can't fit `pytest-` as a prefix.

See:
- https://github.com/databrickslabs/pytester
- https://pypi.org/project/databricks-labs-pytester/