### PR TITLE
testing: restore pytest-asyncio integration test

### DIFF
--- a/testing/plugins_integration/pytest.ini
+++ b/testing/plugins_integration/pytest.ini
@@ -1,7 +1,6 @@
 [pytest]
 strict_markers = True
-; Temporarily disabled until adds support for pytest 9.
-; asyncio_mode = strict
+asyncio_mode = strict
 filterwarnings =
     error::pytest.PytestWarning
     ignore:usefixtures.* without arguments has no effect:pytest.PytestWarning

--- a/testing/plugins_integration/requirements.txt
+++ b/testing/plugins_integration/requirements.txt
@@ -1,7 +1,6 @@
 anyio[trio]==4.11.0
 django==5.2.8
-# Temporarily disabled until adds support for pytest 9.
-#pytest-asyncio==1.2.0
+pytest-asyncio==1.3.0
 pytest-bdd==8.1.0
 pytest-cov==7.0.0
 pytest-django==4.11.1

--- a/tox.ini
+++ b/tox.ini
@@ -175,8 +175,7 @@ commands =
     pytest --html=simple.html simple_integration.py
     pytest --reruns 5 simple_integration.py pytest_rerunfailures_integration.py
     pytest pytest_anyio_integration.py
-    # Temporarily disabled until adds support for pytest 9.
-    # pytest pytest_asyncio_integration.py
+    pytest pytest_asyncio_integration.py
     pytest pytest_mock_integration.py
     pytest pytest_trio_integration.py
     pytest pytest_twisted_integration.py


### PR DESCRIPTION
This reverts commit 041aacad506b6c6891f2898f2bd378e0896e8b86.

Latest version has added support for pytest 9.