### PR TITLE
ci: restore full windows coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,6 +139,7 @@ jobs:
             python: "3.14"
             os: windows-latest
             tox_env: "py314"
+            use_coverage: true
 
           # Use separate jobs for different unittest flavors (twisted, asynctest) to ensure proper coverage.
           - name: "ubuntu-py310-unittest-asynctest"


### PR DESCRIPTION
Since 01dce85a89eb0b3e881303784267f14b94d9691f, we don't have a CI job on windows with coverage enabled which runs the full test suite. The unittest/twisted ones only run `test_unittest.py`.

Enable coverage for one of the full jobs.