### PR TITLE
Issues a warning when a function is not collected as a test case just because it uses `@pytest.fixture` (#12989)

### DIFF
--- a/changelog/12989.improvement.rst
+++ b/changelog/12989.improvement.rst
@@ -1,1 +1,1 @@
-A warning is now issued when tests incorrectly use :class:`@pytest.fixture`, whereas this was previously silently ignored.
+Issues a warning when a function is not collected as a test case just because it uses :py:func:`@pytest.fixture`

--- a/changelog/12989.improvement.rst
+++ b/changelog/12989.improvement.rst
@@ -1,0 +1,1 @@
+A warning is now issued when tests incorrectly use :class:`@pytest.fixture`, whereas this was previously silently ignored.

--- a/changelog/12989.improvement.rst
+++ b/changelog/12989.improvement.rst
@@ -1,1 +1,8 @@
-Issues a warning when a function is not collected as a test case just because it uses :py:func:`@pytest.fixture`
+Issues a warning when a function is not collected as a test case just because it uses :py:func:`pytest.fixture`.
+This helps beginners distinguish fixtures from tests; experienced users can ignore the warning via config.
+
+.. code-block:: ini
+
+    [pytest]
+    filterwarnings =
+        ignore:.*becomes a fixture.*:pytest.PytestCollectionWarning

--- a/doc/en/explanation/fixtures.rst
+++ b/doc/en/explanation/fixtures.rst
@@ -88,6 +88,65 @@ prefer.  You can also start out from existing :ref:`unittest.TestCase
 style <unittest.TestCase>`.
 
 
+Distinguishing fixtures and tests
+------------------------------------
+
+Fixtures and tests may seem similar: both are functions (or methods) and both can utilize fixtures.
+However, there is a fundamental difference:
+
+- **Tests** are the leading role.
+  They can actively use :ref:`mark <mark>` and fixtures.
+
+- **Fixtures** are supporting role.
+  They cannot use mark or tests and only be used directly or indirectly by test cases.
+
+
+Two classic traps:
+
+
+- Will not fail, because adding any tags to the fixture is invalid
+
+.. code-block:: python
+
+    import warnings
+
+
+    @pytest.fixture
+    @pytest.mark.filterwarnings("error")  # fixture cannot use mark
+    def server():
+        print("fixture is running!")
+
+
+    def test_foo(server):
+        warnings.warn(UserWarning("api v1, should use functions from v2"))
+
+
+
+- No code will execute, because the ``test_foo`` becomes a fixture after using ``@pytest.fixture``
+
+
+.. code-block:: python
+
+    @pytest.fixture
+    def server():
+        print("fixture is running!")
+
+
+    @pytest.fixture  # turn test case into fixtures
+    def test_foo(server):
+        warnings.warn(UserWarning("api v1, should use functions from v2"))
+
+
+
+.. versionadded:: 8.0
+
+Applying a mark to a fixture function now issues a warning and will become an error in pytest 9.0.
+
+
+.. versionadded:: 8.4
+
+Issues a warning when a function is not collected as a test case just because it uses ``@pytest.fixture``
+
 
 Fixture errors
 --------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -403,6 +403,7 @@ filterwarnings = [
     "ignore:VendorImporter\\.find_spec\\(\\) not found; falling back to find_module\\(\\):ImportWarning",
     # https://github.com/pytest-dev/execnet/pull/127
     "ignore:isSet\\(\\) is deprecated, use is_set\\(\\) instead:DeprecationWarning",
+    "ignore:.*becomes a fixture.*:pytest.PytestCollectionWarning",
 ]
 pytester_example_dir = "testing/example_scripts"
 markers = [

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -354,6 +354,16 @@ class PyCollector(PyobjMixin, nodes.Collector, abc.ABC):
 
     def istestfunction(self, obj: object, name: str) -> bool:
         if self.funcnamefilter(name) or self.isnosetest(obj):
+            if isinstance(obj, fixtures.FixtureFunctionDefinition):
+                self.warn(
+                    PytestCollectionWarning(
+                        f"cannot collect test function {name!r},"
+                        f"because it used the '@pytest.fixture' than becomes a fixture "
+                        f"(from: {self.nodeid})"
+                    )
+                )
+                return False
+
             if isinstance(obj, (staticmethod, classmethod)):
                 # staticmethods and classmethods need to be unwrapped.
                 obj = safe_getattr(obj, "__func__", False)

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -783,6 +783,26 @@ class TestFunction:
             ]
         )
 
+    @pytest.mark.filterwarnings("default::UserWarning")
+    def test_function_used_fixture(self, pytester: Pytester):
+        pytester.makeini("[pytest]")
+        pytester.makepyfile(
+            """
+            import pytest
+            @pytest.fixture
+            def test_function():
+                pass
+        """
+        )
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines(
+            [
+                "collected 0 items",
+                "*== warnings summary ==*",
+                "*because it used the '@pytest.fixture' than becomes a fixture*",
+            ]
+        )
+
 
 class TestSorting:
     def test_check_equality(self, pytester: Pytester) -> None:


### PR DESCRIPTION
close #12989 .

- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits.
- [x] Create a new changelog file in the `changelog` folder



A function is declared as a test case using the convention of the `test` prefix in its name ， or as a fixture using the `pytest.fixture` decorator.

When both are used simultaneously, it is not possible to have both a test case and a fixture.

So a warning is issued to remind the user: no test case, only a fixture.

Example

```python
import pytest

@pytest.fixture
def test_function():
    pass


```

```
(venv) C:\Users\administrator\pytest\demo>pytest
============================= test session starts ==============================
platform win32 -- Python 3.12.0, pytest-8.4.0.dev262+gf160963c4.d20241211, pluggy-1.5.0
rootdir: C:\Users\administrator\pytest\demo
configfile: pytest.ini
plugins: hypothesis-6.111.0, xdist-3.6.1
collected 0 items                                                               

=============================== warnings summary =============================== 
test_aa.py:1
  C:\Users\administrator\pytest\demo\test_aa.py:1: PytestCollectionWarning: ca
nnot collect test function 'test_function',because it used the '@pytest.fixture' than becomes a fixture (from: test_aa.py)
    import warnings

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================== 1 warning in 0.26s ==============================
```
