### PR TITLE
Change PytestRemovedIn9Warning to error by default

### DIFF
--- a/changelog/13779.breaking.rst
+++ b/changelog/13779.breaking.rst
@@ -1,0 +1,22 @@
+**PytestRemovedIn9Warning deprecation warnings are now errors by default.**
+
+Following our plan to remove deprecated features with as little disruption as
+possible, all warnings of type ``PytestRemovedIn9Warning`` now generate errors
+instead of warning messages by default.
+
+**The affected features will be effectively removed in pytest 9.1**, so please consult the
+:ref:`deprecations` section in the docs for directions on how to update existing code.
+
+In the pytest ``9.0.X`` series, it is possible to change the errors back into warnings as a
+stopgap measure by adding this to your ``pytest.ini`` file:
+
+.. code-block:: ini
+
+    [pytest]
+    filterwarnings =
+        ignore::pytest.PytestRemovedIn9Warning
+
+But this will stop working when pytest ``9.1`` is released.
+
+**If you have concerns** about the removal of a specific feature, please add a
+comment to :issue:`13779`.

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -27,8 +27,7 @@ DEPRECATED_EXTERNAL_PLUGINS = {
 }
 
 
-# This can be* removed pytest 8, but it's harmless and common, so no rush to remove.
-# * If you're in the future: "could have been".
+# This could have been removed pytest 8, but it's harmless and common, so no rush to remove.
 YIELD_FIXTURE = PytestDeprecationWarning(
     "@pytest.yield_fixture is deprecated.\n"
     "Use @pytest.fixture instead; they are the same."

--- a/src/_pytest/warning_types.py
+++ b/src/_pytest/warning_types.py
@@ -56,6 +56,12 @@ class PytestRemovedIn9Warning(PytestDeprecationWarning):
     __module__ = "pytest"
 
 
+class PytestRemovedIn10Warning(PytestDeprecationWarning):
+    """Warning class for features that will be removed in pytest 10."""
+
+    __module__ = "pytest"
+
+
 @final
 class PytestExperimentalApiWarning(PytestWarning, FutureWarning):
     """Warning category used to denote experiments in pytest.

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -41,8 +41,7 @@ def catch_warnings_for_item(
             warnings.filterwarnings("always", category=DeprecationWarning)
             warnings.filterwarnings("always", category=PendingDeprecationWarning)
 
-        # To be enabled in pytest 9.0.0.
-        # warnings.filterwarnings("error", category=pytest.PytestRemovedIn9Warning)
+        warnings.filterwarnings("error", category=pytest.PytestRemovedIn9Warning)
 
         apply_warning_filters(config_filters, cmdline_filters)
 

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -82,6 +82,7 @@ from _pytest.warning_types import PytestDeprecationWarning
 from _pytest.warning_types import PytestExperimentalApiWarning
 from _pytest.warning_types import PytestFDWarning
 from _pytest.warning_types import PytestRemovedIn9Warning
+from _pytest.warning_types import PytestRemovedIn10Warning
 from _pytest.warning_types import PytestReturnNotNoneWarning
 from _pytest.warning_types import PytestUnhandledThreadExceptionWarning
 from _pytest.warning_types import PytestUnknownMarkWarning
@@ -133,6 +134,7 @@ __all__ = [
     "PytestFDWarning",
     "PytestPluginManager",
     "PytestRemovedIn9Warning",
+    "PytestRemovedIn10Warning",
     "PytestReturnNotNoneWarning",
     "PytestUnhandledThreadExceptionWarning",
     "PytestUnknownMarkWarning",

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1324,7 +1324,7 @@ def test_warning_on_sync_test_async_fixture(pytester: Pytester) -> None:
                     pass
         """
     )
-    result = pytester.runpytest()
+    result = pytester.runpytest("-Wdefault::pytest.PytestRemovedIn9Warning")
     result.stdout.fnmatch_lines(
         [
             "*== warnings summary ==*",
@@ -1354,7 +1354,7 @@ def test_warning_on_sync_test_async_fixture_gen(pytester: Pytester) -> None:
                 ...
         """
     )
-    result = pytester.runpytest()
+    result = pytester.runpytest("-Wdefault::pytest.PytestRemovedIn9Warning")
     result.stdout.fnmatch_lines(
         [
             "*== warnings summary ==*",
@@ -1388,7 +1388,7 @@ def test_warning_on_sync_test_async_autouse_fixture(pytester: Pytester) -> None:
                     pass
         """
     )
-    result = pytester.runpytest()
+    result = pytester.runpytest("-Wdefault::pytest.PytestRemovedIn9Warning")
     result.stdout.fnmatch_lines(
         [
             "*== warnings summary ==*",

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -562,7 +562,8 @@ class TestDeprecationWarningsByDefault:
         )
 
 
-@pytest.mark.skip("not relevant until pytest 9.0")
+# In 9.1, uncomment below and change RemovedIn9 -> RemovedIn10.
+# @pytest.mark.skip("not relevant until pytest 10.0")
 @pytest.mark.parametrize("change_default", [None, "ini", "cmdline"])
 def test_removed_in_x_warning_as_error(pytester: Pytester, change_default) -> None:
     """This ensures that PytestRemovedInXWarnings raised by pytest are turned into errors.


### PR DESCRIPTION
Per our backward compatibility policy.

Fix #13779