### PR TITLE
regendoc: remove CI environment variables

### DIFF
--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -310,6 +310,7 @@ class CallableBool:
 def running_on_ci() -> bool:
     """Check if we're currently running on a CI system."""
     # Only enable CI mode if one of these env variables is defined and non-empty.
+    # Note: review `regendoc` tox env in case this list is changed.
     env_vars = ["CI", "BUILD_NUMBER"]
     return any(os.environ.get(var) for var in env_vars)
 

--- a/tox.ini
+++ b/tox.ini
@@ -168,6 +168,10 @@ commands =
 setenv =
     # We don't want this warning to reach regen output.
     PYTHONWARNDEFAULTENCODING=
+    # Remove CI markers: pytest auto-detects those and uses more verbose output, which is undesirable
+    # for the example documentation.
+    CI=
+    BUILD_NUMBER=
 
 [testenv:plugins]
 description =


### PR DESCRIPTION
pytest auto-detects and uses more verbose output when running in CI.

Change tox:regendoc to remove those environment variables, because we do not want extra verbose output in the user documentation.

See #13938 (comment).