### PR TITLE
Update capture-warnings.rst: Fix PEP number in link

### DIFF
--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -250,7 +250,7 @@ See :ref:`@pytest.mark.filterwarnings <filterwarnings>` and
     the :envvar:`python:PYTHONWARNINGS` environment variable or the
     ``-W`` command-line option, pytest will not configure any filters by default.
 
-    Also pytest doesn't follow :pep:`506` suggestion of resetting all warning filters because
+    Also pytest doesn't follow :pep:`565` suggestion of resetting all warning filters because
     it might break test suites that configure warning filters themselves
     by calling :func:`warnings.simplefilter` (see :issue:`2430` for an example of that).
 


### PR DESCRIPTION
This was linking to a completely unrelated PEP, presumably due to a typo.

Sorry there's no changelog, filing from my phone.

<hr>

Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features. **(Not a feature.)**
- [ ] Include new tests or update existing tests when applicable. **(Testing this would be probabilistic at best.)**
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information. **(I don't know of an issue for this.)**

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) **(it is)** please:

<details>
- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
</details>
