### PR TITLE
Docs: clarify multiple arguments in pytest.mark.filterwarnings

### DIFF
--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -160,6 +160,15 @@ You can specify multiple filters with separate decorators:
     def test_one():
         assert api_v1() == 1
 
+You can also pass multiple filters to a single mark by providing multiple arguments:
+
+.. code-block:: python
+
+    # Later arguments take precedence, matching warnings.filterwarnings behavior.
+    @pytest.mark.filterwarnings("error", "ignore:api v1")
+    def test_one():
+        assert api_v1() == 1
+
 .. important::
 
     Regarding decorator order and filter precedence:


### PR DESCRIPTION
## Summary
Follow-up clarification for #12966.

This PR adds a docs example showing that multiple warning filters can be passed to a single `@pytest.mark.filterwarnings(...)` call, and clarifies that later arguments take precedence (matching `warnings.filterwarnings` behavior).

Docs-only change; no runtime behavior changes.