### PR TITLE
config: add support for ini option aliases

### DIFF
--- a/changelog/13829.feature.rst
+++ b/changelog/13829.feature.rst
@@ -1,0 +1,5 @@
+Added support for ini option aliases via the ``aliases`` parameter in :meth:`Parser.addini() <pytest.Parser.addini>`.
+
+Plugins can now register alternative names for ini options,
+allowing for more flexibility in configuration naming and supporting backward compatibility when renaming options.
+The canonical name always takes precedence if both the canonical name and an alias are specified in the configuration file.

--- a/testing/test_findpaths.py
+++ b/testing/test_findpaths.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 from _pytest.config import UsageError
 from _pytest.config.findpaths import get_common_ancestor
 from _pytest.config.findpaths import get_dirs_from_args
+from _pytest.config.findpaths import IniValue
 from _pytest.config.findpaths import is_fs_root
 from _pytest.config.findpaths import load_config_dict_from_file
 import pytest
@@ -24,13 +25,13 @@ class TestLoadConfigDictFromFile:
         """[pytest] section in pytest.ini files is read correctly"""
         fn = tmp_path / "pytest.ini"
         fn.write_text("[pytest]\nx=1", encoding="utf-8")
-        assert load_config_dict_from_file(fn) == {"x": "1"}
+        assert load_config_dict_from_file(fn) == {"x": IniValue("1", "file")}
 
     def test_custom_ini(self, tmp_path: Path) -> None:
         """[pytest] section in any .ini file is read correctly"""
         fn = tmp_path / "custom.ini"
         fn.write_text("[pytest]\nx=1", encoding="utf-8")
-        assert load_config_dict_from_file(fn) == {"x": "1"}
+        assert load_config_dict_from_file(fn) == {"x": IniValue("1", "file")}
 
     def test_custom_ini_without_section(self, tmp_path: Path) -> None:
         """Custom .ini files without [pytest] section are not considered for configuration"""
@@ -48,7 +49,7 @@ class TestLoadConfigDictFromFile:
         """Custom .cfg files with [tool:pytest] section are read correctly"""
         fn = tmp_path / "custom.cfg"
         fn.write_text("[tool:pytest]\nx=1", encoding="utf-8")
-        assert load_config_dict_from_file(fn) == {"x": "1"}
+        assert load_config_dict_from_file(fn) == {"x": IniValue("1", "file")}
 
     def test_unsupported_pytest_section_in_cfg_file(self, tmp_path: Path) -> None:
         """.cfg files with [pytest] section are no longer supported and should fail to alert users"""
@@ -96,11 +97,11 @@ class TestLoadConfigDictFromFile:
             encoding="utf-8",
         )
         assert load_config_dict_from_file(fn) == {
-            "x": "1",
-            "y": "20.0",
-            "values": ["tests", "integration"],
-            "name": "foo",
-            "heterogeneous_array": [1, "str"],
+            "x": IniValue("1", "file"),
+            "y": IniValue("20.0", "file"),
+            "values": IniValue(["tests", "integration"], "file"),
+            "name": IniValue("foo", "file"),
+            "heterogeneous_array": IniValue([1, "str"], "file"),  # type: ignore[list-item]
         }
 
 


### PR DESCRIPTION
Fix #13829.

Currently based on #13830 -- please skip that commit.