### PR TITLE
Remove unintentionally-unconditional skips

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -203,7 +203,7 @@ Short version
 
 #. Write a ``changelog`` entry: ``changelog/2574.bugfix.rst``, use issue id number
    and one of ``feature``, ``improvement``, ``bugfix``, ``doc``, ``deprecation``,
-   ``breaking``, or ``vendor`` for the issue type.
+   ``breaking``, ``vendor``, ``packaging``, ``contrib``, or ``misc`` for the issue type.
 
 
 #. Unless your change is a trivial or a documentation fix (e.g., a typo or reword of a small section) please
@@ -305,7 +305,8 @@ Here is a simple overview, with pytest-specific bits:
 
 #. Create a new changelog entry in ``changelog``. The file should be named ``<issueid>.<type>.rst``,
    where *issueid* is the number of the issue related to the change and *type* is one of
-   ``feature``, ``improvement``, ``bugfix``, ``doc``, ``deprecation``, ``breaking``, or ``vendor``.
+   ``feature``, ``improvement``, ``bugfix``, ``doc``, ``deprecation``, ``breaking``, ``vendor``,
+   ``packaging``, ``contrib``, or ``misc``.
    You may skip creating the changelog entry if the change doesn't affect the
    documented behaviour of pytest.
 

--- a/changelog/13842.contrib.rst
+++ b/changelog/13842.contrib.rst
@@ -1,1 +1,0 @@
-Improve a few ``py`` tests.

--- a/testing/_py/test_local.py
+++ b/testing/_py/test_local.py
@@ -207,10 +207,9 @@ class CommonFSTests:
         assert "sampledir" in lst
         assert path1.sep.join(["sampledir", "otherfile"]) not in lst
 
-    @pytest.mark.parametrize("fil", ["*dir"])
-    def test_visit_filterfunc_is_string(self, path1, fil):
+    def test_visit_filterfunc_is_string(self, path1):
         lst = []
-        for i in path1.visit(fil):
+        for i in path1.visit("*dir"):
             lst.append(i.relto(path1))
         assert len(lst), 2  # noqa: PLC1802,RUF040
         assert "sampledir" in lst


### PR DESCRIPTION
`pytest.mark.skip("string condition")` always skips. I assume these were meant to be `pytest.mark.skipif`.

~~Do test-only fixes need a changelog entry?~~ (Yes, at least according to CI)