### PR TITLE
Fix `disable_test_id_escaping_and_forfeit_all_rights_to_community_support` option when using `pytest.param(..., id="...")`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -406,6 +406,7 @@ Sviatoslav Sydorenko
 Sylvain Marié
 Tadek Teleżyński
 Takafumi Arakaki
+Takumi Otani
 Taneli Hukkinen
 Tanvi Mehta
 Tanya Agarwal

--- a/changelog/9037.bugfix.rst
+++ b/changelog/9037.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed an issue that ``disable_test_id_escaping_and_forfeit_all_rights_to_community_support`` option doesn't work with ``pytest.param(..., id="...")`` in parametrized tests.
+apply test id escaping opt out as configured by the ``disable_test_id_escaping_and_forfeit_all_rights_to_community_support`` option to ids from  ``pytest.param(..., id="...")`` in parametrized tests.

--- a/changelog/9037.bugfix.rst
+++ b/changelog/9037.bugfix.rst
@@ -1,1 +1,1 @@
-apply test id escaping opt out as configured by the ``disable_test_id_escaping_and_forfeit_all_rights_to_community_support`` option to ids from  ``pytest.param(..., id="...")`` in parametrized tests.
+Honor :confval:`disable_test_id_escaping_and_forfeit_all_rights_to_community_support` when escaping ids in parametrized tests.

--- a/changelog/9037.bugfix.rst
+++ b/changelog/9037.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue that ``disable_test_id_escaping_and_forfeit_all_rights_to_community_support`` option doesn't work with ``pytest.param(..., id="...")`` in parametrized tests.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1332,6 +1332,29 @@ passed multiple times. The expected format is ``name=value``. For example::
         console_output_style = classic
 
 
+.. confval:: disable_test_id_escaping_and_forfeit_all_rights_to_community_support
+
+   .. versionadded:: 4.4
+
+   pytest by default escapes any non-ascii characters used in unicode strings
+   for the parametrization because it has several downsides.
+   If however you would like to use unicode strings in parametrization
+   and see them in the terminal as is (non-escaped), use this option
+   in your ``pytest.ini``:
+
+   .. code-block:: ini
+
+       [pytest]
+       disable_test_id_escaping_and_forfeit_all_rights_to_community_support = True
+
+   Keep in mind however that this might cause unwanted side effects and
+   even bugs depending on the OS used and plugins currently installed,
+   so use it at your own risk.
+
+   Default: ``False``.
+
+   See :ref:`parametrizemark`.
+
 .. confval:: doctest_encoding
 
 

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -21,7 +21,6 @@ from typing import Union
 import warnings
 
 from .._code import getfslineno
-from ..compat import ascii_escaped
 from ..compat import NOTSET
 from ..compat import NotSetType
 from _pytest.config import Config
@@ -92,7 +91,6 @@ class ParameterSet(NamedTuple):
         if id is not None:
             if not isinstance(id, str):
                 raise TypeError(f"Expected id to be a string, got {type(id)}: {id!r}")
-            id = ascii_escaped(id)
         return cls(values, marks, id)
 
     @classmethod

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -924,7 +924,7 @@ class IdMaker:
         for idx, parameterset in enumerate(self.parametersets):
             if parameterset.id is not None:
                 # ID provided directly - pytest.param(..., id="...")
-                yield parameterset.id
+                yield _ascii_escaped_by_config(parameterset.id, self.config)
             elif self.ids and idx < len(self.ids) and self.ids[idx] is not None:
                 # ID provided in the IDs list - parametrize(..., ids=[...]).
                 yield self._idval_from_value_required(self.ids[idx], idx)

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -635,13 +635,6 @@ class TestMetafunc:
             def __init__(self, config):
                 self.config = config
 
-            @property
-            def hook(self):
-                return self
-
-            def pytest_make_parametrize_id(self, **kw):
-                pass
-
             def getini(self, name):
                 return self.config[name]
 

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -625,6 +625,44 @@ class TestMetafunc:
             ).make_unique_parameterset_ids()
             assert result == [expected]
 
+    def test_idmaker_with_param_id_and_config(self) -> None:
+        """Unit test for expected behavior to create ids with pytest.param(id=...) and
+        disable_test_id_escaping_and_forfeit_all_rights_to_community_support
+        option (#9037).
+        """
+
+        class MockConfig:
+            def __init__(self, config):
+                self.config = config
+
+            @property
+            def hook(self):
+                return self
+
+            def pytest_make_parametrize_id(self, **kw):
+                pass
+
+            def getini(self, name):
+                return self.config[name]
+
+        option = "disable_test_id_escaping_and_forfeit_all_rights_to_community_support"
+
+        values: list[tuple[Any, str]] = [
+            (MockConfig({option: True}), "ação"),
+            (MockConfig({option: False}), "a\\xe7\\xe3o"),
+        ]
+        for config, expected in values:
+            result = IdMaker(
+                ("a",),
+                [pytest.param("string", id="ação")],
+                None,
+                None,
+                config,
+                None,
+                None,
+            ).make_unique_parameterset_ids()
+            assert result == [expected]
+
     def test_idmaker_duplicated_empty_str(self) -> None:
         """Regression test for empty strings parametrized more than once (#11563)."""
         result = IdMaker(


### PR DESCRIPTION
Closes #9037 .
The additional test cases were implemented in almost the same way as the existing similar test cases.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.
- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.
- [X] Add yourself to `AUTHORS` in alphabetical order.
