### PR TITLE
separate subtests failures to give better indication on tests analysis

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -395,6 +395,7 @@ Roland Puntaier
 Romain Dorgueil
 Roman Bolshakov
 Ronny Pfannschmidt
+Roni Kishner
 Ross Lawley
 Ruaridh Williamson
 Russel Winder

--- a/changelog/13986.bugfix.rst
+++ b/changelog/13986.bugfix.rst
@@ -1,0 +1,6 @@
+Show subtests failures separate from normal test failures in the final test summary.
+
+Subtest failures are now reported separately as "subtests failed" instead of being counted as regular "failed" tests, providing clearer statistics.
+
+For example, a test with 3 subtests where 1 fails and 2 pass now shows:
+``1 failed, 2 subtests passed, 1 subtests failed`` instead of ``2 failed, 2 subtests passed``.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -510,8 +510,9 @@ def _config_for_test() -> Generator[Config]:
 
 # Regex to match the session duration string in the summary: "74.34s".
 rex_session_duration = re.compile(r"\d+\.\d\ds")
-# Regex to match all the counts and phrases in the summary line: "34 passed, 111 skipped".
-rex_outcome = re.compile(r"(\d+) (\w+)")
+# Regex to match all the counts and phrases in the summary line:
+# "34 passed, 111 skipped, 3 subtests passed, 1 subtests failed".
+rex_outcome = re.compile(r"(\d+) ([\w\s]+?)(?=,| in|$)")
 
 
 @final
@@ -578,7 +579,7 @@ class RunResult:
         for line in reversed(lines):
             if rex_session_duration.search(line):
                 outcomes = rex_outcome.findall(line)
-                ret = {noun: int(count) for (count, noun) in outcomes}
+                ret = {noun.strip(): int(count) for (count, noun) in outcomes}
                 break
         else:
             raise ValueError("Pytest terminal summary report not found")
@@ -586,6 +587,9 @@ class RunResult:
         to_plural = {
             "warning": "warnings",
             "error": "errors",
+            "subtest failed": "subtests failed",
+            "subtest passed": "subtests passed",
+            "subtest skipped": "subtests skipped",
         }
         return {to_plural.get(k, k): v for k, v in ret.items()}
 

