### PR TITLE
doc: Change training to remote only

### DIFF
--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -2,7 +2,7 @@
 
 .. sidebar:: **Next Open Trainings and Events**
 
-    - `Professional Testing with Python <https://python-academy.com/courses/python_course_testing.html>`_, via `Python Academy <https://www.python-academy.com/>`_ (3 day in-depth training), **March 4th -- 6th 2025**, Leipzig (DE) / Remote
+    - `Professional Testing with Python <https://python-academy.com/courses/python_course_testing.html>`_, via `Python Academy <https://www.python-academy.com/>`_ (3 day in-depth training), **March 4th -- 6th 2025**, Remote
 
     Also see :doc:`previous talks and blogposts <talks>`
 


### PR DESCRIPTION
Since we only have 4 sign-ups so far (2 of them originally on-site), we decided to switch to remote-only.