### PR TITLE
Bugfix for pytest plugins set to  hypothesis pytestplugin (#12647)

### DIFF
--- a/changelog/12647.bugfix.rst
+++ b/changelog/12647.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes #12647. When using the _hypothesis_pytestplugin all tests are green.

--- a/changelog/12647.bugfix.rst
+++ b/changelog/12647.bugfix.rst
@@ -1,1 +1,0 @@
-Fixes #12647. When using the _hypothesis_pytestplugin all tests are green.

--- a/changelog/12647.contrib.rst
+++ b/changelog/12647.contrib.rst
@@ -1,0 +1,1 @@
+Fixed running the test suite with the ``hypothesis`` pytest plugin.

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -8,6 +8,7 @@ import pytest
 
 def test_version_verbose(pytester: Pytester, pytestconfig, monkeypatch) -> None:
     monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
+    monkeypatch.delenv("PYTEST_PLUGINS", raising=False)
     result = pytester.runpytest("--version", "--version")
     assert result.ret == 0
     result.stdout.fnmatch_lines([f"*pytest*{pytest.__version__}*imported from*"])
@@ -17,6 +18,7 @@ def test_version_verbose(pytester: Pytester, pytestconfig, monkeypatch) -> None:
 
 def test_version_less_verbose(pytester: Pytester, pytestconfig, monkeypatch) -> None:
     monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
+    monkeypatch.delenv("PYTEST_PLUGINS", raising=False)
     result = pytester.runpytest("--version")
     assert result.ret == 0
     result.stdout.fnmatch_lines([f"pytest {pytest.__version__}"])

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -859,6 +859,7 @@ class TestTerminalFunctional:
         self, monkeypatch: MonkeyPatch, pytester: Pytester, request
     ) -> None:
         monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
+        monkeypatch.delenv("PYTEST_PLUGINS", raising=False)
         pytester.makepyfile(
             """
             def test_passes():


### PR DESCRIPTION
Fixes #12647.

Indeed it's enough to add `monkeypatch.delenv("PYTEST_PLUGINS", raising=False)` to the failing tests, as the @mtelka suggested.
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] I humbly consider the change as trivial. Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
