### PR TITLE
[DRAFT] Integrate pytest subtests

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -271,6 +271,7 @@ default_plugins = (
     "logging",
     "reports",
     "faulthandler",
+    "subtests",
 )
 
 builtin_plugins = {

--- a/src/_pytest/subtests.py
+++ b/src/_pytest/subtests.py
@@ -1,0 +1,502 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Generator
+from collections.abc import Iterator
+from collections.abc import Mapping
+from contextlib import contextmanager
+from contextlib import ExitStack
+from contextlib import nullcontext
+import sys
+import time
+from typing import Any
+from typing import ContextManager
+from typing import TYPE_CHECKING
+from unittest import TestCase
+
+import attr
+import pluggy
+
+from _pytest._code import ExceptionInfo
+from _pytest.capture import CaptureFixture
+from _pytest.capture import FDCapture
+from _pytest.capture import SysCapture
+from _pytest.fixtures import SubRequest
+from _pytest.logging import catching_logs
+from _pytest.logging import LogCaptureHandler
+from _pytest.reports import TestReport
+from _pytest.runner import CallInfo
+from _pytest.runner import check_interactive_exception
+from _pytest.unittest import TestCaseFunction
+import pytest
+
+
+if TYPE_CHECKING:
+    from types import TracebackType
+    from typing import Literal
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("subtests")
+    group.addoption(
+        "--no-subtests-shortletter",
+        action="store_true",
+        dest="no_subtests_shortletter",
+        default=False,
+        help="Disables subtest output 'dots' in non-verbose mode (EXPERIMENTAL)",
+    )
+    group.addoption(
+        "--no-subtests-reports",
+        action="store_true",
+        dest="no_subtests_reports",
+        default=False,
+        help="Disables subtest output unless it's a failed subtest (EXPERIMENTAL)",
+    )
+
+
+@attr.s
+class SubTestContext:
+    msg: str | None = attr.ib()
+    kwargs: dict[str, Any] = attr.ib()
+
+
+@attr.s(init=False)
+class SubTestReport(TestReport):  # type: ignore[misc]
+    context: SubTestContext = attr.ib()
+
+    @property
+    def head_line(self) -> str:
+        _, _, domain = self.location
+        return f"{domain} {self.sub_test_description()}"
+
+    def sub_test_description(self) -> str:
+        parts = []
+        if isinstance(self.context.msg, str):
+            parts.append(f"[{self.context.msg}]")
+        if self.context.kwargs:
+            params_desc = ", ".join(
+                f"{k}={v!r}" for (k, v) in sorted(self.context.kwargs.items())
+            )
+            parts.append(f"({params_desc})")
+        return " ".join(parts) or "(<subtest>)"
+
+    def _to_json(self) -> dict:
+        data = super()._to_json()
+        del data["context"]
+        data["_report_type"] = "SubTestReport"
+        data["_subtest.context"] = attr.asdict(self.context)
+        return data
+
+    @classmethod
+    def _from_json(cls, reportdict: dict[str, Any]) -> SubTestReport:
+        report = super()._from_json(reportdict)
+        context_data = reportdict["_subtest.context"]
+        report.context = SubTestContext(
+            msg=context_data["msg"], kwargs=context_data["kwargs"]
+        )
+        return report
+
+    @classmethod
+    def _from_test_report(cls, test_report: TestReport) -> SubTestReport:
+        return super()._from_json(test_report._to_json())
+
+
+def _addSkip(self: TestCaseFunction, testcase: TestCase, reason: str) -> None:
+    from unittest.case import _SubTest  # type: ignore[attr-defined]
+
+    if isinstance(testcase, _SubTest):
+        self._originaladdSkip(testcase, reason)  # type: ignore[attr-defined]
+        if self._excinfo is not None:
+            exc_info = self._excinfo[-1]
+            self.addSubTest(testcase.test_case, testcase, exc_info)  # type: ignore[attr-defined]
+    else:
+        # For python < 3.11: the non-subtest skips have to be added by `_originaladdSkip` only after all subtest
+        # failures are processed by `_addSubTest`. (`self.instance._outcome` has no attribute `skipped/errors` anymore.)
+        # For python < 3.11, we also need to check if `self.instance._outcome` is `None` (this happens if the test
+        # class/method is decorated with `unittest.skip`, see #173).
+        if sys.version_info < (3, 11) and self.instance._outcome is not None:
+            subtest_errors = [
+                x
+                for x, y in self.instance._outcome.errors
+                if isinstance(x, _SubTest) and y is not None
+            ]
+            if len(subtest_errors) == 0:
+                self._originaladdSkip(testcase, reason)  # type: ignore[attr-defined]
+        else:
+            self._originaladdSkip(testcase, reason)  # type: ignore[attr-defined]
+
+
+def _addSubTest(
+    self: TestCaseFunction,
+    test_case: Any,
+    test: TestCase,
+    exc_info: tuple[type[BaseException], BaseException, TracebackType] | None,
+) -> None:
+    msg = test._message if isinstance(test._message, str) else None  # type: ignore[attr-defined]
+    call_info = make_call_info(
+        ExceptionInfo(exc_info, _ispytest=True) if exc_info else None,
+        start=0,
+        stop=0,
+        duration=0,
+        when="call",
+    )
+    report = self.ihook.pytest_runtest_makereport(item=self, call=call_info)
+    sub_report = SubTestReport._from_test_report(report)
+    sub_report.context = SubTestContext(msg, dict(test.params))  # type: ignore[attr-defined]
+    self.ihook.pytest_runtest_logreport(report=sub_report)
+    if check_interactive_exception(call_info, sub_report):
+        self.ihook.pytest_exception_interact(
+            node=self, call=call_info, report=sub_report
+        )
+
+    # For python < 3.11: add non-subtest skips once all subtest failures are processed by # `_addSubTest`.
+    if sys.version_info < (3, 11):
+        from unittest.case import _SubTest  # type: ignore[attr-defined]
+
+        non_subtest_skip = [
+            (x, y)
+            for x, y in self.instance._outcome.skipped
+            if not isinstance(x, _SubTest)
+        ]
+        subtest_errors = [
+            (x, y)
+            for x, y in self.instance._outcome.errors
+            if isinstance(x, _SubTest) and y is not None
+        ]
+        # Check if we have non-subtest skips: if there are also sub failures, non-subtest skips are not treated in
+        # `_addSubTest` and have to be added using `_originaladdSkip` after all subtest failures are processed.
+        if len(non_subtest_skip) > 0 and len(subtest_errors) > 0:
+            # Make sure we have processed the last subtest failure
+            last_subset_error = subtest_errors[-1]
+            if exc_info is last_subset_error[-1]:
+                # Add non-subtest skips (as they could not be treated in `_addSkip`)
+                for testcase, reason in non_subtest_skip:
+                    self._originaladdSkip(testcase, reason)  # type: ignore[attr-defined]
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    TestCaseFunction.addSubTest = _addSubTest  # type: ignore[attr-defined]
+    TestCaseFunction.failfast = False  # type: ignore[attr-defined]
+    # This condition is to prevent `TestCaseFunction._originaladdSkip` being assigned again in a subprocess from a
+    # parent python process where `addSkip` is already `_addSkip`. A such case is when running tests in
+    # `test_subtests.py` where `pytester.runpytest` is used. Without this guard condition, `_originaladdSkip` is
+    # assigned to `_addSkip` which is wrong as well as causing an infinite recursion in some cases.
+    if not hasattr(TestCaseFunction, "_originaladdSkip"):
+        TestCaseFunction._originaladdSkip = TestCaseFunction.addSkip  # type: ignore[attr-defined]
+    TestCaseFunction.addSkip = _addSkip  # type: ignore[method-assign]
+
+    # Hack (#86): the terminal does not know about the "subtests"
+    # status, so it will by default turn the output to yellow.
+    # This forcibly adds the new 'subtests' status.
+    import _pytest.terminal
+
+    new_types = tuple(
+        f"subtests {outcome}" for outcome in ("passed", "failed", "skipped")
+    )
+    # We need to check if we are not re-adding because we run our own tests
+    # with pytester in-process mode, so this will be called multiple times.
+    if new_types[0] not in _pytest.terminal.KNOWN_TYPES:
+        _pytest.terminal.KNOWN_TYPES = _pytest.terminal.KNOWN_TYPES + new_types  # type: ignore[assignment]
+
+    _pytest.terminal._color_for_type.update(
+        {
+            f"subtests {outcome}": _pytest.terminal._color_for_type[outcome]
+            for outcome in ("passed", "failed", "skipped")
+            if outcome in _pytest.terminal._color_for_type
+        }
+    )
+
+
+def pytest_unconfigure() -> None:
+    if hasattr(TestCaseFunction, "addSubTest"):
+        del TestCaseFunction.addSubTest
+    if hasattr(TestCaseFunction, "failfast"):
+        del TestCaseFunction.failfast
+    if hasattr(TestCaseFunction, "_originaladdSkip"):
+        TestCaseFunction.addSkip = TestCaseFunction._originaladdSkip  # type: ignore[method-assign]
+        del TestCaseFunction._originaladdSkip
+
+
+@pytest.fixture
+def subtests(request: SubRequest) -> Generator[SubTests, None, None]:
+    """Provides subtests functionality."""
+    capmam = request.node.config.pluginmanager.get_plugin("capturemanager")
+    if capmam is not None:
+        suspend_capture_ctx = capmam.global_and_fixture_disabled
+    else:
+        suspend_capture_ctx = nullcontext
+    yield SubTests(request.node.ihook, suspend_capture_ctx, request)
+
+
+@attr.s
+class SubTests:
+    ihook: pluggy.HookRelay = attr.ib()
+    suspend_capture_ctx: Callable[[], ContextManager] = attr.ib()
+    request: SubRequest = attr.ib()
+
+    @property
+    def item(self) -> pytest.Item:
+        return self.request.node
+
+    def test(
+        self,
+        msg: str | None = None,
+        **kwargs: Any,
+    ) -> _SubTestContextManager:
+        """
+        Context manager for subtests, capturing exceptions raised inside the subtest scope and handling
+        them through the pytest machinery.
+
+        Usage:
+
+        .. code-block:: python
+
+            with subtests.test(msg="subtest"):
+                assert 1 == 1
+        """
+        return _SubTestContextManager(
+            self.ihook,
+            msg,
+            kwargs,
+            request=self.request,
+            suspend_capture_ctx=self.suspend_capture_ctx,
+        )
+
+
+@attr.s(auto_attribs=True)
+class _SubTestContextManager:
+    """
+    Context manager for subtests, capturing exceptions raised inside the subtest scope and handling
+    them through the pytest machinery.
+
+    Note: initially this logic was implemented directly in SubTests.test() as a @contextmanager, however
+    it is not possible to control the output fully when exiting from it due to an exception when
+    in --exitfirst mode, so this was refactored into an explicit context manager class (#134).
+    """
+
+    ihook: pluggy.HookRelay
+    msg: str | None
+    kwargs: dict[str, Any]
+    suspend_capture_ctx: Callable[[], ContextManager]
+    request: SubRequest
+
+    def __enter__(self) -> None:
+        __tracebackhide__ = True
+
+        self._start = time.time()
+        self._precise_start = time.perf_counter()
+        self._exc_info = None
+
+        self._exit_stack = ExitStack()
+        self._captured_output = self._exit_stack.enter_context(
+            capturing_output(self.request)
+        )
+        self._captured_logs = self._exit_stack.enter_context(
+            capturing_logs(self.request)
+        )
+
+    def __exit__(
+        self,
+        exc_type: type[Exception] | None,
+        exc_val: Exception | None,
+        exc_tb: TracebackType | None,
+    ) -> bool:
+        __tracebackhide__ = True
+        try:
+            if exc_val is not None:
+                exc_info = ExceptionInfo.from_exception(exc_val)
+            else:
+                exc_info = None
+        finally:
+            self._exit_stack.close()
+
+        precise_stop = time.perf_counter()
+        duration = precise_stop - self._precise_start
+        stop = time.time()
+
+        call_info = make_call_info(
+            exc_info, start=self._start, stop=stop, duration=duration, when="call"
+        )
+        report = self.ihook.pytest_runtest_makereport(
+            item=self.request.node, call=call_info
+        )
+        sub_report = SubTestReport._from_test_report(report)
+        sub_report.context = SubTestContext(self.msg, self.kwargs.copy())
+
+        self._captured_output.update_report(sub_report)
+        self._captured_logs.update_report(sub_report)
+
+        with self.suspend_capture_ctx():
+            self.ihook.pytest_runtest_logreport(report=sub_report)
+
+        if check_interactive_exception(call_info, sub_report):
+            self.ihook.pytest_exception_interact(
+                node=self.request.node, call=call_info, report=sub_report
+            )
+
+        if exc_val is not None:
+            if self.request.session.shouldfail:
+                return False
+        return True
+
+
+def make_call_info(
+    exc_info: ExceptionInfo[BaseException] | None,
+    *,
+    start: float,
+    stop: float,
+    duration: float,
+    when: Literal["collect", "setup", "call", "teardown"],
+) -> CallInfo:
+    return CallInfo(
+        None,
+        exc_info,
+        start=start,
+        stop=stop,
+        duration=duration,
+        when=when,
+        _ispytest=True,
+    )
+
+
+@contextmanager
+def capturing_output(request: SubRequest) -> Iterator[Captured]:
+    option = request.config.getoption("capture", None)
+
+    # capsys or capfd are active, subtest should not capture.
+    capman = request.config.pluginmanager.getplugin("capturemanager")
+    capture_fixture_active = getattr(capman, "_capture_fixture", None)
+
+    if option == "sys" and not capture_fixture_active:
+        with ignore_pytest_private_warning():
+            fixture = CaptureFixture(SysCapture, request)
+    elif option == "fd" and not capture_fixture_active:
+        with ignore_pytest_private_warning():
+            fixture = CaptureFixture(FDCapture, request)
+    else:
+        fixture = None
+
+    if fixture is not None:
+        fixture._start()
+
+    captured = Captured()
+    try:
+        yield captured
+    finally:
+        if fixture is not None:
+            out, err = fixture.readouterr()
+            fixture.close()
+            captured.out = out
+            captured.err = err
+
+
+@contextmanager
+def capturing_logs(
+    request: SubRequest,
+) -> Iterator[CapturedLogs | NullCapturedLogs]:
+    logging_plugin = request.config.pluginmanager.getplugin("logging-plugin")
+    if logging_plugin is None:
+        yield NullCapturedLogs()
+    else:
+        handler = LogCaptureHandler()
+        handler.setFormatter(logging_plugin.formatter)
+
+        captured_logs = CapturedLogs(handler)
+        with catching_logs(handler):
+            yield captured_logs
+
+
+@contextmanager
+def ignore_pytest_private_warning() -> Generator[None, None, None]:
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            "A private pytest class or function was used.",
+            category=pytest.PytestDeprecationWarning,
+        )
+        yield
+
+
+@attr.s
+class Captured:
+    out = attr.ib(default="", type=str)
+    err = attr.ib(default="", type=str)
+
+    def update_report(self, report: pytest.TestReport) -> None:
+        if self.out:
+            report.sections.append(("Captured stdout call", self.out))
+        if self.err:
+            report.sections.append(("Captured stderr call", self.err))
+
+
+class CapturedLogs:
+    def __init__(self, handler: LogCaptureHandler) -> None:
+        self._handler = handler
+
+    def update_report(self, report: pytest.TestReport) -> None:
+        report.sections.append(("Captured log call", self._handler.stream.getvalue()))
+
+
+class NullCapturedLogs:
+    def update_report(self, report: pytest.TestReport) -> None:
+        pass
+
+
+def pytest_report_to_serializable(report: pytest.TestReport) -> dict[str, Any] | None:
+    if isinstance(report, SubTestReport):
+        return report._to_json()
+    return None
+
+
+def pytest_report_from_serializable(data: dict[str, Any]) -> SubTestReport | None:
+    if data.get("_report_type") == "SubTestReport":
+        return SubTestReport._from_json(data)
+    return None
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_report_teststatus(
+    report: pytest.TestReport,
+    config: pytest.Config,
+) -> tuple[str, str, str | Mapping[str, bool]] | None:
+    if report.when != "call" or not isinstance(report, SubTestReport):
+        return None
+
+    outcome = report.outcome
+    description = report.sub_test_description()
+    no_output = ("", "", "")
+
+    if hasattr(report, "wasxfail"):
+        if config.option.no_subtests_reports and outcome != "skipped":
+            return no_output
+        elif outcome == "skipped":
+            category = "xfailed"
+            short = "y"  # x letter is used for regular xfail, y for subtest xfail
+            status = "SUBXFAIL"
+        elif outcome == "passed":
+            category = "xpassed"
+            short = "Y"  # X letter is used for regular xpass, Y for subtest xpass
+            status = "SUBXPASS"
+        else:
+            # This should not normally happen, unless some plugin is setting wasxfail without
+            # the correct outcome. Pytest expects the call outcome to be either skipped or passed in case of xfail.
+            # Let's pass this report to the next hook.
+            return None
+        short = "" if config.option.no_subtests_shortletter else short
+        return f"subtests {category}", short, f"{description} {status}"
+
+    if config.option.no_subtests_reports and outcome != "failed":
+        return no_output
+    elif report.passed:
+        short = "" if config.option.no_subtests_shortletter else ","
+        return f"subtests {outcome}", short, f"{description} SUBPASS"
+    elif report.skipped:
+        short = "" if config.option.no_subtests_shortletter else "-"
+        return outcome, short, f"{description} SUBSKIP"
+    elif outcome == "failed":
+        short = "" if config.option.no_subtests_shortletter else "u"
+        return outcome, short, f"{description} SUBFAIL"
+
+    return None

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -30,7 +30,6 @@ from _pytest.python import Class
 from _pytest.python import Function
 from _pytest.python import Module
 from _pytest.runner import CallInfo
