### PR TITLE
scripts/release: add missing `build` to `towncrier` call

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -121,7 +121,7 @@ def pre_release(
 
 def changelog(version: str, write_out: bool = False) -> None:
     addopts = [] if write_out else ["--draft"]
-    check_call(["towncrier", "--yes", "--version", version, *addopts])
+    check_call(["towncrier", "build", "--yes", "--version", version, *addopts])
 
 
 def main() -> None:


### PR DESCRIPTION
Probably a new thing, but without it it just succeeds without doing anything.