### PR TITLE
Import numpy conditionally in `pytest.approx`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -261,6 +261,7 @@ Leonardus Chen
 Lev Maximov
 Levon Saldamli
 Lewis Cowles
+Liam DeVoe
 Llandy Riveron Del Risco
 Loic Esteve
 lovetheguitar

--- a/changelog/13563.bugfix.rst
+++ b/changelog/13563.bugfix.rst
@@ -1,0 +1,1 @@
+:func:`pytest.approx` now only imports ``numpy`` if NumPy is already in ``sys.modules``. This fixes unconditional import behavior introduced in `8.4.0`.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -426,12 +426,9 @@ class ApproxScalar(ApproxBase):
             # Check if `val` is a native bool or numpy bool.
             if isinstance(val, bool):
                 return True
-            try:
-                import numpy as np
-
+            if np := sys.modules.get("numpy"):
                 return isinstance(val, np.bool_)
-            except ImportError:
-                return False
+            return False
 
         asarray = _as_numpy_array(actual)
         if asarray is not None:


### PR DESCRIPTION
Introduced in https://github.com/pytest-dev/pytest/pull/13338.

This matches existing conditional-import behavior in `pytest.approx`, and improves runtime for users of `pytest.approx and not numpy`.