### PR TITLE
RELEASING: remove testing-in-python mailing list

### DIFF
--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -168,8 +168,7 @@ Both automatic and manual processes described above follow the same steps from t
 
    To the following mailing lists:
 
-   * python-announce-list@python.org (all releases)
-   * testing-in-python@lists.idyll.org (only major/minor releases)
+   * python-announce-list@python.org
 
    And announce it with the ``#pytest`` hashtag on:
 


### PR DESCRIPTION
Seems no longer active (possibly dead): https://github.com/pytest-dev/pytest/pull/13472#issuecomment-2932108014

If anyone has other knowledge we can definitely keep it.