--- a/testing/test_subtests.py
+++ b/testing/test_subtests.py
@@ -30,32 +30,32 @@ def test_failures(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch) ->
         """
     )
     summary_lines = [
-        "*=== FAILURES ===*",
-        #
-        "*___ test_foo [[]foo subtest[]] ___*",
-        "*AssertionError: foo subtest failure",
+        "*= FAILURES =*",
         #
         "*___ test_foo ___*",
         "contains 1 failed subtest",
         #
-        "*___ test_bar [[]bar subtest[]] ___*",
-        "*AssertionError: bar subtest failure",
+        "*___ test_foo [[]foo subtest[]] ___*",
+        "*AssertionError: foo subtest failure",
         #
         "*___ test_bar ___*",
         "*AssertionError: test_bar also failed",
         #
+        "*___ test_bar [[]bar subtest[]] ___*",
+        "*AssertionError: bar subtest failure",
+        #
         "*=== short test summary info ===*",
-        "SUBFAILED[[]foo subtest[]] test_*.py::test_foo - AssertionError*",
         "FAILED test_*.py::test_foo - contains 1 failed subtest",
-        "SUBFAILED[[]bar subtest[]] test_*.py::test_bar - AssertionError*",
+        "SUBFAILED[[]foo subtest[]] test_*.py::test_foo - AssertionError*",
         "FAILED test_*.py::test_bar - AssertionError*",
+        "SUBFAILED[[]bar subtest[]] test_*.py::test_bar - AssertionError*",
     ]
     result = pytester.runpytest()
     result.stdout.fnmatch_lines(
         [
             "test_*.py uFuF.    *     [[]100%[]]",
             *summary_lines,
-            "* 4 failed, 1 passed in *",
+            "* 2 failed, 1 passed, 2 subtests failed in *",
         ]
     )
 
@@ -69,7 +69,7 @@ def test_failures(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch) ->
             "test_*.py::test_zaz SUBPASSED[[]zaz subtest[]]    *     [[]100%[]]",
             "test_*.py::test_zaz PASSED                        *     [[]100%[]]",
             *summary_lines,
-            "* 4 failed, 1 passed, 1 subtests passed in *",
+            "* 2 failed, 1 passed, 1 subtests passed, 2 subtests failed in *",
         ]
     )
     pytester.makeini(
@@ -87,7 +87,7 @@ def test_failures(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch) ->
             "test_*.py::test_bar FAILED                        *     [[] 66%[]]",
             "test_*.py::test_zaz PASSED                        *     [[]100%[]]",
             *summary_lines,
-            "* 4 failed, 1 passed in *",
+            "* 2 failed, 1 passed, 2 subtests failed in *",
         ]
     )
     result.stdout.no_fnmatch_line("test_*.py::test_zaz SUBPASSED[[]zaz subtest[]]*")
@@ -307,7 +307,7 @@ def test_subtests_and_parametrization(
             "*.py::test_foo[[]1[]] SUBFAILED[[]custom[]] (i=1) *[[]100%[]]",
             "*.py::test_foo[[]1[]] FAILED                      *[[]100%[]]",
             "contains 1 failed subtest",
-            "* 4 failed, 4 subtests passed in *",
+            "* 2 failed, 4 subtests passed, 2 subtests failed in *",
         ]
     )
 
@@ -325,7 +325,7 @@ def test_subtests_and_parametrization(
             "*.py::test_foo[[]1[]] SUBFAILED[[]custom[]] (i=1) *[[]100%[]]",
             "*.py::test_foo[[]1[]] FAILED                      *[[]100%[]]",
             "contains 1 failed subtest",
-            "* 4 failed in *",
+            "* 2 failed, 2 subtests failed in *",
         ]
     )
 
@@ -344,7 +344,7 @@ def test_subtests_fail_top_level_test(pytester: pytest.Pytester) -> None:
     result = pytester.runpytest("-v")
     result.stdout.fnmatch_lines(
         [
-            "* 2 failed, 2 subtests passed in *",
+            "* 1 failed, 2 subtests passed, 1 subtests failed in *",
         ]
     )
 
@@ -365,7 +365,7 @@ def test_subtests_do_not_overwrite_top_level_failure(pytester: pytest.Pytester) 
     result.stdout.fnmatch_lines(
         [
             "*AssertionError: top-level failure",
-            "* 2 failed, 2 subtests passed in *",
+            "* 1 failed, 2 subtests passed, 1 subtests failed in *",
         ]
     )
 
@@ -386,14 +386,14 @@ def test_subtests_last_failed_step_wise(pytester: pytest.Pytester, flag: str) ->
     result = pytester.runpytest("-v")
     result.stdout.fnmatch_lines(
         [
-            "* 2 failed, 2 subtests passed in *",
+            "* 1 failed, 2 subtests passed, 1 subtests failed in *",
         ]
     )
 
     result = pytester.runpytest("-v", flag)
     result.stdout.fnmatch_lines(
         [
-            "* 2 failed, 2 subtests passed in *",
+            "* 1 failed, 2 subtests passed, 1 subtests failed in *",
         ]
     )
 
@@ -427,7 +427,7 @@ class TestUnittestSubTest:
         result = pytester.runpytest()
         result.stdout.fnmatch_lines(
             [
-                "* 3 failed, 2 passed in *",
+                "* 1 failed, 2 passed, 2 subtests failed in *",
             ]
         )
 
@@ -578,9 +578,7 @@ class TestUnittestSubTest:
         result.stdout.fnmatch_lines(
             [
                 "*.py u.                                                           *            [[]100%[]]",
-                "*=== short test summary info ===*",
-                "SUBFAILED[[]subtest 2[]] *.py::T::test_foo - AssertionError: fail subtest 2",
-                "* 1 failed, 1 passed in *",
+                "* 1 passed, 1 subtests failed in *",
             ]
         )
 
@@ -590,9 +588,9 @@ class TestUnittestSubTest:
                 "*.py::T::test_foo SUBSKIPPED[[]subtest 1[]] (skip subtest 1)      *            [[]100%[]]",
                 "*.py::T::test_foo SUBFAILED[[]subtest 2[]]                        *            [[]100%[]]",
                 "*.py::T::test_foo PASSED                                          *            [[]100%[]]",
+                "*=== short test summary info ===*",
                 "SUBSKIPPED[[]subtest 1[]] [[]1[]] *.py:*: skip subtest 1",
-                "SUBFAILED[[]subtest 2[]] *.py::T::test_foo - AssertionError: fail subtest 2",
-                "* 1 failed, 1 passed, 1 skipped in *",
+                "* 1 passed, 1 skipped, 1 subtests failed in *",
             ]
         )
 
@@ -607,9 +605,7 @@ class TestUnittestSubTest:
             [
                 "*.py::T::test_foo SUBFAILED[[]subtest 2[]]                        *            [[]100%[]]",
                 "*.py::T::test_foo PASSED                                          *            [[]100%[]]",
-                "*=== short test summary info ===*",
-                r"SUBFAILED[[]subtest 2[]] *.py::T::test_foo - AssertionError: fail subtest 2",
-                r"* 1 failed, 1 passed in *",
+                "* 1 passed, 1 subtests failed in *",
             ]
         )
         result.stdout.no_fnmatch_line(
@@ -814,7 +810,7 @@ class TestLogging:
         result = pytester.runpytest("-p no:logging")
         result.stdout.fnmatch_lines(
             [
-                "*2 failed in*",
+                "*1 failed, 1 subtests failed in*",
             ]
         )
         result.stdout.no_fnmatch_line("*root:test_no_logging.py*log line*")
@@ -899,12 +895,16 @@ def test_exitfirst(pytester: pytest.Pytester) -> None:
         """
     )
     result = pytester.runpytest("--exitfirst")
