### PR TITLE
fix: show correct program name in argparse help/errors

### DIFF
--- a/changelog/1764.deprecation.rst
+++ b/changelog/1764.deprecation.rst
@@ -1,0 +1,2 @@
+:func:`pytest.console_main` is now deprecated and will be removed in pytest 10.
+It was never intended for programmatic use; use :func:`pytest.main` instead.

--- a/changelog/1764.improvement.rst
+++ b/changelog/1764.improvement.rst
@@ -1,0 +1,1 @@
+Improved argparse program name to show ``pytest``, ``python -m pytest``, or ``pytest.main()`` based on how pytest was invoked, making help and error messages clearer.

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -117,6 +117,8 @@ nitpick_ignore = [
     ("py:class", "ScopeName"),
     ("py:class", "BaseExcT_1"),
     ("py:class", "ExcT_1"),
+    # Deprecated, intentionally not added to reference docs.
+    ("py:func", "pytest.console_main"),
 ]
 
 add_module_names = False

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -42,6 +42,31 @@ node-based matching instead of fragile string prefix matching.
 In pytest 10, the ``baseid`` and ``nodeid`` string parameters will be removed.
 
 
+.. _console-main:
+
+``pytest.console_main()``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 9.1
+
+:func:`pytest.console_main` is deprecated and will be removed in pytest 10.
+
+This function is the CLI entry point used internally by the ``pytest`` console script
+and ``python -m pytest``. It was never intended for programmatic use, and exposing it
+in the public API led to confusion with :func:`pytest.main`, which is the correct way
+to invoke pytest from Python code.
+
+If you are calling ``pytest.console_main()`` in your code, replace it with :func:`pytest.main`:
+
+.. code-block:: python
+
+    # Deprecated
+    pytest.console_main()
+
+    # Use this instead
+    exit_code = pytest.main()
+
+
 .. _pastebin-deprecated:
 
 The ``--pastebin`` option

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,8 @@ urls.Funding = "https://docs.pytest.org/en/stable/sponsor.html"
 urls.Homepage = "https://docs.pytest.org/en/latest/"
 urls.Source = "https://github.com/pytest-dev/pytest"
 urls.Tracker = "https://github.com/pytest-dev/pytest/issues"
