### PR TITLE
Add feauture of parametrize declaration order #13223

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -135,6 +135,7 @@ Dheeraj C K
 Dhiren Serai
 Diego Russo
 Dima Gerasimov
+Dionisia Koronellou
 Dmitry Dygalo
 Dmitry Pribysh
 Dominic Mortlock

--- a/changelog/13223.feature.rst
+++ b/changelog/13223.feature.rst
@@ -1,0 +1,3 @@
+Add `parametrize_order` config option to control the order of multiple parametrize marks.
+
+By default, stacked `@pytest.mark.parametrize` decorators are applied in application order (from bottom to top). With this new config option set to `declaration`, they are applied in the order they are declared in the source code, which can make test case generation more intuitive.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1264,6 +1264,11 @@ class Config:
             type="args",
             default=[],
         )
+        self._parser.addini(
+            "parametrize_order",
+            "Order for stacked parametrize marks: 'application' (default) or 'declaration'",
+            default="application",
+        )
         self._override_ini = ns.override_ini or ()
 
     def _consider_importhook(self, args: Sequence[str]) -> None:

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -281,7 +281,9 @@ class PyobjMixin(nodes.Node):
             # XXX evil hack
             # used to avoid Function marker duplication
             if self._ALLOW_MARKERS:
-                self.own_markers.extend(get_unpacked_marks(self.obj))
+                self.own_markers.extend(
+                    get_unpacked_marks(self.obj, config=self.config)
+                )
                 # This assumes that `obj` is called before there is a chance
                 # to add custom keys to `self.keywords`, so no fear of overriding.
                 self.keywords.update((mark.name, mark) for mark in self.own_markers)
@@ -1598,7 +1600,7 @@ class Function(PyobjMixin, nodes.Item):
         # Note: when FunctionDefinition is introduced, we should change ``originalname``
         # to a readonly property that returns FunctionDefinition.name.
 
-        self.own_markers.extend(get_unpacked_marks(self.obj))
+        self.own_markers.extend(get_unpacked_marks(self.obj, config=self.config))
         if callspec:
             self.callspec = callspec
             self.own_markers.extend(callspec.marks)


### PR DESCRIPTION
This pull request closes #13223 and #5621 by introducing support for controlling the order of stacked `@pytest.mark.parametrize` decorators using the `parametrize_order` option in `pytest.ini`. By setting this option to "declaration", the parameter sets are applied in the order they are written in the source code, rather than the default application order (bottom to top for python decorators). The implementation includes updates to the mark handling logic. The PR also adds a test verifying the order of applied parameters, decorators and proper integration with existing pytest functionality. 