### PR TITLE
Rename 13480.bugfix to 13480.contrib

### DIFF
--- a/changelog/13480.bugfix.rst
+++ b/changelog/13480.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a few test failures in pytest's own test suite when run with ``-Wdefault`` or a similar override.

--- a/changelog/13480.contrib.rst
+++ b/changelog/13480.contrib.rst
@@ -1,0 +1,1 @@
+Self-testing: fixed a few test failures when run with ``-Wdefault`` or a similar override.


### PR DESCRIPTION
Since this is related only to internal testing and does not affect end-users, it is more appropriate to announce it in the "Contributor" section of the changelog.

Follow up to #13481.
