### PR TITLE
Fix known_args_namespace containing duplicate append-action values

### DIFF
--- a/changelog/13484.bugfix.rst
+++ b/changelog/13484.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``known_args_namespace`` containing duplicate values for append-action arguments like ``-W`` due to re-parsing into the same namespace.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1358,7 +1358,7 @@ class Config:
         self._parser.extra_info["config source"] = via
         try:
             self._parser.parse_known_and_unknown_args(
-                args, namespace=copy.copy(self.option)
+                args, namespace=copy.deepcopy(self.option)
             )
         finally:
             self._parser.extra_info.pop("config source", None)
@@ -1500,7 +1500,7 @@ class Config:
                     + args
                 )
 
-        ns = self._parser.parse_known_args(args, namespace=copy.copy(self.option))
+        ns = self._parser.parse_known_args(args, namespace=copy.deepcopy(self.option))
         rootpath, inipath, inicfg, ignored_config_files = determine_setup(
             inifile=ns.inifilename,
             override_ini=ns.override_ini,
@@ -1533,7 +1533,7 @@ class Config:
             )
 
         self.known_args_namespace = self._parser.parse_known_args(
-            args, namespace=copy.copy(self.option)
+            args, namespace=copy.deepcopy(self.option)
         )
         self._checkversion()
         self._consider_importhook()
@@ -1550,7 +1550,9 @@ class Config:
         # are going to be loaded.
         self.pluginmanager.consider_env()
 
-        self._parser.parse_known_args(args, namespace=self.known_args_namespace)
+        self.known_args_namespace = self._parser.parse_known_args(
+            args, namespace=copy.deepcopy(self.option)
+        )
 
         self._validate_plugins()
         self._warn_about_skipped_plugins()

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -2327,9 +2327,7 @@ class TestOverrideIniArgs:
         )
         assert result.ret == _pytest.config.ExitCode.USAGE_ERROR
 
-    def test_append_args_not_duplicated(
-        self, _config_for_test, _sys_snapshot
-    ) -> None:
+    def test_append_args_not_duplicated(self, _config_for_test, _sys_snapshot) -> None:
         """Append-action args should not be duplicated after multiple parses (#13484)."""
         config = _config_for_test
         config.parse(["-Werror"], addopts=True)

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -2327,6 +2327,14 @@ class TestOverrideIniArgs:
         )
         assert result.ret == _pytest.config.ExitCode.USAGE_ERROR
 
+    def test_append_args_not_duplicated(
+        self, _config_for_test, _sys_snapshot
+    ) -> None:
+        """Append-action args should not be duplicated after multiple parses (#13484)."""
+        config = _config_for_test
+        config.parse(["-Werror"], addopts=True)
+        assert config.known_args_namespace.pythonwarnings == ["error"]
+
     def test_override_ini_does_not_contain_paths(
         self, _config_for_test, _sys_snapshot
     ) -> None:


### PR DESCRIPTION
## Summary

Fixes #13484

`Config.known_args_namespace` contains duplicate values for append-action arguments (e.g., `-Werror` produces `pythonwarnings=['error', 'error']`).

Two root causes:

1. **Third parse re-uses existing namespace**: After the initial `known_args_namespace` is populated (line 1535), a third `parse_known_args` call (line 1553) re-parses into the same namespace object. For append-action arguments, this appends values that are already present.

2. **Shallow copy shares mutable state**: `copy.copy()` on an `argparse.Namespace` creates a shallow copy — list attributes (like those from append actions) are shared between the original and the copy. Parsing into the copy mutates the original.

Fix: Replace the third parse's direct namespace reuse with a fresh `deepcopy(self.option)`, and change all `copy.copy(self.option)` calls to `copy.deepcopy(self.option)`.

## Test plan

- [x] Added `test_append_args_not_duplicated` verifying `-Werror` produces exactly `['error']`
- [x] 244/245 `test_config.py` tests pass (1 pre-existing subprocess failure)
- [x] 31/32 `test_warnings.py` tests pass (1 pre-existing subprocess failure)
- [x] 52 plugin-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)