### PR TITLE
[9.0.x] config: restore `config.inicfg`

### DIFF
--- a/changelog/13946.bugfix.rst
+++ b/changelog/13946.bugfix.rst
@@ -1,0 +1,3 @@
+The private ``config.inicfg`` attribute was changed in a breaking manner in pytest 9.0.0.
+Due to its usage in the ecosystem, it is now restored to working order using a compatibility shim.
+It will be deprecated in pytest 9.1 and removed in pytest 10.

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -60,7 +60,7 @@ class TestParseIni:
         _, _, cfg, _ = locate_config(Path.cwd(), [sub])
         assert cfg["name"] == ConfigValue("value", origin="file", mode="ini")
         config = pytester.parseconfigure(str(sub))
-        assert config.inicfg["name"] == ConfigValue("value", origin="file", mode="ini")
+        assert config._inicfg["name"] == ConfigValue("value", origin="file", mode="ini")
 
     def test_setupcfg_uses_toolpytest_with_pytest(self, pytester: Pytester) -> None:
         p1 = pytester.makepyfile("def test(): pass")
@@ -1434,10 +1434,10 @@ class TestConfigFromdictargs:
 
         # this indicates this is the file used for getting configuration values
         assert config.inipath == inipath
-        assert config.inicfg.get("name") == ConfigValue(
+        assert config._inicfg.get("name") == ConfigValue(
             "value", origin="file", mode="ini"
         )
-        assert config.inicfg.get("should_not_be_set") is None
+        assert config._inicfg.get("should_not_be_set") is None
 
 
 def test_options_on_small_file_do_not_blow_up(pytester: Pytester) -> None:
@@ -2277,7 +2277,7 @@ class TestOverrideIniArgs:
         monkeypatch.setenv("PYTEST_ADDOPTS", f"-o cache_dir={cache_dir}")
         config = _config_for_test
         config.parse([], addopts=True)
-        assert config.inicfg.get("cache_dir") == ConfigValue(
+        assert config._inicfg.get("cache_dir") == ConfigValue(
             cache_dir, origin="override", mode="ini"
         )
 
@@ -2318,7 +2318,7 @@ class TestOverrideIniArgs:
         """Check that -o no longer swallows all options after it (#3103)"""
         config = _config_for_test
         config.parse(["-o", "cache_dir=/cache", "/some/test/path"])
-        assert config.inicfg.get("cache_dir") == ConfigValue(
+        assert config._inicfg.get("cache_dir") == ConfigValue(
             "/cache", origin="override", mode="ini"
         )
 
@@ -2999,3 +2999,45 @@ class TestNativeTomlConfig:
 
         with pytest.raises(TypeError, match=r"expects a string.*got int"):
             config.getini("string_not_string")
+
+
+class TestInicfgDeprecation:
+    """Tests for the upcoming deprecation of config.inicfg."""
+
+    def test_inicfg_deprecated(self, pytester: Pytester) -> None:
+        """Test that accessing config.inicfg issues a deprecation warning (not yet)."""
+        pytester.makeini(
+            """
+            [pytest]
+            minversion = 3.0
+            """
+        )
+        config = pytester.parseconfig()
+
+        inicfg = config.inicfg
+
+        assert config.getini("minversion") == "3.0"
+        assert inicfg["minversion"] == "3.0"
+        assert inicfg.get("minversion") == "3.0"
+        del inicfg["minversion"]
+        inicfg["minversion"] = "4.0"
+        assert list(inicfg.keys()) == ["minversion"]
+        assert list(inicfg.items()) == [("minversion", "4.0")]
+        assert len(inicfg) == 1
+
+    def test_issue_13946_setting_bool_no_longer_crashes(
+        self, pytester: Pytester
+    ) -> None:
+        """Regression test for #13946 - setting inicfg doesn't cause a crash."""
+        pytester.makepyfile(
+            """
+            def pytest_configure(config):
+                config.inicfg["xfail_strict"] = True
+
+            def test():
+                pass
+            """
+        )
+
+        result = pytester.runpytest()
+        assert result.ret == 0


### PR DESCRIPTION
Fix #13955.

(cherry picked from commit 173892066bbeddecb2c05ab89cccbdd5b1916a02)