### PR TITLE
config: `freeze_support` is not a plugin, remove from `default_plugins`

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -269,7 +269,6 @@ default_plugins = (
     "junitxml",
     "doctest",
     "cacheprovider",
-    "freeze_support",
     "setuponly",
     "setupplan",
     "stepwise",


### PR DESCRIPTION
There is no need to inspect this module as a plugin, it only contains an API function.