### PR TITLE
fix `AttributeError`  crash when using `--import-mode=importlib`

### DIFF
--- a/changelog/13026.bugfix.rst
+++ b/changelog/13026.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed ``AttributeError``  crash when using ``--import-mode=importlib`` when top-level directory same name as the standard library.
+Fixed :class:`AttributeError`  crash when using ``--import-mode=importlib`` when top-level directory same name as another module of the standard library.

--- a/changelog/13026.bugfix.rst
+++ b/changelog/13026.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``AttributeError``  crash when using ``--import-mode=importlib`` when top-level directory same name as the standard library.

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -668,7 +668,7 @@ def _import_module_using_spec(
     parent_module: ModuleType | None = None
     if parent_module_name:
         parent_module = sys.modules.get(parent_module_name)
-        if parent_module is None:
+        if parent_module is None or not hasattr(parent_module, "__path__"):
             # Get parent_location based on location, get parent_path based on path.
             if module_path.name == "__init__.py":
                 # If the current module is in a package,

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -668,7 +668,10 @@ def _import_module_using_spec(
     parent_module: ModuleType | None = None
     if parent_module_name:
         parent_module = sys.modules.get(parent_module_name)
-        if parent_module is None or not hasattr(parent_module, "__path__"):
+        # If the parent_module lacks the `__path__` attribute, AttributeError when finding a submodule's spec,
+        # requiring re-import according to the path.
+        need_reimport = not hasattr(parent_module, "__path__")
+        if parent_module is None or need_reimport:
             # Get parent_location based on location, get parent_path based on path.
             if module_path.name == "__init__.py":
                 # If the current module is in a package,


### PR DESCRIPTION
closes #13026 .


- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits.
- [X] Create a new changelog file in the `changelog` folder.


Only parent modules with the `__path__` attribute can be used by the `find_spec` function, and most of the standard library does not meet this condition.


https://github.com/python/cpython/blob/3.9/Lib/importlib/_bootstrap_external.py#L1223
```python
   def _find_parent_path_names(self):
        """Returns a tuple of (parent-module-name, parent-path-attr-name)"""
        parent, dot, me = self._name.rpartition('.')
        if dot == '':
            # This is a top-level module. sys.path contains the parent path.
            return 'sys', 'path'
        # Not a top-level module. parent-module.__path__ contains the
        #  parent path.
        return parent, '__path__'
```


So this PR adds a condition check.

