### PR TITLE
runner: correctly cleanup item _request/funcargs if an exception was reraised during call (e.g. KeyboardInterrupt)

### DIFF
--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -127,23 +127,25 @@ def runtestprotocol(
         # This only happens if the item is re-run, as is done by
         # pytest-rerunfailures.
         item._initrequest()  # type: ignore[attr-defined]
-    rep = call_and_report(item, "setup", log)
-    reports = [rep]
-    if rep.passed:
-        if item.config.getoption("setupshow", False):
-            show_test_item(item)
-        if not item.config.getoption("setuponly", False):
-            reports.append(call_and_report(item, "call", log))
-    # If the session is about to fail or stop, teardown everything - this is
-    # necessary to correctly report fixture teardown errors (see #11706)
-    if item.session.shouldfail or item.session.shouldstop:
-        nextitem = None
-    reports.append(call_and_report(item, "teardown", log, nextitem=nextitem))
-    # After all teardown hooks have been called
-    # want funcargs and request info to go away.
-    if hasrequest:
-        item._request = False  # type: ignore[attr-defined]
-        item.funcargs = None  # type: ignore[attr-defined]
+    try:
+        rep = call_and_report(item, "setup", log)
+        reports = [rep]
+        if rep.passed:
+            if item.config.getoption("setupshow", False):
+                show_test_item(item)
+            if not item.config.getoption("setuponly", False):
+                reports.append(call_and_report(item, "call", log))
+        # If the session is about to fail or stop, teardown everything - this is
+        # necessary to correctly report fixture teardown errors (see #11706)
+        if item.session.shouldfail or item.session.shouldstop:
+            nextitem = None
+        reports.append(call_and_report(item, "teardown", log, nextitem=nextitem))
+    finally:
+        # After all teardown hooks have been called (or an exception was reraised)
+        # want funcargs and request info to go away.
+        if hasrequest:
+            item._request = False  # type: ignore[attr-defined]
+            item.funcargs = None  # type: ignore[attr-defined]
     return reports
 
 


### PR DESCRIPTION
In my test suite, I have some objects that rely on garbage collection to be cleaned up correctly. This is not amazing, but it's how the code is structured for now. If I interrupt tests with Ctrl+C, or by manually raising `KeyboardInterrupt` in a test, these objects are not cleaned up any more.

`call_and_report` re-raises `Exit` and `KeyboardInterrupt`, which breaks the cleanup logic in `runtestprotocol` that unsets the item funcargs (which is where my objects end up living as references, as they're passed in as fixtures).

By just wrapping the entire block with `try: ... finally: ...`, cleanup works again as expected.

I'm going to hold off on updating changelog/AUTHORS until this PR is accepted!

### Template checklist things:

- [n/a] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable (hard to test CPython reference/GC behaviour, suggestions appreciated).
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [n/a] Add text like ``closes #XYZW`` to the PR description and/or commits

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
