### PR TITLE
subtests: avoid double `saferepr()`

### DIFF
--- a/src/_pytest/subtests.py
+++ b/src/_pytest/subtests.py
@@ -91,7 +91,7 @@ class SubtestReport(TestReport):
             parts.append(f"[{self.context.msg}]")
         if self.context.kwargs:
             params_desc = ", ".join(
-                f"{k}={saferepr(v)}" for (k, v) in self.context.kwargs.items()
+                f"{k}={v}" for (k, v) in self.context.kwargs.items()
             )
             parts.append(f"({params_desc})")
         return " ".join(parts) or "(<subtest>)"

--- a/testing/test_subtests.py
+++ b/testing/test_subtests.py
@@ -305,9 +305,9 @@ def test_subtests_and_parametrization(
     result = pytester.runpytest("-v")
     result.stdout.fnmatch_lines(
         [
-            "*.py::test_foo[[]0[]] SUBFAILED[[]custom[]] (i='1') *[[] 50%[]]",
+            "*.py::test_foo[[]0[]] SUBFAILED[[]custom[]] (i=1) *[[] 50%[]]",
             "*.py::test_foo[[]0[]] FAILED                        *[[] 50%[]]",
-            "*.py::test_foo[[]1[]] SUBFAILED[[]custom[]] (i='1') *[[]100%[]]",
+            "*.py::test_foo[[]1[]] SUBFAILED[[]custom[]] (i=1) *[[]100%[]]",
             "*.py::test_foo[[]1[]] FAILED                        *[[]100%[]]",
             "contains 1 failed subtest",
             "* 4 failed, 4 subtests passed in *",
@@ -323,9 +323,9 @@ def test_subtests_and_parametrization(
     result = pytester.runpytest("-v")
     result.stdout.fnmatch_lines(
         [
-            "*.py::test_foo[[]0[]] SUBFAILED[[]custom[]] (i='1') *[[] 50%[]]",
+            "*.py::test_foo[[]0[]] SUBFAILED[[]custom[]] (i=1) *[[] 50%[]]",
             "*.py::test_foo[[]0[]] FAILED                        *[[] 50%[]]",
-            "*.py::test_foo[[]1[]] SUBFAILED[[]custom[]] (i='1') *[[]100%[]]",
+            "*.py::test_foo[[]1[]] SUBFAILED[[]custom[]] (i=1) *[[]100%[]]",
             "*.py::test_foo[[]1[]] FAILED                        *[[]100%[]]",
             "contains 1 failed subtest",
             "* 4 failed in *",
@@ -710,12 +710,12 @@ class TestCapture:
         result = pytester.runpytest(f"--capture={mode}")
         result.stdout.fnmatch_lines(
             [
-                "*__ test (i=\"'A'\") __*",
+                "*__ test (i='A') __*",
                 "*Captured stdout call*",
                 "hello stdout A",
                 "*Captured stderr call*",
                 "hello stderr A",
-                "*__ test (i=\"'B'\") __*",
+                "*__ test (i='B') __*",
                 "*Captured stdout call*",
                 "hello stdout B",
                 "*Captured stderr call*",
@@ -736,8 +736,8 @@ class TestCapture:
                 "hello stdout A",
                 "uhello stdout B",
                 "uend test",
-                "*__ test (i=\"'A'\") __*",
-                "*__ test (i=\"'B'\") __*",
+                "*__ test (i='A') __*",
+                "*__ test (i='B') __*",
                 "*__ test __*",
             ]
         )


### PR DESCRIPTION
#13963 makes sure that values of `SubtestContext.kwargs` are strings by applying `saferepr()`. Thus, there is no need to apply `saferepr()` again for the description.

Avoiding the second `saferepr()` results in nicer output and avoids a change in the output compared to previous pytest versions.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
