### PR TITLE
main: reject arguments like `pytest x.py[1]` instead of ignoring the `[]`

### DIFF
--- a/changelog/13716.bugfix.rst
+++ b/changelog/13716.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where a nonsensical invocation like ``pytest x.py[a]`` (a file cannot be parametrized) was silently treated as ``pytest x.py``. This is now a usage error.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -1066,9 +1066,11 @@ def resolve_collection_argument(
     If the path doesn't exist, raise UsageError.
     If the path is a directory and selection parts are present, raise UsageError.
     """
-    base, squacket, rest = str(arg).partition("[")
+    base, squacket, rest = arg.partition("[")
     strpath, *parts = base.split("::")
-    if parts:
+    if squacket:
+        if not parts:
+            raise UsageError(f"path cannot contain [] parametrization: {arg}")
         parts[-1] = f"{parts[-1]}{squacket}{rest}"
     module_name = None
     if as_pypath:

--- a/testing/test_main.py
+++ b/testing/test_main.py
@@ -220,6 +220,20 @@ class TestResolveCollectionArgument:
             module_name=None,
         )
 
+    @pytest.mark.parametrize(
+        "arg", ["x.py[a]", "x.py[a]::foo", "x/y.py[a]::foo::bar", "x.py[a]::foo[b]"]
+    )
+    def test_path_parametrization_not_allowed(
+        self, invocation_path: Path, arg: str
+    ) -> None:
+        with pytest.raises(
+            UsageError, match=r"path cannot contain \[\] parametrization"
+        ):
+            resolve_collection_argument(
+                invocation_path,
+                arg,
+            )
+
     def test_does_not_exist(self, invocation_path: Path) -> None:
         """Given a file/module that does not exist raises UsageError."""
         with pytest.raises(


### PR DESCRIPTION
Fix #13716.