### PR TITLE
python_api: improve approx assert message on mappings with only extra elements

### DIFF
--- a/changelog/13722.bugfix.rst
+++ b/changelog/13722.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a misleading assertion failure message when using :func:`pytest.approx` on mappings with differing lengths.

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -236,6 +236,12 @@ class ApproxMapping(ApproxBase):
     def _repr_compare(self, other_side: Mapping[object, float]) -> list[str]:
         import math
 
+        if len(self.expected) != len(other_side):
+            return [
+                "Impossible to compare mappings with different sizes.",
+                f"Lengths: {len(self.expected)} and {len(other_side)}",
+            ]
+
         approx_side_as_map = {
             k: self._approx_scalar(v) for k, v in self.expected.items()
         }

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -741,6 +741,17 @@ class TestApprox:
             ],
         )
 
+    def test_dict_differing_lengths(self, assert_approx_raises_regex):
+        assert_approx_raises_regex(
+            {"a": 0},
+            {"a": 0, "b": 1},
+            [
+                "  ",
+                r"  Impossible to compare mappings with different sizes\.",
+                r"  Lengths: 2 and 1",
+            ],
+        )
+
     def test_numpy_array(self):
         np = pytest.importorskip("numpy")
 


### PR DESCRIPTION
Fix #13722