### PR TITLE
Improvement for Parser.addini to facilite parsing of 'int' and 'float' values

### DIFF
--- a/changelog/11381.improvement.rst
+++ b/changelog/11381.improvement.rst
@@ -1,4 +1,4 @@
-The ``type`` parameter of the ``parser.addini`` method now accepts the **int** and **float** literals, facilitating the parsing of configuration values in the **ini** file.
+The ``type`` parameter of the ``parser.addini`` method now accepts `"int"` and ``"float"`` parameters, facilitating the parsing of configuration values in the configuration file.
 
 Example:
 

--- a/changelog/11381.improvement.rst
+++ b/changelog/11381.improvement.rst
@@ -2,7 +2,7 @@ The ``type`` parameter of the ``parser.addini`` method now accepts the **int** a
 
 Example:
 
-.. code-block:: pytest
+.. code-block:: python
 
   def pytest_addoption(parser):
       parser.addini(

--- a/changelog/11381.improvement.rst
+++ b/changelog/11381.improvement.rst
@@ -5,18 +5,8 @@ Example:
 .. code-block:: python
 
   def pytest_addoption(parser):
-      parser.addini(
-          "int_value",
-          type="int",
-          default=2,
-          help="my int value"
-      )
-      parser.addini(
-          "float_value",
-          type="float",
-          default=4.2,
-          help="my float value"
-      )
+      parser.addini("int_value", type="int", default=2, help="my int value")
+      parser.addini("float_value", type="float", default=4.2, help="my float value")
 
 The `pytest.ini` file:
 

--- a/changelog/11381.improvement.rst
+++ b/changelog/11381.improvement.rst
@@ -20,7 +20,7 @@ Example:
 
 The `pytest.ini` file:
 
-.. code-block:: pytest
+.. code-block:: ini
 
   [pytest]
   int_value = 3

--- a/changelog/11381.improvement.rst
+++ b/changelog/11381.improvement.rst
@@ -1,0 +1,27 @@
+The ``type`` parameter of the ``parser.addini`` method now accepts the **int** and **float** literals, allowing the usage of those data types in the **ini** file.
+
+Example:
+
+.. code-block:: pytest
+
+  def pytest_addoption(parser):
+      parser.addini(
+          "int_value",
+          type="int",
+          default=2,
+          help="my int value"
+      )
+      parser.addini(
+          "float_value",
+          type="float",
+          default=4.2,
+          help="my float value"
+      )
+
+The **pytest.ini** file:
+
+.. code-block:: pytest
+
+  [pytest]
+  int_value = 3
+  float_value = 5.4

--- a/changelog/11381.improvement.rst
+++ b/changelog/11381.improvement.rst
@@ -18,7 +18,7 @@ Example:
           help="my float value"
       )
 
-The **pytest.ini** file:
+The `pytest.ini` file:
 
 .. code-block:: pytest
 

--- a/changelog/11381.improvement.rst
+++ b/changelog/11381.improvement.rst
@@ -1,4 +1,4 @@
-The ``type`` parameter of the ``parser.addini`` method now accepts the **int** and **float** literals, allowing the usage of those data types in the **ini** file.
+The ``type`` parameter of the ``parser.addini`` method now accepts the **int** and **float** literals, facilitating the parsing of configuration values in the **ini** file.
 
 Example:
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -33,6 +33,7 @@ from typing import final
 from typing import IO
 from typing import TextIO
 from typing import TYPE_CHECKING
+from typing import Union
 import warnings
 
 import pluggy
@@ -1645,6 +1646,7 @@ class Config:
                 if self.inipath is not None
                 else self.invocation_params.dir
             )
+            value = cast(Union[str, list[str]], value)
             input_values = shlex.split(value) if isinstance(value, str) else value
             return [dp / x for x in input_values]
         elif type == "args":
@@ -1659,6 +1661,7 @@ class Config:
         elif type == "string":
             return value
         elif type == "int":
+            value = cast(str, value)
             try:
                 return int(value)
             except ValueError:
@@ -1666,6 +1669,7 @@ class Config:
                     f"invalid integer value for option {name}: {value!r}"
                 ) from None
         elif type == "float":
+            value = cast(str, value)
             try:
                 return float(value)
             except ValueError:
@@ -1675,6 +1679,7 @@ class Config:
         elif type is None:
             return value
         else:
