### PR TITLE
Defer annotation eval on Python 3.14

### DIFF
--- a/changelog/13549.bugfix.rst
+++ b/changelog/13549.bugfix.rst
@@ -1,0 +1,1 @@
+Pytest no longer evaluates type annotations on Python 3.14 when inspecting a function signature.

--- a/changelog/13549.bugfix.rst
+++ b/changelog/13549.bugfix.rst
@@ -1,1 +1,3 @@
-Pytest no longer evaluates type annotations on Python 3.14 when inspecting a function signature.
+No longer evaluate type annotations in Python ``3.14`` when inspecting function signatures. 
+
+This prevents crashes during module collection when modules do not explicitly use ``from __future__ import annotations`` and import types for annotations within a ``if TYPE_CHECKING:`` block.

--- a/changelog/13549.bugfix.rst
+++ b/changelog/13549.bugfix.rst
@@ -1,3 +1,3 @@
-No longer evaluate type annotations in Python ``3.14`` when inspecting function signatures. 
+No longer evaluate type annotations in Python ``3.14`` when inspecting function signatures.
 
 This prevents crashes during module collection when modules do not explicitly use ``from __future__ import annotations`` and import types for annotations within a ``if TYPE_CHECKING:`` block.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -8,7 +8,7 @@ import enum
 import functools
 import inspect
 from inspect import Parameter
-from inspect import signature
+from inspect import Signature
 import os
 from pathlib import Path
 import sys
@@ -17,6 +17,10 @@ from typing import Final
 from typing import NoReturn
 
 import py
+
+
+if sys.version_info >= (3, 14):
+    from annotationlib import Format
 
 
 #: constant to prepare valuing pylib path replacements/lazy proxies later on
@@ -58,6 +62,13 @@ def is_async_function(func: object) -> bool:
     """Return True if the given function seems to be an async function or
     an async generator."""
     return iscoroutinefunction(func) or inspect.isasyncgenfunction(func)
+
+
+def signature(obj: Callable[..., Any]) -> Signature:
+    """Return signature without evaluating annotations."""
+    if sys.version_info >= (3, 14):
+        return inspect.signature(obj, annotation_format=Format.STRING)
+    return inspect.signature(obj)
 
 
 def getlocation(function, curdir: str | os.PathLike[str] | None = None) -> str:

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -49,6 +49,7 @@ from _pytest.compat import NOTSET
 from _pytest.compat import NotSetType
 from _pytest.compat import safe_getattr
 from _pytest.compat import safe_isclass
+from _pytest.compat import signature
 from _pytest.config import _PluggyPlugin
 from _pytest.config import Config
 from _pytest.config import ExitCode
@@ -804,8 +805,8 @@ class SubRequest(FixtureRequest):
         path, lineno = getfslineno(factory)
         if isinstance(path, Path):
             path = bestrelpath(self._pyfuncitem.session.path, path)
-        signature = inspect.signature(factory)
-        return f"{path}:{lineno + 1}:  def {factory.__name__}{signature}"
+        sig = signature(factory)
+        return f"{path}:{lineno + 1}:  def {factory.__name__}{sig}"
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         self._fixturedef.addfinalizer(finalizer)

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -8,7 +8,6 @@ from collections.abc import Iterator
 from collections.abc import MutableMapping
 from functools import cached_property
 from functools import lru_cache
-from inspect import signature
 import os
 import pathlib
 from pathlib import Path
@@ -29,6 +28,7 @@ from _pytest._code.code import TerminalRepr
 from _pytest._code.code import Traceback
 from _pytest._code.code import TracebackStyle
 from _pytest.compat import LEGACY_PATH
+from _pytest.compat import signature
 from _pytest.config import Config
 from _pytest.config import ConftestImportFailure
 from _pytest.config.compat import _check_path


### PR DESCRIPTION
Fixes #13549