### PR TITLE
Fix strict options from addopts

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -380,6 +380,7 @@ Piotr Banaszkiewicz
 Piotr Helm
 Poulami Sau
 Prakhar Gurunani
+Praneeth Kodumagulla
 Prashant Anand
 Prashant Sharma
 Pulkit Goyal

--- a/changelog/14442.bugfix.rst
+++ b/changelog/14442.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a regression where ``--strict-markers`` and ``--strict-config`` specified through ``addopts`` were silently ignored.

--- a/changelog/14442.bugfix.rst
+++ b/changelog/14442.bugfix.rst
@@ -1,1 +1,3 @@
-Fixed a regression where ``--strict-markers`` and ``--strict-config`` specified through ``addopts`` were silently ignored.
+Fixed a regression in pytest 9.0 where :option:`--strict-markers` and :option:`--strict-config` specified through :confval:`addopts` were silently ignored.
+
+Note that when targeting pytest >= 9.0, it's nicer to use :confval:`strict_markers` and :confval:`strict_config`, or :ref:`strict mode <strict mode>`.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -50,6 +50,7 @@ from .exceptions import UsageError as UsageError
 from .findpaths import ConfigDict
 from .findpaths import ConfigValue
 from .findpaths import determine_setup
+from .findpaths import parse_override_ini
 from _pytest import __version__
 import _pytest._code
 from _pytest._code import ExceptionInfo
@@ -1520,6 +1521,8 @@ class Config:
         self.known_args_namespace = self._parser.parse_known_args(
             args, namespace=copy.copy(self.option)
         )
+        self._inicfg.update(parse_override_ini(self.known_args_namespace.override_ini))
+        self._inicache.clear()
         self._checkversion()
         self._consider_importhook()
         self._configure_python_path()
@@ -1541,7 +1544,6 @@ class Config:
         self.known_args_namespace = self._parser.parse_known_args(
             args, namespace=copy.copy(self.option)
         )
-
         self._validate_plugins()
         self._warn_about_skipped_plugins()
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1521,8 +1521,12 @@ class Config:
         self.known_args_namespace = self._parser.parse_known_args(
             args, namespace=copy.copy(self.option)
         )
-        self._inicfg.update(parse_override_ini(self.known_args_namespace.override_ini))
-        self._inicache.clear()
+        if addopts:
+            # addopts may have added overrides (especially via OverrideIniAction).
+            # The thing can be endlessly circular but we only do one level (#14442).
+            if overrides := parse_override_ini(self.known_args_namespace.override_ini):
+                self._inicfg.update(overrides)
+                self._inicache.clear()
         self._checkversion()
         self._consider_importhook()
         self._configure_python_path()
@@ -1544,6 +1548,7 @@ class Config:
         self.known_args_namespace = self._parser.parse_known_args(
             args, namespace=copy.copy(self.option)
         )
+
         self._validate_plugins()
         self._warn_about_skipped_plugins()
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -491,6 +491,20 @@ class TestParseIni:
         result.stderr.fnmatch_lines("ERROR: Unknown config option: unknown_option")
         assert result.ret == pytest.ExitCode.USAGE_ERROR
 
