### PR TITLE
Deduplicate pythonwarnings to fix -W duplication

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1417,6 +1417,10 @@ class Config:
         self.known_args_namespace = self._parser.parse_known_args(
             args, namespace=copy.copy(self.known_args_namespace)
         )
+        
+        # Deduplicate pythonwarnings to fix duplicate -W entries
+        warnings = getattr(self.known_args_namespace, "pythonwarnings", [])
+        self.known_args_namespace.pythonwarnings = list(dict.fromkeys(warnings)
 
         self._validate_plugins()
         self._warn_about_skipped_plugins()

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1417,7 +1417,7 @@ class Config:
         self.known_args_namespace = self._parser.parse_known_args(
             args, namespace=copy.copy(self.known_args_namespace)
         )
-        
+
         # Deduplicate pythonwarnings to fix duplicate -W entries
         warnings = getattr(self.known_args_namespace, "pythonwarnings", [])
         self.known_args_namespace.pythonwarnings = list(dict.fromkeys(warnings)


### PR DESCRIPTION
Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.


What this PR does:

This PR adds deduplication step after the second command-line argument parse in _pytest/config/__init__.py to ensure that --pythonwarnings (-W) values are unique.


closes #13484 

Who can review:
@bluetech @nicoddemus @RonnyPfannschmidt 
