### PR TITLE
use callable protocols for pytest.skip/exit/fail/xfail instead of _WithException wrapper with __call__ attribute

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -134,6 +134,7 @@ Deysha Rivera
 Dheeraj C K
 Dhiren Serai
 Diego Russo
+Dima Gerasimov
 Dmitry Dygalo
 Dmitry Pribysh
 Dominic Mortlock

--- a/changelog/13445.bugfix.rst
+++ b/changelog/13445.bugfix.rst
@@ -1,0 +1,1 @@
+Made the type annotations of :func:`pytest.skip` and friends more spec-complaint to have them work across more type checkers.

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -104,6 +104,34 @@ exit: _Exit = _Exit()
 
 
 class _Skip:
+    """Skip an executing test with the given message.
+
+    This function should be called only during testing (setup, call or teardown) or
+    during collection by using the ``allow_module_level`` flag.  This function can
+    be called in doctests as well.
+
+    :param reason:
+        The message to show the user as reason for the skip.
+
+    :param allow_module_level:
+        Allows this function to be called at module level.
+        Raising the skip exception at module level will stop
+        the execution of the module and prevent the collection of all tests in the module,
+        even those defined before the `skip` call.
+
+        Defaults to False.
+
+    :raises pytest.skip.Exception:
+        The exception that is raised.
+
+    .. note::
+        It is better to use the :ref:`pytest.mark.skipif ref` marker when
+        possible to declare a test to be skipped under certain conditions
+        like mismatching platforms or dependencies.
+        Similarly, use the ``# doctest: +SKIP`` directive (see :py:data:`doctest.SKIP`)
+        to skip a doctest statically.
+    """
+
     Exception: ClassVar[type[Skipped]] = Skipped
 
     def __call__(self, reason: str = "", allow_module_level: bool = False) -> NoReturn:
@@ -112,33 +140,6 @@ class _Skip:
 
 
 skip: _Skip = _Skip()
-"""Skip an executing test with the given message.
-
-This function should be called only during testing (setup, call or teardown) or
-during collection by using the ``allow_module_level`` flag.  This function can
-be called in doctests as well.
-
-:param reason:
-    The message to show the user as reason for the skip.
-
-:param allow_module_level:
-    Allows this function to be called at module level.
-    Raising the skip exception at module level will stop
-    the execution of the module and prevent the collection of all tests in the module,
-    even those defined before the `skip` call.
-
-    Defaults to False.
-
-:raises pytest.skip.Exception:
-    The exception that is raised.
-
-.. note::
-    It is better to use the :ref:`pytest.mark.skipif ref` marker when
-    possible to declare a test to be skipped under certain conditions
-    like mismatching platforms or dependencies.
-    Similarly, use the ``# doctest: +SKIP`` directive (see :py:data:`doctest.SKIP`)
-    to skip a doctest statically.
-"""
 
 
 class _Fail:

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -104,34 +104,6 @@ exit: _Exit = _Exit()
 
 
 class _Skip:
-    """Skip an executing test with the given message.
-
-    This function should be called only during testing (setup, call or teardown) or
-    during collection by using the ``allow_module_level`` flag.  This function can
-    be called in doctests as well.
-
-    :param reason:
-        The message to show the user as reason for the skip.
-
-    :param allow_module_level:
-        Allows this function to be called at module level.
-        Raising the skip exception at module level will stop
-        the execution of the module and prevent the collection of all tests in the module,
-        even those defined before the `skip` call.
-
-        Defaults to False.
-
-    :raises pytest.skip.Exception:
-        The exception that is raised.
-
-    .. note::
-        It is better to use the :ref:`pytest.mark.skipif ref` marker when
-        possible to declare a test to be skipped under certain conditions
-        like mismatching platforms or dependencies.
-        Similarly, use the ``# doctest: +SKIP`` directive (see :py:data:`doctest.SKIP`)
-        to skip a doctest statically.
-    """
-
     Exception: ClassVar[type[Skipped]] = Skipped
 
     def __call__(self, reason: str = "", allow_module_level: bool = False) -> NoReturn:
@@ -140,6 +112,33 @@ class _Skip:
 
 
 skip: _Skip = _Skip()
+"""Skip an executing test with the given message.
+
+This function should be called only during testing (setup, call or teardown) or
+during collection by using the ``allow_module_level`` flag.  This function can
+be called in doctests as well.
+
+:param reason:
+    The message to show the user as reason for the skip.
+
+:param allow_module_level:
+    Allows this function to be called at module level.
+    Raising the skip exception at module level will stop
+    the execution of the module and prevent the collection of all tests in the module,
+    even those defined before the `skip` call.
+
+    Defaults to False.
+
+:raises pytest.skip.Exception:
+    The exception that is raised.
+
+.. note::
+    It is better to use the :ref:`pytest.mark.skipif ref` marker when
+    possible to declare a test to be skipped under certain conditions
+    like mismatching platforms or dependencies.
+    Similarly, use the ``# doctest: +SKIP`` directive (see :py:data:`doctest.SKIP`)
+    to skip a doctest statically.
+"""
 
 
 class _Fail:

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import sys
 from typing import Any
