### PR TITLE
Clarify retention policy

### DIFF
--- a/changelog/14180.doc.rst
+++ b/changelog/14180.doc.rst
@@ -1,0 +1,2 @@
+Clarify :confval:`tmp_path_retention_policy` by documenting that `failed` removes the files of passing tests in the teardown
+step but `none` only removes the files of tests at the end of the test session -- by :user:`jenshnielsen`.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -2465,7 +2465,7 @@ passed multiple times. The expected format is ``name=value``. For example::
 
 .. confval:: tmp_path_retention_count
 
-   How many sessions should we keep the `tmp_path` directories,
+   How many sessions should we keep the :fixture:`tmp_path` directories,
    according to :confval:`tmp_path_retention_policy`.
 
    .. tab:: toml
@@ -2489,11 +2489,11 @@ passed multiple times. The expected format is ``name=value``. For example::
 
 
 
-   Controls which directories created by the `tmp_path` fixture are kept around,
+   Controls which directories created by the :fixture:`tmp_path` fixture are kept around,
    based on test outcome.
 
     * `all`: retains directories for all tests, regardless of the outcome.
-    * `failed`: retains directories only for tests with outcome `error` or `failed`. Non-retained directories are removed during teardown of the tmp_path fixture.
+    * `failed`: retains directories only for tests with outcome `error` or `failed`. Non-retained directories are removed during teardown of the :fixture:`tmp_path` fixture.
     * `none`: directories are always removed after each test session ends, regardless of the outcome.
 
    .. tab:: toml

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -2493,8 +2493,8 @@ passed multiple times. The expected format is ``name=value``. For example::
    based on test outcome.
 
     * `all`: retains directories for all tests, regardless of the outcome.
-    * `failed`: retains directories only for tests with outcome `error` or `failed`.
-    * `none`: directories are always removed after each test ends, regardless of the outcome.
+    * `failed`: retains directories only for tests with outcome `error` or `failed`. Non-retained directories are removed during teardown of the tmp_path fixture.
+    * `none`: directories are always removed after each test session ends, regardless of the outcome.
 
    .. tab:: toml
 


### PR DESCRIPTION
While debugging a test session that ran out of diskspace in CI tried different retention policies. From reading the docs I would have expected that both `failed` and `none` would remove tmp files during teardown of the test but reading the code and testing locally I can see that when `none` is used the fixtures are not removed until the end of the session. 

This PR tweaks the docs slightly to make that clearer by documenting that `failed` removes the files of passing tests in the teardown step but `none` only removes the files of tests at the end of the test session.


