### PR TITLE
Remove outdated warning about faulthandler_timeout on Windows

### DIFF
--- a/changelog/13492.doc.rst
+++ b/changelog/13492.doc.rst
@@ -1,0 +1,1 @@
+Fixed outdated warning about ``faulthandler`` not working on Windows.

--- a/doc/en/how-to/failures.rst
+++ b/doc/en/how-to/failures.rst
@@ -112,7 +112,7 @@ on the command-line.
 
 Also the :confval:`faulthandler_timeout=X<faulthandler_timeout>` configuration option can be used
 to dump the traceback of all threads if a test takes longer than ``X``
-seconds to finish (not available on Windows).
+seconds to finish.
 
 .. note::
 


### PR DESCRIPTION

This PR removes the outdated warning regarding `faulthandler_timeout` on Windows as suggested in issue #13456.

The option is now functional on Windows, so the "(not available on Windows)" note has been removed from the documentation (`failures.rst`).
