### PR TITLE
Update default value for pythonpath ini option

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1518,7 +1518,10 @@ class Config:
         self._parser.addini("addopts", "Extra command line options", "args")
         self._parser.addini("minversion", "Minimally required pytest version")
         self._parser.addini(
-            "pythonpath", type="paths", help="Add paths to sys.path", default=[self._parser.extra_info["rootdir"]]
+            "pythonpath",
+            type="paths",
+            help="Add paths to sys.path",
+            default=[self._parser.extra_info["rootdir"]],
         )
         self._parser.addini(
             "required_plugins",


### PR DESCRIPTION
Update default value for pythonpath ini option allowing to pass rootdir path for running the pytest command from within a child folder but at the same time able to resolve the path for outside modules by passing the rootdir option. Without this change unable to run pytest for a particular file within the folder if it is importing from outside the cwd, resulting in unable to find the module.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
