### PR TITLE
Fix type annotation for parametrize ids to allow HIDDEN_PARAM

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1208,7 +1208,9 @@ class Metafunc:
         argnames: str | Sequence[str],
         argvalues: Iterable[ParameterSet | Sequence[object] | object],
         indirect: bool | Sequence[str] = False,
-        ids: Iterable[str | _HiddenParam | None] | Callable[[Any], object | None] | None = None,
+        ids: Iterable[str | _HiddenParam | None]
+        | Callable[[Any], object | None]
+        | None = None,
         scope: _ScopeName | None = None,
         *,
         _param_mark: Mark | None = None,
@@ -1404,7 +1406,9 @@ class Metafunc:
     def _resolve_parameter_set_ids(
         self,
         argnames: Sequence[str],
-        ids: Iterable[str | _HiddenParam | None] | Callable[[Any], object | None] | None,
+        ids: Iterable[str | _HiddenParam | None]
+        | Callable[[Any], object | None]
+        | None,
         parametersets: Sequence[ParameterSet],
         nodeid: str,
     ) -> list[str | _HiddenParam]:


### PR DESCRIPTION
## Description

The `ids` parameter of `pytest.mark.parametrize` was typed as `Iterable[object | None]`, which while technically broad enough to accept any value, doesn't explicitly indicate that `HIDDEN_PARAM` is a valid value. This causes mypy to report type errors when using `ids=[pytest.HIDDEN_PARAM]`.

Changed `ids` type from `Iterable[object | None]` to `Iterable[str | _HiddenParam | None]` to match `ParameterSet.id` and make the type more specific and readable.

## Changes

- `IdMaker.ids`: `Sequence[object | None]` -> `Sequence[str | _HiddenParam | None]`
- `Metafunc.parametrize` `ids` param: `Iterable[object | None]` -> `Iterable[str | _HiddenParam | None]`
- `Metafunc._resolve_parameter_set_ids` `ids` param: `Iterable[object | None]` -> `Iterable[str | _HiddenParam | None]`
- `Metafunc._validate_ids` `ids` param: `Iterable[object | None]` -> `Iterable[str | _HiddenParam | None]`

Fixes #14234
