### PR TITLE
fix #13031: use the concrete id NOTSET for the empty parameter list

### DIFF
--- a/changelog/13031.improvement.rst
+++ b/changelog/13031.improvement.rst
@@ -1,0 +1,2 @@
+``pytest.mark.parametrize([], idfunc=...)`` will no longer trigger a call to ``idfunc`` with internal objects.
+instead the concrete id ``NOTSET`` is used.

--- a/changelog/13031.improvement.rst
+++ b/changelog/13031.improvement.rst
@@ -1,2 +1,1 @@
-``pytest.mark.parametrize([], idfunc=...)`` will no longer trigger a call to ``idfunc`` with internal objects.
-instead the concrete id ``NOTSET`` is used.
+An empty parameter set as in ``pytest.mark.parametrize([], ids=idfunc)`` will no longer trigger a call to ``idfunc`` with internal objects.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -47,18 +47,18 @@ def get_empty_parameterset_mark(
 ) -> MarkDecorator:
     from ..nodes import Collector
 
+    argslisting = ", ".join(argnames)
+
     fs, lineno = getfslineno(func)
-    reason = f"got empty parameter set {argnames!r}, function {func.__name__} at {fs}:{lineno}"
+    reason = f"got empty parameter set for ({argslisting})"
     requested_mark = config.getini(EMPTY_PARAMETERSET_OPTION)
     if requested_mark in ("", None, "skip"):
         mark = MARK_GEN.skip(reason=reason)
     elif requested_mark == "xfail":
         mark = MARK_GEN.xfail(reason=reason, run=False)
     elif requested_mark == "fail_at_collect":
-        f_name = func.__name__
-        _, lineno = getfslineno(func)
         raise Collector.CollectError(
-            f"Empty parameter set in '{f_name}' at line {lineno + 1}"
+            f"Empty parameter set in '{func.__name__}' at line {lineno + 1}"
         )
     else:
         raise LookupError(requested_mark)
@@ -181,7 +181,9 @@ class ParameterSet(NamedTuple):
             # parameter set with NOTSET values, with the "empty parameter set" mark applied to it.
             mark = get_empty_parameterset_mark(config, argnames, func)
             parameters.append(
-                ParameterSet(values=(NOTSET,) * len(argnames), marks=[mark], id=None)
+                ParameterSet(
+                    values=(NOTSET,) * len(argnames), marks=[mark], id="NOTSET"
+                )
             )
         return argnames, parameters
 

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1048,6 +1048,31 @@ def test_parameterset_for_fail_at_collect(pytester: Pytester) -> None:
     assert result.ret == ExitCode.INTERRUPTED
 
 
+def test_paramset_empty_no_idfunc(
+    pytester: Pytester, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p1 = pytester.makepyfile(
+        """
+        import pytest
+
+        def idfunc(value):
+            raise ValueError()
+        @pytest.mark.parametrize("param", [], ids=idfunc)
+        def test(param):
+            pass
+        """
+    )
+    result = pytester.runpytest(p1, "-v", "-rs")
+    result.stdout.fnmatch_lines(
+        [
+            "* collected 1 item",
+            "test_paramset_empty_no_idfunc* SKIPPED *",
+            "SKIPPED [1] test_paramset_empty_no_idfunc.py:5: got empty parameter set for (param)",
+            "*= 1 skipped in *",
+        ]
+    )
+
+
 def test_parameterset_for_parametrize_bad_markname(pytester: Pytester) -> None:
     with pytest.raises(pytest.UsageError):
         test_parameterset_for_parametrize_marks(pytester, "bad")

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1051,6 +1051,7 @@ def test_parameterset_for_fail_at_collect(pytester: Pytester) -> None:
 def test_paramset_empty_no_idfunc(
     pytester: Pytester, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """An empty parameter set should not call the user provided id function (#13031)."""
     p1 = pytester.makepyfile(
         """
         import pytest


### PR DESCRIPTION


this ensures we dont invoke idfunc with the internal NOTSET enum token

closes #13031
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
