### PR TITLE
Docs: clarify conftest usage and fixture import pitfalls

### DIFF
--- a/changelog/13148.doc.rst
+++ b/changelog/13148.doc.rst
@@ -1,1 +1,1 @@
-Clarified fixture visibility, conftest usage, and why importing fixtures is discouraged. 
+Clarified fixture visibility, conftest usage, and why importing fixtures is discouraged.

--- a/changelog/13148.doc.rst
+++ b/changelog/13148.doc.rst
@@ -1,0 +1,1 @@
+Clarified fixture visibility, conftest usage, and why importing fixtures is discouraged. 

--- a/changelog/13148.doc.rst
+++ b/changelog/13148.doc.rst
@@ -1,1 +1,2 @@
-Clarified fixture visibility, conftest usage, and why importing fixtures is discouraged.
+:ref:`Clarified <smtpshared>` fixture visibility, conftest usage, and why importing fixtures is discouraged.
+

--- a/changelog/13148.doc.rst
+++ b/changelog/13148.doc.rst
@@ -1,2 +1,1 @@
 :ref:`Clarified <smtpshared>` fixture visibility, conftest usage, and why importing fixtures is discouraged.
-

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -407,7 +407,7 @@ so that tests from multiple test modules in the directory can access the fixture
         return smtplib.SMTP("smtp.gmail.com", 587, timeout=5)
 
 Using ``conftest.py`` is the recommended way to share fixtures across multiple test modules.
-The ``scope`` setting controls how long a fixture value is cached 
+The ``scope`` setting controls how long a fixture value is cached
 (for example, once per test function or once per module).
 The file where the fixture is defined determines which tests are able to use it.
 
@@ -416,7 +416,7 @@ fixtures to be registered in more than one place, which can lead to confusing be
 fixtures running more than once.
 
 As a rule of thumb, don't import fixtures from test files or ``conftest.py`` for runtime use.
-If imports are needed only for editor or type checker support, use ``typing.TYPE_CHECKING`` or forward 
+If imports are needed only for editor or type checker support, use ``typing.TYPE_CHECKING`` or forward
 references so those imports are not executed during test collection.
 
 .. code-block:: python

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -391,9 +391,25 @@ Multiple test functions in a test module will thus
 each receive the same ``smtp_connection`` fixture instance, thus saving time.
 Possible values for ``scope`` are: ``function``, ``class``, ``module``, ``package`` or ``session``.
 
-The next example puts the fixture function into a separate ``conftest.py`` file
+.. note::
+
+   Fixture *scope* controls lifetime and caching, not visibility.
+   Visibility is determined by where the fixture is defined (test module,
+   ``conftest.py``, or plugin).
+
+The next example puts the fixture function into a separate :ref:`conftest.py <conftest>` file
 so that tests from multiple test modules in the directory can
 access the fixture function:
+
+.. note::
+
+   This is the recommended way to share fixtures across multiple test modules.
+   Avoid importing fixtures from other test files or from ``conftest.py``,
+   as importing fixtures can cause them to be registered in multiple modules and
+   lead to confusing behavior (such as fixtures running more than once).
+
+   As a rule of thumb: **never import fixtures from test files or conftest.py,
+   unless it is only for type annotations**.
 
 .. code-block:: python
 

--- a/doc/en/how-to/fixtures.rst
+++ b/doc/en/how-to/fixtures.rst
@@ -391,25 +391,8 @@ Multiple test functions in a test module will thus
 each receive the same ``smtp_connection`` fixture instance, thus saving time.
 Possible values for ``scope`` are: ``function``, ``class``, ``module``, ``package`` or ``session``.
 
-.. note::
-
-   Fixture *scope* controls lifetime and caching, not visibility.
-   Visibility is determined by where the fixture is defined (test module,
-   ``conftest.py``, or plugin).
-
 The next example puts the fixture function into a separate :ref:`conftest.py <conftest>` file
-so that tests from multiple test modules in the directory can
-access the fixture function:
-
-.. note::
-
-   This is the recommended way to share fixtures across multiple test modules.
-   Avoid importing fixtures from other test files or from ``conftest.py``,
-   as importing fixtures can cause them to be registered in multiple modules and
-   lead to confusing behavior (such as fixtures running more than once).
-
-   As a rule of thumb: **never import fixtures from test files or conftest.py,
-   unless it is only for type annotations**.
+so that tests from multiple test modules in the directory can access the fixture function.
 
 .. code-block:: python
 
@@ -423,6 +406,18 @@ access the fixture function:
     def smtp_connection():
         return smtplib.SMTP("smtp.gmail.com", 587, timeout=5)
 
+Using ``conftest.py`` is the recommended way to share fixtures across multiple test modules.
+The ``scope`` setting controls how long a fixture value is cached 
+(for example, once per test function or once per module).
+The file where the fixture is defined determines which tests are able to use it.
+
+Avoid importing fixtures from other test files or from ``conftest.py``: importing can cause
+fixtures to be registered in more than one place, which can lead to confusing behavior such as
+fixtures running more than once.
+
+As a rule of thumb, don't import fixtures from test files or ``conftest.py`` for runtime use.
+If imports are needed only for editor or type checker support, use ``typing.TYPE_CHECKING`` or forward 
+references so those imports are not executed during test collection.
 
 .. code-block:: python
 


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->This PR clarifies fixture visibility vs scope, recommends conftest.py for sharing fixtures, and documents why importing fixtures is discouraged.

Clarifies that fixture scope controls lifetime and caching, not visibility

Explicitly explains that fixture visibility depends on where it is defined (test module, conftest.py, or plugin)

Recommends conftest.py as the correct and supported way to share fixtures across multiple test modules

Adds a clear warning against importing fixtures from test files or conftest.py, which can cause duplicate registration and confusing behavior

Adds a simple rule of thumb: never import fixtures except for type annotations

Links readers to the reference documentation for deeper technical details

closes #13148
