### PR TITLE
 assertion/rewrite: fix test crash on assert failure with `terminalreporter` disabled

### DIFF
--- a/changelog/14377.bugfix.rst
+++ b/changelog/14377.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed crash in `Config.get_terminal_writer` when an assertion fails with the ``terminalreporter`` plugin disabled.

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -205,7 +205,11 @@ def pytest_sessionfinish(session: Session) -> None:
 def pytest_assertrepr_compare(
     config: Config, op: str, left: Any, right: Any
 ) -> list[str] | None:
-    highlighter = config.get_terminal_writer()._highlight
+    if config.pluginmanager.has_plugin("terminalreporter"):
+        highlighter = config.get_terminal_writer()._highlight
+    else:
+        # Keep it plaintext when not using terminalrepoterer (#14377).
+        highlighter = util.dummy_highlighter
     return util.assertrepr_compare(
         op=op,
         left=left,

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -205,4 +205,11 @@ def pytest_sessionfinish(session: Session) -> None:
 def pytest_assertrepr_compare(
     config: Config, op: str, left: Any, right: Any
 ) -> list[str] | None:
-    return util.assertrepr_compare(config=config, op=op, left=left, right=right)
+    highlighter = config.get_terminal_writer()._highlight
+    return util.assertrepr_compare(
+        op=op,
+        left=left,
+        right=right,
+        verbose=config.get_verbosity(Config.VERBOSITY_ASSERTIONS),
+        highlighter=highlighter,
+    )

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -174,11 +174,14 @@ def has_default_eq(obj: object) -> bool:
 
 
 def assertrepr_compare(
-    config: Config, op: str, left: object, right: object
+    op: str,
+    left: object,
+    right: object,
+    *,
+    verbose: int,
+    highlighter: _HighlightFunc,
 ) -> list[str] | None:
     """Return specialised explanations for some operators/operands."""
-    verbose = config.get_verbosity(Config.VERBOSITY_ASSERTIONS)
-
     # Strings which normalize equal are often hard to distinguish when printed; use ascii() to make this easier.
     # See issue #3246.
     use_ascii = (
@@ -201,7 +204,6 @@ def assertrepr_compare(
         right_repr = saferepr(right, maxsize=maxsize, use_ascii=use_ascii)
 
     summary = f"{left_repr} {op} {right_repr}"
-    highlighter = config.get_terminal_writer()._highlight
 
     explanation = None
     try:

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -24,7 +24,13 @@ def mock_config(verbose: int = 0, assertion_override: int | None = None):
         def _highlight(self, source, lexer="python"):
             return source
 
+    class PluginManager:
+        def has_plugin(self, name: str) -> bool:
+            return True
+
     class Config:
+        pluginmanager = PluginManager()
+
         def get_terminal_writer(self):
             return TerminalWriter()
 

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -2404,3 +2404,22 @@ class TestSafereprUnbounded:
             _saferepr(self.Help)
             == f"<class '{Path(__file__).stem}.{self.__class__.__name__}.Help'>"
         )
+
+
+def test_assertion_failure_when_terminalreporter_is_disabled(
+    pytester: Pytester,
+) -> None:
+    """Assertion rewriting doesn't crash when the terminalreporter plugin is
+    disabled (#14378)."""
+    pytester.makepyfile(
+        """
+        import pytest
+
+        def test():
+            with pytest.raises(AssertionError) as excinfo:
+                assert 0 == 1
+            assert excinfo.value.args[0] == 'assert 0 == 1'
+        """
+    )
+    reprec = pytester.inline_run("-p", "no:terminalreporter")
+    reprec.assertoutcome(passed=1)


### PR DESCRIPTION
Based on #14383. Replaces #14378  (see there for some context).

The `config.get_terminal_writer()` in `assertrepr_compare` (=> the function injected by assertion rewriting for every `assert`) requires the `terminalreporter` plugin, so it crashed when the plugin is disabled.

Fix #14377.