### PR TITLE
docs: guard pytestconfig.cache example when cacheprovider is disabled

### DIFF
--- a/changelog/14148.doc.rst
+++ b/changelog/14148.doc.rst
@@ -1,0 +1,2 @@
+Documented a safe ``pytestconfig.cache`` access pattern when the
+``cacheprovider`` plugin is disabled.

--- a/doc/en/how-to/cache.rst
+++ b/doc/en/how-to/cache.rst
@@ -200,7 +200,8 @@ The new config.cache object
 Plugins or conftest.py support code can get a cached value using the
 pytest ``config`` object.  Here is a basic example plugin which
 implements a :ref:`fixture <fixture>` which reuses previously created state
-across pytest invocations:
+across pytest invocations. The example below also works when the
+``cacheprovider`` plugin is disabled:
 
 .. code-block:: python
 
@@ -214,11 +215,16 @@ across pytest invocations:
 
     @pytest.fixture
     def mydata(pytestconfig):
-        val = pytestconfig.cache.get("example/value", None)
+        cache = getattr(pytestconfig, "cache", None)
+        if cache is None:
+            expensive_computation()
+            return 42
+
+        val = cache.get("example/value", None)
         if val is None:
             expensive_computation()
             val = 42
-            pytestconfig.cache.set("example/value", val)
+            cache.set("example/value", val)
         return val
 
 

--- a/doc/en/how-to/cache.rst
+++ b/doc/en/how-to/cache.rst
@@ -200,8 +200,7 @@ The new config.cache object
 Plugins or conftest.py support code can get a cached value using the
 pytest ``config`` object.  Here is a basic example plugin which
 implements a :ref:`fixture <fixture>` which reuses previously created state
-across pytest invocations. The example below also works when the
-``cacheprovider`` plugin is disabled:
+across pytest invocations:
 
 .. code-block:: python
 
@@ -217,6 +216,8 @@ across pytest invocations. The example below also works when the
     def mydata(pytestconfig):
         cache = getattr(pytestconfig, "cache", None)
         if cache is None:
+            # pytestconfig not having the cache attribute means the
+            # cache plugin is disabled.
             expensive_computation()
             return 42
 


### PR DESCRIPTION
- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [x] Allow maintainers to push and squash when merging my commits.

### Description
Update the `config.cache` example in `doc/en/how-to/cache.rst` to safely handle cases where the `cacheprovider` plugin is disabled.

The fixture now uses `getattr(pytestconfig, "cache", None)` and falls back gracefully when cache support is unavailable, which avoids `AttributeError` in the documented pattern.

Closes #14148