### PR TITLE
Fix broken contact reference in contributing.rst by adding proper contact link

### DIFF
--- a/changelog/14010.doc.rst
+++ b/changelog/14010.doc.rst
@@ -1,1 +1,0 @@
-Fixed broken :ref: links in CONTRIBUTING.rst.


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

## What
Fixed two instances of broken `:ref:`Talk <contact>`` references in CONTRIBUTING.rst

## Changes Made
- Replaced `:ref:`Talk <contact>` to developers` with proper RST link `Talk to developers <https://docs.pytest.org/en/stable/contact.html>`_ in the "Fix bugs" section
- Replaced `:ref:`Talk <contact>` to developers` with proper RST link `Talk to developers <https://docs.pytest.org/en/stable/contact.html>`_ in the "Implement features" section

## Why
The original reStructuredText `:ref:` syntax was malformed and not rendering as clickable links, which could confuse new contributors trying to contact the development team. The new links directly point to the pytest contact documentation page.

## Result
Now contributors can easily click through to the contact channels page instead of seeing broken references.