### PR TITLE
Fix autouse fixtures running in @unittest.skip classes

### DIFF
--- a/changelog/13885.bugfix.rst
+++ b/changelog/13885.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed autouse fixtures defined inside a :class:`unittest.TestCase` class running even when the class is decorated with :func:`unittest.skip` or :func:`unittest.skipIf` -- regression since pytest 8.1.0.

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -182,7 +182,7 @@ class UnitTestCase(Class):
         with @unittest.skip or @unittest.skipIf (#13885)."""
 
         def unittest_skip_fixture(request: FixtureRequest) -> None:
-            reason = cls.__unittest_skip_why__
+            reason = getattr(cls, "__unittest_skip_why__", "")
             raise skip.Exception(reason, _use_item_location=True)
 
         self.session._fixturemanager._register_fixture(

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -244,6 +244,27 @@ def test_unittest_skip_issue148(pytester: Pytester) -> None:
     reprec.assertoutcome(skipped=1)
 
 
+def test_unittest_skip_with_autouse_fixture(pytester: Pytester) -> None:
+    """Autouse fixtures inside a @unittest.skipIf class should not run (#13885)."""
+    pytester.makepyfile(
+        """
+        import unittest
+        import pytest
+
+        @unittest.skipIf(True, "skip reason")
+        class TestSkipped(unittest.TestCase):
+            @pytest.fixture(autouse=True)
+            def my_fixture(self):
+                raise RuntimeError("fixture should not run")
+
+            def test_one(self):
+                pass
+    """
+    )
+    reprec = pytester.inline_run()
+    reprec.assertoutcome(skipped=1)
+
+
 def test_method_and_teardown_failing_reporting(pytester: Pytester) -> None:
     pytester.makepyfile(
         """


### PR DESCRIPTION
Fixes #13885.

When a `unittest.TestCase` is decorated with `@unittest.skipIf(True, ...)` or `@unittest.skip`, autouse pytest fixtures defined inside the class were still being executed. This is a regression since pytest 8.1.0.

## Root cause

Commit c8792bd changed fixture registration so that when a class is skipped (`_is_skipped(cls)` is True), the unittest setup fixtures are not registered. However, `parsefactories` still discovers user-defined autouse fixtures inside the class. With no skip fixture registered, there is nothing to preempt the user fixtures, so they run and crash.

## Fix

Register a dedicated skip fixture for classes marked with `@unittest.skip`/`@unittest.skipIf`. This fixture raises `skip.Exception` before any other fixtures run, ensuring the class is properly skipped.

## Test

Added `test_unittest_skip_with_autouse_fixture` that reproduces the regression: a `@unittest.skipIf(True, ...)` class with an autouse fixture that raises RuntimeError. Before the fix, the fixture ran and caused an error. After the fix, the test is properly skipped.