### PR TITLE
Fix Config.get_terminal_writer() crash when terminalreporter is unregistered

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,6 +44,7 @@ Anna Tasiopoulou
 Anthon van der Neut
 Anthony Shaw
 Anthony Sottile
+Antoine Leclair
 Anton Grinevich
 Anton Lodder
 Anton Zhilin

--- a/changelog/14377.bugfix.rst
+++ b/changelog/14377.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :meth:`pytest.Config.get_terminal_writer` crashing with an internal ``AssertionError`` when the terminal reporter plugin has been unregistered (for example, by :pypi:`pytest-tap` in streaming mode). A fresh terminal writer is now created on demand.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1173,7 +1173,8 @@ class Config:
         terminalreporter: TerminalReporter | None = self.pluginmanager.get_plugin(
             "terminalreporter"
         )
-        assert terminalreporter is not None
+        if terminalreporter is None:
+            return create_terminal_writer(self)
         return terminalreporter._tw
 
     def pytest_cmdline_parse(

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1682,6 +1682,29 @@ class TestSetAssertions:
         )
 
 
+def test_assertrepr_compare_without_terminalreporter(pytester: Pytester) -> None:
+    pytester.makeconftest(
+        """
+        import pytest
+
+        @pytest.hookimpl(trylast=True)
+        def pytest_configure(config):
+            reporter = config.pluginmanager.get_plugin("terminalreporter")
+            config.pluginmanager.unregister(reporter)
+        """
+    )
+    pytester.makepyfile(
+        """
+        def test_hello():
+            assert "actual" == "expected"
+        """
+    )
+    reprec = pytester.inline_run()
+    _passed, _skipped, failed = reprec.listoutcomes()
+    assert len(failed) == 1
+    assert "assert 'actual' == 'expected'" in str(failed[0].longrepr)
+
+
 def test_assertrepr_loaded_per_dir(pytester: Pytester) -> None:
     pytester.makepyfile(test_base=["def test_base(): assert 1 == 2"])
     a = pytester.mkdir("a")

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1386,6 +1386,15 @@ class TestConfigAPI:
 
         assert report == ["cleanup_first", "raise_1", "raise_2", "cleanup_last"]
 
+    def test_get_terminal_writer_without_terminalreporter(
+        self, pytester: Pytester
+    ) -> None:
+        from _pytest._io import TerminalWriter
+
+        config = pytester.parseconfig()
+        config.pluginmanager.unregister(name="terminalreporter")
+        assert isinstance(config.get_terminal_writer(), TerminalWriter)
+
 
 class TestConfigFromdictargs:
     def test_basic_behavior(self, _sys_snapshot) -> None:


### PR DESCRIPTION
Closes #14377.

### The fix

`Config.get_terminal_writer()` had a hard `assert terminalreporter is not None` that crashes when a plugin (e.g. `pytest-tap` in streaming mode) unregisters the terminal reporter. It now falls back to `create_terminal_writer(self)` — the same factory `TerminalReporter.__init__` uses internally — so the happy path is unchanged and callers keep working when the reporter is gone.

This fixes the reported assertion-diff crash, and also covers `runner.show_test_item` (`--collect-only -q`) and `setuponly._show_fixture_action` (`--setup-only`/`--setup-plan`), which hit the same assert in their respective modes.

### Does this change the behavior?

For the use case of `pytest-tap`, I don't think it changes the behavior for the assertion path — `assertrepr_compare` only uses `_highlight`, which is a pure string transformation; nothing gets written to stdout, so pytest-tap's TAP output is unaffected. In practice, it's a slight behavior change, so please let me know if you think this could have bad side effects, e.g. for other plugins.

For `show_test_item` / `setuponly` the fresh writer would actually emit to stdout, but those paths used to crash, so this seems strictly better. Happy to revisit if you'd rather silence them in that case.

### Tests

- `test_config.py::TestConfigAPI::test_get_terminal_writer_without_terminalreporter` — direct contract test on `get_terminal_writer()` with the plugin unregistered.
- `test_assertion.py::test_assertrepr_compare_without_terminalreporter` — `pytester` integration test reproducing the pytest-tap scenario end-to-end.

Both fail without the fix and pass with it.

### Checklist

- [x] New tests added.
- [x] Allow maintainers to push and squash when merging my commits.
- [x] `closes #14377`.
- [x] AI was used to assist; credited in the `Co-authored-by` trailer. I reviewed every line and own the change.
- [x] `changelog/14377.bugfix.rst` added.
- [x] Added myself to `AUTHORS` in alphabetical order.