+    def test_strict_config_from_addopts(self, pytester: Pytester) -> None:
+        pytester.makeini(
+            """
+            [pytest]
+            addopts = --strict-config
+            unknown_option = 1
+            """
+        )
+
+        result = pytester.runpytest()
+
+        result.stderr.fnmatch_lines(["ERROR: Unknown config option: unknown_option"])
+        assert result.ret == pytest.ExitCode.USAGE_ERROR
+
     @pytest.mark.filterwarnings("default::pytest.PytestConfigWarning")
     def test_disable_warnings_plugin_disables_config_warnings(
         self, pytester: Pytester

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -475,34 +475,25 @@ class TestParseIni:
         result = pytester.runpytest()
         result.stdout.no_fnmatch_line("*PytestConfigWarning*")
 
-    @pytest.mark.parametrize("option_name", ["strict_config", "strict"])
-    def test_strict_config_ini_option(
-        self, pytester: Pytester, option_name: str
-    ) -> None:
+    @pytest.mark.parametrize(
+        "option",
+        [
+            "strict_config = true",
+            "strict = true",
+            "addopts = --strict-config",
+        ],
+    )
+    def test_strict_config_ini_option(self, pytester: Pytester, option: str) -> None:
         """Test that strict_config and strict ini options enable strict config checking."""
         pytester.makeini(
             f"""
             [pytest]
             unknown_option = 1
-            {option_name} = True
+            {option}
             """
         )
         result = pytester.runpytest()
         result.stderr.fnmatch_lines("ERROR: Unknown config option: unknown_option")
-        assert result.ret == pytest.ExitCode.USAGE_ERROR
-
-    def test_strict_config_from_addopts(self, pytester: Pytester) -> None:
-        pytester.makeini(
-            """
-            [pytest]
-            addopts = --strict-config
-            unknown_option = 1
-            """
-        )
-
-        result = pytester.runpytest()
-
-        result.stderr.fnmatch_lines(["ERROR: Unknown config option: unknown_option"])
         assert result.ret == pytest.ExitCode.USAGE_ERROR
 
     @pytest.mark.filterwarnings("default::pytest.PytestConfigWarning")

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -213,6 +213,31 @@ def test_strict_prohibits_unregistered_markers(
     )
 
 
+def test_strict_markers_from_addopts(pytester: Pytester) -> None:
+    pytester.makeini(
+        """
+        [pytest]
+        addopts = --strict-markers
+        """
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.unregisteredmark
+        def test_hello():
+            pass
+        """
+    )
+
+    result = pytester.runpytest()
+
+    result.stdout.fnmatch_lines(
+        ["'unregisteredmark' not found in `markers` configuration option"]
+    )
+    assert result.ret == pytest.ExitCode.INTERRUPTED
+
+
 @pytest.mark.parametrize(
     ("expr", "expected_passed"),
     [

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -184,11 +184,16 @@ def test_mark_on_pseudo_function(pytester: Pytester) -> None:
 
 
 @pytest.mark.parametrize(
-    "option_name", ["--strict-markers", "--strict", "strict_markers", "strict"]
+    "option",
+    [
+        "--strict-markers",
+        "--strict",
+        "strict_markers = true",
+        "strict = true",
+        "addopts = --strict-markers",
+    ],
 )
-def test_strict_prohibits_unregistered_markers(
-    pytester: Pytester, option_name: str
-) -> None:
+def test_strict_prohibits_unregistered_markers(pytester: Pytester, option: str) -> None:
     pytester.makepyfile(
         """
         import pytest
@@ -197,45 +202,20 @@ def test_strict_prohibits_unregistered_markers(
             pass
     """
     )
-    if option_name in ("strict_markers", "strict"):
+    if option.startswith("-"):
+        result = pytester.runpytest(option)
+    else:
         pytester.makeini(
             f"""
             [pytest]
-            {option_name} = true
+            {option}
             """
         )
         result = pytester.runpytest()
-    else:
-        result = pytester.runpytest(option_name)
     assert result.ret != 0
     result.stdout.fnmatch_lines(
         ["'unregisteredmark' not found in `markers` configuration option"]
     )
-
-
-def test_strict_markers_from_addopts(pytester: Pytester) -> None:
-    pytester.makeini(
-        """
-        [pytest]
-        addopts = --strict-markers
-        """
-    )
-    pytester.makepyfile(
-        """
-        import pytest
-
-        @pytest.mark.unregisteredmark
-        def test_hello():
-            pass
-        """
-    )
-
-    result = pytester.runpytest()
-
-    result.stdout.fnmatch_lines(
-        ["'unregisteredmark' not found in `markers` configuration option"]
-    )
-    assert result.ret == pytest.ExitCode.INTERRUPTED
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #14442

This fixes a pytest 9 regression where `--strict-markers` and
`--strict-config` were ignored when configured through `addopts`

`addopts` is parsed after the initial config discovery step, so the
`OverrideIniAction` compatibility path updated the parsed argparse namespace,
but the generated ini overrides were not applied back into `_inicfg`

As a result, later `getini()` calls still saw the default values for
`strict_markers` and `strict_config`

This change applies parsed ini overrides after parsing the full argument list
including `addopts`, and clears the ini cache so later `getini()` calls use the
updated values

Added regression coverage for:

- `--strict-config` from `addopts`
- `--strict-markers` from `addopts`

Tested with:

```bash
python -m pytest -q \
  testing/test_config.py::TestParseIni::test_strict_config_from_addopts \
  testing/test_mark.py::test_strict_markers_from_addopts

python -m pytest -q \
  testing/test_config.py::TestParseIni::test_invalid_config_options \
  testing/test_mark.py::test_strict_prohibits_unregistered_markers