### PR TITLE
Fix phantom nodeid for tests collected outside rootpath (#13254)

### DIFF
--- a/changelog/13254.bugfix.rst
+++ b/changelog/13254.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed misleading node IDs displayed for tests collected from paths outside ``rootdir``; pytest no longer synthesizes a phantom path by joining ``rootdir`` with the bare node ID in that case.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1227,6 +1227,12 @@ class Config:
             base_path_part, *nodeid_part = nodeid.split("::")
             # Only process path part
             fullpath = self.rootpath / base_path_part
+            if not fullpath.exists():
+                # nodeid was resolved relative to an initial path rather than
+                # to rootpath (see ``_check_initialpaths_for_relpath`` in
+                # ``nodes.py``), so joining rootpath with it gives a phantom
+                # path that doesn't exist. Leave the nodeid alone (#13254).
+                return nodeid
             relative_path = bestrelpath(self.invocation_params.dir, fullpath)
 
             nodeid = "::".join([relative_path, *nodeid_part])

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -3408,6 +3408,45 @@ class TestNodeIDHandling:
             ]
         )
 
+    def test_nodeid_outside_rootpath_not_synthesized(self, pytester: Pytester) -> None:
+        """Regression test for #13254.
+
+        When tests collected from a path outside ``rootpath`` are reported,
+        ``Config.cwd_relative_nodeid`` should not synthesize a path by joining
+        ``rootpath`` with the bare nodeid, since that produces a string that
+        does not point to a real file (e.g. ``aa/test_b.py`` when the test
+        is actually at ``../b/bb/test_b.py``).
+        """
+        # Put pytest.ini under ``a/aa`` so ``rootpath`` is ``a/aa``.
+        (pytester.path / "a" / "aa").mkdir(parents=True)
+        (pytester.path / "a" / "aa" / "pytest.ini").write_text(
+            "[pytest]\n", encoding="utf-8"
+        )
+        (pytester.path / "a" / "aa" / "test_a.py").write_text(
+            "def test_a():\n    pass\n", encoding="utf-8"
+        )
+        # And a test file living *outside* rootpath.
+        (pytester.path / "b" / "bb").mkdir(parents=True)
+        (pytester.path / "b" / "bb" / "test_b.py").write_text(
+            "def test_b():\n    pass\n", encoding="utf-8"
+        )
+
+        # Invoke pytest from ``a`` so ``invocation_params.dir`` differs from
+        # ``rootpath`` and both invocation paths straddle the rootpath.
+        os.chdir(pytester.path / "a")
+        result = pytester.runpytest("./aa", "../b/bb", "-vv")
+
+        result.assert_outcomes(passed=2)
+        # The in-rootpath test keeps its cwd-relative nodeid.
+        result.stdout.re_match_lines([r".*aa[\\/]test_a\.py::test_a .*PASSED.*"])
+        # The out-of-rootpath test must be reported by its bare nodeid
+        # (plus the ``<-`` location hint), never as ``aa/test_b.py`` which
+        # would be a phantom path that does not exist.
+        result.stdout.re_match_lines(
+            [r"^test_b\.py::test_b <- .*b[\\/]bb[\\/]test_b\.py .*PASSED.*"]
+        )
+        result.stdout.no_re_match_line(r".*aa[\\/]test_b\.py::test_b.*")
+
 
 class TestTerminalProgressPlugin:
     """Tests for the TerminalProgressPlugin."""


### PR DESCRIPTION
Fixes #13254.

### Problem

When pytest collects tests from a path that lives outside `rootpath`
(for example a `pytest.ini` inside `tests/a/aa/` while an additional
test file sits at `tests/b/bb/test_b.py`), the displayed node ID for
the out-of-rootpath test is a synthesized path that does not exist on
disk.

Minimal reproducer:

```
tests/
├── a/aa/pytest.ini
├── a/aa/test_a.py
└── b/bb/test_b.py
```

Run from `tests/a/`:

```
pytest ./aa ../b/bb -vv
```

Before this change:

```
aa\test_a.py::test_a PASSED
aa\test_b.py::test_b <- ..\..\b\bb\test_b.py PASSED
```

`aa\test_b.py` does not exist; the file is actually at `../../b/bb/test_b.py`.

### Cause

`Node.__init__` in `src/_pytest/nodes.py` falls back to
`_check_initialpaths_for_relpath` when the collected path cannot be
expressed relative to `rootpath`. That yields a bare node ID like
`test_b.py::test_b`. `Config.cwd_relative_nodeid` then assumed every
node ID was rootpath-relative and rebuilt the display string as
`rootpath / base_path_part`, which in this case points nowhere.

### Fix

Check whether the synthesized `fullpath` actually exists on disk. If
it does not, the node ID was resolved via the initial paths (not
rootpath), so return it unchanged. The `<- ...` location hint rendered
by the terminal reporter continues to show the real file location, so
the correct path information is still presented without the misleading
prefix.

After this change the same invocation produces:

```
aa\test_a.py::test_a PASSED
test_b.py::test_b <- ..\..\b\bb\test_b.py PASSED
```

### Tests

Added `TestNodeIDHandling::test_nodeid_outside_rootpath_not_synthesized`
in `testing/test_terminal.py`. The test reproduces the issue layout
and asserts that the displayed node ID for the out-of-rootpath test
does not gain a phantom `aa/` prefix. The full `testing/test_config.py`
and `testing/test_terminal.py` suites pass locally on Windows
(Python 3.13) alongside `testing/test_collection.py`,
`testing/test_session.py`, `testing/test_nodes.py`,
`testing/test_reports.py`, and `testing/test_skipping.py`
(841 passed total).

### Notes

This is my first contribution to pytest; happy to adjust the comment
wording, changelog phrasing, or test placement if preferred.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
