### PR TITLE
fix: allow HIDDEN_PARAM in parametrize ids type annotation

### DIFF
--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -532,7 +532,7 @@ if TYPE_CHECKING:
             argvalues: Collection[ParameterSet | Sequence[object] | object],
             *,
             indirect: bool | Sequence[str] = ...,
-            ids: Iterable[None | str | float | int | bool]
+            ids: Iterable[None | str | float | int | bool | _HiddenParam]
             | Callable[[Any], object | None]
             | None = ...,
             scope: _ScopeName | None = ...,
@@ -549,7 +549,7 @@ if TYPE_CHECKING:
             argvalues: Iterable[ParameterSet | Sequence[object] | object],
             *,
             indirect: bool | Sequence[str] = ...,
-            ids: Iterable[None | str | float | int | bool]
+            ids: Iterable[None | str | float | int | bool | _HiddenParam]
             | Callable[[Any], object | None]
             | None = ...,
             scope: _ScopeName | None = ...,


### PR DESCRIPTION
## What

Add  to the  parameter type union in  overloads.

## Why

Currently, the  parameter type is , but  (a  sentinel) is a valid value that should be accepted. This causes mypy to report a false positive:



The  field already accepts , so this is consistent.

## Changes

- Added  to the union type in both  overloads in 

Fixes #14234