### PR TITLE
Fix selftests with Pygments >= 2.19.0

### DIFF
--- a/changelog/13112.contrib.rst
+++ b/changelog/13112.contrib.rst
@@ -1,0 +1,1 @@
+Fixed selftest failures in ``test_terminal.py`` with Pygments >= 2.19.0

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -2,12 +2,11 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-import importlib.metadata
 import dataclasses
+import importlib.metadata
 import re
 import sys
 
-import pygments
 from packaging.version import Version
 
 from _pytest.monkeypatch import MonkeyPatch

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -2,9 +2,13 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+import importlib.metadata
 import dataclasses
 import re
 import sys
+
+import pygments
+from packaging.version import Version
 
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pytester import Pytester
@@ -168,6 +172,9 @@ def color_mapping():
 
     Used by tests which check the actual colors output by pytest.
     """
+    # https://github.com/pygments/pygments/commit/d24e272894a56a98b1b718d9ac5fabc20124882a
+    pygments_version = Version(importlib.metadata.version("pygments"))
+    pygments_has_kwspace_hl = pygments_version >= Version("2.19")
 
     class ColorMapping:
         COLORS = {
@@ -180,6 +187,7 @@ def color_mapping():
             "bold": "\x1b[1m",
             "reset": "\x1b[0m",
             "kw": "\x1b[94m",
+            "kwspace": "\x1b[90m \x1b[39;49;00m" if pygments_has_kwspace_hl else " ",
             "hl-reset": "\x1b[39;49;00m",
             "function": "\x1b[92m",
             "number": "\x1b[94m",

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1294,13 +1294,13 @@ def test_color_yes(pytester: Pytester, color_mapping) -> None:
                 "=*= FAILURES =*=",
                 "{red}{bold}_*_ test_this _*_{reset}",
                 "",
-                "    {reset}{kw}def{hl-reset} {function}test_this{hl-reset}():{endline}",
+                "    {reset}{kw}def{hl-reset}{kwspace}{function}test_this{hl-reset}():{endline}",
                 ">       fail(){endline}",
                 "",
                 "{bold}{red}test_color_yes.py{reset}:5: ",
                 "_ _ * _ _*",
                 "",
-                "    {reset}{kw}def{hl-reset} {function}fail{hl-reset}():{endline}",
+                "    {reset}{kw}def{hl-reset}{kwspace}{function}fail{hl-reset}():{endline}",
                 ">       {kw}assert{hl-reset} {number}0{hl-reset}{endline}",
                 "{bold}{red}E       assert 0{reset}",
                 "",
@@ -2580,7 +2580,7 @@ class TestCodeHighlight:
         result.stdout.fnmatch_lines(
             color_mapping.format_for_fnmatch(
                 [
-                    "    {reset}{kw}def{hl-reset} {function}test_foo{hl-reset}():{endline}",
+                    "    {reset}{kw}def{hl-reset}{kwspace}{function}test_foo{hl-reset}():{endline}",
                     ">       {kw}assert{hl-reset} {number}1{hl-reset} == {number}10{hl-reset}{endline}",
                     "{bold}{red}E       assert 1 == 10{reset}",
                 ]
@@ -2602,7 +2602,7 @@ class TestCodeHighlight:
         result.stdout.fnmatch_lines(
             color_mapping.format_for_fnmatch(
                 [
-                    "    {reset}{kw}def{hl-reset} {function}test_foo{hl-reset}():{endline}",
+                    "    {reset}{kw}def{hl-reset}{kwspace}{function}test_foo{hl-reset}():{endline}",
                     "        {print}print{hl-reset}({str}'''{hl-reset}{str}{hl-reset}",
                     ">   {str}    {hl-reset}{str}'''{hl-reset}); {kw}assert{hl-reset} {number}0{hl-reset}{endline}",
                     "{bold}{red}E       assert 0{reset}",
@@ -2625,7 +2625,7 @@ class TestCodeHighlight:
         result.stdout.fnmatch_lines(
             color_mapping.format_for_fnmatch(
                 [
-                    "    {reset}{kw}def{hl-reset} {function}test_foo{hl-reset}():{endline}",
+                    "    {reset}{kw}def{hl-reset}{kwspace}{function}test_foo{hl-reset}():{endline}",
                     ">       {kw}assert{hl-reset} {number}1{hl-reset} == {number}10{hl-reset}{endline}",
                     "{bold}{red}E       assert 1 == 10{reset}",
                 ]


### PR DESCRIPTION
With Pygments 2.19, the Python lexer now emits
Text.Whitespace (rather than Text) tokens after "def", which get highlighted as "bright black".

See https://github.com/pygments/pygments/issues/1905

Fixes #13112

(also fixes the current CI failures, I hope!)