+            value = cast(Union[str, list[str]], value)
             return self._getini_unknown_type(name, type, value)
 
     def _getconftest_pathlist(

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1662,12 +1662,12 @@ class Config:
             try:
                 return int(value)
             except ValueError:
-                raise ValueError(f"invalid integer value {value!r}")
+                raise ValueError(f"invalid integer value {value!r}") from None
         elif type == "float":
             try:
                 return float(value)
             except ValueError:
-                raise ValueError(f"invalid float value {value!r}")
+                raise ValueError(f"invalid float value {value!r}") from None
         elif type is None:
             return value
         else:

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1662,12 +1662,16 @@ class Config:
             try:
                 return int(value)
             except ValueError:
-                raise ValueError(f"invalid integer value for option {name}: {value!r}") from None
+                raise ValueError(
+                    f"invalid integer value for option {name}: {value!r}"
+                ) from None
         elif type == "float":
             try:
                 return float(value)
             except ValueError:
-                raise ValueError(f"invalid float value for option {name}: {value!r}") from None
+                raise ValueError(
+                    f"invalid float value for option {name}: {value!r}"
+                ) from None
         elif type is None:
             return value
         else:

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1667,7 +1667,7 @@ class Config:
             try:
                 return float(value)
             except ValueError:
-                raise ValueError(f"invalid float value {value!r}") from None
+                raise ValueError(f"invalid float value for option {name}: {value!r}") from None
         elif type is None:
             return value
         else:

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1647,10 +1647,6 @@ class Config:
                 if self.inipath is not None
                 else self.invocation_params.dir
             )
-            if not isinstance(value, (str, Sequence)):
-                raise TypeError(
-                    f"Expected str or sequence for option {name} of type str/list, but got: {value!r}"
-                ) from None
             input_values = shlex.split(value) if isinstance(value, str) else value
             return [dp / x for x in input_values]
         elif type == "args":
@@ -1665,15 +1661,15 @@ class Config:
         elif type == "string":
             return value
         elif type == "int":
-            if not isinstance(value, (str, int)):
+            if not isinstance(value, str):
                 raise TypeError(
-                    f"Expected str or int for option {name} of type integer, but got: {value!r}"
+                    f"Expected an int string for option {name} of type integer, but got: {value!r}"
                 ) from None
             return int(value)
         elif type == "float":
-            if not isinstance(value, (str, float)):
+            if not isinstance(value, str):
                 raise TypeError(
-                    f"Expected str or float for option {name} of type float, but got: {value!r}"
+                    f"Expected a float string for option {name} of type float, but got: {value!r}"
                 ) from None
             return float(value)
         elif type is None:

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1607,8 +1607,10 @@ class Config:
 
     # Meant for easy monkeypatching by legacypath plugin.
     # Can be inlined back (with no cover removed) once legacypath is gone.
-    def _getini_unknown_type(self, name: str, type: str, value: str | list[str]):
-        msg = f"unknown configuration type: {type}"
+    def _getini_unknown_type(self, name: str, type: str, value: object):
+        msg = (
+            f"Option {name} has unknown configuration type {type} with value {value!r}"
+        )
         raise ValueError(msg, value)  # pragma: no cover
 
     def _getini(self, name: str):
@@ -1671,16 +1673,12 @@ class Config:
         elif type == "float":
             if not isinstance(value, (str, float)):
                 raise TypeError(
-                    f"Expected str or flot for option {name} of type float, but got: {value!r}"
+                    f"Expected str or float for option {name} of type float, but got: {value!r}"
                 ) from None
             return float(value)
         elif type is None:
             return value
         else:
-            if not isinstance(value, (str, Sequence)):
-                raise TypeError(
-                    f"Expected str or sequence for option {name} of type str/list, but got: {value!r}"
-                ) from None
             return self._getini_unknown_type(name, type, value)
 
     def _getconftest_pathlist(

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1611,7 +1611,7 @@ class Config:
         msg = (
             f"Option {name} has unknown configuration type {type} with value {value!r}"
         )
-        raise ValueError(msg, value)  # pragma: no cover
+        raise ValueError(msg)  # pragma: no cover
 
     def _getini(self, name: str):
         try:

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -33,7 +33,6 @@ from typing import final
 from typing import IO
 from typing import TextIO
 from typing import TYPE_CHECKING
-from typing import Union
 import warnings
 
 import pluggy
@@ -1646,7 +1645,10 @@ class Config:
                 if self.inipath is not None
                 else self.invocation_params.dir
             )
