### PR TITLE
Cherry-pick release 8.3.5

### DIFF
--- a/changelog/10558.doc.rst
+++ b/changelog/10558.doc.rst
@@ -1,1 +1,0 @@
-Fix ambiguous docstring of :func:`pytest.Config.getoption`.

--- a/changelog/10829.doc.rst
+++ b/changelog/10829.doc.rst
@@ -1,1 +1,0 @@
-Improve documentation on the current handling of the ``--basetemp`` option and its lack of retention functionality (:ref:`temporary directory location and retention`).

--- a/changelog/11777.bugfix.rst
+++ b/changelog/11777.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed issue where sequences were still being shortened even with ``-vv`` verbosity.

--- a/changelog/12497.contrib.rst
+++ b/changelog/12497.contrib.rst
@@ -1,1 +1,0 @@
-Fixed two failing pdb-related tests on Python 3.13.

--- a/changelog/12592.bugfix.rst
+++ b/changelog/12592.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed :class:`KeyError` crash when using ``--import-mode=importlib`` in a directory layout where a directory contains a child directory with the same name.

--- a/changelog/12818.bugfix.rst
+++ b/changelog/12818.bugfix.rst
@@ -1,1 +1,0 @@
-Assertion rewriting now preserves the source ranges of the original instructions, making it play well with tools that deal with the ``AST``, like `executing <https://github.com/alexmojaki/executing>`__.

--- a/changelog/12842.doc.rst
+++ b/changelog/12842.doc.rst
@@ -1,3 +1,0 @@
-Added dedicated page about using types with pytest.
-
-See :ref:`types` for detailed usage.

--- a/changelog/12849.bugfix.rst
+++ b/changelog/12849.bugfix.rst
@@ -1,1 +1,0 @@
-ANSI escape codes for colored output now handled correctly in :func:`pytest.fail` with `pytrace=False`.

--- a/changelog/12866.doc.rst
+++ b/changelog/12866.doc.rst
@@ -1,1 +1,0 @@
-Improved cross-references concerning the :fixture:`recwarn` fixture.

--- a/changelog/12888.bugfix.rst
+++ b/changelog/12888.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed broken input when using Python 3.13+ and a ``libedit`` build of Python, such as on macOS or with uv-managed Python binaries from the ``python-build-standalone`` project. This could manifest e.g. by a broken prompt when using ``Pdb``, or seeing empty inputs with manual usage of ``input()`` and suspended capturing.

--- a/changelog/12966.doc.rst
+++ b/changelog/12966.doc.rst
@@ -1,1 +1,0 @@
-Clarify :ref:`filterwarnings` docs on filter precedence/order when using multiple :ref:`@pytest.mark.filterwarnings <pytest.mark.filterwarnings ref>` marks.

--- a/changelog/13026.bugfix.rst
+++ b/changelog/13026.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed :class:`AttributeError`  crash when using ``--import-mode=importlib`` when top-level directory same name as another module of the standard library.

--- a/changelog/13053.bugfix.rst
+++ b/changelog/13053.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a regression in pytest 8.3.4 where, when using ``--import-mode=importlib``, a directory containing py file with the same name would cause an ``ImportError``

--- a/changelog/13083.bugfix.rst
+++ b/changelog/13083.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed issue where pytest could crash if one of the collected directories got removed during collection.

--- a/changelog/13112.contrib.rst
+++ b/changelog/13112.contrib.rst
@@ -1,1 +1,0 @@
-Fixed selftest failures in ``test_terminal.py`` with Pygments >= 2.19.0

--- a/changelog/13256.contrib.rst
+++ b/changelog/13256.contrib.rst
@@ -1,2 +1,0 @@
-Support for Towncier versions released in 2024 has been re-enabled
-when building Sphinx docs -- by :user:`webknjaz`.

