### PR TITLE
Fix decimal.FloatOperation error in pytest.approx Decimal __repr__ 

### DIFF
--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -530,6 +530,25 @@ class ApproxDecimal(ApproxScalar):
     DEFAULT_ABSOLUTE_TOLERANCE = Decimal("1e-12")
     DEFAULT_RELATIVE_TOLERANCE = Decimal("1e-6")
 
+    def __repr__(self) -> str:
+        if isinstance(self.rel, float):
+            rel = Decimal.from_float(self.rel)
+        else:
+            rel = self.rel
+
+        if isinstance(self.abs, float):
+            abs_ = Decimal.from_float(self.abs)
+        else:
+            abs_ = self.abs
+
+        if rel is not None and Decimal("1e-3") <= rel <= Decimal("1e3"):
+            tol_str = f"{rel:.1e}"
+        elif abs_ is not None:
+            tol_str = f"{abs_:.1e}"
+        else:
+            tol_str = "???"
+
+        return f"{self.expected} ± {tol_str}"
 
 def approx(expected, rel=None, abs=None, nan_ok: bool = False) -> ApproxBase:
     """Assert that two numbers (or two ordered sequences of numbers) are equal to each other

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -1015,6 +1015,12 @@ class TestApprox:
         expected_repr = "approx([1 ± 1.0e-06, 2 ± 2.0e-06, 3 ± 3.0e-06, 4 ± 4.0e-06])"
         assert repr(approx(expected)) == expected_repr
 
+    def test_decimal_approx_repr(self, monkeypatch):
+        monkeypatch.setitem(decimal.getcontext().traps, decimal.FloatOperation, True)
+        approx_obj = pytest.approx(decimal.Decimal("2.60"))
+        print(f"Attempting to represent pytest.approx(Decimal): {approx_obj}") 
+        assert decimal.Decimal("2.600001") == approx_obj
+
     def test_allow_ordered_sequences_only(self) -> None:
         """pytest.approx() should raise an error on unordered sequences (#9692)."""
         with pytest.raises(TypeError, match="only supports ordered sequences"):


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Fix #13530

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [✅ ] Include new tests or update existing tests when applicable.
- [✅] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Fix #13530

## Summary  

This PR addresses a decimal.FloatOperation error that happens when calling repr() on a pytest.approx object created with a decimal.Decimal value. The error arises from comparing and formatting Decimal and float values without proper conversion, which activates the FloatOperation trap.  

## Changes  

I modified the __repr__ method to carefully handle Decimal and float attributes. This is done by explicitly converting float values to Decimal before comparisons and formatting.  
I added checks for None to prevent invalid comparisons.  
I avoided direct comparisons between float and Decimal that can lead to FloatOperation exceptions.  

## Testing  

I created a minimal test to reproduce the FloatOperation error from pytest.approx(Decimal)'s repr().  
The test passes after applying this fix, confirming that the issue is resolved.  


