### PR TITLE
improvement: show return type annotations in fixtures

### DIFF
--- a/changelog/13676.improvement.rst
+++ b/changelog/13676.improvement.rst
@@ -1,1 +1,1 @@
-Added return type annotations in ``fixtures`` and ``fixtures-per-test``.
+Return type annotations are now shown in ``--fixtures`` and ``--fixtures-per-test``.

--- a/changelog/13676.improvement.rst
+++ b/changelog/13676.improvement.rst
@@ -1,0 +1,1 @@
+Added return type annotations in ``fixtures`` and ``fixtures-per-test``.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -2015,7 +2015,7 @@ def _showfixtures_main(config: Config, session: Session) -> None:
         tw.line()
 
 
-def get_return_annotation(fixture_func: Callable) -> str:
+def get_return_annotation(fixture_func: Callable[..., Any]) -> str:
     try:
         sig = signature(fixture_func)
         annotation = sig.return_annotation

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1911,6 +1911,9 @@ def _show_fixtures_per_test(config: Config, session: Session) -> None:
             return
         prettypath = _pretty_fixture_path(invocation_dir, fixture_def.func)
         tw.write(f"{argname}", green=True)
+        ret_annotation = get_return_annotation(fixture_def)
+        if ret_annotation:
+            tw.write(f" -> {ret_annotation}", cyan=True)
         tw.write(f" -- {prettypath}", yellow=True)
         tw.write("\n")
         fixture_doc = inspect.getdoc(fixture_def.func)
@@ -1995,6 +1998,9 @@ def _showfixtures_main(config: Config, session: Session) -> None:
         if verbose <= 0 and argname.startswith("_"):
             continue
         tw.write(f"{argname}", green=True)
+        ret_annotation = get_return_annotation(fixturedef)
+        if ret_annotation:
+            tw.write(f" -> {ret_annotation}", cyan=True)
         if fixturedef.scope != "function":
             tw.write(f" [{fixturedef.scope} scope]", cyan=True)
         tw.write(f" -- {prettypath}", yellow=True)
@@ -2007,6 +2013,17 @@ def _showfixtures_main(config: Config, session: Session) -> None:
         else:
             tw.line("    no docstring available", red=True)
         tw.line()
+
+
+def get_return_annotation(fixturedef: FixtureDef[object]) -> str:
+    try:
+        sig = signature(fixturedef.func)
+        annotation = sig.return_annotation
+        if annotation is not sig.empty and annotation != inspect._empty:
+            return inspect.formatannotation(annotation)
+    except (ValueError, TypeError):
+        pass
+    return ""
 
 
 def write_docstring(tw: TerminalWriter, doc: str, indent: str = "    ") -> None:

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -2020,11 +2020,13 @@ def get_return_annotation(fixture_func: Callable[..., Any]) -> str:
         sig = signature(fixture_func)
         annotation = sig.return_annotation
         if annotation is not sig.empty:
+            if type(annotation) == type(None):
+                return "None"
             if isinstance(annotation, str):
                 return annotation
             if annotation.__module__ == "typing":
                 return str(annotation).replace("typing.", "")
-            return annotation.__name__
+            return str(annotation.__name__)
     except (ValueError, TypeError):
         pass
     return ""

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -2017,13 +2017,13 @@ def _showfixtures_main(config: Config, session: Session) -> None:
 
 
 def get_return_annotation(fixture_func: Callable[..., Any]) -> str:
-    pattern = re.compile(r'\b(?:(?:<[^>]+>|[A-Za-z_]\w*)\.)+([A-Za-z_]\w*)\b')
+    pattern = re.compile(r"\b(?:(?:<[^>]+>|[A-Za-z_]\w*)\.)+([A-Za-z_]\w*)\b")
 
     sig = str(signature(fixture_func))
     sig_parts = sig.split(" -> ")
     if len(sig_parts) < 2:
         return ""
