### PR TITLE
Fix scandir() crash by returning [] when directory is not found (#13083)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -360,6 +360,7 @@ Ran Benita
 Raphael Castaneda
 Raphael Pierzina
 Rafal Semik
+Reza Mousavi
 Raquel Alegre
 Ravi Chandra
 Reagan Lee

--- a/changelog/13083.bugfix.rst
+++ b/changelog/13083.bugfix.rst
@@ -1,6 +1,1 @@
-13083.bugfix.rst:
-
-Fix issue where scandir failed for empty or non-existent directories.
-
-- Issue: https://github.com/pytest-dev/pytest/issues/13083
-- Authors: Reza Mousavi
+Fixed issue where pytest could crash if one of the collected directories got removed during collection.

--- a/changelog/13083.bugfix.rst
+++ b/changelog/13083.bugfix.rst
@@ -1,0 +1,6 @@
+13083.bugfix.rst:
+
+Fix issue where scandir failed for empty or non-existent directories.
+
+- Issue: https://github.com/pytest-dev/pytest/issues/13083
+- Authors: Reza Mousavi

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -955,23 +955,27 @@ def scandir(
 
     The returned entries are sorted according to the given key.
     The default is to sort by name.
+    If the directory does not exist, return an empty list.
     """
-    entries = []
-    with os.scandir(path) as s:
-        # Skip entries with symlink loops and other brokenness, so the caller
-        # doesn't have to deal with it.
-        for entry in s:
-            try:
-                entry.is_file()
-            except OSError as err:
-                if _ignore_error(err):
-                    continue
-                raise
-            entries.append(entry)
-    entries.sort(key=sort_key)  # type: ignore[arg-type]
-    return entries
-
-
+    try:
+        entries = []
+        with os.scandir(path) as s:
+            # Skip entries with symlink loops and other brokenness, so the caller
+            # doesn't have to deal with it.
+            for entry in s:
+                try:
+                    entry.is_file()
+                except OSError as err:
+                    if _ignore_error(err):
+                        continue
+                    raise
+                entries.append(entry)
+        entries.sort(key=sort_key)  # type: ignore[arg-type]
+        return entries
+    except FileNotFoundError:
+        return []
+    
+    
 def visit(
     path: str | os.PathLike[str], recurse: Callable[[os.DirEntry[str]], bool]
 ) -> Iterator[os.DirEntry[str]]:

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -957,7 +957,7 @@ def scandir(
     The default is to sort by name.
     If the directory does not exist, return an empty list.
     """
-    entries = [] 
+    entries = []
     # Attempt to create a scandir iterator for the given path.
     try:
         scandir_iter = os.scandir(path)

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -974,8 +974,8 @@ def scandir(
         return entries
     except FileNotFoundError:
         return []
-    
-    
+
+
 def visit(
     path: str | os.PathLike[str], recurse: Callable[[os.DirEntry[str]], bool]
 ) -> Iterator[os.DirEntry[str]]:

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -578,7 +578,7 @@ def test_scandir_with_non_existent_directory() -> None:
     assert result == []
 
 
-def test_scandir_handles_os_error():
+def test_scandir_handles_os_error() -> None:
     # Create a mock entry that will raise an OSError when is_file is called
     mock_entry = unittest.mock.MagicMock()
     mock_entry.is_file.side_effect = OSError("Permission denied")

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -581,13 +581,13 @@ def test_scandir_with_non_existent_directory() -> None:
 def test_scandir_handles_os_error() -> None:
     # Create a mock entry that will raise an OSError when is_file is called
     mock_entry = unittest.mock.MagicMock()
-    mock_entry.is_file.side_effect = OSError("Permission denied")
+    mock_entry.is_file.side_effect = OSError("some permission error")
     # Mock os.scandir to return an iterator with our mock entry
     with unittest.mock.patch("os.scandir") as mock_scandir:
         mock_scandir.return_value.__enter__.return_value = [mock_entry]
         # Call the scandir function with a path
         # We expect an OSError to be raised here
-        with pytest.raises(OSError, match="Permission denied"):
+        with pytest.raises(OSError, match="some permission error"):
             scandir("/fake/path")
         # Verify that the is_file method was called on the mock entry
         mock_entry.is_file.assert_called_once()


### PR DESCRIPTION
This PR addresses issue #13083 by modifying the scandir function to handle the case where a non-existent directory is provided. Previously, the function did not return a result for such cases, potentially leading to unhandled errors. Now, if the directory does not exist, the function will return an empty list instead.

Changes made:

Updated scandir to catch FileNotFoundError and return an empty list if the directory does not exist.
Updated the function docstring to reflect the new behavior.
Testing:

Also two tests were added. 
Closes #13083