### PR TITLE
runner: don't treat `unittest.SkipTest` as an interactive exception

### DIFF
--- a/changelog/13917.bugfix.rst
+++ b/changelog/13917.bugfix.rst
@@ -1,0 +1,1 @@
+:class:`unittest.SkipTest` is no longer considered an interactive exception, i.e. :hook:`pytest_exception_interact` is no longer called for it.

--- a/src/_pytest/debugging.py
+++ b/src/_pytest/debugging.py
@@ -294,10 +294,7 @@ class PdbInvoke:
             sys.stdout.write(out)
             sys.stdout.write(err)
         assert call.excinfo is not None
-
-        unittest = sys.modules.get("unittest")
-        if unittest is None or not isinstance(call.excinfo.value, unittest.SkipTest):
-            _enter_pdb(node, call.excinfo, report)
+        _enter_pdb(node, call.excinfo, report)
 
     def pytest_internalerror(self, excinfo: ExceptionInfo[BaseException]) -> None:
         exc_or_tb = _postmortem_exc_or_tb(excinfo)

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -271,7 +271,10 @@ def check_interactive_exception(call: CallInfo[object], report: BaseReport) -> b
     if hasattr(report, "wasxfail"):
         # Exception was expected.
         return False
-    if isinstance(call.excinfo.value, Skipped | bdb.BdbQuit):
+    unittest = sys.modules.get("unittest")
+    if isinstance(call.excinfo.value, Skipped | bdb.BdbQuit) or (
+        unittest is not None and isinstance(call.excinfo.value, unittest.SkipTest)
+    ):
         # Special control flow exception.
         return False
     return True


### PR DESCRIPTION
Fix #13917. 

Instead of special casing in the debugging plugin, it seems more correct to just not treat `unittest.SkipTest` as an interactive exception, similarly to pytest's own `Skipped`. The `pytest_make_collect_report` hook in runner.py already treats them the same. This fixes the issue more generally.