### PR TITLE
Add a space after the test name with `--setup-show`

### DIFF
--- a/changelog/14430.improvement.rst
+++ b/changelog/14430.improvement.rst
@@ -1,0 +1,1 @@
+When using ``--setup-show``, a space is now printed after the test name (and possibly used fixtures), to separate it from the test result.

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -132,9 +132,10 @@ def runtestprotocol(
         rep = call_and_report(item, "setup", log)
         reports = [rep]
         if rep.passed:
+            setup_only = item.config.getoption("setuponly", False)
             if item.config.getoption("setupshow", False):
-                show_test_item(item)
-            if not item.config.getoption("setuponly", False):
+                show_test_item(item, add_space=not setup_only)
+            if not setup_only:
                 reports.append(call_and_report(item, "call", log))
         # If the session is about to fail or stop, teardown everything - this is
         # necessary to correctly report fixture teardown errors (see #11706)
@@ -150,7 +151,7 @@ def runtestprotocol(
     return reports
 
 
-def show_test_item(item: Item) -> None:
+def show_test_item(item: Item, *, add_space: bool) -> None:
     """Show test function, parameters and the fixtures of the test item."""
     tw = item.config.get_terminal_writer()
     tw.line()
@@ -159,6 +160,8 @@ def show_test_item(item: Item) -> None:
     used_fixtures = sorted(getattr(item, "fixturenames", []))
     if used_fixtures:
         tw.write(f" (fixtures used: {', '.join(used_fixtures)})")
+    if add_space:
+        tw.write(" ")
     tw.flush()
 
 

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -4433,11 +4433,11 @@ def test_fixture_post_finalizer_hook_exception(pytester: Pytester) -> None:
         [
             "test_fixtures.py::test_first ",
             "        SETUP    F my_fixture",
-            "        test_fixtures.py::test_first (fixtures used: my_fixture, request)PASSED",
+            "        test_fixtures.py::test_first (fixtures used: my_fixture, request) PASSED",
             "test_fixtures.py::test_first ERROR",
             "test_fixtures.py::test_second ",
             "        SETUP    F my_fixture",
-            "        test_fixtures.py::test_second (fixtures used: my_fixture, request)PASSED",
+            "        test_fixtures.py::test_second (fixtures used: my_fixture, request) PASSED",
             "        TEARDOWN F my_fixture",
         ],
         consecutive=True,

--- a/testing/test_setuponly.py
+++ b/testing/test_setuponly.py
@@ -276,7 +276,7 @@ def test_show_fixtures_and_execute_test(pytester: Pytester) -> None:
     assert result.ret == 1
 
     result.stdout.fnmatch_lines(
-        ["*SETUP    F arg*", "*test_arg (fixtures used: arg)F*", "*TEARDOWN F arg*"]
+        ["*SETUP    F arg*", "*test_arg (fixtures used: arg) F*", "*TEARDOWN F arg*"]
     )
 
 


### PR DESCRIPTION
Before, a test's result was printed immediately after --setup-show output:

    SETUP    F fixt
    test_show.py::test_a (fixtures used: fixt)PASSED
    TEARDOWN F fixt

In the extreme case, with monochrome output or yellow and white colors being close to each other, an "x" for an xfailing test can be misinterpreted as part of a test name:

    test_show.py::test_xfailx

This adds a space to clearly distinguish the output:

    test_show.py::test_a (fixtures used: fixt) PASSED

and

    test_show.py::test_xfail x

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
