### PR TITLE
Refactor: simplify get_scope_node by using a mapping dictionary

### DIFF
--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -135,22 +135,35 @@ def get_scope_package(
 
 
 def get_scope_node(node: nodes.Node, scope: Scope) -> nodes.Node | None:
+    """
+    Returns the parent node of the specified scope for a given node.
+
+    Based on the provided scope (Function, Class, Module, Package, or Session),
+    this function retrieves the appropriate parent node using the `getparent()` method.
+    A mapping of scope types to their corresponding pytest classes is used to determine
+    which parent node to return.
+
+    Parameters:
+    - node (nodes.Node): The node for which the parent node is being retrieved.
+    - scope (Scope): The scope level (e.g., Function, Class, Module) for which the parent node is sought.
+
+    Returns:
+    - nodes.Node | None: The parent node corresponding to the specified scope, or None if not found.
+    """
     import _pytest.python
 
-    if scope is Scope.Function:
-        # Type ignored because this is actually safe, see:
-        # https://github.com/python/mypy/issues/4717
-        return node.getparent(nodes.Item)  # type: ignore[type-abstract]
-    elif scope is Scope.Class:
-        return node.getparent(_pytest.python.Class)
-    elif scope is Scope.Module:
-        return node.getparent(_pytest.python.Module)
-    elif scope is Scope.Package:
-        return node.getparent(_pytest.python.Package)
-    elif scope is Scope.Session:
-        return node.getparent(_pytest.main.Session)
-    else:
-        assert_never(scope)
+    scope_map = {
+        "function": nodes.Item,
+        "class": _pytest.python.Class,
+        "module": _pytest.python.Module,
+        "package": _pytest.python.Package,
+        "session": _pytest.main.Session,
+    }
+
+    parent_class = scope_map.get(scope.value)
+    # Type ignored because this is actually safe, see:
+    # https://github.com/python/mypy/issues/4717
+    return node.getparent(parent_class)  # type: ignore[arg-type]
 
 
 def getfixturemarker(obj: object) -> FixtureFunctionMarker | None:


### PR DESCRIPTION
### **PR Description: Refactor get_scope_node to use a mapping dictionary**
This PR refactors the get_scope_node function to improve its readability and maintainability. Previously, the function used a multi-level if-elif structure to match scope values with corresponding classes. I replaced this structure with a dictionary (scope_map) that maps each Scope to its corresponding class, reducing repetition and simplifying the code. Additionally, I also added a docstring with a clear explanation of the function's purpose.

### **_Key improvements:_**

- Reduction of repetition: The repeated calls to getparent() for different scopes were replaced with a single call using a mapped value from the scope_map dictionary.
- Better readability: Using a dictionary makes it clearer which scope corresponds to which class, and makes it easier to add new scope mappings if necessary.
- This should make the code easier to understand and extend while maintaining the same functionality.
- A docstring explaining the purpose of the function