### PR TITLE
Fix issue #13047: Handle numpy booleans in pytest.approx

### DIFF
--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 from typing import TypeVar
 
 import _pytest._code
+import numpy as np
 from _pytest.outcomes import fail
 
 
@@ -438,7 +439,7 @@ class ApproxScalar(ApproxBase):
             return all(self.__eq__(a) for a in asarray.flat)
 
         # Short-circuit exact equality, except for bool
-        if isinstance(self.expected, bool) and not isinstance(actual, bool):
+        if isinstance(self.expected, (bool, np.bool_)) and not isinstance(actual, (bool, np.bool_)):
             return False
         elif actual == self.expected:
             return True
@@ -447,9 +448,9 @@ class ApproxScalar(ApproxBase):
         # NB: we need Complex, rather than just Number, to ensure that __abs__,
         # __sub__, and __float__ are defined. Also, consider bool to be
         # nonnumeric, even though it has the required arithmetic.
-        if isinstance(self.expected, bool) or not (
-            isinstance(self.expected, (Complex, Decimal))
-            and isinstance(actual, (Complex, Decimal))
+        if isinstance(self.expected, (bool, np.bool_)) or not (
+                isinstance(self.expected, (Complex, Decimal))
+                and isinstance(actual, (Complex, Decimal))
         ):
             return False
 

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -20,8 +20,9 @@ from typing import overload
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
-import _pytest._code
 import numpy as np
+
+import _pytest._code
 from _pytest.outcomes import fail
 
 
@@ -439,7 +440,9 @@ class ApproxScalar(ApproxBase):
             return all(self.__eq__(a) for a in asarray.flat)
 
         # Short-circuit exact equality, except for bool
-        if isinstance(self.expected, (bool, np.bool_)) and not isinstance(actual, (bool, np.bool_)):
+        if isinstance(self.expected, (bool, np.bool_)) and not isinstance(
+            actual, (bool, np.bool_)
+        ):
             return False
         elif actual == self.expected:
             return True
@@ -449,8 +452,8 @@ class ApproxScalar(ApproxBase):
         # __sub__, and __float__ are defined. Also, consider bool to be
         # nonnumeric, even though it has the required arithmetic.
         if isinstance(self.expected, (bool, np.bool_)) or not (
-                isinstance(self.expected, (Complex, Decimal))
-                and isinstance(actual, (Complex, Decimal))
+            isinstance(self.expected, (Complex, Decimal))
+            and isinstance(actual, (Complex, Decimal))
         ):
             return False
 


### PR DESCRIPTION
This pull request addresses the issue where np.False_ == pytest.approx(False) returns False instead of True after updating to pytest 8.3.4. The issue was introduced by PR #9354, which enforced strict equality for boolean values in pytest.approx.

Changes:
Modify the __eq__ method in the ApproxScalar class to handle numpy booleans appropriately.
This ensures that comparisons between numpy booleans and regular booleans work as expected.

Issue Link: [#13047](https://github.com/pytest-dev/pytest/issues/13047)