### PR TITLE
Enable triggering the test workflow manually

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ on:
     - reopened  # default
     - ready_for_review  # used in PRs created from the release workflow
 
+  workflow_dispatch:  # allows manual triggering of the workflow
+
 env:
   PYTEST_ADDOPTS: "--color=yes"
 


### PR DESCRIPTION
Useful in cases we want to run the `test` workflow without any code changes, e.g. to compare a previous run that was successful a few days ago but `main` appears to be broken without code changes a few days later.
