### PR TITLE
Handle unittest.SkipTest during collection as error (#10821)

### DIFF
--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -409,8 +409,6 @@ def pytest_make_collect_report(collector: Collector) -> CollectReport:
     else:
         skip_exceptions = [Skipped]
         unittest = sys.modules.get("unittest")
-        if unittest is not None:
-            skip_exceptions.append(unittest.SkipTest)
         if isinstance(call.excinfo.value, tuple(skip_exceptions)):
             outcome = "skipped"
             r_ = collector._repr_failure_py(call.excinfo, "line")

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1718,3 +1718,24 @@ def test_abstract_testcase_is_not_collected(pytester: Pytester) -> None:
     result = pytester.runpytest()
     assert result.ret == ExitCode.OK
     result.assert_outcomes(passed=1)
+
+def test_unittest_skip_alias_misuse_fails(pytester):
+    pytester.makepyfile(
+        """
+        import unittest
+
+        broken = unittest.skip("broken")
+
+        class MyTests(unittest.TestCase):
+            @broken
+            def test_good(self):
+                assert True
+
+            @broken("bar")
+            def test_bad(self):
+                assert False
+        """
+    )
+
+    result = pytester.runpytest()
+    result.assert_outcomes(errors=1, skipped=0)

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1719,6 +1719,7 @@ def test_abstract_testcase_is_not_collected(pytester: Pytester) -> None:
     assert result.ret == ExitCode.OK
     result.assert_outcomes(passed=1)
 
+
 def test_unittest_skip_alias_misuse_fails(pytester):
     pytester.makepyfile(
         """


### PR DESCRIPTION
## Summary
Fixes issue #10821 where misuse of an aliased `unittest.skip` decorator can cause pytest to silently skip an entire module during collection.

## Changes
- Removed handling of `unittest.SkipTest` as a collection-time skip
- Now surfaces as a collection error instead of silently skipping
- Added regression test to reproduce the issue

## Reproduction
```python
import unittest

broken = unittest.skip("broken")

class MyTests(unittest.TestCase):
    @broken
    def test_good(self):
        assert True

    @broken("bar")
    def test_bad(self):
        assert False