### PR TITLE
[DONT REVIEW] WIP: Migrate Node __init__ logic to from_parent factory methods

### DIFF
--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -253,10 +253,12 @@ class DoctestItem(Item):
         self,
         name: str,
         parent: DoctestTextfile | DoctestModule,
+        *,
         runner: doctest.DocTestRunner,
         dtest: doctest.DocTest,
+        **kw,
     ) -> None:
-        super().__init__(name, parent)
+        super().__init__(name, parent, **kw)
         self.runner = runner
         self.dtest = dtest
 

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -591,7 +591,6 @@ class Session(nodes.Collector):
         super().__init__(
             name="",
             path=config.rootpath,
-            fspath=None,
             parent=None,
             config=config,
             session=self,
@@ -611,11 +610,12 @@ class Session(nodes.Collector):
 
         self._bestrelpathcache: dict[Path, str] = _bestrelpath_cache(config.rootpath)
 
-        self.config.pluginmanager.register(self, name="session")
-
     @classmethod
     def from_config(cls, config: Config) -> Session:
+        """The public constructor for Session."""
         session: Session = cls._create(config=config)
+        # Register session as a plugin after construction.
+        config.pluginmanager.register(session, name="session")
         return session
 
     def __repr__(self) -> str:

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -1611,8 +1611,8 @@ def test_class_from_parent(request: FixtureRequest) -> None:
     """Ensure Class.from_parent can forward custom arguments to the constructor."""
 
     class MyCollector(pytest.Class):
-        def __init__(self, name, parent, x):
-            super().__init__(name, parent)
+        def __init__(self, *, x, **kw):
+            super().__init__(**kw)
             self.x = x
 
         @classmethod


### PR DESCRIPTION
## Summary

Refactors Node constructors to be simple assignment-only, moving all derivation logic to `from_parent` factory methods.

## Changes

- `Node.from_parent` computes `config`/`session` from parent
- `FSCollector.from_parent` computes `name`/`nodeid` from path
- `Item.from_parent` performs diamond inheritance check before construction
- `Session.from_config` handles plugin registration post-construction
- Removed `fspath` parameter (was `PytestRemovedIn9Warning`)
- Removed non-cooperative constructor fallback in `NodeMeta._create`

## Blockers

This PR depends on prior changes that need separate PRs first:

1. **Diamond inheritance warning registration** - The warning is currently registered incorrectly and needs fixing before this can land

---

*Opening as draft to preserve work-in-progress state. Not ready for review.*