### PR TITLE
Fix duplicate values in Config.known_args_namespace for append actions

### DIFF
--- a/changelog/13484.bugfix.rst
+++ b/changelog/13484.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``-W`` option values being duplicated in ``Config.known_args_namespace``.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1483,6 +1483,8 @@ class Config:
                     + args
                 )
 
+        # At this point, self.option contains only defaults from the _processopt
+        # callback.
         ns = self._parser.parse_known_args(args, namespace=copy.copy(self.option))
         rootpath, inipath, inicfg, ignored_config_files = determine_setup(
             inifile=ns.inifilename,
@@ -1533,7 +1535,12 @@ class Config:
         # are going to be loaded.
         self.pluginmanager.consider_env()
 
-        self._parser.parse_known_args(args, namespace=self.known_args_namespace)
+        # Parse again, now including options added in pytest_addoption
+        # by third-party plugins loaded above. This way they're available
+        # on early_config in the pytest_load_initial_conftests hook call below.
+        self.known_args_namespace = self._parser.parse_known_args(
+            args, namespace=copy.copy(self.option)
+        )
 
         self._validate_plugins()
         self._warn_about_skipped_plugins()

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -1038,3 +1038,12 @@ class TestMaxWarnings:
         result = pytester.runpytest()
         result.assert_outcomes(passed=1, warnings=1)
         assert result.ret == ExitCode.OK
+
+
+def test_pythonwarnings_not_duplicated(pytester: Pytester) -> None:
+    """Regression test for #13484: -W values should not be duplicated in
+    known_args_namespace due to the arg parser being called multiple times."""
+    config = pytester.parseconfig("-W", "error")
+    warnings_list = config.known_args_namespace.pythonwarnings
+    assert warnings_list is not None
+    assert warnings_list == ["error"]


### PR DESCRIPTION
Ran into #13484 while looking at the config parsing code. The third `parse_known_args` call passes `self.known_args_namespace` as the namespace, which already has values from the second parse. For `action="append"` options like `-W`, this causes duplicates.

Fix is to use `copy.copy(self.option)` instead, same as the first two calls. This way each parse starts from a clean namespace and `append` actions don't accumulate across multiple parses.

Not sure if there was a reason the third call used `known_args_namespace` directly, but from what I can tell the only new things after the second parse are plugin-registered options, and those would still be picked up correctly with a fresh namespace.

Closes #13484
