### PR TITLE
Fix nested caplog.filtering with same filter object

### DIFF
--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -585,11 +585,14 @@ class LogCaptureFixture:
 
         .. versionadded:: 7.5
         """
-        self.handler.addFilter(filter_)
+        filter_was_present = filter_ in self.handler.filters
+        if not filter_was_present:
+            self.handler.addFilter(filter_)
         try:
             yield
         finally:
-            self.handler.removeFilter(filter_)
+            if not filter_was_present:
+                self.handler.removeFilter(filter_)
 
 
 @fixture

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -206,6 +206,25 @@ def test_with_statement_filtering(caplog: pytest.LogCaptureFixture) -> None:
     assert unfiltered_tuple == ("test_fixture", 20, "handler call")
 
 
+def test_with_statement_filtering_nested_same_filter(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class NoCaptureFilter(logging.Filter):
+        def filter(self, _record: logging.LogRecord) -> bool:
+            return False
+
+    filter_obj = NoCaptureFilter()
+
+    with caplog.at_level(logging.INFO):
+        with caplog.filtering(filter_obj):
+            logger.info("Will not be captured")
+            with caplog.filtering(filter_obj):
+                logger.info("Will also not be captured")
+            logger.info("Will still not be captured")
+
+    assert caplog.records == []
+
+
 @pytest.mark.parametrize(
     "level_str,expected_disable_level",
     [


### PR DESCRIPTION
## Summary
- Fix caplog.filtering so nested use with the same filter object does not remove the outer filter too early.
- Only add/remove the filter when this context manager actually changed handler state.
- Add a regression test for nested caplog.filtering with the same filter instance.

## Why
Issue #14189 reports that nested caplog.filtering can unexpectedly remove an active filter, causing logs to leak into capture inside the outer context.

## Validation
- python -m pytest -q testing/logging/test_fixture.py -k with_statement_filtering
