### PR TITLE
Preserve dict insertion order in safeformat output (fixes #13503)

### DIFF
--- a/changelog/13503.bugfix.rst
+++ b/changelog/13503.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes dict output in assertion failures to preserve insertion order. (#13503)

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -87,7 +87,7 @@ def safeformat(obj: object) -> str:
     with a short exception info.
     """
     try:
-        return pprint.pformat(obj)
+        return pprint.pformat(obj, sort_dicts=False)
     except Exception as exc:
         return _format_repr_exception(exc, obj)
 

--- a/testing/io/test_saferepr.py
+++ b/testing/io/test_saferepr.py
@@ -192,3 +192,14 @@ def test_saferepr_unlimited_exc():
     assert saferepr_unlimited(A()).startswith(
         "<[ValueError(42) raised in repr()] A object at 0x"
     )
+
+
+def test_saferepr_dict_insertion_order():
+    from _pytest._io.saferepr import safeformat
+    d = {}
+    d["z"] = 1
+    d["a"] = 2
+    d["m"] = 3
+    output = safeformat(d)
+    # output should contain 'z', 'a', 'm' in this order (not 'a', 'm', 'z')
+    assert output.find("'z'") < output.find("'a'") < output.find("'m'")


### PR DESCRIPTION
This PR ensures that dictionaries in assertion output retain their insertion order, instead of displaying keys in alphabetical order. This matches Python 3.7+ dict behavior and improves debugging clarity for users.

- Updates `safeformat` to use `sort_dicts=False` with `pprint.pformat`.
- Adds a test to verify that dictionary keys are shown in insertion order in output.

Closes #13503.

