### PR TITLE
config: Add a test for -o with invalid option

### DIFF
--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -2356,7 +2356,14 @@ class TestOverrideIniArgs:
             }
         )
         result = pytester.runpytest("--override-ini", "pythonpath=src")
-        assert result.parseoutcomes() == {"passed": 1}
+        result.assert_outcomes(passed=1)
+
+    def test_override_ini_invalid_option(self, pytester: Pytester) -> None:
+        result = pytester.runpytest("--override-ini", "doesnotexist=true")
+        result.stdout.fnmatch_lines([
+            "=*= warnings summary =*=",
+            "*PytestConfigWarning:*Unknown config option: doesnotexist",
+        ])
 
 
 def test_help_via_addopts(pytester: Pytester) -> None:


### PR DESCRIPTION
This was ignored until #13830. With that change, it now gets correctly surfaced to the user as a warning (or error with --strict-config), so we should have a test for it.