### PR TITLE
fix(pytester): add type annotations to makepyfile and maketxtfile params

### DIFF
--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -862,7 +862,7 @@ class Pytester:
         """
         return self.makefile(".toml", pyproject=source)
 
-    def makepyfile(self, *args, **kwargs) -> Path:
+    def makepyfile(self, *args: str, **kwargs: str) -> Path:
         r"""Shortcut for .makefile() with a .py extension.
 
         Defaults to the test name with a '.py' extension, e.g test_foobar.py, overwriting
@@ -882,7 +882,7 @@ class Pytester:
         """
         return self._makefile(".py", args, kwargs)
 
-    def maketxtfile(self, *args, **kwargs) -> Path:
+    def maketxtfile(self, *args: str, **kwargs: str) -> Path:
         r"""Shortcut for .makefile() with a .txt extension.
 
         Defaults to the test name with a '.txt' extension, e.g test_foobar.txt, overwriting


### PR DESCRIPTION
Fixes #14396

`makepyfile` and `maketxtfile` were missing type annotations on their `*args` and `**kwargs` parameters, while sibling method `makefile` already had them as `*args: str, **kwargs: str`. This caused Pyright (strict mode) and basedpyright (default) to report `reportUnknownMemberType` at call sites.

Adds matching annotations to both methods.