### PR TITLE
[FEAT] Exposing autoused fixture names as global variable for tests

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -141,6 +141,7 @@ Eduardo Schettino
 Edward Haigh
 Eero Vaher
 Eli Boyarski
+Élie Goudout
 Elizaveta Shashkova
 Éloi Rivard
 Emil Hjelm

--- a/changelog/13180.feature.rst
+++ b/changelog/13180.feature.rst
@@ -1,0 +1,5 @@
+Exposed autoused fixture names as global variables for tests.
+
+Two caveats:
+- It is still not possible to directly use, for example, `autoused_int_fixture += 1` without a prior `global autoused_int_fixture` statement in test definition.
+- This feature makes the test work on an augmented copy of its `.__globals__` dict. So if the test actually modifies `globals()` (which looks like a terrible idea and is probably discouraged somewhere in pytest docs), it may cause issues.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -150,6 +150,10 @@ def pytest_pyfunc_call(pyfuncitem: Function) -> object | None:
         async_fail(pyfuncitem.nodeid)
     funcargs = pyfuncitem.funcargs
     testargs = {arg: funcargs[arg] for arg in pyfuncitem._fixtureinfo.argnames}
+    autoused = {arg: funcargs[arg] for arg in funcargs if arg not in testargs}
+    testfunction = types.FunctionType(
+        testfunction.__code__, testfunction.__globals__ | autoused
+    )
     result = testfunction(**testargs)
     if hasattr(result, "__await__") or hasattr(result, "__aiter__"):
         async_fail(pyfuncitem.nodeid)


### PR DESCRIPTION
Closes #13171.

### Action list
- [ ] Include documentation.
- [ ] Include new tests.
- [ ] Pass tests locally.
- [X] Allow maintainers to push and squash when merging my commits: OK.
- [X] Create a new changelog file.
- [X] Add yourself to `AUTHORS` in alphabetical order.

----
Exposes autoused fixture names as global variables for tests.
```python
# conftest.py
@pytest.fixture(autouse=True)
def null():
    return object()
```
```python
# test_file.py
def test_func_returns_nondefault(func):
    assert func(default=null) is not null
```
Here, there's no need to add `null` to the test signature! 🤩
In many cases, this will clean test files **significantly**.

---

Two caveats that will be documented:

- It is still not possible to directly use, for example, `autoused_int_fixture += 1` without a prior `global autoused_int_fixture` statement in test definition.
- This feature makes the test work on an augmented copy of its `.__globals__` dict. So if the test actually modifies `globals()` (which looks like a **terrible** idea and is probably discouraged somewhere in pytest docs), it may cause issues.
