### PR TITLE
ci: `gh release create` needs a checkout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,6 +120,11 @@ jobs:
     permissions:
       contents: write
     steps:
+    - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+        persist-credentials: true
+
     - name: Download Package
       uses: actions/download-artifact@v6
       with:


### PR DESCRIPTION
Not sure why, but it failed without one in CI:

```
$ gh release create --notes-file gh-release-notes.md --verify-tag "$VERSION" dist/*
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```