### PR TITLE
code: use current excinfo when formatting chained BaseExceptionGroup

### DIFF
--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -1188,11 +1188,11 @@ class FormattedExcinfo:
                 reprtraceback: ReprTraceback | ReprTracebackNative
                 if isinstance(e, BaseExceptionGroup):
                     # don't filter any sub-exceptions since they shouldn't have any internal frames
-                    traceback = filter_excinfo_traceback(self.tbfilter, excinfo)
+                    traceback = filter_excinfo_traceback(self.tbfilter, excinfo_)
                     reprtraceback = ReprTracebackNative(
                         format_exception(
-                            type(excinfo.value),
-                            excinfo.value,
+                            type(excinfo_.value),
+                            excinfo_.value,
                             traceback[0]._rawentry if traceback else None,
                         )
                     )


### PR DESCRIPTION
In `repr_excinfo`, when the current exception `e` is a `BaseExceptionGroup`, the code uses the original `excinfo` parameter instead of `excinfo_` (which tracks the current exception as the method walks the `__cause__`/`__context__` chain):

```python
while e is not None and id(e) not in seen:
    seen.add(id(e))

    if excinfo_:
        ...
        if isinstance(e, BaseExceptionGroup):
            traceback = filter_excinfo_traceback(self.tbfilter, excinfo)   # should be excinfo_
            reprtraceback = ReprTracebackNative(
                format_exception(
                    type(excinfo.value),   # should be excinfo_
                    excinfo.value,         # should be excinfo_
                    ...
```

On the first loop iteration this doesn't matter since `excinfo_` starts as `excinfo`. But when walking the exception chain, `excinfo_` is reassigned to `ExceptionInfo.from_exception(e)` while `excinfo` still points to the original. So for any chained `BaseExceptionGroup`, the traceback filtering is applied to the wrong exception and `format_exception` formats the original exception instead of the current one.

The non-group branch already correctly uses `excinfo_`:
```python
else:
    reprtraceback = self.repr_traceback(excinfo_)
```

This fix replaces the three occurrences of `excinfo` with `excinfo_` inside the `BaseExceptionGroup` branch.
