### PR TITLE
Fix prepare-release-pr script

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -30,7 +30,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        persist-credentials: false
+        # persist-credentials is needed in order for us to push the release branch.
+        persist-credentials: true
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -47,13 +48,15 @@ jobs:
       env:
         BRANCH: ${{ github.event.inputs.branch }}
         PRERELEASE: ${{ github.event.inputs.prerelease }}
+        GH_TOKEN: ${{ github.token }}
       run: |
-        tox -e prepare-release-pr -- "$BRANCH" ${{ github.token }} --prerelease="$PRERELEASE"
+        tox -e prepare-release-pr -- "$BRANCH" --prerelease="$PRERELEASE"
 
     - name: Prepare release PR (major release)
       if: github.event.inputs.major == 'yes'
       env:
         BRANCH: ${{ github.event.inputs.branch }}
         PRERELEASE: ${{ github.event.inputs.prerelease }}
+        GH_TOKEN: ${{ github.token }}
       run: |
-        tox -e prepare-release-pr -- "$BRANCH" ${{ github.token }} --major --prerelease="$PRERELEASE"
+        tox -e prepare-release-pr -- "$BRANCH" --major --prerelease="$PRERELEASE"

--- a/scripts/prepare-release-pr.py
+++ b/scripts/prepare-release-pr.py
@@ -10,8 +10,7 @@ The appropriate version will be obtained based on the given branch automatically
 
 After that, it will create a release using the `release` tox environment, and push a new PR.
 
-**Token**: currently the token from the GitHub Actions is used, pushed with
-`pytest bot <pytestbot@gmail.com>` commit author.
+Note: the script uses the `gh` command-line tool, so `GH_TOKEN` must be set in the environment.
 """
 
 from __future__ import annotations
@@ -25,7 +24,6 @@ from subprocess import run
 
 from colorama import Fore
 from colorama import init
-from github3.repos import Repository
 
 
 class InvalidFeatureRelease(Exception):
@@ -54,17 +52,7 @@ After the workflow has been approved by a core maintainer, the package will be u
 """
 
 
-def login(token: str) -> Repository:
-    import github3
-
-    github = github3.login(token=token)
-    owner, repo = SLUG.split("/")
-    return github.repository(owner, repo)
-
-
-def prepare_release_pr(
-    base_branch: str, is_major: bool, token: str, prerelease: str
-) -> None:
+def prepare_release_pr(base_branch: str, is_major: bool, prerelease: str) -> None:
     print()
     print(f"Processing release for branch {Fore.CYAN}{base_branch}")
 
@@ -131,22 +119,25 @@ def prepare_release_pr(
         check=True,
     )
 
-    oauth_url = f"https://{token}:x-oauth-basic@github.com/{SLUG}.git"
     run(
-        ["git", "push", oauth_url, f"HEAD:{release_branch}", "--force"],
+        ["git", "push", f"HEAD:{release_branch}", "--force"],
         check=True,
     )
     print(f"Branch {Fore.CYAN}{release_branch}{Fore.RESET} pushed.")
 
     body = PR_BODY.format(version=version)
-    repo = login(token)
-    pr = repo.create_pull(
-        f"Prepare release {version}",
-        base=base_branch,
-        head=release_branch,
-        body=body,
+    run(
+        [
+            "gh",
+            "pr",
+            "new",
+            f"--base={base_branch}",
+            f"--head={release_branch}",
+            f"--title=Release {version}",
+            f"--body={body}",
+        ],
+        check=True,
     )
-    print(f"Pull request {Fore.CYAN}{pr.url}{Fore.RESET} created.")
 
 
 def find_next_version(
@@ -163,7 +154,7 @@ def find_next_version(
     last_version = valid_versions[-1]
 
     if is_major:
-        return f"{last_version[0]+1}.0.0{prerelease}"
+        return f"{last_version[0] + 1}.0.0{prerelease}"
     elif is_feature_release:
         return f"{last_version[0]}.{last_version[1] + 1}.0{prerelease}"
     else:
@@ -174,14 +165,12 @@ def main() -> None:
     init(autoreset=True)
     parser = argparse.ArgumentParser()
     parser.add_argument("base_branch")
-    parser.add_argument("token")
     parser.add_argument("--major", action="store_true", default=False)
     parser.add_argument("--prerelease", default="")
     options = parser.parse_args()
     prepare_release_pr(
         base_branch=options.base_branch,
         is_major=options.major,
-        token=options.token,
         prerelease=options.prerelease,
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -189,11 +189,7 @@ usedevelop = True
 passenv = *
 deps =
     colorama
-    github3.py
     pre-commit>=2.9.3
-    wheel
-    # https://github.com/twisted/towncrier/issues/340
-    towncrier<21.3.0
 commands = python scripts/release.py {posargs}
 
 [testenv:prepare-release-pr]


### PR DESCRIPTION
The script is [currently failing with](https://github.com/pytest-dev/pytest/actions/runs/13615071695/job/38057071681):

```
remote: Support for password authentication was removed on August 13, 2021.
remote: Please see https://docs.github.com/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls for information on currently recommended modes of authentication.
fatal: Authentication failed for 'https://github.com/pytest-dev/pytest.git/'
```

Decided to remove the usage of `github3` and use the `gh` command-line tool directly, which simplifies the script, integrates nicely with GH, and enables to run it locally seamlessly.

---

Note: decided to push to `8.3.x` first so I can test it right away -- I will port back to `main` afterwards.