### PR TITLE
Conflicting custom arguments bugfix #12824

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,6 +39,7 @@ Andrzej Klajnert
 Andrzej Ostrowski
 Andy Freeland
 Anita Hammer
+Anna Tasiopoulou
 Anthon van der Neut
 Anthony Shaw
 Anthony Sottile

--- a/changelog/12824.bugfix.rst
+++ b/changelog/12824.bugfix.rst
@@ -1,0 +1,2 @@
+Improve option conflict detection to prevent silently overriding built-in options
+like ``--keyword``.

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -2537,3 +2537,29 @@ class TestVerbosity:
             config.get_verbosity(TestVerbosity.SOME_OUTPUT_TYPE)
             == TestVerbosity.SOME_OUTPUT_VERBOSITY_LEVEL
         )
+
+
+def test_conflicting_option_raises_error(pytester):
+    """Test that adding conflicting options raises a clear error."""
+    pytester.makepyfile(
+        """
+        def test_dummy():
+            pass
+        """
+    )
+
+    pytester.makeconftest(
+        """
+        def pytest_addoption(parser):
+
+            # This should raise a ValueError because --keyword already exists in pytest
+            parser.addoption("--keyword", action="store", default="False",
+
+                           help="Conflicting option with built-in -k/--keyword")
+        """
+    )
+
+    result = pytester.runpytest()
+    result.stderr.fnmatch_lines(
+        ["*option names*--keyword*conflict with existing registered options*"]
+    )


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
