### PR TITLE
Docs: clarify subtest output colors

### DIFF
--- a/doc/en/how-to/subtests.rst
+++ b/doc/en/how-to/subtests.rst
@@ -29,8 +29,11 @@ Each assertion failure or error is caught by the context manager and reported in
 .. code-block:: pytest
 
     $ pytest -q test_subtest.py
-    uuuuuF                                                               [100%]
-    ================================= FAILURES =================================
+    uuUuUF                                                                [100%]
+
+Note that passed subtests are shown in green while failed subtests are shown in red when color output is enabled.
+
+================================= FAILURES =================================
     _______________________ test [custom message] (i=1) ________________________
 
     subtests = <_pytest.subtests.Subtests object at 0xdeadbeef0001>


### PR DESCRIPTION
This PR improves the subtests documentation by clarifying how passed and failed
subtests are displayed when color output is enabled.

The explanatory sentence was moved outside the example output block so it is
not interpreted as terminal output.

Documentation-only change. No functional code changes.