### PR TITLE
Fix `pytest.mark.usefixtures()` without arguments silently erroring

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -103,6 +103,7 @@ Cornelius Riemenschneider
 CrazyMerlyn
 Cristian Vera
 Cyrus Maden
+Daara Shaw
 Damian Skrzypczak
 Daniel Grana
 Daniel Hahler
@@ -209,6 +210,7 @@ Jeff Rackauckas
 Jeff Widman
 Jenni Rinker
 Jens Tröger
+Jiajun Xu
 John Eddie Ayson
 John Litborn
 John Towler

--- a/changelog/12426.improvement.rst
+++ b/changelog/12426.improvement.rst
@@ -1,1 +1,1 @@
-A warning in now issued when @pytest.mark.usefixtures() is used without specifying any fixtures. Previously, empty usefixtures markers were silently ignored.
+A warning is now issued when @pytest.mark.usefixtures() is used without specifying any fixtures. Previously, empty usefixtures markers were silently ignored.

--- a/changelog/12426.improvement.rst
+++ b/changelog/12426.improvement.rst
@@ -1,1 +1,1 @@
-A warning is now issued when @pytest.mark.usefixtures() is used without specifying any fixtures. Previously, empty usefixtures markers were silently ignored.
+A warning is now issued when :ref:`pytest.mark.usefixtures ref` is used without specifying any fixtures. Previously, empty usefixtures markers were silently ignored.

--- a/changelog/12426.improvement.rst
+++ b/changelog/12426.improvement.rst
@@ -1,0 +1,1 @@
+A warning in now issued when @pytest.mark.usefixtures() is used without specifying any fixtures. Previously, empty usefixtures markers were silently ignored.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -71,6 +71,7 @@ from _pytest.scope import _ScopeName
 from _pytest.scope import HIGH_SCOPES
 from _pytest.scope import Scope
 from _pytest.warning_types import PytestRemovedIn9Warning
+from _pytest.warning_types import PytestWarning
 
 
 if sys.version_info < (3, 11):
@@ -1564,7 +1565,9 @@ class FixtureManager:
         """Return the names of usefixtures fixtures applicable to node."""
         for marker_node, mark in node.iter_markers_with_node(name="usefixtures"):
             if not mark.args:
