### PR TITLE
Fix parametrized mark over staticmethod decorator

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -150,6 +150,7 @@ Eric Yuan
 Erik Aronesty
 Erik Hasse
 Erik M. Bray
+Ethan Wass
 Evan Kepner
 Evgeny Seliverstov
 Fabian Sturm

--- a/changelog/12863.bugfix.rst
+++ b/changelog/12863.bugfix.rst
@@ -1,1 +1,1 @@
-Fix :func:`pytest.mark.parametrize <pytest.mark.xfail>` marker placed above `@staticmethod`
+Fix :ref:`pytest.mark.parametrize <pytest.mark.parametrize ref>` marker placed above `@staticmethod`

--- a/changelog/12863.bugfix.rst
+++ b/changelog/12863.bugfix.rst
@@ -1,0 +1,1 @@
+Fix :func:`pytest.mark.parametrize` marker placed above `@staticmethod`

--- a/changelog/12863.bugfix.rst
+++ b/changelog/12863.bugfix.rst
@@ -1,1 +1,1 @@
-Fix :ref:`pytest.mark.parametrize <pytest.mark.parametrize ref>` marker placed above `@staticmethod`
+Fix applying markers, including :ref:`pytest.mark.parametrize <pytest.mark.parametrize ref>` when placed above `@staticmethod` or `@classmethod`.

--- a/changelog/12863.bugfix.rst
+++ b/changelog/12863.bugfix.rst
@@ -1,1 +1,1 @@
-Fix :func:`pytest.mark.parametrize` marker placed above `@staticmethod`
+Fix :func:`pytest.mark.parametrize <pytest.mark.xfail>` marker placed above `@staticmethod`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,7 +334,7 @@ disable = [
 
 [tool.codespell]
 ignore-words-list = "afile,asend,asser,assertio,feld,hove,ned,noes,notin,paramete,parth,socio-economic,tesults,varius,wil"
-skip = "*/plugin_list.rst"
+skip = "AUTHORS,*/plugin_list.rst"
 write-changes = true
 
 [tool.check-wheel-contents]

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -349,7 +349,7 @@ class MarkDecorator:
         if args and not kwargs:
             func = args[0]
             is_class = inspect.isclass(func)
-            marking_func = func.__func__ if isinstance(func, staticmethod) else func
+            marking_func = getattr(func, "__func__", func)
             if len(args) == 1 and (istestfunc(marking_func) or is_class):
                 store_mark(marking_func, self.mark, stacklevel=3)
                 return func

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -350,7 +350,11 @@ class MarkDecorator:
             func = args[0]
             is_class = inspect.isclass(func)
             if len(args) == 1 and (istestfunc(func) or is_class):
-                store_mark(func, self.mark, stacklevel=3)
+                if isinstance(func, staticmethod):
+                    # If the marker decorates a staticmethod, store on the test func
+                    store_mark(func.__func__, self.mark, stacklevel=3)
+                else:
+                    store_mark(func, self.mark, stacklevel=3)
                 return func
         return self.with_args(*args, **kwargs)
 

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -349,9 +349,13 @@ class MarkDecorator:
         if args and not kwargs:
             func = args[0]
             is_class = inspect.isclass(func)
-            marking_func = getattr(func, "__func__", func)
-            if len(args) == 1 and (istestfunc(marking_func) or is_class):
-                store_mark(marking_func, self.mark, stacklevel=3)
+            # For staticmethods/classmethods, the marks are eventually fetched from the
+            # function object, not the descriptor, so unwrap.
+            unwrapped_func = func
+            if isinstance(func, (staticmethod, classmethod)):
+                unwrapped_func = func.__func__
+            if len(args) == 1 and (istestfunc(unwrapped_func) or is_class):
+                store_mark(unwrapped_func, self.mark, stacklevel=3)
                 return func
         return self.with_args(*args, **kwargs)
 

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -349,12 +349,9 @@ class MarkDecorator:
         if args and not kwargs:
             func = args[0]
             is_class = inspect.isclass(func)
-            if len(args) == 1 and (istestfunc(func) or is_class):
-                if isinstance(func, staticmethod):
-                    # If the marker decorates a staticmethod, store on the test func
-                    store_mark(func.__func__, self.mark, stacklevel=3)
-                else:
-                    store_mark(func, self.mark, stacklevel=3)
+            marking_func = func.__func__ if isinstance(func, staticmethod) else func
+            if len(args) == 1 and (istestfunc(marking_func) or is_class):
+                store_mark(marking_func, self.mark, stacklevel=3)
                 return func
         return self.with_args(*args, **kwargs)
 

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1226,3 +1226,20 @@ def test_mark_fixture_order_mro(pytester: Pytester):
     )
     result = pytester.runpytest(foo)
     result.assert_outcomes(passed=1)
