### PR TITLE
testing: add regression test for get_user() swallowing OSError (#13835)

### DIFF
--- a/changelog/13835.bugfix.rst
+++ b/changelog/13835.bugfix.rst
@@ -1,0 +1,1 @@
+:func:`get_user` now correctly returns ``None`` when :func:`getpass.getuser` raises :exc:`OSError`, which Python 3.13 introduced when no username environment variable is set (previously only :exc:`ImportError` and :exc:`KeyError` were caught).

--- a/changelog/13835.bugfix.rst
+++ b/changelog/13835.bugfix.rst
@@ -1,1 +1,1 @@
-:func:`get_user` now correctly returns ``None`` when :func:`getpass.getuser` raises :exc:`OSError`, which Python 3.13 introduced when no username environment variable is set (previously only :exc:`ImportError` and :exc:`KeyError` were caught).
+``get_user()`` now correctly returns ``None`` when ``getpass.getuser()`` raises :exc:`OSError`, which Python 3.13 introduced when no username environment variable is set (previously only :exc:`ImportError` and :exc:`KeyError` were caught).

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -368,6 +368,21 @@ def test_get_user(monkeypatch):
     assert get_user() is None
 
 
+def test_get_user_oserror(monkeypatch):
+    """Test that get_user() returns None when getpass.getuser() raises OSError.
+
+    Python 3.13 changed getpass.getuser() to raise OSError (instead of
+    ImportError or KeyError) when no username can be determined from the
+    environment. Regression test for #13835.
+    """
+
+    def raise_oserror():
+        raise OSError("No username set in the environment")
+
+    monkeypatch.setattr("getpass.getuser", raise_oserror)
+    assert get_user() is None
+
+
 class TestNumberedDir:
     PREFIX = "fun-"
 


### PR DESCRIPTION
## Summary

Closes #13835.

Python 3.13 changed `getpass.getuser()` to raise `OSError` (instead of `ImportError` or `KeyError`) when no username can be determined from the environment. This caused pytest to crash on Python 3.13+/Windows when username env vars were absent.

The exception-handling fix was already applied in #11875 (`get_user()` now catches `OSError`), but no test existed to prevent future regressions.

## Changes

- **`testing/test_tmpdir.py`**: Added `test_get_user_oserror()` — patches `getpass.getuser` to raise `OSError` and asserts `get_user()` returns `None` instead of propagating the exception. The test is cross-platform (no `skipif` needed since it mocks the function directly).
- **`changelog/13835.bugfix.rst`**: Changelog entry for the already-fixed bug, so the fix is documented in the next release notes.

## Test output

```
testing/test_tmpdir.py::test_get_user_uid_not_found PASSED
testing/test_tmpdir.py::test_get_user SKIPPED (win only)
testing/test_tmpdir.py::test_get_user_oserror PASSED
```