### PR TITLE
Fix broken ``approx`` when mixing numpy booleans and booleans

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,6 +58,7 @@ Ashley Whetter
 Aviral Verma
 Aviv Palivoda
 Babak Keyvani
+Bahram Farahmand
 Barney Gale
 Ben Brown
 Ben Gartner

--- a/changelog/13047.bugfix.rst
+++ b/changelog/13047.bugfix.rst
@@ -1,0 +1,1 @@
+* Fixed an issue in equality checks where `bool` and `numpy.bool_` types were not handled consistently. This ensures proper handling of native and numpy boolean types. See #13047.

--- a/changelog/13047.bugfix.rst
+++ b/changelog/13047.bugfix.rst
@@ -1,1 +1,1 @@
-* Fixed an issue in equality checks where `bool` and `numpy.bool_` types were not handled consistently. This ensures proper handling of native and numpy boolean types. See #13047.
+* Fixed an issue in equality checks where `bool` and `numpy.bool_` types were not handled consistently. 

--- a/changelog/13047.bugfix.rst
+++ b/changelog/13047.bugfix.rst
@@ -1,23 +1,17 @@
-Bug Fix :func:`pytest.approx` to restore consistent handling of equality checks between `bool` and `numpy.bool_` types.
-  * This behavior was accidentally changed in version 8.3.4 and has now been restored to match the behavior of version 8.3.3.
-  * Users relying on comparisons between `bool` and `numpy.bool_` can now expect consistent results as before.
+Restore :func:`pytest.approx` handling of equality checks between `bool` and `numpy.bool_` types.
 
-    Example:
+Comparing `bool` and `numpy.bool_` using :func:`pytest.approx` accidentally changed in version `8.3.4` and `8.3.5` to no longer match:
 
-    **Behavior on pytest 8.3.4:**
+.. code-block:: python
 
-    .. code-block:: console
+    >>> import numpy as np
+    >>> from pytest import approx
+    >>> [np.True_, np.True_] == pytest.approx([True, True])
+    False
 
-        >>> import numpy as np
-        >>> from pytest import approx
-        >>> np.False_ == pytest.approx(False)
-        False
+This has now been fixed:
 
-    **Behavior on pytest 8.3.3:**
+.. code-block:: python
 
-    .. code-block:: console
-
-        >>> import numpy as np
-        >>> from pytest import approx
-        >>> np.False_ == pytest.approx(False)
-        True
+    >>> [np.True_, np.True_] == pytest.approx([True, True])
+    True