-    assert result.parseoutcomes()["failed"] == 2
+    outcomes = result.parseoutcomes()
+    assert outcomes["failed"] == 1
+    assert outcomes["subtests failed"] == 1
     result.stdout.fnmatch_lines(
         [
-            "SUBFAILED*[[]sub1[]] *.py::test_foo - assert False*",
+            "*=== short test summary info ===*",
             "FAILED *.py::test_foo - assert False",
-            "* stopping after 2 failures*",
+            "SUBFAILED[[]sub1[]] *.py::test_foo - assert False",
+            "*stopping after 2 failures*",
+            "*1 failed, 1 subtests failed*",
         ],
         consecutive=True,
     )
@@ -926,7 +926,7 @@ def test_do_not_swallow_pytest_exit(pytester: pytest.Pytester) -> None:
     result.stdout.fnmatch_lines(
         [
             "* _pytest.outcomes.Exit *",
-            "* 1 failed in *",
+            "*1 failed, 1 subtests failed in*",
         ]
     )
 
@@ -952,9 +952,9 @@ def test_nested(pytester: pytest.Pytester) -> None:
         [
             "SUBFAILED[b] test_nested.py::test - AssertionError: b failed",
             "SUBFAILED[a] test_nested.py::test - AssertionError: a failed",
-            "* 3 failed in *",
         ]
     )
+    result.stdout.fnmatch_lines(["* 3 failed in *"])
 
 
 def test_serialization() -> None:


### PR DESCRIPTION
## Description

This PR fixes the double-counting of subtest failures in pytest's final test summary. Previously, when a test with subtests had failures, both the subtest failure and the top-level test failure were counted as regular "failed" tests, leading to inflated failure counts.

## Changes

- Modified `pytest_report_teststatus` hook in `src/_pytest/subtests.py` to return `"subtests failed"` category instead of `"failed"` for subtest failures
- Updated `_determine_main_color` in `src/_pytest/terminal.py` to consider `"subtests failed"` when determining the main color (red)
- Enhanced `parse_summary_nouns` in `src/_pytest/pytester.py`:
  - Updated regex to handle multi-word outcomes like "subtests failed"
  - Added pluralization mapping for subtest outcomes
  - Added whitespace handling for parsed outcomes
- Updated test expectations in `testing/test_subtests.py` to match the new summary format

## Example

**Before:**
`===================== 2 failed, 2 subtests passed in 0.02s =====================`
**After:**
`===================== 1 failed, 2 subtests passed, 1 subtests failed in 0.02s =====================`

This provides clear visibility into:
- How many top-level tests failed (1 failed)
- How many subtests failed (1 subtests failed)  
- How many subtests passed (2 subtests passed)

Closes #13986