### PR TITLE
Enable record_property for junit_family=xunit2

### DIFF
--- a/changelog/14315.improvement.rst
+++ b/changelog/14315.improvement.rst
@@ -1,0 +1,1 @@
+Enabled ``record_property`` when using ``junit_family=xunit2``.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -288,7 +288,6 @@ def record_property(request: FixtureRequest) -> Callable[[str, object], None]:
         def test_function(record_property):
             record_property("example_key", 1)
     """
-    _warn_incompatibility_with_xunit2(request, "record_property")
 
     def append_property(name: str, value: object) -> None:
         request.node.user_properties.append((name, value))

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1379,11 +1379,45 @@ def test_record_attribute(pytester: Pytester, run_and_parse: RunAndParse) -> Non
 
 
 @pytest.mark.filterwarnings("default")
+def test_record_property_xunit2(pytester: Pytester, run_and_parse: RunAndParse) -> None:
+    pytester.makeini(
+        """
+        [pytest]
+        junit_family = xunit2
+    """
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture
+        def other(record_property):
+            record_property("bar", 1)
+
+        def test_record(record_property, other):
+            record_property("foo", "<1")
+    """
+    )
+
+    result, dom = run_and_parse(family=None)
+    node = dom.get_first_by_tag("testsuite")
+    tnode = node.get_first_by_tag("testcase")
+    psnode = tnode.get_first_by_tag("properties")
+    pnodes = psnode.find_by_tag("property")
+    pnodes[0].assert_attr(name="bar", value="1")
+    pnodes[1].assert_attr(name="foo", value="<1")
+
+    result.stdout.no_fnmatch_line(
+        "*record_property is incompatible with junit_family 'xunit2'*"
+    )
+
+
+@pytest.mark.filterwarnings("default")
 @pytest.mark.parametrize("fixture_name", ["record_xml_attribute", "record_property"])
 def test_record_fixtures_xunit2(
     pytester: Pytester, fixture_name: str, run_and_parse: RunAndParse
 ) -> None:
-    """Ensure record_xml_attribute and record_property drop values when outside of legacy family."""
+    """Ensure xunit2 still warns for record_xml_attribute, but record_property remains supported."""
     pytester.makeini(
         """
         [pytest]
@@ -1403,16 +1437,16 @@ def test_record_fixtures_xunit2(
     )
 
     result, _dom = run_and_parse(family=None)
-    expected_lines = []
     if fixture_name == "record_xml_attribute":
-        expected_lines.append(
-            "*test_record_fixtures_xunit2.py:6:*record_xml_attribute is an experimental feature"
+        expected_lines = [
+            "*test_record_fixtures_xunit2.py:6:*record_xml_attribute is incompatible "
+            "with junit_family 'xunit2' (use 'legacy' or 'xunit1')"
+        ]
+        result.stdout.fnmatch_lines(expected_lines)
+    else:
+        result.stdout.no_fnmatch_line(
+            "*record_property is incompatible with junit_family 'xunit2'*"
         )
-    expected_lines = [
-        f"*test_record_fixtures_xunit2.py:6:*{fixture_name} is incompatible "
-        "with junit_family 'xunit2' (use 'legacy' or 'xunit1')"
-    ]
-    result.stdout.fnmatch_lines(expected_lines)
 
 
 def test_random_report_log_xdist(


### PR DESCRIPTION
Refs #14315
## Summary
This change enables `record_property` when `junit_family=xunit2` is used.

## What changed
- removed the xunit2 incompatibility warning for `record_property`
- added a test covering `record_property` with `junit_family=xunit2`
- updated the existing xunit2 fixture warning test so that `record_xml_attribute` still warns, but `record_property` does not

## Testing
- `pytest testing/test_junitxml.py -q`
- `pre-commit run --files src/_pytest/junitxml.py testing/test_junitxml.py`