### PR TITLE
Sunset the mailing list contact information

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -139,9 +139,8 @@ The objectives of the ``pytest-dev`` organisation are:
 * Sharing some of the maintenance responsibility (in case a maintainer no
   longer wishes to maintain a plugin)
 
-You can submit your plugin by subscribing to the `pytest-dev mail list
-<https://mail.python.org/mailman/listinfo/pytest-dev>`_ and writing a
-mail pointing to your existing pytest plugin repository which must have
+You can submit your plugin by posting a new topic in the `pytest-dev GitHub Discussions
+<https://github.com/pytest-dev/pytest/discussions>`_ pointing to your existing pytest plugin repository which must have
 the following:
 
 - PyPI presence with packaging metadata that contains a ``pytest-``

--- a/doc/en/contact.rst
+++ b/doc/en/contact.rst
@@ -35,7 +35,6 @@ Mail
 ----
 
 - `Testing In Python`_: a mailing list for Python testing tools and discussion.
-- `pytest-dev at python.org`_ a mailing list for pytest specific announcements and discussions.
 - Mail to `core@pytest.org <mailto:core@pytest.org>`_ for topics that cannot be
   discussed in public. Mails sent there will be distributed among the members
   in the pytest core team, who can also be contacted individually:
@@ -58,4 +57,3 @@ Other
 .. _`pytest issue tracker`: https://github.com/pytest-dev/pytest/issues
 .. _`pytest discussions`: https://github.com/pytest-dev/pytest/discussions
 .. _`Testing in Python`: http://lists.idyll.org/listinfo/testing-in-python
-.. _`pytest-dev at python.org`: http://mail.python.org/mailman/listinfo/pytest-dev


### PR DESCRIPTION
As discussed recently in https://mail.python.org/archives/list/pytest-dev@python.org/thread/Y2HCDCXAAN6PLY63KLLY7FSUFDR6G5LC/, we will archive the mailing in favor of GitHub Discussions.
