### PR TITLE
Fix conftest fixture scoping when testpaths points outside rootdir

### DIFF
--- a/changelog/14004.bugfix.rst
+++ b/changelog/14004.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed conftest.py fixture scoping when ``testpaths`` points outside ``rootdir``.
+
+Nodeids for paths outside ``rootdir`` are now computed more meaningfully:
+paths in site-packages use a ``site://`` prefix, nearby paths use relative
+paths with ``..`` components, and far-away paths use absolute paths.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1644,8 +1644,15 @@ class FixtureManager:
 
     def _getautousenames(self, node: nodes.Node) -> Iterator[str]:
         """Return the names of autouse fixtures applicable to node."""
+        seen_nodeids: set[str] = set()
         for parentnode in node.listchain():
-            basenames = self._nodeid_autousenames.get(parentnode.nodeid)
+            nodeid = parentnode.nodeid
+            # Avoid yielding duplicates when multiple nodes share the same nodeid
+            # (e.g., Session and root Directory both have nodeid "").
+            if nodeid in seen_nodeids:
+                continue
+            seen_nodeids.add(nodeid)
+            basenames = self._nodeid_autousenames.get(nodeid)
             if basenames:
                 yield from basenames
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1629,14 +1629,13 @@ class FixtureManager:
             # case-insensitive systems (Windows) and other normalization issues
             # (issue #11816).
             conftestpath = absolutepath(plugin_name)
-            try:
-                nodeid = str(conftestpath.parent.relative_to(self.config.rootpath))
-            except ValueError:
-                nodeid = ""
-            if nodeid == ".":
-                nodeid = ""
-            elif nodeid:
-                nodeid = nodes.norm_sep(nodeid)
+            # initial_paths not available yet at plugin registration time,
+            # so we skip that step and fall back to bestrelpath
+            nodeid = nodes.compute_nodeid_prefix_for_path(
+                path=conftestpath.parent,
+                rootpath=self.config.rootpath,
+                invocation_dir=self.config.invocation_params.dir,
+            )
         else:
             nodeid = None
 

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -733,11 +733,13 @@ class FSCollector(Collector, abc.ABC):
             session = parent.session
 
         if nodeid is None:
-            nodeid = compute_nodeid_prefix_for_path(
-                path=path,
-                rootpath=session.config.rootpath,
-                invocation_dir=session.config.invocation_params.dir,
-            )
+            try:
+                nodeid = str(path.relative_to(session.config.rootpath))
+            except ValueError:
+                nodeid = _check_initialpaths_for_relpath(session._initialpaths, path)
+
+            if nodeid:
+                nodeid = norm_sep(nodeid)
 
         super().__init__(
             name=name,

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -578,17 +578,28 @@ def _get_site_packages_dirs() -> frozenset[Path]:
 
     dirs: set[Path] = set()
     # Standard site-packages
-    for sp in site.getsitepackages():
+    # getsitepackages() may not exist in some virtualenv configurations
+    try:
+        site_packages = site.getsitepackages()
+    except AttributeError:
+        site_packages = []
+    for sp in site_packages:
         try:
             dirs.add(Path(sp).resolve())
         except OSError:
+            # Path resolution can fail (deleted dir, permission issues, etc.)
             pass
     # User site-packages
-    user_site = site.getusersitepackages()
+    # getusersitepackages() may not exist in some virtualenv configurations
+    try:
+        user_site = site.getusersitepackages()
+    except AttributeError:
+        user_site = None
     if user_site:
         try:
             dirs.add(Path(user_site).resolve())
         except OSError:
+            # Path resolution can fail (deleted dir, permission issues, etc.)
             pass
     return frozenset(dirs)
 

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
+import os
 from pathlib import Path
 import re
 import warnings
@@ -289,7 +290,8 @@ class TestNodeidPrefixComputation:
         )
 
         # Should use absolute path since it's more than 2 levels up
-        assert result == str(far_away)
+        # Use nodes.SEP for cross-platform compatibility (nodeids always use forward slashes)
+        assert result == str(far_away).replace(os.sep, nodes.SEP)
 
     def test_compute_nodeid_rootpath_itself(self, tmp_path: Path) -> None:
         """Test nodeid computation for rootpath itself returns empty string."""

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -169,3 +169,162 @@ def test_failure_with_changed_cwd(pytester: Pytester) -> None:
     )
     result = pytester.runpytest()
     result.stdout.fnmatch_lines([str(p) + ":*: AssertionError", "*1 failed in *"])
