### PR TITLE
support IPython DummyMod as __main__ module for pytest fixtures

### DIFF
--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1736,7 +1736,11 @@ class FixtureManager:
 
         module_types = (types.ModuleType,)
         # support IPython's DummyMod if the module containing it has been imported
-        if (DummyMod := getattr(sys.modules.get("IPython.core.interactiveshell"), "DummyMod", None)) is not None:
+        if (
+            DummyMod := getattr(
+                sys.modules.get("IPython.core.interactiveshell"), "DummyMod", None
+            )
+        ) is not None:
             module_types += (DummyMod,)
         # Avoid accessing `@property` (and other descriptors) when iterating fixtures.
         if not safe_isclass(holderobj) and not isinstance(holderobj, module_types):

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1734,8 +1734,11 @@ class FixtureManager:
         if holderobj in self._holderobjseen:
             return
 
+        module_types = (types.ModuleType,)
+        if (DummyMod := getattr(sys.modules.get("IPython.core.interactiveshell"), "DummyMod", None)) is not None:
+            module_types += (DummyMod,)
         # Avoid accessing `@property` (and other descriptors) when iterating fixtures.
-        if not safe_isclass(holderobj) and not isinstance(holderobj, types.ModuleType):
+        if not safe_isclass(holderobj) and not isinstance(holderobj, module_types):
             holderobj_tp: object = type(holderobj)
         else:
             holderobj_tp = holderobj

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1735,6 +1735,7 @@ class FixtureManager:
             return
 
         module_types = (types.ModuleType,)
+        # support IPython's DummyMod if the module containing it has been imported
         if (DummyMod := getattr(sys.modules.get("IPython.core.interactiveshell"), "DummyMod", None)) is not None:
             module_types += (DummyMod,)
         # Avoid accessing `@property` (and other descriptors) when iterating fixtures.


### PR DESCRIPTION
This PR fixes a corner case when using ipytest with certain IPython environments. Some environments, such as Databricks, use an IPython feature where the user_ns of the interactive shell is specified ahead of time. Because this user_ns doubles as the main module's `__dict__`, the official module type cannot be used, since `__dict__` is a read-only attribute. To work around this, IPython uses a fake module type called `DummyMod` to handle this case. However, instances of `DummyMod` do not pass the isinstance check added in https://github.com/pytest-dev/pytest/commit/c6a529032231ccddd3040e8ab1a5a756eb9ea4a0. To fix, check if we've imported the module that contains `DummyMod`, and if so, add `DummyMod` to the isinstance check.

Test plan: verified manually.
