### PR TITLE
testing: Explicitly pass `-Werror` to tests needing it

### DIFF
--- a/changelog/13480.bugfix.rst
+++ b/changelog/13480.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a few test failures in pytest's own test suite when run with ``-Wdefault`` or a similar override.

--- a/testing/test_threadexception.py
+++ b/testing/test_threadexception.py
@@ -211,7 +211,7 @@ def test_unhandled_thread_exception_after_teardown(pytester: Pytester) -> None:
         """
     )
 
-    result = pytester.runpytest()
+    result = pytester.runpytest("-Werror")
 
     # TODO: should be a test failure or error
     assert result.ret == pytest.ExitCode.INTERNAL_ERROR

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -149,6 +149,7 @@ def test_unicode(pytester: Pytester) -> None:
     )
 
 
+@pytest.mark.skip("issue #13485")
 def test_works_with_filterwarnings(pytester: Pytester) -> None:
     """Ensure our warnings capture does not mess with pre-installed filters (#2430)."""
     pytester.makepyfile(


### PR DESCRIPTION
Explicitly pass `-Werror` to `runpytester()` in the few additional tests needing it, in order to fix test failures when the test suite is run with `-Wdefault` or a similar override.

Fixes #13480

----

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
