### PR TITLE
pytester: avoid unraisableexception gc collects in inline runs to speed up test suite

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -65,7 +65,6 @@ from _pytest.pathlib import make_numbered_dir
 from _pytest.reports import CollectReport
 from _pytest.reports import TestReport
 from _pytest.tmpdir import TempPathFactory
-from _pytest.unraisableexception import gc_collect_iterations_key
 from _pytest.warning_types import PytestFDWarning
 
 
@@ -1093,6 +1092,8 @@ class Pytester:
             Typically we reraise keyboard interrupts from the child run. If
             True, the KeyboardInterrupt exception is captured.
         """
+        from _pytest.unraisableexception import gc_collect_iterations_key
+
         # (maybe a cpython bug?) the importlib cache sometimes isn't updated
         # properly between file creation and inline_run (especially if imports
         # are interspersed with file creation)

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -2175,7 +2175,8 @@ def test_invocation_args(pytester: Pytester) -> None:
     plugins = config.invocation_params.plugins
     assert len(plugins) == 2
     assert plugins[0] is plugin
-    assert type(plugins[1]).__name__ == "Collect"  # installed by pytester.inline_run()
+    # Installed by pytester.inline_run().
+    assert type(plugins[1]).__name__ == "PytesterHelperPlugin"
 
     # args cannot be None
     with pytest.raises(TypeError):


### PR DESCRIPTION
This is an alternative to #13513. I had to change some tests to run in a subprocess and tweak them a bit to make it work.

Fixes #13482.

Closes #13513.