### PR TITLE
add assertion to FixtureLookupError.formatrepr

### DIFF
--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -805,6 +805,15 @@ class FixtureLookupError(LookupError):
         stack = [self.request._pyfuncitem.obj]
         stack.extend(map(lambda x: x.func, self.fixturestack))
         msg = self.msg
+        # This function currently makes an assumption that a non-None msg means we
+        # have a non-empty `self.fixturestack`. This is currently true, but if
+        # somebody at some point want to extend the use of FixtureLookupError to
+        # new cases it might break.
+        # Add the assert to make it clearer to developer that this will fail, otherwise
+        # it crashes because `fspath` does not get set due to `stack` being empty.
+        assert (
+            self.msg is None or self.fixturestack
+        ), "formatrepr assumptions broken, rewrite it to handle it"
         if msg is not None:
             # The last fixture raise an error, let's present
             # it at the requesting side.


### PR DESCRIPTION
Broken out from #12930 where I originally was going to raise a `FixtureLookupError` but noticed that `formatrepr` crashed. I haven't researched thoroughly why it's currently making these assumptions, but it *will* crash if this assert doesn't hold - so thought I'd at least save some developer time in case anybody tries to use `FixtureLookupError` again (e.g. when #12930 turns into an error)