### PR TITLE
raises: add missing | metacharacter to is_fully_escaped and unescape

### DIFF
--- a/changelog/13192.bugfix.rst
+++ b/changelog/13192.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed `|` (pipe) not being treated as a regex meta-character that needs escaping in :func:`pytest.raises(match=...) <pytest.raises>`.

--- a/src/_pytest/raises.py
+++ b/src/_pytest/raises.py
@@ -363,14 +363,14 @@ def _check_raw_type(
 
 def is_fully_escaped(s: str) -> bool:
     # we know we won't compile with re.VERBOSE, so whitespace doesn't need to be escaped
-    metacharacters = "{}()+.*?^$[]"
+    metacharacters = "{}()+.*?^$[]|"
     return not any(
         c in metacharacters and (i == 0 or s[i - 1] != "\\") for (i, c) in enumerate(s)
     )
 
 
 def unescape(s: str) -> str:
-    return re.sub(r"\\([{}()+-.*?^$\[\]\s\\])", r"\1", s)
+    return re.sub(r"\\([{}()+-.*?^$\[\]\s\\|])", r"\1", s)
 
 
 # These classes conceptually differ from ExceptionInfo in that ExceptionInfo is tied, and

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -430,3 +430,12 @@ class TestRaises:
         pattern_with_flags = re.compile(r"INVALID LITERAL", re.IGNORECASE)
         with pytest.raises(ValueError, match=pattern_with_flags):
             int("asdf")
+
+    def test_pipe_is_treated_as_regex_metacharacter(self) -> None:
+        """| (pipe) must be recognized as a regex metacharacter."""
+        from _pytest.raises import is_fully_escaped
+        from _pytest.raises import unescape
+
+        assert not is_fully_escaped("foo|bar")
+        assert is_fully_escaped(r"foo\|bar")
+        assert unescape(r"foo\|bar") == "foo|bar"


### PR DESCRIPTION
`is_fully_escaped` checks whether a match pattern body (inside `^...$`) contains only escaped regex metacharacters, so pytest knows it can treat it as a literal string for diff output. The current metacharacter list is:

```python
metacharacters = "{}()+.*?^$[]"
```

This is missing `|`, the regex alternation operator. A pattern like `^foo|bar$` would pass the `is_fully_escaped` check even though the `|` makes it a regex alternation rather than a literal. This causes `rawmatch` to be set to the unescaped value `foo|bar`, leading to a misleading diff in the failure message.

The `unescape` function has the same omission in its character class, so `\|` wouldn't be unescaped even if someone properly escaped it.

This adds `|` to both the metacharacter list in `is_fully_escaped` and the character class in `unescape`.
