### PR TITLE
📦📝 Allow modern Towncrier in docs builds

### DIFF
--- a/changelog/13256.contrib.rst
+++ b/changelog/13256.contrib.rst
@@ -1,0 +1,2 @@
+Support for Towncier versions released in 2024 has been re-enabled
+when building Sphinx docs -- by :user:`webknjaz`.

--- a/doc/en/broken-dep-constraints.txt
+++ b/doc/en/broken-dep-constraints.txt
@@ -1,6 +1,2 @@
 # This file contains transitive dependencies that need to be pinned for some reason.
 # Eventually this file will be empty, but in this case keep it around for future use.
-
-# Pin towncrier temporarily due to incompatibility with sphinxcontrib-towncrier:
-# https://github.com/sphinx-contrib/sphinxcontrib-towncrier/issues/92
-towncrier<24.7


### PR DESCRIPTION
https://github.com/sphinx-contrib/sphinxcontrib-towncrier/issues/92 has been resolved and the recent Towncrier versions are compatible with the `sphinxcontrib.towncrier` Sphinx extension project yet again.