### PR TITLE
Fix ambiguous docstring of pytest.Config

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -118,6 +118,7 @@ Dave Hunt
 David Díaz-Barquero
 David Mohr
 David Paul Röthlisberger
+David Peled
 David Szotten
 David Vierra
 Daw-Ran Liou

--- a/changelog/10558.doc.rst
+++ b/changelog/10558.doc.rst
@@ -1,0 +1,1 @@
+Fix ambiguous docstring of `pytest.Config.getoption`.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1699,9 +1699,10 @@ class Config:
 
         :param name: Name of the option.  You may also specify
             the literal ``--OPT`` option instead of the "dest" option name.
-        :param default: Default value if no option of that name exists.
-        :param skip: If True, raise pytest.skip if option does not exists
-            or has a None value.
+        :param default: Fallback value if no option of that name is declared.
+             Note this parameter will be ignored when the option is declared even if the option's value is None.
+        :param skip: If True, raise pytest.skip if option is undeclared or has a None value.
+            Note that even if True, if a default was specified it will be returned instead of a skip.
         """
         name = self._opt2dest.get(name, name)
         try:


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
For context see #10558.