+from typing import ClassVar
 from typing import NoReturn
 
 from .warning_types import PytestDeprecationWarning
@@ -78,112 +79,120 @@ class XFailed(Failed):
 
 
 class _Exit:
-    Exception: type[Exit] = Exit
+    """Exit testing process.
+
+    :param reason:
+        The message to show as the reason for exiting pytest.  reason has a default value
+        only because `msg` is deprecated.
+
+    :param returncode:
+        Return code to be used when exiting pytest. None means the same as ``0`` (no error),
+        same as :func:`sys.exit`.
+
+    :raises pytest.exit.Exception:
+        The exception that is raised.
+    """
+
+    Exception: ClassVar[type[Exit]] = Exit
 
     def __call__(self, reason: str = "", returncode: int | None = None) -> NoReturn:
-        """Exit testing process.
-
-        :param reason:
-            The message to show as the reason for exiting pytest.  reason has a default value
-            only because `msg` is deprecated.
-
-        :param returncode:
-            Return code to be used when exiting pytest. None means the same as ``0`` (no error),
-            same as :func:`sys.exit`.
-
-        :raises pytest.exit.Exception:
-            The exception that is raised.
-        """
         __tracebackhide__ = True
         raise Exit(msg=reason, returncode=returncode)
 
 
+exit: _Exit = _Exit()
+
+
 class _Skip:
-    Exception: type[Skipped] = Skipped
+    """Skip an executing test with the given message.
+
+    This function should be called only during testing (setup, call or teardown) or
+    during collection by using the ``allow_module_level`` flag.  This function can
+    be called in doctests as well.
+
+    :param reason:
+        The message to show the user as reason for the skip.
+
+    :param allow_module_level:
+        Allows this function to be called at module level.
+        Raising the skip exception at module level will stop
+        the execution of the module and prevent the collection of all tests in the module,
+        even those defined before the `skip` call.
+
+        Defaults to False.
+
+    :raises pytest.skip.Exception:
+        The exception that is raised.
+
+    .. note::
+        It is better to use the :ref:`pytest.mark.skipif ref` marker when
+        possible to declare a test to be skipped under certain conditions
+        like mismatching platforms or dependencies.
+        Similarly, use the ``# doctest: +SKIP`` directive (see :py:data:`doctest.SKIP`)
+        to skip a doctest statically.
+    """
+
+    Exception: ClassVar[type[Skipped]] = Skipped
 
     def __call__(self, reason: str = "", allow_module_level: bool = False) -> NoReturn:
-        """Skip an executing test with the given message.
-
-        This function should be called only during testing (setup, call or teardown) or
-        during collection by using the ``allow_module_level`` flag.  This function can
-        be called in doctests as well.
-
-        :param reason:
-            The message to show the user as reason for the skip.
-
-        :param allow_module_level:
-            Allows this function to be called at module level.
-            Raising the skip exception at module level will stop
-            the execution of the module and prevent the collection of all tests in the module,
-            even those defined before the `skip` call.
-
-            Defaults to False.
-
-        :raises pytest.skip.Exception:
-            The exception that is raised.
-
-        .. note::
-            It is better to use the :ref:`pytest.mark.skipif ref` marker when
-            possible to declare a test to be skipped under certain conditions
-            like mismatching platforms or dependencies.
-            Similarly, use the ``# doctest: +SKIP`` directive (see :py:data:`doctest.SKIP`)
-            to skip a doctest statically.
-        """
         __tracebackhide__ = True
         raise Skipped(msg=reason, allow_module_level=allow_module_level)
 
 
+skip: _Skip = _Skip()
+
+
 class _Fail:
-    Exception: type[Failed] = Failed
+    """Explicitly fail an executing test with the given message.
+
+    :param reason:
+        The message to show the user as reason for the failure.
+
+    :param pytrace:
+        If False, msg represents the full failure information and no
+        python traceback will be reported.
+
+    :raises pytest.fail.Exception:
+        The exception that is raised.
+    """
+
+    Exception: ClassVar[type[Failed]] = Failed
 
     def __call__(self, reason: str = "", pytrace: bool = True) -> NoReturn:
-        """Explicitly fail an executing test with the given message.
-
-        :param reason:
-            The message to show the user as reason for the failure.
-
-        :param pytrace:
-            If False, msg represents the full failure information and no
-            python traceback will be reported.
-
-        :raises pytest.fail.Exception:
-            The exception that is raised.
-        """
         __tracebackhide__ = True
         raise Failed(msg=reason, pytrace=pytrace)
 
 
