### PR TITLE
docs: fix grammar in typing docs

### DIFF
--- a/doc/en/explanation/types.rst
+++ b/doc/en/explanation/types.rst
@@ -11,7 +11,7 @@ Typing in pytest
 Why type tests?
 ---------------
 
-Typing tests provides significant advantages:
+Typing tests provide significant advantages:
 
 - **Readability:** Clearly defines expected inputs and outputs, improving readability, especially in complex or parameterized tests.
 


### PR DESCRIPTION
A small grammar fix in doc/en/explanation/types.rst:

- "Typing tests provides" -> "Typing tests provide"