--- a/changelog/9353.bugfix.rst
+++ b/changelog/9353.bugfix.rst
@@ -1,1 +1,0 @@
-:func:`pytest.approx` now uses strict equality when given booleans.

--- a/doc/en/announce/index.rst
+++ b/doc/en/announce/index.rst
@@ -6,6 +6,7 @@ Release announcements
    :maxdepth: 2
 
 
+   release-8.3.4
    release-8.3.3
    release-8.3.2
    release-8.3.1

--- a/doc/en/announce/index.rst
+++ b/doc/en/announce/index.rst
@@ -6,6 +6,7 @@ Release announcements
    :maxdepth: 2
 
 
+   release-8.3.5
    release-8.3.4
    release-8.3.3
    release-8.3.2

--- a/doc/en/announce/release-8.3.4.rst
+++ b/doc/en/announce/release-8.3.4.rst
@@ -1,0 +1,30 @@
+pytest-8.3.4
+=======================================
+
+pytest 8.3.4 has just been released to PyPI.
+
+This is a bug-fix release, being a drop-in replacement. To upgrade::
+
+  pip install --upgrade pytest
+
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
+
+Thanks to all of the contributors to this release:
+
+* Bruno Oliveira
+* Florian Bruhin
+* Frank Hoffmann
+* Jakob van Santen
+* Leonardus Chen
+* Pierre Sassoulas
+* Pradeep Kumar
+* Ran Benita
+* Serge Smertin
+* Stefaan Lippens
+* Sviatoslav Sydorenko (Святослав Сидоренко)
+* dongfangtianyu
+* suspe
+
+
+Happy testing,
+The pytest Development Team

--- a/doc/en/announce/release-8.3.5.rst
+++ b/doc/en/announce/release-8.3.5.rst
@@ -1,0 +1,26 @@
+pytest-8.3.5
+=======================================
+
+pytest 8.3.5 has just been released to PyPI.
+
+This is a bug-fix release, being a drop-in replacement.
+
+The full changelog is available at https://docs.pytest.org/en/stable/changelog.html.
+
+Thanks to all of the contributors to this release:
+
+* Bruno Oliveira
+* Florian Bruhin
+* John Litborn
+* Kenny Y
+* Ran Benita
+* Sadra Barikbin
+* Vincent (Wen Yu) Ge
+* delta87
+* dongfangtianyu
+* mwychung
+* 🇺🇦 Sviatoslav Sydorenko (Святослав Сидоренко)
+
+
+Happy testing,
+The pytest Development Team

--- a/doc/en/builtin.rst
+++ b/doc/en/builtin.rst
@@ -178,16 +178,11 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
         Return a :class:`pytest.TempdirFactory` instance for the test session.
 
     tmpdir -- .../_pytest/legacypath.py:305
-        Return a temporary directory path object which is unique to each test
-        function invocation, created as a sub directory of the base temporary
-        directory.
-
-        By default, a new base temporary directory is created each test session,
-        and old bases are removed after 3 sessions, to aid in debugging. If
-        ``--basetemp`` is used then it is cleared each session. See
-        :ref:`temporary directory location and retention`.
-
-        The returned object is a `legacy_path`_ object.
+        Return a temporary directory (as `legacy_path`_ object)
+        which is unique to each test function invocation.
+        The temporary directory is created as a subdirectory
+        of the base temporary directory, with configurable retention,
+        as discussed in :ref:`temporary directory location and retention`.
 
         .. note::
             These days, it is preferred to use ``tmp_path``.
@@ -236,22 +231,15 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
 
         See :ref:`warnings` for information on warning categories.
 
-    tmp_path_factory [session scope] -- .../_pytest/tmpdir.py:242
+    tmp_path_factory [session scope] -- .../_pytest/tmpdir.py:241
         Return a :class:`pytest.TempPathFactory` instance for the test session.
 
