### PR TITLE
Fix pdb selftests on Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,7 +147,7 @@ jobs:
           - name: "ubuntu-py313"
             python: "3.13-dev"
             os: ubuntu-latest
-            tox_env: "py313"
+            tox_env: "py313-pexpect"
             use_coverage: true
           - name: "ubuntu-pypy3"
             python: "pypy-3.9"

--- a/changelog/12497.contrib.rst
+++ b/changelog/12497.contrib.rst
@@ -1,0 +1,1 @@
+Fixed two failing pdb-related tests on Python 3.13.

--- a/testing/test_debugging.py
+++ b/testing/test_debugging.py
@@ -771,9 +771,13 @@ class TestPDB:
             x = 5
         """
         )
+        if sys.version_info[:2] >= (3, 13):
+            break_line = "pytest.set_trace()"
+        else:
+            break_line = "x = 5"
         child = pytester.spawn(f"{sys.executable} {p1}")
-        child.expect("x = 5")
-        child.expect("Pdb")
+        child.expect_exact(break_line)
+        child.expect_exact("Pdb")
         child.sendeof()
         self.flush(child)
 
@@ -788,9 +792,13 @@ class TestPDB:
                 pass
         """
         )
+        if sys.version_info[:2] >= (3, 13):
+            break_line = "pytest.set_trace()"
+        else:
+            break_line = "x = 5"
         child = pytester.spawn_pytest(str(p1))
-        child.expect("x = 5")
-        child.expect("Pdb")
+        child.expect_exact(break_line)
+        child.expect_exact("Pdb")
         child.sendeof()
         self.flush(child)
 


### PR DESCRIPTION
Python 3.13 makes pdb break on the breakpoint() call, rather than on the next line:
https://docs.python.org/3/whatsnew/3.13.html#pdb

Also runs the pdb tests on Python 3.13 in CI.
See #12884 for a more proper solution for that.

Fixes #12497

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
