### PR TITLE
Add minimum-pre-commit-version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+minimum_pre_commit_version: "4.4.0"
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: "v0.14.4"


### PR DESCRIPTION
In https://github.com/pytest-dev/pytest/pull/13939 we are using the new `language: unsupported` setting, which was introduced in pre-commit 4.4.0.

Configure minimum pre-commit version to ensure the installed pre-commit supports it (https://github.com/pytest-dev/pytest/pull/13938#issuecomment-3519164822).
