### PR TITLE
feat: a Nix build environment

### DIFF
--- a/changelog/14520.contrib.rst
+++ b/changelog/14520.contrib.rst
@@ -1,0 +1,1 @@
+Flake-based Nix build environments are now supported via ``nix develop``.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772047000,
+        "narHash": "sha256-7DaQVv4R97cii/Qdfy4tmDZMB2xxtyIvNGSwXBBhSmo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1267bb4920d0fc06ea916734c11b0bf004bbe17e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1772501647,
+        "narHash": "sha256-SwHOuy/sMYZWLrekijAkq9mHVIZXCW1Hvkeh7Z9F65Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "043c57fef481a2407f557d12344daf00a27d081e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,6 @@
 {
-  description = "Development environment for Pytest";
+  # The pytest core team doesn't maintain this flake.
+  description = "Unofficial Nix development environment for Pytest";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,70 @@
+{
+  description = "Development environment for Pytest";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs = { self, nixpkgs, nixpkgs-unstable, systems }:
+    let
+      forAllSystems = nixpkgs.lib.genAttrs (import systems);
+      mkPkgs = system: import nixpkgs {
+        inherit system;
+        overlays = [ self.overlays.newer-pre-commit ];
+      };
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = mkPkgs system;
+        in
+        {
+          fhs-test-env = pkgs.buildFHSEnv {
+            name = "fhs-test-env";
+            targetPkgs = fhspkgs:
+              let
+                python313-with-tox = pkgs.python313.withPackages (ps: with ps; [
+                  tox
+                ]);
+              in
+              [
+                python313-with-tox
+
+                # other Pythons
+                fhspkgs.python310
+                fhspkgs.python311
+                fhspkgs.python312
+                fhspkgs.python314
+
+                fhspkgs.bashInteractive
+                fhspkgs.pre-commit
+
+              ];
+            runScript = "bash";
+          };
+        });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = mkPkgs system;
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [ self.packages.${system}.fhs-test-env ];
+            shellHook = "exec fhs-test-env";
+          };
+        });
+
+      overlays = {
+        newer-pre-commit = final: prev: {
+          pre-commit =
+            let
+              pkgs = import nixpkgs-unstable { inherit (final.stdenv.hostPlatform) system; };
+            in
+            pkgs.pre-commit;
+        };
+      };
+    };
+}


### PR DESCRIPTION
## Overview

This commit creates a flake.nix file defining a minimal build environment for Nix users. If you have Nix installed, you can run

    nix develop

to enter an environment where

    tox -e linting,py310,py311,py312,py313,py314

work as expected.

## Details

This change does not impose any changes on existing workflows; it is intended only to make it easier for Nix users to contribute to `pytest`.

For those Nix users, this change does not even package `pytest` as a Nix derivation; instead, it provides a minimal build environment that behaves like an "ordinary" Python environment, albeit one with all `pytest`-supported versions of Python installed.

## Testing

The commands

```sh
nix develop
```

followed by

```sh
tox -e linting,py310,py311,py312,py313,py314
```

passes.

Closes #14250.
