### PR TITLE
Fix 13314 add all plugins to pytester subprocess

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -345,6 +345,7 @@ Pavel Karateev
 Pavel Zhukov
 Paweł Adamczak
 Pedro Algarvio
+Peter Kovary
 Petter Strandmark
 Philipp Loose
 Pierre Sassoulas

--- a/changelog/13314.bugfix.rst
+++ b/changelog/13314.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug where `pytester.runpytest_subprocess` only included the first plugin from `pytester.plugins`. Now it correctly includes all of them.
+Fix bug where ``pytester.runpytest_subprocess`` only included the first plugin from ``pytester.plugins``. Now it correctly includes all of them.

--- a/changelog/13314.bugfix.rst
+++ b/changelog/13314.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where `pytester.runpytest_subprocess` only included the first plugin from `pytester.plugins`. Now it correctly includes all of them.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1488,8 +1488,8 @@ class Pytester:
         p = make_numbered_dir(root=self.path, prefix="runpytest-", mode=0o700)
         args = (f"--basetemp={p}", *args)
         plugins = [x for x in self.plugins if isinstance(x, str)]
-        if plugins:
-            args = ("-p", plugins[0], *args)
+        for plugin in reversed(plugins):
+            args = ("-p", plugin, *args)
         args = self._getpytestargs() + args
         return self.run(*args, timeout=timeout)
 

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -472,6 +472,20 @@ def test_pytester_run_timeout_expires(pytester: Pytester) -> None:
         pytester.runpytest_subprocess(testfile, timeout=1)
 
 
+def test_pytester_subprocess_with_plugins(pytester: Pytester) -> None:
+    testfile = pytester.makepyfile(
+        """
+        def test_plugins(pytestconfig):
+            plugins = pytestconfig.pluginmanager.list_name_plugin()
+            assert ("plug_1", None) in plugins
+            assert ("plug_2", None) in plugins
+        """
+    )
+    pytester.plugins.extend(["no:plug_1", "no:plug_2"])
+
+    pytester.runpytest_subprocess().assert_outcomes(passed=1)
+
+
 def test_linematcher_with_nonlist() -> None:
     """Test LineMatcher with regard to passing in a set (accidentally)."""
     from _pytest._code.source import Source


### PR DESCRIPTION
Closes #13314

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.
- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.
- [X] Add yourself to `AUTHORS` in alphabetical order.
