### PR TITLE
Remove resultlog from the docs

### DIFF
--- a/doc/en/how-to/output.rst
+++ b/doc/en/how-to/output.rst
@@ -571,29 +571,6 @@ That will cause pytest to truncate the assertions to 10 lines or 90 characters, 
 Setting both :confval:`truncation_limit_lines` and :confval:`truncation_limit_chars` to ``0`` will disable the truncation.
 However, setting only one of those values will disable one truncation mode, but will leave the other one intact.
 
-Creating resultlog format files
---------------------------------------------------
-
-To create plain-text machine-readable result files you can issue:
-
-.. code-block:: bash
-
-    pytest --resultlog=path
-
-and look at the content at the ``path`` location.  Such files are used e.g.
-by the `PyPy-test`_ web page to show test results over several revisions.
-
-.. warning::
-
-    This option is rarely used and is scheduled for removal in pytest 6.0.
-
-    If you use this option, consider using the new `pytest-reportlog <https://github.com/pytest-dev/pytest-reportlog>`__ plugin instead.
-
-    See :ref:`the deprecation docs <resultlog deprecated>` for more information.
-
-
-.. _`PyPy-test`: http://buildbot.pypy.org/summary
-
 
 Creating JUnitXML format files
 ----------------------------------------------------


### PR DESCRIPTION
It was removed by https://github.com/pytest-dev/pytest/commit/d69abff2c7de8bc65b7f1ef867dec5b5b9c564bd in version `6.1.0`.

Fixes #13464
