### PR TITLE
Fix removed pytest.config reference in historical-notes

### DIFF
--- a/doc/en/historical-notes.rst
+++ b/doc/en/historical-notes.rst
@@ -267,13 +267,13 @@ The equivalent with "boolean conditions" is:
 
 .. code-block:: python
 
-    @pytest.mark.skipif(not pytest.config.getvalue("db"), reason="--db was not specified")
+    @pytest.mark.skipif(not request.config.getvalue("db"), reason="--db was not specified")
     def test_function():
         pass
 
 .. note::
 
-    You cannot use ``pytest.config.getvalue()`` in code
+    You cannot use ``request.config.getvalue()`` in code
     imported before pytest's argument parsing takes place.  For example,
     ``conftest.py`` files are imported before command line parsing and thus
     ``config.getvalue()`` will not execute correctly.


### PR DESCRIPTION
## Summary

The documentation showed `pytest.config.getvalue()` as an example, but this API was removed in newer pytest versions.

## Fix

Changed `pytest.config.getvalue("db")` to `request.config.getvalue("db")` which is the correct modern equivalent.

Also updated the note to reference `request.config.getvalue()` instead of `pytest.config.getvalue()`.

Fixes #14216