### PR TITLE
warn on ambiguous -p plugin module usage

### DIFF
--- a/changelog/14135.bugfix.rst
+++ b/changelog/14135.bugfix.rst
@@ -1,0 +1,1 @@
+Pytest now warns when ``-p`` loads a module with no pytest hooks but a ``pytest11`` entry-point exists in one of its submodules, helping catch wrong plugin names when plugin autoloading is disabled.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -878,8 +878,9 @@ class PytestPluginManager(PluginManager):
         importspec = "_pytest." + modname if modname in builtin_plugins else modname
         self.rewrite_hook.mark_rewrite(importspec)
 
+        loaded = False
         if consider_entry_points:
-            loaded = self.load_setuptools_entrypoints("pytest11", name=modname)
+            loaded = bool(self.load_setuptools_entrypoints("pytest11", name=modname))
             if loaded:
                 return
 
@@ -900,6 +901,45 @@ class PytestPluginManager(PluginManager):
             self.skipped_plugins.append((modname, e.msg or ""))
         else:
             self.register(mod, modname)
+            if consider_entry_points and not loaded:
+                self._warn_about_submodule_entrypoint_plugin(modname, mod)
+
+    def _warn_about_submodule_entrypoint_plugin(
+        self, modname: str, mod: _PluggyPlugin
+    ) -> None:
+        if self._plugin_has_pytest_hooks(mod):
+            return
+
+        modname_prefix = f"{modname}."
+        suggested = {
+            ep.name
+            for dist in importlib.metadata.distributions()
+            for ep in dist.entry_points
+            if ep.group == "pytest11"
+            and ep.name != modname
+            and isinstance(getattr(ep, "value", None), str)
+            and getattr(ep, "value").split(":", 1)[0].startswith(modname_prefix)
+        }
+        if not suggested:
+            return
+
+        suggestion = (
+            f"-p {sorted(suggested)[0]}"
+            if len(suggested) == 1
+            else "one of: " + ", ".join(f"-p {name}" for name in sorted(suggested))
+        )
+        warnings.warn(
+            PytestConfigWarning(
+                f'Plugin "{modname}" contains no pytest hooks. '
+                f"Did you mean to use {suggestion}?"
+            ),
+            stacklevel=3,
+        )
+
+    def _plugin_has_pytest_hooks(self, plugin: _PluggyPlugin) -> bool:
+        return any(
+            self.parse_hookimpl_opts(plugin, attr) is not None for attr in dir(plugin)
+        )
 
 
 def _get_plugin_specs_as_list(

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -930,8 +930,7 @@ class PytestPluginManager(PluginManager):
         )
         warnings.warn(
             PytestConfigWarning(
-                f'Plugin "{modname}" contains no pytest hooks. '
-                f"Did you mean to use {suggestion}?"
+                f'Plugin "{modname}" contains no pytest hooks. Did you mean to use {suggestion}?'
             ),
             stacklevel=3,
         )

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -10,6 +10,7 @@ import platform
 import re
 import sys
 import textwrap
+import types
 from typing import Any
 
 import _pytest._code
@@ -30,6 +31,7 @@ from _pytest.config.findpaths import locate_config
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pathlib import absolutepath
 from _pytest.pytester import Pytester
+from _pytest.warning_types import PytestConfigWarning
 from _pytest.warning_types import PytestDeprecationWarning
 import pytest
 
@@ -1688,6 +1690,50 @@ def test_disable_plugin_autoload(
             enable_plugin_method == "env_var" and disable_plugin_method
         )
     # __spec__ is present when testing locally on pypy, but not in CI ????
