### PR TITLE
runner: make PYTEST_CURRENT_TEST thread-safe with threading.local()

### DIFF
--- a/changelog/13844.bugfix.rst
+++ b/changelog/13844.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed :envvar:`PYTEST_CURRENT_TEST` to work correctly in multi-threaded test execution (:issue:`13844`).
+The environment variable now uses thread-local storage, ensuring each thread sees its own current test.


### PR DESCRIPTION
Closes #13844

`PYTEST_CURRENT_TEST` is now properly thread-safe for the upcoming native multi-threaded test execution.

- Uses a module-level ``threading.local()`` to isolate the current test per thread
- ``os.environ["PYTEST_CURRENT_TEST"]`` is still updated and always cleaned up, so only hung tests remain visible in ``htop``/``ps``
- 100% backward compatible – single-threaded behavior unchanged
- No thread naming required, no extra environment variables

Added tests for concurrent execution and full cleanup verification.

**Note:** Codecov shows 84% because the FALSE branch of `if hasattr(_current_test_local, "value")` is uncovered. This branch
  only occurs if teardown runs without setup on a fresh thread, which doesn't happen in practice. All functional paths are
  tested.