### PR TITLE
Fix prepare-release-pr script

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -30,7 +30,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        persist-credentials: false
+        # persist-credentials is needed in order for us to push the release branch.
+        persist-credentials: true
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -47,13 +48,15 @@ jobs:
       env:
         BRANCH: ${{ github.event.inputs.branch }}
         PRERELEASE: ${{ github.event.inputs.prerelease }}
+        GH_TOKEN: ${{ github.token }}
       run: |
-        tox -e prepare-release-pr -- "$BRANCH" ${{ github.token }} --prerelease="$PRERELEASE"
+        tox -e prepare-release-pr -- "$BRANCH" --prerelease="$PRERELEASE"
 
     - name: Prepare release PR (major release)
       if: github.event.inputs.major == 'yes'
       env:
         BRANCH: ${{ github.event.inputs.branch }}
         PRERELEASE: ${{ github.event.inputs.prerelease }}
+        GH_TOKEN: ${{ github.token }}
       run: |
-        tox -e prepare-release-pr -- "$BRANCH" ${{ github.token }} --major --prerelease="$PRERELEASE"
+        tox -e prepare-release-pr -- "$BRANCH" --major --prerelease="$PRERELEASE"

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -137,6 +137,10 @@ Both automatic and manual processes described above follow the same steps from t
    in https://github.com/pytest-dev/pytest/actions/workflows/deploy.yml, using the ``release-MAJOR.MINOR.PATCH`` branch
    as source.
 
+   Using the command-line::
+
+     $ gh workflow run deploy.yml -R pytest-dev/pytest --ref=release-{VERSION} -f version={VERSION}
+
    This job will require approval from ``pytest-dev/core``, after which it will publish to PyPI
    and tag the repository.
 

--- a/tox.ini
+++ b/tox.ini
@@ -188,11 +188,8 @@ usedevelop = True
 passenv = *
 deps =
     colorama
-    github3.py
     pre-commit>=2.9.3
-    wheel
-    # https://github.com/twisted/towncrier/issues/340
-    towncrier<21.3.0
+    towncrier
 commands = python scripts/release.py {posargs}
 
 [testenv:prepare-release-pr]


### PR DESCRIPTION
The script is [currently failing with](https://github.com/pytest-dev/pytest/actions/runs/13615071695/job/38057071681):

```
remote: Support for password authentication was removed on August 13, 2021.
remote: Please see https://docs.github.com/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls for information on currently recommended modes of authentication.
fatal: Authentication failed for 'https://github.com/pytest-dev/pytest.git/'
```

Decided to remove the usage of `github3` and use the `gh` command-line tool directly, which simplifies the script, integrates nicely with GH, and enables to run it locally seamlessly.
