### PR TITLE
Mark ``yield_fixture`` as deprecated

### DIFF
--- a/changelog/14340.improvement.rst
+++ b/changelog/14340.improvement.rst
@@ -1,0 +1,1 @@
+Marked ``yield_fixture`` as deprecated with ``deprecated`` decorator.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING
 from typing import TypeVar
 import warnings
 
+from .compat import deprecated
 import _pytest
 from _pytest import nodes
 from _pytest._code import getfslineno
@@ -1416,6 +1417,9 @@ def fixture(
     return fixture_marker
 
 
+@deprecated(
+    "pytest.yield_fixture is deprecated, use pytest.fixture to access configuration values instead.",
+)
 def yield_fixture(
     fixture_function=None,
     *args,

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -26,7 +26,7 @@ from _pytest.fixtures import fixture
 from _pytest.fixtures import FixtureDef
 from _pytest.fixtures import FixtureLookupError
 from _pytest.fixtures import FixtureRequest
-from _pytest.fixtures import yield_fixture
+from _pytest.fixtures import yield_fixture  # type: ignore[deprecated]
 from _pytest.freeze_support import freeze_includes
 from _pytest.legacypath import TempdirFactory
 from _pytest.legacypath import Testdir

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -68,7 +68,7 @@ def test_hookimpl_via_function_attributes_are_deprecated():
 def test_yield_fixture_is_deprecated() -> None:
     with pytest.warns(DeprecationWarning, match=r"yield_fixture is deprecated"):
 
-        @pytest.yield_fixture
+        @pytest.yield_fixture  # type: ignore[deprecated]
         def fix():
             assert False
 


### PR DESCRIPTION
yield_fixture` is deprecated, is it ok to use the `deprecated` decorator on it?

https://github.com/pytest-dev/pytest/blob/959cd47af8b618e3ce2182c837131824f24018c8/src/_pytest/fixtures.py#L1434-L1435

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
