### PR TITLE
Include pytest.HIDDEN_PARAM in parametrize(ids=...) type annotations

### DIFF
--- a/changelog/14234.bugfix.rst
+++ b/changelog/14234.bugfix.rst
@@ -1,0 +1,1 @@
+Allow :ref:`pytest.HIDDEN_PARAM <hidden-param>` in :ref:`@pytest.mark.parametrize(ids=...) <pytest.mark.parametrize ref>` typing.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -532,7 +532,7 @@ if TYPE_CHECKING:
             argvalues: Collection[ParameterSet | Sequence[object] | object],
             *,
             indirect: bool | Sequence[str] = ...,
-            ids: Iterable[None | str | float | int | bool]
+            ids: Iterable[None | str | float | int | bool | _HiddenParam]
             | Callable[[Any], object | None]
             | None = ...,
             scope: ScopeName | None = ...,

--- a/testing/typing_checks.py
+++ b/testing/typing_checks.py
@@ -61,6 +61,12 @@ def check_testreport_attributes(report: TestReport) -> None:
     assert_type(report.location, tuple[str, int | None, str])
 
 
+# Issue #14234.
+@pytest.mark.parametrize("x", [1, 2], ids=[pytest.HIDDEN_PARAM, "visible"])
+def test_hidden_param(x: int) -> None:
+    pass
+
+
 # Test @pytest.mark.parametrize iterator argvalues deprecation.
 # Will be complain about unused type ignore if doesn't work.
 @pytest.mark.parametrize("x", iter(range(10)))  # type: ignore[deprecated]


### PR DESCRIPTION
# Summary
Closes #14234

The `ids` keyword argument of `pytest.mark.parametrize` did not allow `pytest.HIDDEN_PARAM`, unlike `pytest.mark.param(id=...)`.

## Problem

The following produced a typing error:

```python
import pytest

@pytest.mark.parametrize(
    "x",
    [1, 2, 3],
    ids=[pytest.HIDDEN_PARAM, "two", "three"],
)
def test_example(x: int) -> None:
    pass
```

## Solution
Modified `_ParametrizeMarkDecorator.__call__()`'s `ids` argument to include the `_HiddenParam` enum.

## Test Cases
Type check for passing `pytest.HIDDEN_PARAM` in the `ids` argument for `pytest.mark.parametrize`

```python
@pytest.mark.parametrize("x", [1, 2], ids=[pytest.HIDDEN_PARAM, "visible"])
def test_hidden_param(x: int) -> None:
    pass
```