+
+
+def test_disable_plugin_autoload_warns_for_submodule_entrypoint(
+    pytester: Pytester, monkeypatch: MonkeyPatch
+) -> None:
+    class DummyEntryPoint:
+        project_name = "pytest-recording"
+        name = "recording"
+        group = "pytest11"
+        version = "1.0"
+        value = "pytest_recording.plugin"
+
+        def load(self):
+            return sys.modules[self.value]
+
+    class Distribution:
+        metadata = {"name": "pytest-recording"}
+        entry_points = (DummyEntryPoint(),)
+        files = ()
+
+    def distributions():
+        return (Distribution(),)
+
+    top_level_plugin = types.ModuleType("pytest_recording")
+    submodule_plugin = types.ModuleType("pytest_recording.plugin")
+
+    def pytest_addoption(parser):
+        parser.addoption("--block-network")
+
+    setattr(submodule_plugin, "pytest_addoption", pytest_addoption)
+
+    monkeypatch.setattr(importlib.metadata, "distributions", distributions)
+    monkeypatch.setitem(sys.modules, "pytest_recording", top_level_plugin)
+    monkeypatch.setitem(sys.modules, "pytest_recording.plugin", submodule_plugin)
+
+    with pytest.warns(
+        PytestConfigWarning,
+        match=r'Plugin "pytest_recording" contains no pytest hooks\. Did you mean to use -p recording\?',
+    ):
+        config = pytester.parseconfig(
+            "--disable-plugin-autoload", "-p", "pytest_recording"
+        )
+
+    assert config.pluginmanager.get_plugin("pytest_recording") is not None
 
 
 def test_plugin_loading_order(pytester: Pytester) -> None:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1713,11 +1713,7 @@ def test_disable_plugin_autoload_warns_for_submodule_entrypoint(
 
     top_level_plugin = types.ModuleType("pytest_recording")
     submodule_plugin = types.ModuleType("pytest_recording.plugin")
-
-    def pytest_addoption(parser):
-        parser.addoption("--block-network")
-
-    setattr(submodule_plugin, "pytest_addoption", pytest_addoption)
+    setattr(submodule_plugin, "pytest_addoption", lambda parser: None)
 
     monkeypatch.setattr(importlib.metadata, "distributions", distributions)
     monkeypatch.setitem(sys.modules, "pytest_recording", top_level_plugin)

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1703,9 +1703,6 @@ def test_disable_plugin_autoload_warns_for_submodule_entrypoint(
         version = "1.0"
         value = "pytest_recording.plugin"
 
-        def load(self):
-            return sys.modules[self.value]
-
     class Distribution:
         metadata = {"name": "pytest-recording"}
         entry_points = (DummyEntryPoint(),)
@@ -1746,9 +1743,6 @@ def test_disable_plugin_autoload_does_not_warn_when_module_has_hooks(
         group = "pytest11"
         version = "1.0"
         value = "pytest_recording.plugin"
-
-        def load(self):
-            return sys.modules[self.value]
 
     class Distribution:
         metadata = {"name": "pytest-recording"}
@@ -1793,9 +1787,6 @@ def test_disable_plugin_autoload_does_not_warn_when_no_submodule_entrypoint(
         version = "1.0"
         value = "other_plugin.plugin"
 
-        def load(self):
-            return sys.modules[self.value]
-
     class Distribution:
         metadata = {"name": "pytest-recording"}
         entry_points = (DummyEntryPoint(),)
@@ -1835,9 +1826,6 @@ def test_disable_plugin_autoload_warns_for_multiple_submodule_entrypoints(
         def __init__(self, name: str, value: str) -> None:
             self.name = name
             self.value = value
-
-        def load(self):
-            return sys.modules[self.value]
 
     class Distribution:
         metadata = {"name": "pytest-recording"}

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1869,6 +1869,36 @@ def test_disable_plugin_autoload_warns_for_multiple_submodule_entrypoints(
     assert config.pluginmanager.get_plugin("pytest_recording") is not None
 
 
+def test_warn_about_submodule_entrypoint_plugin_direct(pytester: Pytester, monkeypatch):
+    class DummyEntryPoint:
+        group = "pytest11"
+        version = "1.0"
+
+        def __init__(self, name: str, value: str):
+            self.name = name
+            self.value = value
+
+    class Distribution:
+        metadata = {"name": "pytest-recording"}
+        entry_points = (DummyEntryPoint("recording", "pytest_recording.plugin"),)
+        files = ()
+
+    def distributions():
+        return (Distribution(),)
+
+    monkeypatch.setattr(importlib.metadata, "distributions", distributions)
+    config = pytester.parseconfig()
+    plugin = types.ModuleType("pytest_recording")
+
+    with pytest.warns(
+        PytestConfigWarning,
+        match=r'Plugin "pytest_recording" contains no pytest hooks\. Did you mean to use -p recording\?',
+    ):
+        config.pluginmanager._warn_about_submodule_entrypoint_plugin(
+            "pytest_recording", plugin
+        )
+
+
 def test_plugin_loading_order(pytester: Pytester) -> None:
     """Test order of plugin loading with `-p`."""
     p1 = pytester.makepyfile(

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -12,6 +12,7 @@ import sys
 import textwrap
 import types
 from typing import Any
+import warnings
 
 import _pytest._code
 from _pytest.config import _get_plugin_specs_as_list
@@ -1728,6 +1729,138 @@ def test_disable_plugin_autoload_warns_for_submodule_entrypoint(
     with pytest.warns(
         PytestConfigWarning,
         match=r'Plugin "pytest_recording" contains no pytest hooks\. Did you mean to use -p recording\?',
+    ):
+        config = pytester.parseconfig(
+            "--disable-plugin-autoload", "-p", "pytest_recording"
+        )
+
+    assert config.pluginmanager.get_plugin("pytest_recording") is not None
+
+
+def test_disable_plugin_autoload_does_not_warn_when_module_has_hooks(
+    pytester: Pytester, monkeypatch: MonkeyPatch
+) -> None:
+    class DummyEntryPoint:
+        project_name = "pytest-recording"
+        name = "recording"
+        group = "pytest11"
+        version = "1.0"
+        value = "pytest_recording.plugin"
+
+        def load(self):
+            return sys.modules[self.value]
+
+    class Distribution:
+        metadata = {"name": "pytest-recording"}
+        entry_points = (DummyEntryPoint(),)
+        files = ()
+
+    def distributions():
+        return (Distribution(),)
+
+    plugin_with_hooks = types.ModuleType("pytest_recording")
+
+    def pytest_addoption(parser):
+        parser.addoption("--block-network")
+
+    setattr(plugin_with_hooks, "pytest_addoption", pytest_addoption)
+
+    monkeypatch.setattr(importlib.metadata, "distributions", distributions)
+    monkeypatch.setitem(sys.modules, "pytest_recording", plugin_with_hooks)
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        config = pytester.parseconfig(
+            "--disable-plugin-autoload", "-p", "pytest_recording"
+        )
+
+    assert config.pluginmanager.get_plugin("pytest_recording") is not None
+    assert not [
+        w
+        for w in captured
+        if isinstance(w.message, PytestConfigWarning)
+        and "contains no pytest hooks" in str(w.message)
+    ]
+
+
+def test_disable_plugin_autoload_does_not_warn_when_no_submodule_entrypoint(
+    pytester: Pytester, monkeypatch: MonkeyPatch
+) -> None:
+    class DummyEntryPoint:
+        project_name = "pytest-recording"
+        name = "recording"
+        group = "pytest11"
+        version = "1.0"
+        value = "other_plugin.plugin"
+
+        def load(self):
+            return sys.modules[self.value]
+
+    class Distribution:
+        metadata = {"name": "pytest-recording"}
+        entry_points = (DummyEntryPoint(),)
+        files = ()
+
+    def distributions():
+        return (Distribution(),)
+
+    monkeypatch.setattr(importlib.metadata, "distributions", distributions)
+    monkeypatch.setitem(
+        sys.modules, "pytest_recording", types.ModuleType("pytest_recording")
+    )
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        config = pytester.parseconfig(
+            "--disable-plugin-autoload", "-p", "pytest_recording"
+        )
+
+    assert config.pluginmanager.get_plugin("pytest_recording") is not None
+    assert not [
+        w
+        for w in captured
+        if isinstance(w.message, PytestConfigWarning)
+        and "contains no pytest hooks" in str(w.message)
+    ]
+
+
+def test_disable_plugin_autoload_warns_for_multiple_submodule_entrypoints(
+    pytester: Pytester, monkeypatch: MonkeyPatch
+) -> None:
+    class DummyEntryPoint:
+        project_name = "pytest-recording"
+        group = "pytest11"
+        version = "1.0"
+
+        def __init__(self, name: str, value: str) -> None:
+            self.name = name
+            self.value = value
+
+        def load(self):
+            return sys.modules[self.value]
+
+    class Distribution:
+        metadata = {"name": "pytest-recording"}
+        entry_points = (
+            DummyEntryPoint("recording", "pytest_recording.plugin"),
+            DummyEntryPoint("recording_alt", "pytest_recording.alt"),
+        )
+        files = ()
+
+    def distributions():
+        return (Distribution(),)
+
+    monkeypatch.setattr(importlib.metadata, "distributions", distributions)
+    monkeypatch.setitem(
+        sys.modules, "pytest_recording", types.ModuleType("pytest_recording")
+    )
+
+    with pytest.warns(
+        PytestConfigWarning,
+        match=(
+            r'Plugin "pytest_recording" contains no pytest hooks\. '
+            r"Did you mean to use one of: -p recording, -p recording_alt\?"
+        ),
     ):
         config = pytester.parseconfig(
             "--disable-plugin-autoload", "-p", "pytest_recording"


### PR DESCRIPTION
## Summary

  `-p <name>` can silently do the wrong thing with `--disable-plugin-autoload`
  when `<name>` is an importable top-level module that has no pytest hooks,
  while the real plugin is exposed via a `pytest11` entry-point submodule.

  This change adds a focused warning in that case:
  - if the imported module has no pytest hooks
  - and a `pytest11` entry-point exists in one of its submodules
  - pytest emits `PytestConfigWarning` suggesting the entry-point name (for
  example `-p recording`)

  closes #14135

  ## Impact

  This improves correctness and UX for plugin selection, especially in autoload-
  disabled runs, by surfacing likely misconfiguration instead of failing
  silently.

  ## How tested

  - Added regression test:
    - `testing/
  test_config.py::test_disable_plugin_autoload_warns_for_submodule_entrypoint`
  - Ran focused tests:
    - `uv run -m pytest testing/test_config.py -k
  "disable_plugin_autoload_warns_for_submodule_entrypoint or
  test_disable_plugin_autoload"`
    - `uv run -m pytest testing/test_pluginmanager.py -k
  "import_plugin_importname or import_plugin_dotted_name"`
  - Ran formatting/lint/hooks on changed files:
    - `uv run --with pre-commit pre-commit run --files src/_pytest/config/
  __init__.py testing/test_config.py changelog/14135.bugfix.rst`

  ## Checklist

  - [ ] Include documentation when adding new features. (Not applicable: bugfix,
  no new feature)
  - [x] Include new tests or update existing tests when applicable.
  - [x] Allow maintainers to push and squash when merging my commits.
  - [x] Add text like `closes #XYZW` to PR description and/or commits.
  - [ ] If AI agents were used, they are credited in `Co-authored-by` commit
  trailers.
  - [x] Create a new changelog file in the `changelog` directory.
  - [ ] Add yourself to `AUTHORS` in alphabetical order. (Not needed for this
  change)