### PR TITLE
Clarify that `capfdbinary` captures on a filedescriptor level.

### DIFF
--- a/doc/en/how-to/capture-stdout-stderr.rst
+++ b/doc/en/how-to/capture-stdout-stderr.rst
@@ -149,10 +149,9 @@ the ``readouterr`` method.
 
 
 
-If the code under test writes non-textual data, you can capture this using
-the ``capfdbinary`` fixture which instead returns ``bytes`` from
-the ``readouterr`` method.  The ``capfdbinary`` fixture operates on the
-filedescriptor level.
+If the code under test writes non-textual data on a filedescriptor level, you
+can capture this using the ``capfdbinary`` fixture which instead returns
+``bytes`` from the ``readouterr`` method.
 
 
 

--- a/doc/en/how-to/capture-stdout-stderr.rst
+++ b/doc/en/how-to/capture-stdout-stderr.rst
@@ -107,7 +107,7 @@ Accessing captured output from a test function
 ---------------------------------------------------
 
 The :fixture:`capsys`, :fixture:`capsysbinary`, :fixture:`capfd`, and :fixture:`capfdbinary` fixtures
-allow access to ``stdout``/``stderr`` output created during test execution. 
+allow access to ``stdout``/``stderr`` output created during test execution.
 
 Here is an example test function that performs some output related checks:
 
@@ -141,7 +141,7 @@ If you want to capture at the file descriptor level you can use
 the :fixture:`capfd` fixture which offers the exact
 same interface but allows to also capture output from
 libraries or subprocesses that directly write to operating
-system level output streams (FD1 and FD2). Similarly to :fixture:`capsysbinary`, :fixture:`capfdbinary` can be 
+system level output streams (FD1 and FD2). Similarly to :fixture:`capsysbinary`, :fixture:`capfdbinary` can be
 used to capture ``bytes`` at the file descriptor level.
 
 

--- a/doc/en/how-to/capture-stdout-stderr.rst
+++ b/doc/en/how-to/capture-stdout-stderr.rst
@@ -145,8 +145,8 @@ system level output streams (FD1 and FD2). Similarly to :fixture:`capsysbinary`,
 used to capture ``bytes`` at the file descriptor level.
 
 
-To temporarily disable capture within a test, both :fixture:`capsys`
-and :fixture:`capfd` have a ``disabled()`` method that can be used
+To temporarily disable capture within a test, the capture fixtures
+have a ``disabled()`` method that can be used
 as a context manager, disabling capture inside the ``with`` block:
 
 .. code-block:: python

--- a/doc/en/how-to/capture-stdout-stderr.rst
+++ b/doc/en/how-to/capture-stdout-stderr.rst
@@ -106,9 +106,10 @@ of the failing function and hide the other one:
 Accessing captured output from a test function
 ---------------------------------------------------
 
-The ``capsys``, ``capsysbinary``, ``capfd``, and ``capfdbinary`` fixtures
-allow access to stdout/stderr output created during test execution.  Here is
-an example test function that performs some output related checks:
+The :fixture:`capsys`, :fixture:`capsysbinary`, :fixture:`capfd`, and :fixture:`capfdbinary` fixtures
+allow access to ``stdout``/``stderr`` output created during test execution. 
+
+Here is an example test function that performs some output related checks:
 
 .. code-block:: python
 
@@ -125,39 +126,27 @@ an example test function that performs some output related checks:
 The ``readouterr()`` call snapshots the output so far -
 and capturing will be continued.  After the test
 function finishes the original streams will
-be restored.  Using ``capsys`` this way frees your
+be restored.  Using :fixture:`capsys` this way frees your
 test from having to care about setting/resetting
 output streams and also interacts well with pytest's
 own per-test capturing.
 
-If you want to capture on filedescriptor level you can use
-the ``capfd`` fixture which offers the exact
-same interface but allows to also capture output from
-libraries or subprocesses that directly write to operating
-system level output streams (FD1 and FD2).
-
-
-
 The return value from ``readouterr`` changed to a ``namedtuple`` with two attributes, ``out`` and ``err``.
 
-
-
-If the code under test writes non-textual data, you can capture this using
-the ``capsysbinary`` fixture which instead returns ``bytes`` from
+If the code under test writes non-textual data (``bytes``), you can capture this using
+the :fixture:`capsysbinary` fixture which instead returns ``bytes`` from
 the ``readouterr`` method.
 
+If you want to capture at the file descriptor level you can use
+the :fixture:`capfd` fixture which offers the exact
+same interface but allows to also capture output from
+libraries or subprocesses that directly write to operating
+system level output streams (FD1 and FD2). Similarly to :fixture:`capsysbinary`, :fixture:`capfdbinary` can be 
+used to capture ``bytes`` at the file descriptor level.
 
 
-
-If the code under test writes non-textual data on a filedescriptor level, you
-can capture this using the ``capfdbinary`` fixture which instead returns
-``bytes`` from the ``readouterr`` method.
-
-
-
-
-To temporarily disable capture within a test, both ``capsys``
-and ``capfd`` have a ``disabled()`` method that can be used
+To temporarily disable capture within a test, both :fixture:`capsys`
+and :fixture:`capfd` have a ``disabled()`` method that can be used
 as a context manager, disabling capture inside the ``with`` block:
 
 .. code-block:: python


### PR DESCRIPTION
This paragraph and the previous paragraph had the same opening clause, making it seem like they were duplicates. I added some text making it clearer that this paragraph is about filedescriptors.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