-    return pattern.sub(r'\1', sig_parts[-1])
+    return pattern.sub(r"\1", sig_parts[-1])
 
 
 def write_docstring(tw: TerminalWriter, doc: str, indent: str = "    ") -> None:

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1911,7 +1911,7 @@ def _show_fixtures_per_test(config: Config, session: Session) -> None:
             return
         prettypath = _pretty_fixture_path(invocation_dir, fixture_def.func)
         tw.write(f"{argname}", green=True)
-        ret_annotation = get_return_annotation(fixture_def)
+        ret_annotation = get_return_annotation(fixture_def.func)
         if ret_annotation:
             tw.write(f" -> {ret_annotation}", cyan=True)
         tw.write(f" -- {prettypath}", yellow=True)
@@ -1998,7 +1998,7 @@ def _showfixtures_main(config: Config, session: Session) -> None:
         if verbose <= 0 and argname.startswith("_"):
             continue
         tw.write(f"{argname}", green=True)
-        ret_annotation = get_return_annotation(fixturedef)
+        ret_annotation = get_return_annotation(fixturedef.func)
         if ret_annotation:
             tw.write(f" -> {ret_annotation}", cyan=True)
         if fixturedef.scope != "function":
@@ -2015,12 +2015,12 @@ def _showfixtures_main(config: Config, session: Session) -> None:
         tw.line()
 
 
-def get_return_annotation(fixturedef: FixtureDef[object]) -> str:
+def get_return_annotation(fixture_func: Callable) -> str:
     try:
-        sig = signature(fixturedef.func)
+        sig = signature(fixture_func)
         annotation = sig.return_annotation
         if annotation is not sig.empty and annotation != inspect._empty:
-            return inspect.formatannotation(annotation)
+            return inspect.formatannotation(annotation).replace("'", "")
     except (ValueError, TypeError):
         pass
     return ""

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -2019,11 +2019,13 @@ def _showfixtures_main(config: Config, session: Session) -> None:
 def get_return_annotation(fixture_func: Callable[..., Any]) -> str:
     pattern = re.compile(r"\b(?:(?:<[^>]+>|[A-Za-z_]\w*)\.)+([A-Za-z_]\w*)\b")
 
-    sig = str(signature(fixture_func))
-    sig_parts = sig.split(" -> ")
-    if len(sig_parts) < 2:
+    sig = signature(fixture_func)
+    return_annotation = sig.return_annotation
+    if return_annotation is sig.empty:
         return ""
-    return pattern.sub(r"\1", sig_parts[-1])
+    if not isinstance(return_annotation, str):
+        return_annotation = inspect.formatannotation(return_annotation)
+    return pattern.sub(r"\1", return_annotation)
 
 
 def write_docstring(tw: TerminalWriter, doc: str, indent: str = "    ") -> None:

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -18,6 +18,7 @@ import functools
 import inspect
 import os
 from pathlib import Path
+import re
 import sys
 import types
 from typing import Any
@@ -2016,20 +2017,13 @@ def _showfixtures_main(config: Config, session: Session) -> None:
 
 
 def get_return_annotation(fixture_func: Callable[..., Any]) -> str:
-    try:
-        sig = signature(fixture_func)
-        annotation = sig.return_annotation
-        if annotation is not sig.empty:
-            if type(annotation) == type(None):
-                return "None"
-            if isinstance(annotation, str):
-                return annotation
-            if annotation.__module__ == "typing":
-                return str(annotation).replace("typing.", "")
-            return str(annotation.__name__)
-    except (ValueError, TypeError):
-        pass
-    return ""
+    pattern = re.compile(r'\b(?:(?:<[^>]+>|[A-Za-z_]\w*)\.)+([A-Za-z_]\w*)\b')
+
+    sig = str(signature(fixture_func))
+    sig_parts = sig.split(" -> ")
+    if len(sig_parts) < 2:
+        return ""
+    return pattern.sub(r'\1', sig_parts[-1])
 
 
 def write_docstring(tw: TerminalWriter, doc: str, indent: str = "    ") -> None:

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -2019,8 +2019,12 @@ def get_return_annotation(fixture_func: Callable[..., Any]) -> str:
     try:
         sig = signature(fixture_func)
         annotation = sig.return_annotation
