### PR TITLE
Add `Instant` class to conveniently track elapsed and start/end times

### DIFF
--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -636,8 +636,7 @@ class LogXML:
         reporter._add_simple("error", "internal error", str(excrepr))
 
     def pytest_sessionstart(self) -> None:
-        self.suite_start_time = timing.time()
-        self.suite_start_perf = timing.perf_counter()
+        self.suite_start_instant = timing.Instant()
 
     def pytest_sessionfinish(self) -> None:
         dirname = os.path.dirname(os.path.abspath(self.logfile))
@@ -645,8 +644,7 @@ class LogXML:
         os.makedirs(dirname, exist_ok=True)
 
         with open(self.logfile, "w", encoding="utf-8") as logfile:
-            suite_stop_perf = timing.perf_counter()
-            suite_time_delta = suite_stop_perf - self.suite_start_perf
+            suite_time_delta = self.suite_start_instant.elapsed_s()
 
             numtests = (
                 self.stats["passed"]
@@ -665,7 +663,9 @@ class LogXML:
                 skipped=str(self.stats["skipped"]),
                 tests=str(numtests),
                 time=f"{suite_time_delta:.3f}",
-                timestamp=datetime.fromtimestamp(self.suite_start_time, timezone.utc)
+                timestamp=datetime.fromtimestamp(
+                    self.suite_start_instant.interval()[0], timezone.utc
+                )
                 .astimezone()
                 .isoformat(),
                 hostname=platform.node(),

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -11,8 +11,6 @@ https://github.com/jenkinsci/xunit-plugin/blob/master/src/main/resources/org/jen
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import datetime
-from datetime import timezone
 import functools
 import os
 import platform
@@ -636,7 +634,7 @@ class LogXML:
         reporter._add_simple("error", "internal error", str(excrepr))
 
     def pytest_sessionstart(self) -> None:
-        self.suite_start_instant = timing.Instant()
+        self.suite_start = timing.Instant()
 
     def pytest_sessionfinish(self) -> None:
         dirname = os.path.dirname(os.path.abspath(self.logfile))
@@ -644,7 +642,7 @@ class LogXML:
         os.makedirs(dirname, exist_ok=True)
 
         with open(self.logfile, "w", encoding="utf-8") as logfile:
-            suite_time_delta = self.suite_start_instant.elapsed_s()
+            duration = self.suite_start.duration()
 
             numtests = (
                 self.stats["passed"]
@@ -662,12 +660,8 @@ class LogXML:
                 failures=str(self.stats["failure"]),
                 skipped=str(self.stats["skipped"]),
                 tests=str(numtests),
-                time=f"{suite_time_delta:.3f}",
-                timestamp=datetime.fromtimestamp(
-                    self.suite_start_instant.interval()[0], timezone.utc
-                )
-                .astimezone()
-                .isoformat(),
+                time=f"{duration.elapsed_s:.3f}",
+                timestamp=duration.start_utc().astimezone().isoformat(),
                 hostname=platform.node(),
             )
             global_properties = self._get_global_properties_node()

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -642,7 +642,7 @@ class LogXML:
         os.makedirs(dirname, exist_ok=True)
 
         with open(self.logfile, "w", encoding="utf-8") as logfile:
-            duration = self.suite_start.duration()
+            duration = self.suite_start.elapsed()
 
             numtests = (
                 self.stats["passed"]
@@ -660,7 +660,7 @@ class LogXML:
                 failures=str(self.stats["failure"]),
                 skipped=str(self.stats["skipped"]),
                 tests=str(numtests),
-                time=f"{duration.elapsed_s:.3f}",
+                time=f"{duration.seconds:.3f}",
                 timestamp=self.suite_start.as_utc().astimezone().isoformat(),
                 hostname=platform.node(),
             )

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -661,7 +661,7 @@ class LogXML:
                 skipped=str(self.stats["skipped"]),
                 tests=str(numtests),
                 time=f"{duration.elapsed_s:.3f}",
-                timestamp=duration.start_utc().astimezone().isoformat(),
+                timestamp=self.suite_start.as_utc().astimezone().isoformat(),
                 hostname=platform.node(),
             )
             global_properties = self._get_global_properties_node()

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1150,7 +1150,7 @@ class Pytester:
 
         if syspathinsert:
             self.syspathinsert()
