### PR TITLE
docs: note pyproject minversion compatibility with pytest<6

### DIFF
--- a/doc/en/reference/customize.rst
+++ b/doc/en/reference/customize.rst
@@ -103,6 +103,10 @@ pyproject.toml
             "integration",
         ]
 
+    For projects that still run pytest versions older than 6.0, keep
+    ``minversion`` in ``pytest.ini`` or ``setup.cfg`` too. Those versions
+    do not read ``pyproject.toml``.
+
 tox.ini
 ~~~~~~~
 


### PR DESCRIPTION
### Summary
- Add a compatibility note to the `pyproject.toml` configuration section.
- Clarify that pytest versions older than 6.0 do not read `pyproject.toml`.
- Recommend keeping `minversion` in `pytest.ini` or `setup.cfg` when supporting older pytest.

Closes #7730

### Notes
- Documentation-only change; no runtime behavior changed.
- Tests are not required for this docs clarification.