### PR TITLE
require codecov patch % to be 100%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,8 @@ codecov:
 
 coverage:
   status:
-    patch: true
+    patch:
+      default:
+        target: 100%  # require patches to be 100%
     project: false
 comment: false


### PR DESCRIPTION
The status quo is for patch coverage to be greater than or equal to the project% (currently 96.87%), which means that in practice it's 100% .. except if a PR is big enough, at which point a couple lines can sneak through.
I just merged #13192 which had 98.26% coverage for no reason, I'll add more tests and stuff in a followup to retroactively get it to 100%.