### PR TITLE
Clarify mixed pass/fail colors in subtests documentation

### DIFF
--- a/doc/en/how-to/subtests.rst
+++ b/doc/en/how-to/subtests.rst
@@ -30,6 +30,10 @@ Each assertion failure or error is caught by the context manager and reported in
 
     $ pytest -q test_subtest.py
     uuuuuF                                                               [100%]
+
+#Note that in the output above, passing subtests are shown in green, while
+failing subtests are shown in red.
+
     ================================= FAILURES =================================
     _______________________ test [custom message] (i=1) ________________________
 


### PR DESCRIPTION
This PR updates the subtests documentation to clarify that the compact
output uses mixed colors: passing subtests are shown in green and failing
subtests in red. The example output itself is unchanged; this only fixes
the misleading interpretation in the docs.

Fixes #13902