### PR TITLE
Fix `test_refcycle_unraisiable_warning_filter_default`

### DIFF
--- a/testing/test_unraisableexception.py
+++ b/testing/test_unraisableexception.py
@@ -321,6 +321,9 @@ def test_refcycle_unraisable_warning_filter_default(pytester: Pytester) -> None:
     # see: https://github.com/pytest-dev/pytest/pull/13057#discussion_r1888396126
     pytester.makepyfile(
         test_it="""
+        import gc
+        gc.disable()
+
         import pytest
 
         class BrokenDel:
@@ -335,8 +338,8 @@ def test_refcycle_unraisable_warning_filter_default(pytester: Pytester) -> None:
         """
     )
 
-    with _disable_gc():
-        result = pytester.runpytest_subprocess("-Wdefault")
+    # since we use subprocess we need to disable gc inside test_it
+    result = pytester.runpytest_subprocess("-Wdefault")
 
     assert result.ret == pytest.ExitCode.OK
 


### PR DESCRIPTION
In https://github.com/pytest-dev/pytest/pull/11671#issuecomment-2622022293 I hit a funky interaction where py39-pluggy started failing because the subprocess started triggering gc.

The patch is from https://github.com/pytest-dev/pytest/pull/11671#issuecomment-2622213433 after graingert noticed the faulty assumption that `with _disable_gc` would have any effect in a subprocess.

The CI only appears to fail in #11671, presumably because of pytest itself getting slightly bigger and triggering a gc, or something.