### PR TITLE
feat(13617): record reason for deselection and allow it to be displayed

### DIFF
--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -446,6 +446,9 @@ def pytest_collection_modifyitems(items: list[nodes.Item], config: Config) -> No
     deselected = []
     for colitem in items:
         if colitem.nodeid.startswith(deselect_prefixes):
+            colitem._deselected_reason = (
+                f"Deselected by --deselect option: {colitem.nodeid}"
+            )
             deselected.append(colitem)
         else:
             remaining.append(colitem)

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -217,6 +217,9 @@ def deselect_by_keyword(items: list[Item], config: Config) -> None:
     deselected = []
     for colitem in items:
         if not expr.evaluate(KeywordMatcher.from_item(colitem)):
+            colitem._deselected_reason = (
+                f"Keyword expression '{keywordexpr}' did not match."
+            )
             deselected.append(colitem)
         else:
             remaining.append(colitem)
@@ -266,9 +269,9 @@ def deselect_by_mark(items: list[Item], config: Config) -> None:
         if expr.evaluate(MarkMatcher.from_markers(item.iter_markers())):
             remaining.append(item)
         else:
+            item._deselected_reason = f"Mark expression '{matchexpr}' did not match."
             deselected.append(item)
     if deselected:
-        config.hook.pytest_deselected(items=deselected)
         items[:] = remaining
 
 

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -144,6 +144,7 @@ class Node(abc.ABC, metaclass=NodeMeta):
     # Note that __dict__ is still available.
     __slots__ = (
         "__dict__",
+        "_deselected_reason",
         "_nodeid",
         "_store",
         "config",
@@ -213,6 +214,9 @@ class Node(abc.ABC, metaclass=NodeMeta):
         self.stash: Stash = Stash()
         # Deprecated alias. Was never public. Can be removed in a few releases.
         self._store = self.stash
+
+        #: A reason for deselection.
+        self._deselected_reason = ""
 
     @classmethod
     def from_parent(cls, parent: Node, **kw) -> Self:

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1452,7 +1452,12 @@ class TerminalReporter:
         if errors:
             main_color = _color_for_type["error"]
             parts += [("%d %s" % pluralize(errors, "error"), {main_color: True})]  # noqa: UP031
-
+        if self.verbosity >= 2:
+            for item in self.stats["deselected"]:
+                self.write_line(
+                    f"Deselected: {item.nodeid}: {item._deselected_reason}",
+                    cyan=True,
+                )
         return parts, main_color
 
 


### PR DESCRIPTION
- starts to record deselection reasons
- display deselected with increased verbosity level

Fixes: #13617

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