-scripts."py.test" = "pytest:console_main"
-scripts.pytest = "pytest:console_main"
+scripts."py.test" = "_pytest.config:_console_main"
+scripts.pytest = "_pytest.config:_console_main"
 
 [tool.setuptools.package-data]
 "_pytest" = [

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -172,9 +172,33 @@ def print_usage_error(e: UsageError, file: TextIO) -> None:
         tw.line(f"ERROR: {msg}\n", red=True)
 
 
+def _get_prog_name(
+    *, invoked_from_console: bool, _argv: list[str] | None = None
+) -> str:
+    """Determine the appropriate program name for argparse based on invocation context.
+
+    :param invoked_from_console: Whether pytest was invoked from the CLI entry point.
+    :param _argv: Optional argv list for testing; defaults to sys.argv.
+    :returns: The program name to display in help and error messages.
+    """
+    if not invoked_from_console:
+        # Called programmatically via pytest.main()
+        return "pytest.main()"
+
+    # Called from CLI - check if it's `python -m pytest` or direct `pytest`
+    argv = sys.argv if _argv is None else _argv
+    argv0 = argv[0] if argv else ""
+    # When running as `python -m pytest`, argv[0] is the path to __main__.py
+    if os.path.basename(argv0) == "__main__.py":
+        return "python -m pytest"
+    return "pytest"
+
+
 def main(
     args: list[str] | os.PathLike[str] | None = None,
     plugins: Sequence[str | _PluggyPlugin] | None = None,
+    *,
+    _invoked_from_console: bool = False,
 ) -> int | ExitCode:
     """Perform an in-process test run.
 
@@ -194,11 +218,13 @@ def main(
         sys.stdout.write(f"pytest {__version__}\n")
         return ExitCode.OK
 
+    prog = _get_prog_name(invoked_from_console=_invoked_from_console)
+
     old_pytest_version = os.environ.get("PYTEST_VERSION")
     try:
         os.environ["PYTEST_VERSION"] = __version__
         try:
-            config = _prepareconfig(new_args, plugins)
+            config = _prepareconfig(new_args, plugins, prog=prog)
         except ConftestImportFailure as e:
             print_conftest_import_error(e, file=sys.stderr)
             return ExitCode.USAGE_ERROR
@@ -228,7 +254,7 @@ def console_main() -> int:
     """
     # https://docs.python.org/3/library/signal.html#note-on-sigpipe
     try:
-        code = main()
+        code = main(_invoked_from_console=True)
         sys.stdout.flush()
         return code
     except BrokenPipeError:
@@ -314,6 +340,8 @@ builtin_plugins = {
 def get_config(
     args: Iterable[str] | None = None,
     plugins: Sequence[str | _PluggyPlugin] | None = None,
+    *,
+    prog: str | None = None,
 ) -> Config:
     # Subsequent calls to main will create a fresh instance.
     pluginmanager = PytestPluginManager()
@@ -322,7 +350,7 @@ def get_config(
         plugins=plugins,
         dir=pathlib.Path.cwd(),
     )
-    config = Config(pluginmanager, invocation_params=invocation_params)
+    config = Config(pluginmanager, invocation_params=invocation_params, prog=prog)
 
     if invocation_params.args:
         # Handle any "-p no:plugin" args.
@@ -348,6 +376,8 @@ def get_plugin_manager() -> PytestPluginManager:
 def _prepareconfig(
     args: list[str] | os.PathLike[str],
     plugins: Sequence[str | _PluggyPlugin] | None = None,
+    *,
+    prog: str | None = None,
 ) -> Config:
     if isinstance(args, os.PathLike):
         args = [os.fspath(args)]
@@ -357,7 +387,7 @@ def _prepareconfig(
         )
         raise TypeError(msg.format(args, type(args)))
 
-    initial_config = get_config(args, plugins)
+    initial_config = get_config(args, plugins, prog=prog)
     pluginmanager = initial_config.pluginmanager
     try:
         if plugins:
@@ -1065,6 +1095,7 @@ class Config:
         pluginmanager: PytestPluginManager,
         *,
         invocation_params: InvocationParams | None = None,
+        prog: str | None = None,
     ) -> None:
         if invocation_params is None:
             invocation_params = self.InvocationParams(
@@ -1088,6 +1119,8 @@ class Config:
             processopt=self._processopt,
             _ispytest=True,
         )
+        if prog is not None:
+            self._parser.prog = prog
         self.pluginmanager = pluginmanager
         """The plugin manager handles plugin registration and hook invocation.
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -243,10 +243,10 @@ def _main(
             os.environ["PYTEST_VERSION"] = old_pytest_version
 
 
-def console_main() -> int:
-    """The CLI entry point of pytest.
+def _console_main() -> int:
+    """The CLI entry point of pytest (internal).
 
-    This function is not meant for programmable use; use `main()` instead.
+    This is the real implementation used by entry points and ``__main__.py``.
     """
     # https://docs.python.org/3/library/signal.html#note-on-sigpipe
     try:
@@ -259,6 +259,21 @@ def console_main() -> int:
         devnull = os.open(os.devnull, os.O_WRONLY)
         os.dup2(devnull, sys.stdout.fileno())
         return 1  # Python exits with error code 1 on EPIPE
+
+
+def console_main() -> int:
+    """The CLI entry point of pytest.
+
+    .. deprecated:: 9.1
+        This function is slated for removal in pytest 10.
+        It is not meant for programmable use; use :func:`pytest.main` instead.
+    """
+    import warnings
+
+    from _pytest.deprecated import CONSOLE_MAIN
+
+    warnings.warn(CONSOLE_MAIN, stacklevel=2)
+    return _console_main()
 
 
 class cmdline:  # compatibility namespace

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -172,23 +172,14 @@ def print_usage_error(e: UsageError, file: TextIO) -> None:
         tw.line(f"ERROR: {msg}\n", red=True)
 
 
-def _get_prog_name(
-    *, invoked_from_console: bool, _argv: list[str] | None = None
-) -> str:
-    """Determine the appropriate program name for argparse based on invocation context.
+def _get_prog_name(argv: Sequence[str]) -> str:
+    """Determine the CLI program name from the argument vector.
 
-    :param invoked_from_console: Whether pytest was invoked from the CLI entry point.
-    :param _argv: Optional argv list for testing; defaults to sys.argv.
-    :returns: The program name to display in help and error messages.
+    :param argv: The argument vector (typically ``sys.argv``).
+    :returns: ``"python -m pytest"`` when invoked via ``python -m``,
+              ``"pytest"`` otherwise.
     """
-    if not invoked_from_console:
-        # Called programmatically via pytest.main()
-        return "pytest.main()"
-
-    # Called from CLI - check if it's `python -m pytest` or direct `pytest`
-    argv = sys.argv if _argv is None else _argv
     argv0 = argv[0] if argv else ""
-    # When running as `python -m pytest`, argv[0] is the path to __main__.py
     if os.path.basename(argv0) == "__main__.py":
         return "python -m pytest"
     return "pytest"
@@ -197,8 +188,6 @@ def _get_prog_name(
 def main(
     args: list[str] | os.PathLike[str] | None = None,
     plugins: Sequence[str | _PluggyPlugin] | None = None,
-    *,
-    _invoked_from_console: bool = False,
 ) -> int | ExitCode:
     """Perform an in-process test run.
 
@@ -209,6 +198,15 @@ def main(
 
     :returns: An exit code.
     """
+    return _main(args=args, plugins=plugins, prog="pytest.main()")
+
+
+def _main(
+    *,
+    args: list[str] | os.PathLike[str] | None = None,
+    plugins: Sequence[str | _PluggyPlugin] | None = None,
+    prog: str,
+) -> int | ExitCode:
     # Handle a single `--version`/`-V` argument early to avoid starting up the entire pytest infrastructure.
     new_args = sys.argv[1:] if args is None else args
     if (
@@ -217,8 +215,6 @@ def main(
     ):
         sys.stdout.write(f"pytest {__version__}\n")
         return ExitCode.OK
-
-    prog = _get_prog_name(invoked_from_console=_invoked_from_console)
 
     old_pytest_version = os.environ.get("PYTEST_VERSION")
     try:
@@ -254,7 +250,7 @@ def console_main() -> int:
     """
     # https://docs.python.org/3/library/signal.html#note-on-sigpipe
     try:
-        code = main(_invoked_from_console=True)
+        code = _main(prog=_get_prog_name(sys.argv))
         sys.stdout.flush()
         return code
     except BrokenPipeError:
@@ -1117,10 +1113,9 @@ class Config:
         self._parser = Parser(
             usage=f"%(prog)s [options] [{FILE_OR_DIR}] [{FILE_OR_DIR}] [...]",
             processopt=self._processopt,
+            prog=prog,
             _ispytest=True,
         )
-        if prog is not None:
-            self._parser.prog = prog
         self.pluginmanager = pluginmanager
         """The plugin manager handles plugin registration and hook invocation.
 

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -34,6 +34,7 @@ class Parser:
         usage: str | None = None,
         processopt: Callable[[Argument], None] | None = None,
         *,
+        prog: str | None = None,
         _ispytest: bool = False,
     ) -> None:
         check_ispytest(_ispytest)
@@ -42,7 +43,7 @@ class Parser:
 
         self._processopt = processopt
         self.extra_info: dict[str, Any] = {}
-        self.optparser = PytestArgumentParser(usage, self.extra_info)
+        self.optparser = PytestArgumentParser(usage, self.extra_info, prog=prog)
         anonymous_arggroup = self.optparser.add_argument_group("Custom options")
         self._anonymous = OptionGroup(
             anonymous_arggroup, "_anonymous", self, _ispytest=True
@@ -383,9 +384,12 @@ class PytestArgumentParser(argparse.ArgumentParser):
         self,
         usage: str | None,
         extra_info: dict[str, str],
+        *,
+        prog: str | None = None,
     ) -> None:
         super().__init__(
             usage=usage,
+            prog=prog,
             add_help=False,
             formatter_class=DropShorterLongHelpFormatter,
             allow_abbrev=False,

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -70,6 +70,12 @@ PARAMETRIZE_NON_COLLECTION_ITERABLE = UnformattedWarning(
     "See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators",
 )
 
+CONSOLE_MAIN = PytestRemovedIn10Warning(
+    "pytest.console_main() is deprecated and will be removed in pytest 10.\n"
+    "It was never intended for programmatic use; use pytest.main() instead.\n"
+    "See https://docs.pytest.org/en/stable/deprecations.html#console-main"
+)
+
 CONFIG_INICFG = PytestRemovedIn10Warning(
     "config.inicfg is deprecated, use config.getini() to access configuration values instead.\n"
     "See https://docs.pytest.org/en/stable/deprecations.html#config-inicfg"

--- a/src/pytest/__main__.py
+++ b/src/pytest/__main__.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import pytest
+from _pytest.config import _console_main
 
 
 if __name__ == "__main__":
-    raise SystemExit(pytest.console_main())
+    raise SystemExit(_console_main())

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import _pytest._code
 from _pytest.config import _get_plugin_specs_as_list
+from _pytest.config import _get_prog_name
 from _pytest.config import _iter_rewritable_modules
 from _pytest.config import _strtobool
 from _pytest.config import Config
@@ -3082,3 +3083,83 @@ class TestInicfgDeprecation:
 
         result = pytester.runpytest()
         assert result.ret == 0
+
+
+class TestProgName:
+    """Test program name display in help and error messages (issue #1764)."""
+
+    def test_get_prog_name_programmatic_invocation(self) -> None:
+        """When invoked programmatically, prog should be 'pytest.main()'."""
+        # Regardless of what argv[0] is, programmatic invocation should
+        # always show pytest.main()
+        assert (
+            _get_prog_name(invoked_from_console=False, _argv=["setup.py", "test"])
+            == "pytest.main()"
+        )
+        assert (
+            _get_prog_name(invoked_from_console=False, _argv=["my_script.py"])
+            == "pytest.main()"
+        )
+
+    def test_get_prog_name_console_pytest(self) -> None:
+        """When invoked via 'pytest' CLI, prog should be 'pytest'."""
+        assert (
+            _get_prog_name(
+                invoked_from_console=True, _argv=["/usr/bin/pytest", "--help"]
+            )
+            == "pytest"
+        )
+        assert (
+            _get_prog_name(invoked_from_console=True, _argv=["pytest", "-v"])
+            == "pytest"
+        )
+
+    def test_get_prog_name_console_python_m_pytest(self) -> None:
+        """When invoked via 'python -m pytest', prog should be 'python -m pytest'."""
+        # When running as python -m pytest, argv[0] is the path to __main__.py
+        assert (
+            _get_prog_name(
+                invoked_from_console=True,
+                _argv=["/path/to/site-packages/pytest/__main__.py", "--help"],
+            )
+            == "python -m pytest"
+        )
+        assert (
+            _get_prog_name(invoked_from_console=True, _argv=["__main__.py", "-v"])
+            == "python -m pytest"
+        )
+
+    def test_get_prog_name_empty_argv(self) -> None:
+        """When argv is empty, should handle gracefully."""
+        # Empty argv with console invocation should default to pytest
+        assert _get_prog_name(invoked_from_console=True, _argv=[]) == "pytest"
+        # Empty argv with programmatic invocation should show pytest.main()
+        assert _get_prog_name(invoked_from_console=False, _argv=[]) == "pytest.main()"
+
+    def test_prog_in_error_message_programmatic(self, pytester: Pytester) -> None:
+        """Error messages should show 'pytest.main()' when called programmatically.
+
+        runpytest_inprocess calls pytest.main() directly, so it should show
+        pytest.main() as the program name.
+        """
+        result = pytester.runpytest_inprocess("--invalid-option-xyz")
+        result.stderr.fnmatch_lines(["*pytest.main(): error:*invalid-option-xyz*"])
+
+    def test_prog_in_error_message_cli(self, pytester: Pytester) -> None:
+        """Error messages should show 'python -m pytest' when called from CLI subprocess.
+
+        runpytest_subprocess runs pytest via 'python -m pytest', so it should
+        show 'python -m pytest' as the program name.
+        """
+        result = pytester.runpytest_subprocess("--invalid-option-xyz")
+        result.stderr.fnmatch_lines(["*python -m pytest: error:*invalid-option-xyz*"])
+
+    def test_prog_in_usage_programmatic(self, pytester: Pytester) -> None:
+        """Usage line should show 'pytest.main()' when called programmatically."""
+        result = pytester.runpytest_inprocess("--help")
+        result.stdout.fnmatch_lines(["usage: pytest.main() *"])
+
+    def test_prog_in_usage_cli(self, pytester: Pytester) -> None:
+        """Usage line should show 'python -m pytest' when called from CLI subprocess."""
+        result = pytester.runpytest_subprocess("--help")
+        result.stdout.fnmatch_lines(["usage: python -m pytest *"])

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -3088,53 +3088,22 @@ class TestInicfgDeprecation:
 class TestProgName:
     """Test program name display in help and error messages (issue #1764)."""
 
-    def test_get_prog_name_programmatic_invocation(self) -> None:
-        """When invoked programmatically, prog should be 'pytest.main()'."""
-        # Regardless of what argv[0] is, programmatic invocation should
-        # always show pytest.main()
-        assert (
-            _get_prog_name(invoked_from_console=False, _argv=["setup.py", "test"])
-            == "pytest.main()"
-        )
-        assert (
-            _get_prog_name(invoked_from_console=False, _argv=["my_script.py"])
-            == "pytest.main()"
-        )
+    def test_get_prog_name_direct_pytest(self) -> None:
+        """When argv[0] is a pytest entry point, prog should be 'pytest'."""
+        assert _get_prog_name(["/usr/bin/pytest", "--help"]) == "pytest"
+        assert _get_prog_name(["pytest", "-v"]) == "pytest"
 
-    def test_get_prog_name_console_pytest(self) -> None:
-        """When invoked via 'pytest' CLI, prog should be 'pytest'."""
+    def test_get_prog_name_python_m_pytest(self) -> None:
+        """When argv[0] is __main__.py, prog should be 'python -m pytest'."""
         assert (
-            _get_prog_name(
-                invoked_from_console=True, _argv=["/usr/bin/pytest", "--help"]
-            )
-            == "pytest"
-        )
-        assert (
-            _get_prog_name(invoked_from_console=True, _argv=["pytest", "-v"])
-            == "pytest"
-        )
-
-    def test_get_prog_name_console_python_m_pytest(self) -> None:
-        """When invoked via 'python -m pytest', prog should be 'python -m pytest'."""
-        # When running as python -m pytest, argv[0] is the path to __main__.py
-        assert (
-            _get_prog_name(
-                invoked_from_console=True,
-                _argv=["/path/to/site-packages/pytest/__main__.py", "--help"],
-            )
+            _get_prog_name(["/path/to/site-packages/pytest/__main__.py", "--help"])
             == "python -m pytest"
         )
-        assert (
-            _get_prog_name(invoked_from_console=True, _argv=["__main__.py", "-v"])
-            == "python -m pytest"
-        )
+        assert _get_prog_name(["__main__.py", "-v"]) == "python -m pytest"
 
     def test_get_prog_name_empty_argv(self) -> None:
-        """When argv is empty, should handle gracefully."""
-        # Empty argv with console invocation should default to pytest
-        assert _get_prog_name(invoked_from_console=True, _argv=[]) == "pytest"
-        # Empty argv with programmatic invocation should show pytest.main()
-        assert _get_prog_name(invoked_from_console=False, _argv=[]) == "pytest.main()"
+        """When argv is empty, should default to 'pytest'."""
+        assert _get_prog_name([]) == "pytest"
 
     def test_prog_in_error_message_programmatic(self, pytester: Pytester) -> None:
         """Error messages should show 'pytest.main()' when called programmatically.

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -19,6 +19,7 @@ from _pytest.config import _iter_rewritable_modules
 from _pytest.config import _strtobool
 from _pytest.config import Config
 from _pytest.config import ConftestImportFailure
+from _pytest.config import console_main
 from _pytest.config import ExitCode
 from _pytest.config import parse_warning_filter
 from _pytest.config.argparsing import get_ini_default_for_type
@@ -3132,3 +3133,12 @@ class TestProgName:
         """Usage line should show 'python -m pytest' when called from CLI subprocess."""
         result = pytester.runpytest_subprocess("--help")
         result.stdout.fnmatch_lines(["usage: python -m pytest *"])
+
+    def test_console_main_deprecated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Calling pytest.console_main() should emit a deprecation warning."""
+        monkeypatch.setattr("_pytest.config._console_main", lambda: 0)
+        with pytest.warns(
+            pytest.PytestRemovedIn10Warning,
+            match="pytest.console_main.*is deprecated",
+        ):
+            console_main()


### PR DESCRIPTION
## Summary
- Display `pytest`, `python -m pytest`, or `pytest.main()` in help/error messages based on how pytest was invoked
- Fixes confusing error messages like `setup.py: error:` when calling `pytest.main()` programmatically

Fixes #1764