### PR TITLE
💅 Migrate `coveragerc` to use `source_pkgs`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,9 +1,11 @@
 [paths]
 _site-packages-to-src-mapping =
-  src/
-  */lib/python*/site-packages/
-  */pypy*/site-packages/
-  *\Lib\site-packages\
+  src
+  */src
+  *\src
+  */lib/pypy*/site-packages
+  */lib/python*/site-packages
+  *\Lib\site-packages
 
 [report]
 skip_covered = true

--- a/.coveragerc
+++ b/.coveragerc
@@ -8,16 +8,16 @@ source = src/
 skip_covered = True
 show_missing = True
 exclude_lines =
-    \#\s*pragma: no cover
-    ^\s*raise NotImplementedError\b
-    ^\s*return NotImplemented\b
-    ^\s*assert False(,|$)
-    ^\s*assert_never\(
+  \#\s*pragma: no cover
+  ^\s*raise NotImplementedError\b
+  ^\s*return NotImplemented\b
+  ^\s*assert False(,|$)
+  ^\s*assert_never\(
 
-    ^\s*if TYPE_CHECKING:
-    ^\s*@overload( |$)
+  ^\s*if TYPE_CHECKING:
+  ^\s*@overload( |$)
 
-    ^\s*@pytest\.mark\.xfail
+  ^\s*@pytest\.mark\.xfail
 
 [run]
 include =

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,7 @@
+[html]
+show_contexts = true
+skip_covered = false
+
 [paths]
 _site-packages-to-src-mapping =
   src

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [paths]
-source = src/
+source =
+  src/
   */lib/python*/site-packages/
   */pypy*/site-packages/
   *\Lib\site-packages\

--- a/.coveragerc
+++ b/.coveragerc
@@ -5,8 +5,8 @@ source = src/
   *\Lib\site-packages\
 
 [report]
-skip_covered = True
-show_missing = True
+skip_covered = true
+show_missing = true
 exclude_lines =
   \#\s*pragma: no cover
   ^\s*raise NotImplementedError\b

--- a/.coveragerc
+++ b/.coveragerc
@@ -33,15 +33,15 @@ cover_pylib = false
 # https://coverage.rtfd.io/en/latest/contexts.html#dynamic-contexts
 # `dynamic_context` conflicts with `pytest-cov` if set here
 dynamic_context = test_function
-include =
-  src/*
-  testing/*
-  */lib/python*/site-packages/_pytest/*
-  */lib/python*/site-packages/pytest.py
-  */pypy*/site-packages/_pytest/*
-  */pypy*/site-packages/pytest.py
-  *\Lib\site-packages\_pytest\*
-  *\Lib\site-packages\pytest.py
+omit =
+  test_eggs.py
+  test_ham.py
+  test_spam.py
 parallel = true
 plugins =
 relative_files = true
+source =
+  .
+source_pkgs =
+  _pytest
+  pytest

--- a/.coveragerc
+++ b/.coveragerc
@@ -29,6 +29,10 @@ exclude_also =
 
 [run]
 branch = true
+cover_pylib = false
+# https://coverage.rtfd.io/en/latest/contexts.html#dynamic-contexts
+# `dynamic_context` conflicts with `pytest-cov` if set here
+dynamic_context = test_function
 include =
   src/*
   testing/*
@@ -39,3 +43,5 @@ include =
   *\Lib\site-packages\_pytest\*
   *\Lib\site-packages\pytest.py
 parallel = true
+plugins =
+relative_files = true

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,16 +1,3 @@
-[run]
-include =
-  src/*
-  testing/*
-  */lib/python*/site-packages/_pytest/*
-  */lib/python*/site-packages/pytest.py
-  */pypy*/site-packages/_pytest/*
-  */pypy*/site-packages/pytest.py
-  *\Lib\site-packages\_pytest\*
-  *\Lib\site-packages\pytest.py
-parallel = 1
-branch = 1
-
 [paths]
 source = src/
   */lib/python*/site-packages/
@@ -31,3 +18,16 @@ exclude_lines =
     ^\s*@overload( |$)
 
     ^\s*@pytest\.mark\.xfail
+
+[run]
+include =
+  src/*
+  testing/*
+  */lib/python*/site-packages/_pytest/*
+  */lib/python*/site-packages/pytest.py
+  */pypy*/site-packages/_pytest/*
+  */pypy*/site-packages/pytest.py
+  *\Lib\site-packages\_pytest\*
+  *\Lib\site-packages\pytest.py
+parallel = 1
+branch = 1

--- a/.coveragerc
+++ b/.coveragerc
@@ -13,6 +13,7 @@ _site-packages-to-src-mapping =
 
 [report]
 skip_covered = true
+skip_empty = true
 show_missing = true
 exclude_also =
   \#\s*pragma: no cover

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [paths]
-source =
+_site-packages-to-src-mapping =
   src/
   */lib/python*/site-packages/
   */pypy*/site-packages/

--- a/.coveragerc
+++ b/.coveragerc
@@ -10,7 +10,7 @@ _site-packages-to-src-mapping =
 [report]
 skip_covered = true
 show_missing = true
-exclude_lines =
+exclude_also =
   \#\s*pragma: no cover
   ^\s*raise NotImplementedError\b
   ^\s*return NotImplemented\b

--- a/.coveragerc
+++ b/.coveragerc
@@ -23,6 +23,7 @@ exclude_lines =
   ^\s*@pytest\.mark\.xfail
 
 [run]
+branch = true
 include =
   src/*
   testing/*
@@ -32,5 +33,4 @@ include =
   */pypy*/site-packages/pytest.py
   *\Lib\site-packages\_pytest\*
   *\Lib\site-packages\pytest.py
-parallel = 1
-branch = 1
+parallel = true


### PR DESCRIPTION
With https://github.com/pytest-dev/pytest/pull/12875/files#r1796219568 I noticed that `src/pytest` is not displayed in Codecov. I've since discovered that the configuration of Coveragepy is quite ancient, and here's my attempt to update it in line with other projects I got. It starts using modern settings with clearer semantics. It also updates the consistency of the config structure.