### PR TITLE
junitxml: preserve setup/call captured output for interlaced reports

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -199,6 +199,7 @@ Hugo van Kemenade
 Hui Wang (coldnight)
 Ian Bicking
 Ian Lesperance
+Ilya Abdolmanafi
 Ilya Konstantinov
 Ionuț Turturică
 Isaac Virshup

--- a/changelog/14078.bugfix.rst
+++ b/changelog/14078.bugfix.rst
@@ -1,0 +1,1 @@
+Fix JUnit XML output to include captured stdout/stderr from setup and call phases when reports are interlaced without xdist metadata.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -586,7 +586,9 @@ class LogXML:
         captured.last_out = report.capstdout
         captured.last_err = report.capstderr
         captured.last_log = report.caplog
-        return _ReportOutput(report, captured.out, captured.err, captured.log, stream_id)
+        return _ReportOutput(
+            report, captured.out, captured.err, captured.log, stream_id
+        )
 
     def finalize(self, report: TestReport) -> None:
         nodeid = getattr(report, "nodeid", report)

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -84,11 +84,14 @@ families["xunit2"] = families["_base"]
 
 
 class _ReportOutput:
-    def __init__(self, report: TestReport, stdout: str, stderr: str, log: str) -> None:
+    def __init__(
+        self, report: TestReport, stdout: str, stderr: str, log: str, stream_id: int
+    ) -> None:
         self.capstdout = stdout
         self.capstderr = stderr
         self.caplog = log
         self.passed = report.passed
+        self.stream_id = stream_id
 
 
 class _CapturedOutput:
@@ -99,6 +102,13 @@ class _CapturedOutput:
         self.last_out = ""
         self.last_err = ""
         self.last_log = ""
+
+
+class _OutputState:
+    def __init__(self) -> None:
+        self.current: _CapturedOutput | None = None
+        self.current_id: int | None = None
+        self.next_id = 0
 
 
 class _NodeReporter:
@@ -501,17 +511,18 @@ class LogXML:
         self.node_reporters_ordered: list[_NodeReporter] = []
         self.global_properties: list[tuple[str, str]] = []
 
-        # List of reports that failed on call but teardown is pending.
-        self.open_reports: list[TestReport] = []
+        # Reports that failed on call but teardown is pending.
+        self.open_reports: dict[tuple[tuple[str, object], int], TestReport] = {}
         self.cnt_double_fail_tests = 0
-        self._captured_output: dict[tuple[str, object], _CapturedOutput] = {}
+        self._output_state: dict[tuple[str, object], _OutputState] = {}
+        self._ambiguous_output: set[tuple[str, object]] = set()
 
         # Replaces convenience family with real family.
         if self.family == "legacy":
             self.family = "xunit1"
 
     def _report_key(self, report: TestReport) -> tuple[str, object]:
-        # Nodeid is stable across phases; avoid xdist-only worker_id/item_index,
+        # Nodeid is not guaranteed unique; avoid xdist-only worker_id/item_index,
         # and include the worker node when present to disambiguate.
         return report.nodeid, getattr(report, "node", None)
 
@@ -523,20 +534,59 @@ class LogXML:
             return current[len(previous) :]
         return current
 
-    def _update_captured_output(self, report: TestReport) -> _CapturedOutput:
+    def _mark_output_ambiguous(self, key: tuple[str, object]) -> None:
+        self._ambiguous_output.add(key)
+        self._output_state.pop(key, None)
+        for report_key in list(self.open_reports):
+            if report_key[0] == key:
+                del self.open_reports[report_key]
+
+    def _current_output_stream(
+        self, report: TestReport
+    ) -> tuple[_CapturedOutput, int] | None:
         key = self._report_key(report)
