### PR TITLE
Fix gh pr new command

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -251,6 +251,7 @@ Kevin Hierro Carrasco
 Kevin J. Foley
 Kian Eliasi
 Kian-Meng Ang
+Kim Soo
 Kodi B. Arfer
 Kojo Idrissa
 Kostis Anagnostopoulos

--- a/changelog/13638.bugfix.rst
+++ b/changelog/13638.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed deprecated ``gh pr new`` command in :file:`scripts/prepare-release-pr.py`. 
+The script now uses ``gh pr create`` which is compatible with GitHub CLI v2.0+.

--- a/scripts/prepare-release-pr.py
+++ b/scripts/prepare-release-pr.py
@@ -130,7 +130,7 @@ def prepare_release_pr(base_branch: str, is_major: bool, prerelease: str) -> Non
         [
             "gh",
             "pr",
-            "new",
+            "create",
             f"--base={base_branch}",
             f"--head={release_branch}",
             f"--title=Release {version}",


### PR DESCRIPTION
Closes #13638

## Description
Fixed deprecated `gh pr new` command in `scripts/prepare-release-pr.py` to use `gh pr create` instead.

## Problem
- `gh pr new` was deprecated in GitHub CLI 2.0 and is no longer a valid command
- Script fails when executed with modern GitHub CLI versions

## Solution
- Replaced `gh pr new` with `gh pr create` in prepare-release-pr.py (line 133)
- Added changelog entry (changelog/13638.bugfix.rst)
- Updated AUTHORS file

