### PR TITLE
config: fix `UserWarning: Do not expect file_or_dir` on some Python 3.12 and 3.13 point versions

### DIFF
--- a/changelog/13910.bugfix.rst
+++ b/changelog/13910.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed `UserWarning: Do not expect file_or_dir` on some earlier Python 3.12 and 3.13 point versions.

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -170,7 +170,7 @@ class Parser:
             arguments, and a list of unknown flag arguments.
         """
         strargs = [os.fspath(x) for x in args]
-        if sys.version_info < (3, 12):
+        if sys.version_info < (3, 12, 8) or (3, 13) <= sys.version_info < (3, 13, 1):
             # Older argparse have a bugged parse_known_intermixed_args.
             namespace, unknown = self.optparser.parse_known_args(strargs, namespace)
             assert namespace is not None


### PR DESCRIPTION
Fix #13910.