-        captured = self._captured_output.setdefault(key, _CapturedOutput())
+        if key in self._ambiguous_output:
+            return None
+        state = self._output_state.setdefault(key, _OutputState())
+        if report.when == "setup":
+            if state.current is not None:
+                self._mark_output_ambiguous(key)
+                return None
+            state.current = _CapturedOutput()
+            state.current_id = state.next_id
+            state.next_id += 1
+        elif state.current is None:
+            state.current = _CapturedOutput()
+            state.current_id = state.next_id
+            state.next_id += 1
+        assert state.current is not None
+        assert state.current_id is not None
+        return state.current, state.current_id
+
+    def _finish_output_stream(self, report: TestReport) -> None:
+        if report.when != "teardown":
+            return
+        key = self._report_key(report)
+        if key in self._ambiguous_output:
+            return
+        state = self._output_state.get(key)
+        if state is None:
+            return
+        state.current = None
+        state.current_id = None
+
+    def _report_output(self, report: TestReport) -> _ReportOutput | None:
+        stream = self._current_output_stream(report)
+        if stream is None:
+            return None
+        captured, stream_id = stream
         captured.out += self._diff_captured_output(captured.last_out, report.capstdout)
         captured.err += self._diff_captured_output(captured.last_err, report.capstderr)
         captured.log += self._diff_captured_output(captured.last_log, report.caplog)
         captured.last_out = report.capstdout
         captured.last_err = report.capstderr
         captured.last_log = report.caplog
-        return captured
-
-    def _report_output(self, report: TestReport) -> _ReportOutput:
-        captured = self._update_captured_output(report)
-        return _ReportOutput(report, captured.out, captured.err, captured.log)
+        return _ReportOutput(report, captured.out, captured.err, captured.log, stream_id)
 
     def finalize(self, report: TestReport) -> None:
         nodeid = getattr(report, "nodeid", report)
@@ -608,16 +658,14 @@ class LogXML:
                 reporter.append_pass(report)
         elif report.failed:
             if report.when == "teardown":
-                report_key = self._report_key(report)
-                close_report = next(
-                    (
-                        rep
-                        for rep in self.open_reports
-                        if self._report_key(rep) == report_key
-                    ),
-                    None,
-                )
-                if close_report:
+                if report_output is not None:
+                    report_key = self._report_key(report)
+                    close_report = self.open_reports.pop(
+                        (report_key, report_output.stream_id), None
+                    )
+                else:
+                    close_report = None
+                if close_report is not None:
                     # We need to open new testcase in case we have failure in
                     # call and error in teardown in order to follow junit
                     # schema.
@@ -626,9 +674,12 @@ class LogXML:
             reporter = self._opentestcase(report)
             if report.when == "call":
                 reporter.append_failure(report)
-                self.open_reports.append(report)
+                if report_output is not None:
+                    report_key = self._report_key(report)
+                    self.open_reports[(report_key, report_output.stream_id)] = report
                 if not self.log_passing_tests:
-                    reporter.write_captured_output(report_output)
+                    if report_output is not None:
+                        reporter.write_captured_output(report_output)
             else:
                 reporter.append_error(report)
         elif report.skipped:
@@ -637,21 +688,14 @@ class LogXML:
         self.update_testcase_duration(report)
         if report.when == "teardown":
             reporter = self._opentestcase(report)
-            reporter.write_captured_output(report_output)
+            if report_output is not None:
+                reporter.write_captured_output(report_output)
 
             self.finalize(report)
