### PR TITLE
Update additional projects list to include my new plugin

### DIFF
--- a/scripts/update-plugin-list.py
+++ b/scripts/update-plugin-list.py
@@ -67,6 +67,7 @@ ADDITIONAL_PROJECTS = {  # set of additional projects to consider as plugins
     "nuts",
     "flask_fixture",
     "databricks-labs-pytester",
+    "tursu",
 }
 
 


### PR DESCRIPTION
Hi everyone,

I've working hard on a new pytest plugin, unfortunatly,

the name of the plugin doesn't starts with `pytest-` (pytest-gherkin was already taken and looks unmaintained).

The project is already on pypi - https://pypi.org/project/tursu/

the code is on github - https://github.com/mardiros/tursu

and documented on my github pages - https://mardiros.github.io/tursu/

I don't know exactly where to promote it, bu starting by refered it from the pluging list should be a good starts.

Thanks for all you works.
