### PR TITLE
typing: default for xfail condition is `True`

### DIFF
--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -509,7 +509,7 @@ if TYPE_CHECKING:
         @overload
         def __call__(
             self,
-            condition: str | bool = False,
+            condition: str | bool = True,
             *conditions: str | bool,
             reason: str = ...,
             run: bool = ...,


### PR DESCRIPTION
This has absolutely no runtime impact (hence no changelog entry), but it makes reading the code less confusing.