### PR TITLE
Simplify pytest_report_teststatus for subtests

### DIFF
--- a/src/_pytest/subtests.py
+++ b/src/_pytest/subtests.py
@@ -380,9 +380,8 @@ def pytest_report_teststatus(
             if quiet:
                 return "", "", ""
             elif outcome == "skipped":
-                category = "xfailed"
-                short = "y"  # x letter is used for regular xfail, y for subtest xfail
-                status = "SUBXFAIL"
+                # x letter is used for regular xfail, y for subtest xfail
+                return "xfailed", "y", f"SUBXFAIL{description}"
             # outcome == "passed" in an xfail is only possible via a @pytest.mark.xfail mark, which
             # is not applicable to a subtest, which only handles pytest.xfail().
             else:  # pragma: no cover
@@ -391,21 +390,15 @@ def pytest_report_teststatus(
                 # passed in case of xfail.
                 # Let's pass this report to the next hook.
                 return None
-            return category, short, f"{status}{description}"
 
         if report.failed:
             return outcome, "u", f"SUBFAILED{description}"
-        else:
-            if report.passed:
-                if quiet:
-                    return "", "", ""
-                else:
-                    return f"subtests {outcome}", "u", f"SUBPASSED{description}"
-            elif report.skipped:
-                if quiet:
-                    return "", "", ""
-                else:
-                    return outcome, "-", f"SUBSKIPPED{description}"
+        elif quiet:
+            return "", "", ""
+        elif report.passed:
+            return f"subtests {outcome}", "u", f"SUBPASSED{description}"
+        elif report.skipped:
+            return outcome, "-", f"SUBSKIPPED{description}"
 
     else:
         failed_subtests_count = config.stash[failed_subtests_key][report.nodeid]


### PR DESCRIPTION
I was trying to figure out what possible outcomes subtests can generate, and found the code a bit hard to read.

I think the first change is a clear improvement. The second change is maybe a bit more questionable, happy to revert that one if people prefer.