### PR TITLE
Display output failure message in insertion order of dictionary

### DIFF
--- a/src/_pytest/_io/pprint.py
+++ b/src/_pytest/_io/pprint.py
@@ -62,6 +62,7 @@ class PrettyPrinter:
         indent: int = 4,
         width: int = 80,
         depth: int | None = None,
+        sort_dicts: bool = True,
     ) -> None:
         """Handle pretty printing operations onto a stream using a set of
         configured parameters.
@@ -74,6 +75,9 @@ class PrettyPrinter:
 
         depth
             The maximum depth to print out nested structures.
+        
+        sort_dicts
+            If true, dict keys are sorted.
 
         """
         if indent < 0:
@@ -85,6 +89,7 @@ class PrettyPrinter:
         self._depth = depth
         self._indent_per_level = indent
         self._width = width
+        self._sort_dicts = sort_dicts
 
     def pformat(self, object: Any) -> str:
         sio = _StringIO()
@@ -162,7 +167,10 @@ class PrettyPrinter:
     ) -> None:
         write = stream.write
         write("{")
-        items = sorted(object.items(), key=_safe_tuple)
+        if self._sort_dicts:
+            items = sorted(object.items(), key=_safe_tuple)
+        else:
+            items = object.items()
         self._format_dict_items(items, stream, indent, allowance, context, level)
         write("}")
 
@@ -608,7 +616,11 @@ class PrettyPrinter:
             components: list[str] = []
             append = components.append
             level += 1
-            for k, v in sorted(object.items(), key=_safe_tuple):
+            if self._sort_dicts:
+                items = sorted(object.items(), key=_safe_tuple)
+            else:
+                items = object.items()
+            for k, v in items:
                 krepr = self._safe_repr(k, context, maxlevels, level)
                 vrepr = self._safe_repr(v, context, maxlevels, level)
                 append(f"{krepr}: {vrepr}")

--- a/testing/test_error_diffs.py
+++ b/testing/test_error_diffs.py
@@ -201,6 +201,70 @@ TESTCASES = [
     pytest.param(
         """
         def test_this():
+            result = {'d': 4, 'c': 3, 'b': 2, 'a': 1}
+            expected = {'d': 4, 'c': 3, 'e': 5}
+            assert result == expected
+        """,
+        """
+        >       assert result == expected
+        E       AssertionError: assert {'d': 4, 'c': 3, 'b': 2, 'a': 1} == {'d': 4, 'c': 3, 'e': 5}
+        E         
+        E         Common items:
+        E         {'d': 4, 'c': 3}
+        E         Left contains 2 more items:
+        E         {'b': 2, 'a': 1}
+        E         Right contains 1 more item:
+        E         {'e': 5}
+        E         
+        E         Full diff:
+        E           {
+        E               'd': 4,
+        E               'c': 3,
+        E         -     'e': 5,
+        E         ?      ^   ^
+        E         +     'b': 2,
+        E         ?      ^   ^
+        E         +     'a': 1,
+        E           }
+        """,
+        id="Compare dicts and check order of diff",
+    ),
+    pytest.param(
+        """
+        def test_this():
+            result = {'c': 3, 'd': 4, 'b': 2, 'a': 1}
+            expected = {'d': 5, 'c': 3, 'b': 1}
+            assert result == expected
+        """,
+        """
+        >       assert result == expected
+        E       AssertionError: assert {'c': 3, 'd': 4, 'b': 2, 'a': 1} == {'d': 5, 'c': 3, 'b': 1}
+        E         
+        E         Common items:
+        E         {'c': 3}
+        E         Differing items:
+        E         {'d': 4} != {'d': 5}
+        E         {'b': 2} != {'b': 1}
+        E         Left contains 1 more item:
+        E         {'a': 1}
+        E         
+        E         Full diff:
+        E           {
+        E         -     'd': 5,
+        E               'c': 3,
+        E         +     'd': 4,
+        E         -     'b': 1,
+        E         ?          ^
+        E         +     'b': 2,
+        E         ?          ^
+        E         +     'a': 1,
+        E           }
+        """,
+        id="Compare dicts with different order and values",
+    ),
+    pytest.param(
+        """
+        def test_this():
             result =   "spmaeggs"
             expected = "spameggs"
             assert result == expected


### PR DESCRIPTION
Closes #13503. This PR updates the failure message formatting to respect the original order of dictionary keys, instead of sorting them alphabetically.

Changes made:

Common items shared by both dictionaries are now shown in the order they appear in the left dictionary.
Items unique to each dictionary are displayed in the order they originally appear in their respective dictionaries.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
