### PR TITLE
doc: Clarify capturing .readouterr() return value

### DIFF
--- a/doc/en/how-to/capture-stdout-stderr.rst
+++ b/doc/en/how-to/capture-stdout-stderr.rst
@@ -131,7 +131,7 @@ test from having to care about setting/resetting
 output streams and also interacts well with pytest's
 own per-test capturing.
 
-The return value from ``readouterr`` changed to a ``namedtuple`` with two attributes, ``out`` and ``err``.
+The return value of ``readouterr()`` is a ``namedtuple`` with two attributes, ``out`` and ``err``.
 
 If the code under test writes non-textual data (``bytes``), you can capture this using
 the :fixture:`capsysbinary` fixture which instead returns ``bytes`` from

--- a/doc/en/how-to/parametrize.rst
+++ b/doc/en/how-to/parametrize.rst
@@ -29,10 +29,6 @@ pytest enables test parametrization at several levels:
 
 .. regendoc: wipe
 
-
-
-    Several improvements.
-
 The builtin :ref:`pytest.mark.parametrize ref` decorator enables
 parametrization of arguments for a test function.  Here is a typical example
 of a test function that implements checking that a certain input leads


### PR DESCRIPTION
This got added in 38fb6aae7830837209c40ec1a4ccb68950bc107c, where the "The return value ... changed" made a lot of sense. However, 9c5da9c0d15ccf7ab9f3a8fbd6540e4a56ea789f removed the "versionadded" without adjusting the wording.

Also see 3a4435fb59604d40c5d2e2f65e9acba99dd9cff0.