-        if annotation is not sig.empty and annotation != inspect._empty:
-            return inspect.formatannotation(annotation).replace("'", "")
+        if annotation is not sig.empty:
+            if isinstance(annotation, str):
+                return annotation
+            if annotation.__module__ == "typing":
+                return str(annotation).replace("typing.", "")
+            return annotation.__name__
     except (ValueError, TypeError):
         pass
     return ""

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -3582,9 +3582,9 @@ class TestShowFixtures:
         result = pytester.runpytest("--fixtures")
         result.stdout.fnmatch_lines(
             [
-                "tmp_path_factory [[]session scope[]] -- .../_pytest/tmpdir.py:*",
+                "tmp_path_factory* [[]session scope[]] -- .../_pytest/tmpdir.py:*",
                 "*for the test session*",
-                "tmp_path -- .../_pytest/tmpdir.py:*",
+                "tmp_path* -- .../_pytest/tmpdir.py:*",
                 "*temporary directory*",
             ]
         )
@@ -3593,9 +3593,9 @@ class TestShowFixtures:
         result = pytester.runpytest("--fixtures", "-v")
         result.stdout.fnmatch_lines(
             [
-                "tmp_path_factory [[]session scope[]] -- .../_pytest/tmpdir.py:*",
+                "tmp_path_factory* [[]session scope[]] -- .../_pytest/tmpdir.py:*",
                 "*for the test session*",
-                "tmp_path -- .../_pytest/tmpdir.py:*",
+                "tmp_path* -- .../_pytest/tmpdir.py:*",
                 "*temporary directory*",
             ]
         )
@@ -3615,13 +3615,31 @@ class TestShowFixtures:
         result = pytester.runpytest("--fixtures", p)
         result.stdout.fnmatch_lines(
             """
-            *tmp_path -- *
+            *tmp_path* -- *
             *fixtures defined from*
             *arg1 -- test_show_fixtures_testmodule.py:6*
             *hello world*
         """
         )
         result.stdout.no_fnmatch_line("*arg0*")
+
+    def test_show_fixtures_return_annotation(self, pytester: Pytester) -> None:
+        p = pytester.makepyfile(
+            '''
+            import pytest
+            @pytest.fixture
+            def six() -> int:
+                return 6
+        '''
+        )
+        result = pytester.runpytest("--fixtures", p)
+        result.stdout.fnmatch_lines(
+            """
+            *tmp_path* -- *
+            *fixtures defined from*
+            *six -> int -- test_show_fixtures_return_annotation.py:3*
+        """
+        )
 
     @pytest.mark.parametrize("testmod", [True, False])
     def test_show_fixtures_conftest(self, pytester: Pytester, testmod) -> None:

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 import sys
 import textwrap
+from typing import Any, Callable
 
 from _pytest.compat import getfuncargnames
 from _pytest.config import ExitCode
@@ -5100,14 +5101,31 @@ def test_get_return_annotation() -> None:
 
     assert get_return_annotation(two_sixes) == "tuple[int, str]"
 
-    def no_annot():
+    def callable_return() -> Callable[..., Any]:
+        return two_sixes
+
+    assert get_return_annotation(callable_return) == "Callable[..., Any]"
+
+    def no_annotation():
         return 6
 
-    assert get_return_annotation(no_annot) == ""
+    assert get_return_annotation(no_annotation) == ""
 
     def none_return() -> None:
         pass
 
     assert get_return_annotation(none_return) == "None"
+
+    class T:
+        pass
+    def class_return() -> T:
+        return T()
+    
+    assert get_return_annotation(class_return) == "T"
+
+    def enum_return() -> ExitCode:
+        return ExitCode(0)
+    
+    assert get_return_annotation(enum_return) == "ExitCode"
 
     assert get_return_annotation(range) == ""

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -4584,6 +4584,52 @@ class TestScopeOrdering:
         reprec.assertoutcome(passed=1)
 
 
