### PR TITLE
terminal: disable terminal progress plugin on iTerm2

### DIFF
--- a/changelog/13896.bugfix.rst
+++ b/changelog/13896.bugfix.rst
@@ -1,0 +1,1 @@
+The terminal progress plugin added in pytest 9.0 is now automatically disabled when iTerm2 is detected, it generated desktop notifications instead of the desired functionality.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -16,6 +16,7 @@ import dataclasses
 import datetime
 from functools import partial
 import inspect
+import os
 from pathlib import Path
 import platform
 import sys
@@ -299,8 +300,15 @@ def pytest_configure(config: Config) -> None:
         config.trace.root.setprocessor("pytest:config", mywriter)
 
     if reporter.isatty():
-        plugin = TerminalProgressPlugin(reporter)
-        config.pluginmanager.register(plugin, "terminalprogress")
+        # Some terminals interpret OSC 9;4 as desktop notification,
+        # skip on those we know (#13896).
+        should_skip_terminal_progress = (
+            # iTerm2 (reported on version 3.6.5).
+            "ITERM_SESSION_ID" in os.environ
+        )
+        if not should_skip_terminal_progress:
+            plugin = TerminalProgressPlugin(reporter)
+            config.pluginmanager.register(plugin, "terminalprogress")
 
 
 def getreportopt(config: Config) -> str:

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -3443,6 +3443,17 @@ class TestTerminalProgressPlugin:
             plugin = config.pluginmanager.get_plugin("terminalprogress")
             assert plugin is None
 
+    def test_disabled_for_iterm2(self, pytester: pytest.Pytester, monkeypatch) -> None:
+        """Should not register the plugin on iTerm2 terminal since it interprets
+        OSC 9;4 as desktop notifications, not progress (#13896)."""
+        monkeypatch.setenv(
+            "ITERM_SESSION_ID", "w0t1p0:3DB6DF06-FE11-40C3-9A66-9E10A193A632"
+        )
+        with patch.object(sys.stdout, "isatty", return_value=True):
+            config = pytester.parseconfigure()
+            plugin = config.pluginmanager.get_plugin("terminalprogress")
+            assert plugin is None
+
     @pytest.mark.parametrize(
         ["state", "progress", "expected"],
         [


### PR DESCRIPTION
Fix #13896