### PR TITLE
fix: preserve bytes type in partial binary capture

### DIFF
--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -702,11 +702,17 @@ class MultiCapture(Generic[AnyStr]):
         """Whether actively capturing -- not suspended or stopped."""
         return self._state == "started"
 
+    def _empty_buffer(self) -> AnyStr:
+        for capture in (self.out, self.err, self.in_):
+            if capture is not None:
+                return capture.EMPTY_BUFFER
+        return cast(AnyStr, "")
+
     def readouterr(self) -> CaptureResult[AnyStr]:
-        out = self.out.snap() if self.out else ""
-        err = self.err.snap() if self.err else ""
-        # TODO: This type error is real, need to fix.
-        return CaptureResult(out, err)  # type: ignore[arg-type]
+        empty = self._empty_buffer()
+        out = self.out.snap() if self.out else empty
+        err = self.err.snap() if self.err else empty
+        return CaptureResult(out, err)
 
 
 def _get_multicapture(method: _CaptureMethod) -> MultiCapture[str]:

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1476,6 +1476,23 @@ def test_capturing_and_logging_fundamentals(pytester: Pytester, method: str) -> 
     assert "atexit" not in result.stderr.str()
 
 
+def test_multicapture_binary_readouterr_uses_bytes_for_missing_stream() -> None:
+    with saved_fd(2):
+        cap = capture.MultiCapture(
+            in_=None,
+            out=None,
+            err=capture.FDCaptureBinary(2),
+        )
+        cap.start_capturing()
+        try:
+            os.write(2, b"hello")
+            outerr = cap.readouterr()
+        finally:
+            cap.stop_capturing()
+
+    assert outerr == CaptureResult(b"", b"hello")
+
+
 def test_error_attribute_issue555(pytester: Pytester) -> None:
     pytester.makepyfile(
         """


### PR DESCRIPTION

**Repo:** pytest-dev/pytest (⭐ 12000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +27/-4

## What
This change fixes `MultiCapture.readouterr()` so that when one of the captured streams is missing, the fallback empty value matches the active capture type instead of always using `""`. A focused regression test covers the binary case where only `stderr` is captured and verifies that the returned `CaptureResult` is `(b"", b"hello")`.

## Why
`MultiCapture` is generic over text and binary capture, but its empty-stream fallback was hard-coded to text. That produced the wrong runtime type for partial binary captures and was already flagged in the source as a real typing problem. The patch makes the runtime behavior consistent with the generic contract and protects it with a targeted test.

## Testing
Verified with a direct local reproduction under `PYTHONPATH=src` that constructs `MultiCapture(in_=None, out=None, err=FDCaptureBinary(2))`, writes to file descriptor 2, and asserts the result is `CaptureResult(b"", b"hello")`. Attempting to run the repo test target via `python -m pytest` was blocked by the host environment: first by auto-loaded external plugins, then by an installed/local pytest mismatch causing fixture recursion and the absence of generated `_pytest._version` when forcing `PYTHONPATH=src`.

## Risk
Low - the change is limited to the empty-buffer fallback for partially configured captures and adds a regression test for the affected binary path.