+class TestGetReturnAnnotation:
+    def test_primitive_return_type(self):
+        def six() -> int:
+            return 6
+
+        assert get_return_annotation(six) == "int"
+
+    def test_compound_return_type(self):
+        def two_sixes() -> tuple[int, str]:
+            return (6, "six")
+
+        assert get_return_annotation(two_sixes) == "tuple[int, str]"
+
+    def test_callable_return_type(self):
+        def callable_return() -> Callable[..., Any]:
+            return self.test_compound_return_type
+
+        assert get_return_annotation(callable_return) == "Callable[..., Any]"
+
+    def test_no_annotation(self):
+        def no_annotation():
+            return 6
+
+        assert get_return_annotation(no_annotation) == ""
+
+    def test_none_return_type(self):
+        def none_return() -> None:
+            pass
+
+        assert get_return_annotation(none_return) == "None"
+
+    def test_custom_class_return_type(self):
+        class T:
+            pass
+        def class_return() -> T:
+            return T()
+        
+        assert get_return_annotation(class_return) == "T"
+
+    def test_enum_return_type(self):
+        def enum_return() -> ExitCode:
+            return ExitCode(0)
+        
+        assert get_return_annotation(enum_return) == "ExitCode"
+
+
 def test_call_fixture_function_error():
     """Check if an error is raised if a fixture function is called directly (#4545)"""
 
@@ -5089,45 +5135,3 @@ def test_collect_positional_only(pytester: Pytester) -> None:
     )
     result = pytester.runpytest()
     result.assert_outcomes(passed=1)
-
-
-def test_get_return_annotation() -> None:
-    def six() -> int:
-        return 6
-
-    assert get_return_annotation(six) == "int"
-
-    def two_sixes() -> tuple[int, str]:
-        return (6, "six")
-
-    assert get_return_annotation(two_sixes) == "tuple[int, str]"
-
-    def callable_return() -> Callable[..., Any]:
-        return two_sixes
-
-    assert get_return_annotation(callable_return) == "Callable[..., Any]"
-
-    def no_annotation():
-        return 6
-
-    assert get_return_annotation(no_annotation) == ""
-
-    def none_return() -> None:
-        pass
-
-    assert get_return_annotation(none_return) == "None"
-
-    class T:
-        pass
-
-    def class_return() -> T:
-        return T()
-
-    assert get_return_annotation(class_return) == "T"
-
-    def enum_return() -> ExitCode:
-        return ExitCode(0)
-
-    assert get_return_annotation(enum_return) == "ExitCode"
-
-    assert get_return_annotation(range) == ""

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1,13 +1,13 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
+from collections.abc import Callable
 from itertools import zip_longest
 import os
 from pathlib import Path
 import sys
 import textwrap
 from typing import Any
-from typing import Callable
 
 from _pytest.compat import getfuncargnames
 from _pytest.config import ExitCode

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1,18 +1,15 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
-from collections.abc import Callable
 from itertools import zip_longest
 import os
 from pathlib import Path
 import sys
 import textwrap
-from typing import Any
 
 from _pytest.compat import getfuncargnames
 from _pytest.config import ExitCode
 from _pytest.fixtures import deduplicate_names
-from _pytest.fixtures import get_return_annotation
 from _pytest.fixtures import TopRequest
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pytester import get_public_names
@@ -3626,23 +3623,6 @@ class TestShowFixtures:
         )
         result.stdout.no_fnmatch_line("*arg0*")
 
-    def test_show_fixtures_return_annotation(self, pytester: Pytester) -> None:
-        p = pytester.makepyfile(
-            """
-            import pytest
-            @pytest.fixture
-            def six() -> int:
-                return 6
-        """
-        )
-        result = pytester.runpytest("--fixtures", p)
-        result.stdout.fnmatch_lines(
-            """
-            *fixtures defined from*
-            *six -> int -- test_show_fixtures_return_annotation.py:3*
-        """
-        )
-
     @pytest.mark.parametrize("testmod", [True, False])
     def test_show_fixtures_conftest(self, pytester: Pytester, testmod) -> None:
         pytester.makeconftest(
@@ -4582,53 +4562,6 @@ class TestScopeOrdering:
         )
         reprec = pytester.inline_run()
         reprec.assertoutcome(passed=1)
