### PR TITLE
Remove 'pip' command hint from release announcement

### DIFF
--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -168,4 +168,4 @@ Both automatic and manual processes described above follow the same steps from t
    * python-announce-list@python.org (all releases)
    * testing-in-python@lists.idyll.org (only major/minor releases)
 
-   And announce it on `Twitter <https://twitter.com/>`_ with the ``#pytest`` hashtag.
+   And announce it on `Twitter <https://twitter.com/>`_ and `BlueSky <https://bsky.app/>`_ with the ``#pytest`` hashtag.

--- a/scripts/release.patch.rst
+++ b/scripts/release.patch.rst
@@ -3,9 +3,7 @@ pytest-{version}
 
 pytest {version} has just been released to PyPI.
 
-This is a bug-fix release, being a drop-in replacement. To upgrade::
-
-  pip install --upgrade pytest
+This is a bug-fix release, being a drop-in replacement.
 
 The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
 


### PR DESCRIPTION
While of course `pip` is still the most used tool to install packages, currently there are a lot of alternatives (`poetry`, `uv`, etc), so it feels a bit dated to suggest `pip install --upgrade` directly on the release announcement.

Also, all the other release notes do not mention `pip` too, so it makes sense to remove it from the patch release announcement.
