### PR TITLE
Fix ExceptionInfo.for_later() not populating _striptext

### DIFF
--- a/changelog/12175.bugfix.rst
+++ b/changelog/12175.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed :meth:`ExceptionInfo.exconly(tryshort=True) <ExceptionInfo.exconly>` not stripping the ``AssertionError`` prefix when the :class:`ExceptionInfo` was created via :meth:`ExceptionInfo.for_later` (e.g. when using :func:`pytest.raises`).
+Fixed :meth:`ExceptionInfo.exconly(tryshort=True) <pytest.ExceptionInfo.exconly>` not stripping the ``AssertionError`` prefix when the :class:`~pytest.ExceptionInfo` was created via :meth:`ExceptionInfo.for_later() <pytest.ExceptionInfo.for_later>` (e.g. when using :func:`pytest.raises`).

--- a/changelog/12175.bugfix.rst
+++ b/changelog/12175.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :meth:`ExceptionInfo.exconly(tryshort=True) <ExceptionInfo.exconly>` not stripping the ``AssertionError`` prefix when the :class:`ExceptionInfo` was created via :meth:`ExceptionInfo.for_later` (e.g. when using :func:`pytest.raises`).

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -591,6 +591,12 @@ class ExceptionInfo(Generic[E]):
         """Fill an unfilled ExceptionInfo created with ``for_later()``."""
         assert self._excinfo is None, "ExceptionInfo was already filled"
         self._excinfo = exc_info
+        if isinstance(exc_info[1], AssertionError):
+            exprinfo = getattr(exc_info[1], "msg", None)
+            if exprinfo is None:
+                exprinfo = saferepr(exc_info[1])
+            if exprinfo and exprinfo.startswith(self._assert_start_repr):
+                self._striptext = "AssertionError: "
 
     @property
     def type(self) -> type[E]:

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -365,6 +365,27 @@ def test_excinfo_for_later() -> None:
     assert "for raises" in str(e)
 
 
+def test_excinfo_for_later_strips_assertion(pytester: Pytester) -> None:
+    """ExceptionInfo created via for_later() should strip AssertionError prefix
+    with exconly(tryshort=True) for rewritten assertions (#12175)."""
+    pytester.makepyfile(
+        """
+        import pytest
+
+        def test_tryshort():
+            with pytest.raises(AssertionError) as exc_info:
+                assert 1 == 2
+            # tryshort should strip 'AssertionError: ' from rewritten assertions
+            result = exc_info.exconly(tryshort=True)
+            assert not result.startswith("AssertionError"), (
+                f"Expected stripped prefix, got: {result!r}"
+            )
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
 def test_excinfo_errisinstance():
     excinfo = pytest.raises(ValueError, h)
     assert excinfo.errisinstance(ValueError)


### PR DESCRIPTION
## Summary

Fixes #12175.

When `ExceptionInfo` is created via `for_later()` (as used by `pytest.raises`), the `_striptext` attribute is never populated. This causes `exconly(tryshort=True)` to not strip the `AssertionError: ` prefix for rewritten assertions.

The fix applies the same `_striptext` logic from `from_exc_info()` inside `fill_unfilled()`, so that `ExceptionInfo` objects created through the `for_later()` path behave consistently with those created via `from_exc_info()`.

## Changes

- `fill_unfilled()` now populates `_striptext` when the exception is an `AssertionError` whose `saferepr` starts with `_assert_start_repr`, matching the logic in `from_exc_info()`
- Added test `test_excinfo_for_later_strips_assertion` verifying the fix
- Added changelog entry

## Test plan

- [x] New test verifies `exconly(tryshort=True)` strips `AssertionError:` prefix for rewritten assertions caught via `pytest.raises`
- [x] Existing `test_excinfo_for_later` and `test_excinfo_exconly` still pass