### PR TITLE
Fix monkeypatch undo when deleting missing attrs/items with raising=False

### DIFF
--- a/changelog/14094.bugfix.rst
+++ b/changelog/14094.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``MonkeyPatch.delattr(..., raising=False)`` and ``MonkeyPatch.delitem(..., raising=False)`` so ``undo()`` restores the original missing state.

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -277,6 +277,7 @@ class MonkeyPatch:
         if not hasattr(target, name):
             if raising:
                 raise AttributeError(name)
+            self._setattr.append((target, name, NOTSET))
         else:
             oldval = getattr(target, name, NOTSET)
             # Avoid class descriptors like staticmethod/classmethod.
@@ -300,6 +301,7 @@ class MonkeyPatch:
         if name not in dic:
             if raising:
                 raise KeyError(name)
+            self._setitem.append((dic, name, NOTSET))
         else:
             self._setitem.append((dic, name, dic.get(name, NOTSET)))
             # Not all Mapping types support indexing, but MutableMapping doesn't support TypedDict
@@ -408,7 +410,10 @@ class MonkeyPatch:
             if value is not NOTSET:
                 setattr(obj, name, value)
             else:
-                delattr(obj, name)
+                try:
+                    delattr(obj, name)
+                except AttributeError:
+                    pass  # Was already deleted, so we have the desired state.
         self._setattr[:] = []
         for dictionary, key, value in reversed(self._setitem):
             if value is NOTSET:

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -117,6 +117,18 @@ def test_delattr() -> None:
     assert A.x == 1
 
 
+def test_delattr_non_existing_with_raising_false() -> None:
+    class A:
+        pass
+
+    monkeypatch = MonkeyPatch()
+    monkeypatch.delattr(A, "x", raising=False)
+    monkeypatch.setattr(A, "x", 1, raising=False)
+    assert A.x == 1  # type: ignore[attr-defined]
+    monkeypatch.undo()
+    assert not hasattr(A, "x")
+
+
 def test_setitem() -> None:
     d = {"x": 1}
     monkeypatch = MonkeyPatch()
@@ -175,6 +187,16 @@ def test_delitem() -> None:
     assert d["x"] == 1500
     monkeypatch.undo()
     assert d == {"hello": "world", "x": 1}
+
+
+def test_delitem_non_existing_with_raising_false() -> None:
+    d: dict[str, object] = {}
+    monkeypatch = MonkeyPatch()
+    monkeypatch.delitem(d, "x", raising=False)
+    monkeypatch.setitem(d, "x", 1)
+    assert d["x"] == 1
+    monkeypatch.undo()
+    assert "x" not in d
 
 
 def test_setenv() -> None:


### PR DESCRIPTION
## Summary
Fixes a state-restoration bug in `MonkeyPatch` when deleting a missing attribute/item with `raising=False`.

Previously:
- `delattr(..., raising=False)` and `delitem(..., raising=False)` did not record the missing state.
- If the test then added that attribute/item, `undo()` would not reliably restore the original missing state.

This change records `NOTSET` for those delete calls, and makes `undo()` tolerant when the target attribute is already absent.

Closes #14094.

## Why this matters
Tests that use non-raising deletes expect monkeypatch teardown to fully restore pre-test state. Without this fix, state could leak after tests.

## How tested
- `uv run -m pytest testing/test_monkeypatch.py -k "delattr_non_existing_with_raising_false or delitem_non_existing_with_raising_false or test_delattr or test_delitem"`
- `uv run -m pytest testing/test_monkeypatch.py`
- `uv run --with pre-commit pre-commit run --files src/_pytest/monkeypatch.py testing/test_monkeypatch.py changelog/14094.bugfix.rst`
