### PR TITLE
fix(raises): guard check callback against AttributeError in RaisesGroup diagnostic path

### DIFF
--- a/src/_pytest/raises.py
+++ b/src/_pytest/raises.py
@@ -1189,11 +1189,18 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
             reason = (
                 cast(str, self._fail_reason) + f" on the {type(exception).__name__}"
             )
+            # Determine whether the check would also match the inner exception,
+            # to produce a helpful hint. Guard against check callbacks that
+            # assume a group-like interface (e.g. accessing .exceptions), since
+            # per the RaisesGroup contract the callback receives the group.
+            try:
+                inner_check_passes = self._check_check(actual_exceptions[0])  # type: ignore[arg-type]
+            except AttributeError:
+                inner_check_passes = False
             if (
                 len(actual_exceptions) == len(self.expected_exceptions) == 1
                 and isinstance(expected := self.expected_exceptions[0], type)
-                # we explicitly break typing here :)
-                and self._check_check(actual_exceptions[0])  # type: ignore[arg-type]
+                and inner_check_passes
             ):
                 self._fail_reason = reason + (
                     f", but did return True for the expected {self._repr_expected(expected)}."


### PR DESCRIPTION
## Summary
Fixes #14324

When a `RaisesGroup` check callback assumes a group-like interface (e.g. accessing `.exceptions`), the diagnostic hint generation in `RaisesGroup.matches()` previously called the same callback with the inner (non-group) exception. This caused an unhandled `AttributeError` that bubbled up as an unexpected exception instead of a clean test failure.

## Details

In `RaisesGroup.matches()`, after the main `_check_check(exception)` call returns `False`, there is a diagnostic branch that checks whether the callback would also match the inner exception — used to suggest `RaisesExc(..., check=...)` as an alternative. That branch calls `_check_check(actual_exceptions[0])`, which invokes the user's callback with the nested exception rather than the group.

For callbacks that only work with groups (like `lambda g: len(g.exceptions) > 1`), this raises `AttributeError`. The fix wraps that diagnostic call in `try/except AttributeError`, setting `inner_check_passes = False` when the callback cannot handle the inner exception type. The existing tests for this diagnostic behavior (`test_check`) continue to pass because they use callbacks that work on both groups and plain exceptions.\n\n## Change Type\n- Bugfix