### PR TITLE
[8.3.x] ci: fix failing jobs due to pluggy requiring Python>=3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         name: [
           "windows-py38",
-          "windows-py38-pluggy",
+          "windows-py39-pluggy",
           "windows-py39",
           "windows-py310",
           "windows-py311",
@@ -63,7 +63,7 @@ jobs:
           "windows-py313",
 
           "ubuntu-py38",
-          "ubuntu-py38-pluggy",
+          "ubuntu-py39-pluggy",
           "ubuntu-py38-freeze",
           "ubuntu-py39",
           "ubuntu-py310",
@@ -88,10 +88,10 @@ jobs:
             os: windows-latest
             tox_env: "py38-unittestextras"
             use_coverage: true
-          - name: "windows-py38-pluggy"
-            python: "3.8"
+          - name: "windows-py39-pluggy"
+            python: "3.9"
             os: windows-latest
-            tox_env: "py38-pluggymain-pylib-xdist"
+            tox_env: "py39-pluggymain-pylib-xdist"
           - name: "windows-py39"
             python: "3.9"
             os: windows-latest
@@ -118,10 +118,10 @@ jobs:
             os: ubuntu-latest
             tox_env: "py38-lsof-numpy-pexpect"
             use_coverage: true
-          - name: "ubuntu-py38-pluggy"
-            python: "3.8"
+          - name: "ubuntu-py39-pluggy"
+            python: "3.9"
             os: ubuntu-latest
-            tox_env: "py38-pluggymain-pylib-xdist"
+            tox_env: "py39-pluggymain-pylib-xdist"
           - name: "ubuntu-py38-freeze"
             python: "3.8"
             os: ubuntu-latest
@@ -192,9 +192,9 @@ jobs:
         contains(
           fromJSON(
             '[
-              "windows-py38-pluggy",
+              "windows-py39-pluggy",
               "windows-py313",
-              "ubuntu-py38-pluggy",
+              "ubuntu-py39-pluggy",
               "ubuntu-py38-freeze",
               "ubuntu-py313",
               "macos-py38",


### PR DESCRIPTION
Some of the pluggy jobs (I guess the ones fetching from git) started to fail since pluggy dropped support for 3.8 and the jobs are running with 3.8. So bump them to 3.9.