### PR TITLE
[8.3.x] Fix sequences being shortened even with `-vv` verbosity.

### DIFF
--- a/changelog/11777.bugfix.rst
+++ b/changelog/11777.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed issue where sequences were still being shortened even with ``-vv`` verbosity.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING
 
 from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE
 from _pytest._io.saferepr import saferepr
+from _pytest._io.saferepr import saferepr_unlimited
 from _pytest._version import version
 from _pytest.assertion import util
 from _pytest.config import Config
@@ -432,6 +433,8 @@ def _saferepr(obj: object) -> str:
         return obj.__name__
 
     maxsize = _get_maxsize_for_saferepr(util._config)
+    if not maxsize:
+        return saferepr_unlimited(obj).replace("\n", "\\n")
     return saferepr(obj, maxsize=maxsize).replace("\n", "\\n")
 
 

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -2525,6 +2525,35 @@ def test_short_summary_with_verbose(
     )
 
 
+def test_full_sequence_print_with_vv(
+    monkeypatch: MonkeyPatch, pytester: Pytester
+) -> None:
+    """Do not truncate sequences in summaries with -vv (#11777)."""
+    monkeypatch.setattr(_pytest.terminal, "running_on_ci", lambda: False)
+
+    pytester.makepyfile(
+        """
+        def test_len_list():
+            l = list(range(10))
+            assert len(l) == 9
+
+        def test_len_dict():
+            d = dict(zip(range(10), range(10)))
+            assert len(d) == 9
+        """
+    )
+
+    result = pytester.runpytest("-vv")
+    assert result.ret == 1
+    result.stdout.fnmatch_lines(
+        [
+            "*short test summary info*",
+            f"*{list(range(10))}*",
+            f"*{dict(zip(range(10), range(10)))}*",
+        ]
+    )
+
+
 @pytest.mark.parametrize(
     "seconds, expected",
     [


### PR DESCRIPTION
Fix #11777

Backport of #13061.