### PR TITLE
Docs: pin sphinx to `<9.0`

### DIFF
--- a/doc/en/requirements.txt
+++ b/doc/en/requirements.txt
@@ -2,7 +2,8 @@
 pluggy>=1.5.0
 pygments-pytest>=2.5.0
 sphinx-removed-in>=0.2.0
-sphinx>=7
+# Pinning to <9.0 due to https://github.com/python-trio/sphinxcontrib-trio/issues/399.
+sphinx>=7,<9.0
 sphinxcontrib-trio
 sphinxcontrib-svg2pdfconverter
 furo


### PR DESCRIPTION
Pinning to `<9.0` to fix doc building.

Related to https://github.com/python-trio/sphinxcontrib-trio/issues/399.
