### PR TITLE
main: use a better windows short-path comparison method

### DIFF
--- a/changelog/13598.bugfix.rst
+++ b/changelog/13598.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed possible collection confusion on Windows when short paths and symlinks are involved.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -39,6 +39,7 @@ from _pytest.pathlib import absolutepath
 from _pytest.pathlib import bestrelpath
 from _pytest.pathlib import fnmatch_ex
 from _pytest.pathlib import safe_exists
+from _pytest.pathlib import samefile_nofollow
 from _pytest.pathlib import scandir
 from _pytest.reports import CollectReport
 from _pytest.reports import TestReport
@@ -935,14 +936,10 @@ class Session(nodes.Collector):
                         is_match = node.path == matchparts[0]
                         if sys.platform == "win32" and not is_match:
                             # In case the file paths do not match, fallback to samefile() to
-                            # account for short-paths on Windows (#11895).
-                            same_file = os.path.samefile(node.path, matchparts[0])
-                            # We don't want to match links to the current node,
-                            # otherwise we would match the same file more than once (#12039).
-                            is_match = same_file and (
-                                os.path.islink(node.path)
-                                == os.path.islink(matchparts[0])
-                            )
+                            # account for short-paths on Windows (#11895). But use a version
+                            # which doesn't resolve symlinks, otherwise we might match the
+                            # same file more than once (#12039).
+                            is_match = samefile_nofollow(node.path, matchparts[0])
 
                     # Name part e.g. `TestIt` in `/a/b/test_file.py::TestIt::test_it`.
                     else:

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -1053,3 +1053,11 @@ def safe_exists(p: Path) -> bool:
         # ValueError: stat: path too long for Windows
         # OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect
         return False
+
+
+def samefile_nofollow(p1: Path, p2: Path) -> bool:
+    """Test whether two paths reference the same actual file or directory.
+
+    Unlike Path.samefile(), does not resolve symlinks.
+    """
+    return os.path.samestat(p1.lstat(), p2.lstat())


### PR DESCRIPTION
The previous check does not account for multiple levels of symlinks: given a -> b -> c, a would match b.

Note, I don't use Windows and can't actually verify it, I only saw it reading the code. But if it's wrong hopefully the existing `test_do_not_collect_symlink_siblings` test will catch it on Windows CI.