### PR TITLE
Add basic implementation of PEP657 style expression markers in tracebacks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,6 +24,7 @@ Alice Purcell
 Allan Feldman
 Aly Sivji
 Amir Elkess
+Ammar Askar
 Anatoly Bubenkoff
 Anders Hovmöller
 Andras Mitzki

--- a/changelog/10224.improvement.rst
+++ b/changelog/10224.improvement.rst
@@ -1,0 +1,18 @@
+pytest's ``short`` and ``long`` traceback styles (:ref:`how-to-modifying-python-tb-printing`)
+now have partial :pep:`657` support and will show specific code segments in the
+traceback.
+
+.. code-block:: pytest
+
+    ================================= FAILURES =================================
+    _______________________ test_gets_correct_tracebacks _______________________
+
+    test_tracebacks.py:12: in test_gets_correct_tracebacks
+        assert manhattan_distance(p1, p2) == 1
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    test_tracebacks.py:6: in manhattan_distance
+        return abs(point_1.x - point_2.x) + abs(point_1.y - point_2.y)
+                               ^^^^^^^^^
+    E   AttributeError: 'NoneType' object has no attribute 'x'
+
+-- by :user:`ammaraskar`

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -233,7 +233,7 @@ class TracebackEntry:
         @property
         def end_lineno_relative(self) -> int | None:
             frame_summary = self.get_python_framesummary()
-            if frame_summary.end_lineno is None:
+            if frame_summary.end_lineno is None:  # pragma: no cover
                 return None
             return frame_summary.end_lineno - 1 - self.frame.code.firstlineno
 

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -215,17 +215,26 @@ class TracebackEntry:
         return stack_summary[0]
 
     @property
-    def end_lineno(self) -> int:
-        return self.get_python_framesummary().end_lineno - 1
+    def end_lineno_relative(self) -> int | None:
+        if sys.version_info < (3, 11):
+            return None
+        frame_summary = self.get_python_framesummary()
+        if frame_summary.end_lineno is None:
+            return None
+        return frame_summary.end_lineno - 1 - self.frame.code.firstlineno
 
     @property
     def colno(self) -> int | None:
         """Starting byte offset of the expression in the traceback entry."""
+        if sys.version_info < (3, 11):
+            return None
         return self.get_python_framesummary().colno
 
     @property
     def end_colno(self) -> int | None:
         """Ending byte offset of the expression in the traceback entry."""
+        if sys.version_info < (3, 11):
+            return None
         return self.get_python_framesummary().end_colno
 
     @property
@@ -1023,8 +1032,8 @@ class FormattedExcinfo:
                 line_index = 0
                 end_line_index, colno, end_colno = None, None, None
             else:
-                line_index = entry.lineno - entry.getfirstlinesource()
-                end_line_index = entry.end_lineno - entry.getfirstlinesource()
+                line_index = entry.relline
+                end_line_index = entry.end_lineno_relative
                 colno = entry.colno
                 end_colno = entry.end_colno
             short = style == "short"

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -22,12 +22,16 @@ class Source:
     def __init__(self, obj: object = None) -> None:
         if not obj:
             self.lines: list[str] = []
+            self.raw_lines: list[str] = []
         elif isinstance(obj, Source):
             self.lines = obj.lines
+            self.raw_lines = obj.raw_lines
         elif isinstance(obj, (tuple, list)):
             self.lines = deindent(x.rstrip("\n") for x in obj)
+            self.raw_lines = list(x.rstrip("\n") for x in obj)
         elif isinstance(obj, str):
             self.lines = deindent(obj.split("\n"))
+            self.raw_lines = obj.split("\n")
         else:
             try:
                 rawcode = getrawcode(obj)
@@ -35,6 +39,7 @@ class Source:
             except TypeError:
                 src = inspect.getsource(obj)  # type: ignore[arg-type]
             self.lines = deindent(src.split("\n"))
+            self.raw_lines = src.split("\n")
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Source):
@@ -58,6 +63,7 @@ class Source:
                 raise IndexError("cannot slice a Source with a step")
             newsource = Source()
             newsource.lines = self.lines[key.start : key.stop]
+            newsource.raw_lines = self.raw_lines[key.start : key.stop]
             return newsource
 
     def __iter__(self) -> Iterator[str]:
@@ -74,6 +80,7 @@ class Source:
         while end > start and not self.lines[end - 1].strip():
             end -= 1
         source = Source()
