### PR TITLE
Replace time.time() with _pytest.timing.perf_counter()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -130,6 +130,7 @@ Daw-Ran Liou
 Debi Mishra
 Denis Kirisov
 Denivy Braiam Rück
+Deysha Rivera
 Dheeraj C K
 Dhiren Serai
 Diego Russo

--- a/changelog/13384.bugfix.rst
+++ b/changelog/13384.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed an issue where pytest could report negative durations due to the use of `time.time()`. 
+Replaced `time.time()` with `_pytest.timing.perf_counter()` for more reliable timing.

--- a/testing/_py/test_local.py
+++ b/testing/_py/test_local.py
@@ -12,6 +12,7 @@ import warnings
 from py import error
 from py.path import local
 
+from _pytest.timing import perf_counter
 import pytest
 
 
@@ -738,7 +739,6 @@ class TestLocalPath(CommonFSTests):
 
     def test_setmtime(self):
         import tempfile
-        import time
 
         try:
             fd, name = tempfile.mkstemp()
@@ -747,7 +747,7 @@ class TestLocalPath(CommonFSTests):
             name = tempfile.mktemp()
             open(name, "w").close()
         try:
-            mtime = int(time.time()) - 100
+            mtime = int(perf_counter()) - 100
             path = local(name)
             assert path.mtime() != mtime
             path.setmtime(mtime)
@@ -1405,7 +1405,7 @@ class TestPOSIXLocalPath:
         import time
 
         path = tmpdir.ensure("samplefile")
-        now = time.time()
+        now = perf_counter()
         atime1 = path.atime()
         # we could wait here but timer resolution is very
         # system dependent
@@ -1413,7 +1413,7 @@ class TestPOSIXLocalPath:
         time.sleep(ATIME_RESOLUTION)
         atime2 = path.atime()
         time.sleep(ATIME_RESOLUTION)
-        duration = time.time() - now
+        duration = perf_counter() - now
         assert (atime2 - atime1) <= duration
 
     def test_commondir(self, path1):

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-import time
 from types import ModuleType
 
 from _pytest.config import ExitCode
@@ -16,6 +15,7 @@ from _pytest.pytester import LineMatcher
 from _pytest.pytester import Pytester
 from _pytest.pytester import SysModulesSnapshot
 from _pytest.pytester import SysPathsSnapshot
+from _pytest.timing import perf_counter
 import pytest
 
 
@@ -451,9 +451,9 @@ def test_pytester_run_with_timeout(pytester: Pytester) -> None:
 
     timeout = 120
 
-    start = time.time()
+    start = perf_counter()
     result = pytester.runpytest_subprocess(testfile, timeout=timeout)
-    end = time.time()
+    end = perf_counter()
     duration = end - start
 
     assert result.ret == ExitCode.OK


### PR DESCRIPTION
This pull request addresses issue #13384, where time.time() was causing pytest to report negative durations due to its susceptibility to system clock adjustments.

The following changes were made:

- Replaced all occurrences of time.time() with _pytest.timing.perf_counter() for more reliable and monotonic timing.
-  Updated the relevant tests to use _pytest.timing.perf_counter() where applicable.
- Added a changelog entry (13384.bugfix.rst) to document the fix.
- Added myself to the AUTHORS file in alphabetical order.

- Closes #13384

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X ] Add yourself to `AUTHORS` in alphabetical order.
-->