-    tmp_path -- .../_pytest/tmpdir.py:257
-        Return a temporary directory path object which is unique to each test
-        function invocation, created as a sub directory of the base temporary
-        directory.
-
-        By default, a new base temporary directory is created each test session,
-        and old bases are removed after 3 sessions, to aid in debugging.
-        This behavior can be configured with :confval:`tmp_path_retention_count` and
-        :confval:`tmp_path_retention_policy`.
-        If ``--basetemp`` is used then it is cleared each session. See
-        :ref:`temporary directory location and retention`.
-
-        The returned object is a :class:`pathlib.Path` object.
+    tmp_path -- .../_pytest/tmpdir.py:256
+        Return a temporary directory (as :class:`pathlib.Path` object)
+        which is unique to each test function invocation.
+        The temporary directory is created as a subdirectory
+        of the base temporary directory, with configurable retention,
+        as discussed in :ref:`temporary directory location and retention`.
 
 
     ========================== no tests ran in 0.12s ===========================

--- a/doc/en/builtin.rst
+++ b/doc/en/builtin.rst
@@ -33,7 +33,7 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
 
         Values can be any object handled by the json stdlib module.
 
-    capsysbinary -- .../_pytest/capture.py:1006
+    capsysbinary -- .../_pytest/capture.py:1024
         Enable bytes capturing of writes to ``sys.stdout`` and ``sys.stderr``.
 
         The captured output is made available via ``capsysbinary.readouterr()``
@@ -51,7 +51,7 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
                 captured = capsysbinary.readouterr()
                 assert captured.out == b"hello\n"
 
-    capfd -- .../_pytest/capture.py:1034
+    capfd -- .../_pytest/capture.py:1052
         Enable text capturing of writes to file descriptors ``1`` and ``2``.
 
         The captured output is made available via ``capfd.readouterr()`` method
@@ -69,7 +69,7 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
                 captured = capfd.readouterr()
                 assert captured.out == "hello\n"
 
-    capfdbinary -- .../_pytest/capture.py:1062
+    capfdbinary -- .../_pytest/capture.py:1080
         Enable bytes capturing of writes to file descriptors ``1`` and ``2``.
 
         The captured output is made available via ``capfd.readouterr()`` method
@@ -87,7 +87,7 @@ For information about fixtures, see :ref:`fixtures`. To see a complete list of a
                 captured = capfdbinary.readouterr()
                 assert captured.out == b"hello\n"
 
-    capsys -- .../_pytest/capture.py:978
+    capsys -- .../_pytest/capture.py:996
         Enable text capturing of writes to ``sys.stdout`` and ``sys.stderr``.
 
         The captured output is made available via ``capsys.readouterr()`` method

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -31,6 +31,47 @@ with advance notice in the **Deprecations** section of releases.
 
 .. towncrier release notes start
 
+pytest 8.3.5 (2025-03-02)
+=========================
+
+Bug fixes
+---------
+
+- `#11777 <https://github.com/pytest-dev/pytest/issues/11777>`_: Fixed issue where sequences were still being shortened even with ``-vv`` verbosity.
+
+
+- `#12888 <https://github.com/pytest-dev/pytest/issues/12888>`_: Fixed broken input when using Python 3.13+ and a ``libedit`` build of Python, such as on macOS or with uv-managed Python binaries from the ``python-build-standalone`` project. This could manifest e.g. by a broken prompt when using ``Pdb``, or seeing empty inputs with manual usage of ``input()`` and suspended capturing.
+
+
+- `#13026 <https://github.com/pytest-dev/pytest/issues/13026>`_: Fixed :class:`AttributeError`  crash when using ``--import-mode=importlib`` when top-level directory same name as another module of the standard library.
+
+
+- `#13053 <https://github.com/pytest-dev/pytest/issues/13053>`_: Fixed a regression in pytest 8.3.4 where, when using ``--import-mode=importlib``, a directory containing py file with the same name would cause an ``ImportError``
+
+
+- `#13083 <https://github.com/pytest-dev/pytest/issues/13083>`_: Fixed issue where pytest could crash if one of the collected directories got removed during collection.
+
+
+
+Improved documentation
+----------------------
+
+- `#12842 <https://github.com/pytest-dev/pytest/issues/12842>`_: Added dedicated page about using types with pytest.
+
+  See :ref:`types` for detailed usage.
+
+
+
+Contributor-facing changes
+--------------------------
+
+- `#13112 <https://github.com/pytest-dev/pytest/issues/13112>`_: Fixed selftest failures in ``test_terminal.py`` with Pygments >= 2.19.0
+
+
+- `#13256 <https://github.com/pytest-dev/pytest/issues/13256>`_: Support for Towncier versions released in 2024 has been re-enabled
+  when building Sphinx docs -- by :user:`webknjaz`.
+
+
 pytest 8.3.4 (2024-12-01)
 =========================
 

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -31,6 +31,47 @@ with advance notice in the **Deprecations** section of releases.
 
 .. towncrier release notes start
 
