### PR TITLE
selftests: Set a timeout for lsof

### DIFF
--- a/changelog/13621.contrib.rst
+++ b/changelog/13621.contrib.rst
@@ -1,0 +1,1 @@
+pytest's own testsuite now handles the ``lsof`` command hanging (e.g. due to unreachable network filesystems), with the affected selftests being skipped after 10 seconds.

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -983,8 +983,13 @@ def tmpfile(pytester: Pytester) -> Generator[BinaryIO]:
 def lsof_check():
     pid = os.getpid()
     try:
-        out = subprocess.check_output(("lsof", "-p", str(pid))).decode()
-    except (OSError, subprocess.CalledProcessError, UnicodeDecodeError) as exc:
+        out = subprocess.check_output(("lsof", "-p", str(pid)), timeout=10).decode()
+    except (
+        OSError,
+        UnicodeDecodeError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ) as exc:
         # about UnicodeDecodeError, see note on pytester
         pytest.skip(f"could not run 'lsof' ({exc!r})")
     yield


### PR DESCRIPTION
In case of hanging filesystems (e.g. unreachable sshfs), `lsof` can hang for a long time (3 minutes in my case). Set a more reasonable timeout and skip the affected test (like already done with other problems regarding lsof) in such a case.