### PR TITLE
doc: add seealso link to src-layout vs flat-layout discussion

### DIFF
--- a/doc/en/explanation/goodpractices.rst
+++ b/doc/en/explanation/goodpractices.rst
@@ -153,7 +153,7 @@ which are better explained in this excellent `blog post`_ by Ionel Cristian Măr
 .. seealso::
 
     :doc:`packaging:discussions/src-layout-vs-flat-layout`
-        The Python Packaging User Guide discusses the trade-offs between the ``src`` layout and flat layout.
+        The Python Packaging User Guide discusses the trade-offs between the ``src`` layout and ``flat`` layout.
 
 Tests as part of application code
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Split from #14181 per @webknjaz's review — keeping changes atomic.

## Changes

Add a ``.. seealso::`` cross-reference in ``goodpractices.rst`` to the packaging.python.org discussion on src layout vs flat layout.

Reworked from the original PR to use intersphinx (via the existing ``packaging`` mapping) instead of a raw URL, per @webknjaz's feedback.

Open question from the previous review: whether a standalone ``.. seealso::`` block is the right approach, or whether linking the existing text inline would be better. Happy to rework if there's a preference.