### PR TITLE
fix missing type annotations on `makepyfile` and `maketxtfile` methods

### DIFF
--- a/changelog/14080.bugfix.rst
+++ b/changelog/14080.bugfix.rst
@@ -1,0 +1,1 @@
+fix missing type annotations on ``Pytester.makepyfile`` and ``Pytester.maketxtfile`` methods.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -862,7 +862,7 @@ class Pytester:
         """
         return self.makefile(".toml", pyproject=source)
 
-    def makepyfile(self, *args: str, **kwargs: str) -> Path:
+    def makepyfile(self, *args: str | bytes, **kwargs: str | bytes) -> Path:
         r"""Shortcut for .makefile() with a .py extension.
 
         Defaults to the test name with a '.py' extension, e.g test_foobar.py, overwriting
@@ -882,7 +882,7 @@ class Pytester:
         """
         return self._makefile(".py", args, kwargs)
 
-    def maketxtfile(self, *args: str, **kwargs: str) -> Path:
+    def maketxtfile(self, *args: str | bytes, **kwargs: str | bytes) -> Path:
         r"""Shortcut for .makefile() with a .txt extension.
 
         Defaults to the test name with a '.txt' extension, e.g test_foobar.txt, overwriting

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -645,6 +645,7 @@ class SysPathsSnapshot:
     def restore(self) -> None:
         sys.path[:], sys.meta_path[:] = self.__saved
 
+_FileContent = tuple[str | bytes, ...] | list[str | bytes] | str | bytes
 
 @final
 class Pytester:
@@ -757,7 +758,7 @@ class Pytester:
         self,
         ext: str,
         lines: Sequence[Any | bytes],
-        files: Mapping[str, str | bytes],
+        files: Mapping[str, _FileContent],
         encoding: str = "utf-8",
     ) -> Path:
         items = list(files.items())
@@ -863,7 +864,7 @@ class Pytester:
         """
         return self.makefile(".toml", pyproject=source)
 
-    def makepyfile(self, *args: str | bytes, **kwargs: str | bytes) -> Path:
+    def makepyfile(self, *args: _FileContent, **kwargs: _FileContent) -> Path:
         r"""Shortcut for .makefile() with a .py extension.
 
         Defaults to the test name with a '.py' extension, e.g test_foobar.py, overwriting
@@ -883,7 +884,7 @@ class Pytester:
         """
         return self._makefile(".py", args, kwargs)
 
-    def maketxtfile(self, *args: str | bytes, **kwargs: str | bytes) -> Path:
+    def maketxtfile(self, *args: _FileContent, **kwargs: _FileContent) -> Path:
         r"""Shortcut for .makefile() with a .txt extension.
 
         Defaults to the test name with a '.txt' extension, e.g test_foobar.txt, overwriting

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -645,7 +645,9 @@ class SysPathsSnapshot:
     def restore(self) -> None:
         sys.path[:], sys.meta_path[:] = self.__saved
 
+
 _FileContent = tuple[str | bytes, ...] | list[str | bytes] | str | bytes
+
 
 @final
 class Pytester:

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -10,6 +10,7 @@ import collections.abc
 from collections.abc import Callable
 from collections.abc import Generator
 from collections.abc import Iterable
+from collections.abc import Mapping
 from collections.abc import Sequence
 import contextlib
 from fnmatch import fnmatch
@@ -756,7 +757,7 @@ class Pytester:
         self,
         ext: str,
         lines: Sequence[Any | bytes],
-        files: dict[str, str | bytes],
+        files: Mapping[str, str | bytes],
         encoding: str = "utf-8",
     ) -> Path:
         items = list(files.items())

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -756,7 +756,7 @@ class Pytester:
         self,
         ext: str,
         lines: Sequence[Any | bytes],
-        files: dict[str, str],
+        files: dict[str, str | bytes],
         encoding: str = "utf-8",
     ) -> Path:
         items = list(files.items())

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -862,7 +862,7 @@ class Pytester:
         """
         return self.makefile(".toml", pyproject=source)
 
-    def makepyfile(self, *args, **kwargs) -> Path:
+    def makepyfile(self, *args: str, **kwargs: str) -> Path:
         r"""Shortcut for .makefile() with a .py extension.
 
         Defaults to the test name with a '.py' extension, e.g test_foobar.py, overwriting
@@ -882,7 +882,7 @@ class Pytester:
         """
         return self._makefile(".py", args, kwargs)
 
-    def maketxtfile(self, *args, **kwargs) -> Path:
+    def maketxtfile(self, *args: str, **kwargs: str) -> Path:
         r"""Shortcut for .makefile() with a .txt extension.
 
         Defaults to the test name with a '.txt' extension, e.g test_foobar.txt, overwriting


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
fixes #14396