-
-
-class TestGetReturnAnnotation:
-    def test_primitive_return_type(self):
-        def six() -> int:
-            return 6
-
-        assert get_return_annotation(six) == "int"
-
-    def test_compound_return_type(self):
-        def two_sixes() -> tuple[int, str]:
-            return (6, "six")
-
-        assert get_return_annotation(two_sixes) == "tuple[int, str]"
-
-    def test_callable_return_type(self):
-        def callable_return() -> Callable[..., Any]:
-            return self.test_compound_return_type
-
-        assert get_return_annotation(callable_return) == "Callable[..., Any]"
-
-    def test_no_annotation(self):
-        def no_annotation():
-            return 6
-
-        assert get_return_annotation(no_annotation) == ""
-
-    def test_none_return_type(self):
-        def none_return() -> None:
-            pass
-
-        assert get_return_annotation(none_return) == "None"
-
-    def test_custom_class_return_type(self):
-        class T:
-            pass
-
-        def class_return() -> T:
-            return T()
-
-        assert get_return_annotation(class_return) == "T"
-
-    def test_enum_return_type(self):
-        def enum_return() -> ExitCode:
-            return ExitCode(0)
-
-        assert get_return_annotation(enum_return) == "ExitCode"
 
 
 def test_call_fixture_function_error():

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -6,7 +6,8 @@ import os
 from pathlib import Path
 import sys
 import textwrap
-from typing import Any, Callable
+from typing import Any
+from typing import Callable
 
 from _pytest.compat import getfuncargnames
 from _pytest.config import ExitCode
@@ -5118,14 +5119,15 @@ def test_get_return_annotation() -> None:
 
     class T:
         pass
+
     def class_return() -> T:
         return T()
-    
+
     assert get_return_annotation(class_return) == "T"
 
     def enum_return() -> ExitCode:
         return ExitCode(0)
-    
+
     assert get_return_annotation(enum_return) == "ExitCode"
 
     assert get_return_annotation(range) == ""

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -4618,15 +4618,16 @@ class TestGetReturnAnnotation:
     def test_custom_class_return_type(self):
         class T:
             pass
+
         def class_return() -> T:
             return T()
-        
+
         assert get_return_annotation(class_return) == "T"
 
     def test_enum_return_type(self):
         def enum_return() -> ExitCode:
             return ExitCode(0)