+
+
+class TestNodeidPrefixComputation:
+    """Tests for nodeid prefix computation for paths outside rootdir."""
+
+    def test_path_in_site_packages_found(self, tmp_path: Path) -> None:
+        """Test _path_in_site_packages finds paths inside site-packages."""
+        fake_site_packages = tmp_path / "site-packages"
+        fake_site_packages.mkdir()
+        pkg_path = fake_site_packages / "mypackage" / "tests" / "test_foo.py"
+        pkg_path.parent.mkdir(parents=True)
+        pkg_path.touch()
+
+        site_packages = frozenset([fake_site_packages])
+        result = nodes._path_in_site_packages(pkg_path, site_packages)
+
+        assert result is not None
+        sp_dir, rel_path = result
+        assert sp_dir == fake_site_packages
+        assert rel_path == Path("mypackage/tests/test_foo.py")
+
+    def test_path_in_site_packages_not_found(self, tmp_path: Path) -> None:
+        """Test _path_in_site_packages returns None for paths outside site-packages."""
+        fake_site_packages = tmp_path / "site-packages"
+        fake_site_packages.mkdir()
+        other_path = tmp_path / "other" / "test_foo.py"
+        other_path.parent.mkdir(parents=True)
+        other_path.touch()
+
+        site_packages = frozenset([fake_site_packages])
+        result = nodes._path_in_site_packages(other_path, site_packages)
+
+        assert result is None
+
+    def test_compute_nodeid_inside_rootpath(self, tmp_path: Path) -> None:
+        """Test nodeid computation for paths inside rootpath."""
+        rootpath = tmp_path / "project"
+        rootpath.mkdir()
+        test_file = rootpath / "tests" / "test_foo.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.touch()
+
+        result = nodes.compute_nodeid_prefix_for_path(
+            path=test_file,
+            rootpath=rootpath,
+            invocation_dir=rootpath,
+            initial_paths=frozenset(),
+            site_packages=frozenset(),
+        )
+
+        assert result == "tests/test_foo.py"
+
+    def test_compute_nodeid_in_initial_paths(self, tmp_path: Path) -> None:
+        """Test nodeid computation for paths relative to initial_paths."""
+        rootpath = tmp_path / "project"
+        rootpath.mkdir()
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        test_file = tests_dir / "test_foo.py"
+        test_file.touch()
+
+        result = nodes.compute_nodeid_prefix_for_path(
+            path=test_file,
+            rootpath=rootpath,
+            invocation_dir=rootpath,
+            initial_paths=frozenset([tests_dir]),
+            site_packages=frozenset(),
+        )
+
+        assert result == "test_foo.py"
+
+    def test_compute_nodeid_in_site_packages(self, tmp_path: Path) -> None:
+        """Test nodeid computation for paths in site-packages uses site:// prefix."""
+        rootpath = tmp_path / "project"
+        rootpath.mkdir()
+        fake_site_packages = tmp_path / "site-packages"
+        fake_site_packages.mkdir()
+        pkg_test = fake_site_packages / "mypackage" / "tests" / "test_foo.py"
+        pkg_test.parent.mkdir(parents=True)
+        pkg_test.touch()
+
+        result = nodes.compute_nodeid_prefix_for_path(
+            path=pkg_test,
+            rootpath=rootpath,
+            invocation_dir=rootpath,
+            initial_paths=frozenset(),
+            site_packages=frozenset([fake_site_packages]),
+        )
+
+        assert result == "site://mypackage/tests/test_foo.py"
+
+    def test_compute_nodeid_nearby_relative(self, tmp_path: Path) -> None:
+        """Test nodeid computation for nearby paths uses relative path."""
+        rootpath = tmp_path / "project"
+        rootpath.mkdir()
+        sibling = tmp_path / "sibling" / "tests" / "test_foo.py"
+        sibling.parent.mkdir(parents=True)
+        sibling.touch()
+
+        result = nodes.compute_nodeid_prefix_for_path(
+            path=sibling,
+            rootpath=rootpath,
+            invocation_dir=rootpath,
+            initial_paths=frozenset(),
+            site_packages=frozenset(),
+        )
+
+        assert result == "../sibling/tests/test_foo.py"
+
+    def test_compute_nodeid_far_away_absolute(self, tmp_path: Path) -> None:
+        """Test nodeid computation for far-away paths uses absolute path."""
+        rootpath = tmp_path / "deep" / "nested" / "project"
+        rootpath.mkdir(parents=True)
+        far_away = tmp_path / "other" / "location" / "tests" / "test_foo.py"
+        far_away.parent.mkdir(parents=True)
+        far_away.touch()
+
+        result = nodes.compute_nodeid_prefix_for_path(
+            path=far_away,
+            rootpath=rootpath,
+            invocation_dir=rootpath,
+            initial_paths=frozenset(),
+            site_packages=frozenset(),
+        )
+
+        # Should use absolute path since it's more than 2 levels up
+        assert result == str(far_away)
+
+    def test_compute_nodeid_rootpath_itself(self, tmp_path: Path) -> None:
+        """Test nodeid computation for rootpath itself returns empty string."""
+        rootpath = tmp_path / "project"
+        rootpath.mkdir()
+
+        result = nodes.compute_nodeid_prefix_for_path(
+            path=rootpath,
+            rootpath=rootpath,
+            invocation_dir=rootpath,
+            initial_paths=frozenset(),
+            site_packages=frozenset(),
+        )
+
+        assert result == ""
+
+    def test_compute_nodeid_initial_path_itself(self, tmp_path: Path) -> None:
+        """Test nodeid computation for initial_path itself returns empty string."""
+        rootpath = tmp_path / "project"
+        rootpath.mkdir()
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+
+        result = nodes.compute_nodeid_prefix_for_path(
+            path=tests_dir,
+            rootpath=rootpath,
+            invocation_dir=rootpath,
+            initial_paths=frozenset([tests_dir]),
+            site_packages=frozenset(),
+        )
+
+        assert result == ""

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -215,14 +215,13 @@ class TestNodeidPrefixComputation:
             path=test_file,
             rootpath=rootpath,
             invocation_dir=rootpath,