+        source.raw_lines = self.raw_lines
         source.lines[:] = self.lines[start:end]
         return source
 
@@ -81,6 +88,7 @@ class Source:
         """Return a copy of the source object with all lines indented by the
         given indent-string."""
         newsource = Source()
+        newsource.raw_lines = self.raw_lines
         newsource.lines = [(indent + line) for line in self.lines]
         return newsource
 
@@ -102,6 +110,7 @@ class Source:
         """Return a new Source object deindented."""
         newsource = Source()
         newsource.lines[:] = deindent(self.lines)
+        newsource.raw_lines = self.raw_lines
         return newsource
 
     def __str__(self) -> str:
@@ -120,6 +129,7 @@ def findsource(obj) -> tuple[Source | None, int]:
         return None, -1
     source = Source()
     source.lines = [line.rstrip() for line in sourcelines]
+    source.raw_lines = sourcelines
     return source, lineno
 
 

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -1411,7 +1411,7 @@ raise ValueError()
             assert line.endswith("mod.py")
             assert tw_mock.lines[48] == ":15: AttributeError"
         else:
-            assert tw_mock.lines[43] == ">       raise AttributeError()"
+            assert tw_mock.lines[43] == ">       if True: raise AttributeError()"
             assert tw_mock.lines[44] == "E       AttributeError"
             assert tw_mock.lines[45] == ""
             line = tw_mock.get_write_msg(46)
@@ -1535,24 +1535,44 @@ raise ValueError()
         r = excinfo.getrepr(style="short")
         r.toterminal(tw_mock)
         out = "\n".join(line for line in tw_mock.lines if isinstance(line, str))
-        expected_out = textwrap.dedent(
-            """\
-            :13: in unreraise
-                reraise()
-            :10: in reraise
-                raise Err() from e
-            E   test_exc_chain_repr_cycle0.mod.Err
+        # Assert highlighting carets in python3.11+
+        if sys.version_info >= (3, 11):
+            expected_out = textwrap.dedent(
+                """\
+                :13: in unreraise
+                    reraise()
+                :10: in reraise
+                    raise Err() from e
+                E   test_exc_chain_repr_cycle0.mod.Err
 
-            During handling of the above exception, another exception occurred:
-            :15: in unreraise
-                raise e.__cause__
-            :8: in reraise
-                fail()
-            :5: in fail
-                return 0 / 0
-                       ^^^^^
-            E   ZeroDivisionError: division by zero"""
-        )
+                During handling of the above exception, another exception occurred:
+                :15: in unreraise
+                    raise e.__cause__
+                :8: in reraise
+                    fail()
+                :5: in fail
+                    return 0 / 0
+                           ^^^^^
+                E   ZeroDivisionError: division by zero"""
+            )
+        else:
+            expected_out = textwrap.dedent(
+                """\
+                :13: in unreraise
+                    reraise()
+                :10: in reraise
+                    raise Err() from e
+                E   test_exc_chain_repr_cycle0.mod.Err
+
+                During handling of the above exception, another exception occurred:
+                :15: in unreraise
+                    raise e.__cause__
+                :8: in reraise
+                    fail()
+                :5: in fail
+                    return 0 / 0
+                E   ZeroDivisionError: division by zero"""
+            )
         assert out == expected_out
 
     def test_exec_type_error_filter(self, importasmod):


### PR DESCRIPTION
Hey folks this is just a proof of concept for https://github.com/pytest-dev/pytest/issues/10224 to serve as a reference for if any contributor wants to give this a full shot.

This adds a very basic implementation of the PEP657 style expression highlighting in the short and long traceback modes. It's not the full fledged python `traceback.py` implementation where we try to differentiate which parts contain operators.

I don't think I'll have time to finish this out fully, there's some interesting problems here like `mypy` complaining because typeshed doesn't have some of the newer `traceback` `FrameSummary` attrs like `colno`. Additionally, since the python offsets are from the start of the line, we have to know the line before it gets de-dented in `Source`.

-----

Example of what it looks like:

<img width="643" alt="image" src="https://github.com/user-attachments/assets/7fb1a20c-525a-42d9-ac49-29128239a6d8" />

and with tb short:

<img width="635" alt="image" src="https://github.com/user-attachments/assets/8a71dd03-0af0-48a2-9de1-ecd35dd72c09" />


