### PR TITLE
Only enable CI mode is `$CI` or `$BUILD_NUMBER` is set to a non-empty string

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -227,6 +227,7 @@ Jon Parise
 Jon Sonesen
 Jonas Obrist
 Jordan Guymon
+Jordan Macdonald
 Jordan Moldow
 Jordan Speicher
 Joseph Hunkeler

--- a/changelog/13766.breaking.rst
+++ b/changelog/13766.breaking.rst
@@ -1,0 +1,2 @@
+Previously, pytest would assume it was running in a CI/CD environment if either of the environment variables `$CI` or `$BUILD_NUMBER` was defined;
+now, CI mode is only activated if at least one of those variables is defined and set to a *non-empty* value.

--- a/doc/en/explanation/ci.rst
+++ b/doc/en/explanation/ci.rst
@@ -17,8 +17,7 @@ adapt some of its behaviours.
 How CI is detected
 ------------------
 
-Pytest knows it is in a CI environment when either one of these environment variables are set,
-regardless of their value:
+Pytest knows it is in a CI environment when either one of these environment variables are set to a non-empty value:
 
 * `CI`: used by many CI systems.
 * `BUILD_NUMBER`: used by Jenkins.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1165,11 +1165,11 @@ Environment variables that can be used to change pytest's behavior.
 
 .. envvar:: CI
 
-When set (regardless of value), pytest acknowledges that is running in a CI process. Alternative to ``BUILD_NUMBER`` variable. See also :ref:`ci-pipelines`.
+When set to a non-empty value, pytest acknowledges that is running in a CI process. See also :ref:`ci-pipelines`.
 
 .. envvar:: BUILD_NUMBER
 
-When set (regardless of value), pytest acknowledges that is running in a CI process. Alternative to CI variable. See also :ref:`ci-pipelines`.
+When set to a non-empty value, pytest acknowledges that is running in a CI process. Alternative to :envvar:`CI`. See also :ref:`ci-pipelines`.
 
 .. envvar:: PYTEST_ADDOPTS
 
@@ -2408,7 +2408,7 @@ All the command-line flags can be obtained by running ``pytest --help``::
                             Plugins that must be present for pytest to run
 
     Environment variables:
-      CI                       When set (regardless of value), pytest knows it is running in a CI process and does not truncate summary info
+      CI                       When set to a non-empty value, pytest knows it is running in a CI process and does not truncate summary info
       BUILD_NUMBER             Equivalent to CI
       PYTEST_ADDOPTS           Extra command line options
       PYTEST_PLUGINS           Comma-separated plugins to load during startup

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -308,5 +308,6 @@ class CallableBool:
 
 def running_on_ci() -> bool:
     """Check if we're currently running on a CI system."""
+    # Only enable CI mode if one of these env variables is defined and non-empty.
     env_vars = ["CI", "BUILD_NUMBER"]
-    return any(var in os.environ for var in env_vars)
+    return any(os.environ.get(var) for var in env_vars)

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -221,7 +221,7 @@ def showhelp(config: Config) -> None:
     vars = [
         (
             "CI",
-            "When set (regardless of value), pytest knows it is running in a "
+            "When set to a non-empty value, pytest knows it is running in a "
             "CI process and does not truncate summary info",
         ),
         ("BUILD_NUMBER", "Equivalent to CI"),

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -567,6 +567,11 @@ class TestAssert_reprcompare:
         result = pytester.runpytest()
         result.stdout.fnmatch_lines(["E         Full diff:"])
 
+        # Setting CI to empty string is same as having it undefined
+        monkeypatch.setenv("CI", "")
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines(["E         Use -v to get more diff"])
+
         monkeypatch.delenv("CI", raising=False)
         result = pytester.runpytest()
         result.stdout.fnmatch_lines(["E         Use -v to get more diff"])
@@ -1464,6 +1469,17 @@ class TestTruncateExplanation:
 
         result = pytester.runpytest("-vv")
         result.stdout.fnmatch_lines(["* 6*"])
+
+        # Setting CI to empty string is same as having it undefined
+        monkeypatch.setenv("CI", "")
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines(
+            [
+                "*+ 1*",
+                "*+ 3*",
+                f"*truncated ({expected_truncated_lines} lines hidden)*use*-vv*",
+            ]
+        )
 
         monkeypatch.setenv("CI", "1")
         result = pytester.runpytest()

--- a/testing/test_faulthandler.py
+++ b/testing/test_faulthandler.py
@@ -79,7 +79,7 @@ def test_disabled(pytester: Pytester) -> None:
         pytest.param(
             True,
             marks=pytest.mark.skipif(
-                "CI" in os.environ
+                bool(os.environ.get("CI"))
                 and sys.platform == "linux"
                 and sys.version_info >= (3, 14),
                 reason="sometimes crashes on CI because of truncated outputs (#7022)",


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [ X Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
Previously, if either `$CI` or `$BUILD_NUMBER` was defined, CI mode would be activated, even if the variable was set to the empty string. This had some unfortunate consequences:
* The easy and obvious method of setting those variables, i.e. `CI="${OTHER_VAR}"`, would not work, because `$CI` would always end up being defined even if `$OTHER_VAR` was undefined.
* The easy and obvious method of clearing those variables at runtime, i.e. `CI="" pytest ...`, would not work, because again `$CI` would still be defined even though it was blank.
    
Now, at least one of those variables must be set to a _non-empty_ string in order to enable CI mode.
  
Closes #13766