### PR TITLE
Fix type hints for `TestReport.when` and `TestReport.location`

### DIFF
--- a/changelog/13345.bugfix.rst
+++ b/changelog/13345.bugfix.rst
@@ -1,0 +1,1 @@
+Fix type hints for :attr:`pytest.TestReport.when` and :attr:`pytest.TestReport.location`.

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -260,6 +260,9 @@ class TestReport(BaseReport):
     """
 
     __test__ = False
+
+    when: Literal["setup", "call", "teardown"]
+    location: tuple[str, int | None, str]
     # Defined by skipping plugin.
     # xfail reason if xfailed, otherwise not defined. Use hasattr to distinguish.
     wasxfail: str


### PR DESCRIPTION
These are set in `TestReport.__init__` but weren't being picked up by type checkers because of the annotations on `BaseReport`.

Fixes #12941.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
