### PR TITLE
feat: Shorten ExceptionGroup summary to a single line

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -176,6 +176,7 @@ Fraser Stark
 Gabriel Landau
 Gabriel Reis
 Garvit Shubham
+Xay Hanmonty
 Gene Wood
 George Kussumoto
 Georgy Dyuldin

--- a/changelog/11235.bugfix.rst
+++ b/changelog/11235.bugfix.rst
@@ -1,0 +1,1 @@
+Shorten `ExceptionGroup` summary to a single line.

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -666,6 +666,9 @@ class ExceptionInfo(Generic[E]):
         ):
             return f"{subexc!r} [single exception in {type(self.value).__name__}]"
 
+        if isinstance(self.value, BaseExceptionGroup):
+            return f"{self.typename}: {self.value.message} ({len(self.value.exceptions)} sub-exceptions)"
+
         lines = format_exception_only(self.type, self.value)
         text = "".join(lines)
         text = text.rstrip()
@@ -1188,18 +1191,7 @@ class FormattedExcinfo:
                 # full support for exception groups added to ExceptionInfo.
                 # See https://github.com/pytest-dev/pytest/issues/9159
                 reprtraceback: ReprTraceback | ReprTracebackNative
-                if isinstance(e, BaseExceptionGroup):
-                    # don't filter any sub-exceptions since they shouldn't have any internal frames
-                    traceback = filter_excinfo_traceback(self.tbfilter, excinfo)
-                    reprtraceback = ReprTracebackNative(
-                        format_exception(
-                            type(excinfo.value),
-                            excinfo.value,
-                            traceback[0]._rawentry,
-                        )
-                    )
-                else:
-                    reprtraceback = self.repr_traceback(excinfo_)
+                reprtraceback = self.repr_traceback(excinfo_)
                 reprcrash = excinfo_._getreprcrash()
             else:
                 # Fallback to native repr if the exception doesn't have a traceback:


### PR DESCRIPTION
This commit modifies the exception reporting for ExceptionGroups to display a single-line summary instead of a multi-line traceback summary. This improves readability for tests that raise ExceptionGroups with many sub-exceptions.

Fixes #11235

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