+pytest 8.3.4 (2024-12-01)
+=========================
+
+Bug fixes
+---------
+
+- `#12592 <https://github.com/pytest-dev/pytest/issues/12592>`_: Fixed :class:`KeyError` crash when using ``--import-mode=importlib`` in a directory layout where a directory contains a child directory with the same name.
+
+
+- `#12818 <https://github.com/pytest-dev/pytest/issues/12818>`_: Assertion rewriting now preserves the source ranges of the original instructions, making it play well with tools that deal with the ``AST``, like `executing <https://github.com/alexmojaki/executing>`__.
+
+
+- `#12849 <https://github.com/pytest-dev/pytest/issues/12849>`_: ANSI escape codes for colored output now handled correctly in :func:`pytest.fail` with `pytrace=False`.
+
+
+- `#9353 <https://github.com/pytest-dev/pytest/issues/9353>`_: :func:`pytest.approx` now uses strict equality when given booleans.
+
+
+
+Improved documentation
+----------------------
+
+- `#10558 <https://github.com/pytest-dev/pytest/issues/10558>`_: Fix ambiguous docstring of :func:`pytest.Config.getoption`.
+
+
+- `#10829 <https://github.com/pytest-dev/pytest/issues/10829>`_: Improve documentation on the current handling of the ``--basetemp`` option and its lack of retention functionality (:ref:`temporary directory location and retention`).
+
+
+- `#12866 <https://github.com/pytest-dev/pytest/issues/12866>`_: Improved cross-references concerning the :fixture:`recwarn` fixture.
+
+
+- `#12966 <https://github.com/pytest-dev/pytest/issues/12966>`_: Clarify :ref:`filterwarnings` docs on filter precedence/order when using multiple :ref:`@pytest.mark.filterwarnings <pytest.mark.filterwarnings ref>` marks.
+
+
+
+Contributor-facing changes
+--------------------------
+
+- `#12497 <https://github.com/pytest-dev/pytest/issues/12497>`_: Fixed two failing pdb-related tests on Python 3.13.
+
+
 pytest 8.3.3 (2024-09-09)
 =========================
 

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -162,7 +162,7 @@ objects, they are still using the default pytest representation:
     rootdir: /home/sweet/project
     collected 8 items
 
-    <Dir parametrize.rst-204>
+    <Dir parametrize.rst-205>
       <Module test_time.py>
         <Function test_timedistance_v0[a0-b0-expected0]>
         <Function test_timedistance_v0[a1-b1-expected1]>
@@ -239,7 +239,7 @@ If you just collect tests you'll also nicely see 'advanced' and 'basic' as varia
     rootdir: /home/sweet/project
     collected 4 items
 
-    <Dir parametrize.rst-204>
+    <Dir parametrize.rst-205>
       <Module test_scenarios.py>
         <Class TestSampleWithScenarios>
           <Function test_demo1[basic]>
