### PR TITLE
doc: fixed typo in file name format (from `*_test.py to *_test.py) on "How to invoke pytest" page

### DIFF
--- a/doc/en/how-to/usage.rst
+++ b/doc/en/how-to/usage.rst
@@ -7,7 +7,7 @@ How to invoke pytest
 ..  seealso:: :ref:`Complete pytest command-line flags reference <command-line-flags>`
 
 In general, pytest is invoked with the command ``pytest`` (see below for :ref:`other ways to invoke pytest
-<invoke-other>`). This will execute all tests in all files whose names follow the form ``test_*.py`` or ``\*_test.py``
+<invoke-other>`). This will execute all tests in all files whose names follow the form ``test_*.py`` or ``*_test.py``
 in the current directory and its subdirectories. More generally, pytest follows :ref:`standard test discovery rules
 <test discovery>`.
 


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

This PR fixes a typo on the page "How to invoke pytest" under the How-to guides. The documentation originally states that files in the form of `\*_test.py` will be executed by pytest. I changed it to `*_test.py` to show that all files ending with `_test.py`, instead of ones that are literally named `*_test.py`, will be executed.