### PR TITLE
config: Do not fail if a warning filter category cannot be imported

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -201,6 +201,7 @@ Ilya Konstantinov
 Ionuț Turturică
 Isaac Virshup
 Israel Fruchter
+Israël Hallé
 Itxaso Aizpurua
 Iwan Briquemont
 Jaap Broekhuizen

--- a/changelog/13732.improvement.rst
+++ b/changelog/13732.improvement.rst
@@ -1,0 +1,1 @@
+Previously, when filtering warnings, pytest would fail if the filter referenced a class that could not be imported. Now, this only outputs a message indicating the problem.

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -2400,8 +2400,6 @@ def test_parse_warning_filter(
         ":" * 5,
         # Invalid action.
         "FOO::",
-        # ImportError when importing the warning class.
-        "::test_parse_warning_filter_failure.NonExistentClass::",
         # Class is not a Warning subclass.
         "::list::",
         # Negative line number.


### PR DESCRIPTION
We stumbled into an issue using tools like [pants](https://www.pantsbuild.org/) that will generate test environment with minimal dependencies. If used with warning filters with categories from third-party library, pytest is going to fail for any test without this third-party. This is unecessary and any workaround in `conftest.py` is impossible due to https://github.com/pytest-dev/pytest/issues/13485

So this PR change the behavior of failed category import to just log a warning and skip the warning entry.