@@ -318,7 +318,7 @@ Let's first see how it looks like at collection time:
     rootdir: /home/sweet/project
     collected 2 items
 
-    <Dir parametrize.rst-204>
+    <Dir parametrize.rst-205>
       <Module test_backends.py>
         <Function test_db_initialized[d1]>
         <Function test_db_initialized[d2]>

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -162,7 +162,7 @@ objects, they are still using the default pytest representation:
     rootdir: /home/sweet/project
     collected 8 items
 
-    <Dir parametrize.rst-205>
+    <Dir parametrize.rst-206>
       <Module test_time.py>
         <Function test_timedistance_v0[a0-b0-expected0]>
         <Function test_timedistance_v0[a1-b1-expected1]>
@@ -239,7 +239,7 @@ If you just collect tests you'll also nicely see 'advanced' and 'basic' as varia
     rootdir: /home/sweet/project
     collected 4 items
 
-    <Dir parametrize.rst-205>
+    <Dir parametrize.rst-206>
       <Module test_scenarios.py>
         <Class TestSampleWithScenarios>
           <Function test_demo1[basic]>
@@ -318,7 +318,7 @@ Let's first see how it looks like at collection time:
     rootdir: /home/sweet/project
     collected 2 items
 
-    <Dir parametrize.rst-205>
+    <Dir parametrize.rst-206>
       <Module test_backends.py>
         <Function test_db_initialized[d1]>
         <Function test_db_initialized[d2]>
@@ -503,11 +503,12 @@ Running it results in some skips if we don't have all the python interpreters in
 .. code-block:: pytest
 
    . $ pytest -rs -q multipython.py
-   ssssssssssss...ssssssssssss                                          [100%]
+   sssssssssssssssssssssssssss                                          [100%]
    ========================= short test summary info ==========================
-   SKIPPED [12] multipython.py:67: 'python3.9' not found
-   SKIPPED [12] multipython.py:67: 'python3.11' not found
-   3 passed, 24 skipped in 0.12s
+   SKIPPED [9] multipython.py:67: 'python3.9' not found
+   SKIPPED [9] multipython.py:67: 'python3.10' not found
+   SKIPPED [9] multipython.py:67: 'python3.11' not found
+   27 skipped in 0.12s
 
 Parametrization of optional implementations/imports
 ---------------------------------------------------

--- a/doc/en/example/pythoncollection.rst
+++ b/doc/en/example/pythoncollection.rst
@@ -152,7 +152,7 @@ The test collection would look like this:
     configfile: pytest.ini
     collected 2 items
 
-    <Dir pythoncollection.rst-205>
+    <Dir pythoncollection.rst-206>
       <Module check_myapp.py>
         <Class CheckMyApp>
           <Function simple_check>
@@ -215,7 +215,7 @@ You can always peek at the collection tree without running tests like this:
     configfile: pytest.ini
     collected 3 items
 
-    <Dir pythoncollection.rst-205>
+    <Dir pythoncollection.rst-206>
       <Dir CWD>
         <Module pythoncollection.py>
           <Function test_function>

--- a/doc/en/example/pythoncollection.rst
+++ b/doc/en/example/pythoncollection.rst
@@ -152,7 +152,7 @@ The test collection would look like this:
     configfile: pytest.ini
     collected 2 items
 
-    <Dir pythoncollection.rst-206>
+    <Dir pythoncollection.rst-207>
       <Module check_myapp.py>
         <Class CheckMyApp>
           <Function simple_check>
@@ -215,7 +215,7 @@ You can always peek at the collection tree without running tests like this:
     configfile: pytest.ini
     collected 3 items
 
-    <Dir pythoncollection.rst-206>
+    <Dir pythoncollection.rst-207>
       <Dir CWD>
         <Module pythoncollection.py>
           <Function test_function>

