### PR TITLE
Preserve dictionary insertion order in assertion output

### DIFF
--- a/src/_pytest/_io/pprint.py
+++ b/src/_pytest/_io/pprint.py
@@ -162,7 +162,8 @@ class PrettyPrinter:
     ) -> None:
         write = stream.write
         write("{")
-        items = sorted(object.items(), key=_safe_tuple)
+        # Preserve insertion order (guaranteed since Python 3.7)
+        items = object.items()
         self._format_dict_items(items, stream, indent, allowance, context, level)
         write("}")
 
@@ -608,7 +609,8 @@ class PrettyPrinter:
             components: list[str] = []
             append = components.append
             level += 1
-            for k, v in sorted(object.items(), key=_safe_tuple):
+            # Preserve insertion order (guaranteed since Python 3.7)
+            for k, v in object.items():
                 krepr = self._safe_repr(k, context, maxlevels, level)
                 vrepr = self._safe_repr(v, context, maxlevels, level)
                 append(f"{krepr}: {vrepr}")

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -510,7 +510,8 @@ def _compare_eq_dict(
         explanation += [f"Omitting {len(same)} identical items, use -vv to show"]
     elif same:
         explanation += ["Common items:"]
-        explanation += highlighter(pprint.pformat(same)).splitlines()
+        # Use custom PrettyPrinter to preserve insertion order
+        explanation += highlighter(PrettyPrinter().pformat(same)).splitlines()
     diff = {k for k in common if left[k] != right[k]}
     if diff:
         explanation += ["Differing items:"]
@@ -526,8 +527,11 @@ def _compare_eq_dict(
         explanation.append(
             f"Left contains {len_extra_left} more item{'' if len_extra_left == 1 else 's'}:"
         )
+        # Preserve insertion order from the original dict - use custom PrettyPrinter
         explanation.extend(
-            highlighter(pprint.pformat({k: left[k] for k in extra_left})).splitlines()
+            highlighter(
+                PrettyPrinter().pformat({k: left[k] for k in left if k in extra_left})
+            ).splitlines()
         )
     extra_right = set_right - set_left
     len_extra_right = len(extra_right)
@@ -535,8 +539,13 @@ def _compare_eq_dict(
         explanation.append(
             f"Right contains {len_extra_right} more item{'' if len_extra_right == 1 else 's'}:"
         )
+        # Preserve insertion order from the original dict - use custom PrettyPrinter
         explanation.extend(
-            highlighter(pprint.pformat({k: right[k] for k in extra_right})).splitlines()
+            highlighter(
+                PrettyPrinter().pformat(
+                    {k: right[k] for k in right if k in extra_right}
+                )
+            ).splitlines()
         )
     return explanation
 


### PR DESCRIPTION
  Fixes #13503

  - Remove alphabetical sorting from PrettyPrinter dict methods
  - Update assertion util to preserve original dict key order
  - Add comprehensive test for insertion order preservation
  - Update existing tests to match new multiline dict formatting

  Dictionary keys are now displayed in insertion order (guaranteed
  since Python 3.7) instead of alphabetically, making debug output
  more intuitive and matching behavior of print().
