### PR TITLE
docs: clarify request fixture in indirect parametrization

### DIFF
--- a/changelog/13155.doc.rst
+++ b/changelog/13155.doc.rst
@@ -1,0 +1,1 @@
+Clarified in the parametrization examples that the built-in ``request`` fixture is used for indirect parametrization and that values are available through ``request.param``.

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -356,6 +356,11 @@ Using the ``indirect=True`` parameter when parametrizing a test allows one to
 parametrize a test with a fixture receiving the values before passing them to a
 test:
 
+The fixture receives the built-in ``request`` fixture object as its first
+argument. For indirect parametrization, each value from
+``@pytest.mark.parametrize`` is available as ``request.param`` inside that
+fixture.
+
 .. code-block:: python
 
     import pytest


### PR DESCRIPTION
## Summary
Clarify the `request` fixture usage in the "Indirect parametrization" example.

This change explicitly states that:
- `request` is the built-in fixture object passed to fixtures.
- indirect values from `@pytest.mark.parametrize(..., indirect=True)` are available as `request.param`.

Closes #13155