### PR TITLE
testing: fix warning from test

### DIFF
--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -440,7 +440,7 @@ def test_accept_unknown_category(pytester: Pytester) -> None:
             pass
     """
     )
-    result = pytester.runpytest("-W", "ignore::bizbaz.Bizbaz")
+    result = pytester.runpytest_subprocess("-W", "ignore::bizbaz.Bizbaz")
     result.stdout.fnmatch_lines(
         [
             f"*== {WARNINGS_SUMMARY_HEADER} ==*",


### PR DESCRIPTION
I'm not sure what's going on but the tested warning from the test somehow leaks into the actual top pytest. Run the test in a subprocess to fix this.

The warning can be seen in CI as well so it's not just me... https://github.com/pytest-dev/pytest/actions/runs/18288416121/job/52069453417#step:7:211