### PR TITLE
Skip symlink sibling test on Windows without symlink support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -320,6 +320,7 @@ Mike Hoyle (hoylemd)
 Mike Lundy
 Milan Lesnek
 Miro Hrončok
+Mulat Mekonen
 mrbean-bremen
 Nathan Goldbaum
 Nathan Rousseau

--- a/changelog/13771.contrib.rst
+++ b/changelog/13771.contrib.rst
@@ -1,0 +1,1 @@
+Skip `test_do_not_collect_symlink_siblings` on Windows environments without symlink support to avoid false negatives.

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -1871,7 +1871,8 @@ def test_do_not_collect_symlink_siblings(
     """
     # Use tmp_path because it creates a symlink with the name "current" next to the directory it creates.
     symlink_path = tmp_path.parent / (tmp_path.name[:-1] + "current")
-    assert symlink_path.is_symlink() is True
+    if not symlink_path.is_symlink():  # pragma: no cover
+        pytest.skip("Symlinks not supported in this environment")
 
     # Create test file.
     tmp_path.joinpath("test_foo.py").write_text("def test(): pass", encoding="UTF-8")


### PR DESCRIPTION
### Summary

On Windows environments without Developer Mode or admin privileges,
symlink creation is not supported. This caused
`test_do_not_collect_symlink_siblings` to fail even though pytest
behavior was correct.

This patch adds a skip condition to avoid false negatives.

### Related issue
Closes #13771 

### Changelog
Added `changelog/12039.bugfix.rst`:
* Skip `test_do_not_collect_symlink_siblings` on Windows without symlink support.
