### PR TITLE
Set `__module__ = "pytest"` on most public types

### DIFF
--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -406,7 +406,7 @@ The :fixture:`recwarn` fixture will record warnings for the whole function:
         assert w.lineno
 
 Both the :fixture:`recwarn` fixture and the :func:`pytest.warns` context manager return the same interface for recorded
-warnings: a :class:`~_pytest.recwarn.WarningsRecorder` instance. To view the recorded warnings, you can
+warnings: a :class:`~pytest.WarningsRecorder` instance. To view the recorded warnings, you can
 iterate over this instance, call ``len`` on it to get the number of recorded
 warnings, or index into it to get a particular recorded warning.
 

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -1107,7 +1107,7 @@ could handle it by adding something like this to the test file:
 Fixtures can introspect the requesting test context
 -------------------------------------------------------------
 
-Fixture functions can accept the :py:class:`request <_pytest.fixtures.FixtureRequest>` object
+Fixture functions can accept the :py:class:`request <pytest.FixtureRequest>` object
 to introspect the "requesting" test function, class or module context.
 Further extending the previous ``smtp_connection`` fixture example, let's
 read an optional server URL from the test module which uses our fixture:
@@ -1180,7 +1180,7 @@ from the module namespace.
 Using markers to pass data to fixtures
 -------------------------------------------------------------
 
-Using the :py:class:`request <_pytest.fixtures.FixtureRequest>` object, a fixture can also access
+Using the :py:class:`request <pytest.FixtureRequest>` object, a fixture can also access
 markers which are applied to a test function. This can be useful to pass data
 into a fixture from a test:
 

--- a/doc/en/how-to/writing_plugins.rst
+++ b/doc/en/how-to/writing_plugins.rst
@@ -456,5 +456,4 @@ in our ``pytest.ini`` to tell pytest where to look for example files.
     ============================ 2 passed in 0.12s =============================
 
 For more information about the result object that ``runpytest()`` returns, and
-the methods that it provides please check out the :py:class:`RunResult
-<_pytest.pytester.RunResult>` documentation.
+the methods that it provides please check out the :class:`~pytest.RunResult` documentation.

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -917,6 +917,8 @@ class CaptureFixture(Generic[AnyStr]):
     """Object returned by the :fixture:`capsys`, :fixture:`capsysbinary`,
     :fixture:`capfd` and :fixture:`capfdbinary` fixtures."""
 
