### PR TITLE
adds `keep_ignores` kwarg to `pytest.warns`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,7 @@ merlinux GmbH, Germany, office at merlinux eu
 Contributors include::
 
 Aaron Coleman
+Aaron Zolnai-Lucas
 Abdeali JK
 Abdelrahman Elbehery
 Abhijeet Kasurde

--- a/changelog/11933.improvement.rst
+++ b/changelog/11933.improvement.rst
@@ -1,0 +1,1 @@
+Now :func:`pytest.warns` can take an optional boolean keyword argument ``keep_ignores`` to keep existing ignore filters active when used as a context manager.

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -404,6 +404,18 @@ class TestWarns:
                 with pytest.warns(FutureWarning, match=r"must be \d+$"):
                     warnings.warn("value must be 42", UserWarning)
 
+    def test_keep_ignores(self) -> None:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", category=UserWarning)
+            with pytest.warns(UserWarning, keep_ignores=True):
+                warnings.warn("keep this warning", UserWarning)
+
+        with pytest.raises(pytest.fail.Exception, match="DID NOT WARN"):
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", message="ignore this")
+                with pytest.warns(UserWarning, keep_ignores=True):
+                    warnings.warn("ignore this warning", FutureWarning)
+
     def test_one_from_multiple_warns(self) -> None:
         with pytest.warns():
             with pytest.raises(pytest.fail.Exception, match="DID NOT WARN"):

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -416,6 +416,12 @@ class TestWarns:
                 with pytest.warns(UserWarning, keep_ignores=True):
                     warnings.warn("ignore this warning", FutureWarning)
 
+        with pytest.raises(pytest.fail.Exception, match="DID NOT WARN"):
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", message="ignore this")
+                with pytest.warns(UserWarning, keep_ignores=True):
+                    warnings.warn("ignore this warning", UserWarning)
+
     def test_one_from_multiple_warns(self) -> None:
         with pytest.warns():
             with pytest.raises(pytest.fail.Exception, match="DID NOT WARN"):


### PR DESCRIPTION
workaround for #11933, but also an improved functionality in its own right. The user may set the keyword argument `keep_ignores` for `pytest.warns` to avoid catching warnings which were filtered out, in pytest configuration or otherwise. Relevant [issue comment](https://github.com/pytest-dev/pytest/issues/11933#issuecomment-2416946436)

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.
- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.
- [X] Add yourself to `AUTHORS` in alphabetical order.
