### PR TITLE
docs: fix misleading docstring about default vs skip=True in getoption

### DIFF
--- a/changelog/13879.doc.rst
+++ b/changelog/13879.doc.rst
@@ -1,0 +1,9 @@
+Clarified `pytest/Config.getoption` docstring to make the exceptional behavior of `default` with `skip=True` explicit.
+
+The previous docstring implied:
+
+- The `default` parameter is ignored when the option is declared.
+
+But actual behavior is:
+
+- The `default` is **not ignored** even if the option is declared, when `skip=True` and the option has `None` value.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1845,12 +1845,15 @@ class Config:
     def getoption(self, name: str, default: Any = notset, skip: bool = False):
         """Return command line option value.
 
-        :param name: Name of the option. You may also specify
-            the literal ``--OPT`` option instead of the "dest" option name.
-        :param default: Fallback value if no option of that name is **declared** via :hook:`pytest_addoption`.
-            Note this parameter will be ignored when the option is **declared** even if the option's value is ``None``.
-        :param skip: If ``True``, raise :func:`pytest.skip` if option is undeclared or has a ``None`` value.
-            Note that even if ``True``, if a default was specified it will be returned instead of a skip.
+        :param name:
+            Name of the option. You may also specify the literal ``--OPT`` option instead of the "dest" option name.
+        :param default:
+            Fallback value if the option is not available.
+            Ignored when the option has been declared (even if its value is ``None``), unless ``skip=True``.
+        :param skip:
+            If ``True``, call :func:`pytest.skip` if the option is undeclared or ``None``.
+            Note that when ``skip=True`` and the ``default`` parameter is provided (even ``None``),
+            the default value is returned instead of skipping.
         """
         name = self._opt2dest.get(name, name)
         try:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -768,6 +768,7 @@ class TestConfigAPI:
         assert config_novalue.getoption("hello") is None
         assert config_novalue.getoption("hello", default=1) is None
         assert config_novalue.getoption("hello", default=1, skip=True) == 1
+        assert config_novalue.getoption("hello", default=None, skip=True) is None
 
     def test_config_getoption_undeclared_option_name(self, pytester: Pytester) -> None:
         config = pytester.parseconfig()
@@ -775,6 +776,7 @@ class TestConfigAPI:
             config.getoption("x")
         assert config.getoption("x", default=1) == 1
         assert config.getoption("x", default=1, skip=True) == 1
+        assert config.getoption("x", default=None, skip=True) is None
 
     def test_config_getoption_unicode(self, pytester: Pytester) -> None:
         pytester.makeconftest(


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

This PR clarifies the `pytest.Config.getoption` docstring to make the exceptional behavior of `default` with `skip=True` explicit.

Also adds a small test verifying that behavior.

### Stituation before this change

The previous docstring implied:

- The `default` parameter is ignored when the option  is declared.

But actual behavior is:

- The `default` is **not ignored** even if the option is declared, when `skip=True` and the option has `None` value.

This can be reproduced by the following test case (already existing in [`testing/test_config.py`](https://github.com/pytest-dev/pytest/blob/76910ca669594849278a30bf6a943b4cd465fa05/testing/test_config.py#L770)):

```python
def test_config_getoption_declared_option_name(self, pytester: Pytester) -> None:
	pytester.makeconftest(
		"""
		def pytest_addoption(parser):
			parser.addoption("--hello", "-X", dest="hello")
	"""
	)
	config_novalue = pytester.parseconfig()
	assert config_novalue.getoption("hello", default=1, skip=True) == 1
```

### Rationale

The `getoption()` behavior involves multiple conditions (whether the option is declared or not, `None` or not, `default`, `skip`), which previously made the docstring easy to misinterpret. This PR avoids multiple "note that ..." caveats and keeps each parameter’s description self-contained and readable.

- The docstring now describes the `skip=True` special case in plain language.
- The misleading reference to the `pytest_addoption` hook was removed, since this method’s behavior is independent of how the option was added.
- The emphasis markup of `**declared**` was removed.
	- It was intended to hint that an option might be declared but still have a `None` value (context: #12886). The new wording states this condition explicitly.
- Clarify the case when `default=None` and `skip=True`.

### Notes
No behavior change;  documentation and test addition only.
Related historical issue: #10558
