### PR TITLE
raises: fix stale loop variable in RaisesGroup error reporting

### DIFF
--- a/changelog/14220.bugfix.rst
+++ b/changelog/14220.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a logic bug in :class:`pytest.RaisesGroup` which would might cause it to display incorrect "It matches `FooError()` which was paired with `BarError`" messages.

--- a/src/_pytest/raises.py
+++ b/src/_pytest/raises.py
@@ -1354,7 +1354,7 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
                 f"\n{indent_1}{self._repr_expected(self.expected_exceptions[i_failed])}"
             )
             for i_actual, actual in enumerate(actual_exceptions):
-                if results.get_result(i_exp, i_actual) is None:
+                if results.get_result(i_failed, i_actual) is None:
                     # we print full repr of match target
                     s += (
                         f"\n{indent_2}It matches {backquote(repr(actual))} which was paired with "

--- a/testing/python/raises_group.py
+++ b/testing/python/raises_group.py
@@ -1350,3 +1350,21 @@ def test_tuples() -> None:
         ),
     ):
         RaisesGroup((ValueError, IndexError))  # type: ignore[call-overload]
+
+
+def test_expected_matching_only_on_matching() -> None:
+    """Regression test for #14220, logic error which caused the "which was
+    paired with" message to appear for wrong pairs."""
+    with (
+        fails_raises_group(
+            "\n"
+            "1 matched exception. \n"
+            "Too few exceptions raised!\n"
+            "The following expected exceptions did not find a match:\n"
+            "  ValueError\n"
+            "  TypeError\n"
+            "    It matches `TypeError()` which was paired with `TypeError`",
+        ),
+        RaisesGroup(TypeError, ValueError, TypeError),
+    ):
+        raise ExceptionGroup("", [TypeError()])


### PR DESCRIPTION
In `RaisesGroup._check_exceptions`, the diagnostic section that builds failure messages for unmatched expected exceptions has a bug on [this line](https://github.com/pytest-dev/pytest/blob/main/src/_pytest/raises.py#L1368):

```python
for i_failed in failed_expected:
    s += (
        f"\n{indent_1}{self._repr_expected(self.expected_exceptions[i_failed])}"
    )
    for i_actual, actual in enumerate(actual_exceptions):
        if results.get_result(i_exp, i_actual) is None:  # <-- bug
```

`i_exp` here is a leftover from the earlier `for i_exp, expected in enumerate(self.expected_exceptions):` loop that computes the full results matrix. By the time we reach this diagnostic loop, `i_exp` holds whatever value it had when that earlier loop finished -- it doesn't track the current `i_failed` iteration at all.

This means the `results.get_result(i_exp, i_actual)` call looks up the wrong expected exception's result, so the "It matches ... which was paired with ..." hints in the failure output can be completely wrong or missing.

Fix: replace `i_exp` with `i_failed`, which is the actual loop variable for the current expected exception being reported.
