### PR TITLE
reduce gc_collect_harder default to 1 on CPython

### DIFF
--- a/changelog/14441.improvement.rst
+++ b/changelog/14441.improvement.rst
@@ -1,0 +1,1 @@
+Reduced the default number of ``gc.collect()`` passes in the ``unraisableexception`` plugin from 5 to 1 on CPython, where reference counting makes a single pass sufficient. PyPy retains 5 passes due to object resurrection via ``__del__``. This can noticeably speed up test suites that trigger many pytester runs.

--- a/src/_pytest/unraisableexception.py
+++ b/src/_pytest/unraisableexception.py
@@ -86,9 +86,14 @@ def collect_unraisable(config: Config) -> None:
 def cleanup(
     *, config: Config, prev_hook: Callable[[sys.UnraisableHookArgs], object]
 ) -> None:
-    # A single collection doesn't necessarily collect everything.
-    # Constant determined experimentally by the Trio project.
-    gc_collect_iterations = config.stash.get(gc_collect_iterations_key, 5)
+    # On PyPy, objects (e.g. coroutines) can survive GC rounds because executing
+    # their __del__ can resurrect them. The Trio project determined experimentally
+    # that 5 passes are needed on PyPy to flush everything. On CPython, reference
+    # counting handles most cleanup immediately, so 1 pass is sufficient.
+    _default_gc_collect_iterations = 5 if hasattr(sys, "pypy_version_info") else 1
+    gc_collect_iterations = config.stash.get(
+        gc_collect_iterations_key, _default_gc_collect_iterations
+    )
     try:
         try:
             gc_collect_harder(gc_collect_iterations)

--- a/src/_pytest/unraisableexception.py
+++ b/src/_pytest/unraisableexception.py
@@ -90,7 +90,7 @@ def cleanup(
     # their __del__ can resurrect them. The Trio project determined experimentally
     # that 5 passes are needed on PyPy to flush everything. On CPython, reference
     # counting handles most cleanup immediately, so 1 pass is sufficient.
-    _default_gc_collect_iterations = 5 if hasattr(sys, "pypy_version_info") else 1
+    _default_gc_collect_iterations = 5 if sys.implementation.name == "pypy" else 1
     gc_collect_iterations = config.stash.get(
         gc_collect_iterations_key, _default_gc_collect_iterations
     )


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

The 5-iteration default was borrowed from the Trio project, where it was determined empirically to handle PyPy's object resurrection behavior: on PyPy, objects like coroutines can survive GC rounds because executing their __del__ can resurrect them.

On CPython, reference counting frees most objects immediately. One GC pass is sufficient to handle reference cycles, as confirmed by all test_unraisableexception tests passing (including the refcycle variants).

Use 1 pass on CPython and retain 5 on PyPy.