### PR TITLE
doc: Remove cancelled training

### DIFF
--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -2,7 +2,6 @@
 
 .. sidebar:: **Next Open Trainings and Events**
 
-    - `Testen mit pytest <https://www.letsboot.ch/kurs/pytest>`_ (German), via `Letsboot <https://www.letsboot.ch/>`_ (3 day in-depth training), **October 29th -- 31st**, Zurich (CH)
     - `Professional Testing with Python <https://python-academy.com/courses/python_course_testing.html>`_, via `Python Academy <https://www.python-academy.com/>`_ (3 day in-depth training), **March 3th -- 5th 2026**, Leipzig (DE) / Remote
 
     Also see :doc:`previous talks and blogposts <talks>`


### PR DESCRIPTION
Unfortunately we had to cancel the training as there were no sign-ups.