### PR TITLE
Fix: use explicit exception cause in RaisesExc.__exit__ when pattern doesn't match

### DIFF
--- a/src/_pytest/raises.py
+++ b/src/_pytest/raises.py
@@ -698,7 +698,7 @@ class RaisesExc(AbstractRaises[BaseExcT_co_default]):
         if not self.matches(exc_val):
             if self._just_propagate:
                 return False
-            raise AssertionError(self._fail_reason)
+            raise AssertionError(self._fail_reason) from exc_val
 
         # Cast to narrow the exception type now that it's verified....
         # even though the TypeGuard in self.matches should be narrowing


### PR DESCRIPTION
## Summary

When `pytest.raises` exits with a regex pattern that doesn't match the raised exception, the `AssertionError` is currently raised as an implicit context (`__context__`). This causes Python to report _"During handling of the above exception, another exception occurred"_, which is misleading — the pattern mismatch is a direct consequence of the exception, not a separate error during handling.

## Change

**1 line changed in** `src/_pytest/raises.py`:

```diff
-            raise AssertionError(self._fail_reason)
+            raise AssertionError(self._fail_reason) from exc_val
```

Using `raise ... from exc_val` sets `__cause__` explicitly, so Python reports _"The above exception was the direct cause of the following exception"_ instead — which accurately describes the relationship.

Fixes #14389