-            initial_paths=frozenset(),
             site_packages=frozenset(),
         )
 
         assert result == "tests/test_foo.py"
 
-    def test_compute_nodeid_in_initial_paths(self, tmp_path: Path) -> None:
-        """Test nodeid computation for paths relative to initial_paths."""
+    def test_compute_nodeid_outside_rootpath(self, tmp_path: Path) -> None:
+        """Test nodeid computation for paths outside rootpath uses bestrelpath."""
         rootpath = tmp_path / "project"
         rootpath.mkdir()
         tests_dir = tmp_path / "tests"
@@ -234,11 +233,11 @@ class TestNodeidPrefixComputation:
             path=test_file,
             rootpath=rootpath,
             invocation_dir=rootpath,
-            initial_paths=frozenset([tests_dir]),
             site_packages=frozenset(),
         )
 
-        assert result == "test_foo.py"
+        # Uses bestrelpath since outside rootpath
+        assert result == "../tests/test_foo.py"
 
     def test_compute_nodeid_in_site_packages(self, tmp_path: Path) -> None:
         """Test nodeid computation for paths in site-packages uses site:// prefix."""
@@ -254,7 +253,6 @@ class TestNodeidPrefixComputation:
             path=pkg_test,
             rootpath=rootpath,
             invocation_dir=rootpath,
-            initial_paths=frozenset(),
             site_packages=frozenset([fake_site_packages]),
         )
 
@@ -272,8 +270,6 @@ class TestNodeidPrefixComputation:
             path=sibling,
             rootpath=rootpath,
             invocation_dir=rootpath,
-            initial_paths=frozenset(),
-            site_packages=frozenset(),
         )
 
         assert result == "../sibling/tests/test_foo.py"
@@ -290,8 +286,6 @@ class TestNodeidPrefixComputation:
             path=far_away,
             rootpath=rootpath,
             invocation_dir=rootpath,
-            initial_paths=frozenset(),
-            site_packages=frozenset(),
         )
 
         # Should use absolute path since it's more than 2 levels up
@@ -306,25 +300,6 @@ class TestNodeidPrefixComputation:
             path=rootpath,
             rootpath=rootpath,
             invocation_dir=rootpath,
-            initial_paths=frozenset(),
-            site_packages=frozenset(),
-        )
-
-        assert result == ""
-
-    def test_compute_nodeid_initial_path_itself(self, tmp_path: Path) -> None:
-        """Test nodeid computation for initial_path itself returns empty string."""
-        rootpath = tmp_path / "project"
-        rootpath.mkdir()
-        tests_dir = tmp_path / "tests"
-        tests_dir.mkdir()
-
-        result = nodes.compute_nodeid_prefix_for_path(
-            path=tests_dir,
-            rootpath=rootpath,
-            invocation_dir=rootpath,
-            initial_paths=frozenset([tests_dir]),
-            site_packages=frozenset(),
         )
 
         assert result == ""


### PR DESCRIPTION
Fixes #14004.

Conftests outside rootpath previously got empty nodeid, making fixtures global. Now uses `compute_nodeid_prefix_for_path` for consistent nodeids based on `bestrelpath` from invocation_dir.