-import pytest
 
 
 if sys.version_info[:2] < (3, 11):
@@ -141,7 +140,7 @@ class UnitTestCase(Class):
             cls = request.cls
             if _is_skipped(cls):
                 reason = cls.__unittest_skip_why__
-                raise pytest.skip.Exception(reason, _use_item_location=True)
+                raise skip.Exception(reason, _use_item_location=True)
             if setup is not None:
                 try:
                     setup()
@@ -182,7 +181,7 @@ class UnitTestCase(Class):
             self = request.instance
             if _is_skipped(self):
                 reason = self.__unittest_skip_why__
-                raise pytest.skip.Exception(reason, _use_item_location=True)
+                raise skip.Exception(reason, _use_item_location=True)
             if setup is not None:
                 setup(self, request.function)
             yield
@@ -280,7 +279,7 @@ class TestCaseFunction(Function):
 
     def addSkip(self, testcase: unittest.TestCase, reason: str) -> None:
         try:
-            raise pytest.skip.Exception(reason, _use_item_location=True)
+            raise skip.Exception(reason, _use_item_location=True)
         except skip.Exception:
             self._addexcinfo(sys.exc_info())
 

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -71,6 +71,7 @@ from _pytest.reports import TestReport
 from _pytest.runner import CallInfo
 from _pytest.stash import Stash
 from _pytest.stash import StashKey
