### PR TITLE
fix(raises): count consecutive backslashes in is_fully_escaped

### DIFF
--- a/src/_pytest/raises.py
+++ b/src/_pytest/raises.py
@@ -345,9 +345,18 @@ def _check_raw_type(
 def is_fully_escaped(s: str) -> bool:
     # we know we won't compile with re.VERBOSE, so whitespace doesn't need to be escaped
     metacharacters = "{}()+.*?^$[]|"
-    return not any(
-        c in metacharacters and (i == 0 or s[i - 1] != "\\") for (i, c) in enumerate(s)
-    )
+    for i, c in enumerate(s):
+        if c in metacharacters:
+            # count consecutive backslashes before this position
+            n = 0
+            j = i - 1
+            while j >= 0 and s[j] == "\\":
+                n += 1
+                j -= 1
+            # odd number of backslashes → escaped; even → not escaped
+            if n % 2 == 0:
+                return False
+    return True
 
 
 def unescape(s: str) -> str:


### PR DESCRIPTION
## Summary

**Fixes #14392**

`is_fully_escaped()` only checked whether the character immediately before a regex metacharacter is a backslash. It did not count how many consecutive backslashes precede the metacharacter.

When two backslashes appear before a metachar (e.g. `r'\.'`), the first backslash escapes the second, so the metachar is left unescaped. But `is_fully_escaped` saw a backslash before the dot and incorrectly returned `True`.\n
## Change

Count consecutive backslashes before each metacharacter. If the count is odd → escaped; if even → not escaped.\n
## Test plan

- All 33 existing tests in `testing/python/raises.py` pass
- Verified with reproduction cases from the issue:\n
  - `is_fully_escaped(r'\.')` → `False` (was wrongly `True`)\n
  - `is_fully_escaped('\\\\|')` → `False` (was wrongly `True`)\n
  - `is_fully_escaped(r'\.')` → `True` (unchanged, correct)\n
  - `is_fully_escaped('hello')` → `True` (unchanged, correct)\n
  - `is_fully_escaped('a.b')` → `False` (unchanged, correct)