### PR TITLE
Add --force-short-summary option and extend sequence printing with -vv

### DIFF
--- a/changelog/11777.bugfix.rst
+++ b/changelog/11777.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed issue where sequences were still being shortened even with ``-vv`` verbosity.

--- a/changelog/12713.feature.rst
+++ b/changelog/12713.feature.rst
@@ -1,0 +1,3 @@
+New `--force-short-summary` option to force condensed summary output regardless of verbosity level.
+
+This lets users still see condensed summary output of failures for quick reference in log files from job outputs, being especially useful if non-condensed output is very verbose.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING
 
 from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE
 from _pytest._io.saferepr import saferepr
+from _pytest._io.saferepr import saferepr_unlimited
 from _pytest._version import version
 from _pytest.assertion import util
 from _pytest.config import Config
@@ -433,6 +434,8 @@ def _saferepr(obj: object) -> str:
         return obj.__name__
 
     maxsize = _get_maxsize_for_saferepr(util._config)
+    if not maxsize:
+        return saferepr_unlimited(obj).replace("\n", "\\n")
     return saferepr(obj, maxsize=maxsize).replace("\n", "\\n")
 
 

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -162,6 +162,13 @@ def pytest_addoption(parser: Parser) -> None:
         help="Do not fold skipped tests in short summary.",
     )
     group._addoption(
+        "--force-short-summary",
+        action="store_true",
+        dest="force_short_summary",
+        default=False,
+        help="Force condensed summary output regardless of verbosity level.",
+    )
+    group._addoption(
         "-q",
         "--quiet",
         action=MoreQuietAction,
@@ -1500,7 +1507,9 @@ def _get_line_with_reprcrash_message(
     except AttributeError:
         pass
     else:
-        if running_on_ci() or config.option.verbose >= 2:
+        if (
+            running_on_ci() or config.option.verbose >= 2
+        ) and not config.option.force_short_summary:
             msg = f" - {msg}"
         else:
             available_width = tw.fullwidth - line_width

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -2617,6 +2617,35 @@ def test_short_summary_with_verbose(
     )
 
 
+def test_full_sequence_print_with_vv(
+    monkeypatch: MonkeyPatch, pytester: Pytester
+) -> None:
+    """Do not truncate sequences in summaries with -vv (#11777)."""
+    monkeypatch.setattr(_pytest.terminal, "running_on_ci", lambda: False)
+
+    pytester.makepyfile(
+        """
+        def test_len_list():
+            l = list(range(10))
+            assert len(l) == 9
+
+        def test_len_dict():
+            d = dict(zip(range(10), range(10)))
+            assert len(d) == 9
+        """
+    )
+
+    result = pytester.runpytest("-vv")
+    assert result.ret == 1
+    result.stdout.fnmatch_lines(
+        [
+            "*short test summary info*",
+            f"*{list(range(10))}*",
+            f"*{dict(zip(range(10), range(10)))}*",
+        ]
+    )
+
+
 def test_force_short_summary(monkeypatch: MonkeyPatch, pytester: Pytester) -> None:
     monkeypatch.setattr(_pytest.terminal, "running_on_ci", lambda: False)
 

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -2617,6 +2617,23 @@ def test_short_summary_with_verbose(
     )
 
 
+def test_force_short_summary(monkeypatch: MonkeyPatch, pytester: Pytester) -> None:
+    monkeypatch.setattr(_pytest.terminal, "running_on_ci", lambda: False)
+
+    pytester.makepyfile(
+        """
+        def test():
+            assert "a\\n" * 10 == ""
+        """
+    )
+
+    result = pytester.runpytest("-vv", "--force-short-summary")
+    assert result.ret == 1
+    result.stdout.fnmatch_lines(
+        ["*short test summary info*", "*AssertionError: assert 'a\\na\\na\\na..."]
+    )
+
+
 @pytest.mark.parametrize(
     "seconds, expected",
     [


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Closes #12713. 

The fix for issue #11777 removed any output shortening in the test summary output when `-vv` is used, leading to potentially long/redundant summary messages. The issue in #11777 is also now fully fixed, as series were still condensed in output even with full verbosity.

Since the removal of the summary shortening has been in place for a while, the addition of a new runtime option seemed to be the best way to address #12713 without changes to existing functionality. `--force-short-summary` was added to always show a shortened summary message regardless of the verbosity setting. Additionally, when using `-vv`, `saferepr_unlimited` is now called to fully resolve #11777.