### PR TITLE
coverage: use `ctrace` core to avoid CI slowdown on Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -446,6 +446,9 @@ include = [
 parallel = true
 branch = true
 patch = [ "subprocess" ]
+# The sysmon core (default since Python 3.14) is much slower.
+# Perhaps: https://github.com/coveragepy/coveragepy/issues/2082
+core = "ctrace"
 
 [tool.coverage.paths]
 source = [


### PR DESCRIPTION
While `sysmon` (default since Python 3.14) is supposed to be faster, it about 3x slower in CI (~24m vs. ~8m) ATM.

https://coverage.readthedocs.io/en/latest/config.html#config-run-core https://coverage.readthedocs.io/en/latest/faq.html#q-coverage-py-is-much-slower-than-i-remember-what-s-going-on