### PR TITLE
[8.3.x] Fix handling of positional-only parameters in test methods (#13377)

### DIFF
--- a/changelog/13377.bugfix.rst
+++ b/changelog/13377.bugfix.rst
@@ -1,0 +1,12 @@
+Fixed handling of test methods with positional-only parameter syntax.
+
+Now, methods are supported that formally define ``self`` as positional-only
+and/or fixture parameters as keyword-only, e.g.:
+
+.. code-block:: python
+
+    class TestClass:
+
+        def test_method(self, /, *, fixture): ...
+
+Before, this caused an internal error in pytest.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -128,7 +128,7 @@ def getfuncargnames(
     # creates a tuple of the names of the parameters that don't have
     # defaults.
     try:
-        parameters = signature(function).parameters
+        parameters = signature(function).parameters.values()
     except (ValueError, TypeError) as e:
         from _pytest.outcomes import fail
 
@@ -139,7 +139,7 @@ def getfuncargnames(
 
     arg_names = tuple(
         p.name
-        for p in parameters.values()
+        for p in parameters
         if (
             p.kind is Parameter.POSITIONAL_OR_KEYWORD
             or p.kind is Parameter.KEYWORD_ONLY
@@ -150,9 +150,9 @@ def getfuncargnames(
         name = function.__name__
 
     # If this function should be treated as a bound method even though
-    # it's passed as an unbound method or function, remove the first
-    # parameter name.
-    if (
+    # it's passed as an unbound method or function, and its first parameter
+    # wasn't defined as positional only, remove the first parameter name.
+    if not any(p.kind is Parameter.POSITIONAL_ONLY for p in parameters) and (
         # Not using `getattr` because we don't want to resolve the staticmethod.
         # Not using `cls.__dict__` because we want to check the entire MRO.
         cls

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -48,7 +48,23 @@ def test_getfuncargnames_methods():
         def f(self, arg1, arg2="hello"):
             raise NotImplementedError()
 
+        def g(self, /, arg1, arg2="hello"):
+            raise NotImplementedError()
+
+        def h(self, *, arg1, arg2="hello"):
+            raise NotImplementedError()
+
+        def j(self, arg1, *, arg2, arg3="hello"):
+            raise NotImplementedError()
+
+        def k(self, /, arg1, *, arg2, arg3="hello"):
+            raise NotImplementedError()
+
     assert getfuncargnames(A().f) == ("arg1",)
+    assert getfuncargnames(A().g) == ("arg1",)
+    assert getfuncargnames(A().h) == ("arg1",)
+    assert getfuncargnames(A().j) == ("arg1", "arg2")
+    assert getfuncargnames(A().k) == ("arg1", "arg2")
 
 
 def test_getfuncargnames_staticmethod():
@@ -4920,3 +4936,22 @@ def test_subfixture_teardown_order(pytester: Pytester) -> None:
     )
     result = pytester.runpytest()
     assert result.ret == 0
+
+
+def test_collect_positional_only(pytester: Pytester) -> None:
+    """Support the collection of tests with positional-only arguments (#13376)."""
+    pytester.makepyfile(
+        """
+        import pytest
+
+        class Test:
+            @pytest.fixture
+            def fix(self):
+                return 1
+
+            def test_method(self, /, fix):
+                assert fix == 1
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
Fixes #13376

Manually cherry-picked due to conflicts.

(cherry picked from commit 61c204a0355c89946cb0f3202820c5a0ec85e13d)

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
