### PR TITLE
add --disable-plugin-autoload

### DIFF
--- a/changelog/13253.feature.rst
+++ b/changelog/13253.feature.rst
@@ -1,0 +1,1 @@
+New flag: :ref:`--disable-plugin-autoload <disable_plugin_autoload>` which works as an alternative to :envvar:`PYTEST_DISABLE_PLUGIN_AUTOLOAD` when setting environment variables is inconvenient; and allows setting it in config files with :confval:`addopts`.

--- a/doc/en/how-to/plugins.rst
+++ b/doc/en/how-to/plugins.rst
@@ -155,7 +155,7 @@ manually specify each plugin with ``-p`` or :envvar:`PYTEST_PLUGINS`, you can us
 
     [pytest]
     addopts = --disable-plugin-autoload -p NAME,NAME2
-    
+
 .. versionadded:: 8.4
 
    The ``--disable-plugin-autoload`` command-line flag.

--- a/doc/en/how-to/plugins.rst
+++ b/doc/en/how-to/plugins.rst
@@ -133,4 +133,25 @@ CI server), you can set ``PYTEST_ADDOPTS`` environment variable to
 
 See :ref:`findpluginname` for how to obtain the name of a plugin.
 
-.. _`builtin plugins`:
+.. _`disable_plugin_autoload`:
+
+Disabling plugins from autoloading
+----------------------------------
+
+If you want to disable plugins from loading automatically, requiring you to
+manually specify each plugin with ``-p`` or :envvar:`PYTEST_PLUGINS`, you can use ``--disable-plugin-autoload`` or :envvar:`PYTEST_DISABLE_PLUGIN_AUTOLOAD`.
+
+.. code-block:: bash
+
+   export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+   export PYTEST_PLUGINS=NAME
+   pytest
+
+.. code-block:: bash
+
+   pytest --disable-plugin-autoload -p NAME,NAME2
+
+.. code-block:: ini
+
+    [pytest]
+    addopts = --disable-plugin-autoload -p NAME,NAME2

--- a/doc/en/how-to/plugins.rst
+++ b/doc/en/how-to/plugins.rst
@@ -138,7 +138,7 @@ See :ref:`findpluginname` for how to obtain the name of a plugin.
 Disabling plugins from autoloading
 ----------------------------------
 
-If you want to disable plugins from loading automatically, requiring you to
+If you want to disable plugins from loading automatically, instead of requiring you to
 manually specify each plugin with ``-p`` or :envvar:`PYTEST_PLUGINS`, you can use ``--disable-plugin-autoload`` or :envvar:`PYTEST_DISABLE_PLUGIN_AUTOLOAD`.
 
 .. code-block:: bash
@@ -155,3 +155,7 @@ manually specify each plugin with ``-p`` or :envvar:`PYTEST_PLUGINS`, you can us
 
     [pytest]
     addopts = --disable-plugin-autoload -p NAME,NAME2
+    
+.. versionadded:: 8.4
+
+   The ``--disable-plugin-autoload`` command-line flag.

--- a/doc/en/how-to/plugins.rst
+++ b/doc/en/how-to/plugins.rst
@@ -144,7 +144,7 @@ manually specify each plugin with ``-p`` or :envvar:`PYTEST_PLUGINS`, you can us
 .. code-block:: bash
 
    export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
