### PR TITLE
docs: hyphenate user-provided scope wording

### DIFF
--- a/src/_pytest/scope.py
+++ b/src/_pytest/scope.py
@@ -64,7 +64,7 @@ class Scope(Enum):
     ) -> Scope:
         """
         Given a scope name from the user, return the equivalent Scope enum. Should be used
-        whenever we want to convert a user provided scope name to its enum object.
+        whenever we want to convert a user-provided scope name to its enum object.
 
         If the scope name is invalid, construct a user friendly message and call pytest.fail.
         """


### PR DESCRIPTION
## Summary
- Hyphenate `user-provided` in the scope docstring.

## Related issue
- N/A

## Guideline alignment
- Read the contribution guide where present and kept this to one focused text-only file change.
- No behavior, test, fixture, changelog, or generated-file changes.

## Validation
- `git diff --check`
- Not run: broader tests are unnecessary for this text-only change.

## AI assistance
- Prepared with Codex and reviewed before submission.
