### PR TITLE
Specify minimum requirements for dependencies

### DIFF
--- a/changelog/13317.packaging.rst
+++ b/changelog/13317.packaging.rst
@@ -1,0 +1,4 @@
+Specified minimum allowed versions of ``colorama``, ``iniconfig``,
+and ``packaging``; and bumped the minimum allowed version
+of ``exceptiongroup`` for ``python_version<'3.11'`` from a release
+candidate to a full release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dynamic = [
 ]
 dependencies = [
     "colorama>=0.4.0; sys_platform=='win32'",
-    "exceptiongroup>=1.0.0rc8; python_version<'3.11'",
+    "exceptiongroup>=1.0.0; python_version<'3.11'",
     "iniconfig>=1.0.0",
     "packaging>=20.0",
     "pluggy>=1.5,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,10 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "colorama; sys_platform=='win32'",
+    "colorama>=0.4.0; sys_platform=='win32'",
     "exceptiongroup>=1.0.0rc8; python_version<'3.11'",
-    "iniconfig",
-    "packaging",
+    "iniconfig>=1.0.0",
+    "packaging>=20.0",
     "pluggy>=1.5,<2",
     "pygments>=2.7.2",
     "tomli>=1; python_version<'3.11'",


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

### Description

This PR specifies minimum allowed versions of `colorama`, `iniconfig`, and `packaging`, and bumps the minimum requirement of `exceptiongroup` to no longer be a release candidate.  

The first draft of this PR specifies minimum allowed versions that are several years old, but these can be changed to be more recent.

### Motivation

[`uv`](https://docs.astral.sh/uv/) has multiple dependency [resolution strategies](https://docs.astral.sh/uv/concepts/resolution/#resolution-strategy):

 - `lowest` will install the lowest allowed version for _all_ dependencies, both direct and indirect (transitive).
 - `lowest-direct` will use the lowest compatible versions for all _direct_ dependencies, while using the latest compatible versions for all other dependencies.

Up until now, `pytest` has not specified the minimum allowed versions of multiple dependencies in `pyproject.toml`.  When I ran `uv pip install pytest==8.3.5 --resolution=lowest` in a fresh virtual environment, it installed `packaging==14.0` (released in 2014 👀) and `iniconfig==0.1` (released in 2010 😅).

It's a fairly common practice in the scientific pythoniverse to run tests against the oldest versions of dependencies.  In practice, using `uv`'s `lowest` dependency resolution strategy results the first release of certain indirect dependencies being installed, like `v0.0.0.1`.  Specifying lower bounds will make it a lot more practical for `pytest` users to test against the oldest allowed versions of both indirect and direct dependencies.

Many thanks to everyone who has contributed to this awesome package! 🎉🎂🎆🪩🌌🥦

### Checklist

- [ ] ~~Include documentation when adding new features.~~
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] ~~Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.~~

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.
- [x] Add yourself to `AUTHORS` in alphabetical order.