### PR TITLE
Fix nested caplog.filtering() removing filter early

### DIFF
--- a/changelog/14189.bugfix.rst
+++ b/changelog/14189.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed nested :meth:`caplog.filtering() <pytest.LogCaptureFixture.filtering>` calls with the same filter removing the filter too early when the inner context exits.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -581,15 +581,22 @@ class LogCaptureFixture:
         :meth:`handler` for the 'with' statement block, and removes that filter at the
         end of the block.
 
+        If the filter is already attached to the handler (e.g. from an outer
+        nested ``filtering()`` call), it is not added again, and will not be
+        removed when the inner block exits.
+
         :param filter_: A custom :class:`logging.Filter` object.
 
         .. versionadded:: 7.5
         """
-        self.handler.addFilter(filter_)
+        already_present = filter_ in self.handler.filters
+        if not already_present:
+            self.handler.addFilter(filter_)
         try:
             yield
         finally:
-            self.handler.removeFilter(filter_)
+            if not already_present:
+                self.handler.removeFilter(filter_)
 
 
 @fixture

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -210,13 +210,15 @@ def test_nested_filtering_same_filter(caplog: pytest.LogCaptureFixture) -> None:
     """Nested ``caplog.filtering()`` with the same filter should not remove
     the filter when the inner context exits (#14189)."""
 
-    def no_capture(record: logging.LogRecord) -> bool:
-        return False
+    class NoCaptureFilter(logging.Filter):
+        def filter(self, record: logging.LogRecord) -> bool:
+            return False
 
+    filter_instance = NoCaptureFilter()
     with caplog.at_level(logging.INFO):
-        with caplog.filtering(no_capture):
+        with caplog.filtering(filter_instance):
             logger.info("outer before inner")
-            with caplog.filtering(no_capture):
+            with caplog.filtering(filter_instance):
                 logger.info("inside inner")
             logger.info("outer after inner")
         logger.info("outside both")


### PR DESCRIPTION
Fixes #14189.

When the same filter is used in nested `caplog.filtering()` context managers, the inner context's exit calls `removeFilter()` which removes the filter entirely — even though the outer context still needs it. This happens because `logging.Handler.removeFilter()` works by identity.

**Fix:** Before adding a filter, check if it's already present on the handler (from an outer `filtering()` call). If so, skip both the add and remove, leaving the outer scope's lifecycle in control.

```python
# Before fix: third warning is incorrectly captured
with caplog.filtering(no_capture):
    logging.warning("filtered")       # not captured ✓
    with caplog.filtering(no_capture):
        logging.warning("filtered")   # not captured ✓
    logging.warning("should be filtered")  # captured ✗ (filter was removed)

# After fix: all three warnings inside outer scope are filtered
```

This is option 1 from the issue — lightweight, no state tracking needed, preserves the existing API contract.