### PR TITLE
docs: Fix wrong statement about sys.modules with importlib import mode

### DIFF
--- a/doc/en/explanation/goodpractices.rst
+++ b/doc/en/explanation/goodpractices.rst
@@ -210,8 +210,8 @@ Note that this layout also works in conjunction with the ``src`` layout mentione
     to avoid surprises such as a test module getting imported twice.
 
     With ``--import-mode=importlib`` things are less convoluted because
-    pytest doesn't need to change ``sys.path`` or ``sys.modules``, making things
-    much less surprising.
+    pytest doesn't need to change ``sys.path``, making things much less
+    surprising.
 
 
 .. _which-import-mode:


### PR DESCRIPTION
Follow-up to #7870, see #12983.

cc @tadeu 