### PR TITLE
doc: Update training info

### DIFF
--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -2,7 +2,7 @@
 
 .. sidebar:: **Next Open Trainings and Events**
 
-    - `Professional Testing with Python <https://python-academy.com/courses/python_course_testing.html>`_, via `Python Academy <https://www.python-academy.com/>`_ (3 day in-depth training), **March 3rd -- 5th 2026**, Remote
+    - `Professional Testing with Python <https://python-academy.com/courses/python_course_testing.html>`_, via `Python Academy <https://www.python-academy.com/>`_ (3 day in-depth training), **March 9th -- 11th 2027**, Leipzig (DE) / Remote
 
     Also see :doc:`previous talks and blogposts <talks>`
 


### PR DESCRIPTION
Next training planned already :upside_down_face: 

I will also have pytest trainings at PyConDE, PyConIT and (if accepted) Europython this year, but I decided to not put all those in as it would make the sidebar a bit too unwieldy.