### PR TITLE
fix(terminal): include subtests in timing progress reports

### DIFF
--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -401,7 +401,7 @@ class TerminalReporter:
         # We use CallableBool here to support both.
         self.isatty = compat.CallableBool(file.isatty())
         self._progress_nodeids_reported: set[str] = set()
-        self._timing_nodeids_reported: set[str] = set()
+        self._timing_reports_reported: set[int] = set()
         self._show_progress_info = self._determine_show_progress_info()
         self._collect_report_last_write = timing.Instant()
         self._already_displayed_warnings: int | None = None
@@ -737,11 +737,14 @@ class TerminalReporter:
                 + self._get_reports_to_display("xfailed")
                 + self._get_reports_to_display("skipped")
                 + self._get_reports_to_display("error")
+                + self._get_reports_to_display("subtests passed")
+                + self._get_reports_to_display("subtests failed")
+                + self._get_reports_to_display("subtests skipped")
                 + self._get_reports_to_display("")
             )
             current_location = all_reports[-1].location[0]
             not_reported = [
-                r for r in all_reports if r.nodeid not in self._timing_nodeids_reported
+                r for r in all_reports if id(r) not in self._timing_reports_reported
             ]
             tests_in_module = sum(
                 i.location[0] == current_location for i in self._session.items
@@ -753,7 +756,7 @@ class TerminalReporter:
             )
             last_in_module = tests_completed == tests_in_module
             if self.showlongtestinfo or last_in_module:
-                self._timing_nodeids_reported.update(r.nodeid for r in not_reported)
+                self._timing_reports_reported.update(id(r) for r in not_reported)
                 return format_node_duration(
                     sum(r.duration for r in not_reported if isinstance(r, TestReport))
                 )

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -162,9 +162,7 @@ class TestTerminal:
         assert "0.000us" not in output
         assert "0.00s" not in output
         # Each subtest sleeps for 0.05s so we expect at least 40ms in the output.
-        result.stdout.re_match_lines(
-            [r".*SUBPASSED\[0\] .*[4-9][0-9]\.[0-9]+ms"]
-        )
+        result.stdout.re_match_lines([r".*SUBPASSED\[0\] .*[4-9][0-9]\.[0-9]+ms"])
 
     def test_internalerror(self, pytester: Pytester, linecomp) -> None:
         modcol = pytester.getmodulecol("def test_one(): pass")

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -140,6 +140,32 @@ class TestTerminal:
         combined = "\n".join(result.stdout.lines + result.stderr.lines)
         assert "INTERNALERROR" not in combined
 
+    def test_console_output_style_times_subtests(self, pytester: Pytester) -> None:
+        pytester.makepyfile(
+            test_repro="""
+                import time
+                def test_example(subtests):
+                    for i in range(2):
+                        with subtests.test(msg=str(i)):
+                            time.sleep(0.05)
+            """,
+        )
+        result = pytester.runpytest(
+            "test_repro.py",
+            "-v",
+            "-o",
+            "console_output_style=times",
+        )
+        result.assert_outcomes(passed=1)
+        # Verify that subtest timing is non-zero (not 0.00s/0.000us).
+        output = result.stdout.str()
+        assert "0.000us" not in output
+        assert "0.00s" not in output
+        # Each subtest sleeps for 0.05s so we expect at least 40ms in the output.
+        result.stdout.re_match_lines(
+            [r".*SUBPASSED\[0\] .*[4-9][0-9]\.[0-9]+ms"]
+        )
+
     def test_internalerror(self, pytester: Pytester, linecomp) -> None:
         modcol = pytester.getmodulecol("def test_one(): pass")
         rep = TerminalReporter(modcol.config, file=linecomp.stringio)


### PR DESCRIPTION
When `console_output_style=times` is used with subtests, all subtests after the first one showed `0.00s` because:

1. `SubtestReport` uses the same `nodeid` as the parent test, so `_timing_nodeids_reported` filtered out subsequent subtest reports.
2. Subtest reports were not included in `all_reports` at all.

Fix by:
- Tracking processed reports by `id()` instead of `nodeid`.
- Including `subtests passed/failed/skipped` in `all_reports`.

Fixes #14412

---

## Changes

- `src/_pytest/terminal.py`: track timing by report id instead of nodeid, include subtest reports in the timing calculation.
- `testing/test_terminal.py`: add regression test `test_console_output_style_times_subtests`.

## Test plan

```
pytest testing/test_terminal.py::TestTerminal::test_console_output_style_times_subtests -v
```

The test verifies that subtest timing is non-zero and shows at least 40ms for a 50ms sleep.
