### PR TITLE
Docs: Add `EXCLUDE_PROJECTS` option to `update-plugin-list.py` (#12901)

### DIFF
--- a/changelog/12901.doc.rst
+++ b/changelog/12901.doc.rst
@@ -1,0 +1,1 @@
+Improved ``update-plugin-list.py`` program by adding ``EXCLUDE_PROJECTS`` mechanism

--- a/scripts/update-plugin-list.py
+++ b/scripts/update-plugin-list.py
@@ -68,6 +68,7 @@ ADDITIONAL_PROJECTS = {  # set of additional projects to consider as plugins
     "flask_fixture",
     "databricks-labs-pytester",
 }
+EXCLUDE_PROJECTS: set[str] = set()
 
 
 def escape_rst(text: str) -> str:
@@ -116,6 +117,7 @@ def pytest_plugin_projects_from_pypi(session: CachedSession) -> dict[str, int]:
         if (
             (name := p["name"]).startswith(("pytest-", "pytest_"))
             or name in ADDITIONAL_PROJECTS
+            and name not in EXCLUDE_PROJECTS
         )
     }
 

--- a/scripts/update-plugin-list.py
+++ b/scripts/update-plugin-list.py
@@ -68,7 +68,9 @@ ADDITIONAL_PROJECTS = {  # set of additional projects to consider as plugins
     "flask_fixture",
     "databricks-labs-pytester",
 }
-EXCLUDE_PROJECTS: set[str] = set()
+EXCLUDE_PROJECTS = {
+    "pytest-crate",
+}
 
 
 def escape_rst(text: str) -> str:


### PR DESCRIPTION
Hi @nicoddemus,

this patch aims to allow excluding specified packages from being listed on the [Pytest Plugin List] page, coming from a proposal where you responded positively to.

- GH-12901

With kind regards,
Andreas.

[Pytest Plugin List]: https://docs.pytest.org/en/latest/reference/plugin_list.html
