### PR TITLE
Improve pytest.Config.getoption docstring

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -118,6 +118,7 @@ Dave Hunt
 David Díaz-Barquero
 David Mohr
 David Paul Röthlisberger
+David Peled
 David Szotten
 David Vierra
 Daw-Ran Liou

--- a/changelog/10558.doc.rst
+++ b/changelog/10558.doc.rst
@@ -1,0 +1,1 @@
+Fix ambiguous docstring of `pytest.Config.getoption`.

--- a/changelog/10558.doc.rst
+++ b/changelog/10558.doc.rst
@@ -1,1 +1,1 @@
-Fix ambiguous docstring of `pytest.Config.getoption`.
+Fix ambiguous docstring of :func:`pytest.Config.getoption`.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1699,9 +1699,10 @@ class Config:
 
         :param name: Name of the option.  You may also specify
             the literal ``--OPT`` option instead of the "dest" option name.
-        :param default: Default value if no option of that name exists.
-        :param skip: If True, raise pytest.skip if option does not exists
-            or has a None value.
+        :param default: Fallback value if no option of that name is declared.
+             Note this parameter will be ignored when the option is declared even if the option's value is None.
+        :param skip: If True, raise pytest.skip if option is undeclared or has a None value.
+            Note that even if True, if a default was specified it will be returned instead of a skip.
         """
         name = self._opt2dest.get(name, name)
         try:

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1697,12 +1697,12 @@ class Config:
     def getoption(self, name: str, default=notset, skip: bool = False):
         """Return command line option value.
 
-        :param name: Name of the option.  You may also specify
+        :param name: Name of the option. You may also specify
             the literal ``--OPT`` option instead of the "dest" option name.
-        :param default: Fallback value if no option of that name is declared.
-             Note this parameter will be ignored when the option is declared even if the option's value is None.
-        :param skip: If True, raise pytest.skip if option is undeclared or has a None value.
-            Note that even if True, if a default was specified it will be returned instead of a skip.
+        :param default: Fallback value if no option of that name is **declared** via :hook:`pytest_addoption`.
+            Note this parameter will be ignored when the option is **declared** even if the option's value is ``None``.
+        :param skip: If ``True``, raise :func:`pytest.skip` if option is undeclared or has a ``None`` value.
+            Note that even if ``True``, if a default was specified it will be returned instead of a skip.
         """
         name = self._opt2dest.get(name, name)
         try:


### PR DESCRIPTION
Also add tests to cement the current behavior.

Supersedes #12879 (I did not have permissions to push an additional commit to it).