### PR TITLE
docs: move collection hooks from reporting to collection section

### DIFF
--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -760,6 +760,19 @@ items, delete or otherwise amend the test items:
 .. hook:: pytest_collection_finish
 .. autofunction:: pytest_collection_finish
 
+During collection, the following hooks are called to track collection progress:
+
+.. hook:: pytest_collectstart
+.. autofunction:: pytest_collectstart
+.. hook:: pytest_make_collect_report
+.. autofunction:: pytest_make_collect_report
+.. hook:: pytest_itemcollected
+.. autofunction:: pytest_itemcollected
+.. hook:: pytest_collectreport
+.. autofunction:: pytest_collectreport
+.. hook:: pytest_deselected
+.. autofunction:: pytest_deselected
+
 Test running (runtest) hooks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -796,16 +809,6 @@ Reporting hooks
 
 Session related reporting hooks:
 
-.. hook:: pytest_collectstart
-.. autofunction:: pytest_collectstart
-.. hook:: pytest_make_collect_report
-.. autofunction:: pytest_make_collect_report
-.. hook:: pytest_itemcollected
-.. autofunction:: pytest_itemcollected
-.. hook:: pytest_collectreport
-.. autofunction:: pytest_collectreport
-.. hook:: pytest_deselected
-.. autofunction:: pytest_deselected
 .. hook:: pytest_report_header
 .. autofunction:: pytest_report_header
 .. hook:: pytest_report_collectionfinish


### PR DESCRIPTION
## Summary

Fixes #12658.

The hooks `pytest_collectstart`, `pytest_make_collect_report`, `pytest_itemcollected`, `pytest_collectreport`, and `pytest_deselected` were listed under the "Reporting hooks" section in the reference docs, but they are collection-related hooks.

This PR moves them to the end of the "Collection hooks" section with a brief introductory line, and removes them from the "Reporting hooks" section.

## Changes

- Moved `pytest_collectstart`, `pytest_make_collect_report`, `pytest_itemcollected`, `pytest_collectreport`, and `pytest_deselected` from "Reporting hooks" to "Collection hooks" section
- Added descriptive text: "During collection, the following hooks are called to track collection progress:"

?? Generated with [Claude Code](https://claude.com/claude-code)