### PR TITLE
Fix for warning test arguments with default values

### DIFF
--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -173,6 +173,21 @@ def get_default_arg_names(function: Callable[..., Any]) -> tuple[str, ...]:
         and p.default is not Parameter.empty
     )
 
+# def check_default_arguments(func, nodeid):
+#     """Check for default arguments in the function and issue warnings."""
+#     sig = inspect.signature(func)
+#     for param in sig.parameters.values():
+#         if param.default is not param.empty:
+#             function_name = func.__name__
+#             async_default_arg_warn(nodeid, function_name, param)
+
+def get_default_name_val(function: Callable[..., Any]) -> dict[str, Any]:
+    sig = signature(function)
+    return {
+        param.name: param.default
+        for param in sig.parameters.values()
+        if param.default is not Parameter.empty
+    }
 
 _non_printable_ascii_translate_table = {
     i: f"\\x{i:02x}" for i in range(128) if i not in range(32, 127)

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -173,13 +173,6 @@ def get_default_arg_names(function: Callable[..., Any]) -> tuple[str, ...]:
         and p.default is not Parameter.empty
     )
 
-# def check_default_arguments(func, nodeid):
-#     """Check for default arguments in the function and issue warnings."""
-#     sig = inspect.signature(func)
-#     for param in sig.parameters.values():
-#         if param.default is not param.empty:
-#             function_name = func.__name__
-#             async_default_arg_warn(nodeid, function_name, param)
 
 def get_default_name_val(function: Callable[..., Any]) -> dict[str, Any]:
     sig = signature(function)
@@ -188,6 +181,7 @@ def get_default_name_val(function: Callable[..., Any]) -> dict[str, Any]:
         for param in sig.parameters.values()
         if param.default is not Parameter.empty
     }
+
 
 _non_printable_ascii_translate_table = {
     i: f"\\x{i:02x}" for i in range(128) if i not in range(32, 127)

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -143,22 +143,9 @@ def async_fail(nodeid: str) -> None:
     fail(msg, pytrace=False)
 
 
-def async_default_arg_warn(nodeid: str, function_name, param) -> None:
-    msg = (
-        "Test function '" + function_name + "' has a default argument '" + param.name + "=" + str(param.default) + "'.\n"
-    )
-    warnings.simplefilter("always", PytestDefaultArgumentWarning)
-    warnings.warn(PytestDefaultArgumentWarning(msg))
-
-            
 @hookimpl(trylast=True)
 def pytest_pyfunc_call(pyfuncitem: Function) -> object | None:
     testfunction = pyfuncitem.obj
-    sig = inspect.signature(testfunction)
-    for param in sig.parameters.values():
-        if param.default is not param.empty:
-            function_name = testfunction.__name__
-            async_default_arg_warn(pyfuncitem.nodeid, function_name, param)
 
     if is_async_function(testfunction):
         async_fail(pyfuncitem.nodeid)

--- a/src/_pytest/warning_types.py
+++ b/src/_pytest/warning_types.py
@@ -44,6 +44,13 @@ class PytestCollectionWarning(PytestWarning):
     __module__ = "pytest"
 
 
+@final
+class PytestDefaultArgumentWarning(PytestWarning):
+    """Warning emitted when a test function has default arguments."""
+    
+    __module__ = "pytest"
+
+
 class PytestDeprecationWarning(PytestWarning, DeprecationWarning):
     """Warning class for features that will be removed in a future version."""
 

--- a/testing/test_default_params.py
+++ b/testing/test_default_params.py
@@ -1,0 +1,52 @@
+from _pytest.pytester import Pytester
+
+def test_no_default_argument(pytester: Pytester) -> None:
+    pytester.makepyfile(
+        """
+        def test_with_default_param(param):
+            assert param == 42
+        """
+    )
+    result = pytester.runpytest()
+    result.stdout.fnmatch_lines([
+        "*fixture 'param' not found*"
+    ])
+
+
+def test_default_argument_warning(pytester: Pytester) -> None:
+    pytester.makepyfile(
+        """
+        def test_with_default_param(param=42):
+            assert param == 42
+        """
+    )
+    result = pytester.runpytest()
+    result.stdout.fnmatch_lines([
+        "*PytestDefaultArgumentWarning: Test function 'test_with_default_param' has a default argument 'param=42'.*"
+    ])
+
+
+def test_no_warning_for_no_default_param(pytester: Pytester) -> None:
+    pytester.makepyfile(
+        """
+        def test_without_default_param(param):
+            assert param is None
+        """
+    )
+    result = pytester.runpytest()
+    assert "PytestDefaultArgumentWarning" not in result.stdout.str()
+    
+
+def test_warning_for_multiple_default_params(pytester: Pytester) -> None:
+    pytester.makepyfile(
+        """
+        def test_with_multiple_defaults(param1=42, param2="default"):
+            assert param1 == 42
+            assert param2 == "default"
+        """
+    )
+    result = pytester.runpytest()
+    result.stdout.fnmatch_lines([
+        "*PytestDefaultArgumentWarning: Test function 'test_with_multiple_defaults' has a default argument 'param1=42'.*",
+        "*PytestDefaultArgumentWarning: Test function 'test_with_multiple_defaults' has a default argument 'param2=default'.*"
+    ])


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

- Closes #12693