-            value = cast(Union[str, list[str]], value)
+            if not isinstance(value, (str, Sequence)):
+                raise TypeError(
+                    f"Expected str or sequence for option {name} of type str/list, but got: {value!r}"
+                ) from None
             input_values = shlex.split(value) if isinstance(value, str) else value
             return [dp / x for x in input_values]
         elif type == "args":
@@ -1661,25 +1663,24 @@ class Config:
         elif type == "string":
             return value
         elif type == "int":
-            value = cast(str, value)
-            try:
-                return int(value)
-            except ValueError:
-                raise ValueError(
-                    f"invalid integer value for option {name}: {value!r}"
+            if not isinstance(value, (str, int)):
+                raise TypeError(
+                    f"Expected str or int for option {name} of type integer, but got: {value!r}"
                 ) from None
+            return int(value)
         elif type == "float":
-            value = cast(str, value)
-            try:
-                return float(value)
-            except ValueError:
-                raise ValueError(
-                    f"invalid float value for option {name}: {value!r}"
+            if not isinstance(value, (str, float)):
+                raise TypeError(
+                    f"Expected str or flot for option {name} of type float, but got: {value!r}"
                 ) from None
+            return float(value)
         elif type is None:
             return value
         else:
-            value = cast(Union[str, list[str]], value)
+            if not isinstance(value, (str, Sequence)):
+                raise TypeError(
+                    f"Expected str or sequence for option {name} of type str/list, but got: {value!r}"
+                ) from None
             return self._getini_unknown_type(name, type, value)
 
     def _getconftest_pathlist(

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1587,6 +1587,8 @@ class Config:
         ``paths``, ``pathlist``, ``args`` and ``linelist`` : empty list ``[]``
         ``bool`` : ``False``
         ``string`` : empty string ``""``
+        ``int`` : ``0``
+        ``float`` : ``0.0``
 
         If neither the ``default`` nor the ``type`` parameter is passed
         while registering the configuration through
@@ -1656,6 +1658,16 @@ class Config:
             return _strtobool(str(value).strip())
         elif type == "string":
             return value
+        elif type == "int":
+            try:
+                return int(value)
+            except ValueError:
+                raise ValueError(f"invalid integer value {value!r}")
+        elif type == "float":
+            try:
+                return float(value)
+            except ValueError:
+                raise ValueError(f"invalid float value {value!r}")
         elif type is None:
             return value
         else:

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1662,7 +1662,7 @@ class Config:
             try:
                 return int(value)
             except ValueError:
-                raise ValueError(f"invalid integer value {value!r}") from None
+                raise ValueError(f"invalid integer value for option {name}: {value!r}") from None
         elif type == "float":
             try:
                 return float(value)

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -191,6 +191,8 @@ class Parser:
                 * ``linelist``: a list of strings, separated by line breaks
                 * ``paths``: a list of :class:`pathlib.Path`, separated as in a shell
                 * ``pathlist``: a list of ``py.path``, separated as in a shell
+                * ``int``: an integer
+                * ``float``: a floating-point number 
 
             For ``paths`` and ``pathlist`` types, they are considered relative to the ini-file.
             In case the execution is happening without an ini-file defined,
@@ -209,7 +211,7 @@ class Parser:
         The value of ini-variables can be retrieved via a call to
         :py:func:`config.getini(name) <pytest.Config.getini>`.
         """
-        assert type in (None, "string", "paths", "pathlist", "args", "linelist", "bool")
+        assert type in (None, "string", "paths", "pathlist", "args", "linelist", "bool", "int", "float")
         if default is NOT_SET:
             default = get_ini_default_for_type(type)
 
@@ -218,7 +220,7 @@ class Parser:
 
 
 def get_ini_default_for_type(
-    type: Literal["string", "paths", "pathlist", "args", "linelist", "bool"] | None,
+    type: Literal["string", "paths", "pathlist", "args", "linelist", "bool", "int", "float"] | None,
 ) -> Any:
     """
     Used by addini to get the default value for a given ini-option type, when
@@ -230,6 +232,10 @@ def get_ini_default_for_type(
         return []
     elif type == "bool":
         return False
+    elif type == "int":
+        return 0
+    elif type == "float":
+        return 0.0
     else:
         return ""
 

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -193,6 +193,10 @@ class Parser:
                 * ``pathlist``: a list of ``py.path``, separated as in a shell
                 * ``int``: an integer
                 * ``float``: a floating-point number
+                
+                .. versionadded:: 8.4
+                
+                    The ``float`` and ``int`` types.
 
             For ``paths`` and ``pathlist`` types, they are considered relative to the ini-file.
             In case the execution is happening without an ini-file defined,

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -192,7 +192,7 @@ class Parser:
                 * ``paths``: a list of :class:`pathlib.Path`, separated as in a shell
                 * ``pathlist``: a list of ``py.path``, separated as in a shell
                 * ``int``: an integer
-                * ``float``: a floating-point number 
+                * ``float``: a floating-point number
 
             For ``paths`` and ``pathlist`` types, they are considered relative to the ini-file.
             In case the execution is happening without an ini-file defined,
@@ -211,7 +211,17 @@ class Parser:
         The value of ini-variables can be retrieved via a call to
         :py:func:`config.getini(name) <pytest.Config.getini>`.
         """
-        assert type in (None, "string", "paths", "pathlist", "args", "linelist", "bool", "int", "float")
+        assert type in (
+            None,
+            "string",
+            "paths",
+            "pathlist",
+            "args",
+            "linelist",
+            "bool",
+            "int",
+            "float",
+        )
         if default is NOT_SET:
             default = get_ini_default_for_type(type)
 
@@ -220,7 +230,10 @@ class Parser:
 
 
 def get_ini_default_for_type(
-    type: Literal["string", "paths", "pathlist", "args", "linelist", "bool", "int", "float"] | None,
+    type: Literal[
+        "string", "paths", "pathlist", "args", "linelist", "bool", "int", "float"
+    ]
+    | None,
 ) -> Any:
     """
     Used by addini to get the default value for a given ini-option type, when

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -193,9 +193,9 @@ class Parser:
                 * ``pathlist``: a list of ``py.path``, separated as in a shell
                 * ``int``: an integer
                 * ``float``: a floating-point number
-                
+
                 .. versionadded:: 8.4
-                
+
                     The ``float`` and ``int`` types.
 
             For ``paths`` and ``pathlist`` types, they are considered relative to the ini-file.

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -21,7 +21,9 @@ if TYPE_CHECKING:
 
     from typing_extensions import TypeAlias
 
-    ConfigDict: TypeAlias = dict[str, Union[str, int, float, list[str]]]
+    # Even though TOML supports richer data types, all values are converted to str/list[str] during
+    # parsing to maintain compatibility with the rest of the configuration system.
+    ConfigDict: TypeAlias = dict[str, Union[str, list[str]]]
 
 
 def _parse_ini_config(path: Path) -> iniconfig.IniConfig:

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 import os
 from pathlib import Path
 import sys
+from typing import TYPE_CHECKING
 
 import iniconfig
 
@@ -13,6 +14,14 @@ from _pytest.outcomes import fail
 from _pytest.pathlib import absolutepath
 from _pytest.pathlib import commonpath
 from _pytest.pathlib import safe_exists
+
+
+if TYPE_CHECKING:
+    from typing import Union
+
+    from typing_extensions import TypeAlias
+
+    ConfigDict: TypeAlias = dict[str, Union[str, int, float, list[str]]]
 
 
 def _parse_ini_config(path: Path) -> iniconfig.IniConfig:
@@ -29,7 +38,7 @@ def _parse_ini_config(path: Path) -> iniconfig.IniConfig:
 
 def load_config_dict_from_file(
     filepath: Path,
-) -> dict[str, str | list[str]] | None:
+) -> ConfigDict | None:
     """Load pytest configuration from the given file path, if supported.
 
     Return None if the file does not contain valid pytest configuration.
@@ -85,7 +94,7 @@ def load_config_dict_from_file(
 def locate_config(
     invocation_dir: Path,
     args: Iterable[Path],
-) -> tuple[Path | None, Path | None, dict[str, str | list[str]]]:
+) -> tuple[Path | None, Path | None, ConfigDict]:
     """Search in the list of arguments for a valid ini-file for pytest,
     and return a tuple of (rootdir, inifile, cfg-dict)."""
     config_names = [
@@ -172,7 +181,7 @@ def determine_setup(
     args: Sequence[str],
     rootdir_cmd_arg: str | None,
     invocation_dir: Path,
-) -> tuple[Path, Path | None, dict[str, int | float | str | list[str]]]:
+) -> tuple[Path, Path | None, ConfigDict]:
     """Determine the rootdir, inifile and ini configuration values from the
     command line arguments.
 

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -172,7 +172,7 @@ def determine_setup(
     args: Sequence[str],
     rootdir_cmd_arg: str | None,
     invocation_dir: Path,
-) -> tuple[Path, Path | None, dict[str, str | list[str]]]:
+) -> tuple[Path, Path | None, dict[str, int | float | str | list[str]]]:
     """Determine the rootdir, inifile and ini configuration values from the
     command line arguments.
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -873,18 +873,18 @@ class TestConfigAPI:
         pytester.makeconftest(
             """
             def pytest_addoption(parser):
-                parser.addini("float_val", "", type="float", default=2.2)
+                parser.addini("ini_param", "", type="float", default=2.2)
         """
         )
         if str_val != "no-ini":
             pytester.makeini(
                 f"""
                 [pytest]
-                float_val={str_val}
+                ini_param={str_val}
             """
             )
         config = pytester.parseconfig()
-        assert config.getini("float_val") == float_val
+        assert config.getini("ini_param") == float_val
 
     def test_addinivalue_line_existing(self, pytester: Pytester) -> None:
         pytester.makeconftest(

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -848,6 +848,50 @@ class TestConfigAPI:
         config = pytester.parseconfig()
         assert config.getini("strip") is bool_val
 
+    @pytest.mark.parametrize(
+        "str_val, int_val", [("10", 10), ("no-ini", 0)]
+    )
+    def test_addini_int(
+        self, pytester: Pytester, str_val: str, int_val: bool
+    ) -> None:
+        pytester.makeconftest(
+            """
+            def pytest_addoption(parser):
+                parser.addini("ini_param", "", type="int", default=2)
+        """
+        )
+        if str_val != "no-ini":
+            pytester.makeini(
+                f"""
+                [pytest]
+                ini_param={str_val}
+            """
+            )
+        config = pytester.parseconfig()
+        assert config.getini("ini_param") == int_val
+
+    @pytest.mark.parametrize(
+        "str_val, float_val", [("10.5", 10.5), ("no-ini", 0.0)]
+    )
+    def test_addini_float(
+        self, pytester: Pytester, str_val: str, float_val: bool
+    ) -> None:
+        pytester.makeconftest(
+            """
+            def pytest_addoption(parser):
+                parser.addini("ini_param", "", type="float", default=2.2)
+        """
+        )
+        if str_val != "no-ini":
+            pytester.makeini(
+                f"""
+                [pytest]
+                ini_param={str_val}
+            """
+            )
+        config = pytester.parseconfig()
+        assert config.getini("ini_param") == float_val
+
     def test_addinivalue_line_existing(self, pytester: Pytester) -> None:
         pytester.makeconftest(
             """

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -866,6 +866,23 @@ class TestConfigAPI:
         config = pytester.parseconfig()
         assert config.getini("ini_param") == int_val
 
+    def test_addini_int_invalid(self, pytester: Pytester) -> None:
+        pytester.makeconftest(
+            """
+            def pytest_addoption(parser):
+                parser.addini("ini_param", "", type="int", default=2)
+        """
+        )
+        pytester.makepyprojecttoml(
+            """
+            [tool.pytest.ini_options]
+            ini_param=["foo"]
+            """
+        )
+        config = pytester.parseconfig()
+        with pytest.raises(TypeError, match="Expected str or int for option ini_param"):
+            _ = config.getini("ini_param")
+
     @pytest.mark.parametrize("str_val, float_val", [("10.5", 10.5), ("no-ini", 2.2)])
     def test_addini_float(
         self, pytester: Pytester, str_val: str, float_val: bool
@@ -885,6 +902,25 @@ class TestConfigAPI:
             )
         config = pytester.parseconfig()
         assert config.getini("ini_param") == float_val
+
+    def test_addini_float_invalid(self, pytester: Pytester) -> None:
+        pytester.makeconftest(
+            """
+            def pytest_addoption(parser):
+                parser.addini("ini_param", "", type="float", default=2.2)
+        """
+        )
+        pytester.makepyprojecttoml(
+            """
+            [tool.pytest.ini_options]
+            ini_param=["foo"]
+            """
+        )
+        config = pytester.parseconfig()
+        with pytest.raises(
+            TypeError, match="Expected str or float for option ini_param"
+        ):
+            _ = config.getini("ini_param")
 
     def test_addinivalue_line_existing(self, pytester: Pytester) -> None:
         pytester.makeconftest(

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -848,7 +848,7 @@ class TestConfigAPI:
         config = pytester.parseconfig()
         assert config.getini("strip") is bool_val
 
-    @pytest.mark.parametrize("str_val, int_val", [("10", 10), ("no-ini", 0)])
+    @pytest.mark.parametrize("str_val, int_val", [("10", 10), ("no-ini", 2)])
     def test_addini_int(self, pytester: Pytester, str_val: str, int_val: bool) -> None:
         pytester.makeconftest(
             """
@@ -866,7 +866,7 @@ class TestConfigAPI:
         config = pytester.parseconfig()
         assert config.getini("ini_param") == int_val
 
-    @pytest.mark.parametrize("str_val, float_val", [("10.5", 10.5), ("no-ini", 0.0)])
+    @pytest.mark.parametrize("str_val, float_val", [("10.5", 10.5), ("no-ini", 2.2)])
     def test_addini_float(
         self, pytester: Pytester, str_val: str, float_val: bool
     ) -> None:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -873,18 +873,18 @@ class TestConfigAPI:
         pytester.makeconftest(
             """
             def pytest_addoption(parser):
-                parser.addini("ini_param", "", type="float", default=2.2)
+                parser.addini("float_val", "", type="float", default=2.2)
         """
         )
         if str_val != "no-ini":
             pytester.makeini(
                 f"""
                 [pytest]
-                ini_param={str_val}
+                float_val={str_val}
             """
             )
         config = pytester.parseconfig()
-        assert config.getini("ini_param") == float_val
+        assert config.getini("float_val") == float_val
 
     def test_addinivalue_line_existing(self, pytester: Pytester) -> None:
         pytester.makeconftest(

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -880,7 +880,9 @@ class TestConfigAPI:
             """
         )
         config = pytester.parseconfig()
-        with pytest.raises(TypeError, match="Expected str or int for option ini_param"):
+        with pytest.raises(
+            TypeError, match="Expected an int string for option ini_param"
+        ):
             _ = config.getini("ini_param")
 
     @pytest.mark.parametrize("str_val, float_val", [("10.5", 10.5), ("no-ini", 2.2)])
@@ -918,7 +920,7 @@ class TestConfigAPI:
         )
         config = pytester.parseconfig()
         with pytest.raises(
-            TypeError, match="Expected str or float for option ini_param"
+            TypeError, match="Expected a float string for option ini_param"
         ):
             _ = config.getini("ini_param")
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -848,12 +848,8 @@ class TestConfigAPI:
         config = pytester.parseconfig()
         assert config.getini("strip") is bool_val
 
-    @pytest.mark.parametrize(
-        "str_val, int_val", [("10", 10), ("no-ini", 0)]
-    )
-    def test_addini_int(
-        self, pytester: Pytester, str_val: str, int_val: bool
-    ) -> None:
+    @pytest.mark.parametrize("str_val, int_val", [("10", 10), ("no-ini", 0)])
+    def test_addini_int(self, pytester: Pytester, str_val: str, int_val: bool) -> None:
         pytester.makeconftest(
             """
             def pytest_addoption(parser):
@@ -870,9 +866,7 @@ class TestConfigAPI:
         config = pytester.parseconfig()
         assert config.getini("ini_param") == int_val
 
-    @pytest.mark.parametrize(
-        "str_val, float_val", [("10.5", 10.5), ("no-ini", 0.0)]
-    )
+    @pytest.mark.parametrize("str_val, float_val", [("10.5", 10.5), ("no-ini", 0.0)])
     def test_addini_float(
         self, pytester: Pytester, str_val: str, float_val: bool
     ) -> None:


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
Implements #11381 
parsing of ``int`` and ``float`` configuration values from the **ini** files has been improved