### PR TITLE
Add note on using mixin classes for abstract test classes in documentation

### DIFF
--- a/changelog/8612.doc.rst
+++ b/changelog/8612.doc.rst
@@ -1,0 +1,5 @@
+Add a recipe for handling abstract test classes in the documentation.
+
+A new example has been added to the documentation to demonstrate how to use a mixin class to handle abstract
+test classes without manually setting the ``__test__`` attribute for subclasses.
+This ensures that subclasses of abstract test classes are automatically collected by pytest.

--- a/doc/en/example/pythoncollection.rst
+++ b/doc/en/example/pythoncollection.rst
@@ -325,3 +325,30 @@ with ``Test`` by setting a boolean ``__test__`` attribute to ``False``.
     # Will not be discovered as a test
     class TestClass:
         __test__ = False
+
+.. note::
+
+   If you are working with abstract test classes and want to avoid manually setting
+   the ``__test__`` attribute for subclasses, you can use a mixin class to handle
+   this automatically. For example:
+
+   .. code-block:: python
+
+       # Mixin to handle abstract test classes
+       class NotATest:
+           def __init_subclass__(cls):
+               cls.__test__ = NotATest not in cls.__bases__
+
+
+       # Abstract test class
+       class AbstractTest(NotATest):
+           pass
+
+
+       # Subclass that will be collected as a test
+       class RealTest(AbstractTest):
+           def test_example(self):
+               assert 1 + 1 == 2
+
+   This approach ensures that subclasses of abstract test classes are automatically
+   collected without needing to explicitly set the ``__test__`` attribute.


### PR DESCRIPTION
### Description
This PR adds a new recipe to the documentation for handling abstract test classes in pytest. The recipe demonstrates how to use a mixin class to automatically manage the __test__ attribute for subclasses of abstract test classes. This ensures that subclasses are collected by pytest without requiring manual configuration.

Closes #8612

## Checklist
- [X] Allow maintainers to push and squash when merging my commits.
- [X] Created a new changelog file: 8612.doc.rst.
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
