### PR TITLE
Remove support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,24 +56,22 @@ jobs:
       fail-fast: false
       matrix:
         name: [
-          "windows-py39-unittest-asynctest",
-          "windows-py39-unittest-twisted24",
-          "windows-py39-unittest-twisted25",
-          "windows-py39-pluggy",
-          "windows-py39-xdist",
-          "windows-py310",
+          "windows-py310-unittest-asynctest",
+          "windows-py310-unittest-twisted24",
+          "windows-py310-unittest-twisted25",
+          "windows-py310-pluggy",
+          "windows-py310-xdist",
           "windows-py311",
           "windows-py312",
           "windows-py313",
           "windows-py314",
 
-          "ubuntu-py39-unittest-asynctest",
-          "ubuntu-py39-unittest-twisted24",
-          "ubuntu-py39-unittest-twisted25",
-          "ubuntu-py39-lsof-numpy-pexpect",
-          "ubuntu-py39-pluggy",
-          "ubuntu-py39-freeze",
-          "ubuntu-py39-xdist",
+          "ubuntu-py310-unittest-asynctest",
+          "ubuntu-py310-unittest-twisted24",
+          "ubuntu-py310-unittest-twisted25",
+          "ubuntu-py310-lsof-numpy-pexpect",
+          "ubuntu-py310-pluggy",
+          "ubuntu-py310-freeze",
           "ubuntu-py310-xdist",
           "ubuntu-py311",
           "ubuntu-py312",
@@ -81,7 +79,6 @@ jobs:
           "ubuntu-py314",
           "ubuntu-pypy3-xdist",
 
-          "macos-py39",
           "macos-py310",
           "macos-py312",
           "macos-py313",
@@ -93,35 +90,30 @@ jobs:
 
         include:
           # Use separate jobs for different unittest flavors (twisted, asynctest) to ensure proper coverage.
-          - name: "windows-py39-unittest-asynctest"
-            python: "3.9"
+          - name: "windows-py310-unittest-asynctest"
+            python: "3.10"
             os: windows-latest
-            tox_env: "py39-asynctest"
+            tox_env: "py310-asynctest"
             use_coverage: true
 
-          - name: "windows-py39-unittest-twisted24"
-            python: "3.9"
+          - name: "windows-py310-unittest-twisted24"
+            python: "3.10"
             os: windows-latest
-            tox_env: "py39-twisted24"
+            tox_env: "py310-twisted24"
             use_coverage: true
 
-          - name: "windows-py39-unittest-twisted25"
-            python: "3.9"
+          - name: "windows-py310-unittest-twisted25"
+            python: "3.10"
             os: windows-latest
-            tox_env: "py39-twisted25"
+            tox_env: "py310-twisted25"
             use_coverage: true
 
-          - name: "windows-py39-pluggy"
-            python: "3.9"
+          - name: "windows-py310-pluggy"
+            python: "3.10"
             os: windows-latest
-            tox_env: "py39-pluggymain-pylib-xdist"
+            tox_env: "py310-pluggymain-pylib-xdist"
 
-          - name: "windows-py39-xdist"
-            python: "3.9"
-            os: windows-latest
-            tox_env: "py39-xdist"
-
-          - name: "windows-py310"
+          - name: "windows-py310-xdist"
             python: "3.10"
             os: windows-latest
             tox_env: "py310-xdist"
@@ -147,44 +139,39 @@ jobs:
             tox_env: "py314"
 
           # Use separate jobs for different unittest flavors (twisted, asynctest) to ensure proper coverage.
-          - name: "ubuntu-py39-unittest-asynctest"
-            python: "3.9"
+          - name: "ubuntu-py310-unittest-asynctest"
+            python: "3.10"
             os: ubuntu-latest
-            tox_env: "py39-asynctest"
+            tox_env: "py310-asynctest"
             use_coverage: true
 
-          - name: "ubuntu-py39-unittest-twisted24"
-            python: "3.9"
+          - name: "ubuntu-py310-unittest-twisted24"
+            python: "3.10"
             os: ubuntu-latest
-            tox_env: "py39-twisted24"
+            tox_env: "py310-twisted24"
             use_coverage: true
 
-          - name: "ubuntu-py39-unittest-twisted25"
-            python: "3.9"
+          - name: "ubuntu-py310-unittest-twisted25"
+            python: "3.10"
             os: ubuntu-latest
-            tox_env: "py39-twisted25"
+            tox_env: "py310-twisted25"
             use_coverage: true
 
-          - name: "ubuntu-py39-lsof-numpy-pexpect"
-            python: "3.9"
+          - name: "ubuntu-py310-lsof-numpy-pexpect"
+            python: "3.10"
             os: ubuntu-latest
-            tox_env: "py39-lsof-numpy-pexpect"
+            tox_env: "py310-lsof-numpy-pexpect"
             use_coverage: true
 
-          - name: "ubuntu-py39-pluggy"
-            python: "3.9"
+          - name: "ubuntu-py310-pluggy"
+            python: "3.10"
             os: ubuntu-latest
-            tox_env: "py39-pluggymain-pylib-xdist"
+            tox_env: "py310-pluggymain-pylib-xdist"
 
-          - name: "ubuntu-py39-freeze"
-            python: "3.9"
+          - name: "ubuntu-py310-freeze"
+            python: "3.10"
             os: ubuntu-latest
-            tox_env: "py39-freeze"
-
-          - name: "ubuntu-py39-xdist"
-            python: "3.9"
-            os: ubuntu-latest
-            tox_env: "py39-xdist"
+            tox_env: "py310-freeze"
 
           - name: "ubuntu-py310-xdist"
             python: "3.10"
@@ -216,16 +203,10 @@ jobs:
             use_coverage: true
 
           - name: "ubuntu-pypy3-xdist"
-            python: "pypy-3.9"
+            python: "pypy-3.10"
             os: ubuntu-latest
             tox_env: "pypy3-xdist"
 
-
-          - name: "macos-py39"
-            python: "3.9"
-            os: macos-latest
-            tox_env: "py39-xdist"
-            use_coverage: true
 
           - name: "macos-py310"
             python: "3.10"
@@ -254,7 +235,7 @@ jobs:
 
 
           - name: "doctesting"
-            python: "3.9"
+            python: "3.10"
             os: ubuntu-latest
             tox_env: "doctesting"
             use_coverage: true
@@ -264,12 +245,12 @@ jobs:
         contains(
           fromJSON(
             '[
-              "windows-py39-pluggy",
+              "windows-py310-pluggy",
               "windows-py313",
-              "ubuntu-py39-pluggy",
-              "ubuntu-py39-freeze",
+              "ubuntu-py310-pluggy",
+              "ubuntu-py310-freeze",
               "ubuntu-py313",
-              "macos-py39",
+              "macos-py310",
               "macos-py313"
             ]'
           ),

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
     hooks:
     -   id: pyupgrade
         args:
-          - "--py39-plus"
+          - "--py310-plus"
         # Manual because ruff does what pyupgrade does and the two are not out of sync
         # often enough to make launching pyupgrade everytime worth it
         stages: [manual]

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -197,7 +197,7 @@ Short version
 #. Follow `PEP-8 <https://www.python.org/dev/peps/pep-0008/>`_ for naming.
 #. Tests are run using ``tox``::
 
-    tox -e linting,py39
+    tox -e linting,py313
 
    The test environments above are usually enough to cover most cases locally.
 
@@ -269,24 +269,24 @@ Here is a simple overview, with pytest-specific bits:
 
 #. Run all the tests
 
-   You need to have Python 3.9 or later available in your system.  Now
+   You need to have a supported Python version available in your system.  Now
    running tests is as simple as issuing this command::
 
-    $ tox -e linting,py39
+    $ tox -e linting,py
 
-   This command will run tests via the "tox" tool against Python 3.9
-   and also perform "lint" coding-style checks.
+   This command will run tests via the "tox" tool against your default Python
+   version and also perform "lint" coding-style checks.
 
 #. You can now edit your local working copy and run the tests again as necessary. Please follow `PEP-8 <https://www.python.org/dev/peps/pep-0008/>`_ for naming.
 
-   You can pass different options to ``tox``. For example, to run tests on Python 3.9 and pass options to pytest
+   You can pass different options to ``tox``. For example, to run tests on Python 3.13 and pass options to pytest
    (e.g. enter pdb on failure) to pytest you can do::
 
-    $ tox -e py39 -- --pdb
+    $ tox -e py313 -- --pdb
 
-   Or to only run tests in a particular test module on Python 3.9::
+   Or to only run tests in a particular test module on Python 3.12::
 
-    $ tox -e py39 -- testing/test_config.py
+    $ tox -e py312 -- testing/test_config.py
 
 
    When committing, ``pre-commit`` will re-format the files if necessary.

--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ Features
 - Can run `unittest <https://docs.pytest.org/en/stable/how-to/unittest.html>`_ (or trial)
   test suites out of the box
 
-- Python 3.9+ or PyPy3
+- Python 3.10+ or PyPy3
 
 - Rich plugin architecture, with over 1300+ `external plugins <https://docs.pytest.org/en/latest/reference/plugin_list.html>`_ and thriving community
 

--- a/changelog/13719.breaking.rst
+++ b/changelog/13719.breaking.rst
@@ -1,0 +1,1 @@
+Support for Python 3.9 is dropped following its end of life.

--- a/doc/en/example/multipython.py
+++ b/doc/en/example/multipython.py
@@ -10,7 +10,7 @@ import textwrap
 import pytest
 
 
-pythonlist = ["python3.9", "python3.10", "python3.11"]
+pythonlist = ["python3.11", "python3.12", "python3.13"]
 
 
 @pytest.fixture(params=pythonlist)

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -9,8 +9,6 @@ Get Started
 Install ``pytest``
 ----------------------------------------
 
-``pytest`` requires: Python 3.8+ or PyPy3.
-
 1. Run the following command in your command line:
 
 .. code-block:: bash

--- a/doc/en/how-to/skipping.rst
+++ b/doc/en/how-to/skipping.rst
@@ -84,14 +84,14 @@ It is also possible to skip the whole module using
 
 If you wish to skip something conditionally then you can use ``skipif`` instead.
 Here is an example of marking a test function to be skipped
-when run on an interpreter earlier than Python3.10:
+when run on an interpreter earlier than Python3.13:
 
 .. code-block:: python
 
     import sys
 
 
-    @pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
+    @pytest.mark.skipif(sys.version_info < (3, 13), reason="requires python3.13 or higher")
     def test_function(): ...
 
 If the condition evaluates to ``True`` during collection, the test function will be skipped,

--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -46,8 +46,6 @@ The ``pytest`` framework makes it easy to write small, readable tests, and can
 scale to support complex functional testing for applications and libraries.
 
 
-``pytest`` requires: Python 3.8+ or PyPy3.
-
 **PyPI package name**: :pypi:`pytest`
 
 A quick example
@@ -104,7 +102,7 @@ Features
 
 - Can run :ref:`unittest <unittest>` (including trial) test suites out of the box
 
-- Python 3.8+ or PyPy 3
+- Python 3.10+ or PyPy 3
 
 - Rich plugin architecture, with over 1300+ :ref:`external plugins <plugin-list>` and thriving community
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ authors = [
     { name = "Florian Bruhin" },
     { name = "Others (See AUTHORS)" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 6 - Mature",
     "Intended Audience :: Developers",
@@ -33,7 +33,6 @@ classifiers = [
     "Operating System :: POSIX",
     "Operating System :: Unix",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -86,10 +85,10 @@ write_to = "src/_pytest/_version.py"
 
 [tool.black]
 # See https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#t-target-version
-target-version = [ "py39", "py310", "py311", "py312", "py313" ]
+target-version = [ "py310", "py311", "py312", "py313" ]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 88
 src = [
     "src",
@@ -520,7 +519,7 @@ files = [
 mypy_path = [
     "src",
 ]
-python_version = "3.9"
+python_version = "3.10"
 check_untyped_defs = true
 disallow_any_generics = true
 disallow_untyped_defs = true
@@ -543,7 +542,7 @@ include = [
 extraPaths = [
     "src",
 ]
-pythonVersion = "3.9"
+pythonVersion = "3.10"
 typeCheckingMode = "basic"
 reportMissingImports = "none"
 reportMissingModuleSource = "none"

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -30,9 +30,8 @@ from typing import Generic
 from typing import Literal
 from typing import overload
 from typing import SupportsIndex
-from typing import TYPE_CHECKING
+from typing import TypeAlias
 from typing import TypeVar
-from typing import Union
 
 import pluggy
 
@@ -55,7 +54,7 @@ if sys.version_info < (3, 11):
 
 TracebackStyle = Literal["long", "short", "line", "no", "native", "value", "auto"]
 
-EXCEPTION_OR_MORE = Union[type[BaseException], tuple[type[BaseException], ...]]
+EXCEPTION_OR_MORE = type[BaseException] | tuple[type[BaseException], ...]
 
 
 class Code:
@@ -469,7 +468,7 @@ def stringify_exception(
         notes = getattr(exc, "__notes__", [])
     except KeyError:
         # Workaround for https://github.com/python/cpython/issues/98778 on
-        # Python <= 3.9, and some 3.10 and 3.11 patch versions.
+        # some 3.10 and 3.11 patch versions.
         HTTPError = getattr(sys.modules.get("urllib.error", None), "HTTPError", ())
         if sys.version_info < (3, 12) and isinstance(exc, HTTPError):
             notes = []
@@ -853,15 +852,10 @@ class ExceptionInfo(Generic[E]):
         return self._group_contains(self.value, expected_exception, match, depth)
 
 
-if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
-
-    # Type alias for the `tbfilter` setting:
-    # bool: If True, it should be filtered using Traceback.filter()
-    # callable: A callable that takes an ExceptionInfo and returns the filtered traceback.
-    TracebackFilter: TypeAlias = Union[
-        bool, Callable[[ExceptionInfo[BaseException]], Traceback]
-    ]
+# Type alias for the `tbfilter` setting:
+# bool: If True, it should be filtered using Traceback.filter()
+# callable: A callable that takes an ExceptionInfo and returns the filtered traceback.
+TracebackFilter: TypeAlias = bool | Callable[[ExceptionInfo[BaseException]], Traceback]
 
 
 @dataclasses.dataclass

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -26,7 +26,7 @@ class Source:
         elif isinstance(obj, Source):
             self.lines = obj.lines
             self.raw_lines = obj.raw_lines
-        elif isinstance(obj, (tuple, list)):
+        elif isinstance(obj, tuple | list):
             self.lines = deindent(x.rstrip("\n") for x in obj)
             self.raw_lines = list(x.rstrip("\n") for x in obj)
         elif isinstance(obj, str):
@@ -155,9 +155,9 @@ def get_statement_startend2(lineno: int, node: ast.AST) -> tuple[int, int | None
     # AST's line numbers start indexing at 1.
     values: list[int] = []
     for x in ast.walk(node):
-        if isinstance(x, (ast.stmt, ast.ExceptHandler)):
+        if isinstance(x, ast.stmt | ast.ExceptHandler):
             # The lineno points to the class/def, so need to include the decorators.
-            if isinstance(x, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            if isinstance(x, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
                 for d in x.decorator_list:
                     values.append(d.lineno - 1)
             values.append(x.lineno - 1)

--- a/src/_pytest/_io/terminalwriter.py
+++ b/src/_pytest/_io/terminalwriter.py
@@ -198,7 +198,8 @@ class TerminalWriter:
             indents = [""] * len(lines)
         source = "\n".join(lines)
         new_lines = self._highlight(source).splitlines()
-        for indent, new_line in zip(indents, new_lines):
+        # Would be better to strict=True but that fails some CI jobs.
+        for indent, new_line in zip(indents, new_lines, strict=False):
             self.line(indent + new_line)
 
     def _get_pygments_lexer(self, lexer: Literal["python", "diff"]) -> Lexer:

--- a/src/_pytest/_py/path.py
+++ b/src/_pytest/_py/path.py
@@ -432,7 +432,7 @@ class LocalPath:
         """Return a string which is the relative part of the path
         to the given 'relpath'.
         """
-        if not isinstance(relpath, (str, LocalPath)):
+        if not isinstance(relpath, str | LocalPath):
             raise TypeError(f"{relpath!r}: not a string or path object")
         strrelpath = str(relpath)
         if strrelpath and strrelpath[-1] != self.sep:

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -131,7 +131,7 @@ def isdict(x: Any) -> bool:
 
 
 def isset(x: Any) -> bool:
-    return isinstance(x, (set, frozenset))
+    return isinstance(x, set | frozenset)
 
 
 def isnamedtuple(obj: Any) -> bool:

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -256,7 +256,7 @@ class LFPluginCollWrapper:
         self, collector: nodes.Collector
     ) -> Generator[None, CollectReport, CollectReport]:
         res = yield
-        if isinstance(collector, (Session, Directory)):
+        if isinstance(collector, Session | Directory):
             # Sort any lf-paths to the beginning.
             lf_paths = self.lfplugin._last_failed_paths
 

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 import os
 from pathlib import Path
 import sys
-from typing import TYPE_CHECKING
+from typing import TypeAlias
 
 import iniconfig
 
@@ -16,14 +16,9 @@ from _pytest.pathlib import commonpath
 from _pytest.pathlib import safe_exists
 
 
-if TYPE_CHECKING:
-    from typing import Union
-
-    from typing_extensions import TypeAlias
-
-    # Even though TOML supports richer data types, all values are converted to str/list[str] during
-    # parsing to maintain compatibility with the rest of the configuration system.
-    ConfigDict: TypeAlias = dict[str, Union[str, list[str]]]
+# Even though TOML supports richer data types, all values are converted to str/list[str] during
+# parsing to maintain compatibility with the rest of the configuration system.
+ConfigDict: TypeAlias = dict[str, str | list[str]]
 
 
 def _parse_ini_config(path: Path) -> iniconfig.IniConfig:

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -324,7 +324,7 @@ class DoctestItem(Item):
             Sequence[doctest.DocTestFailure | doctest.UnexpectedException] | None
         ) = None
         if isinstance(
-            excinfo.value, (doctest.DocTestFailure, doctest.UnexpectedException)
+            excinfo.value, doctest.DocTestFailure | doctest.UnexpectedException
         ):
             failures = [excinfo.value]
         elif isinstance(excinfo.value, MultipleDoctestFailures):
@@ -530,24 +530,6 @@ class DoctestModule(Module):
                         source_lines,
                     )
 
-            if sys.version_info < (3, 10):
-
-                def _find(
-                    self, tests, obj, name, module, source_lines, globs, seen
-                ) -> None:
-                    """Override _find to work around issue in stdlib.
-
-                    https://github.com/pytest-dev/pytest/issues/3456
-                    https://github.com/python/cpython/issues/69718
-                    """
-                    if _is_mocked(obj):
-                        return  # pragma: no cover
-                    with _patch_unwrap_mock_aware():
-                        # Type ignored because this is a private function.
-                        super()._find(  # type:ignore[misc]
-                            tests, obj, name, module, source_lines, globs, seen
-                        )
-
             if sys.version_info < (3, 13):
 
                 def _from_module(self, module, object):
@@ -657,7 +639,7 @@ def _init_checker_class() -> type[doctest.OutputChecker]:
             if len(wants) != len(gots):
                 return got
             offset = 0
-            for w, g in zip(wants, gots):
+            for w, g in zip(wants, gots, strict=True):
                 fraction: str | None = w.group("fraction")
                 exponent: str | None = w.group("exponent1")
                 if exponent is None:

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -26,11 +26,9 @@ from typing import Final
 from typing import final
 from typing import Generic
 from typing import NoReturn
-from typing import Optional
 from typing import overload
 from typing import TYPE_CHECKING
 from typing import TypeVar
-from typing import Union
 import warnings
 
 import _pytest
@@ -88,26 +86,24 @@ FixtureValue = TypeVar("FixtureValue")
 # The type of the fixture function (type variable).
 FixtureFunction = TypeVar("FixtureFunction", bound=Callable[..., object])
 # The type of a fixture function (type alias generic in fixture value).
-_FixtureFunc = Union[
-    Callable[..., FixtureValue], Callable[..., Generator[FixtureValue]]
-]
+_FixtureFunc = Callable[..., FixtureValue] | Callable[..., Generator[FixtureValue]]
 # The type of FixtureDef.cached_result (type alias generic in fixture value).
-_FixtureCachedResult = Union[
+_FixtureCachedResult = (
     tuple[
         # The result.
         FixtureValue,
         # Cache key.
         object,
         None,
-    ],
-    tuple[
+    ]
+    | tuple[
         None,
         # Cache key.
         object,
         # The exception and the original traceback.
-        tuple[BaseException, Optional[types.TracebackType]],
-    ],
-]
+        tuple[BaseException, types.TracebackType | None],
+    ]
+)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/_pytest/mark/__init__.py
+++ b/src/_pytest/mark/__init__.py
@@ -7,7 +7,6 @@ from collections.abc import Collection
 from collections.abc import Iterable
 from collections.abc import Set as AbstractSet
 import dataclasses
-from typing import Optional
 from typing import TYPE_CHECKING
 
 from .expression import Expression
@@ -45,7 +44,7 @@ __all__ = [
 ]
 
 
-old_mark_config_key = StashKey[Optional[Config]]()
+old_mark_config_key = StashKey[Config | None]()
 
 
 def param(

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -18,7 +18,6 @@ from typing import NamedTuple
 from typing import overload
 from typing import TYPE_CHECKING
 from typing import TypeVar
-from typing import Union
 import warnings
 
 from .._code import getfslineno
@@ -302,7 +301,7 @@ class Mark:
 # A generic parameter designating an object to which a Mark may
 # be applied -- a test function (callable) or class.
 # Note: a lambda is not allowed, but this can't be represented.
-Markable = TypeVar("Markable", bound=Union[Callable[..., object], type])
+Markable = TypeVar("Markable", bound=Callable[..., object] | type)
 
 
 @dataclasses.dataclass
@@ -396,7 +395,7 @@ class MarkDecorator:
             # For staticmethods/classmethods, the marks are eventually fetched from the
             # function object, not the descriptor, so unwrap.
             unwrapped_func = func
-            if isinstance(func, (staticmethod, classmethod)):
+            if isinstance(func, staticmethod | classmethod):
                 unwrapped_func = func.__func__
             if len(args) == 1 and (istestfunc(unwrapped_func) or is_class):
                 store_mark(unwrapped_func, self.mark, stacklevel=3)

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -348,7 +348,7 @@ def cleanup_candidates(root: Path, prefix: str, keep: int) -> Iterator[Path]:
     entries = find_prefixed(root, prefix)
     entries, entries2 = itertools.tee(entries)
     numbers = map(parse_num, extract_suffixes(entries2, prefix))
-    for entry, number in zip(entries, numbers):
+    for entry, number in zip(entries, numbers, strict=True):
         if number <= max_delete:
             yield Path(entry)
 

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -113,7 +113,7 @@ class ApproxBase:
 
 def _recursive_sequence_map(f, x):
     """Recursively map a function over a sequence of arbitrary depth"""
-    if isinstance(x, (list, tuple)):
+    if isinstance(x, list | tuple):
         seq_type = type(x)
         return seq_type(_recursive_sequence_map(f, xi) for xi in x)
     elif _is_sequence_like(x):
@@ -245,7 +245,7 @@ class ApproxMapping(ApproxBase):
         max_rel_diff = -math.inf
         different_ids = []
         for (approx_key, approx_value), other_value in zip(
-            approx_side_as_map.items(), other_side.values()
+            approx_side_as_map.items(), other_side.values(), strict=True
         ):
             if approx_value != other_value:
                 if approx_value.expected is not None and other_value is not None:
@@ -327,7 +327,7 @@ class ApproxSequenceLike(ApproxBase):
         max_rel_diff = -math.inf
         different_ids = []
         for i, (approx_value, other_value) in enumerate(
-            zip(approx_side_as_map, other_side)
+            zip(approx_side_as_map, other_side, strict=True)
         ):
             if approx_value != other_value:
                 try:
@@ -365,7 +365,7 @@ class ApproxSequenceLike(ApproxBase):
         return super().__eq__(actual)
 
     def _yield_comparisons(self, actual):
-        return zip(actual, self.expected)
+        return zip(actual, self.expected, strict=True)
 
     def _check_type(self) -> None:
         __tracebackhide__ = True
@@ -394,7 +394,7 @@ class ApproxScalar(ApproxBase):
         # handle complex numbers, e.g. (inf + 1j).
         if (
             isinstance(self.expected, bool)
-            or (not isinstance(self.expected, (Complex, Decimal)))
+            or (not isinstance(self.expected, Complex | Decimal))
             or math.isinf(abs(self.expected) or isinstance(self.expected, bool))
         ):
             return str(self.expected)
@@ -447,8 +447,8 @@ class ApproxScalar(ApproxBase):
         # __sub__, and __float__ are defined. Also, consider bool to be
         # non-numeric, even though it has the required arithmetic.
         if is_bool(self.expected) or not (
-            isinstance(self.expected, (Complex, Decimal))
-            and isinstance(actual, (Complex, Decimal))
+            isinstance(self.expected, Complex | Decimal)
+            and isinstance(actual, Complex | Decimal)
         ):
             return False
 
@@ -766,7 +766,7 @@ def approx(expected, rel=None, abs=None, nan_ok: bool = False) -> ApproxBase:
         cls = ApproxNumpy
     elif _is_sequence_like(expected):
         cls = ApproxSequenceLike
-    elif isinstance(expected, Collection) and not isinstance(expected, (str, bytes)):
+    elif isinstance(expected, Collection) and not isinstance(expected, str | bytes):
         msg = f"pytest.approx() only supports ordered sequences, but got: {expected!r}"
         raise TypeError(msg)
     else:
@@ -779,7 +779,7 @@ def _is_sequence_like(expected: object) -> bool:
     return (
         hasattr(expected, "__getitem__")
         and isinstance(expected, Sized)
-        and not isinstance(expected, (str, bytes))
+        and not isinstance(expected, str | bytes)
     )
 
 

--- a/src/_pytest/raises.py
+++ b/src/_pytest/raises.py
@@ -29,9 +29,9 @@ if TYPE_CHECKING:
 
     # for some reason Sphinx does not play well with 'from types import TracebackType'
     import types
+    from typing import TypeGuard
 
     from typing_extensions import ParamSpec
-    from typing_extensions import TypeGuard
     from typing_extensions import TypeVar
 
     P = ParamSpec("P")

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -459,7 +459,7 @@ class CollectErrorRepr(TerminalRepr):
 def pytest_report_to_serializable(
     report: CollectReport | TestReport,
 ) -> dict[str, Any] | None:
-    if isinstance(report, (TestReport, CollectReport)):
+    if isinstance(report, TestReport | CollectReport):
         data = report._to_json()
         data["$report_type"] = report.__class__.__name__
         return data

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -262,7 +262,7 @@ def check_interactive_exception(call: CallInfo[object], report: BaseReport) -> b
     if hasattr(report, "wasxfail"):
         # Exception was expected.
         return False
-    if isinstance(call.excinfo.value, (Skipped, bdb.BdbQuit)):
+    if isinstance(call.excinfo.value, Skipped | bdb.BdbQuit):
         # Special control flow exception.
         return False
     return True

--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -10,7 +10,6 @@ import os
 import platform
 import sys
 import traceback
-from typing import Optional
 
 from _pytest.config import Config
 from _pytest.config import hookimpl
@@ -236,7 +235,7 @@ def evaluate_xfail_marks(item: Item) -> Xfail | None:
 
 
 # Saves the xfail mark evaluation. Can be refreshed during call if None.
-xfailed_key = StashKey[Optional[Xfail]]()
+xfailed_key = StashKey[Xfail | None]()
 
 
 @hookimpl(tryfirst=True)
@@ -285,7 +284,7 @@ def pytest_runtest_makereport(
             raises = xfailed.raises
             if raises is None or (
                 (
-                    isinstance(raises, (type, tuple))
+                    isinstance(raises, type | tuple)
                     and isinstance(call.excinfo.value, raises)
                 )
                 or (

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -14,7 +14,6 @@ import sys
 import traceback
 import types
 from typing import TYPE_CHECKING
-from typing import Union
 
 import _pytest._code
 from _pytest.compat import is_async_function
@@ -43,10 +42,10 @@ if TYPE_CHECKING:
     import twisted.trial.unittest
 
 
-_SysExcInfoType = Union[
-    tuple[type[BaseException], BaseException, types.TracebackType],
-    tuple[None, None, None],
-]
+_SysExcInfoType = (
+    tuple[type[BaseException], BaseException, types.TracebackType]
+    | tuple[None, None, None]
+)
 
 
 def pytest_pycollect_makeitem(

--- a/testing/_py/test_local.py
+++ b/testing/_py/test_local.py
@@ -18,8 +18,7 @@ import pytest
 @contextlib.contextmanager
 def ignore_encoding_warning():
     with warnings.catch_warnings():
-        if sys.version_info >= (3, 10):
-            warnings.simplefilter("ignore", EncodingWarning)  # noqa: F821
+        warnings.simplefilter("ignore", EncodingWarning)
         yield
 
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -111,7 +111,7 @@ def tw_mock():
         def _write_source(self, lines, indents=()):
             if not indents:
                 indents = [""] * len(lines)
-            for indent, line in zip(indents, lines):
+            for indent, line in zip(indents, lines, strict=True):
                 self.line(indent + line)
 
         def line(self, line, **kw):

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -77,7 +77,7 @@ def assert_approx_raises_regex(pytestconfig):
         )
 
         for i, (obtained_line, expected_line) in enumerate(
-            zip(obtained_message, expected_message)
+            zip(obtained_message, expected_message, strict=True)
         ):
             regex = re.compile(expected_line)
             assert regex.match(obtained_line) is not None, (

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
+from itertools import zip_longest
 import os
 from pathlib import Path
 import sys
@@ -3043,7 +3044,7 @@ class TestFixtureMarker:
         ]
         import pprint
 
-        pprint.pprint(list(zip(values, expected)))
+        pprint.pprint(list(zip_longest(values, expected)))
         assert values == expected
 
     def test_parametrized_fixture_teardown_order(self, pytester: Pytester) -> None:

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -429,7 +429,7 @@ class TestMetafunc:
 
     def test_idmaker_with_bytes_regex(self) -> None:
         result = IdMaker(
-            ("a"), [pytest.param(re.compile(b"foo"), 1.0)], None, None, None, None, None
+            ("a"), [pytest.param(re.compile(b"foo"))], None, None, None, None, None
         ).make_unique_parameterset_ids()
         assert result == ["foo"]
 

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -395,8 +395,8 @@ class TestRaises:
     def test_issue_11872(self) -> None:
         """Regression test for #11872.
 
-        urllib.error.HTTPError on Python<=3.9 raises KeyError instead of
-        AttributeError on invalid attribute access.
+        urllib.error.HTTPError on some Python 3.10/11 minor releases raises
+        KeyError instead of AttributeError on invalid attribute access.
 
         https://github.com/python/cpython/issues/98778
         """

--- a/testing/python/raises_group.py
+++ b/testing/python/raises_group.py
@@ -292,7 +292,7 @@ def test_catch_unwrapped_exceptions() -> None:
     # if users want one of several exception types they need to use a RaisesExc
     # (which the error message suggests)
     with RaisesGroup(
-        RaisesExc(check=lambda e: isinstance(e, (SyntaxError, ValueError))),
+        RaisesExc(check=lambda e: isinstance(e, SyntaxError | ValueError)),
         allow_unwrapped=True,
     ):
         raise ValueError

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -132,7 +132,7 @@ class TestAssertionRewrite:
             if isinstance(node, ast.Import):
                 continue
             for n in [node, *ast.iter_child_nodes(node)]:
-                assert isinstance(n, (ast.stmt, ast.expr))
+                assert isinstance(n, ast.stmt | ast.expr)
                 for location in [
                     (n.lineno, n.col_offset),
                     (n.end_lineno, n.end_col_offset),
@@ -2263,10 +2263,6 @@ class TestPyCacheDir:
 
         assert get_cache_dir(Path(source)) == Path(expected)
 
-    @pytest.mark.skipif(
-        sys.version_info[:2] == (3, 9) and sys.platform.startswith("win"),
-        reason="#9298",
-    )
     def test_sys_pycache_prefix_integration(
         self, tmp_path, monkeypatch, pytester: Pytester
     ) -> None:

--- a/testing/test_compat.py
+++ b/testing/test_compat.py
@@ -16,7 +16,7 @@ import pytest
 
 
 if TYPE_CHECKING:
-    from typing_extensions import Literal
+    from typing import Literal
 
 
 def test_real_func_loop_limit() -> None:

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -661,8 +661,7 @@ class TestPython:
         node = dom.get_first_by_tag("testsuite")
         node.assert_attr(failures=3, tests=3)
         tnodes = node.find_by_tag("testcase")
-        assert len(tnodes) == 3
-        for tnode, char in zip(tnodes, "<&'"):
+        for tnode, char in zip(tnodes, "<&'", strict=True):
             tnode.assert_attr(
                 classname="test_failure_escape", name=f"test_func[{char}]"
             )

--- a/testing/test_reports.py
+++ b/testing/test_reports.py
@@ -101,8 +101,7 @@ class TestReportSerialization:
 
         rep_entries = rep.longrepr.reprtraceback.reprentries
         a_entries = a.longrepr.reprtraceback.reprentries
-        assert len(rep_entries) == len(a_entries)  # python < 3.10 zip(strict=True)
-        for a_entry, rep_entry in zip(a_entries, rep_entries):
+        for a_entry, rep_entry in zip(a_entries, rep_entries, strict=True):
             assert isinstance(rep_entry, ReprEntry)
             assert rep_entry.reprfileloc is not None
             assert rep_entry.reprfuncargs is not None
@@ -146,8 +145,7 @@ class TestReportSerialization:
 
         rep_entries = rep.longrepr.reprtraceback.reprentries
         a_entries = a.longrepr.reprtraceback.reprentries
-        assert len(rep_entries) == len(a_entries)  # python < 3.10 zip(strict=True)
-        for rep_entry, a_entry in zip(rep_entries, a_entries):
+        for rep_entry, a_entry in zip(rep_entries, a_entries, strict=True):
             assert isinstance(rep_entry, ReprEntryNative)
             assert rep_entry.lines == a_entry.lines
 

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
-import sys
 import textwrap
 
 from _pytest.pytester import Pytester
@@ -1136,22 +1135,13 @@ def test_errors_in_xfail_skip_expressions(pytester: Pytester) -> None:
     """
     )
     result = pytester.runpytest()
-    markline = "            ^"
-    pypy_version_info = getattr(sys, "pypy_version_info", None)
-    if pypy_version_info is not None:
-        markline = markline[7:]
 
-    if sys.version_info >= (3, 10):
-        expected = [
-            "*ERROR*test_nameerror*",
-            "*asd*",
-            "",
-            "During handling of the above exception, another exception occurred:",
-        ]
-    else:
-        expected = [
-            "*ERROR*test_nameerror*",
-        ]
+    expected = [
+        "*ERROR*test_nameerror*",
+        "*asd*",
+        "",
+        "During handling of the above exception, another exception occurred:",
+    ]
 
     expected += [
         "*evaluating*skipif*condition*",
@@ -1159,7 +1149,7 @@ def test_errors_in_xfail_skip_expressions(pytester: Pytester) -> None:
         "*ERROR*test_syntax*",
         "*evaluating*xfail*condition*",
         "    syntax error",
-        markline,
+        "            ^",
         "SyntaxError: invalid syntax",
         "*1 pass*2 errors*",
     ]

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -2677,7 +2677,7 @@ def test_full_sequence_print_with_vv(
         [
             "*short test summary info*",
             f"*{list(range(10))}*",
-            f"*{dict(zip(range(10), range(10)))}*",
+            f"*{dict(zip(range(10), range(10), strict=True))}*",
         ]
     )
 

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -280,8 +280,7 @@ def test_warning_recorded_hook(pytester: Pytester) -> None:
         ("call warning", "runtest", "test_warning_recorded_hook.py::test_func"),
         ("teardown warning", "runtest", "test_warning_recorded_hook.py::test_func"),
     ]
-    assert len(collected) == len(expected)  # python < 3.10 zip(strict=True)
-    for collected_result, expected_result in zip(collected, expected):
+    for collected_result, expected_result in zip(collected, expected, strict=True):
         assert collected_result[0] == expected_result[0], str(collected)
         assert collected_result[1] == expected_result[1], str(collected)
         assert collected_result[2] == expected_result[2], str(collected)

--- a/testing/typing_checks.py
+++ b/testing/typing_checks.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import contextlib
 from typing import Literal
-from typing import Optional
 
 from typing_extensions import assert_type
 
@@ -52,10 +51,10 @@ def check_monkeypatch_typeddict(monkeypatch: MonkeyPatch) -> None:
 def check_raises_is_a_context_manager(val: bool) -> None:
     with pytest.raises(RuntimeError) if val else contextlib.nullcontext() as excinfo:
         pass
-    assert_type(excinfo, Optional[pytest.ExceptionInfo[RuntimeError]])
+    assert_type(excinfo, pytest.ExceptionInfo[RuntimeError] | None)
 
 
 # Issue #12941.
 def check_testreport_attributes(report: TestReport) -> None:
     assert_type(report.when, Literal["setup", "call", "teardown"])
-    assert_type(report.location, tuple[str, Optional[int], str])
+    assert_type(report.location, tuple[str, int | None, str])

--- a/testing/typing_raises_group.py
+++ b/testing/typing_raises_group.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 import sys
-from typing import Callable
-from typing import Union
 
 from typing_extensions import assert_type
 
@@ -160,10 +159,7 @@ def check_nested_raisesgroups_contextmanager() -> None:
     assert_type(
         excinfo.value.exceptions[0],
         # this union is because of how typeshed defines .exceptions
-        Union[
-            ExceptionGroup[ValueError],
-            ExceptionGroup[ExceptionGroup[ValueError]],
-        ],
+        ExceptionGroup[ValueError] | ExceptionGroup[ExceptionGroup[ValueError]],
     )
 
 
@@ -240,8 +236,5 @@ def check_check_typing() -> None:
     # `BaseExceptiongroup` should perhaps be `ExceptionGroup`, but close enough
     assert_type(
         RaisesGroup(ValueError).check,
-        Union[
-            Callable[[BaseExceptionGroup[ValueError]], bool],
-            None,
-        ],
+        Callable[[BaseExceptionGroup[ValueError]], bool] | None,
     )

--- a/tox.ini
+++ b/tox.ini
@@ -4,18 +4,17 @@ minversion = 3.20.0
 distshare = {homedir}/.tox/distshare
 envlist =
     linting
-    py39
     py310
     py311
     py312
     py313
     py314
     pypy3
-    py39-{pexpect,xdist,twisted24,twisted25,asynctest,numpy,pluggymain,pylib}
+    py310-{pexpect,xdist,twisted24,twisted25,asynctest,numpy,pluggymain,pylib}
     doctesting
     doctesting-coverage
     plugins
-    py39-freeze
+    py310-freeze
     docs
     docs-checklinks
 
@@ -58,10 +57,11 @@ setenv =
 
     # See https://docs.python.org/3/library/io.html#io-encoding-warning
     # If we don't enable this, neither can any of our downstream users!
-    PYTHONWARNDEFAULTENCODING=1
+    # pylib is not PYTHONWARNDEFAULTENCODING clean, so don't set for it.
+    !pylib: PYTHONWARNDEFAULTENCODING=1
 
     # Configuration to run with coverage similar to CI, e.g.
-    # "tox -e py39-coverage".
+    # "tox -e py313-coverage".
     coverage: _PYTEST_TOX_COVERAGE_RUN=coverage run -m
     coverage: _PYTEST_TOX_EXTRA_DEP=coverage-enable-subprocess
     coverage: COVERAGE_FILE={toxinidir}/.coverage
@@ -182,7 +182,7 @@ commands =
     pytest pytest_twisted_integration.py
     pytest simple_integration.py --force-sugar --flakes
 
-[testenv:py39-freeze]
+[testenv:py310-freeze]
 description =
     test pytest frozen with `pyinstaller` under `{basepython}`
 changedir = testing/freeze


### PR DESCRIPTION
It will be end-of-life (or on its last breaths) by the time of the next release.

I tried to cover everything, but might have missed something.

The biggest annoyance is the lint which forces explicit `strict` on `zip` calls. I was tempted to add the lint to ignores, but it's actually a good lint so I audited all `zip` calls, hopefully I got it right. It did bring up #13723.

Refs #13719