### PR TITLE
prepare-release-pr: open PRs as draft

### DIFF
--- a/scripts/prepare-release-pr.py
+++ b/scripts/prepare-release-pr.py
@@ -135,6 +135,7 @@ def prepare_release_pr(base_branch: str, is_major: bool, prerelease: str) -> Non
             f"--head={release_branch}",
             f"--title=Release {version}",
             f"--body={body}",
+            "--draft",
         ],
         check=True,
     )


### PR DESCRIPTION
This way we can trigger the CI jobs just by marking the draft as ready, similar to how the `update-plugin-list` workflow works.
