### PR TITLE
junitxml: do not print summary with `--quiet`

### DIFF
--- a/changelog/13700.improvement.rst
+++ b/changelog/13700.improvement.rst
@@ -1,0 +1,1 @@
+`--junitxml`  no longer prints the `generated xml file` summary at the end of the pytest session when `--quiet` is given.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -674,8 +674,11 @@ class LogXML:
             testsuites.append(suite_node)
             logfile.write(ET.tostring(testsuites, encoding="unicode"))
 
-    def pytest_terminal_summary(self, terminalreporter: TerminalReporter) -> None:
-        terminalreporter.write_sep("-", f"generated xml file: {self.logfile}")
+    def pytest_terminal_summary(
+        self, terminalreporter: TerminalReporter, config: pytest.Config
+    ) -> None:
+        if config.get_verbosity() >= 0:
+            terminalreporter.write_sep("-", f"generated xml file: {self.logfile}")
 
     def add_global_property(self, name: str, value: object) -> None:
         __tracebackhide__ = True

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1822,3 +1822,13 @@ def test_logging_passing_tests_disabled_logs_output_for_failing_test_issue5430(
         assert junit_logging == "no"
         assert len(node.find_by_tag("system-err")) == 0
         assert len(node.find_by_tag("system-out")) == 0
+
+
+def test_no_message_quiet(pytester: Pytester) -> None:
+    """Do not show the summary banner when --quiet is given (#13700)."""
+    pytester.makepyfile("def test(): pass")
+    result = pytester.runpytest("--junitxml=pytest.xml")
+    result.stdout.fnmatch_lines("* generated xml file: *")
+
+    result = pytester.runpytest("--junitxml=pytest.xml", "--quiet")
+    result.stdout.no_fnmatch_line("* generated xml file: *")


### PR DESCRIPTION
Fix #13700
