### PR TITLE
[8.3.x] Fix CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
         persist-credentials: false
 
     - name: Build and Check Package
-      uses: hynek/build-and-inspect-python-package@v2.6.0
+      uses: hynek/build-and-inspect-python-package@v2.12.0
       with:
         attest-build-provenance-github: 'true'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
     - name: Build and Check Package
-      uses: hynek/build-and-inspect-python-package@v2.6.0
+      uses: hynek/build-and-inspect-python-package@v2.12.0
 
   build:
     needs: [package]


### PR DESCRIPTION
Otherwise the build is broken as Python 3.13 is used, but the pinned pydantic-core version doesn't have support.

build-and-inspect-python-package v2.6.0: https://github.com/hynek/build-and-inspect-python-package/blob/v2.6.0/requirements/tools.txt#L297

v2.12.0: https://github.com/hynek/build-and-inspect-python-package/blob/v2.12.0/requirements/tools.txt#L303

3.13 support added in Pydantic v2.8.0: https://docs.pydantic.dev/latest/changelog/#v280-2024-07-01

and build-and-inspect-python-package uses `python-version: 3.x`: https://github.com/hynek/build-and-inspect-python-package/blob/v2.12.0/action.yml#L58

which I'm assuming broke this by switching from 3.12 to 3.13 at some point.