-        now = timing.perf_counter()
+        now = timing.Instant()
         capture = _get_multicapture("sys")
         capture.start_capturing()
         try:
@@ -1179,9 +1179,7 @@ class Pytester:
             sys.stderr.write(err)
 
         assert reprec.ret is not None
-        res = RunResult(
-            reprec.ret, out.splitlines(), err.splitlines(), timing.perf_counter() - now
-        )
+        res = RunResult(reprec.ret, out.splitlines(), err.splitlines(), now.elapsed_s())
         res.reprec = reprec  # type: ignore
         return res
 
@@ -1408,7 +1406,7 @@ class Pytester:
         print("     in:", Path.cwd())
 
         with p1.open("w", encoding="utf8") as f1, p2.open("w", encoding="utf8") as f2:
-            now = timing.perf_counter()
+            now = timing.Instant()
             popen = self.popen(
                 cmdargs,
                 stdin=stdin,
@@ -1445,7 +1443,7 @@ class Pytester:
 
         with contextlib.suppress(ValueError):
             ret = ExitCode(ret)
-        return RunResult(ret, out, err, timing.perf_counter() - now)
+        return RunResult(ret, out, err, now.elapsed_s())
 
     def _dump_lines(self, lines, fp):
         try:

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1150,7 +1150,7 @@ class Pytester:
 
         if syspathinsert:
             self.syspathinsert()
-        now = timing.Instant()
+        instant = timing.Instant()
         capture = _get_multicapture("sys")
         capture.start_capturing()
         try:
@@ -1179,7 +1179,9 @@ class Pytester:
             sys.stderr.write(err)
 
         assert reprec.ret is not None
-        res = RunResult(reprec.ret, out.splitlines(), err.splitlines(), now.elapsed_s())
+        res = RunResult(
+            reprec.ret, out.splitlines(), err.splitlines(), instant.duration().elapsed_s
+        )
         res.reprec = reprec  # type: ignore
         return res
 
@@ -1406,7 +1408,7 @@ class Pytester:
         print("     in:", Path.cwd())
 
         with p1.open("w", encoding="utf8") as f1, p2.open("w", encoding="utf8") as f2:
-            now = timing.Instant()
+            instant = timing.Instant()
             popen = self.popen(
                 cmdargs,
                 stdin=stdin,
@@ -1443,7 +1445,7 @@ class Pytester:
 
         with contextlib.suppress(ValueError):
             ret = ExitCode(ret)
-        return RunResult(ret, out, err, now.elapsed_s())
+        return RunResult(ret, out, err, instant.duration().elapsed_s)
 
     def _dump_lines(self, lines, fp):
         try:

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1180,7 +1180,7 @@ class Pytester:
 
         assert reprec.ret is not None
         res = RunResult(
-            reprec.ret, out.splitlines(), err.splitlines(), instant.duration().elapsed_s
+            reprec.ret, out.splitlines(), err.splitlines(), instant.elapsed().seconds
         )
         res.reprec = reprec  # type: ignore
         return res
@@ -1445,7 +1445,7 @@ class Pytester:
 
         with contextlib.suppress(ValueError):
             ret = ExitCode(ret)
-        return RunResult(ret, out, err, instant.duration().elapsed_s)
+        return RunResult(ret, out, err, instant.elapsed().seconds)
 
     def _dump_lines(self, lines, fp):
         try:

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -347,11 +347,11 @@ class CallInfo(Generic[TResult]):
             if reraise is not None and isinstance(excinfo.value, reraise):
                 raise
             result = None
-        duration = instant.duration()
+        duration = instant.elapsed()
         return cls(
             start=duration.start.time,
             stop=duration.stop.time,
-            duration=duration.elapsed_s,
+            duration=duration.seconds,
             when=when,
             result=result,
             excinfo=excinfo,

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -347,12 +347,11 @@ class CallInfo(Generic[TResult]):
             if reraise is not None and isinstance(excinfo.value, reraise):
                 raise
             result = None
-        duration = instant.elapsed_s()
-        start, stop = instant.interval()
+        duration = instant.duration()
         return cls(
-            start=start,
-            stop=stop,
-            duration=duration,
+            start=duration.start,
+            stop=duration.stop,
+            duration=duration.elapsed_s,
             when=when,
             result=result,
             excinfo=excinfo,

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -339,8 +339,7 @@ class CallInfo(Generic[TResult]):
             function, instead of being wrapped in the CallInfo.
         """
         excinfo = None
-        start = timing.time()
-        precise_start = timing.perf_counter()
+        instant = timing.Instant()
         try:
             result: TResult | None = func()
         except BaseException:
@@ -348,10 +347,8 @@ class CallInfo(Generic[TResult]):
             if reraise is not None and isinstance(excinfo.value, reraise):
                 raise
             result = None
-        # use the perf counter
-        precise_stop = timing.perf_counter()
-        duration = precise_stop - precise_start
-        stop = timing.time()
+        duration = instant.elapsed_s()
+        start, stop = instant.interval()
         return cls(
             start=start,
             stop=stop,

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -349,8 +349,8 @@ class CallInfo(Generic[TResult]):
             result = None
         duration = instant.duration()
         return cls(
-            start=duration.start,
-            stop=duration.stop,
+            start=duration.start.time,
+            stop=duration.stop.time,
             duration=duration.elapsed_s,
             when=when,
             result=result,

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -789,7 +789,7 @@ class TerminalReporter:
         if not final:
             # Only write the "collecting" report every `REPORT_COLLECTING_RESOLUTION`.
             if (
-                self._collect_report_last_instant.elapsed_s()
+                self._collect_report_last_instant.duration().elapsed_s
                 < REPORT_COLLECTING_RESOLUTION
             ):
                 return
@@ -821,7 +821,7 @@ class TerminalReporter:
     @hookimpl(trylast=True)
     def pytest_sessionstart(self, session: Session) -> None:
         self._session = session
-        self._session_start_instant = timing.Instant()
+        self._session_start = timing.Instant()
         if not self.showheader:
             return
         self.write_sep("=", "test session starts", bold=True)
@@ -1200,7 +1200,7 @@ class TerminalReporter:
         if self.verbosity < -1:
             return
 
-        session_duration = self._session_start_instant.elapsed_s()
+        session_duration = self._session_start.duration()
         (parts, main_color) = self.build_summary_stats_line()
         line_parts = []
 
@@ -1215,7 +1215,7 @@ class TerminalReporter:
         msg = ", ".join(line_parts)
 
         main_markup = {main_color: True}
-        duration = f" in {format_session_duration(session_duration)}"
+        duration = f" in {format_session_duration(session_duration.elapsed_s)}"
         duration_with_markup = self._tw.markup(duration, **main_markup)
         if display_sep:
             fullwidth += len(duration_with_markup) - len(duration)

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -391,7 +391,7 @@ class TerminalReporter:
         self._progress_nodeids_reported: set[str] = set()
         self._timing_nodeids_reported: set[str] = set()
         self._show_progress_info = self._determine_show_progress_info()
-        self._collect_report_last_instant = timing.Instant()
+        self._collect_report_last_write = timing.Instant()
         self._already_displayed_warnings: int | None = None
         self._keyboardinterrupt_memo: ExceptionRepr | None = None
 
@@ -789,11 +789,11 @@ class TerminalReporter:
         if not final:
             # Only write the "collecting" report every `REPORT_COLLECTING_RESOLUTION`.
             if (
-                self._collect_report_last_instant.duration().elapsed_s
+                self._collect_report_last_write.duration().elapsed_s
                 < REPORT_COLLECTING_RESOLUTION
             ):
                 return
-            self._collect_report_last_instant = timing.Instant()
+            self._collect_report_last_write = timing.Instant()
 
         errors = len(self.stats.get("error", []))
         skipped = len(self.stats.get("skipped", []))

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -789,7 +789,7 @@ class TerminalReporter:
         if not final:
             # Only write the "collecting" report every `REPORT_COLLECTING_RESOLUTION`.
             if (
-                self._collect_report_last_write.duration().elapsed_s
+                self._collect_report_last_write.elapsed().seconds
                 < REPORT_COLLECTING_RESOLUTION
             ):
                 return
@@ -1200,7 +1200,7 @@ class TerminalReporter:
         if self.verbosity < -1:
             return
 
-        session_duration = self._session_start.duration()
+        session_duration = self._session_start.elapsed()
         (parts, main_color) = self.build_summary_stats_line()
         line_parts = []
 
@@ -1215,7 +1215,7 @@ class TerminalReporter:
         msg = ", ".join(line_parts)
 
         main_markup = {main_color: True}
-        duration = f" in {format_session_duration(session_duration.elapsed_s)}"
+        duration = f" in {format_session_duration(session_duration.seconds)}"
         duration_with_markup = self._tw.markup(duration, **main_markup)
         if display_sep:
             fullwidth += len(duration_with_markup) - len(duration)

--- a/src/_pytest/timing.py
+++ b/src/_pytest/timing.py
@@ -31,16 +31,16 @@ class Instant:
     """
 
     # Creation time of this instant, using time.time(), to measure actual time.
-    # Use a `lambda` to initialize the default to correctly get the mocked time via `MockTiming`.
+    # Note: using a `lambda` to correctly get the mocked time via `MockTiming`.
     time: float = dataclasses.field(default_factory=lambda: time(), init=False)
 
     # Performance counter tick of the instant, used to measure precise elapsed time.
-    # Use a `lambda` to initialize the default to correctly get the mocked time via `MockTiming`.
+    # Note: using a `lambda` to correctly get the mocked time via `MockTiming`.
     perf_count: float = dataclasses.field(
         default_factory=lambda: perf_counter(), init=False
     )
 
-    def duration(self) -> Duration:
+    def elapsed(self) -> Duration:
         """Measure the duration since `Instant` was created."""
         return Duration(start=self, stop=Instant())
 
@@ -51,14 +51,14 @@ class Instant:
 
 @dataclasses.dataclass(frozen=True)
 class Duration:
-    """A span of time as measured by `Instant.duration()`."""
+    """A span of time as measured by `Instant.elapsed()`."""
 
     start: Instant
     stop: Instant
 
     @property
-    def elapsed_s(self) -> float:
-        """Elapsed time of the duration, in seconds, measured using a performance counter for precise timing."""
+    def seconds(self) -> float:
+        """Elapsed time of the duration in seconds, measured using a performance counter for precise timing."""
         return self.stop.perf_count - self.start.perf_count
 
 

--- a/src/_pytest/timing.py
+++ b/src/_pytest/timing.py
@@ -20,6 +20,38 @@ if TYPE_CHECKING:
     from pytest import MonkeyPatch
 
 
+class Instant:
+    """
+    Provides a measurement of timing between different points in the code.
+
+    Useful to compute the elapsed time between two points in time,
+    using a performance counter, and the beginning/end in actual times (as seconds since epoch).
+
+    Inspired by Rust's `std::time::Instant`.
+    """
+
+    def __init__(self) -> None:
+        import _pytest.timing  # noqa: PLW0406
+
+        self._start_perf = _pytest.timing.perf_counter()
+        self._start_time = _pytest.timing.time()
+
+    def elapsed_s(self) -> float:
+        """Return the elapsed time (in seconds) since this Instant was created, using a precise clock."""
+        import _pytest.timing  # noqa: PLW0406
+
+        return _pytest.timing.perf_counter() - self._start_perf
+
+    def interval(self) -> tuple[float, float]:
+        """Return the beginning and end times of this instant, in seconds since epoch, as provided by time.time()."""
+        import _pytest.timing  # noqa: PLW0406
+
+        return self._start_time, _pytest.timing.time()
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"Instant(start_time={self._start_time}, elapsed_s={self.elapsed_s()})"
+
+
 @dataclasses.dataclass
 class MockTiming:
     """Mocks _pytest.timing with a known object that can be used to control timing in tests

--- a/testing/_py/test_local.py
+++ b/testing/_py/test_local.py
@@ -12,7 +12,6 @@ import warnings
 from py import error
 from py.path import local
 
-import _pytest.timing
 import pytest
 
 
@@ -747,7 +746,8 @@ class TestLocalPath(CommonFSTests):
             name = tempfile.mktemp()
             open(name, "w").close()
         try:
-            mtime = int(_pytest.timing.time()) - 100
+            # Do not use _pytest.timing here, as we do not want time mocking to affect this test.
+            mtime = int(time.time()) - 100
             path = local(name)
             assert path.mtime() != mtime
             path.setmtime(mtime)
@@ -1405,7 +1405,8 @@ class TestPOSIXLocalPath:
         import time
 
         path = tmpdir.ensure("samplefile")
-        now = _pytest.timing.Instant()
+        # Do not use _pytest.timing here, as we do not want time mocking to affect this test.
+        now = time.time()
         atime1 = path.atime()
         # we could wait here but timer resolution is very
         # system dependent
@@ -1413,7 +1414,7 @@ class TestPOSIXLocalPath:
         time.sleep(ATIME_RESOLUTION)
         atime2 = path.atime()
         time.sleep(ATIME_RESOLUTION)
-        duration = now.elapsed_s()
+        duration = time.time() - now
         assert (atime2 - atime1) <= duration
 
     def test_commondir(self, path1):

--- a/testing/_py/test_local.py
+++ b/testing/_py/test_local.py
@@ -1405,7 +1405,7 @@ class TestPOSIXLocalPath:
         import time
 
         path = tmpdir.ensure("samplefile")
-        now = _pytest.timing.perf_counter()
+        now = _pytest.timing.Instant()
         atime1 = path.atime()
         # we could wait here but timer resolution is very
         # system dependent
@@ -1413,7 +1413,7 @@ class TestPOSIXLocalPath:
         time.sleep(ATIME_RESOLUTION)
         atime2 = path.atime()
         time.sleep(ATIME_RESOLUTION)
-        duration = _pytest.timing.perf_counter() - now
+        duration = now.elapsed_s()
         assert (atime2 - atime1) <= duration
 
     def test_commondir(self, path1):

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -453,10 +453,10 @@ def test_pytester_run_with_timeout(pytester: Pytester) -> None:
 
     instant = _pytest.timing.Instant()
     result = pytester.runpytest_subprocess(testfile, timeout=timeout)
-    duration = instant.elapsed_s()
+    duration = instant.duration()
 
     assert result.ret == ExitCode.OK
-    assert duration < timeout
+    assert duration.elapsed_s < timeout
 
 
 def test_pytester_run_timeout_expires(pytester: Pytester) -> None:

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -451,10 +451,9 @@ def test_pytester_run_with_timeout(pytester: Pytester) -> None:
 
     timeout = 120
 
-    start = _pytest.timing.perf_counter()
+    instant = _pytest.timing.Instant()
     result = pytester.runpytest_subprocess(testfile, timeout=timeout)
-    end = _pytest.timing.perf_counter()
-    duration = end - start
+    duration = instant.elapsed_s()
 
     assert result.ret == ExitCode.OK
     assert duration < timeout

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -453,10 +453,10 @@ def test_pytester_run_with_timeout(pytester: Pytester) -> None:
 
     instant = _pytest.timing.Instant()
     result = pytester.runpytest_subprocess(testfile, timeout=timeout)
-    duration = instant.duration()
+    duration = instant.elapsed()
 
     assert result.ret == ExitCode.OK
-    assert duration.elapsed_s < timeout
+    assert duration.seconds < timeout
 
 
 def test_pytester_run_timeout_expires(pytester: Pytester) -> None:


### PR DESCRIPTION
Throughout the codebase we often need to track elapsed times, using a performance clock, and also start/end times that given seconds since epoch (via `time.time()`).

`Instant` encapsulates both functionalities to simplify the code and ensure we are using the correct functions from `_pytest.timing`, which we can mock in tests for reliability.

Built on top of https://github.com/pytest-dev/pytest/pull/13394, will rebase once it gets merged.