### PR TITLE
[refactor] Start using match case in 'assertrepr_compare'

### DIFF
--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -162,11 +162,7 @@ def assertrepr_compare(
                 )
             case (str(), "not in", str()):
                 source = _notin_text(left, right, verbose, truncation_budget)
-            case (
-                AbstractSet(),
-                "!=" | ">=" | "<=" | ">" | "<",
-                AbstractSet(),
-            ):
+            case (AbstractSet(), "!=" | ">=" | "<=" | ">" | "<", AbstractSet()):
                 source = SET_COMPARISON_FUNCTIONS[op](left, right, highlighter, verbose)
             case _:
                 source = iter(())

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from collections.abc import Iterator
 from collections.abc import Sequence
+from collections.abc import Set as AbstractSet
 from unicodedata import normalize
 
 from _pytest import outcomes
@@ -14,8 +15,6 @@ from _pytest._io.saferepr import saferepr
 from _pytest._io.saferepr import saferepr_unlimited
 from _pytest.assertion._compare_any import _compare_eq_any
 from _pytest.assertion._compare_set import SET_COMPARISON_FUNCTIONS
-from _pytest.assertion._guards import isset
-from _pytest.assertion._guards import istext
 from _pytest.assertion._typing import _AssertionTextDiffStyle
 from _pytest.assertion._typing import _HighlightFunc
 from _pytest.assertion._typing import NO_TRUNCATION_BUDGET
@@ -151,21 +150,26 @@ def assertrepr_compare(
     summary = f"{left_repr} {op} {right_repr}"
 
     try:
-        if op == "==":
-            source = _compare_eq_any(
-                left,
-                right,
-                highlighter,
-                verbose,
-                assertion_text_diff_style,
-                truncation_budget,
-            )
-        elif op == "not in" and istext(left) and istext(right):
-            source = _notin_text(left, right, verbose, truncation_budget)
-        elif op in {"!=", ">=", "<=", ">", "<"} and isset(left) and isset(right):
-            source = SET_COMPARISON_FUNCTIONS[op](left, right, highlighter, verbose)
-        else:
-            source = iter(())
+        match (left, op, right):
+            case (_, "==", _):
+                source = _compare_eq_any(
+                    left,
+                    right,
+                    highlighter,
+                    verbose,
+                    assertion_text_diff_style,
+                    truncation_budget,
+                )
+            case (str(), "not in", str()):
+                source = _notin_text(left, right, verbose, truncation_budget)
+            case (
+                AbstractSet(),
+                "!=" | ">=" | "<=" | ">" | "<",
+                AbstractSet(),
+            ):
+                source = SET_COMPARISON_FUNCTIONS[op](left, right, highlighter, verbose)
+            case _:
+                source = iter(())
 
         # Only yield the summary if there is a detailed explanation.
         # Make sure there's a separating empty line after the summary.


### PR DESCRIPTION
Following https://github.com/pytest-dev/pytest/pull/13727, there's some potential for match in ``assertrepr_compare`` (a lot of isinstance check are hidden inside helper function like isset isttxt, issequence, etc), and maybe some refactor to do to be able to benefit from it (in the case of set here it's to avoid creating the dict at runtime). I'm starting small, but I think it's possible to do more later.

It might be beneficial to extract function from util.py into _compare_cls.py, _compare_dict.py, _compare_iterable.py, _compare_sequence.py, _compare_set.py, _compare_str.py, assertrepr_compare.py, and format_explanation.py first, let me know if you want me to do that so that the initial match refactor PR is more focused. If I don't do that, it's better to review this PR by hiding white spaces and commit by commit.



