### PR TITLE
add missing colon

### DIFF
--- a/src/_pytest/raises.py
+++ b/src/_pytest/raises.py
@@ -559,7 +559,7 @@ class RaisesExc(AbstractRaises[BaseExcT_co_default]):
         The type is checked with :func:`isinstance`, and does not need to be an exact match.
         If that is wanted you can use the ``check`` parameter.
 
-    :kwparam str | Pattern[str] match
+    :kwparam str | Pattern[str] match:
         A regex to match.
 
     :kwparam Callable[[BaseException], bool] check:


### PR DESCRIPTION
super small formatting error I noticed when reading the docs https://docs.pytest.org/en/stable/reference/reference.html#pytest.RaisesExc

I checked that this didn't occur elsewhere with `git grep ':\(kw\)\?param[^:]*$'`, which we could add to pre-commit