### PR TITLE
Clarify caplog.set_level() is a threshold level

### DIFF
--- a/doc/en/how-to/logging.rst
+++ b/doc/en/how-to/logging.rst
@@ -93,7 +93,8 @@ messages.  This is supported by the ``caplog`` fixture:
 
 By default the level is set on the root logger,
 however as a convenience it is also possible to set the log level of any
-logger:
+logger.  The level set is a threshold level: logging messages which are less
+severe than this level will not be captured.
 
 .. code-block:: python
 


### PR DESCRIPTION
Good day

This PR addresses issue #9146 which requested clearer documentation for the caplog.set_level() method.

## Problem

The previous documentation said:
> By default the level is set on the root logger, however as a convenience it is also possible to set the log level of any logger:

This did not make it clear that caplog.set_level() sets a **threshold level** — meaning logging messages less severe than the set level will be ignored, similar to Python's logging.setLevel() behavior.

## Solution

Updated the documentation in doc/en/how-to/logging.rst to clarify:

> By default the level is set on the root logger, however as a convenience it is also possible to set the log level of any logger. The level set is a threshold level: logging messages which are less severe than this level will not be captured.

This mirrors the language used in Python's official logging documentation for setLevel().

## Changes

- **File**: doc/en/how-to/logging.rst
- **Change**: Added clarification that the level is a threshold — messages less severe than the level will not be captured

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof