### PR TITLE
Update rm_rf function to force remove directories

### DIFF
--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -160,15 +160,13 @@ def get_extended_length_path_str(path: str) -> str:
 
 
 def rm_rf(path: Path) -> None:
-    """Remove the path contents recursively, even if some elements
-    are read-only."""
-    path = ensure_extended_length_path(path)
-    onerror = partial(on_rm_rf_error, start_path=path)
-    if sys.version_info >= (3, 12):
-        shutil.rmtree(str(path), onexc=onerror)
-    else:
-        shutil.rmtree(str(path), onerror=onerror)
-
+    """Force remove directory even if it's not empty."""
+    for root, dirs, files in os.walk(path, topdown=False):
+        for file in files:
+            os.remove(os.path.join(root, file))
+        for dir in dirs:
+            shutil.rmtree(os.path.join(root,dir), ignore_errors=True)
+    shutil.rmtree(path, ignore_errors=True)
 
 def find_prefixed(root: Path, prefix: str) -> Iterator[os.DirEntry[str]]:
     """Find all elements in root that begin with the prefix, case-insensitive."""


### PR DESCRIPTION
closes  #13269 
In previous `rm_rf` function Uses `shutil.rmtree(path, onerror=onerror)`, which recursively deletes everything, handling errors via onerror.

Now i update the `rm_rf `function to Explicitly walks the directory tree bottom-up `(topdown=False)` and removes files first, then subdirectories before deleting the main directory.

Now there are no more warnings after passing all tests.

![Screenshot from 2025-03-03 01-00-05](https://github.com/user-attachments/assets/56f4a3c0-8648-40f8-976c-f63600636060)
