### PR TITLE
DEP: bump minimal requirements for iniconfig (1.0.0 -> 1.0.1) and packaging (20.0.0 -> 22.0.0)

### DIFF
--- a/changelog/13791.packaging.rst
+++ b/changelog/13791.packaging.rst
@@ -1,0 +1,2 @@
+Minimum requirements on ``iniconfig`` and ``packaging`` were bumped
+to ``1.0.1`` and ``22.0.0``, respectively.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,8 @@ dynamic = [
 dependencies = [
     "colorama>=0.4; sys_platform=='win32'",
     "exceptiongroup>=1; python_version<'3.11'",
-    "iniconfig>=1",
-    "packaging>=20",
+    "iniconfig>=1.0.1",
+    "packaging>=22",
     "pluggy>=1.5,<2",
     "pygments>=2.7.2",
     "tomli>=1; python_version<'3.11'",


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [N/A] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
-->


This is a quick follow up to #13317 to make it even easier for downstream packages to test with uv's `--resolution=lowest`:
- iniconfig 1.0.1 has a wheel, while 1.0.0 doesn't. It currently builds fine, but using a wheel makes it even less likely to break in the future (for instance if setuptools breaks building 1.0.0)
- packaging 22.0.0 is the first zero-dependency version, which avoids any incompatibilities with *its* dependencies, most importantly including `six`, which I think is bound to break one day or another.