### PR TITLE
Fix `-V` to show version information

### DIFF
--- a/changelog/14381.bugfix.rst
+++ b/changelog/14381.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``-V`` (short form of ``--version``) to properly display the current version.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -182,9 +182,12 @@ def main(
 
     :returns: An exit code.
     """
-    # Handle a single `--version` argument early to avoid starting up the entire pytest infrastructure.
+    # Handle a single `--version`/`-V` argument early to avoid starting up the entire pytest infrastructure.
     new_args = sys.argv[1:] if args is None else args
-    if isinstance(new_args, Sequence) and new_args.count("--version") == 1:
+    if (
+        isinstance(new_args, Sequence)
+        and (new_args.count("--version") + new_args.count("-V")) == 1
+    ):
         sys.stdout.write(f"pytest {__version__}\n")
         return ExitCode.OK
 

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -16,10 +16,11 @@ def test_version_verbose(pytester: Pytester, pytestconfig, monkeypatch) -> None:
         result.stdout.fnmatch_lines(["*registered third-party plugins:", "*at*"])
 
 
-def test_version_less_verbose(pytester: Pytester) -> None:
-    """Single ``--version`` parameter should display only the pytest version, without loading plugins (#13574)."""
+@pytest.mark.parametrize("flag", ["--version", "-V"])
+def test_version_less_verbose(pytester: Pytester, flag: str) -> None:
+    """Single ``--version`` or ``-V`` should display only the pytest version, without loading plugins (#13574)."""
     pytester.makeconftest("print('This should not be printed')")
-    result = pytester.runpytest_subprocess("--version")
+    result = pytester.runpytest_subprocess(flag)
     assert result.ret == ExitCode.OK
     assert result.stdout.str().strip() == f"pytest {pytest.__version__}"
 


### PR DESCRIPTION
This regressed in #13575.

Fixes #14381.