-        
+
         assert get_return_annotation(enum_return) == "ExitCode"
 
 

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -3625,12 +3625,12 @@ class TestShowFixtures:
 
     def test_show_fixtures_return_annotation(self, pytester: Pytester) -> None:
         p = pytester.makepyfile(
-            '''
+            """
             import pytest
             @pytest.fixture
             def six() -> int:
                 return 6
-        '''
+        """
         )
         result = pytester.runpytest("--fixtures", p)
         result.stdout.fnmatch_lines(

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -5098,7 +5098,7 @@ def test_get_return_annotation() -> None:
     def two_sixes() -> tuple[int, str]:
         return (6, "six")
 
-    assert get_return_annotation(two_sixes) == "Tuple[int, str]"
+    assert get_return_annotation(two_sixes) == "tuple[int, str]"
 
     def no_annot():
         return 6
@@ -5109,3 +5109,5 @@ def test_get_return_annotation() -> None:
         pass
 
     assert get_return_annotation(none_return) == "None"
+
+    assert get_return_annotation(range) == ""

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -6,7 +6,6 @@ import os
 from pathlib import Path
 import sys
 import textwrap
-from typing import Tuple
 
 from _pytest.compat import getfuncargnames
 from _pytest.config import ExitCode
@@ -5089,19 +5088,24 @@ def test_collect_positional_only(pytester: Pytester) -> None:
     result = pytester.runpytest()
     result.assert_outcomes(passed=1)
 
+
 def test_get_return_annotation() -> None:
     def six() -> int:
         return 6
+
     assert get_return_annotation(six) == "int"
 
-    def two_sixes() -> Tuple[int, str]:
+    def two_sixes() -> tuple[int, str]:
         return (6, "six")
+
     assert get_return_annotation(two_sixes) == "Tuple[int, str]"
 
     def no_annot():
         return 6
+
     assert get_return_annotation(no_annot) == ""
 
     def none_return() -> None:
         pass
+
     assert get_return_annotation(none_return) == "None"

--- a/testing/python/fixtures_return_annotation.py
+++ b/testing/python/fixtures_return_annotation.py
@@ -1,6 +1,5 @@
 # mypy: allow-untyped-defs
-from __future__ import annotations
-
+# ruff: noqa: FA100
 from collections.abc import Callable
 from typing import Any
 
@@ -60,6 +59,12 @@ class TestGetReturnAnnotation:
             return range(2)
 
         assert get_return_annotation(with_args) == "range"
+
+    def test_string_return_annotation(self):
+        def string_return_annotation() -> "int":
+            return 6
+
+        assert get_return_annotation(string_return_annotation) == "int"
 
     def test_invalid_return_type(self):
         def bad_annotation() -> 6:  # type: ignore

--- a/testing/python/fixtures_return_annotation.py
+++ b/testing/python/fixtures_return_annotation.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -55,7 +56,7 @@ class TestGetReturnAnnotation:
         assert get_return_annotation(enum_return) == "ExitCode"
 
     def test_with_arg_annotations(self):
-        def with_args(a: Callable[[], None], b: list) -> range:
+        def with_args(a: Callable[[], None], b: str) -> range:
             return range(2)
 
         assert get_return_annotation(with_args) == "range"

--- a/testing/python/fixtures_return_annotation.py
+++ b/testing/python/fixtures_return_annotation.py
@@ -1,0 +1,110 @@
+from collections.abc import Callable
+from typing import Any
+
+from _pytest.config import ExitCode
+from _pytest.fixtures import get_return_annotation
+from _pytest.pytester import Pytester
+
+
+class TestGetReturnAnnotation:
+    def test_primitive_return_type(self):
+        def six() -> int:
+            return 6
+
+        assert get_return_annotation(six) == "int"
+
+    def test_compound_return_type(self):
+        def two_sixes() -> tuple[int, str]:
+            return (6, "six")
+
+        assert get_return_annotation(two_sixes) == "tuple[int, str]"
+
+    def test_callable_return_type(self):
+        def callable_return() -> Callable[..., Any]:
+            return self.test_compound_return_type
+
+        assert get_return_annotation(callable_return) == "Callable[..., Any]"
+
+    def test_no_annotation(self):
+        def no_annotation():
+            return 6
+
+        assert get_return_annotation(no_annotation) == ""
+
+    def test_none_return_type(self):
+        def none_return() -> None:
+            pass
+
+        assert get_return_annotation(none_return) == "None"
+
+    def test_custom_class_return_type(self):
+        class T:
+            pass
+
+        def class_return() -> T:
+            return T()
+
+        assert get_return_annotation(class_return) == "T"
+
+    def test_enum_return_type(self):
+        def enum_return() -> ExitCode:
+            return ExitCode(0)
+
+        assert get_return_annotation(enum_return) == "ExitCode"
+
+    def test_with_arg_annotations(self):
+        def with_args(a: Callable[[], None], b: list) -> range:
+            return range(2)
+
+        assert get_return_annotation(with_args) == "range"
+
+    def test_invalid_return_type(self):
+        def bad_annotation() -> 6: # type: ignore
+            return 6
+
+        assert get_return_annotation(bad_annotation) == "6"
+
+    def test_unobtainable_signature(self):
+        assert get_return_annotation(len) == ""
+
+
+def test_fixtures_return_annotation(pytester: Pytester) -> None:
+    p = pytester.makepyfile(
+        """
+        import pytest
+        @pytest.fixture
+        def six() -> int:
+            return 6
+    """
+    )
+    result = pytester.runpytest("--fixtures", p)
+    result.stdout.fnmatch_lines(
+        """
+        *fixtures defined from*
+        *six -> int -- test_fixtures_return_annotation.py:3*
+    """
+    )
+
+
+def test_fixtures_per_test_return_annotation(pytester: Pytester) -> None:
+    p = pytester.makepyfile(
+        """
+        import pytest
+        @pytest.fixture
+        def five() -> int:
+            return 5
+        def test_five(five):
+            pass
+    """
+    )
+
+    result = pytester.runpytest("--fixtures-per-test", p)
+    assert result.ret == 0
+
+    result.stdout.fnmatch_lines(
+        [
+            "*fixtures used by test_five*",
+            "*(test_fixtures_per_test_return_annotation.py:6)*",
+            "five -> int -- test_fixtures_per_test_return_annotation.py:3",
+        ]
+    )

--- a/testing/python/fixtures_return_annotation.py
+++ b/testing/python/fixtures_return_annotation.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
-# ruff: noqa: FA100
+from __future__ import annotations
+
 from collections.abc import Callable
 from typing import Any
 
@@ -61,7 +62,7 @@ class TestGetReturnAnnotation:
         assert get_return_annotation(with_args) == "range"
 
     def test_string_return_annotation(self):
-        def string_return_annotation() -> "int":
+        def string_return_annotation() -> int:
             return 6
 
         assert get_return_annotation(string_return_annotation) == "int"

--- a/testing/python/fixtures_return_annotation.py
+++ b/testing/python/fixtures_return_annotation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Callable
 from typing import Any
 
@@ -59,7 +61,7 @@ class TestGetReturnAnnotation:
         assert get_return_annotation(with_args) == "range"
 
     def test_invalid_return_type(self):
-        def bad_annotation() -> 6: # type: ignore
+        def bad_annotation() -> 6:  # type: ignore
             return 6
 
         assert get_return_annotation(bad_annotation) == "6"

--- a/testing/python/show_fixtures_per_test.py
+++ b/testing/python/show_fixtures_per_test.py
@@ -160,6 +160,30 @@ def test_verbose_include_private_fixtures_and_loc(pytester: Pytester) -> None:
     )
 
 
+def test_show_return_annotation(pytester: Pytester) -> None:
+    p = pytester.makepyfile(
+        '''
+        import pytest
+        @pytest.fixture
+        def five() -> int:
+            return 5
+        def test_five(five):
+            pass
+    '''
+    )
+
+    result = pytester.runpytest("--fixtures-per-test", p)
+    assert result.ret == 0
+
+    result.stdout.fnmatch_lines(
+        [
+            "*fixtures used by test_five*",
+            "*(test_show_return_annotation.py:6)*",
+            "five -> int -- test_show_return_annotation.py:3",
+        ]
+    )
+
+
 def test_doctest_items(pytester: Pytester) -> None:
     pytester.makepyfile(
         '''

--- a/testing/python/show_fixtures_per_test.py
+++ b/testing/python/show_fixtures_per_test.py
@@ -160,30 +160,6 @@ def test_verbose_include_private_fixtures_and_loc(pytester: Pytester) -> None:
     )
 
 
-def test_show_return_annotation(pytester: Pytester) -> None:
-    p = pytester.makepyfile(
-        """
-        import pytest
-        @pytest.fixture
-        def five() -> int:
-            return 5
-        def test_five(five):
-            pass
-    """
-    )
-
-    result = pytester.runpytest("--fixtures-per-test", p)
-    assert result.ret == 0
-
-    result.stdout.fnmatch_lines(
-        [
-            "*fixtures used by test_five*",
-            "*(test_show_return_annotation.py:6)*",
-            "five -> int -- test_show_return_annotation.py:3",
-        ]
-    )
-
-
 def test_doctest_items(pytester: Pytester) -> None:
     pytester.makepyfile(
         '''

--- a/testing/python/show_fixtures_per_test.py
+++ b/testing/python/show_fixtures_per_test.py
@@ -162,14 +162,14 @@ def test_verbose_include_private_fixtures_and_loc(pytester: Pytester) -> None:
 
 def test_show_return_annotation(pytester: Pytester) -> None:
     p = pytester.makepyfile(
-        '''
+        """
         import pytest
         @pytest.fixture
         def five() -> int:
             return 5
         def test_five(five):
             pass
-    '''
+    """
     )
 
     result = pytester.runpytest("--fixtures-per-test", p)


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
closes #13676 