### PR TITLE
fix: replace 2 bare except clauses with except Exception

### DIFF
--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -166,7 +166,7 @@ class TestSourceParsing:
                 x = (
                    y +
                    z)
-            except:
+            except Exception:
                 pass
         """
         )

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -372,7 +372,7 @@ def test_testcase_adderrorandfailure_defers(pytester: Pytester, type: str) -> No
                     result.add{type}(self, excinfo._excinfo)
                 except KeyboardInterrupt:
                     raise
-                except:
+                except Exception:
                     pytest.fail("add{type} should not raise")
             def test_hello(self):
                 pass


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance.