### PR TITLE
doc: fix toml type of verbosity options in API reference

### DIFF
--- a/changelog/13904.bugfix.rst
+++ b/changelog/13904.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the TOML type of the verbosity settings in the API reference from number to string.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -2596,7 +2596,7 @@ passed multiple times. The expected format is ``name=value``. For example::
         .. code-block:: toml
 
             [pytest]
-            verbosity_assertions = 2
+            verbosity_assertions = "2"
 
     .. tab:: ini
 
@@ -2618,7 +2618,7 @@ passed multiple times. The expected format is ``name=value``. For example::
         .. code-block:: toml
 
             [pytest]
-            verbosity_subtests = 1
+            verbosity_subtests = "1"
 
     .. tab:: ini
 
@@ -2645,7 +2645,7 @@ passed multiple times. The expected format is ``name=value``. For example::
         .. code-block:: toml
 
             [pytest]
-            verbosity_test_cases = 2
+            verbosity_test_cases = "2"
 
     .. tab:: ini
 


### PR DESCRIPTION
Fix #13904.