### PR TITLE
Restore skipping tests via `raise unittest.SkipTest`

### DIFF
--- a/changelog/13895.bugfix.rst
+++ b/changelog/13895.bugfix.rst
@@ -1,0 +1,1 @@
+Restore support for skipping tests via ``raise unittest.SkipTest``.

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -476,6 +476,14 @@ def pytest_runtest_makereport(item: Item, call: CallInfo[None]) -> None:
             except AttributeError:
                 pass
 
+    # Convert unittest.SkipTest to pytest.skip.
+    # This covers explicit `raise unittest.SkipTest`.
+    unittest = sys.modules.get("unittest")
+    if unittest and call.excinfo and isinstance(call.excinfo.value, unittest.SkipTest):
+        excinfo = call.excinfo
+        call2 = CallInfo[None].from_call(lambda: skip(str(excinfo.value)), call.when)
+        call.excinfo = call2.excinfo
+
 
 def _is_skipped(obj) -> bool:
     """Return True if the given object has been marked with @unittest.skip."""


### PR DESCRIPTION
Revert "Remove unused code related to `nose` (#13528)"

This reverts commit a620d24376eb2c4bc964f2b6efcc694a4adbbe21 and modifies it adding tests and docs.

Fixes #13895
