### PR TITLE
Fix -v hint in raises match diff not working

### DIFF
--- a/changelog/14214.bugfix.rst
+++ b/changelog/14214.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``-v`` hint in :func:`pytest.raises` match diff not working because assertion verbosity was not propagated.

--- a/src/_pytest/raises.py
+++ b/src/_pytest/raises.py
@@ -492,12 +492,19 @@ class AbstractRaises(ABC, Generic[BaseExcT_co]):
             else ""
         )
         if isinstance(self.rawmatch, str):
-            # TODO: it instructs to use `-v` to print leading text, but that doesn't work
-            # I also don't know if this is the proper entry point, or tool to use at all
+            from _pytest.assertion.util import _config
             from _pytest.assertion.util import _diff_text
             from _pytest.assertion.util import dummy_highlighter
+            from _pytest.config import Config
 
-            diff = _diff_text(self.rawmatch, stringified_exception, dummy_highlighter)
+            verbose = (
+                _config.get_verbosity(Config.VERBOSITY_ASSERTIONS)
+                if _config is not None
+                else 0
+            )
+            diff = _diff_text(
+                self.rawmatch, stringified_exception, dummy_highlighter, verbose
+            )
             self._fail_reason = ("\n" if diff[0][0] == "-" else "") + "\n".join(diff)
             return False
 

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -487,3 +487,29 @@ class TestRaises:
         assert not is_fully_escaped("\\\\|")
         # r"\\\\|" is the string \\\\| (4 backslashes + pipe): even count, pipe is unescaped
         assert not is_fully_escaped(r"\\\\|")
+
+    def test_raises_match_verbose_diff(self, pytester: Pytester) -> None:
+        """Test that -v flag shows full diff in raises match failure (#14214)."""
+        pytester.makepyfile(
+            """
+            import re
+            import pytest
+
+            def test_raises_v_hint():
+                prefix = "A" * 60
+                expected = prefix + " expected_ending"
+                actual = prefix + " actual_ending"
+
+                with pytest.raises(
+                    ValueError, match=f"^{re.escape(expected)}$"
+                ):
+                    raise ValueError(actual)
+            """
+        )
+        # Without -v: should show "Skipping ... identical leading characters"
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines(["*Skipping*identical leading*"])
+
+        # With -v: should NOT show "Skipping" — full diff shown
+        result_v = pytester.runpytest("-v")
+        assert "Skipping" not in result_v.stdout.str()


### PR DESCRIPTION
## Summary
- `_check_match` called `_diff_text` without passing verbosity, so `verbose` always defaulted to `0`
- The "Skipping N identical leading characters in diff, use -v to show" hint was non-functional
- Now reads `VERBOSITY_ASSERTIONS` from the module-level `_config` set during test protocol

## Test plan
- [x] Added pytester integration test verifying:
  - Without `-v`: output contains "Skipping ... identical leading characters"
  - With `-v`: output shows full diff without truncation
- [x] All 66 existing `TestRaises` tests pass

Fixes #14214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)