### PR TITLE
Fixed ``--pyargs`` not finding modules in the current directory when running pytest from a subdirectory

### DIFF
--- a/changelog/14048.bugfix.rst
+++ b/changelog/14048.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``--pyargs`` not finding modules in the current directory when running pytest from a subdirectory, particularly when using tox.
+
+The invocation directory is now added to ``sys.path`` early during initialization when ``--pyargs`` is used, ensuring that ``importlib.util.find_spec()`` can locate modules in the current working directory.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1274,6 +1274,14 @@ class Config:
         # early_config.args it not set yet. But we need it for
         # discovering the initial conftests. So "pre-run" the logic here.
         # It will be done for real in `parse()`.
+
+        # When using --pyargs, ensure invocation_dir is in sys.path so that
+        # modules in the current directory can be found by importlib.
+        if early_config.known_args_namespace.pyargs:
+            invocation_dir_str = str(early_config.invocation_params.dir)
+            if invocation_dir_str not in sys.path:
+                sys.path.insert(0, invocation_dir_str)
+
         args, _args_source = early_config._decide_args(
             args=early_config.known_args_namespace.file_or_dir,
             pyargs=early_config.known_args_namespace.pyargs,


### PR DESCRIPTION
Fixes: #14048 