--- a/changelog/13047.bugfix.rst
+++ b/changelog/13047.bugfix.rst
@@ -2,7 +2,7 @@ Restore :func:`pytest.approx` handling of equality checks between `bool` and `nu
 
 Comparing `bool` and `numpy.bool_` using :func:`pytest.approx` accidentally changed in version `8.3.4` and `8.3.5` to no longer match:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> import numpy as np
     >>> from pytest import approx
@@ -11,7 +11,7 @@ Comparing `bool` and `numpy.bool_` using :func:`pytest.approx` accidentally chan
 
 This has now been fixed:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> [np.True_, np.True_] == pytest.approx([True, True])
     True

--- a/changelog/13047.bugfix.rst
+++ b/changelog/13047.bugfix.rst
@@ -1,1 +1,23 @@
-* Fixed an issue in equality checks where `bool` and `numpy.bool_` types were not handled consistently.
+Bug Fix :func:`pytest.approx` to restore consistent handling of equality checks between `bool` and `numpy.bool_` types.
+  * This behavior was accidentally changed in version 8.3.4 and has now been restored to match the behavior of version 8.3.3.
+  * Users relying on comparisons between `bool` and `numpy.bool_` can now expect consistent results as before.
+
+    Example:
+
+    **Behavior on pytest 8.3.4:**
+
+    .. code-block:: console
+
+        >>> import numpy as np
+        >>> from pytest import approx
+        >>> np.False_ == pytest.approx(False)
+        False
+
+    **Behavior on pytest 8.3.3:**
+
+    .. code-block:: console
+
+        >>> import numpy as np
+        >>> from pytest import approx
+        >>> np.False_ == pytest.approx(False)
+        True

--- a/changelog/13047.bugfix.rst
+++ b/changelog/13047.bugfix.rst
@@ -1,1 +1,1 @@
-* Fixed an issue in equality checks where `bool` and `numpy.bool_` types were not handled consistently. 
+* Fixed an issue in equality checks where `bool` and `numpy.bool_` types were not handled consistently.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -421,14 +421,26 @@ class ApproxScalar(ApproxBase):
     def __eq__(self, actual) -> bool:
         """Return whether the given value is equal to the expected value
         within the pre-specified tolerance."""
+
+        def is_bool(val: Any) -> bool:
+            # Check if `val` is a native bool or numpy bool.
+            if isinstance(val, bool):
+                return True
+            try:
+                import numpy as np
+
+                return isinstance(val, np.bool_)
+            except ImportError:
+                return False
+
         asarray = _as_numpy_array(actual)
         if asarray is not None:
             # Call ``__eq__()`` manually to prevent infinite-recursion with
             # numpy<1.13.  See #3748.
             return all(self.__eq__(a) for a in asarray.flat)
 
-        # Short-circuit exact equality, except for bool
-        if isinstance(self.expected, bool) and not isinstance(actual, bool):
+        # Short-circuit exact equality, except for bool and np.bool_
+        if is_bool(self.expected) and not is_bool(actual):
             return False
         elif actual == self.expected:
             return True
@@ -436,8 +448,8 @@ class ApproxScalar(ApproxBase):
         # If either type is non-numeric, fall back to strict equality.
         # NB: we need Complex, rather than just Number, to ensure that __abs__,
         # __sub__, and __float__ are defined. Also, consider bool to be
-        # nonnumeric, even though it has the required arithmetic.
-        if isinstance(self.expected, bool) or not (
+        # non-numeric, even though it has the required arithmetic.
+        if is_bool(self.expected) or not (
             isinstance(self.expected, (Complex, Decimal))
             and isinstance(actual, (Complex, Decimal))
         ):

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -645,7 +645,7 @@ class TestApprox:
         assert False == approx(False)  # noqa: E712
         assert True != approx(False)  # noqa: E712
         assert True != approx(False, abs=2)  # noqa: E712
-        assert 1 != approx(True)        
+        assert 1 != approx(True)
 
     def test_expecting_bool_numpy(self) -> None:
         """Check approx comparing with numpy.bool (#13047)."""

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -641,11 +641,17 @@ class TestApprox:
             assert approx(x, rel=5e-7, abs=0) != a
 
     def test_expecting_bool(self) -> None:
+        np = pytest.importorskip("numpy")
         assert True == approx(True)  # noqa: E712
         assert False == approx(False)  # noqa: E712
         assert True != approx(False)  # noqa: E712
         assert True != approx(False, abs=2)  # noqa: E712
         assert 1 != approx(True)
+        assert np.False_ != approx(True)
+        assert np.True_ != approx(False)
+        assert np.True_ == approx(True)
+        assert np.False_ == approx(False)
+        assert np.True_ != approx(False, abs=2)
 
     def test_list(self):
         actual = [1 + 1e-7, 2 + 1e-8]

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -641,12 +641,15 @@ class TestApprox:
             assert approx(x, rel=5e-7, abs=0) != a
 
     def test_expecting_bool(self) -> None:
-        np = pytest.importorskip("numpy")
         assert True == approx(True)  # noqa: E712
         assert False == approx(False)  # noqa: E712
         assert True != approx(False)  # noqa: E712
         assert True != approx(False, abs=2)  # noqa: E712
-        assert 1 != approx(True)
+        assert 1 != approx(True)        
+
+    def test_expecting_bool_numpy(self) -> None:
+        """Check approx comparing with numpy.bool (#13047)."""
+        np = pytest.importorskip("numpy")
         assert np.False_ != approx(True)
         assert np.True_ != approx(False)
         assert np.True_ == approx(True)


### PR DESCRIPTION
## Description

Fixed an issue in equality checks where `bool` and `numpy.bool_` types were not handled consistently.  
This ensures proper handling of native and numpy boolean types. See #13047.

Fix #13047

## Checklist

- [X] Include documentation when adding new features. *(Not applicable)*
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits.
- [X] Added `closes #13047` to link this PR to the issue.
- [X] Created a new changelog file: `13047.bugfix.rst`.
- [X] Added myself to `AUTHORS` in alphabetical order.
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
