### PR TITLE
remove `git fetch` from tox docs environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -103,13 +103,7 @@ basepython = python3.12 # sync with rtd to get errors
 usedevelop = True
 deps =
     -r{toxinidir}/doc/en/requirements.txt
-allowlist_externals =
-  git
 commands =
-    # Retrieve possibly missing commits:
-    -git fetch --unshallow
-    -git fetch --tags
-
     sphinx-build \
       -j auto \
       -W --keep-going \


### PR DESCRIPTION
It's a pain to have these when testing locally, they're unnecessary, and will prompt for ssh password (my ssh-agent env vars aren't passing through to tox).

Testing to see if this breaks CI
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