--- a/doc/en/example/reportingdemo.rst
+++ b/doc/en/example/reportingdemo.rst
@@ -568,12 +568,12 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     E        +  where False = <built-in method startswith of str object at 0xdeadbeef0027>('456')
     E        +    where <built-in method startswith of str object at 0xdeadbeef0027> = '123'.startswith
     E        +      where '123' = <function TestMoreErrors.test_startswith_nested.<locals>.f at 0xdeadbeef0029>()
-    E        +    and   '456' = <function TestMoreErrors.test_startswith_nested.<locals>.g at 0xdeadbeef002a>()
+    E        +    and   '456' = <function TestMoreErrors.test_startswith_nested.<locals>.g at 0xdeadbeef0003>()
 
     failure_demo.py:237: AssertionError
     _____________________ TestMoreErrors.test_global_func ______________________
 
-    self = <failure_demo.TestMoreErrors object at 0xdeadbeef002b>
+    self = <failure_demo.TestMoreErrors object at 0xdeadbeef002a>
 
         def test_global_func(self):
     >       assert isinstance(globf(42), float)
@@ -584,18 +584,18 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:240: AssertionError
     _______________________ TestMoreErrors.test_instance _______________________
 
-    self = <failure_demo.TestMoreErrors object at 0xdeadbeef002c>
+    self = <failure_demo.TestMoreErrors object at 0xdeadbeef002b>
 
         def test_instance(self):
             self.x = 6 * 7
     >       assert self.x != 42
     E       assert 42 != 42
-    E        +  where 42 = <failure_demo.TestMoreErrors object at 0xdeadbeef002c>.x
+    E        +  where 42 = <failure_demo.TestMoreErrors object at 0xdeadbeef002b>.x
 
     failure_demo.py:244: AssertionError
     _______________________ TestMoreErrors.test_compare ________________________
 
-    self = <failure_demo.TestMoreErrors object at 0xdeadbeef002d>
+    self = <failure_demo.TestMoreErrors object at 0xdeadbeef002c>
 
         def test_compare(self):
     >       assert globf(10) < 5
@@ -605,7 +605,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:247: AssertionError
     _____________________ TestMoreErrors.test_try_finally ______________________
 
-    self = <failure_demo.TestMoreErrors object at 0xdeadbeef002e>
+    self = <failure_demo.TestMoreErrors object at 0xdeadbeef002d>
 
         def test_try_finally(self):
             x = 1
@@ -616,7 +616,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:252: AssertionError
     ___________________ TestCustomAssertMsg.test_single_line ___________________
 
-    self = <failure_demo.TestCustomAssertMsg object at 0xdeadbeef002f>
+    self = <failure_demo.TestCustomAssertMsg object at 0xdeadbeef002e>
 
         def test_single_line(self):
             class A:
@@ -631,7 +631,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:263: AssertionError
     ____________________ TestCustomAssertMsg.test_multiline ____________________
 
-    self = <failure_demo.TestCustomAssertMsg object at 0xdeadbeef0030>
+    self = <failure_demo.TestCustomAssertMsg object at 0xdeadbeef002f>
 
         def test_multiline(self):
             class A:
@@ -650,7 +650,7 @@ Here is a nice run of several failures and how ``pytest`` presents things:
     failure_demo.py:270: AssertionError
     ___________________ TestCustomAssertMsg.test_custom_repr ___________________
 
-    self = <failure_demo.TestCustomAssertMsg object at 0xdeadbeef0031>
+    self = <failure_demo.TestCustomAssertMsg object at 0xdeadbeef0030>
 
         def test_custom_repr(self):
             class JSON:

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -164,7 +164,7 @@ Now we'll get feedback on a bad argument:
 
     $ pytest -q --cmdopt=type3
     ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
-    pytest: error: argument --cmdopt: invalid choice: 'type3' (choose from 'type1', 'type2')
+    pytest: error: argument --cmdopt: invalid choice: 'type3' (choose from type1, type2)
 
 
 If you need to provide more detailed error messages, you can use the

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -22,7 +22,7 @@ Install ``pytest``
 .. code-block:: bash
 
     $ pytest --version