+    __module__ = "pytest"
+
     def __init__(
         self,
         captureclass: type[CaptureBase[AnyStr]],

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -403,6 +403,8 @@ class PytestPluginManager(PluginManager):
     * ``conftest.py`` loading during start-up.
     """
 
+    __module__ = "pytest"
+
     def __init__(self) -> None:
         from _pytest.assertion import DummyRewriteHook
         from _pytest.assertion import RewriteHook
@@ -980,6 +982,8 @@ class Config:
         Object containing parameters regarding the :func:`pytest.main`
         invocation.
     """
+
+    __module__ = "pytest"
 
     @final
     @dataclasses.dataclass(frozen=True)

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -36,6 +36,8 @@ class Parser:
         there's an error processing the command line arguments.
     """
 
+    __module__ = "pytest"
+
     prog: str | None = None
 
     def __init__(
@@ -369,6 +371,8 @@ class Argument:
 
 class OptionGroup:
     """A group of options shown in its own section."""
+
+    __module__ = "pytest"
 
     def __init__(
         self,

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -249,6 +249,8 @@ def _get_runner(
 
 
 class DoctestItem(Item):
+    __module__ = "pytest"
+
     def __init__(
         self,
         name: str,

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -366,6 +366,8 @@ class FixtureRequest(abc.ABC):
     ``param`` attribute in case the fixture is parametrized.
     """
 
+    __module__ = "pytest"
+
     def __init__(
         self,
         pyfuncitem: Function,
@@ -801,6 +803,8 @@ class SubRequest(FixtureRequest):
 class FixtureLookupError(LookupError):
     """Could not return a requested fixture (missing or invalid)."""
 
+    __module__ = "pytest"
+
     def __init__(
         self, argname: str | None, request: FixtureRequest, msg: str | None = None
     ) -> None:
@@ -963,6 +967,8 @@ class FixtureDef(Generic[FixtureValue]):
     Note: At this time, only explicitly documented fields and methods are
     considered public stable API.
     """
+
+    __module__ = "pytest"
 
     def __init__(
         self,

--- a/src/_pytest/legacypath.py
+++ b/src/_pytest/legacypath.py
@@ -47,6 +47,8 @@ class Testdir:
     to `legacy_path` objects as necessary.
     """
 
+    __module__ = "pytest"
+
     __test__ = False
 
     CLOSE_STDIN: Final = Pytester.CLOSE_STDIN

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -404,6 +404,8 @@ class LogCaptureHandler(logging_StreamHandler):
 class LogCaptureFixture:
     """Provides access and control of log capturing."""
 
+    __module__ = "pytest"
+
     def __init__(self, item: nodes.Node, *, _ispytest: bool = False) -> None:
         check_ispytest(_ispytest)
         self._item = item

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -506,6 +506,8 @@ class Dir(nodes.Directory):
         collectors.
     """
 
+    __module__ = "pytest"
+
     @classmethod
     def from_parent(  # type: ignore[override]
         cls,
@@ -551,6 +553,8 @@ class Session(nodes.Collector):
 
     ``Session`` collects the initial paths given as arguments to pytest.
     """
+
+    __module__ = "pytest"
 
     Interrupted = Interrupted
     Failed = Failed

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -546,6 +546,8 @@ class MarkGenerator:
     applies a 'slowtest' :class:`Mark` on ``test_function``.
     """
 
+    __module__ = "pytest"
+
     # See TYPE_CHECKING above.
     if TYPE_CHECKING:
         skip: _SkipMarkDecorator

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -129,6 +129,8 @@ class MonkeyPatch:
         :meth:`undo` explicitly.
     """
 
+    __module__ = "pytest"
+
     def __init__(self) -> None:
         self._setattr: list[tuple[object, str, object]] = []
         self._setitem: list[tuple[Mapping[Any, Any], object, object]] = []

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -126,8 +126,8 @@ class NodeMeta(abc.ABCMeta):
 
 
 class Node(abc.ABC, metaclass=NodeMeta):
-    r"""Base class of :class:`Collector` and :class:`Item`, the components of
-    the test collection tree.
+    r"""Base class of :class:`~pytest.Collector` and :class:`~pytest.Item`,
+    the components of the test collection tree.
 
     ``Collector``\'s are the internal nodes of the tree, and ``Item``\'s are the
     leaf nodes.
@@ -503,6 +503,8 @@ class Collector(Node, abc.ABC):
     the collection tree.
     """
 
+    __module__ = "pytest"
+
     class CollectError(Exception):
         """An error during collection, contains a custom message."""
 
@@ -633,6 +635,8 @@ class File(FSCollector, abc.ABC):
     :ref:`non-python tests`.
     """
 
+    __module__ = "pytest"
+
 
 class Directory(FSCollector, abc.ABC):
     """Base class for collecting files from a directory.
@@ -651,12 +655,16 @@ class Directory(FSCollector, abc.ABC):
     :ref:`custom directory collectors`.
     """
 
+    __module__ = "pytest"
+
 
 class Item(Node, abc.ABC):
     """Base class of all test invocation items.
 
     Note that for a single function there might be multiple test invocation items.
     """
+
+    __module__ = "pytest"
 
     nextitem = None
 

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -231,6 +231,8 @@ class RecordedHookCall:
         assert calls[0].item is an_item
     """
 
+    __module__ = "pytest"
+
     def __init__(self, name: str, kwargs) -> None:
         self.__dict__.update(kwargs)
         self._name = name
@@ -254,6 +256,8 @@ class HookRecorder:
     This wraps all the hook calls in the plugin manager, recording each call
     before propagating the normal calls.
     """
+
+    __module__ = "pytest"
 
     def __init__(
         self, pluginmanager: PytestPluginManager, *, _ispytest: bool = False
@@ -518,6 +522,8 @@ rex_outcome = re.compile(r"(\d+) (\w+)")
 class RunResult:
     """The result of running a command from :class:`~pytest.Pytester`."""
 
+    __module__ = "pytest"
+
     def __init__(
         self,
         ret: int | ExitCode,
@@ -654,6 +660,8 @@ class Pytester:
     It attempts to isolate the test run from external factors as much as possible, modifying
     the current working directory to :attr:`path` and environment variables during initialization.
     """
+
+    __module__ = "pytest"
 
     __test__ = False
 
@@ -1221,7 +1229,7 @@ class Pytester:
         """Return a new pytest :class:`pytest.Config` instance from given
         commandline args.
 
-        This invokes the pytest bootstrapping code in _pytest.config to create a
+        This invokes the pytest bootstrapping code to create a
         new :py:class:`pytest.PytestPluginManager` and call the
         :hook:`pytest_cmdline_parse` hook to create a new :class:`pytest.Config`
         instance.
@@ -1564,6 +1572,8 @@ class LineMatcher:
     The constructor takes a list of lines without their trailing newlines, i.e.
     ``text.splitlines()``.
     """
+
+    __module__ = "pytest"
 
     def __init__(self, lines: list[str]) -> None:
         self.lines = lines

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -547,6 +547,8 @@ def importtestmodule(
 class Module(nodes.File, PyCollector):
     """Collector for test classes and functions in a Python module."""
 
+    __module__ = "pytest"
+
     def _getobj(self):
         return importtestmodule(self.path, self.config)
 
@@ -642,6 +644,8 @@ class Package(nodes.Directory):
         Now inherits from :class:`~pytest.Directory`.
     """
 
+    __module__ = "pytest"
+
     def __init__(
         self,
         fspath: LEGACY_PATH | None,
@@ -735,6 +739,8 @@ def _get_first_non_fixture_func(obj: object, names: Iterable[str]) -> object | N
 
 class Class(PyCollector):
     """Collector for test methods (and nested classes) in a Python class."""
+
+    __module__ = "pytest"
 
     @classmethod
     def from_parent(cls, parent, *, name, obj=None, **kw) -> Self:  # type: ignore[override]
@@ -1124,6 +1130,8 @@ class Metafunc:
     test configuration or values specified in the class or module where a
     test function is defined.
     """
+
+    __module__ = "pytest"
 
     def __init__(
         self,
@@ -1565,6 +1573,8 @@ class Function(PyobjMixin, nodes.Item):
         for example when it contains decorations like those added by parametrization
         (``my_func[my_param]``).
     """
+
+    __module__ = "pytest"
 
     # Disable since functions handle it themselves.
     _ALLOW_MARKERS = False

--- a/src/_pytest/raises.py
+++ b/src/_pytest/raises.py
@@ -580,6 +580,8 @@ class RaisesExc(AbstractRaises[BaseExcT_co_default]):
             ...
     """
 
+    __module__ = "pytest"
+
     # Trio bundled hypothesis monkeypatching, we will probably instead assume that
     # hypothesis will handle that in their pytest plugin by the time this is released.
     # Alternatively we could add a version of get_pretty_function_description ourselves
@@ -842,6 +844,8 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
         If installed and imported (in e.g. ``conftest.py``), the ``hypothesis`` library will
         monkeypatch this output to provide shorter & more readable repr's.
     """
+
+    __module__ = "pytest"
 
     # allow_unwrapped=True requires: singular exception, exception not being
     # RaisesGroup instance, match is None, check is None

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -32,7 +32,7 @@ T = TypeVar("T")
 
 @fixture
 def recwarn() -> Generator[WarningsRecorder]:
-    """Return a :class:`WarningsRecorder` instance that records all warnings emitted by test functions.
+    """Return a :class:`~pytest.WarningsRecorder` instance that records all warnings emitted by test functions.
 
     See :ref:`warnings` for information on warning categories.
     """
@@ -179,6 +179,8 @@ class WarningsRecorder(warnings.catch_warnings):
         differently; see :ref:`ensuring_function_triggers`.
 
     """
+
+    __module__ = "pytest"
 
     def __init__(self, *, _ispytest: bool = False) -> None:
         check_ispytest(_ispytest)

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -259,6 +259,8 @@ class TestReport(BaseReport):
     Reports can contain arbitrary extra attributes.
     """
 
+    __module__ = "pytest"
+
     __test__ = False
 
     # Defined by skipping plugin.
@@ -402,6 +404,8 @@ class CollectReport(BaseReport):
 
     Reports can contain arbitrary extra attributes.
     """
+
+    __module__ = "pytest"
 
     when = "collect"
 

--- a/src/_pytest/stash.py
+++ b/src/_pytest/stash.py
@@ -23,6 +23,8 @@ class StashKey(Generic[T]):
     .. versionadded:: 7.0
     """
 
+    __module__ = "pytest"
+
     __slots__ = ()
 
 
@@ -66,6 +68,8 @@ class Stash:
 
     .. versionadded:: 7.0
     """
+
+    __module__ = "pytest"
 
     __slots__ = ("_storage",)
 

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -372,6 +372,8 @@ class WarningReport:
 
 @final
 class TerminalReporter:
+    __module__ = "pytest"
+
     def __init__(self, config: Config, file: TextIO | None = None) -> None:
         import _pytest.config
 


### PR DESCRIPTION
It doesn't seem possible to cleanly set it on dataclasses and namedtuple types, so skipped these for now.

Fix #13812.