### PR TITLE
Fix internal mypy error on Windows

### DIFF
--- a/src/_pytest/_py/error.py
+++ b/src/_pytest/_py/error.py
@@ -92,7 +92,9 @@ class ErrorMaker:
                 raise
             if sys.platform == "win32":
                 try:
-                    cls = self._geterrnoclass(_winerrnomap[value.errno])
+                    # error: Invalid index type "Optional[int]" for "dict[int, int]"; expected type "int"  [index]
+                    # OK to ignore because we catch the KeyError below.
+                    cls = self._geterrnoclass(_winerrnomap[value.errno])  # type:ignore[index]
                 except KeyError:
                     raise value
             else:


### PR DESCRIPTION
When running `pre-commit` on Windows, I get the error below:

```
src\_pytest\_py\error.py:95: error: Invalid index type "Optional[int]" for "dict[int, int]"; expected type "int"  [index]
Found 1 error in 1 file (checked 234 source files)
```

Ignore the error because we do catch the `KeyError` anyway.