-    pytest 8.3.4
+    pytest 8.3.5
 
 .. _`simpletest`:
 

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -22,7 +22,7 @@ Install ``pytest``
 .. code-block:: bash
 
     $ pytest --version
-    pytest 8.3.3
+    pytest 8.3.4
 
 .. _`simpletest`:
 

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -1418,7 +1418,7 @@ Running the above tests results in the following test IDs being used:
    rootdir: /home/sweet/project
    collected 12 items
 
-   <Dir fixtures.rst-224>
+   <Dir fixtures.rst-225>
      <Module test_anothersmtp.py>
        <Function test_showhelo[smtp.gmail.com]>
        <Function test_showhelo[mail.python.org]>

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -1418,7 +1418,7 @@ Running the above tests results in the following test IDs being used:
    rootdir: /home/sweet/project
    collected 12 items
 
-   <Dir fixtures.rst-225>
+   <Dir fixtures.rst-227>
      <Module test_anothersmtp.py>
        <Function test_showhelo[smtp.gmail.com]>
        <Function test_showhelo[mail.python.org]>

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -2102,7 +2102,7 @@ All the command-line flags can be obtained by running ``pytest --help``::
                             Show cache contents, don't perform collection or
                             tests. Optional argument: glob (default: '*').
       --cache-clear         Remove all cache contents at start of test run
-      --lfnf={all,none}, --last-failed-no-failures={all,none}
+      --lfnf, --last-failed-no-failures={all,none}
                             With ``--lf``, determines whether to execute tests
                             when there are no previously (known) failures or
                             when no cached ``lastfailed`` data was found.
@@ -2148,11 +2148,13 @@ All the command-line flags can be obtained by running ``pytest --help``::
                             Whether code should be highlighted (only if --color
                             is also enabled). Default: yes.
       --pastebin=mode       Send failed|all info to bpaste.net pastebin service
-      --junit-xml=path      Create junit-xml style report file at given path
-      --junit-prefix=str    Prepend prefix to classnames in junit-xml output
+      --junitxml, --junit-xml=path
+                            Create junit-xml style report file at given path
+      --junitprefix, --junit-prefix=str
+                            Prepend prefix to classnames in junit-xml output
 
     pytest-warnings:
-      -W PYTHONWARNINGS, --pythonwarnings=PYTHONWARNINGS
+      -W, --pythonwarnings PYTHONWARNINGS
                             Set which warnings to report, see -W option of
                             Python itself
       --maxfail=num         Exit after first num failures or errors
@@ -2161,7 +2163,7 @@ All the command-line flags can be obtained by running ``pytest --help``::
       --strict-markers      Markers not registered in the `markers` section of
                             the configuration file raise errors
       --strict              (Deprecated) alias to --strict-markers
-      -c FILE, --config-file=FILE
+      -c, --config-file FILE
                             Load configuration from `FILE` instead of trying to
                             locate one of the implicit configuration files.
       --continue-on-collection-errors
@@ -2215,7 +2217,7 @@ All the command-line flags can be obtained by running ``pytest --help``::
                             Store internal tracing debug information in this log
                             file. This file is opened with 'w' and truncated as
                             a result, care advised. Default: pytestdebug.log.
-      -o OVERRIDE_INI, --override-ini=OVERRIDE_INI
+      -o, --override-ini OVERRIDE_INI
                             Override ini option with "option=value" style, e.g.
                             `-o xfail_strict=True -o cache_dir=cache`.
       --assert=MODE         Control assertion debugging tools.


### PR DESCRIPTION
Release 8.3.5

(cherry picked from commit f004b11caf49fa6fbacc8648bbc9c650a2e08bec)

---

Really sorry, but it seems when I released `8.3.4` I missed this step, that's why we are bringing the changes for `8.3.4` and `8.3.5` to `main`. 😓 