### PR TITLE
config: set `__module__ = "pytest"` on `UsageError` and `ExitCode`

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -110,6 +110,8 @@ class ExitCode(enum.IntEnum):
     #: pytest couldn't find tests.
     NO_TESTS_COLLECTED = 5
 
+    __module__ = "pytest"
+
 
 class ConftestImportFailure(Exception):
     def __init__(

--- a/src/_pytest/config/exceptions.py
+++ b/src/_pytest/config/exceptions.py
@@ -7,6 +7,8 @@ from typing import final
 class UsageError(Exception):
     """Error in pytest usage or invocation."""
 
+    __module__ = "pytest"
+
 
 class PrintHelp(Exception):
     """Raised when pytest should print its help to skip the rest of the


### PR DESCRIPTION
These types occasionally get displayed by their qualified name, let's make it nicer using the user-facing path.