### PR TITLE
Fix quadratic-time behavior when handling `unittest` subtests in Python 3.10

### DIFF
--- a/changelog/13965.bugfix.rst
+++ b/changelog/13965.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed quadratic-time behavior when handling ``unittest`` subtests in Python 3.10.


### PR DESCRIPTION
Fix #13965
Close #13970
