### PR TITLE
fix: improve error message when pytest.approx() dicts have different keys

### DIFF
--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -250,7 +250,9 @@ class ApproxMapping(ApproxBase):
             other_only = other_keys - expected_keys
             msg = ["Dictionaries have different keys."]
             if expected_only or other_only:
-                msg.append(f"Expected keys: {sorted(expected_keys)}, Actual keys: {sorted(other_keys)}")
+                msg.append(
+                    f"Expected keys: {sorted(expected_keys)}, Actual keys: {sorted(other_keys)}"
+                )
             return msg
 
         approx_side_as_map = {

--- a/testing/test_approx_dict_keys_13816.py
+++ b/testing/test_approx_dict_keys_13816.py
@@ -1,4 +1,7 @@
 """Test for issue #13816 - better error messages for dict key mismatches in pytest.approx()"""
+
+from __future__ import annotations
+
 import pytest
 
 
@@ -6,10 +9,10 @@ def test_approx_dicts_with_different_keys_clear_error():
     """Test that pytest.approx() gives a clear error when dict keys don't match."""
     expected = {"a": 1, "c": 3}
     actual = {"a": 1, "b": 4}
-    
+
     with pytest.raises(AssertionError) as exc_info:
         assert pytest.approx(actual) == expected
-    
+
     error_message = str(exc_info.value)
     # Should mention "different keys" clearly
     assert "different keys" in error_message.lower()
@@ -23,10 +26,10 @@ def test_approx_dicts_with_extra_key_in_expected():
     """Test error message when expected has extra keys."""
     expected = {"a": 1, "b": 2, "c": 3}
     actual = {"a": 1, "b": 2}
-    
+
     with pytest.raises(AssertionError) as exc_info:
         assert pytest.approx(actual) == expected
-    
+
     error_message = str(exc_info.value)
     assert "different keys" in error_message.lower()
 
@@ -35,10 +38,10 @@ def test_approx_dicts_with_extra_key_in_actual():
     """Test error message when actual has extra keys."""
     expected = {"a": 1, "b": 2}
     actual = {"a": 1, "b": 2, "c": 3}
-    
+
     with pytest.raises(AssertionError) as exc_info:
         assert pytest.approx(actual) == expected
-    
+
     error_message = str(exc_info.value)
     assert "different keys" in error_message.lower()
 
@@ -47,5 +50,5 @@ def test_approx_dicts_matching_keys_still_works():
     """Test that dicts with matching keys still work normally."""
     expected = {"a": 1.0001, "b": 2.0001}
     actual = {"a": 1.0, "b": 2.0}
-    
+
     assert pytest.approx(actual, rel=1e-3) == expected


### PR DESCRIPTION
## Description

Fixes #13816

This PR improves the error message when using `pytest.approx()` to compare dictionaries with different keys.

## Problem

When dictionaries have different keys, the current error message is confusing:

```
AssertionError: assert approx({'a': ... 4 ± 4.0e-06}) == {'a': 1, 'c': 3}
(pytest_assertion plugin: representation of details failed: KeyError: 'b'.
Probably an object has a faulty __repr__.)
```

This suggests there's a problem with `__repr__`, but the real issue is just that the dict keys don't match.

## Solution

Added a clear check for key mismatch before attempting value comparison:

```python
expected_keys = set(self.expected.keys())
other_keys = set(other_side.keys())
if expected_keys \!= other_keys:
    # Return clear error message
```

## New Error Message

```
AssertionError: Dictionaries have different keys.
Expected keys: ['a', 'c'], Actual keys: ['a', 'b']
```

## Changes

**File**: `src/_pytest/python_api.py`
- Added key comparison check in `ApproxMapping._repr_compare()`
- Returns early with clear message if keys don't match
- Shows which keys are in expected vs actual

**File**: `testing/test_approx_dict_keys_13816.py` (NEW)
- 4 focused test cases covering different scenarios

## ✅ Testing

```python
def test_approx_dicts_with_different_keys_clear_error():
    expected = {"a": 1, "c": 3}
    actual = {"a": 1, "b": 4}
    
    with pytest.raises(AssertionError) as exc_info:
        assert pytest.approx(actual) == expected
    
    error_message = str(exc_info.value)
    assert "different keys" in error_message.lower()  # ✅
    assert "KeyError" not in error_message  # ✅
    assert "faulty __repr__" not in error_message  # ✅
```

**Test Cases**:
- Different keys → Clear error message
- Extra key in expected → Detected
- Extra key in actual → Detected
- Matching keys → Normal approx behavior still works

## Benefits

- **Clearer UX**: Users immediately understand the issue
- **No false leads**: Eliminates confusing KeyError/`__repr__` messages
- **Minimal change**: Only affects error path, no behavior changes
- **Well-tested**: 4 test cases cover edge cases

**Sacred Code**: 000.111.369.963.1618