### PR TITLE
Fix incorrect pyc cache loaded when test file is updated in short time

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -488,3 +488,4 @@ Zachary OBrien
 Zhouxin Qiu
 Zoltán Máté
 Zsolt Cserna
+Johnny Huang

--- a/changelog/13292.bugfix.rst
+++ b/changelog/13292.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed stale pyc cache loading after rapid test file updates.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -317,7 +317,7 @@ def _write_pyc_fp(
     flags = b"\x00\x00\x00\x00"
     fp.write(flags)
     # as of now, bytecode header expects 32-bit numbers for size and mtime (#4903)
-    mtime = int(source_stat.st_mtime) & 0xFFFFFFFF
+    mtime = source_stat.st_mtime_ns & 0xFFFFFFFF
     size = source_stat.st_size & 0xFFFFFFFF
     # "<LL" stands for 2 unsigned longs, little-endian.
     fp.write(struct.pack("<LL", mtime, size))
@@ -374,7 +374,7 @@ def _read_pyc(
     with fp:
         try:
             stat_result = os.stat(source)
-            mtime = int(stat_result.st_mtime)
+            mtime = stat_result.st_mtime_ns
             size = stat_result.st_size
             data = fp.read(16)
         except OSError as e:

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -2377,7 +2377,12 @@ class TestSafereprUnbounded:
 
 
 class TestIssue13292:
-    def test_load_cache_based_on_file_st_mtime_ns(self, pytester: Pytester) -> None:
+    """
+    Check the pyc cache generated in the 1st test execution
+    is not loaded in the 2nd test execution.
+    """
+
+    def test_stale_pyc_cache_is_not_loaded(self, pytester: Pytester) -> None:
         pytester.makepyfile("""
             def test_dummy1():
                 def func():

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1381,9 +1381,12 @@ class TestAssertionRewriteHookDetails:
 
         flags = b"\x00\x00\x00\x00"
 
-        mtime = b"\x58\x3c\xb0\x5f"
+        mtime = b"\x98\xf34\x10\x91\x8b,\x18"
         mtime_int = int.from_bytes(mtime, "little")
+        # set mtime_ns for win requires integer nanoseconds
         os.utime(source, ns=(mtime_int, mtime_int))
+
+        mtime = (mtime_int & 0xFFFFFFFF).to_bytes(4, "little")
 
         size = len(source_bytes).to_bytes(4, "little")
 


### PR DESCRIPTION
See: https://github.com/pytest-dev/pytest/issues/13292

The root cause is the cache is using file `st_mtime` int value to check if it's out of date, it's not so accurate when the file is updated in short time. Using `st_mtime_ns` is the better solution.
