### PR TITLE
test: cover tmpdir get_user OSError fallback

### DIFF
--- a/changelog/13835.bugfix.rst
+++ b/changelog/13835.bugfix.rst
@@ -1,0 +1,1 @@
+The tmpdir user detection fallback is covered for Python 3.13+ environments where ``getpass.getuser()`` raises ``OSError``.

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -357,14 +357,30 @@ def test_get_user_uid_not_found():
     assert get_user() is None
 
 
-@pytest.mark.skipif(not sys.platform.startswith("win"), reason="win only")
-def test_get_user(monkeypatch):
-    """Test that get_user() function works even if environment variables
-    required by getpass module are missing from the environment on Windows
-    (#1010).
+def test_get_user_handles_oserror(monkeypatch: MonkeyPatch) -> None:
+    """Test that get_user() handles getpass.getuser() raising OSError.
+
+    Python 3.13+ consistently raises OSError when no username can be
+    determined from the environment (for example on Windows with no username
+    environment variables set).
     """
-    monkeypatch.delenv("USER", raising=False)
-    monkeypatch.delenv("USERNAME", raising=False)
+
+    def raise_oserror() -> str:
+        raise OSError("No username set in the environment")
+
+    monkeypatch.setattr("getpass.getuser", raise_oserror)
+
+    assert get_user() is None
+
+
+@pytest.mark.skipif(not sys.platform.startswith("win"), reason="win only")
+def test_get_user(monkeypatch: MonkeyPatch) -> None:
+    """Test that get_user() works even if the environment variables
+    required by getpass are missing from the environment on Windows (#1010,
+    #13835).
+    """
+    for envvar in ("LOGNAME", "USER", "LNAME", "USERNAME"):
+        monkeypatch.delenv(envvar, raising=False)
     assert get_user() is None
 
 


### PR DESCRIPTION
## Summary
- add regression coverage for `tmpdir.get_user()` when `getpass.getuser()` raises `OSError`
- update the Windows env-var clearing test to remove all username variables checked by `getpass`

Refs #13835

## Verification
- `python -m pytest testing/test_tmpdir.py::test_get_user_handles_oserror testing/test_tmpdir.py::test_get_user -q` ✅ (`1 passed, 1 skipped`)
- `python -m pytest testing/test_tmpdir.py::test_tmp_path_fallback_tox_env testing/test_tmpdir.py::test_tmp_path_fallback_uid_not_found testing/test_tmpdir.py::test_get_user_uid_not_found testing/test_tmpdir.py::test_get_user_handles_oserror testing/test_tmpdir.py::test_get_user testing/test_tmpdir.py::test_tmp_path_factory_handles_invalid_dir_characters -q` ✅ (`5 passed, 1 skipped`)
- `python -m pytest testing/test_tmpdir.py -q` ✅ (`40 passed, 1 skipped`)

## Duplicate PR check
- Checked issue comments/timeline and PR searches for `13835`, `getpass/getuser/OSError/tmpdir`, and `No username set in the environment`.
- No open PR was found; only related PR #13836 is closed/unmerged.
