### PR TITLE
Bug fix/scandir collection error

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,6 +21,7 @@ Alexander Johnson
 Alexander King
 Alexei Kozlenok
 Alice Purcell
+Alison Day
 Allan Feldman
 Aly Sivji
 Amir Elkess

--- a/changelog/13083.bugfix.rst
+++ b/changelog/13083.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes an issue where the :func:`_pytest.pathlib.scandir` function crashes if the directory to scan does not exist by catching the ``FileNotFoundError`` and returning an empty array.

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -957,17 +957,21 @@ def scandir(
     The default is to sort by name.
     """
     entries = []
-    with os.scandir(path) as s:
-        # Skip entries with symlink loops and other brokenness, so the caller
-        # doesn't have to deal with it.
-        for entry in s:
-            try:
-                entry.is_file()
-            except OSError as err:
-                if _ignore_error(err):
-                    continue
-                raise
-            entries.append(entry)
+    try:
+        with os.scandir(path) as s:
+            scanned = list(s)
+    except FileNotFoundError:
+        return []
+    # Skip entries with symlink loops and other brokenness, so the caller
+    # doesn't have to deal with it.
+    for entry in scanned:
+        try:
+            entry.is_file()
+        except OSError as err:
+            if _ignore_error(err):
+                continue
+            raise
+        entries.append(entry)
     entries.sort(key=sort_key)  # type: ignore[arg-type]
     return entries
 


### PR DESCRIPTION
Closes #13083 

I added a quick check to the scandir() function to ensure that the directory to scan still exists, and was not deleted during collection. This error handling keeps the function from crashing by catching the FileNotFoundError and returning if found.