+from _pytest.subtests import SubTests
 from _pytest.terminal import TerminalReporter
 from _pytest.terminal import TestShortLogReport
 from _pytest.tmpdir import TempPathFactory
@@ -146,6 +147,7 @@ __all__ = [
     "Session",
     "Stash",
     "StashKey",
+    "SubTests",
     "TempPathFactory",
     "TempdirFactory",
     "TerminalReporter",

--- a/testing/test_subtests.py
+++ b/testing/test_subtests.py
@@ -1,0 +1,839 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Literal
+
+import pytest
+
+
+IS_PY311 = sys.version_info[:2] >= (3, 11)
+
+
+@pytest.mark.parametrize("mode", ["normal", "xdist"])
+class TestFixture:
+    """
+    Tests for ``subtests`` fixture.
+    """
+
+    @pytest.fixture
+    def simple_script(self, pytester: pytest.Pytester) -> None:
+        pytester.makepyfile(
+            """
+            def test_foo(subtests):
+                for i in range(5):
+                    with subtests.test(msg="custom", i=i):
+                        assert i % 2 == 0
+        """
+        )
+
+    def test_simple_terminal_normal(
+        self,
+        simple_script: None,
+        pytester: pytest.Pytester,
+        mode: Literal["normal", "xdist"],
+    ) -> None:
+        if mode == "normal":
+            result = pytester.runpytest()
+            expected_lines = ["collected 1 item"]
+        else:
+            assert mode == "xdist"
+            pytest.importorskip("xdist")
+            result = pytester.runpytest("-n1")
+            expected_lines = ["1 worker [1 item]"]
+
+        expected_lines += [
+            "* test_foo [[]custom[]] (i=1) *",
+            "* test_foo [[]custom[]] (i=3) *",
+            "* 2 failed, 1 passed, 3 subtests passed in *",
+        ]
+        result.stdout.fnmatch_lines(expected_lines)
+
+    def test_simple_terminal_verbose(
+        self,
+        simple_script: None,
+        pytester: pytest.Pytester,
+        mode: Literal["normal", "xdist"],
+    ) -> None:
+        if mode == "normal":
+            result = pytester.runpytest("-v")
+            expected_lines = [
+                "*collected 1 item",
+                "test_simple_terminal_verbose.py::test_foo [[]custom[]] (i=0) SUBPASS *100%*",
+                "test_simple_terminal_verbose.py::test_foo [[]custom[]] (i=1) SUBFAIL *100%*",
+                "test_simple_terminal_verbose.py::test_foo [[]custom[]] (i=2) SUBPASS *100%*",
+                "test_simple_terminal_verbose.py::test_foo [[]custom[]] (i=3) SUBFAIL *100%*",
+                "test_simple_terminal_verbose.py::test_foo [[]custom[]] (i=4) SUBPASS *100%*",
+                "test_simple_terminal_verbose.py::test_foo PASSED *100%*",
+            ]
+        else:
+            assert mode == "xdist"
+            pytest.importorskip("xdist")
+            result = pytester.runpytest("-n1", "-v")
+            expected_lines = [
+                "1 worker [1 item]",
+                "*gw0*100%* test_simple_terminal_verbose.py::test_foo*",
+                "*gw0*100%* test_simple_terminal_verbose.py::test_foo*",
+                "*gw0*100%* test_simple_terminal_verbose.py::test_foo*",
+                "*gw0*100%* test_simple_terminal_verbose.py::test_foo*",
+                "*gw0*100%* test_simple_terminal_verbose.py::test_foo*",
+                "*gw0*100%* test_simple_terminal_verbose.py::test_foo*",
+            ]
+
+        expected_lines += [
+            "* test_foo [[]custom[]] (i=1) *",
+            "* test_foo [[]custom[]] (i=3) *",
+            "* 2 failed, 1 passed, 3 subtests passed in *",
+        ]
+        result.stdout.fnmatch_lines(expected_lines)
+
+    def test_skip(
+        self, pytester: pytest.Pytester, mode: Literal["normal", "xdist"]
+    ) -> None:
+        pytester.makepyfile(
+            """
+            import pytest
+            def test_foo(subtests):
+                for i in range(5):
+                    with subtests.test(msg="custom", i=i):
+                        if i % 2 == 0:
+                            pytest.skip('even number')
+        """
+        )
+        if mode == "normal":
+            result = pytester.runpytest()
+            expected_lines = ["collected 1 item"]
+        else:
+            assert mode == "xdist"
+            pytest.importorskip("xdist")
+            result = pytester.runpytest("-n1")
+            expected_lines = ["1 worker [1 item]"]
+        expected_lines += ["* 1 passed, 3 skipped, 2 subtests passed in *"]
+        result.stdout.fnmatch_lines(expected_lines)
+
+    def test_xfail(
+        self, pytester: pytest.Pytester, mode: Literal["normal", "xdist"]
+    ) -> None:
+        pytester.makepyfile(
+            """
+            import pytest
+            def test_foo(subtests):
+                for i in range(5):
+                    with subtests.test(msg="custom", i=i):
+                        if i % 2 == 0:
+                            pytest.xfail('even number')
+        """
+        )
+        if mode == "normal":
+            result = pytester.runpytest()
+            expected_lines = ["collected 1 item"]
+        else:
+            assert mode == "xdist"
+            pytest.importorskip("xdist")
+            result = pytester.runpytest("-n1")
+            expected_lines = ["1 worker [1 item]"]
+        expected_lines += ["* 1 passed, 2 subtests passed, 3 subtests xfailed in *"]
+        result.stdout.fnmatch_lines(expected_lines)
+
+    def test_typing_exported(
+        self, pytester: pytest.Pytester, mode: Literal["normal", "xdist"]
+    ) -> None:
+        pytester.makepyfile(
+            """
+            from pytest import SubTests
+
+            def test_typing_exported(subtests: SubTests) -> None:
+                assert isinstance(subtests, SubTests)
+            """
+        )
+        if mode == "normal":
+            result = pytester.runpytest()
+            expected_lines = ["collected 1 item"]
+        else:
+            assert mode == "xdist"
+            pytest.importorskip("xdist")
+            result = pytester.runpytest("-n1")
+            expected_lines = ["1 worker [1 item]"]
+        expected_lines += ["* 1 passed *"]
+        result.stdout.fnmatch_lines(expected_lines)
+
+    def test_no_subtests_reports(
+        self, pytester: pytest.Pytester, mode: Literal["normal", "xdist"]
+    ) -> None:
+        pytester.makepyfile(
+            """
+            import pytest
+
+            def test_foo(subtests):
+                for i in range(5):
+                    with subtests.test(msg="custom", i=i):
+                        pass
+        """
+        )
+        # Without `--no-subtests-reports`, subtests are reported normally.
+        result = pytester.runpytest("-v")
+        result.stdout.fnmatch_lines(
+            [
+                "*collected 1 item*",
+                "test_no_subtests_reports.py::test_foo * (i=0) SUBPASS*",
+                "*test_no_subtests_reports.py::test_foo PASSED*",
+                "* 1 passed, 5 subtests passed in*",
+            ]
+        )
+
+        # With `--no-subtests-reports`, passing subtests are no longer reported.
+        result = pytester.runpytest("-v", "--no-subtests-reports")
+        result.stdout.fnmatch_lines(
+            [
+                "*collected 1 item*",
+                "*test_no_subtests_reports.py::test_foo PASSED*",
+                "* 1 passed in*",
+            ]
+        )
+        result.stdout.no_fnmatch_line("*SUBPASS*")
+
+        # Rewrite the test file so the tests fail. Even with the flag, failed subtests are still reported.
+        pytester.makepyfile(
+            """
+            import pytest
+
+            def test_foo(subtests):
+                for i in range(5):
+                    with subtests.test(msg="custom", i=i):
+                        assert False
+        """
+        )
+        result = pytester.runpytest("-v", "--no-subtests-reports")
+        result.stdout.fnmatch_lines(
+            [
+                "*collected 1 item*",
+                "test_no_subtests_reports.py::test_foo * (i=0) SUBFAIL*",
+                "*test_no_subtests_reports.py::test_foo PASSED*",
+                "* 5 failed, 1 passed in*",
+            ]
+        )
+
+
+class TestSubTest:
+    """
+    Test Test.subTest functionality.
+    """
+
+    @pytest.fixture
+    def simple_script(self, pytester: pytest.Pytester) -> Path:
+        return pytester.makepyfile(
+            """
+            from unittest import TestCase, main
+
+            class T(TestCase):
+
+                def test_foo(self):
+                    for i in range(5):
+                        with self.subTest(msg="custom", i=i):
+                            self.assertEqual(i % 2, 0)
+
+            if __name__ == '__main__':
+                main()
+        """
+        )
+
+    @pytest.mark.parametrize("runner", ["unittest", "pytest-normal", "pytest-xdist"])
+    def test_simple_terminal_normal(
+        self,
+        simple_script: Path,
+        pytester: pytest.Pytester,
+        runner: Literal["unittest", "pytest-normal", "pytest-xdist"],
+    ) -> None:
+        suffix = ".test_foo" if IS_PY311 else ""
+        if runner == "unittest":
+            result = pytester.run(sys.executable, simple_script)
+            result.stderr.fnmatch_lines(
+                [
+                    f"FAIL: test_foo (__main__.T{suffix}) [custom] (i=1)",
+                    "AssertionError: 1 != 0",
+                    f"FAIL: test_foo (__main__.T{suffix}) [custom] (i=3)",
+                    "AssertionError: 1 != 0",
+                    "Ran 1 test in *",
+                    "FAILED (failures=2)",
+                ]
+            )
+        else:
+            if runner == "pytest-normal":
+                result = pytester.runpytest(simple_script)
+                expected_lines = ["collected 1 item"]
+            else:
+                assert runner == "pytest-xdist"
+                pytest.importorskip("xdist")
+                result = pytester.runpytest(simple_script, "-n1")
+                expected_lines = ["1 worker [1 item]"]
+            result.stdout.fnmatch_lines(
+                expected_lines
+                + [
+                    "* T.test_foo [[]custom[]] (i=1) *",
+                    "E  * AssertionError: 1 != 0",
+                    "* T.test_foo [[]custom[]] (i=3) *",
+                    "E  * AssertionError: 1 != 0",
+                    "* 2 failed, 1 passed, 3 subtests passed in *",
+                ]
+            )
+
+    @pytest.mark.parametrize("runner", ["unittest", "pytest-normal", "pytest-xdist"])
+    def test_simple_terminal_verbose(
+        self,
+        simple_script: Path,
+        pytester: pytest.Pytester,
+        runner: Literal["unittest", "pytest-normal", "pytest-xdist"],
+    ) -> None:
+        suffix = ".test_foo" if IS_PY311 else ""
+        if runner == "unittest":
+            result = pytester.run(sys.executable, simple_script, "-v")
+            result.stderr.fnmatch_lines(
+                [
+                    f"test_foo (__main__.T{suffix}) ... ",
+                    f"FAIL: test_foo (__main__.T{suffix}) [custom] (i=1)",
+                    "AssertionError: 1 != 0",
+                    f"FAIL: test_foo (__main__.T{suffix}) [custom] (i=3)",
+                    "AssertionError: 1 != 0",
+                    "Ran 1 test in *",
+                    "FAILED (failures=2)",
+                ]
+            )
+        else:
+            if runner == "pytest-normal":
+                result = pytester.runpytest(simple_script, "-v")
+                expected_lines = [
+                    "*collected 1 item",
+                    "test_simple_terminal_verbose.py::T::test_foo [[]custom[]] (i=1) SUBFAIL *100%*",
+                    "test_simple_terminal_verbose.py::T::test_foo [[]custom[]] (i=3) SUBFAIL *100%*",
+                    "test_simple_terminal_verbose.py::T::test_foo PASSED *100%*",
+                ]
+            else:
+                assert runner == "pytest-xdist"
+                pytest.importorskip("xdist")
+                result = pytester.runpytest(simple_script, "-n1", "-v")
+                expected_lines = [
+                    "1 worker [1 item]",
+                    "*gw0*100%* SUBFAIL test_simple_terminal_verbose.py::T::test_foo*",
+                    "*gw0*100%* SUBFAIL test_simple_terminal_verbose.py::T::test_foo*",
+                    "*gw0*100%* PASSED test_simple_terminal_verbose.py::T::test_foo*",
+                ]
+            result.stdout.fnmatch_lines(
+                expected_lines
+                + [
+                    "* T.test_foo [[]custom[]] (i=1) *",
+                    "E  * AssertionError: 1 != 0",
+                    "* T.test_foo [[]custom[]] (i=3) *",
+                    "E  * AssertionError: 1 != 0",
+                    "* 2 failed, 1 passed, 3 subtests passed in *",
+                ]
+            )
+
+    @pytest.mark.parametrize("runner", ["unittest", "pytest-normal", "pytest-xdist"])
+    def test_skip(
+        self,
+        pytester: pytest.Pytester,
+        runner: Literal["unittest", "pytest-normal", "pytest-xdist"],
+    ) -> None:
+        p = pytester.makepyfile(
+            """
+            from unittest import TestCase, main
+
+            class T(TestCase):
+
+                def test_foo(self):
+                    for i in range(5):
+                        with self.subTest(msg="custom", i=i):
+                            if i % 2 == 0:
+                                self.skipTest('even number')
+
+            if __name__ == '__main__':
+                main()
+        """
+        )
+        if runner == "unittest":
+            result = pytester.runpython(p)
+            result.stderr.fnmatch_lines(["Ran 1 test in *", "OK (skipped=3)"])
+        else:
+            pytest.xfail("Not producing the expected results (#5)")
+            result = pytester.runpytest(p)  # type:ignore[unreachable]
+            result.stdout.fnmatch_lines(
+                ["collected 1 item", "* 3 skipped, 1 passed in *"]
+            )
+
+    @pytest.mark.parametrize("runner", ["unittest", "pytest-normal", "pytest-xdist"])
+    @pytest.mark.xfail(reason="Not producing the expected results (#5)")
+    def test_xfail(
+        self,
+        pytester: pytest.Pytester,
+        runner: Literal["unittest", "pytest-normal", "pytest-xdist"],
+    ) -> None:
+        p = pytester.makepyfile(
+            """
+            import pytest
+            from unittest import expectedFailure, TestCase, main
+
+            class T(TestCase):
+                @expectedFailure
+                def test_foo(self):
+                    for i in range(5):
+                        with self.subTest(msg="custom", i=i):
+                            if i % 2 == 0:
+                                raise pytest.xfail('even number')
+
+            if __name__ == '__main__':
+                main()
+        """
+        )
+        if runner == "unittest":
+            result = pytester.runpython(p)
+            result.stderr.fnmatch_lines(["Ran 1 test in *", "OK (expected failures=3)"])
+        else:
+            result = pytester.runpytest(p)
+            result.stdout.fnmatch_lines(
+                ["collected 1 item", "* 3 xfailed, 1 passed in *"]
+            )
+
+    @pytest.mark.parametrize("runner", ["pytest-normal"])
+    def test_only_original_skip_is_called(
+        self,
+        pytester: pytest.Pytester,
+        monkeypatch: pytest.MonkeyPatch,
+        runner: Literal["pytest-normal"],
+    ) -> None:
+        """Regression test for #173."""
+        monkeypatch.setenv("COLUMNS", "200")
+        p = pytester.makepyfile(
+            """
+            import unittest
+            from unittest import TestCase, main
+
+            @unittest.skip("skip this test")
+            class T(unittest.TestCase):
+                def test_foo(self):
+                    assert 1 == 2
+
+            if __name__ == '__main__':
+                main()
+        """
+        )
+        result = pytester.runpytest(p, "-v", "-rsf")
+        result.stdout.fnmatch_lines(
+            ["SKIPPED [1] test_only_original_skip_is_called.py:6: skip this test"]
+        )
+
+    @pytest.mark.parametrize("runner", ["unittest", "pytest-normal", "pytest-xdist"])
+    def test_skip_with_failure(
+        self,
+        pytester: pytest.Pytester,
+        monkeypatch: pytest.MonkeyPatch,
+        runner: Literal["unittest", "pytest-normal", "pytest-xdist"],
+    ) -> None:
+        monkeypatch.setenv("COLUMNS", "200")
+        p = pytester.makepyfile(
+            """
+            import pytest
+            from unittest import expectedFailure, TestCase, main
+
+            class T(TestCase):
+                def test_foo(self):
+                    for i in range(10):
+                        with self.subTest("custom message", i=i):
+                            if i < 4:
+                                self.skipTest(f"skip subtest i={i}")
+                            assert i < 4
+
+            if __name__ == '__main__':
+                main()
+        """
+        )
+        if runner == "unittest":
+            result = pytester.runpython(p)
+            if sys.version_info < (3, 11):
+                result.stderr.re_match_lines(
+                    [
+                        r"FAIL: test_foo \(__main__\.T\) \[custom message\] \(i=4\).*",
+                        r"FAIL: test_foo \(__main__\.T\) \[custom message\] \(i=9\).*",
+                        r"Ran 1 test in .*",
+                        r"FAILED \(failures=6, skipped=4\)",
+                    ]
+                )
+            else:
+                result.stderr.re_match_lines(
+                    [
+                        r"FAIL: test_foo \(__main__\.T\.test_foo\) \[custom message\] \(i=4\).*",
+                        r"FAIL: test_foo \(__main__\.T\.test_foo\) \[custom message\] \(i=9\).*",
+                        r"Ran 1 test in .*",
+                        r"FAILED \(failures=6, skipped=4\)",
+                    ]
+                )
+        elif runner == "pytest-normal":
+            result = pytester.runpytest(p, "-v", "-rsf")
+            result.stdout.re_match_lines(
+                [
+                    r"test_skip_with_failure.py::T::test_foo \[custom message\] \(i=0\) SUBSKIP \(skip subtest i=0\) .*",
+                    r"test_skip_with_failure.py::T::test_foo \[custom message\] \(i=3\) SUBSKIP \(skip subtest i=3\) .*",
+                    r"test_skip_with_failure.py::T::test_foo \[custom message\] \(i=4\) SUBFAIL .*",
+                    r"test_skip_with_failure.py::T::test_foo \[custom message\] \(i=9\) SUBFAIL .*",
+                    "test_skip_with_failure.py::T::test_foo PASSED .*",
+                    r"[custom message] (i=0) SUBSKIP [1] test_skip_with_failure.py:5: skip subtest i=0",
+                    r"[custom message] (i=0) SUBSKIP [1] test_skip_with_failure.py:5: skip subtest i=3",
+                    r"[custom message] (i=4) SUBFAIL test_skip_with_failure.py::T::test_foo - AssertionError: assert 4 < 4",
+                    r"[custom message] (i=9) SUBFAIL test_skip_with_failure.py::T::test_foo - AssertionError: assert 9 < 4",
+                    r".* 6 failed, 1 passed, 4 skipped in .*",
+                ]
+            )
+        else:
+            pytest.xfail("Not producing the expected results (#5)")
+            result = pytester.runpytest(p)  # type:ignore[unreachable]
+            result.stdout.fnmatch_lines(
+                ["collected 1 item", "* 3 skipped, 1 passed in *"]
+            )
+
+    @pytest.mark.parametrize("runner", ["unittest", "pytest-normal", "pytest-xdist"])
+    def test_skip_with_failure_and_non_subskip(
+        self,
+        pytester: pytest.Pytester,
+        monkeypatch: pytest.MonkeyPatch,
+        runner: Literal["unittest", "pytest-normal", "pytest-xdist"],
+    ) -> None:
+        monkeypatch.setenv("COLUMNS", "200")
+        p = pytester.makepyfile(
+            """
+            import pytest
+            from unittest import expectedFailure, TestCase, main
+
+            class T(TestCase):
+                def test_foo(self):
+                    for i in range(10):
+                        with self.subTest("custom message", i=i):
+                            if i < 4:
+                                self.skipTest(f"skip subtest i={i}")
+                            assert i < 4
+                    self.skipTest(f"skip the test")
+
+            if __name__ == '__main__':
+                main()
+        """
+        )
+        if runner == "unittest":
+            result = pytester.runpython(p)
+            if sys.version_info < (3, 11):
+                result.stderr.re_match_lines(
+                    [
+                        r"FAIL: test_foo \(__main__\.T\) \[custom message\] \(i=4\).*",
+                        r"FAIL: test_foo \(__main__\.T\) \[custom message\] \(i=9\).*",
+                        r"Ran 1 test in .*",
+                        r"FAILED \(failures=6, skipped=5\)",
+                    ]
+                )
+            else:
+                result.stderr.re_match_lines(
+                    [
+                        r"FAIL: test_foo \(__main__\.T\.test_foo\) \[custom message\] \(i=4\).*",
+                        r"FAIL: test_foo \(__main__\.T\.test_foo\) \[custom message\] \(i=9\).*",
+                        r"Ran 1 test in .*",
+                        r"FAILED \(failures=6, skipped=5\)",
+                    ]
+                )
+        elif runner == "pytest-normal":
+            result = pytester.runpytest(p, "-v", "-rsf")
+            # The `(i=0)` is not correct but it's given by pytest `TerminalReporter` without `--no-fold-skipped`
+            result.stdout.re_match_lines(
+                [
+                    r"test_skip_with_failure_and_non_subskip.py::T::test_foo \[custom message\] \(i=4\) SUBFAIL .*",
+                    r"test_skip_with_failure_and_non_subskip.py::T::test_foo SKIPPED \(skip the test\)",
+                    r"\[custom message\] \(i=0\) SUBSKIP \[1\] test_skip_with_failure_and_non_subskip.py:5: skip subtest i=3",
+                    r"\[custom message\] \(i=0\) SUBSKIP \[1\] test_skip_with_failure_and_non_subskip.py:5: skip the test",
+                    r"\[custom message\] \(i=4\) SUBFAIL test_skip_with_failure_and_non_subskip.py::T::test_foo",
+                    r".* 6 failed, 5 skipped in .*",
+                ]
+            )
+            # Check with `--no-fold-skipped` (which gives the correct information).
+            if sys.version_info >= (3, 10) and pytest.version_tuple[:2] >= (8, 3):
+                result = pytester.runpytest(p, "-v", "--no-fold-skipped", "-rsf")
+                result.stdout.re_match_lines(
+                    [
+                        r"test_skip_with_failure_and_non_subskip.py::T::test_foo \[custom message\] \(i=4\) SUBFAIL .*",
+                        r"test_skip_with_failure_and_non_subskip.py::T::test_foo SKIPPED \(skip the test\).*",
+                        r"\[custom message\] \(i=3\) SUBSKIP test_skip_with_failure_and_non_subskip.py::T::test_foo - Skipped: skip subtest i=3",
+                        r"SKIPPED test_skip_with_failure_and_non_subskip.py::T::test_foo - Skipped: skip the test",
+                        r"\[custom message\] \(i=4\) SUBFAIL test_skip_with_failure_and_non_subskip.py::T::test_foo",
+                        r".* 6 failed, 5 skipped in .*",
+                    ]
+                )
+        else:
+            pytest.xfail("Not producing the expected results (#5)")
+            result = pytester.runpytest(p)  # type:ignore[unreachable]
+            result.stdout.fnmatch_lines(
+                ["collected 1 item", "* 3 skipped, 1 passed in *"]
+            )
+
+
+class TestCapture:
+    def create_file(self, pytester: pytest.Pytester) -> None:
+        pytester.makepyfile(
+            """
+                    import sys
+                    def test(subtests):
+                        print()
+                        print('start test')
+
+                        with subtests.test(i='A'):
+                            print("hello stdout A")
+                            print("hello stderr A", file=sys.stderr)
+                            assert 0
+
+                        with subtests.test(i='B'):
+                            print("hello stdout B")
+                            print("hello stderr B", file=sys.stderr)
+                            assert 0
+
+                        print('end test')
+                        assert 0
+                """
+        )
+
+    def test_capturing(self, pytester: pytest.Pytester) -> None:
+        self.create_file(pytester)
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines(
+            [
+                "*__ test (i='A') __*",
+                "*Captured stdout call*",
+                "hello stdout A",
+                "*Captured stderr call*",
+                "hello stderr A",
+                "*__ test (i='B') __*",
+                "*Captured stdout call*",
+                "hello stdout B",
+                "*Captured stderr call*",
+                "hello stderr B",
+                "*__ test __*",
+                "*Captured stdout call*",
+                "start test",
+                "end test",
+            ]
+        )
+
+    def test_no_capture(self, pytester: pytest.Pytester) -> None:
+        self.create_file(pytester)
+        result = pytester.runpytest("-s")
+        result.stdout.fnmatch_lines(
+            [
+                "start test",
+                "hello stdout A",
+                "uhello stdout B",
+                "uend test",
+                "*__ test (i='A') __*",
+                "*__ test (i='B') __*",
+                "*__ test __*",
+            ]
+        )
+        result.stderr.fnmatch_lines(["hello stderr A", "hello stderr B"])
+
+    @pytest.mark.parametrize("fixture", ["capsys", "capfd"])
+    def test_capture_with_fixture(
+        self, pytester: pytest.Pytester, fixture: Literal["capsys", "capfd"]
+    ) -> None:
+        pytester.makepyfile(
+            rf"""
+            import sys
+
+            def test(subtests, {fixture}):
+                print('start test')
+
+                with subtests.test(i='A'):
+                    print("hello stdout A")
+                    print("hello stderr A", file=sys.stderr)
+
+                out, err = {fixture}.readouterr()
+                assert out == 'start test\nhello stdout A\n'
+                assert err == 'hello stderr A\n'
+            """
+        )
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines(
+            [
+                "*1 passed*",
+            ]
+        )
+
+
+class TestLogging:
+    def create_file(self, pytester: pytest.Pytester) -> None:
+        pytester.makepyfile(
+            """
+            import logging
+
+            def test_foo(subtests):
+                logging.info("before")
+
+                with subtests.test("sub1"):
+                    print("sub1 stdout")
+                    logging.info("sub1 logging")
+
+                with subtests.test("sub2"):
+                    print("sub2 stdout")
+                    logging.info("sub2 logging")
+                    assert False
+            """
+        )
+
+    def test_capturing(self, pytester: pytest.Pytester) -> None:
+        self.create_file(pytester)
+        result = pytester.runpytest("--log-level=INFO")
+        result.stdout.fnmatch_lines(
+            [
+                "*___ test_foo [[]sub2[]] __*",
+                "*-- Captured stdout call --*",
+                "sub2 stdout",
+                "*-- Captured log call ---*",
+                "INFO     root:test_capturing.py:12 sub2 logging",
+                "*== short test summary info ==*",
+            ]
+        )
+
+    def test_caplog(self, pytester: pytest.Pytester) -> None:
+        pytester.makepyfile(
+            """
+            import logging
+
+            def test(subtests, caplog):
+                caplog.set_level(logging.INFO)
+                logging.info("start test")
+
+                with subtests.test("sub1"):
+                    logging.info("inside %s", "subtest1")
+
+                assert len(caplog.records) == 2
+                assert caplog.records[0].getMessage() == "start test"
+                assert caplog.records[1].getMessage() == "inside subtest1"
+            """
+        )
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines(
+            [
+                "*1 passed*",
+            ]
+        )
+
+    def test_no_logging(self, pytester: pytest.Pytester) -> None:
+        pytester.makepyfile(
+            """
+            import logging
+
+            def test(subtests):
+                logging.info("start log line")
+
+                with subtests.test("sub passing"):
+                    logging.info("inside %s", "passing log line")
+
+                with subtests.test("sub failing"):
+                    logging.info("inside %s", "failing log line")
+                    assert False
+
+                logging.info("end log line")
+            """
+        )
+        result = pytester.runpytest("-p no:logging")
+        result.stdout.fnmatch_lines(
+            [
+                "*1 passed*",
+            ]
+        )
+        result.stdout.no_fnmatch_line("*root:test_no_logging.py*log line*")
+
+
+class TestDebugging:
+    """Check --pdb support for subtests fixture and TestCase.subTest."""
+
+    class _FakePdb:
+        """
+        Fake debugger class implementation that tracks which methods were called on it.
+        """
+
+        quitting: bool = False
+        calls: list[str] = []
+
+        def __init__(self, *_: object, **__: object) -> None:
+            self.calls.append("init")
+
+        def reset(self) -> None:
+            self.calls.append("reset")
+
+        def interaction(self, *_: object) -> None:
+            self.calls.append("interaction")
+
+    @pytest.fixture(autouse=True)
+    def cleanup_calls(self) -> None:
+        self._FakePdb.calls.clear()
+
+    def test_pdb_fixture(
+        self, pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pytester.makepyfile(
+            """
+            def test(subtests):
+                with subtests.test():
+                    assert 0
+            """
+        )
+        self.runpytest_and_check_pdb(pytester, monkeypatch)
+
+    def test_pdb_unittest(
+        self, pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pytester.makepyfile(
+            """
+            from unittest import TestCase
+            class Test(TestCase):
+                def test(self):
+                    with self.subTest():
+                        assert 0
+            """
+        )
+        self.runpytest_and_check_pdb(pytester, monkeypatch)
+
+    def runpytest_and_check_pdb(
+        self, pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Install the fake pdb implementation in _pytest.subtests so we can reference
+        # it in the command line (any module would do).
+        import _pytest.subtests
+
+        monkeypatch.setattr(
+            _pytest.subtests, "_CustomPdb", self._FakePdb, raising=False
+        )
+        result = pytester.runpytest("--pdb", "--pdbcls=_pytest.subtests:_CustomPdb")
+
+        # Ensure pytest entered in debugging mode when encountering the failing
+        # assert.
+        result.stdout.fnmatch_lines("*entering PDB*")
+        assert self._FakePdb.calls == ["init", "reset", "interaction"]
+
+
+def test_exitfirst(pytester: pytest.Pytester) -> None:
+    """
+    Validate that when passing --exitfirst the test exits after the first failed subtest.
+    """
+    pytester.makepyfile(
+        """
+        def test_foo(subtests):
+            with subtests.test("sub1"):
+                assert False
+
+            with subtests.test("sub2"):
+                assert False
+        """
+    )
+    result = pytester.runpytest("--exitfirst")
+    assert result.parseoutcomes()["failed"] == 2
+    result.stdout.fnmatch_lines(
+        [
+            "*[[]sub1[]] SUBFAIL test_exitfirst.py::test_foo - assert False*",
+            "FAILED test_exitfirst.py::test_foo - assert False",
+            "* stopping after 2 failures*",
+        ],
+        consecutive=True,
+    )
+    result.stdout.no_fnmatch_line("*sub2*")  # sub2 not executed.


### PR DESCRIPTION


This PR copies the files from `pytest-subtests` and performs minimal integration.
I'm opening this to gauge whether everyone is on board with integrating this feature into the core.

## Why?

### Pros
* `subtests` is a standard `unittest` feature, so it makes sense for pytest to support it as well.
* Provides a simple alternative to parametrization.
* Adds the ability to generate new test cases at runtime during the test execution, which is not possible with parametrization.
* While it can exist as an external plugin, it requires many hacks, and better report integration is not easily achievable without core integration (off the top of my head: issues with terminal reporting, last failed and stepwise support, among others).

### Cons
* Adds another maintenance burden to the core.

## TODO

If everyone is on board, I will take the time this week to polish it and get it ready to merge ASAP:

* **Cleanup the implementation**: Currently it relies on monkey-patching, which should no longer be needed since we can modify the core code directly.
* **Documentation**: The feature should be documented as experimental -- meaning that while the feature itself is solid, we are still working out details such as how to best report subtest failures, integration with other plugins, etc.
* **Fix lint and testing failures** (obviously).

## Related
* #1367
* https://github.com/pytest-dev/pytest-subtests/issues/71