-            report_key = self._report_key(report)
-            close_report = next(
-                (
-                    rep
-                    for rep in self.open_reports
-                    if self._report_key(rep) == report_key
-                ),
-                None,
-            )
-            if close_report:
-                self.open_reports.remove(close_report)
-            self._captured_output.pop(report_key, None)
+            if report_output is not None:
+                report_key = self._report_key(report)
+                self.open_reports.pop((report_key, report_output.stream_id), None)
+            self._finish_output_stream(report)
 
     def update_testcase_duration(self, report: TestReport) -> None:
         """Accumulate total duration for nodeid from given report and update

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -8,8 +8,8 @@ import platform
 from typing import Any
 from typing import cast
 from typing import TYPE_CHECKING
-import xml.etree.ElementTree as ET
 from xml.dom import minidom
+import xml.etree.ElementTree as ET
 
 import xmlschema
 

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1865,6 +1865,91 @@ def test_interlaced_reports_capture_output(
         assert (expected in system_err_text) is expect_err
 
 
+def test_interlaced_reports_nodeid_collision(pytester: Pytester) -> None:
+    pytester.makeconftest(
+        """
+        import pytest
+        from _pytest.runner import call_and_report
+
+        _reports = []
+
+        @pytest.hookimpl(tryfirst=True)
+        def pytest_runtest_protocol(item, nextitem):
+            item.ihook.pytest_runtest_logstart(
+                nodeid=item.nodeid, location=item.location
+            )
+            reports = [call_and_report(item, "setup", log=False)]
+            if reports[0].passed:
+                reports.append(call_and_report(item, "call", log=False))
+            reports.append(
+                call_and_report(item, "teardown", log=False, nextitem=nextitem)
+            )
+            item.ihook.pytest_runtest_logfinish(
+                nodeid=item.nodeid, location=item.location
+            )
+
+            _reports.append(reports)
+            if nextitem is not None:
+                return True
+
+            ihook = item.ihook
+            for reports in _reports:
+                ihook.pytest_runtest_logreport(report=reports[0])
+            for reports in _reports:
+                if len(reports) == 3:
+                    ihook.pytest_runtest_logreport(report=reports[1])
+            for reports in reversed(_reports):
+                ihook.pytest_runtest_logreport(report=reports[-1])
+            return True
+
+        @pytest.hookimpl(hookwrapper=True, tryfirst=True)
+        def pytest_runtest_logreport(report):
+            if report.when in ("setup", "call", "teardown"):
+                report.nodeid = "collided::nodeid"
+                sections = []
+                for name, content in report.sections:
+                    if name.startswith("Captured "):
+                        if name.endswith(f" {report.when}"):
+                            sections.append((name, content))
+                    else:
+                        sections.append((name, content))
+                report.sections = sections
+            yield
+        """
+    )
+    pytester.makepyfile(
+        """
+        import sys
+        import pytest
+
+        @pytest.fixture
+        def setup_output(request):
+            print(f"SETUP_STDOUT_{request.node.name}")
+            sys.stderr.write(f"SETUP_STDERR_{request.node.name}\\n")
+
+        def test_one(setup_output):
+            print("CALL_STDOUT_test_one")
+            sys.stderr.write("CALL_STDERR_test_one\\n")
+
+        def test_two(setup_output):
+            print("CALL_STDOUT_test_two")
+            sys.stderr.write("CALL_STDERR_test_two\\n")
+        """
+    )
+
+    xml_path = pytester.path.joinpath("junit.xml")
+    result = pytester.runpytest(
+        f"--junitxml={xml_path}",
+        "--override-ini=junit_family=xunit1",
+        "--override-ini=junit_logging=all",
+    )
+    assert result.ret == 0
+
+    root = ET.parse(xml_path).getroot()
+    assert not list(root.iter("system-out"))
+    assert not list(root.iter("system-err"))
+
+
 @parametrize_families
 def test_logging_passing_tests_disabled_does_not_log_test_output(
     pytester: Pytester, run_and_parse: RunAndParse, xunit_family: str


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
### Summary

This PR fixes an issue where `junitxml` could drop captured output from the **setup** and **call** phases when test reports arrive in an **interlaced** order. Refs #14078.

### Problem

The current interlaced-report handling in `junitxml` assumes the presence of `pytest-xdist`-specific report attributes. When reports do not carry those attributes, captured `stdout`/`stderr` from setup and call phases may be lost and never written to the final JUnit XML, even when `junit_logging` is configured to include it.

### Fix

Captured output is now buffered per test node and written out once the report sequence completes, ensuring setup and call output is preserved regardless of report ordering. The existing `junit_logging` behavior and output suppression semantics are unchanged.

### Tests

A deterministic regression test was added that replays reports in a fixed interlaced order and asserts that:

- setup and call output is included when `junit_logging=all`
- only stdout is included for `system-out`
- only stderr is included for `system-err`

Tests run:

```bash
python -m pytest testing/test_junitxml.py
python -m pytest testing/test_junitxml.py -k interlaced
```

### Notes

The regression test uses internal helpers to keep the scenario deterministic with minimal scaffolding. If preferred, it can be rewritten to avoid internal APIs at the cost of additional complexity.