+fail: _Fail = _Fail()
+
+
 class _XFail:
-    Exception: type[XFailed] = XFailed
+    """Imperatively xfail an executing test or setup function with the given reason.
+
+    This function should be called only during testing (setup, call or teardown).
+
+    No other code is executed after using ``xfail()`` (it is implemented
+    internally by raising an exception).
+
+    :param reason:
+        The message to show the user as reason for the xfail.
+
+    .. note::
+        It is better to use the :ref:`pytest.mark.xfail ref` marker when
+        possible to declare a test to be xfailed under certain conditions
+        like known bugs or missing features.
+
+    :raises pytest.xfail.Exception:
+        The exception that is raised.
+    """
+
+    Exception: ClassVar[type[XFailed]] = XFailed
 
     def __call__(self, reason: str = "") -> NoReturn:
-        """Imperatively xfail an executing test or setup function with the given reason.
-
-        This function should be called only during testing (setup, call or teardown).
-
-        No other code is executed after using ``xfail()`` (it is implemented
-        internally by raising an exception).
-
-        :param reason:
-            The message to show the user as reason for the xfail.
-
-        .. note::
-            It is better to use the :ref:`pytest.mark.xfail ref` marker when
-            possible to declare a test to be xfailed under certain conditions
-            like known bugs or missing features.
-
-        :raises pytest.xfail.Exception:
-            The exception that is raised.
-        """
         __tracebackhide__ = True
         raise XFailed(msg=reason)
 
 
-# Exposed helper methods.
-
-exit: _Exit = _Exit()
-skip: _Skip = _Skip()
-fail: _Fail = _Fail()
 xfail: _XFail = _XFail()
 
 

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -1075,7 +1075,8 @@ class TestTracebackCutting:
     def test_skip_simple(self):
         with pytest.raises(pytest.skip.Exception) as excinfo:
             pytest.skip("xxx")
-        assert excinfo.traceback[-1].frame.code.name == "skip"
+        if sys.version_info >= (3, 11):
+            assert excinfo.traceback[-1].frame.code.raw.co_qualname == "_Skip.__call__"
         assert excinfo.traceback[-1].ishidden(excinfo)
         assert excinfo.traceback[-2].frame.code.name == "test_skip_simple"
         assert not excinfo.traceback[-2].ishidden(excinfo)


### PR DESCRIPTION
This is a more canonical way of typing generic callbacks/decorators
 (see https://mypy.readthedocs.io/en/stable/protocols.html#callback-protocols)

This helps with potential issues/ambiguity with `__call__` semanics in
type checkers -- according to python spec, `__call__` needs to be present
on the class, rather than as an instance attribute to be considered callable.

This worked in mypy because it didn't handle the spec 100% correctly (in this case this has no negative consequences)

However, `ty` type checker is stricter/more correct about it and every `pytest.skip` usage results in:

`error[call-non-callable]: Object of type `_WithException[Unknown, <class 'Skipped'>]` is not callable`

For more context, see:
- https://github.com/astral-sh/ruff/pull/17832#issuecomment-2855425767
- https://discuss.python.org/t/when-should-we-assume-callable-types-are-method-descriptors/92938

Testing:

Tested with running mypy against the following snippet:
```
import pytest
reveal_type(pytest.skip)
reveal_type(pytest.skip.Exception)
reveal_type(pytest.skip(reason="whatever"))
```

Before the change:

```
$ mypy test_pytest_skip.py
test_pytest_skip.py:2: note: Revealed type is "_pytest.outcomes._WithException[def (reason: builtins.str =, *, allow_module_level: builtins.bool =) -> Never, def (msg: Union[builtins.str, None] =, pytrace: builtins.bool =, allow_module_level: builtins.bool =, *, _use_item_location: builtins.bool =) -> _pytest.outcomes.Skipped]"
test_pytest_skip.py:3: note: Revealed type is "def (msg: Union[builtins.str, None] =, pytrace: builtins.bool =, allow_module_level: builtins.bool =, *, _use_item_location: builtins.bool =) -> _pytest.outcomes.Skipped"
test_pytest_skip.py:4: note: Revealed type is "Never"
```

After the change:
```
$ mypy test_pytest_skip.py
test_pytest_skip.py:2: note: Revealed type is "_pytest.outcomes._Skip"
test_pytest_skip.py:3: note: Revealed type is "type[_pytest.outcomes.Skipped]"
test_pytest_skip.py:4: note: Revealed type is "Never"
```

`ty` type checker is also inferring the same types correctly now.

All types are matching and propagated correctly (most importantly, `Never` as a result of `pytest.skip(...)` call