-                marker_node.warn(Warning("usefixtures() is empty, so it has no effect"))
+                marker_node.warn(
+                    PytestWarning("usefixtures() without arguments has no effect")
+                )
             yield from mark.args
 
     def getfixtureclosure(

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1566,7 +1566,9 @@ class FixtureManager:
         for marker_node, mark in node.iter_markers_with_node(name="usefixtures"):
             if not mark.args:
                 marker_node.warn(
-                    PytestWarning("usefixtures() without arguments has no effect")
+                    PytestWarning(
+                        f"usefixtures() in {node.nodeid} without arguments has no effect"
+                    )
                 )
             yield from mark.args
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1567,6 +1567,8 @@ class FixtureManager:
     def _getusefixturesnames(self, node: nodes.Item) -> Iterator[str]:
         """Return the names of usefixtures fixtures applicable to node."""
         for mark in node.iter_markers(name="usefixtures"):
+            if not mark.args:
+                warnings.warn(f"Warning: empty usefixtures in {node.name}.")
             yield from mark.args
 
     def getfixtureclosure(

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1569,7 +1569,7 @@ class FixtureManager:
         for marker_node, mark in node.iter_markers_with_node(name="usefixtures"):
             if not mark.args:
                 location = getattr(marker_node, "location", "unknown location")
-                node.warn(Warning(f"empty usefixtures in {node.name} from {location}."))
+                node.warn(Warning(f"usefixtures() is empty, so it has no effect"))
             yield from mark.args
 
     def getfixtureclosure(

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1568,8 +1568,7 @@ class FixtureManager:
         """Return the names of usefixtures fixtures applicable to node."""
         for marker_node, mark in node.iter_markers_with_node(name="usefixtures"):
             if not mark.args:
-                location = getattr(marker_node, "location", "unknown location")
-                node.warn(Warning(f"usefixtures() is empty, so it has no effect"))
+                marker_node.warn(Warning("usefixtures() is empty, so it has no effect"))
             yield from mark.args
 
     def getfixtureclosure(

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1566,9 +1566,10 @@ class FixtureManager:
 
     def _getusefixturesnames(self, node: nodes.Item) -> Iterator[str]:
         """Return the names of usefixtures fixtures applicable to node."""
-        for mark in node.iter_markers(name="usefixtures"):
+        for marker_node, mark in node.iter_markers_with_node(name="usefixtures"):
             if not mark.args:
-                warnings.warn(f"Warning: empty usefixtures in {node.name}.")
+                location = getattr(marker_node, "location", "unknown location")
+                node.warn(Warning(f"empty usefixtures in {node.name} from {location}."))
             yield from mark.args
 
     def getfixtureclosure(

--- a/testing/plugins_integration/pytest.ini
+++ b/testing/plugins_integration/pytest.ini
@@ -3,4 +3,5 @@ addopts = --strict-markers
 asyncio_mode = strict
 filterwarnings =
     error::pytest.PytestWarning
+    ignore:usefixtures.* without arguments has no effect:pytest.PytestWarning
     ignore:.*.fspath is deprecated and will be replaced by .*.path.*:pytest.PytestDeprecationWarning

--- a/testing/plugins_integration/pytest.ini
+++ b/testing/plugins_integration/pytest.ini
@@ -3,5 +3,4 @@ addopts = --strict-markers
 asyncio_mode = strict
 filterwarnings =
     error::pytest.PytestWarning
-    ignore:usefixtures.* without arguments has no effect:pytest.PytestWarning
     ignore:.*.fspath is deprecated and will be replaced by .*.path.*:pytest.PytestDeprecationWarning

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1448,7 +1448,8 @@ class TestFixtureUsages:
         )
         result = pytester.runpytest()
         result.stdout.fnmatch_lines(
-            "*PytestWarning: usefixtures() without arguments has no effect"
+            "*PytestWarning: usefixtures() in test_empty_usefixtures_marker.py::test_one"
+            " without arguments has no effect"
         )
 
     def test_usefixtures_ini(self, pytester: Pytester) -> None:

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1435,6 +1435,19 @@ class TestFixtureUsages:
         reprec = pytester.inline_run()
         reprec.assertoutcome(passed=2)
 
+    def test_empty_usefixtures_marker(self, pytester: Pytester) -> None:
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.usefixtures()
+            def test_one():
+                assert 1 == 1
+        """
+        )
+        reprec = pytester.inline_run()
+        reprec.assertoutcome(failed=1)
+
     def test_usefixtures_ini(self, pytester: Pytester) -> None:
         pytester.makeini(
             """

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1436,6 +1436,7 @@ class TestFixtureUsages:
         reprec.assertoutcome(passed=2)
 
     def test_empty_usefixtures_marker(self, pytester: Pytester) -> None:
+        """Empty usefixtures() marker issues a warning (#12439)."""
         pytester.makepyfile(
             """
             import pytest
@@ -1447,7 +1448,7 @@ class TestFixtureUsages:
         )
         result = pytester.runpytest()
         result.stdout.fnmatch_lines(
-            "*Warning: usefixtures() is empty, so it has no effect"
+            "*PytestWarning: usefixtures() without arguments has no effect"
         )
 
     def test_usefixtures_ini(self, pytester: Pytester) -> None:

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1445,8 +1445,10 @@ class TestFixtureUsages:
                 assert 1 == 1
         """
         )
-        reprec = pytester.inline_run()
-        reprec.assertoutcome(failed=1)
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines(
+            "*Warning: usefixtures() is empty, so it has no effect"
+        )
 
     def test_usefixtures_ini(self, pytester: Pytester) -> None:
         pytester.makeini(


### PR DESCRIPTION
Follow up to #12439.

Closes #12426
Closes #12439
