### PR TITLE
Fix help sections for CLI options

### DIFF
--- a/changelog/13221.doc.rst
+++ b/changelog/13221.doc.rst
@@ -1,0 +1,1 @@
+Improved grouping of CLI options in the ``--help`` output.

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -48,7 +48,7 @@ _CaptureMethod = Literal["fd", "sys", "no", "tee-sys"]
 
 def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("general")
-    group._addoption(
+    group.addoption(
         "--capture",
         action="store",
         default="fd",
@@ -56,7 +56,7 @@ def pytest_addoption(parser: Parser) -> None:
         choices=["fd", "sys", "no", "tee-sys"],
         help="Per-test capturing method: one of fd|sys|no|tee-sys",
     )
-    group._addoption(
+    group._addoption(  # private to use reserved lower-case short option
         "-s",
         action="store_const",
         const="no",

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -40,13 +40,13 @@ def _validate_usepdb_cls(value: str) -> tuple[str, str]:
 
 def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("general")
-    group._addoption(
+    group.addoption(
         "--pdb",
         dest="usepdb",
         action="store_true",
         help="Start the interactive Python debugger on errors or KeyboardInterrupt",
     )
-    group._addoption(
+    group.addoption(
         "--pdbcls",
         dest="usepdb_cls",
         metavar="modulename:classname",
@@ -54,7 +54,7 @@ def pytest_addoption(parser: Parser) -> None:
         help="Specify a custom interactive Python debugger for use with --pdb."
         "For example: --pdbcls=IPython.terminal.debugger:TerminalPdb",
     )
-    group._addoption(
+    group.addoption(
         "--trace",
         dest="trace",
         action="store_true",

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -55,14 +55,14 @@ def pytest_addoption(parser: Parser) -> None:
         help="Display pytest version and information about plugins. "
         "When given twice, also display information about plugins.",
     )
-    group._addoption(
+    group._addoption(  # private to use reserved lower-case short option
         "-h",
         "--help",
         action=HelpAction,
         dest="help",
         help="Show help message and configuration info",
     )
-    group._addoption(
+    group._addoption(  # private to use reserved lower-case short option
         "-p",
         action="append",
         dest="plugins",
@@ -90,7 +90,7 @@ def pytest_addoption(parser: Parser) -> None:
         "This file is opened with 'w' and truncated as a result, care advised. "
         "Default: pytestdebug.log.",
     )
-    group._addoption(
+    group._addoption(  # private to use reserved lower-case short option
         "-o",
         "--override-ini",
         dest="override_ini",

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -92,20 +92,6 @@ def pytest_addoption(parser: Parser) -> None:
         const=1,
         help="Exit instantly on first error or failed test",
     )
-    group = parser.getgroup("pytest-warnings")
-    group.addoption(
-        "-W",
-        "--pythonwarnings",
-        action="append",
-        help="Set which warnings to report, see -W option of Python itself",
-    )
-    parser.addini(
-        "filterwarnings",
-        type="linelist",
-        help="Each line specifies a pattern for "
-        "warnings.filterwarnings. "
-        "Processed after -W/--pythonwarnings.",
-    )
     group._addoption(
         "--maxfail",
         metavar="num",
@@ -155,6 +141,21 @@ def pytest_addoption(parser: Parser) -> None:
         help="Define root directory for tests. Can be relative path: 'root_dir', './root_dir', "
         "'root_dir/another_dir/'; absolute path: '/home/user/root_dir'; path with variables: "
         "'$HOME/root_dir'.",
+    )
+
+    group = parser.getgroup("pytest-warnings")
+    group.addoption(
+        "-W",
+        "--pythonwarnings",
+        action="append",
+        help="Set which warnings to report, see -W option of Python itself",
+    )
+    parser.addini(
+        "filterwarnings",
+        type="linelist",
+        help="Each line specifies a pattern for "
+        "warnings.filterwarnings. "
+        "Processed after -W/--pythonwarnings.",
     )
 
     group = parser.getgroup("collect", "collection")

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -54,35 +54,6 @@ if TYPE_CHECKING:
 
 
 def pytest_addoption(parser: Parser) -> None:
-    parser.addini(
-        "norecursedirs",
-        "Directory patterns to avoid for recursion",
-        type="args",
-        default=[
-            "*.egg",
-            ".*",
-            "_darcs",
-            "build",
-            "CVS",
-            "dist",
-            "node_modules",
-            "venv",
-            "{arch}",
-        ],
-    )
-    parser.addini(
-        "testpaths",
-        "Directories to search for tests when no files or directories are given on the "
-        "command line",
-        type="args",
-        default=[],
-    )
-    parser.addini(
-        "collect_imported_tests",
-        "Whether to collect tests in imported modules outside `testpaths`",
-        type="bool",
-        default=True,
-    )
     group = parser.getgroup("general", "Running and selection options")
     group._addoption(
         "-x",
@@ -126,13 +97,6 @@ def pytest_addoption(parser: Parser) -> None:
         dest="inifilename",
         help="Load configuration from `FILE` instead of trying to locate one of the "
         "implicit configuration files.",
-    )
-    group._addoption(
-        "--continue-on-collection-errors",
-        action="store_true",
-        default=False,
-        dest="continue_on_collection_errors",
-        help="Force test execution even if collection errors occur",
     )
     group._addoption(
         "--rootdir",
@@ -219,6 +183,13 @@ def pytest_addoption(parser: Parser) -> None:
         default=False,
         help="Don't ignore tests in a local virtualenv directory",
     )
+    group._addoption(
+        "--continue-on-collection-errors",
+        action="store_true",
+        default=False,
+        dest="continue_on_collection_errors",
+        help="Force test execution even if collection errors occur",
+    )
     group.addoption(
         "--import-mode",
         default="prepend",
@@ -226,6 +197,35 @@ def pytest_addoption(parser: Parser) -> None:
         dest="importmode",
         help="Prepend/append to sys.path when importing test modules and conftest "
         "files. Default: prepend.",
+    )
+    parser.addini(
+        "norecursedirs",
+        "Directory patterns to avoid for recursion",
+        type="args",
+        default=[
+            "*.egg",
+            ".*",
+            "_darcs",
+            "build",
+            "CVS",
+            "dist",
+            "node_modules",
+            "venv",
+            "{arch}",
+        ],
+    )
+    parser.addini(
+        "testpaths",
+        "Directories to search for tests when no files or directories are given on the "
+        "command line",
+        type="args",
+        default=[],
+    )
+    parser.addini(
+        "collect_imported_tests",
+        "Whether to collect tests in imported modules outside `testpaths`",
+        type="bool",
+        default=True,
     )
     parser.addini(
         "consider_namespace_packages",

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 
 def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("general", "Running and selection options")
-    group._addoption(
+    group._addoption(  # private to use reserved lower-case short option
         "-x",
         "--exitfirst",
         action="store_const",
@@ -63,7 +63,7 @@ def pytest_addoption(parser: Parser) -> None:
         const=1,
         help="Exit instantly on first error or failed test",
     )
-    group._addoption(
+    group.addoption(
         "--maxfail",
         metavar="num",
         action="store",
@@ -72,19 +72,19 @@ def pytest_addoption(parser: Parser) -> None:
         default=0,
         help="Exit after first num failures or errors",
     )
-    group._addoption(
+    group.addoption(
         "--strict-config",
         action="store_true",
         help="Any warnings encountered while parsing the `pytest` section of the "
         "configuration file raise errors",
     )
-    group._addoption(
+    group.addoption(
         "--strict-markers",
         action="store_true",
         help="Markers not registered in the `markers` section of the configuration "
         "file raise errors",
     )
-    group._addoption(
+    group.addoption(
         "--strict",
         action="store_true",
         help="(Deprecated) alias to --strict-markers",
@@ -166,7 +166,7 @@ def pytest_addoption(parser: Parser) -> None:
         default=False,
         help="Don't ignore tests in a local virtualenv directory",
     )
-    group._addoption(
+    group.addoption(
         "--continue-on-collection-errors",
         action="store_true",
         default=False,
@@ -218,7 +218,7 @@ def pytest_addoption(parser: Parser) -> None:
     )
 
     group = parser.getgroup("debugconfig", "test session debugging and configuration")
-    group._addoption(
+    group._addoption(  # private to use reserved lower-case short option
         "-c",
         "--config-file",
         metavar="FILE",
@@ -227,7 +227,7 @@ def pytest_addoption(parser: Parser) -> None:
         help="Load configuration from `FILE` instead of trying to locate one of the "
         "implicit configuration files.",
     )
-    group._addoption(
+    group.addoption(
         "--rootdir",
         action="store",
         dest="rootdir",

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -89,23 +89,6 @@ def pytest_addoption(parser: Parser) -> None:
         action="store_true",
         help="(Deprecated) alias to --strict-markers",
     )
-    group._addoption(
-        "-c",
-        "--config-file",
-        metavar="FILE",
-        type=str,
-        dest="inifilename",
-        help="Load configuration from `FILE` instead of trying to locate one of the "
-        "implicit configuration files.",
-    )
-    group._addoption(
-        "--rootdir",
-        action="store",
-        dest="rootdir",
-        help="Define root directory for tests. Can be relative path: 'root_dir', './root_dir', "
-        "'root_dir/another_dir/'; absolute path: '/home/user/root_dir'; path with variables: "
-        "'$HOME/root_dir'.",
-    )
 
     group = parser.getgroup("pytest-warnings")
     group.addoption(
@@ -235,6 +218,23 @@ def pytest_addoption(parser: Parser) -> None:
     )
 
     group = parser.getgroup("debugconfig", "test session debugging and configuration")
+    group._addoption(
+        "-c",
+        "--config-file",
+        metavar="FILE",
+        type=str,
+        dest="inifilename",
+        help="Load configuration from `FILE` instead of trying to locate one of the "
+        "implicit configuration files.",
+    )
+    group._addoption(
+        "--rootdir",
+        action="store",
+        dest="rootdir",
+        help="Define root directory for tests. Can be relative path: 'root_dir', './root_dir', "
+        "'root_dir/another_dir/'; absolute path: '/home/user/root_dir'; path with variables: "
+        "'$HOME/root_dir'.",
+    )
     group.addoption(
         "--basetemp",
         dest="basetemp",

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -79,7 +79,7 @@ def param(
 
 def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("general")
-    group._addoption(
+    group._addoption(  # private to use reserved lower-case short option
         "-k",
         action="store",
         dest="keyword",
@@ -99,7 +99,7 @@ def pytest_addoption(parser: Parser) -> None:
         "The matching is case-insensitive.",
     )
 
-    group._addoption(
+    group._addoption(  # private to use reserved lower-case short option
         "-m",
         action="store",
         dest="markexpr",

--- a/src/_pytest/pastebin.py
+++ b/src/_pytest/pastebin.py
@@ -20,7 +20,7 @@ pastebinfile_key = StashKey[IO[bytes]]()
 
 def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("terminal reporting")
-    group._addoption(
+    group.addoption(
         "--pastebin",
         metavar="mode",
         action="store",

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -132,7 +132,7 @@ class TestShortLogReport(NamedTuple):
 
 def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("terminal reporting", "Reporting", after="general")
-    group._addoption(
+    group._addoption(  # private to use reserved lower-case short option
         "-v",
         "--verbose",
         action="count",
@@ -140,35 +140,35 @@ def pytest_addoption(parser: Parser) -> None:
         dest="verbose",
         help="Increase verbosity",
     )
-    group._addoption(
+    group.addoption(
         "--no-header",
         action="store_true",
         default=False,
         dest="no_header",
         help="Disable header",
     )
-    group._addoption(
+    group.addoption(
         "--no-summary",
         action="store_true",
         default=False,
         dest="no_summary",
         help="Disable summary",
     )
-    group._addoption(
+    group.addoption(
         "--no-fold-skipped",
         action="store_false",
         dest="fold_skipped",
         default=True,
         help="Do not fold skipped tests in short summary.",
     )
-    group._addoption(
+    group.addoption(
         "--force-short-summary",
         action="store_true",
         dest="force_short_summary",
         default=False,
         help="Force condensed summary output regardless of verbosity level.",
     )
-    group._addoption(
+    group._addoption(  # private to use reserved lower-case short option
         "-q",
         "--quiet",
         action=MoreQuietAction,
@@ -176,14 +176,14 @@ def pytest_addoption(parser: Parser) -> None:
         dest="verbose",
         help="Decrease verbosity",
     )
-    group._addoption(
+    group.addoption(
         "--verbosity",
         dest="verbose",
         type=int,
         default=0,
         help="Set verbosity. Default: 0.",
     )
-    group._addoption(
+    group._addoption(  # private to use reserved lower-case short option
         "-r",
         action="store",
         dest="reportchars",
@@ -195,7 +195,7 @@ def pytest_addoption(parser: Parser) -> None:
         "(w)arnings are enabled by default (see --disable-warnings), "
         "'N' can be used to reset the list. (default: 'fE').",
     )
-    group._addoption(
+    group.addoption(
         "--disable-warnings",
         "--disable-pytest-warnings",
         default=False,
@@ -203,7 +203,7 @@ def pytest_addoption(parser: Parser) -> None:
         action="store_true",
         help="Disable warnings summary",
     )
-    group._addoption(
+    group._addoption(  # private to use reserved lower-case short option
         "-l",
         "--showlocals",
         action="store_true",
@@ -211,13 +211,13 @@ def pytest_addoption(parser: Parser) -> None:
         default=False,
         help="Show locals in tracebacks (disabled by default)",
     )
-    group._addoption(
+    group.addoption(
         "--no-showlocals",
         action="store_false",
         dest="showlocals",
         help="Hide locals in tracebacks (negate --showlocals passed through addopts)",
     )
-    group._addoption(
+    group.addoption(
         "--tb",
         metavar="style",
         action="store",
@@ -226,14 +226,14 @@ def pytest_addoption(parser: Parser) -> None:
         choices=["auto", "long", "short", "no", "line", "native"],
         help="Traceback print mode (auto/long/short/line/native/no)",
     )
-    group._addoption(
+    group.addoption(
         "--xfail-tb",
         action="store_true",
         dest="xfail_tb",
         default=False,
         help="Show tracebacks for xfail (as long as --tb != no)",
     )
-    group._addoption(
+    group.addoption(
         "--show-capture",
         action="store",
         dest="showcapture",
@@ -242,14 +242,14 @@ def pytest_addoption(parser: Parser) -> None:
         help="Controls how captured stdout/stderr/log is shown on failed tests. "
         "Default: all.",
     )
-    group._addoption(
+    group.addoption(
         "--fulltrace",
         "--full-trace",
         action="store_true",
         default=False,
         help="Don't cut any tracebacks (default is to cut)",
     )
-    group._addoption(
+    group.addoption(
         "--color",
         metavar="color",
         action="store",
@@ -258,7 +258,7 @@ def pytest_addoption(parser: Parser) -> None:
         choices=["yes", "no", "auto"],
         help="Color terminal output (yes/no/auto)",
     )
-    group._addoption(
+    group.addoption(
         "--code-highlight",
         default="yes",
         choices=["yes", "no"],


### PR DESCRIPTION
Probably best reviewed commit by commit. Notably, this fixes:

    pytest-warnings:
      -W, --pythonwarnings PYTHONWARNINGS
                            Set which warnings to report, see -W option of Python itself
      --maxfail=num         Exit after first num failures or errors
      --strict-config       Any warnings encountered while parsing the `pytest` section of the configuration file raise errors
      --strict-markers      Markers not registered in the `markers` section of the configuration file raise errors
      --strict              (Deprecated) alias to --strict-markers
      -c, --config-file FILE
                            Load configuration from `FILE` instead of trying to locate one of the implicit configuration files.
      --continue-on-collection-errors
                            Force test execution even if collection errors occur
      --rootdir=ROOTDIR     Define root directory for tests. Can be relative path: 'root_dir', './root_dir', 'root_dir/another_dir/'; absolute path: '/home/user/root_dir'; path with variables: '$HOME/root_dir'.

which makes no sense for anything except the first option, and is a regression in 19e99ab4131fbd709ce0e5a17694e1be3b22f355.

Other than that, it moves:

- `--continue-on-collection-errors` to "collection" rather than "general"
- `--config-file` and `--rootdir` to "test session [...] configuration" (where we also have things like `--basetemp` and `--override-ini`) instead of "general"

Finally, it cleans up incorrectly cargo-culted usage of `group._addoption` instead of `group.addoption`.

Not sure if this needs a changelog?