### PR TITLE
Access parametrization ids

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -70,6 +70,7 @@ Benjamin Schubert
 Bernard Pratz
 Bo Wu
 Bob Ippolito
+Brendan Cazier
 Brian Dorsey
 Brian Larsen
 Brian Maissy

--- a/changelog/13907.improvement.rst
+++ b/changelog/13907.improvement.rst
@@ -1,0 +1,1 @@
+Added a new attribute to the Callspec2 class with the stringified (either automatically or with an explicit `ids` parameter) ID of parametrization values.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1113,6 +1113,8 @@ class CallSpec2:
     _idlist: Sequence[str] = dataclasses.field(default_factory=tuple)
     # Marks which will be applied to the item.
     marks: list[Mark] = dataclasses.field(default_factory=list)
+    # Parametrization mapping for each argname to an ID.
+    ids: dict[str | tuple[str, ...], str] = dataclasses.field(default_factory=dict)
 
     def setmulti(
         self,
@@ -1142,6 +1144,14 @@ class CallSpec2:
             _arg2scope=arg2scope,
             _idlist=self._idlist if id is HIDDEN_PARAM else [*self._idlist, id],
             marks=[*self.marks, *normalize_mark_list(marks)],
+            ids=self.ids
+            if id is HIDDEN_PARAM
+            else {
+                **self.ids,
+                _argnames[0]
+                if len(_argnames := tuple(argnames)) == 1
+                else _argnames: id,
+            },
         )
 
     def getparam(self, name: str) -> object:

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1090,6 +1090,50 @@ def test_parameterset_for_parametrize_bad_markname(pytester: Pytester) -> None:
         test_parameterset_for_parametrize_marks(pytester, "bad")
 
 
+def test_parametrization_callspec_ids(pytester: Pytester):
+    pytester.makepyfile(
+        """
+import pytest
+
+class CustomClass:
+    pass
+
+def custom_function():
+    return None
+
+all_ids = [
+    {("tuple_one", "tuple_two"): "t1a-t2a", "id_function": "11", "id_explicit": "one", "name": "first"},
+    {("tuple_one", "tuple_two"): "t1a-t2a", "id_function": "11", "id_explicit": "one", "name": "2"},
+    {("tuple_one", "tuple_two"): "t1a-t2a", "id_function": "11", "id_explicit": "one", "name": "3.5"},
+    {("tuple_one", "tuple_two"): "t1a-t2a", "id_function": "11", "id_explicit": "one", "name": "True"},
+    {("tuple_one", "tuple_two"): "t1a-t2a", "id_function": "11", "id_explicit": "one", "name": "<lambda>"},
+    {("tuple_one", "tuple_two"): "t1a-t2a", "id_function": "11", "id_explicit": "one", "name": "CustomClass"},
+    {("tuple_one", "tuple_two"): "t1a-t2a", "id_function": "11", "id_explicit": "one", "name": "custom_function"},
+    {("tuple_one", "tuple_two"): "t1b-t2b", "id_function": "11", "id_explicit": "one", "name": "first"},
+    {("tuple_one", "tuple_two"): "t1b-t2b", "id_function": "11", "id_explicit": "one", "name": "2"},
+    {("tuple_one", "tuple_two"): "t1b-t2b", "id_function": "11", "id_explicit": "one", "name": "3.5"},
+    {("tuple_one", "tuple_two"): "t1b-t2b", "id_function": "11", "id_explicit": "one", "name": "True"},
+    {("tuple_one", "tuple_two"): "t1b-t2b", "id_function": "11", "id_explicit": "one", "name": "<lambda>"},
+    {("tuple_one", "tuple_two"): "t1b-t2b", "id_function": "11", "id_explicit": "one", "name": "CustomClass"},
+    {("tuple_one", "tuple_two"): "t1b-t2b", "id_function": "11", "id_explicit": "one", "name": "custom_function"}
+]
+
+@pytest.mark.parametrize("name", ("first", 2, 3.5, True, lambda k: k, CustomClass, custom_function))
+@pytest.mark.parametrize("id_explicit", (1,), ids=("one",))
+@pytest.mark.parametrize("id_function", (1,), ids=lambda k: f"{k}{k}")
+@pytest.mark.parametrize(("tuple_one", "tuple_two"), (("t1a", "t2a"), ("t1b", "t2b")))
+def test_more(name, id_explicit, id_function, tuple_one, tuple_two, request):
+    ids = request.node.callspec.ids
+    assert ids in all_ids
+"""
+    )
+
+    reprec = pytester.inline_run()
+    passed, skipped, failed = reprec.countoutcomes()
+    assert passed == 14
+    assert skipped == failed == 0
+
+
 def test_mark_expressions_no_smear(pytester: Pytester) -> None:
     pytester.makepyfile(
         """


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->

This PR adds a new attribute to the `Callspec2` class to provide the ID associated with a particular set of parametrizations.

We are using the parametrization data in a report generation tool we use, and accessing the IDs (particularly when it's either defined as the `ids=[<parametrization names>]` or `ids=<parametrization function>`) is not trivial as is.

Some tests are added to demonstrate the feature, particularly with different object types used in the parametrizations.