### PR TITLE
docs: explain +/- markers in failed string equality diffs

### DIFF
--- a/doc/en/how-to/assert.rst
+++ b/doc/en/how-to/assert.rst
@@ -436,6 +436,10 @@ Special comparisons are done for a number of cases:
 * comparing long sequences: first failing indices
 * comparing dicts: different entries
 
+In string context diffs, lines prefixed with ``-`` come from the left-hand side
+of ``assert left == right``, while lines prefixed with ``+`` come from the
+right-hand side.
+
 See the :ref:`reporting demo <tbreportdemo>` for many more examples.
 
 Defining your own explanation for failed assertions


### PR DESCRIPTION
### Summary
- Add a short explanation for string context diff markers in assertion output.
- Clarify that `-` lines come from the left-hand side of `assert left == right`.
- Clarify that `+` lines come from the right-hand side.

Closes #3721

### Notes
- Documentation-only change; no runtime behavior changed.
- Tests are not required for this docs clarification.