### PR TITLE
Prevent `readline` from bugging out when the `editline` backend is used

### DIFF
--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -80,6 +80,20 @@ def _colorama_workaround() -> None:
             pass
 
 
+def _readline_workaround() -> None:
+    """Ensure :mod:`readline` is imported as it fails otherwise when the
+    ``editline`` (``libedit``) backend is used.
+
+    Since Python 3.13, :mod:`readline` is imported at the root of the
+    :mod:`pdb` module, as a side effect of importing :mod:`rlcompleter`.
+    """
+    if sys.version_info >= (3, 13):
+        try:
+            import readline  # noqa: F401
+        except ImportError:
+            pass
+
+
 def _windowsconsoleio_workaround(stream: TextIO) -> None:
     """Workaround for Windows Unicode console handling.
 
@@ -141,6 +155,7 @@ def pytest_load_initial_conftests(early_config: Config) -> Generator[None]:
     if ns.capture == "fd":
         _windowsconsoleio_workaround(sys.stdout)
     _colorama_workaround()
+    _readline_workaround()
     pluginmanager = early_config.pluginmanager
     capman = CaptureManager(ns.capture)
     pluginmanager.register(capman, "capturemanager")


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Fixes https://github.com/pytest-dev/pytest/issues/12888.

Seems like having `readline` (or `rlcompleter`, which imports `readline`) imported at the root of the `pdb` module (as it is on 3.13) introduces the issue, but I'm not sure why. Perhaps the `libedit` backend tries to read something from stdin on startup? (Because running `pytest -s` works).
