### PR TITLE
[ruff configuration] Fix legacy alias and top-level linter settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: "v0.13.1"
   hooks:
-    - id: ruff
+    - id: ruff-check
       args: ["--fix"]
     - id: ruff-format
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/doc/en/example/.ruff.toml
+++ b/doc/en/example/.ruff.toml
@@ -1,1 +1,1 @@
-ignore = ["RUF059"]
+lint.ignore = ["RUF059"]


### PR DESCRIPTION
This isn't seen unless there's a ruff error locally.
