### PR TITLE
pre-commit: `language: system` is deprecated in favor of `language: unsupported`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
     -   id: pylint
         name: pylint
         entry: pylint
-        language: system
+        language: unsupported
         types: [python]
         args: ["-rn", "-sn", "--fail-on=I", "--enable-all-extentions"]
         require_serial: true


### PR DESCRIPTION
As per the pre-commit changelog: https://github.com/pre-commit/pre-commit/blob/main/CHANGELOG.md#440---2025-11-08

This was originally found in https://github.com/pytest-dev/pytest/pull/13938.
