### PR TITLE
testing: skip `pkg_resources` tests if modern setuptools

### DIFF
--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 import types
 
+import setuptools
+
 from _pytest.config import ExitCode
 from _pytest.pathlib import symlink_or_skip
 from _pytest.pytester import Pytester
@@ -722,10 +724,14 @@ class TestInvocationVariants:
         assert result.ret != 0
         result.stderr.fnmatch_lines(["*not*found*test_missing*"])
 
-    def test_cmdline_python_namespace_package(
+    @pytest.mark.skipif(
+        int(setuptools.__version__.split(".")[0]) >= 80,
+        reason="modern setuptools removing pkg_resources",
+    )
+    def test_cmdline_python_legacy_namespace_package(
         self, pytester: Pytester, monkeypatch
     ) -> None:
-        """Test --pyargs option with namespace packages (#1567).
+        """Test --pyargs option with legacy namespace packages (#1567).
 
         Ref: https://packaging.python.org/guides/packaging-namespace-packages/
         """

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -8,6 +8,8 @@ import re
 import sys
 import textwrap
 
+import setuptools
+
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pytester import Pytester
 import pytest
@@ -429,6 +431,10 @@ def test_context_classmethod() -> None:
 
 
 @pytest.mark.filterwarnings(r"ignore:.*\bpkg_resources\b:DeprecationWarning")
+@pytest.mark.skipif(
+    int(setuptools.__version__.split(".")[0]) >= 80,
+    reason="modern setuptools removing pkg_resources",
+)
 def test_syspath_prepend_with_namespace_packages(
     pytester: Pytester, monkeypatch: MonkeyPatch
 ) -> None:


### PR DESCRIPTION
setuptools is intending to remove `pkg_resources` at the end of the year. Version 80.9.0 changed the deprecation to a UserMessage which broke the test. Instead of making them compatible, just skip them on versions >= 80 in preparation for the final removal.

Following [Ronny's suggestion](https://github.com/pytest-dev/pytest/pull/13442#issuecomment-2911689268).
