### PR TITLE
Make assertion rewrite warning messages filterable 

### DIFF
--- a/changelog/5473.improvement.rst
+++ b/changelog/5473.improvement.rst
@@ -1,0 +1,1 @@
+Replace `:` with `;` in the assertion rewrite warning message so it can be filtered using standard Python warning filters before calling :func:`pytest.main`.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -281,7 +281,7 @@ class AssertionRewritingHook(importlib.abc.MetaPathFinder, importlib.abc.Loader)
 
         self.config.issue_config_time_warning(
             PytestAssertRewriteWarning(
-                f"Module already imported so cannot be rewritten: {name}"
+                f"Module already imported so cannot be rewritten; {name}"
             ),
             stacklevel=5,
         )

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1197,7 +1197,23 @@ def test_rewritten():
         )
         # needs to be a subprocess because pytester explicitly disables this warning
         result = pytester.runpytest_subprocess()
-        result.stdout.fnmatch_lines(["*Module already imported*: _pytest"])
+        result.stdout.fnmatch_lines(["*Module already imported*; _pytest"])
+
+    def test_rewrite_warning_ignore(self, pytester: Pytester) -> None:
+        pytester.makeconftest(
+            """
+            import pytest
+            pytest.register_assert_rewrite("_pytest")
+        """
+        )
+        # needs to be a subprocess because pytester explicitly disables this warning
+        result = pytester.runpytest_subprocess(
+            "-W",
+            "ignore:Module already imported so cannot be rewritten; _pytest:pytest.PytestAssertRewriteWarning",
+        )
+        # Previously, when the message pattern used to contain an extra `:`, an error was raised.
+        assert not result.stderr.str().strip()
+        result.stdout.no_fnmatch_line("*Module already imported*; _pytest")
 
     def test_rewrite_module_imported_from_conftest(self, pytester: Pytester) -> None:
         pytester.makeconftest(


### PR DESCRIPTION
Hi,

can you please consider patch to mare assertion rewrite warning messages filterable using the standard `-W` option. It addresses #5473.

The issue arises when a Python package defines a `pytest` plugin, and also calls `pytest.main()` programmatically, after importing one of its own submodules. Because the module is already imported, `pytest.main()` cannot rewrite its assertions and emits a warning like:

```Module already imported so cannot be rewritten: basilisp```

Unfortunately, the `:` in the message conflicts with Python’s warning filter syntax, where `:` is used as a delimiter. This prevents users from filtering out the warning via `-W`.

This patch replaces the `:` in the warning message with a `;`, making it possible to write a valid warning filter like:

`-W ignore:Module already imported so cannot be rewritten; mymodule:pytest.PytestAssertRewriteWarning`

We believe there's no need to force assertion rewriting simply because a module defines a plugin, and users should be able to suppress this warning when needed.

For background and alternative solutions considered, see https://github.com/pytest-dev/pytest/issues/5473#issuecomment-2874319476.

Happy to discuss further or consider alternatives.

- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [X] Create a new changelog file in the `changelog` folder

Thanks

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