-   export PYTEST_PLUGINS=NAME
+   export PYTEST_PLUGINS=NAME,NAME2
    pytest
 
 .. code-block:: bash

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1161,8 +1161,9 @@ as discussed in :ref:`temporary directory location and retention`.
 .. envvar:: PYTEST_DISABLE_PLUGIN_AUTOLOAD
 
 When set, disables plugin auto-loading through :std:doc:`entry point packaging
-metadata <packaging:guides/creating-and-discovering-plugins>`. Only explicitly
-specified plugins will be loaded.
+metadata <packaging:guides/creating-and-discovering-plugins>`. Only plugins
+explicitly specified in :envvar:`PYTEST_PLUGINS` or with ``-p`` will be loaded.
+See also :ref:`--disable-plugin-autoload <disable_plugin_autoload>`.
 
 .. envvar:: PYTEST_PLUGINS
 
@@ -1171,6 +1172,8 @@ Contains comma-separated list of modules that should be loaded as plugins:
 .. code-block:: bash
 
     export PYTEST_PLUGINS=mymodule.plugin,xdist
+
+See also ``-p``.
 
 .. envvar:: PYTEST_THEME
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -70,6 +70,7 @@ from _pytest.warning_types import warn_explicit_for
 
 
 if TYPE_CHECKING:
+    from _pytest.assertions.rewrite import AssertionRewritingHook
     from _pytest.cacheprovider import Cache
     from _pytest.terminal import TerminalReporter
 
@@ -1271,6 +1272,10 @@ class Config:
         """
         ns, unknown_args = self._parser.parse_known_and_unknown_args(args)
         mode = getattr(ns, "assertmode", "plain")
+
+        disable_autoload = getattr(ns, "disable_plugin_autoload", False) | bool(
+            os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
+        )
         if mode == "rewrite":
             import _pytest.assertion
 
@@ -1279,16 +1284,18 @@ class Config:
             except SystemError:
                 mode = "plain"
             else:
-                self._mark_plugins_for_rewrite(hook)
+                self._mark_plugins_for_rewrite(hook, disable_autoload)
         self._warn_about_missing_assertion(mode)
 
-    def _mark_plugins_for_rewrite(self, hook) -> None:
+    def _mark_plugins_for_rewrite(
+        self, hook: AssertionRewritingHook, disable_autoload: bool
+    ) -> None:
         """Given an importhook, mark for rewrite any top-level
         modules or packages in the distribution package for
         all pytest plugins."""
         self.pluginmanager.rewrite_hook = hook
 
-        if os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
+        if disable_autoload:
             # We don't autoload from distribution package entry points,
             # no need to continue.
             return
@@ -1393,10 +1400,15 @@ class Config:
         self._consider_importhook(args)
         self._configure_python_path()
         self.pluginmanager.consider_preparse(args, exclude_only=False)
-        if not os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
-            # Don't autoload from distribution package entry point. Only
-            # explicitly specified plugins are going to be loaded.
+        if (
+            not os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
+            and not self.known_args_namespace.disable_plugin_autoload
+        ):
+            # Autoloading from distribution package entry point has
+            # not been disabled.
             self.pluginmanager.load_setuptools_entrypoints("pytest11")
+        # Otherwise only plugins explicitly specified in PYTEST_PLUGINS
+        # are going to be loaded.
         self.pluginmanager.consider_env()
 
         self.known_args_namespace = self._parser.parse_known_args(
@@ -1419,7 +1431,7 @@ class Config:
         except ConftestImportFailure as e:
             if self.known_args_namespace.help or self.known_args_namespace.version:
                 # we don't want to prevent --help/--version to work
-                # so just let is pass and print a warning at the end
+                # so just let it pass and print a warning at the end
                 self.issue_config_time_warning(
                     PytestConfigWarning(f"could not load initial conftests: {e.path}"),
                     stacklevel=2,

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1273,7 +1273,7 @@ class Config:
         ns, unknown_args = self._parser.parse_known_and_unknown_args(args)
         mode = getattr(ns, "assertmode", "plain")
 
-        disable_autoload = getattr(ns, "disable_plugin_autoload", False) | bool(
+        disable_autoload = getattr(ns, "disable_plugin_autoload", False) or bool(
             os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
         )
         if mode == "rewrite":

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -70,7 +70,7 @@ def pytest_addoption(parser: Parser) -> None:
         metavar="name",
         help="Early-load given plugin module name or entry point (multi-allowed). "
         "To avoid loading of plugins, use the `no:` prefix, e.g. "
-        "`no:doctest`. See also --disable-plugin-autoload",
+        "`no:doctest`. See also --disable-plugin-autoload.",
     )
     group.addoption(
         "--disable-plugin-autoload",

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -70,7 +70,14 @@ def pytest_addoption(parser: Parser) -> None:
         metavar="name",
         help="Early-load given plugin module name or entry point (multi-allowed). "
         "To avoid loading of plugins, use the `no:` prefix, e.g. "
-        "`no:doctest`.",
+        "`no:doctest`. See also --disable-plugin-autoload",
+    )
+    group.addoption(
+        "--disable-plugin-autoload",
+        action="store_true",
+        default=False,
+        help="Disable plugin auto-loading through entry point packaging metadata. "
+        "Only plugins explicitly specified in -p or env var PYTEST_PLUGINS will be loaded.",
     )
     group.addoption(
         "--traceconfig",

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -218,10 +218,40 @@ class TestImportHookInstallation:
         assert result.ret == 0
 
     @pytest.mark.parametrize("mode", ["plain", "rewrite"])
+    @pytest.mark.parametrize("disable_plugin_autoload", ["env_var", "cli", ""])
+    @pytest.mark.parametrize("explicit_specify", ["env_var", "cli", ""])
     def test_installed_plugin_rewrite(
-        self, pytester: Pytester, mode, monkeypatch
+        self,
+        pytester: Pytester,
+        mode: str,
+        monkeypatch: pytest.MonkeyPatch,
+        disable_plugin_autoload: str,
+        explicit_specify: str,
     ) -> None:
-        monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
+        args = ["mainwrapper.py", "-s", f"--assert={mode}"]
+        if disable_plugin_autoload == "env_var":
+            monkeypatch.setenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
+        elif disable_plugin_autoload == "cli":
+            monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
+            args.append("--disable-plugin-autoload")
+        else:
+            assert disable_plugin_autoload == ""
+            monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
+
+        # FIXME: if it's already loaded then you get a ValueError: "Plugin already
+        # registered under a different name."
+        # vaguely related to https://github.com/pytest-dev/pytest/issues/5661
+        name = "spamplugin" if disable_plugin_autoload else "spam"
+        # is there a single dotted name that can be used either way? idk
+
+        if explicit_specify == "env_var":
+            monkeypatch.setenv("PYTEST_PLUGINS", name)
+        elif explicit_specify == "cli":
+            args.append("-p")
+            args.append(name)
+        else:
+            assert explicit_specify == ""
+
         # Make sure the hook is installed early enough so that plugins
         # installed via distribution package are rewritten.
         pytester.mkdir("hampkg")
@@ -275,20 +305,29 @@ class TestImportHookInstallation:
                 check_first([10, 30], 30)
 
             def test2(check_first2):
-                check_first([10, 30], 30)
+                check_first2([10, 30], 30)
             """,
         }
         pytester.makepyfile(**contents)
-        result = pytester.run(
-            sys.executable, "mainwrapper.py", "-s", f"--assert={mode}"
-        )
+        result = pytester.run(sys.executable, *args)
         if mode == "plain":
             expected = "E       AssertionError"
         elif mode == "rewrite":
             expected = "*assert 10 == 30*"
         else:
             assert 0
-        result.stdout.fnmatch_lines([expected])
+
+        if not disable_plugin_autoload or explicit_specify:
+            result.assert_outcomes(failed=2)
+            result.stdout.fnmatch_lines([expected, expected])
+        else:
+            result.assert_outcomes(errors=2)
+            result.stdout.fnmatch_lines(
+                [
+                    "E       fixture 'check_first' not found",
+                    "E       fixture 'check_first2' not found",
+                ]
+            )
 
     def test_rewrite_ast(self, pytester: Pytester) -> None:
         pytester.mkdir("pkg")

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -238,11 +238,7 @@ class TestImportHookInstallation:
             assert disable_plugin_autoload == ""
             monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
 
-        # FIXME: if it's already loaded then you get a ValueError: "Plugin already
-        # registered under a different name."
-        # vaguely related to https://github.com/pytest-dev/pytest/issues/5661
-        name = "spamplugin" if disable_plugin_autoload else "spam"
-        # is there a single dotted name that can be used either way? idk
+        name = "spamplugin"
 
         if explicit_specify == "env_var":
             monkeypatch.setenv("PYTEST_PLUGINS", name)
@@ -280,7 +276,7 @@ class TestImportHookInstallation:
             import pytest
 
             class DummyEntryPoint(object):
-                name = 'spam'
+                name = 'spamplugin'
                 module_name = 'spam.py'
                 group = 'pytest11'
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1373,7 +1373,7 @@ def test_disable_plugin_autoload(
 
     has_loaded = config.pluginmanager.get_plugin("mytestplugin") is not None
     # it should load if it's enabled, or we haven't disabled autoloading
-    assert has_loaded == bool(enable_plugin_method) or not disable_plugin_method
+    assert has_loaded == (bool(enable_plugin_method) or not disable_plugin_method)
 
     # The reason for the discrepancy between 'has_loaded' and __loader__ being accessed
     # appears to be the monkeypatching of importlib.metadata.distributions; where

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1380,8 +1380,9 @@ def test_disable_plugin_autoload(
     # files being empty means that _mark_plugins_for_rewrite doesn't find the plugin.
     # But enable_method==flag ends up in mark_rewrite being called and __loader__
     # being accessed.
-    assert ("__loader__" in PseudoPlugin.attrs_used) == has_loaded and not (
-        enable_plugin_method in ("env_var", "") and not disable_plugin_method
+    assert ("__loader__" in PseudoPlugin.attrs_used) == (
+        has_loaded
+        and not (enable_plugin_method in ("env_var", "") and not disable_plugin_method)
     )
 
     # __spec__ is accessed in AssertionRewritingHook.exec_module, which would be


### PR DESCRIPTION
fixes #8969

I'm pretty sure the implementation is solid, but I have a bunch of question marks in comments that should be resolved before merging. I can probably resolve them on my own by digging deep enough into the innards, but wouldn't mind explanations if somebody is more familiar with that territory.

I'm not entirely sure that `test_installed_plugin_rewrite` should be parametrized to hell, as opposed to creating a dedicated test.

I also found a random unrelated typo in `test_installed_plugin_rewrite` with `check_first` -> `check_first2`, so fixed that + improved the `fnmatch_lines`.

- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

