### PR TITLE
Schedule deprecated legacy hook marks for removal in pytest 10

### DIFF
--- a/changelog/14335.deprecation.rst
+++ b/changelog/14335.deprecation.rst
@@ -1,0 +1,2 @@
+The method of configuring hooks using markers, deprecated since pytest 7.2, is now scheduled to be removed in pytest 10.
+See :ref:`hook-markers` for more details.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -171,8 +171,12 @@ Simply remove the ``__init__.py`` file entirely.
 Python 3.3+ natively supports namespace packages without ``__init__.py``.
 
 
+.. _hook-markers:
+
 Configuring hook specs/impls using markers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 7.2
 
 Before pluggy, pytest's plugin library, was its own package and had a clear API,
 pytest just used ``pytest.mark`` to configure hooks.

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -39,7 +39,7 @@ PRIVATE = PytestDeprecationWarning("A private pytest class or function was used.
 
 
 HOOK_LEGACY_MARKING = UnformattedWarning(
-    PytestDeprecationWarning,
+    PytestRemovedIn10Warning,
     "The hook{type} {fullname} uses old-style configuration options (marks or attributes).\n"
     "Please use the pytest.hook{type}({hook_opts}) decorator instead\n"
     " to configure the hooks.\n"


### PR DESCRIPTION
By the time pytest 10 is released, this will have been deprecated for more than 5 years (0fdacb6db5806dcc2c01d80e6dfe0e5fcd24034e), and the alternative syntax available for over 10 years
(d2a5c7f99b8d178f170c1ca6579690ce84e00b3d), which seems like enough time.

Removal will simplify PytestPluginManager and leave us with one way for setting hookspec/hookimpl options (the plan after removal is to just treat the old markers as normal markers, not hard-error on them).