### PR TITLE
[minor] avoid test failing if the working path contains the string 'error'

### DIFF
--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -2996,7 +2996,7 @@ class TestFixtureMarker:
             *3 passed*
         """
         )
-        result.stdout.no_fnmatch_line("*error*")
+        assert result.ret == 0
 
     def test_fixture_finalizer(self, pytester: Pytester) -> None:
         pytester.makeconftest(


### PR DESCRIPTION
Very minor irk, I got this test failing because I created a git worktree that contained the string "error".