### PR TITLE
WIP! Disable assertion rewriting of external modules

### DIFF
--- a/changelog/13403.bugfix.rst
+++ b/changelog/13403.bugfix.rst
@@ -1,0 +1,1 @@
+Disable assertion rewriting of external modules

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+import os
 import sys
 from typing import Any
 from typing import TYPE_CHECKING
@@ -106,7 +107,14 @@ class AssertionState:
     def __init__(self, config: Config, mode) -> None:
         self.mode = mode
         self.trace = config.trace.root.get("assertion")
+        self.config=config
         self.hook: rewrite.AssertionRewritingHook | None = None
+
+    @property
+    def rootpath(self):
+        """Get current root path (current working dir)
+        """
+        return str(self.config.invocation_params.dir)
 
 
 def install_importhook(config: Config) -> rewrite.AssertionRewritingHook:

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -107,13 +107,12 @@ class AssertionState:
     def __init__(self, config: Config, mode) -> None:
         self.mode = mode
         self.trace = config.trace.root.get("assertion")
-        self.config=config
+        self.config = config
         self.hook: rewrite.AssertionRewritingHook | None = None
 
     @property
     def rootpath(self):
-        """Get current root path (current working dir)
-        """
+        """Get current root path (current working dir)"""
         return str(self.config.invocation_params.dir)
 
 

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -238,8 +238,9 @@ class AssertionRewritingHook(importlib.abc.MetaPathFinder, importlib.abc.Loader)
         # modules not passed explicitly on the command line are only
         # rewritten if they match the naming convention for test files
         fn_path = PurePath(fn)
+
         for pat in self.fnpats:
-            if fnmatch_ex(pat, fn_path):
+            if fnmatch_ex(pat, fn_path) and fn_path.is_relative_to(state.rootpath):
                 state.trace(f"matched test file {fn!r}")
                 return True
 

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -749,11 +749,15 @@ class Pytester:
         This is done automatically upon instantiation.
         """
         self._monkeypatch.chdir(self.path)
-        self._monkeypatch.setattr(self._request.config,"invocation_params", Config.InvocationParams(
-                args= self._request.config.invocation_params.args,
+        self._monkeypatch.setattr(
+            self._request.config,
+            "invocation_params",
+            Config.InvocationParams(
+                args=self._request.config.invocation_params.args,
                 plugins=self._request.config.invocation_params.plugins,
                 dir=Path(self._path),
-        ))
+            ),
+        )
 
     def _makefile(
         self,

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -749,6 +749,11 @@ class Pytester:
         This is done automatically upon instantiation.
         """
         self._monkeypatch.chdir(self.path)
+        self._monkeypatch.setattr(self._request.config,"invocation_params", Config.InvocationParams(
+                args= self._request.config.invocation_params.args,
+                plugins=self._request.config.invocation_params.plugins,
+                dir=Path(self._path),
+        ))
 
     def _makefile(
         self,

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -23,10 +23,6 @@ from typing import cast
 from unittest import mock
 import zipfile
 
-from mock.mock import Mock
-
-from _pytest.monkeypatch import MonkeyPatch
-
 import _pytest._code
 from _pytest._io.saferepr import DEFAULT_REPR_MAX_SIZE
 from _pytest.assertion import util
@@ -1310,14 +1306,18 @@ class TestAssertionRewriteHookDetails:
         config = pytester.parseconfig()
         state = AssertionState(config, "rewrite")
         assert state.rootpath == str(config.invocation_params.dir)
-        new_rootpath =str(pytester.path / "test")
+        new_rootpath = str(pytester.path / "test")
         if not os.path.exists(new_rootpath):
             os.mkdir(new_rootpath)
-        monkeypatch.setattr(config,"invocation_params", Config.InvocationParams(
-            args= (),
-            plugins=(),
-            dir=Path(new_rootpath),
-        ))
+        monkeypatch.setattr(
+            config,
+            "invocation_params",
+            Config.InvocationParams(
+                args=(),
+                plugins=(),
+                dir=Path(new_rootpath),
+            ),
+        )
         state = AssertionState(config, "rewrite")
         assert state.rootpath == new_rootpath
 
@@ -1327,7 +1327,6 @@ class TestAssertionRewriteHookDetails:
     @pytest.mark.skipif(
         sys.platform.startswith("sunos5"), reason="cannot remove cwd on Solaris"
     )
-
     def test_write_pyc(self, pytester: Pytester, tmp_path) -> None:
         from _pytest.assertion import AssertionState
         from _pytest.assertion.rewrite import _write_pyc
@@ -2025,11 +2024,15 @@ class TestEarlyRewriteBailout:
         rootpath = f"{os.getcwd()}/tests"
         if not os.path.exists(rootpath):
             mkdir(rootpath)
-        monkeypatch.setattr(pytester._request.config,"invocation_params", Config.InvocationParams(
-            args= (),
-            plugins=(),
-            dir=Path(rootpath),
-        ))
+        monkeypatch.setattr(
+            pytester._request.config,
+            "invocation_params",
+            Config.InvocationParams(
+                args=(),
+                plugins=(),
+                dir=Path(rootpath),
+            ),
+        )
         with mock.patch.object(hook, "fnpats", ["*.py"]):
             assert hook.find_spec("file") is None
 
@@ -2051,13 +2054,13 @@ class TestEarlyRewriteBailout:
         if not os.path.exists(rootpath):
             mkdir(rootpath)
         monkeypatch.setattr(
-                pytester._request.config,
-                "invocation_params",
-                Config.InvocationParams(
-                    args= (),
-                    plugins=(),
-                    dir=Path(rootpath),
-                )
+            pytester._request.config,
+            "invocation_params",
+            Config.InvocationParams(
+                args=(),
+                plugins=(),
+                dir=Path(rootpath),
+            ),
         )
         with mock.patch.object(hook, "fnpats", ["*.py"]):
             assert hook.find_spec("conftest") is not None
@@ -2083,13 +2086,13 @@ class TestEarlyRewriteBailout:
         if not os.path.exists(rootpath):
             mkdir(rootpath)
         monkeypatch.setattr(
-                pytester._request.config,
-                "invocation_params",
-                Config.InvocationParams(
-                    args= (),
-                    plugins=(),
-                    dir=Path(rootpath),
-                )
+            pytester._request.config,
+            "invocation_params",
+            Config.InvocationParams(
+                args=(),
+                plugins=(),
+                dir=Path(rootpath),
+            ),
         )
         with mock.patch.object(hook, "fnpats", ["*.py"]):
             assert hook.find_spec("plugin") is not None


### PR DESCRIPTION
Disable assertion rewriting of external modules. Closes https://github.com/pytest-dev/pytest/issues/13403.
Created by squashing commits https://github.com/pytest-dev/pytest/pull/13421 to process code coverage.
<!--
Thanks for submitting a PR, your contribution is really appreciated! to process code coverage

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
