### PR TITLE
Handle --version eagerly to avoid loading the entire infrastructure

### DIFF
--- a/changelog/13574.improvement.rst
+++ b/changelog/13574.improvement.rst
@@ -1,0 +1,7 @@
+The single argument ``--version`` no longer loads the entire plugin infrastructure, making it faster and more reliable when displaying only the pytest version.
+
+Passing ``--version`` twice (e.g., ``pytest --version --version``) retains the original behavior, showing both the pytest version and plugin information.
+
+.. note::
+
+    Since ``--version`` is now processed early, it only takes effect when passed directly via the command line. It will not work if set through other mechanisms, such as :envvar:`PYTEST_ADDOPTS` or :confval:`addopts`.

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -140,28 +140,28 @@ def pytest_cmdline_parse() -> Generator[None, Config, Config]:
     return config
 
 
-def showversion(config: Config) -> None:
-    if config.option.version > 1:
-        sys.stdout.write(
-            f"This is pytest version {pytest.__version__}, imported from {pytest.__file__}\n"
-        )
-        plugininfo = getpluginversioninfo(config)
-        if plugininfo:
-            for line in plugininfo:
-                sys.stdout.write(line + "\n")
-    else:
-        sys.stdout.write(f"pytest {pytest.__version__}\n")
+def show_version_verbose(config: Config) -> None:
+    """Show verbose pytest version installation, including plugins."""
+    sys.stdout.write(
+        f"This is pytest version {pytest.__version__}, imported from {pytest.__file__}\n"
+    )
+    plugininfo = getpluginversioninfo(config)
+    if plugininfo:
+        for line in plugininfo:
+            sys.stdout.write(line + "\n")
 
 
 def pytest_cmdline_main(config: Config) -> int | ExitCode | None:
-    if config.option.version > 0:
-        showversion(config)
-        return 0
+    # Note: a single `--version` argument is handled directly by `Config.main()` to avoid starting up the entire
+    # pytest infrastructure just to display the version (#13574).
+    if config.option.version > 1:
+        show_version_verbose(config)
+        return ExitCode.OK
     elif config.option.help:
         config._do_configure()
         showhelp(config)
         config._ensure_unconfigure()
-        return 0
+        return ExitCode.OK
     return None
 
 

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -868,7 +868,7 @@ def test_error_during_readouterr(pytester: Pytester) -> None:
         FDCapture.snap = bad_snap
     """
     )
-    result = pytester.runpytest_subprocess("-p", "pytest_xyz", "--version")
+    result = pytester.runpytest_subprocess("-p", "pytest_xyz")
     result.stderr.fnmatch_lines(
         ["*in bad_snap", "    raise Exception('boom')", "Exception: boom"]
     )

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -612,20 +612,14 @@ class TestConfigCmdlineParsing:
         assert config.getini("custom") == "1"
 
     def test_absolute_win32_path(self, pytester: Pytester) -> None:
-        temp_ini_file = pytester.makefile(
-            ".ini",
-            custom="""
-            [pytest]
-            addopts = --version
-        """,
-        )
+        temp_ini_file = pytester.makeini("[pytest]")
         from os.path import normpath
 
         temp_ini_file_norm = normpath(str(temp_ini_file))
         ret = pytest.main(["-c", temp_ini_file_norm])
-        assert ret == ExitCode.OK
+        assert ret == ExitCode.NO_TESTS_COLLECTED
         ret = pytest.main(["--config-file", temp_ini_file_norm])
-        assert ret == ExitCode.OK
+        assert ret == ExitCode.NO_TESTS_COLLECTED
 
 
 class TestConfigAPI:
@@ -2121,7 +2115,7 @@ def test_help_and_version_after_argument_error(pytester: Pytester) -> None:
 
     result = pytester.runpytest("--version")
     result.stdout.fnmatch_lines([f"pytest {pytest.__version__}"])
-    assert result.ret == ExitCode.USAGE_ERROR
+    assert result.ret == ExitCode.OK
 
 
 def test_help_formatter_uses_py_get_terminal_width(monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
Currently, handling `--version` in `pytest_cmdline_main` requires loading the entire infrastructure, which can be slow depending on the installed plugins.

This change introduces a marginal behavioral difference, though it should not cause any issues in practice.

Fixes #13574
