### PR TITLE
 Fix scope resolution for parametrized fixtures using dict order

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1526,9 +1526,10 @@ def _find_parametrized_scope(
     if all_arguments_are_fixtures:
         fixturedefs = arg2fixturedefs or {}
         used_scopes = [
-            fixturedef[-1]._scope
-            for name, fixturedef in fixturedefs.items()
-            if name in argnames
+            fixturedefs[name][-1] ._scope     # correction part
+            for name in argnames
+            if name in fixturedefs
+
         ]
         # Takes the most narrow scope from used fixtures.
         return min(used_scopes, default=Scope.Function)

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1526,10 +1526,9 @@ def _find_parametrized_scope(
     if all_arguments_are_fixtures:
         fixturedefs = arg2fixturedefs or {}
         used_scopes = [
-            fixturedefs[name][-1] ._scope     # correction part
+            fixturedefs[name][-1]._scope  # correction part
             for name in argnames
             if name in fixturedefs
-
         ]
         # Takes the most narrow scope from used fixtures.
         return min(used_scopes, default=Scope.Function)


### PR DESCRIPTION
Fixes #13503

When all parametrized arguments are indirect, pytest determines the
narrowest scope from the fixtures involved. If fixture definitions
are provided as a dict, the previous logic could select an incorrect
scope.

This change ensures the correct scope is selected by using the last
fixture definition associated with each argument.
