### PR TITLE
Exclude parametrize pseudo-fixtures from --fixtures-per-test

### DIFF
--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1967,8 +1967,15 @@ def _show_fixtures_per_test(config: Config, session: Session) -> None:
         tw.sep("-", f"fixtures used by {item.name}")
         # TODO: Fix this type ignore.
         tw.sep("-", f"({get_best_relpath(item.function)})")  # type: ignore[attr-defined]
+
+        # Exclude parametrize pseudo-fixtures.
+        parametrize_args = _get_direct_parametrize_args(item)
+
         # dict key not used in loop but needed for sorting.
-        for _, fixturedefs in sorted(info.name2fixturedefs.items()):
+        for argname, fixturedefs in sorted(info.name2fixturedefs.items()):
+            # Skip parametrize arguments - they are not real fixtures.
+            if argname in parametrize_args:
+                continue
             assert fixturedefs is not None
             if not fixturedefs:
                 continue


### PR DESCRIPTION
Previously, `pytest --fixtures-per-test` would display parameter names from `@pytest.mark.parametrize` decorators as if they were real fixtures, showing them with "no docstring available" and pointing to internal pytest code (`_pytest/python.py`).

This fix uses the existing `_get_direct_parametrize_args()` function to identify and exclude these pseudo-fixtures from the `--fixtures-per-test` output, ensuring only actual user-defined fixtures are displayed.

### Example

**Before this fix:**
------------------ fixtures used by test_example[1] ------------------- real_fixture -- test_file.py:3 A real fixture. x -- .../_pytest/python.py:1110 ← Should not appear no docstring available


**After this fix:**
------------------ fixtures used by test_example[1] ------------------- real_fixture -- test_file.py:3 A real fixture.


### Changes

- Modified `_show_fixtures_per_test()` in `src/_pytest/fixtures.py` to filter out parametrize arguments
- Added regression test `test_parametrize_pseudo_fixtures_excluded` to verify pseudo-fixtures are excluded

Closes #11295

---

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->