### PR TITLE
doc: fix TOML example for `tmp_path_retention_count`, it's a string

### DIFF
--- a/changelog/13904.bugfix.rst
+++ b/changelog/13904.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the TOML type of the :confval:`tmp_path_retention_count` settings in the API reference from number to string.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -2465,14 +2465,14 @@ passed multiple times. The expected format is ``name=value``. For example::
 .. confval:: tmp_path_retention_count
 
    How many sessions should we keep the `tmp_path` directories,
-   according to `tmp_path_retention_policy`.
+   according to :confval:`tmp_path_retention_policy`.
 
    .. tab:: toml
 
        .. code-block:: toml
 
             [pytest]
-            tmp_path_retention_count = 3
+            tmp_path_retention_count = "3"
 
    .. tab:: ini
 

--- a/src/_pytest/tmpdir.py
+++ b/src/_pytest/tmpdir.py
@@ -225,13 +225,16 @@ def pytest_addoption(parser: Parser) -> None:
     parser.addini(
         "tmp_path_retention_count",
         help="How many sessions should we keep the `tmp_path` directories, according to `tmp_path_retention_policy`.",
-        default=3,
+        default="3",
+        # NOTE: Would have been better as an `int` but can't change it now.
+        type="string",
     )
 
     parser.addini(
         "tmp_path_retention_policy",
         help="Controls which directories created by the `tmp_path` fixture are kept around, based on test outcome. "
         "(all/failed/none)",
+        type="string",
         default="all",
     )
 


### PR DESCRIPTION
Fix #13904.