### PR TITLE
[9.0.x] coverage: use `ctrace` core to avoid CI slowdown on Python 3.14

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,6 +10,9 @@ include =
   *\Lib\site-packages\pytest.py
 parallel = 1
 branch = 1
+# The sysmon core (default since Python 3.14) is much slower.
+# Perhaps: https://github.com/coveragepy/coveragepy/issues/2082
+core = ctrace
 
 [paths]
 source = src/


### PR DESCRIPTION
coverage: use `ctrace` core to avoid CI slowdown on Python 3.14 (cherry picked from commit 1b5200c0f056ec58f5620417d3157aea3ba33c87)

Manual backport of https://github.com/pytest-dev/pytest/pull/13991.

