### PR TITLE
Track dynamic fixture dependencies

### DIFF
--- a/changelog/14287.bugfix.rst
+++ b/changelog/14287.bugfix.rst
@@ -1,0 +1,1 @@
+Dynamic fixture dependencies via :func:`request.getfixturevalue() <pytest.FixtureRequest.getfixturevalue>` are now shown in ``--setuponly`` output.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -377,8 +377,9 @@ class FixtureRequest(abc.ABC):
         # collection. Dynamically requested fixtures (using
         # `request.getfixturevalue("foo")`) are added dynamically.
         self._arg2fixturedefs: Final = arg2fixturedefs
-        # The argnames evaluated in the current test item, mapping to the FixtureDef
-        # they resolved to.
+        # The argnames evaluated in the current test item so far, mapping
+        # to the FixtureDef they resolved to. Shared by the TopRequest and all
+        # of its SubRequests.
         self._fixture_defs: Final = fixture_defs
         # FixtureDefs requested through this specific `request` object.
         # Allows tracking dependencies on fixtures.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -377,9 +377,12 @@ class FixtureRequest(abc.ABC):
         # collection. Dynamically requested fixtures (using
         # `request.getfixturevalue("foo")`) are added dynamically.
         self._arg2fixturedefs: Final = arg2fixturedefs
-        # The evaluated argnames so far, mapping to the FixtureDef they resolved
-        # to.
+        # The argnames evaluated in the current test item, mapping to the FixtureDef
+        # they resolved to.
         self._fixture_defs: Final = fixture_defs
+        # FixtureDefs requested through this specific `request` object.
+        # Allows tracking dependencies on fixtures.
+        self._own_fixture_defs: Final[dict[str, FixtureDef[object]]] = {}
         # Notes on the type of `param`:
         # -`request.param` is only defined in parametrized fixtures, and will raise
         #   AttributeError otherwise. Python typing has no notion of "undefined", so
@@ -555,6 +558,7 @@ class FixtureRequest(abc.ABC):
         fixturedef = self._fixture_defs.get(argname)
         if fixturedef is not None:
             self._check_scope(fixturedef, fixturedef._scope)
+            self._own_fixture_defs[argname] = fixturedef
             return fixturedef
 
         # Find the appropriate fixturedef.
@@ -616,6 +620,7 @@ class FixtureRequest(abc.ABC):
             self, scope, param, param_index, fixturedef, _ispytest=True
         )
 
+        self._own_fixture_defs[argname] = fixturedef
         # Make sure the fixture value is cached, running it if it isn't
         fixturedef.execute(request=subrequest)
 

--- a/testing/test_setuponly.py
+++ b/testing/test_setuponly.py
@@ -162,6 +162,40 @@ def test_show_fixtures_with_parameters(pytester: Pytester, mode) -> None:
     )
 
 
+def test_show_fixtures_with_parameters_and_deps(pytester: Pytester) -> None:
+    p = pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture
+        def static_dep():
+            pass
+
+        @pytest.fixture
+        def dynamic_dep():
+            pass
+
+        @pytest.fixture
+        def param_fixture(static_dep, request):
+            request.getfixturevalue('dynamic_dep')
+
+        @pytest.mark.parametrize('param_fixture', [1], indirect=True)
+        def test_indirect(param_fixture):
+            pass
+        """
+    )
+
+    result = pytester.runpytest("--setup-only", p)
+    assert result.ret == 0
+
+    result.stdout.fnmatch_lines(
+        [
+            "        SETUP    F param_fixture[1] (fixtures used: dynamic_dep, static_dep)",
+            "        TEARDOWN F param_fixture[1]",
+        ]
+    )
+
+
 def test_show_fixtures_with_parameter_ids(pytester: Pytester, mode) -> None:
     pytester.makeconftest(
         '''
@@ -215,12 +249,15 @@ def test_dynamic_fixture_request(pytester: Pytester) -> None:
     p = pytester.makepyfile(
         """
         import pytest
+
         @pytest.fixture()
         def dynamically_requested_fixture():
             pass
+
         @pytest.fixture()
         def dependent_fixture(request):
             request.getfixturevalue('dynamically_requested_fixture')
+
         def test_dyn(dependent_fixture):
             pass
     """
@@ -232,6 +269,8 @@ def test_dynamic_fixture_request(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(
         [
             "*SETUP    F dynamically_requested_fixture",
+            "*SETUP    F dependent_fixture (fixtures used: dynamically_requested_fixture)",
+            "*TEARDOWN F dependent_fixture",
             "*TEARDOWN F dynamically_requested_fixture",
         ]
     )


### PR DESCRIPTION
This PR adds `FixtureRequest._own_fixture_defs` and uses it for a more accurate `--setuponly` and `--setupshow` output. This might be a bit overkill for this specific purpose, but `_own_fixture_defs` can also be used to track fixture dependencies for proper teardown in case of parametrized fixtures, see PR #14104.

Fixes: #14287