+
+
+# @pytest.mark.issue("https://github.com/pytest-dev/pytest/issues/12863")
+def test_mark_parametrize_over_staticmethod(pytester: Pytester) -> None:
+    foo = pytester.makepyfile(
+        """
+        import pytest
+
+        class TestClass:
+            @pytest.mark.parametrize("value", [1, 2])
+            @staticmethod
+            def test_foo(value: int):
+                assert value in [1, 2]
+        """
+    )
+    result = pytester.runpytest(foo)
+    result.assert_outcomes(passed=2)

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1228,7 +1228,6 @@ def test_mark_fixture_order_mro(pytester: Pytester):
     result.assert_outcomes(passed=1)
 
 
-# @pytest.mark.issue("https://github.com/pytest-dev/pytest/issues/12863")
 def test_mark_parametrize_over_staticmethod(pytester: Pytester) -> None:
     """Check that applying marks works as intended on classmethods and staticmethods.
 

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1230,7 +1230,11 @@ def test_mark_fixture_order_mro(pytester: Pytester):
 
 # @pytest.mark.issue("https://github.com/pytest-dev/pytest/issues/12863")
 def test_mark_parametrize_over_staticmethod(pytester: Pytester) -> None:
-    foo = pytester.makepyfile(
+    """Check that applying marks works as intended on classmethods and staticmethods.
+
+    Regression test for #12863.
+    """
+    pytester.makepyfile(
         """
         import pytest
 
@@ -1240,11 +1244,21 @@ def test_mark_parametrize_over_staticmethod(pytester: Pytester) -> None:
             def test_classmethod_wrapper(cls, value: int):
                 assert value in [1, 2]
 
+            @classmethod
+            @pytest.mark.parametrize("value", [1, 2])
+            def test_classmethod_wrapper_on_top(cls, value: int):
+                assert value in [1, 2]
+
             @pytest.mark.parametrize("value", [1, 2])
             @staticmethod
             def test_staticmethod_wrapper(value: int):
                 assert value in [1, 2]
+
+            @staticmethod
+            @pytest.mark.parametrize("value", [1, 2])
+            def test_staticmethod_wrapper_on_top(value: int):
+                assert value in [1, 2]
         """
     )
-    result = pytester.runpytest(foo)
-    result.assert_outcomes(passed=4)
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=8)

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1236,10 +1236,15 @@ def test_mark_parametrize_over_staticmethod(pytester: Pytester) -> None:
 
         class TestClass:
             @pytest.mark.parametrize("value", [1, 2])
+            @classmethod
+            def test_classmethod_wrapper(cls, value: int):
+                assert value in [1, 2]
+
+            @pytest.mark.parametrize("value", [1, 2])
             @staticmethod
-            def test_foo(value: int):
+            def test_staticmethod_wrapper(value: int):
                 assert value in [1, 2]
         """
     )
     result = pytester.runpytest(foo)
-    result.assert_outcomes(passed=2)
+    result.assert_outcomes(passed=4)


### PR DESCRIPTION
Fixed parametrized markers over staticmethod and classmethod decorators.
closes #12863 

An interesting thing about this solution and python (<3.9 vs 3.10<) compatibility:
In python3.10, they changed `@staticmethod` and `@classmethod` decorators to inherit method attributes.
Before that version, functions wrapped with them did not return true for  `callable()` func, so it failed tests for py39 and succeeded for py310. 
[link to changelog](https://docs.python.org/3/whatsnew/3.10.html#other-language-changes)


For example: 
```python
from pytest import mark

class TestA:
    @mark.parametrize("value", [1, 2])
    @staticmethod
    def test_foo(value: int):
        """Didn't work. Now fixed :)"""

    @pytest.mark.parametrize("value", [1, 2])
    @classmethod
    def test_bar(cls, value: int):
        """Didn't work. Now fixed :)"""

    @staticmethod
    @mark.parametrize("value", [1, 2])
    def test_baz(value: int):
        """Works"""
```