### PR TITLE
feat(rewrite): address assertion rewriting blind spots with systematic tests

### DIFF
--- a/changelog/14445.bugfix.rst
+++ b/changelog/14445.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed assertion rewriting evaluating walrus operator (``:=``) expressions multiple times, causing incorrect test results when the expression had side effects (e.g., incrementing a counter or calling a function).

--- a/scripts/diff-assert-rewrite.py
+++ b/scripts/diff-assert-rewrite.py
@@ -1,0 +1,202 @@
+"""Compare assert-rewrite output between two pytest versions (or worktree).
+
+Runs the dump script for both sides (in parallel) and shows a unified diff.
+Supports all three output formats: source, ast, and compact.
+
+Usage::
+
+    # Two released versions:
+    python scripts/diff-assert-rewrite.py --left 7.4.0 --right 8.0.0 example.py
+
+    # Release vs local worktree:
+    python scripts/diff-assert-rewrite.py --left 8.3.0 --right worktree example.py
+
+    # Compact AST diff (strips position noise):
+    python scripts/diff-assert-rewrite.py --left 7.4.0 --right worktree -f compact example.py
+
+    # All formats at once:
+    python scripts/diff-assert-rewrite.py --left 7.4.0 --right 8.0.0 -f all example.py
+"""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+import difflib
+from pathlib import Path
+import sys
+
+
+_DUMP_SCRIPT = Path(__file__).resolve().parent / "dump-assert-rewrite.py"
+
+_FORMATS = ("source", "ast", "compact")
+
+
+def _label(spec: str) -> str:
+    return "worktree" if spec == "worktree" else f"pytest=={spec}"
+
+
+def get_dump(spec: str, file_path: Path, fmt: str) -> str:
+    """Run the dump script for a single side and return its output."""
+    # Import inline so this file stays lightweight at module level.
+    import subprocess
+
+    args = [sys.executable, str(_DUMP_SCRIPT)]
+    if spec == "worktree":
+        args.append("--worktree")
+    else:
+        args.extend(["--pytest-version", spec])
+    args.extend(["--format", fmt, str(file_path)])
+
+    result = subprocess.run(args, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        raise SystemExit(f"Dump failed for {_label(spec)}")
+    return result.stdout
+
+
+def colored_diff(lines: list[str]) -> str:
+    """Apply ANSI colours to a unified-diff line list."""
+    RED = "\033[31m"
+    GREEN = "\033[32m"
+    CYAN = "\033[36m"
+    RESET = "\033[0m"
+
+    out: list[str] = []
+    for line in lines:
+        if line.startswith(("---", "+++")):
+            out.append(f"{CYAN}{line}{RESET}")
+        elif line.startswith("-"):
+            out.append(f"{RED}{line}{RESET}")
+        elif line.startswith("+"):
+            out.append(f"{GREEN}{line}{RESET}")
+        elif line.startswith("@@"):
+            out.append(f"{CYAN}{line}{RESET}")
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
+def show_diff(
+    left_text: str,
+    right_text: str,
+    *,
+    left_label: str,
+    right_label: str,
+    fmt: str,
+    context: int,
+    use_color: bool,
+) -> bool:
+    """Print a unified diff; return True if differences were found."""
+    if left_text == right_text:
+        return False
+
+    diff_lines = list(
+        difflib.unified_diff(
+            left_text.splitlines(),
+            right_text.splitlines(),
+            fromfile=f"{left_label} [{fmt}]",
+            tofile=f"{right_label} [{fmt}]",
+            n=context,
+        )
+    )
+
+    if use_color:
+        print(colored_diff(diff_lines))
+    else:
+        print("\n".join(diff_lines))
+
+    return True
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--left",
+        required=True,
+        metavar="VER|worktree",
+        help="Left side: pytest version or 'worktree'",
+    )
+    parser.add_argument(
+        "--right",
+        required=True,
+        metavar="VER|worktree",
+        help="Right side: pytest version or 'worktree'",
+    )
+    parser.add_argument(
+        "--format",
+        "-f",
+        dest="fmt",
+        choices=(*_FORMATS, "all"),
+        default="source",
+        help="Output format (default: source)",
+    )
+    parser.add_argument(
+        "--context",
+        "-C",
+        type=int,
+        default=3,
+        help="Context lines in diff (default: 3)",
+    )
+    parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable coloured output",
+    )
+    parser.add_argument("file", type=Path, help="Python file to compare")
+    args = parser.parse_args(argv)
+
+    if not args.file.is_file():
+        raise SystemExit(f"File not found: {args.file}")
+
+    formats = _FORMATS if args.fmt == "all" else (args.fmt,)
+    use_color = not args.no_color and sys.stdout.isatty()
+    left_label = _label(args.left)
+    right_label = _label(args.right)
+
+    # Fetch all needed dumps in parallel (both sides x all formats).
+    jobs: dict[tuple[str, str], str] = {}
+    with ThreadPoolExecutor(max_workers=len(formats) * 2) as pool:
+        futures = {
+            (side, fmt): pool.submit(get_dump, spec, args.file, fmt)
+            for fmt in formats
+            for side, spec in [("left", args.left), ("right", args.right)]
+        }
+        for key, future in futures.items():
+            jobs[key] = future.result()
+
+    any_diff = False
+    for fmt in formats:
+        if len(formats) > 1:
+            header = f"=== {fmt} ==="
+            if use_color:
+                header = f"\033[1m{header}\033[0m"
+            print(header)
+
+        had_diff = show_diff(
+            jobs[("left", fmt)],
+            jobs[("right", fmt)],
+            left_label=left_label,
+            right_label=right_label,
+            fmt=fmt,
+            context=args.context,
+            use_color=use_color,
+        )
+        if not had_diff:
+            print(
+                f"No differences in {fmt} output between {left_label} and {right_label}"
+            )
+        else:
+            any_diff = True
+
+        if len(formats) > 1:
+            print()
+
+    raise SystemExit(1 if any_diff else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dump-assert-rewrite.py
+++ b/scripts/dump-assert-rewrite.py
@@ -1,0 +1,166 @@
+"""Dump the assert-rewritten form of a Python file for a specific pytest version.
+
+Uses ``uv run`` to execute the rewriter in an ephemeral environment, so any
+released pytest version can be inspected without installing it globally.
+
+Usage::
+
+    # Rewritten source (default):
+    python scripts/dump-assert-rewrite.py --pytest-version 8.0.0 example.py
+
+    # Using local worktree:
+    python scripts/dump-assert-rewrite.py --worktree example.py
+
+    # Compact AST (best for diffing -- no position attributes):
+    python scripts/dump-assert-rewrite.py --worktree --format compact example.py
+
+    # Full AST with positions:
+    python scripts/dump-assert-rewrite.py --pytest-version 7.4.0 --format ast example.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+
+# Self-contained script executed inside the target pytest environment.
+# Reads source from stdin, writes the rewritten form to stdout.
+_WORKER_SCRIPT = textwrap.dedent("""\
+    import ast
+    import sys
+
+    source = sys.stdin.buffer.read()
+    fmt = sys.argv[1]
+
+    try:
+        from _pytest.assertion.rewrite import rewrite_asserts
+    except ImportError:
+        sys.exit("Could not import rewrite_asserts from this pytest version")
+
+    tree = ast.parse(source)
+    try:
+        rewrite_asserts(tree, source)
+    except TypeError:
+        # pytest < 6 did not accept the source parameter
+        tree = ast.parse(source)
+        rewrite_asserts(tree)
+
+    ast.fix_missing_locations(tree)
+
+    if fmt == "source":
+        print(ast.unparse(tree))
+    elif fmt == "ast":
+        print(ast.dump(tree, indent=2))
+    elif fmt == "compact":
+        print(ast.dump(tree, indent=2, include_attributes=False))
+    else:
+        sys.exit(f"Unknown format: {fmt!r}")
+""")
+
+
+def run_worker(
+    *,
+    pytest_version: str | None,
+    worktree: bool,
+    file_content: bytes,
+    fmt: str,
+) -> str:
+    """Execute the worker script and return its stdout."""
+    if worktree:
+        repo_root = Path(__file__).resolve().parent.parent
+        env = os.environ.copy()
+        env["PYTHONPATH"] = (
+            str(repo_root / "src") + os.pathsep + env.get("PYTHONPATH", "")
+        )
+        cmd = [sys.executable, "-c", _WORKER_SCRIPT, fmt]
+    else:
+        assert pytest_version is not None
+        cmd = [
+            "uv",
+            "run",
+            "--no-project",
+            "--with",
+            f"pytest=={pytest_version}",
+            "--",
+            "python",
+            "-c",
+            _WORKER_SCRIPT,
+            fmt,
+        ]
+        env = None
+
+    try:
+        result = subprocess.run(
+            cmd, input=file_content, capture_output=True, check=False, env=env
+        )
+    except FileNotFoundError as exc:
+        if "uv" in str(exc):
+            raise SystemExit(
+                "'uv' not found — install it: https://docs.astral.sh/uv/"
+            ) from exc
+        raise
+
+    if result.returncode != 0:
+        label = version_label(pytest_version=pytest_version, worktree=worktree)
+        sys.stderr.buffer.write(result.stderr)
+        raise SystemExit(f"Worker failed for {label}")
+
+    return result.stdout.decode()
+
+
+def version_label(*, pytest_version: str | None = None, worktree: bool = False) -> str:
+    """Human-readable label for a pytest source."""
+    return "worktree" if worktree else f"pytest=={pytest_version}"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument(
+        "--pytest-version",
+        metavar="VER",
+        help="Released pytest version (e.g. 8.0.0)",
+    )
+    src.add_argument(
+        "--worktree",
+        action="store_true",
+        help="Use the local worktree's src/",
+    )
+    parser.add_argument(
+        "--format",
+        dest="fmt",
+        choices=("source", "ast", "compact"),
+        default="source",
+        help="Output format (default: source)",
+    )
+    parser.add_argument("file", type=Path, help="Python file to rewrite")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = build_parser().parse_args(argv)
+
+    if not args.file.is_file():
+        raise SystemExit(f"File not found: {args.file}")
+
+    output = run_worker(
+        pytest_version=args.pytest_version,
+        worktree=args.worktree,
+        file_content=args.file.read_bytes(),
+        fmt=args.fmt,
+    )
+    sys.stdout.write(output)
+    if output and not output.endswith("\n"):
+        sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/example_asserts.py
+++ b/scripts/example_asserts.py
@@ -1,0 +1,42 @@
+"""Example file for dump-assert-rewrite.py and diff-assert-rewrite.py.
+
+Includes bluetech's walrus-in-BoolOp case from the #14445 review, plus
+other common assertion patterns useful for spotting rewrite changes.
+"""
+
+from __future__ import annotations
+
+
+def side_effect() -> bool:
+    return True
+
+
+def test_walrus_boolop() -> None:
+    """Bluetech's example: walrus reassignment inside BoolOp."""
+    assert (x := side_effect()) and (x := False)  # noqa: F841
+
+
+def test_simple_equality() -> None:
+    x = 1
+    assert x == 2
+
+
+def test_comparison() -> None:
+    a = [1, 2, 3]
+    b = [1, 2, 4]
+    assert a == b
+
+
+def test_boolean() -> None:
+    x = True
+    y = False
+    assert x and y
+
+
+def test_membership() -> None:
+    assert 5 in [1, 2, 3]
+
+
+def test_message() -> None:
+    value = 42
+    assert value > 100, f"expected > 100, got {value}"

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -1072,6 +1072,20 @@ class AssertionRewriter(ast.NodeVisitor):
         new_starred = ast.Starred(res, starred.ctx)
         return new_starred, "*" + expl
 
+    def visit_IfExp(self, ifexp: ast.IfExp) -> tuple[ast.Name, str]:
+        # Introspect the condition but keep branches as-is to preserve
+        # short-circuit semantics (only the selected branch is evaluated).
+        cond_res, cond_expl = self.visit(ifexp.test)
+        # Reconstruct the IfExp with the rewritten condition but original
+        # branches to avoid evaluating both sides.
+        res = self.assign(
+            ast.copy_location(ast.IfExp(cond_res, ifexp.body, ifexp.orelse), ifexp)
+        )
+        res_expl = self.explanation_param(self.display(res))
+        pat = "%s\n{%s = (... if %s else ...)\n}"
+        expl = pat % (res_expl, res_expl, cond_expl)
+        return res, expl
+
     def visit_Subscript(self, subscript: ast.Subscript) -> tuple[ast.Name, str]:
         if not isinstance(subscript.ctx, ast.Load):
             return self.generic_visit(subscript)

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -985,12 +985,13 @@ class AssertionRewriter(ast.NodeVisitor):
             call = ast.Call(app, [expl_format], [])
             self.expl_stmts.append(ast.Expr(call))
             if i < levels:
-                cond: ast.expr = res
+                # Use res_var (already assigned above) rather than res directly,
+                # so that NamedExpr operands aren't evaluated a second time.
+                cond: ast.expr = ast.Name(res_var, ast.Load())
                 if is_or:
                     cond = ast.UnaryOp(ast.Not(), cond)
-                # Capture the condition in a temp variable so the explanation
-                # path (which runs after walrus operators may have modified
-                # the original variable) sees the correct truthiness.
+                # Capture the condition in a stable temp for the explanation
+                # path — res_var is overwritten by subsequent operands.
                 cond_var = self.variable()
                 body.append(ast.Assign([ast.Name(cond_var, ast.Store())], cond))
                 expl_cond: ast.expr = ast.Name(cond_var, ast.Load())  # noqa: F841

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import ast
-from collections import defaultdict
 from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Iterator
@@ -58,19 +57,12 @@ if TYPE_CHECKING:
     from _pytest.assertion import AssertionState
 
 
-class Sentinel:
-    pass
-
-
 assertstate_key = StashKey["AssertionState"]()
 
 # pytest caches rewritten pycs in pycache dirs
 PYTEST_TAG = f"{sys.implementation.cache_tag}-pytest-{version}"
 PYC_EXT = ".py" + ((__debug__ and "c") or "o")
 PYC_TAIL = "." + PYTEST_TAG + PYC_EXT
-
-# Special marker that denotes we have just left a scope definition
-_SCOPE_END_MARKER = Sentinel()
 
 
 class AssertionRewritingHook(importlib.abc.MetaPathFinder, importlib.abc.Loader):
@@ -652,14 +644,8 @@ class AssertionRewriter(ast.NodeVisitor):
        .push_format_context() and .pop_format_context() which allows
        to build another %-formatted string while already building one.
 
-    :scope: A tuple containing the current scope used for variables_overwrite.
-
-    :variables_overwrite: A dict filled with references to variables
-       that change value within an assert. This happens when a variable is
-       reassigned with the walrus operator
-
-    This state, except the variables_overwrite,  is reset on every new assert
-    statement visited and used by the other visitors.
+    This state is reset on every new assert statement visited and used by
+    the other visitors.
     """
 
     def __init__(
@@ -675,10 +661,6 @@ class AssertionRewriter(ast.NodeVisitor):
         else:
             self.enable_assertion_pass_hook = False
         self.source = source
-        self.scope: tuple[ast.AST, ...] = ()
-        self.variables_overwrite: defaultdict[tuple[ast.AST, ...], dict[str, str]] = (
-            defaultdict(dict)
-        )
 
     def run(self, mod: ast.Module) -> None:
         """Find all assert statements in *mod* and rewrite them."""
@@ -728,16 +710,9 @@ class AssertionRewriter(ast.NodeVisitor):
         mod.body[pos:pos] = imports
 
         # Collect asserts.
-        self.scope = (mod,)
-        nodes: list[ast.AST | Sentinel] = [mod]
+        nodes: list[ast.AST] = [mod]
         while nodes:
             node = nodes.pop()
-            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
-                self.scope = tuple((*self.scope, node))
-                nodes.append(_SCOPE_END_MARKER)
-            if node == _SCOPE_END_MARKER:
-                self.scope = self.scope[:-1]
-                continue
             assert isinstance(node, ast.AST)
             for name, field in ast.iter_fields(node):
                 if isinstance(field, list):
@@ -964,15 +939,17 @@ class AssertionRewriter(ast.NodeVisitor):
         return self.statements
 
     def visit_NamedExpr(self, name: ast.NamedExpr) -> tuple[ast.NamedExpr, str]:
-        # This method handles the 'walrus operator' repr of the target
-        # name if it's a local variable or _should_repr_global_name()
-        # thinks it's acceptable.
+        # Return the NamedExpr as-is so it evaluates in its natural position
+        # (preserving left-to-right evaluation order). For the explanation,
+        # reference the target variable (already assigned by the walrus) to
+        # avoid re-evaluating the expression.
         locs = ast.Call(self.builtin("locals"), [], [])
         target_id = name.target.id
+        target_name = ast.Name(target_id, ast.Load())
         inlocs = ast.Compare(ast.Constant(target_id), [ast.In()], [locs])
-        dorepr = self.helper("_should_repr_global_name", name)
+        dorepr = self.helper("_should_repr_global_name", target_name)
         test = ast.BoolOp(ast.Or(), [inlocs, dorepr])
-        expr = ast.IfExp(test, self.display(name), ast.Constant(target_id))
+        expr = ast.IfExp(test, self.display(target_name), ast.Constant(target_id))
         return name, self.explanation_param(expr)
 
     def visit_Name(self, name: ast.Name) -> tuple[ast.Name, str]:
@@ -998,20 +975,9 @@ class AssertionRewriter(ast.NodeVisitor):
         for i, v in enumerate(boolop.values):
             if i:
                 fail_inner: list[ast.stmt] = []
-                # cond is set in a prior loop iteration below
-                self.expl_stmts.append(ast.If(cond, fail_inner, []))  # noqa: F821
+                # expl_cond is set in a prior loop iteration below
+                self.expl_stmts.append(ast.If(expl_cond, fail_inner, []))  # noqa: F821
                 self.expl_stmts = fail_inner
-                match v:
-                    # Check if the left operand is an ast.NamedExpr and the value has already been visited
-                    case ast.Compare(
-                        left=ast.NamedExpr(target=ast.Name(id=target_id))
-                    ) if target_id in [
-                        e.id for e in boolop.values[:i] if hasattr(e, "id")
-                    ]:
-                        pytest_temp = self.variable()
-                        self.variables_overwrite[self.scope][target_id] = v.left  # type:ignore[assignment]
-                        # mypy's false positive, we're checking that the 'target' attribute exists.
-                        v.left.target.id = pytest_temp  # type:ignore[attr-defined]
             self.push_format_context()
             res, expl = self.visit(v)
             body.append(ast.Assign([ast.Name(res_var, ast.Store())], res))
@@ -1022,8 +988,16 @@ class AssertionRewriter(ast.NodeVisitor):
                 cond: ast.expr = res
                 if is_or:
                     cond = ast.UnaryOp(ast.Not(), cond)
+                # Capture the condition in a temp variable so the explanation
+                # path (which runs after walrus operators may have modified
+                # the original variable) sees the correct truthiness.
+                cond_var = self.variable()
+                body.append(ast.Assign([ast.Name(cond_var, ast.Store())], cond))
+                expl_cond: ast.expr = ast.Name(cond_var, ast.Load())  # noqa: F841
                 inner: list[ast.stmt] = []
-                self.statements.append(ast.If(cond, inner, []))
+                self.statements.append(
+                    ast.If(ast.Name(cond_var, ast.Load()), inner, [])
+                )
                 self.statements = body = inner
         self.statements = save
         self.expl_stmts = fail_save
@@ -1053,19 +1027,10 @@ class AssertionRewriter(ast.NodeVisitor):
         new_args = []
         new_kwargs = []
         for arg in call.args:
-            if isinstance(arg, ast.Name) and arg.id in self.variables_overwrite.get(
-                self.scope, {}
-            ):
-                arg = self.variables_overwrite[self.scope][arg.id]  # type:ignore[assignment]
             res, expl = self.visit(arg)
             arg_expls.append(expl)
             new_args.append(res)
         for keyword in call.keywords:
-            match keyword.value:
-                case ast.Name(id=id) if id in self.variables_overwrite.get(
-                    self.scope, {}
-                ):
-                    keyword.value = self.variables_overwrite[self.scope][id]  # type:ignore[assignment]
             res, expl = self.visit(keyword.value)
             new_kwargs.append(ast.keyword(keyword.arg, res))
             if keyword.arg:
@@ -1100,17 +1065,13 @@ class AssertionRewriter(ast.NodeVisitor):
 
     def visit_Compare(self, comp: ast.Compare) -> tuple[ast.expr, str]:
         self.push_format_context()
-        # We first check if we have overwritten a variable in the previous assert
-        match comp.left:
-            case ast.Name(id=name_id) if name_id in self.variables_overwrite.get(
-                self.scope, {}
-            ):
-                comp.left = self.variables_overwrite[self.scope][name_id]  # type: ignore[assignment]
-            case ast.NamedExpr(target=ast.Name(id=target_id)):
-                self.variables_overwrite[self.scope][target_id] = comp.left  # type: ignore[assignment]
         left_res, left_expl = self.visit(comp.left)
         if isinstance(comp.left, ast.Compare | ast.BoolOp):
             left_expl = f"({left_expl})"
+        # If the left operand is a NamedExpr, assign it to a temp so the
+        # walrus executes before any right-side expressions are hoisted.
+        if isinstance(left_res, ast.NamedExpr):
+            left_res = self.assign(left_res)
         res_variables = [self.variable() for i in range(len(comp.ops))]
         load_names: list[ast.expr] = [ast.Name(v, ast.Load()) for v in res_variables]
         store_names = [ast.Name(v, ast.Store()) for v in res_variables]
@@ -1119,13 +1080,16 @@ class AssertionRewriter(ast.NodeVisitor):
         syms: list[ast.expr] = []
         results = [left_res]
         for i, op, next_operand in it:
+            # If the next operand is a walrus that assigns to the same name as
+            # the current left_res, we must freeze left_res's value before the
+            # walrus modifies it.
             match (next_operand, left_res):
                 case (
                     ast.NamedExpr(target=ast.Name(id=target_id)),
                     ast.Name(id=name_id),
                 ) if target_id == name_id:
-                    next_operand.target.id = self.variable()
-                    self.variables_overwrite[self.scope][name_id] = next_operand  # type: ignore[assignment]
+                    left_res = self.assign(left_res)
+                    results[-1] = left_res
 
             next_res, next_expl = self.visit(next_operand)
             if isinstance(next_operand, ast.Compare | ast.BoolOp):
@@ -1138,6 +1102,12 @@ class AssertionRewriter(ast.NodeVisitor):
             res_expr = ast.copy_location(ast.Compare(left_res, [op], [next_res]), comp)
             self.statements.append(ast.Assign([store_names[i]], res_expr))
             left_res, left_expl = next_res, next_expl
+        # Replace NamedExpr entries in results with their target variable
+        # to avoid re-evaluating walrus operators in the explanation path.
+        results = [
+            ast.Name(r.target.id, ast.Load()) if isinstance(r, ast.NamedExpr) else r
+            for r in results
+        ]
         # Use pytest.assertion.util._reprcompare if that's available.
         expl_call = self.helper(
             "_call_reprcompare",

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -940,9 +940,8 @@ class AssertionRewriter(ast.NodeVisitor):
 
     def visit_NamedExpr(self, name: ast.NamedExpr) -> tuple[ast.NamedExpr, str]:
         # Return the NamedExpr as-is so it evaluates in its natural position
-        # (preserving left-to-right evaluation order). For the explanation,
-        # reference the target variable (already assigned by the walrus) to
-        # avoid re-evaluating the expression.
+        # (preserving left-to-right evaluation order in function calls, etc.).
+        # For the explanation, reference the target variable.
         locs = ast.Call(self.builtin("locals"), [], [])
         target_id = name.target.id
         target_name = ast.Name(target_id, ast.Load())
@@ -981,12 +980,17 @@ class AssertionRewriter(ast.NodeVisitor):
             self.push_format_context()
             res, expl = self.visit(v)
             body.append(ast.Assign([ast.Name(res_var, ast.Store())], res))
+            # For Name/NamedExpr operands, track the value in a stable
+            # @py_assert variable so the explanation shows the value at
+            # evaluation time — even if a later walrus overwrites the name.
+            if isinstance(v, ast.NamedExpr | ast.Name):
+                tracked = self.assign(ast.Name(res_var, ast.Load()))
+                for key in self.stack[-1]:
+                    self.stack[-1][key] = self.display(tracked)
             expl_format = self.pop_format_context(ast.Constant(expl))
             call = ast.Call(app, [expl_format], [])
             self.expl_stmts.append(ast.Expr(call))
             if i < levels:
-                # Use res_var (already assigned above) rather than res directly,
-                # so that NamedExpr operands aren't evaluated a second time.
                 cond: ast.expr = ast.Name(res_var, ast.Load())
                 if is_or:
                     cond = ast.UnaryOp(ast.Not(), cond)
@@ -1069,8 +1073,6 @@ class AssertionRewriter(ast.NodeVisitor):
         left_res, left_expl = self.visit(comp.left)
         if isinstance(comp.left, ast.Compare | ast.BoolOp):
             left_expl = f"({left_expl})"
-        # If the left operand is a NamedExpr, assign it to a temp so the
-        # walrus executes before any right-side expressions are hoisted.
         if isinstance(left_res, ast.NamedExpr):
             left_res = self.assign(left_res)
         res_variables = [self.variable() for i in range(len(comp.ops))]
@@ -1095,9 +1097,6 @@ class AssertionRewriter(ast.NodeVisitor):
             next_res, next_expl = self.visit(next_operand)
             if isinstance(next_operand, ast.Compare | ast.BoolOp):
                 next_expl = f"({next_expl})"
-            # Assign NamedExpr comparators to a temp so each walrus evaluates
-            # exactly once — critical for chained comparisons where the same
-            # node would otherwise be re-evaluated as left_res next iteration.
             if isinstance(next_res, ast.NamedExpr):
                 next_res = self.assign(next_res)
             results.append(next_res)

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -969,40 +969,56 @@ class AssertionRewriter(ast.NodeVisitor):
         body = save = self.statements
         fail_save = self.expl_stmts
         levels = len(boolop.values) - 1
+        # Pre-scan: for each operand position, collect the set of variable
+        # names that a *later* operand's walrus operator will overwrite.
+        # An operand needs a snapshot only when its value references a name
+        # in this set (otherwise the explanation would show the post-walrus
+        # value instead of the value at evaluation time).
+        later_walrus_targets: list[set[str]] = [set() for _ in boolop.values]
+        seen: set[str] = set()
+        for idx in range(len(boolop.values) - 1, -1, -1):
+            later_walrus_targets[idx] = set(seen)
+            for node in ast.walk(boolop.values[idx]):
+                if isinstance(node, ast.NamedExpr):
+                    seen.add(node.target.id)
         self.push_format_context()
-        # Process each operand, short-circuiting if needed.
+        # Process each operand, short-circuiting as needed.
         for i, v in enumerate(boolop.values):
             if i:
                 fail_inner: list[ast.stmt] = []
-                # expl_cond is set in a prior loop iteration below
-                self.expl_stmts.append(ast.If(expl_cond, fail_inner, []))  # noqa: F821
+                # cond is set in a prior loop iteration below
+                self.expl_stmts.append(ast.If(cond, fail_inner, []))  # noqa: F821
                 self.expl_stmts = fail_inner
             self.push_format_context()
             res, expl = self.visit(v)
             body.append(ast.Assign([ast.Name(res_var, ast.Store())], res))
-            # For Name/NamedExpr operands, track the value in a stable
-            # @py_assert variable so the explanation shows the value at
-            # evaluation time — even if a later walrus overwrites the name.
-            if isinstance(v, ast.NamedExpr | ast.Name):
-                tracked = self.assign(ast.Name(res_var, ast.Load()))
+            # Snapshot when the raw ``res`` node would be unsafe to reuse
+            # as a condition or explanation reference:
+            #  - NamedExpr (non-last): reusing the node re-evaluates the
+            #    walrus expression including any side effects.
+            #  - Name whose variable a later walrus overwrites: the
+            #    explanation would show the post-walrus value.
+            needs_snapshot = (isinstance(v, ast.NamedExpr) and i < levels) or (
+                isinstance(v, ast.Name) and v.id in later_walrus_targets[i]
+            )
+            if needs_snapshot:
+                snapshot = self.assign(ast.Name(res_var, ast.Load()))
+                res = snapshot
                 for key in self.stack[-1]:
-                    self.stack[-1][key] = self.display(tracked)
+                    self.stack[-1][key] = self.display(snapshot)
             expl_format = self.pop_format_context(ast.Constant(expl))
             call = ast.Call(app, [expl_format], [])
             self.expl_stmts.append(ast.Expr(call))
             if i < levels:
-                cond: ast.expr = ast.Name(res_var, ast.Load())
+                # Short-circuit: and → continue if truthy; or → if falsy.
+                # ``res`` is a stable reference (Name vars are only
+                # snapshotted when a later walrus would corrupt them;
+                # calls/compares return @py_assert vars from assign()).
+                cond: ast.expr = res
                 if is_or:
                     cond = ast.UnaryOp(ast.Not(), cond)
-                # Capture the condition in a stable temp for the explanation
-                # path — res_var is overwritten by subsequent operands.
-                cond_var = self.variable()
-                body.append(ast.Assign([ast.Name(cond_var, ast.Store())], cond))
-                expl_cond: ast.expr = ast.Name(cond_var, ast.Load())  # noqa: F841
                 inner: list[ast.stmt] = []
-                self.statements.append(
-                    ast.If(ast.Name(cond_var, ast.Load()), inner, [])
-                )
+                self.statements.append(ast.If(cond, inner, []))
                 self.statements = body = inner
         self.statements = save
         self.expl_stmts = fail_save

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -1072,6 +1072,23 @@ class AssertionRewriter(ast.NodeVisitor):
         new_starred = ast.Starred(res, starred.ctx)
         return new_starred, "*" + expl
 
+    def visit_Subscript(self, subscript: ast.Subscript) -> tuple[ast.Name, str]:
+        if not isinstance(subscript.ctx, ast.Load):
+            return self.generic_visit(subscript)
+        # For Slice objects (a[1:3]), fall back to generic — decomposing
+        # start/stop/step is rarely useful in assertion messages.
+        if isinstance(subscript.slice, ast.Slice):
+            return self.generic_visit(subscript)
+        value, value_expl = self.visit(subscript.value)
+        slice_res, slice_expl = self.visit(subscript.slice)
+        res = self.assign(
+            ast.copy_location(ast.Subscript(value, slice_res, ast.Load()), subscript)
+        )
+        res_expl = self.explanation_param(self.display(res))
+        pat = "%s\n{%s = %s[%s]\n}"
+        expl = pat % (res_expl, res_expl, value_expl, slice_expl)
+        return res, expl
+
     def visit_Attribute(self, attr: ast.Attribute) -> tuple[ast.Name, str]:
         if not isinstance(attr.ctx, ast.Load):
             return self.generic_visit(attr)

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -1095,6 +1095,11 @@ class AssertionRewriter(ast.NodeVisitor):
             next_res, next_expl = self.visit(next_operand)
             if isinstance(next_operand, ast.Compare | ast.BoolOp):
                 next_expl = f"({next_expl})"
+            # Assign NamedExpr comparators to a temp so each walrus evaluates
+            # exactly once — critical for chained comparisons where the same
+            # node would otherwise be re-evaluated as left_res next iteration.
+            if isinstance(next_res, ast.NamedExpr):
+                next_res = self.assign(next_res)
             results.append(next_res)
             sym = BINOP_MAP[op.__class__]
             syms.append(ast.Constant(sym))
@@ -1103,12 +1108,6 @@ class AssertionRewriter(ast.NodeVisitor):
             res_expr = ast.copy_location(ast.Compare(left_res, [op], [next_res]), comp)
             self.statements.append(ast.Assign([store_names[i]], res_expr))
             left_res, left_expl = next_res, next_expl
-        # Replace NamedExpr entries in results with their target variable
-        # to avoid re-evaluating walrus operators in the explanation path.
-        results = [
-            ast.Name(r.target.id, ast.Load()) if isinstance(r, ast.NamedExpr) else r
-            for r in results
-        ]
         # Use pytest.assertion.util._reprcompare if that's available.
         expl_call = self.helper(
             "_call_reprcompare",

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -1043,6 +1043,12 @@ class AssertionRewriter(ast.NodeVisitor):
         return res, explanation
 
     def visit_Call(self, call: ast.Call) -> tuple[ast.Name, str]:
+        # For method calls (obj.method()), produce a flat explanation like
+        # "where result = obj.method(args)" instead of nesting the attribute
+        # access as a separate "where method = obj.method" line.
+        if isinstance(call.func, ast.Attribute) and isinstance(call.func.ctx, ast.Load):
+            return self._visit_method_call(call)
+
         new_func, func_expl = self.visit(call.func)
         arg_expls = []
         new_args = []
@@ -1065,6 +1071,43 @@ class AssertionRewriter(ast.NodeVisitor):
         res_expl = self.explanation_param(self.display(res))
         outer_expl = f"{res_expl}\n{{{res_expl} = {expl}\n}}"
         return res, outer_expl
+
+    def _visit_method_call(self, call: ast.Call) -> tuple[ast.Name, str]:
+        r"""Handle obj.method(...) calls with a flat explanation format.
+
+        Produces: "result\n{result = obj_repr.method(args)\n}"
+        instead of nesting the bound-method intermediate.
+        """
+        attr = call.func
+        assert isinstance(attr, ast.Attribute)
+
+        # Visit the object (receiver) for introspection.
+        obj_res, obj_expl = self.visit(attr.value)
+
+        # Visit arguments.
+        arg_expls = []
+        new_args = []
+        new_kwargs = []
+        for arg in call.args:
+            res, expl = self.visit(arg)
+            arg_expls.append(expl)
+            new_args.append(res)
+        for keyword in call.keywords:
+            res, expl = self.visit(keyword.value)
+            new_kwargs.append(ast.keyword(keyword.arg, res))
+            if keyword.arg:
+                arg_expls.append(keyword.arg + "=" + expl)
+            else:
+                arg_expls.append("**" + expl)
+
+        # Build the call using the rewritten object's attribute.
+        new_func = ast.Attribute(obj_res, attr.attr, ast.Load())
+        new_call = ast.copy_location(ast.Call(new_func, new_args, new_kwargs), call)
+        res = self.assign(new_call)
+        res_expl = self.explanation_param(self.display(res))
+        args_str = ", ".join(arg_expls)
+        expl = f"{res_expl}\n{{{res_expl} = {obj_expl}.{attr.attr}({args_str})\n}}"
+        return res, expl
 
     def visit_Starred(self, starred: ast.Starred) -> tuple[ast.Starred, str]:
         # A Starred node can appear in a function call.

--- a/testing/python/raises_group.py
+++ b/testing/python/raises_group.py
@@ -1237,8 +1237,7 @@ def test_assert_matches() -> None:
         match=wrap_escape(
             "`ValueError()` is not an instance of `TypeError`\n"
             "assert False\n"
-            " +  where False = matches(ValueError())\n"
-            " +    where matches = RaisesExc(TypeError).matches"
+            " +  where False = RaisesExc(TypeError).matches(ValueError())"
         ),
     ):
         # you'd need to do this arcane incantation

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1689,7 +1689,7 @@ class TestAssertionRewriteWalrusOperator:
         )
         result = pytester.runpytest()
         assert result.ret == 1
-        result.stdout.fnmatch_lines(["*assert not (False and False is False)"])
+        result.stdout.fnmatch_lines(["*assert not (True and False is False)"])
 
     def test_assertion_walrus_operator_boolean_none_fails(
         self, pytester: Pytester
@@ -1703,7 +1703,7 @@ class TestAssertionRewriteWalrusOperator:
         )
         result = pytester.runpytest()
         assert result.ret == 1
-        result.stdout.fnmatch_lines(["*assert not (None and None is None)"])
+        result.stdout.fnmatch_lines(["*assert not (True and None is None)"])
 
     def test_assertion_walrus_operator_value_changes_cleared_after_each_test(
         self, pytester: Pytester
@@ -1947,6 +1947,24 @@ class TestIssue14445:
         )
         result = pytester.runpytest()
         assert result.ret == 0
+
+    def test_walrus_boolop_same_target_correct_explanation(
+        self, pytester: Pytester
+    ) -> None:
+        """Multiple walrus operators to the same name in a BoolOp must show
+        each operand's value at evaluation time, not the final value."""
+        pytester.makepyfile(
+            """
+            def side_effect():
+                return True
+
+            def test_walrus_boolop():
+                assert (x := side_effect()) and (x := False)
+        """
+        )
+        result = pytester.runpytest()
+        assert result.ret == 1
+        result.stdout.fnmatch_lines(["*assert (True and False)"])
 
 
 @pytest.mark.skipif(

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1929,7 +1929,6 @@ class TestIssue14445:
         result = pytester.runpytest()
         assert result.ret == 0
 
-    @pytest.mark.xfail(reason="Chained compare re-evaluates walrus with same target")
     def test_walrus_no_double_eval_chained_compare(self, pytester: Pytester) -> None:
         """Same walrus target in chained comparison must evaluate each once."""
         pytester.makepyfile(

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1910,6 +1910,46 @@ class TestIssue14445:
         result = pytester.runpytest()
         assert result.ret == 0
 
+    @pytest.mark.xfail(reason="BoolOp condition re-evaluates walrus operand")
+    def test_walrus_no_double_eval_in_boolop(self, pytester: Pytester) -> None:
+        """Bare walrus as a BoolOp operand must not be evaluated twice."""
+        pytester.makepyfile(
+            """
+            call_count = 0
+
+            def side_effect():
+                global call_count
+                call_count += 1
+                return call_count
+
+            def test_walrus_boolop():
+                assert (x := side_effect()) and x == 1
+                assert call_count == 1
+        """
+        )
+        result = pytester.runpytest()
+        assert result.ret == 0
+
+    @pytest.mark.xfail(reason="Chained compare re-evaluates walrus with same target")
+    def test_walrus_no_double_eval_chained_compare(self, pytester: Pytester) -> None:
+        """Same walrus target in chained comparison must evaluate each once."""
+        pytester.makepyfile(
+            """
+            call_count = 0
+
+            def track(value):
+                global call_count
+                call_count += 1
+                return value
+
+            def test_walrus_chained():
+                assert (x := track(1)) < (x := track(3)) < (x := track(5))
+                assert call_count == 3
+        """
+        )
+        result = pytester.runpytest()
+        assert result.ret == 0
+
 
 @pytest.mark.skipif(
     sys.maxsize <= (2**31 - 1), reason="Causes OverflowError on 32bit systems"

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1689,7 +1689,7 @@ class TestAssertionRewriteWalrusOperator:
         )
         result = pytester.runpytest()
         assert result.ret == 1
-        result.stdout.fnmatch_lines(["*assert not (True and False is False)"])
+        result.stdout.fnmatch_lines(["*assert not (False and False is False)"])
 
     def test_assertion_walrus_operator_boolean_none_fails(
         self, pytester: Pytester
@@ -1703,7 +1703,7 @@ class TestAssertionRewriteWalrusOperator:
         )
         result = pytester.runpytest()
         assert result.ret == 1
-        result.stdout.fnmatch_lines(["*assert not (True and None is None)"])
+        result.stdout.fnmatch_lines(["*assert not (None and None is None)"])
 
     def test_assertion_walrus_operator_value_changes_cleared_after_each_test(
         self, pytester: Pytester
@@ -1841,6 +1841,70 @@ class TestIssue11239:
             def test_2():
                 db = {"x": 2}
                 assert (state := db.get("x")) is not None
+        """
+        )
+        result = pytester.runpytest()
+        assert result.ret == 0
+
+
+class TestIssue14445:
+    """Regression tests for #14445: walrus operator double evaluation."""
+
+    def test_walrus_no_double_eval_basic(self, pytester: Pytester) -> None:
+        """Walrus captures the value at assignment time, not re-evaluated later."""
+        pytester.makepyfile(
+            """
+            class Counter:
+                def __init__(self):
+                    self.value = 0
+                def increment(self):
+                    self.value += 1
+
+            def test_walrus_in_assertion_basic():
+                c = Counter()
+                assert (before := c.value) == 0
+                c.increment()
+                assert before != (after := c.value)
+        """
+        )
+        result = pytester.runpytest()
+        assert result.ret == 0
+
+    def test_walrus_no_double_eval_running_counter(self, pytester: Pytester) -> None:
+        """Walrus increments fire exactly once per assert statement."""
+        pytester.makepyfile(
+            """
+            def test_walrus_running_counter():
+                count = 0
+                items = []
+                items.append("a")
+                assert (count := count + 1) == len(items)
+                items.append("b")
+                assert (count := count + 1) == len(items)
+                items.append("c")
+                assert (count := count + 1) == len(items)
+                assert count == 3
+        """
+        )
+        result = pytester.runpytest()
+        assert result.ret == 0
+
+    def test_walrus_no_double_eval_in_function_call(self, pytester: Pytester) -> None:
+        """Walrus in function call arguments not evaluated twice."""
+        pytester.makepyfile(
+            """
+            call_count = 0
+
+            def side_effect():
+                global call_count
+                call_count += 1
+                return call_count
+
+            def test_walrus_side_effect():
+                assert (val := side_effect()) == 1
+                assert val == 1
+                assert (val := side_effect()) == 2
+                assert val == 2
         """
         )
         result = pytester.runpytest()

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1910,7 +1910,6 @@ class TestIssue14445:
         result = pytester.runpytest()
         assert result.ret == 0
 
-    @pytest.mark.xfail(reason="BoolOp condition re-evaluates walrus operand")
     def test_walrus_no_double_eval_in_boolop(self, pytester: Pytester) -> None:
         """Bare walrus as a BoolOp operand must not be evaluated twice."""
         pytester.makepyfile(

--- a/testing/test_assertrewrite_coverage.py
+++ b/testing/test_assertrewrite_coverage.py
@@ -295,3 +295,474 @@ def check():
     x = [1, 2, 3]
     assert len(x) == 3
 """)
+
+
+# ---------------------------------------------------------------------------
+# Introspection matrix: verify what information each expression type exposes
+# ---------------------------------------------------------------------------
+
+
+class TestIntrospectionCompare:
+    """Comparisons (==, !=, <, >, <=, >=, in, not in, is, is not)."""
+
+    def test_simple_equality(self) -> None:
+        assert_introspects(
+            """
+def check():
+    x = 3
+    assert x == 5
+""",
+            must_contain=["assert 3 == 5"],
+        )
+
+    def test_chained_compare(self) -> None:
+        # Chained compares only show the failing pair
+        assert_introspects(
+            """
+def check():
+    x = 10
+    assert 1 < x < 5
+""",
+            must_contain=["assert 10 < 5"],
+        )
+
+    def test_in_operator(self) -> None:
+        assert_introspects(
+            """
+def check():
+    x = 4
+    assert x in [1, 2, 3]
+""",
+            must_contain=["assert 4 in [1, 2, 3]"],
+        )
+
+    def test_not_in_operator(self) -> None:
+        assert_introspects(
+            """
+def check():
+    x = 2
+    assert x not in [1, 2, 3]
+""",
+            must_contain=["assert 2 not in [1, 2, 3]"],
+        )
+
+    def test_is_operator(self) -> None:
+        assert_introspects(
+            """
+def check():
+    x = []
+    y = []
+    assert x is y
+""",
+            must_contain=["assert [] is []"],
+        )
+
+
+class TestIntrospectionBoolOp:
+    """Boolean operations (and, or) with short-circuit."""
+
+    def test_and_both_shown(self) -> None:
+        assert_introspects(
+            """
+def check():
+    a = True
+    b = False
+    assert a and b
+""",
+            must_contain=["(True and False)"],
+        )
+
+    def test_or_both_shown(self) -> None:
+        assert_introspects(
+            """
+def check():
+    a = False
+    b = False
+    assert a or b
+""",
+            must_contain=["(False or False)"],
+        )
+
+    def test_and_short_circuit(self) -> None:
+        assert_introspects(
+            """
+def check():
+    a = False
+    assert a and explode
+""",
+            must_contain=["False"],
+        )
+
+
+class TestIntrospectionUnaryOp:
+    """Unary operations (not, ~, -, +)."""
+
+    def test_not(self) -> None:
+        assert_introspects(
+            """
+def check():
+    x = True
+    assert not x
+""",
+            must_contain=["assert not True"],
+        )
+
+    def test_invert(self) -> None:
+        # ~(-1) == 0, which is falsy
+        assert_introspects(
+            """
+def check():
+    x = -1
+    assert ~x
+""",
+            must_contain=["assert ~-1"],
+        )
+
+
+class TestIntrospectionBinOp:
+    """Binary operations (+, -, *, /, etc.)."""
+
+    def test_addition(self) -> None:
+        assert_introspects(
+            """
+def check():
+    x = 3
+    y = 4
+    assert x + y == 10
+""",
+            must_contain=["(3 + 4)"],
+        )
+
+    def test_subtraction(self) -> None:
+        assert_introspects(
+            """
+def check():
+    x = 3
+    y = 4
+    assert x - y == 10
+""",
+            must_contain=["(3 - 4)"],
+        )
+
+
+class TestIntrospectionCall:
+    """Function/method calls."""
+
+    def test_simple_call_shows_result(self) -> None:
+        # Currently local functions show full repr in the "where" line
+        assert_introspects(
+            """
+def check():
+    def f():
+        return 42
+    assert f() == 100
+""",
+            must_contain=["where 42 = ", "()"],
+        )
+
+    def test_call_with_args_shows_result(self) -> None:
+        assert_introspects(
+            """
+def check():
+    def f(x):
+        return x * 2
+    assert f(3) == 10
+""",
+            must_contain=["where 6 = ", "(3)"],
+        )
+
+    @pytest.mark.xfail(
+        reason="Local function calls show full <function ...> repr: blind spot"
+    )
+    def test_simple_call_clean_name(self) -> None:
+        """Ideally the message should show 'f()' not '<function ... at 0x...>()'."""
+        assert_introspects(
+            """
+def check():
+    def f():
+        return 42
+    assert f() == 100
+""",
+            must_contain=["where 42 = f()"],
+            must_not_contain=["<function"],
+        )
+
+    def test_method_call_shows_result(self) -> None:
+        assert_introspects(
+            """
+def check():
+    class Obj:
+        def method(self):
+            return 42
+    obj = Obj()
+    assert obj.method() == 100
+""",
+            must_contain=["42", "100"],
+        )
+
+
+class TestIntrospectionAttribute:
+    """Attribute access."""
+
+    def test_attribute_access(self) -> None:
+        assert_introspects(
+            """
+def check():
+    class Obj:
+        x = 3
+        def __repr__(self):
+            return "Obj()"
+    obj = Obj()
+    assert obj.x == 5
+""",
+            must_contain=["where 3 = Obj().x"],
+        )
+
+
+class TestIntrospectionName:
+    """Variable name display."""
+
+    def test_local_variable_shown(self) -> None:
+        assert_introspects(
+            """
+def check():
+    result = 42
+    assert result == 100
+""",
+            must_contain=["assert 42 == 100"],
+        )
+
+
+class TestIntrospectionSubscript:
+    """Subscript / indexing — currently hits generic_visit."""
+
+    @pytest.mark.xfail(reason="Subscript not introspected: blind spot")
+    def test_dict_subscript_shows_key_and_container(self) -> None:
+        assert_introspects(
+            """
+def check():
+    d = {"a": 1, "b": 2}
+    assert d["a"] == 99
+""",
+            must_contain=["where 1 = ", '["a"]'],
+        )
+
+    @pytest.mark.xfail(reason="Subscript not introspected: blind spot")
+    def test_list_subscript_shows_index_and_container(self) -> None:
+        assert_introspects(
+            """
+def check():
+    items = [10, 20, 30]
+    assert items[1] == 99
+""",
+            must_contain=["where 20 = ", "[1]"],
+        )
+
+    def test_subscript_semantics_preserved(self) -> None:
+        assert_semantically_equivalent("""
+def check():
+    d = {"key": "value"}
+    assert d["key"] == "wrong"
+""")
+
+    def test_subscript_in_compare_shows_value(self) -> None:
+        """Even without decomposition, the value is shown in comparisons."""
+        assert_introspects(
+            """
+def check():
+    d = {"a": 1}
+    assert d["a"] == 99
+""",
+            must_contain=["assert 1 == 99"],
+        )
+
+
+class TestIntrospectionIfExp:
+    """Ternary / if-expression — currently hits generic_visit."""
+
+    @pytest.mark.xfail(reason="IfExp not introspected: blind spot")
+    def test_ifexp_shows_condition_and_branch(self) -> None:
+        assert_introspects(
+            """
+def check():
+    flag = True
+    assert (0 if flag else 1) == 1
+""",
+            must_contain=["flag", "True"],
+        )
+
+    def test_ifexp_semantics_preserved(self) -> None:
+        assert_semantically_equivalent("""
+def check():
+    flag = True
+    assert (0 if flag else 1) == 1
+""")
+
+    def test_ifexp_in_compare_shows_result(self) -> None:
+        assert_introspects(
+            """
+def check():
+    flag = True
+    assert (0 if flag else 1) == 99
+""",
+            must_contain=["assert 0 == 99"],
+        )
+
+
+class TestIntrospectionContainerLiteral:
+    """Container literals ([...], {...}, {k:v}) — currently hits generic_visit."""
+
+    @pytest.mark.xfail(reason="Container literals not introspected: blind spot")
+    def test_list_literal_shows_elements(self) -> None:
+        assert_introspects(
+            """
+def check():
+    def f():
+        return 99
+    assert [f(), 2, 3] == [1, 2, 3]
+""",
+            must_contain=["where 99 = f()"],
+        )
+
+    def test_list_literal_semantics_preserved(self) -> None:
+        assert_semantically_equivalent("""
+def check():
+    assert [1, 2, 3] == [1, 2, 4]
+""")
+
+    def test_dict_literal_semantics_preserved(self) -> None:
+        assert_semantically_equivalent("""
+def check():
+    assert {"a": 1} == {"a": 2}
+""")
+
+
+class TestIntrospectionComprehension:
+    """Comprehensions — currently hits generic_visit."""
+
+    def test_listcomp_semantics_preserved(self) -> None:
+        assert_semantically_equivalent("""
+def check():
+    assert [x * 2 for x in range(3)] == [0, 2, 5]
+""")
+
+    def test_listcomp_in_compare_shows_result(self) -> None:
+        assert_introspects(
+            """
+def check():
+    assert [x * 2 for x in range(3)] == [0, 2, 5]
+""",
+            must_contain=["[0, 2, 4]"],
+        )
+
+
+class TestIntrospectionFString:
+    """F-string expressions — currently hits generic_visit."""
+
+    def test_fstring_semantics_preserved(self) -> None:
+        assert_semantically_equivalent("""
+def check():
+    x = 42
+    assert f"value={x}" == "value=99"
+""")
+
+    def test_fstring_in_compare_shows_result(self) -> None:
+        assert_introspects(
+            """
+def check():
+    x = 42
+    assert f"value={x}" == "value=99"
+""",
+            must_contain=["value=42"],
+        )
+
+
+class TestIntrospectionMethodCall:
+    """Method calls — bound method intermediate display."""
+
+    def test_method_call_result_shown(self) -> None:
+        assert_introspects(
+            """
+def check():
+    class Obj:
+        def compute(self):
+            return 42
+        def __repr__(self):
+            return "Obj()"
+    obj = Obj()
+    assert obj.compute() == 100
+""",
+            must_contain=["where 42 = "],
+        )
+
+    @pytest.mark.xfail(
+        reason="Method call shows noisy bound-method intermediate: blind spot"
+    )
+    def test_method_call_no_bound_method_noise(self) -> None:
+        """The 'where method = obj.method' line is noisy and unhelpful."""
+        msg = get_failure_message("""
+def check():
+    class Obj:
+        def compute(self):
+            return 42
+        def __repr__(self):
+            return "Obj()"
+    obj = Obj()
+    assert obj.compute() == 100
+""")
+        lines = msg.splitlines()
+        # Ideally the message should NOT have a separate "where compute = ..."
+        # line showing the bound method object — it adds noise without value
+        for line in lines:
+            assert "where compute = " not in line, (
+                f"Noisy bound-method intermediate found:\n{msg}"
+            )
+
+    def test_callable_variable_shows_result(self) -> None:
+        # Current behavior: shows full function repr, not variable name
+        assert_introspects(
+            """
+def check():
+    def factory():
+        return 42
+    fn = factory
+    assert fn() == 100
+""",
+            must_contain=["where 42 = ", "()"],
+        )
+
+    @pytest.mark.xfail(reason="Callable variables show <function ...> repr: blind spot")
+    def test_callable_variable_clean_name(self) -> None:
+        """Ideally should show 'fn()' not '<function factory at 0x...>()'."""
+        assert_introspects(
+            """
+def check():
+    def factory():
+        return 42
+    fn = factory
+    assert fn() == 100
+""",
+            must_contain=["where 42 = fn()"],
+            must_not_contain=["<function"],
+        )
+
+
+class TestIntrospectionWalrus:
+    """Walrus operator (:=) — has dedicated visitor."""
+
+    def test_walrus_in_compare(self) -> None:
+        assert_introspects(
+            """
+def check():
+    x = 10
+    assert (y := x * 2) == 100
+""",
+            must_contain=["assert 20 == 100"],
+        )
+
+    def test_walrus_semantics_preserved(self) -> None:
+        assert_semantically_equivalent("""
+def check():
+    x = 10
+    assert (y := x * 2) == 100
+""")

--- a/testing/test_assertrewrite_coverage.py
+++ b/testing/test_assertrewrite_coverage.py
@@ -1,0 +1,297 @@
+"""Systematic coverage tests for assertion rewriting.
+
+This module provides a structured testing framework that verifies assertion
+rewriting behavior across all expression types, checking:
+
+1. Introspection depth: failure messages contain expected intermediate values
+2. Semantic correctness: rewritten code has identical behavior to original
+3. Single evaluation: side-effecting expressions are not evaluated multiple times
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Callable
+from collections.abc import Mapping
+import sys
+import textwrap
+from typing import cast
+
+from _pytest.assertion.rewrite import rewrite_asserts
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _rewrite_source(src: str) -> ast.Module:
+    """Parse and rewrite assertions in source code."""
+    tree = ast.parse(src)
+    rewrite_asserts(tree, src.encode())
+    return tree
+
+
+def get_failure_message(
+    src: str,
+    extra_ns: Mapping[str, object] | None = None,
+) -> str:
+    """Compile rewritten source, execute it, and return the failure message.
+
+    The source should contain a function named ``check`` with a failing assert.
+    Returns the AssertionError message string.
+
+    Raises AssertionError via pytest.fail if the code does not raise.
+    """
+    src = textwrap.dedent(src)
+    mod = _rewrite_source(src)
+    code = compile(mod, "<test>", "exec")
+    ns: dict[str, object] = {}
+    if extra_ns is not None:
+        ns.update(extra_ns)
+    exec(code, ns)
+    func = cast(Callable[[], None], ns["check"])
+    try:
+        func()
+    except AssertionError:
+        s = str(sys.exc_info()[1])
+        if not s.startswith("assert"):
+            return "AssertionError: " + s
+        return s
+    else:
+        pytest.fail("check() did not raise AssertionError")
+
+
+def assert_introspects(
+    src: str,
+    *,
+    must_contain: list[str],
+    must_not_contain: list[str] | None = None,
+    extra_ns: Mapping[str, object] | None = None,
+) -> str:
+    """Verify a failing assert produces a message with expected intermediate values.
+
+    Parameters
+    ----------
+    src : str
+        Source code containing a ``check()`` function with a failing assertion.
+    must_contain : list[str]
+        Substrings that MUST appear in the failure message.
+    must_not_contain : list[str] | None
+        Substrings that must NOT appear in the failure message.
+    extra_ns : Mapping[str, object] | None
+        Additional namespace entries available during execution.
+
+    Returns
+    -------
+    str
+        The full failure message (for further inspection if needed).
+    """
+    msg = get_failure_message(src, extra_ns=extra_ns)
+    for expected in must_contain:
+        assert expected in msg, (
+            f"Expected {expected!r} in failure message.\nGot:\n{msg}"
+        )
+    for unexpected in must_not_contain or []:
+        assert unexpected not in msg, (
+            f"Did NOT expect {unexpected!r} in failure message.\nGot:\n{msg}"
+        )
+    return msg
+
+
+def assert_single_evaluation(
+    src: str,
+    *,
+    expected_call_count: int = 1,
+    extra_ns: Mapping[str, object] | None = None,
+) -> None:
+    """Verify side-effecting expressions in assert are evaluated exactly once.
+
+    The source should define a ``check()`` function and use a ``counter`` list
+    (provided via extra_ns or defined in the source) that tracks how many times
+    a side-effecting expression is evaluated.
+
+    Parameters
+    ----------
+    src : str
+        Source containing a ``check()`` function whose assert has side effects.
+    expected_call_count : int
+        How many times the side-effecting expression should be evaluated.
+    extra_ns : Mapping[str, object] | None
+        Additional namespace. Should include ``counter`` if not defined in src.
+    """
+    src = textwrap.dedent(src)
+    mod = _rewrite_source(src)
+    code = compile(mod, "<test>", "exec")
+    ns: dict[str, object] = {"counter": [0]}
+    if extra_ns is not None:
+        ns.update(extra_ns)
+    exec(code, ns)
+    func = cast(Callable[[], None], ns["check"])
+    counter = cast(list[int], ns["counter"])
+    counter[0] = 0
+    try:
+        func()
+    except AssertionError:
+        pass
+    actual = counter[0]
+    assert actual == expected_call_count, (
+        f"Expression evaluated {actual} times, expected {expected_call_count}"
+    )
+
+
+def assert_passes_when_true(
+    src: str,
+    *,
+    extra_ns: Mapping[str, object] | None = None,
+) -> None:
+    """Verify rewritten assertion does not raise when the condition is true.
+
+    Parameters
+    ----------
+    src : str
+        Source containing a ``check()`` function with a passing assertion.
+    extra_ns : Mapping[str, object] | None
+        Additional namespace entries available during execution.
+    """
+    src = textwrap.dedent(src)
+    mod = _rewrite_source(src)
+    code = compile(mod, "<test>", "exec")
+    ns: dict[str, object] = {}
+    if extra_ns is not None:
+        ns.update(extra_ns)
+    exec(code, ns)
+    func = cast(Callable[[], None], ns["check"])
+    func()
+
+
+def assert_semantically_equivalent(
+    src: str,
+    *,
+    extra_ns: Mapping[str, object] | None = None,
+) -> None:
+    """Verify rewritten code has same pass/fail semantics as unrewritten code.
+
+    Runs the source both with and without rewriting, and asserts they agree
+    on whether an AssertionError is raised.
+
+    Parameters
+    ----------
+    src : str
+        Source containing a ``check()`` function with an assertion.
+    extra_ns : Mapping[str, object] | None
+        Additional namespace entries available during execution.
+    """
+    src = textwrap.dedent(src)
+
+    # Run without rewriting
+    plain_code = compile(src, "<test-plain>", "exec")
+    plain_ns: dict[str, object] = {}
+    if extra_ns is not None:
+        plain_ns.update(extra_ns)
+    exec(plain_code, plain_ns)
+    plain_func = cast(Callable[[], None], plain_ns["check"])
+    plain_raised = False
+    try:
+        plain_func()
+    except AssertionError:
+        plain_raised = True
+
+    # Run with rewriting
+    mod = _rewrite_source(src)
+    rewritten_code = compile(mod, "<test-rewritten>", "exec")
+    rewritten_ns: dict[str, object] = {}
+    if extra_ns is not None:
+        rewritten_ns.update(extra_ns)
+    exec(rewritten_code, rewritten_ns)
+    rewritten_func = cast(Callable[[], None], rewritten_ns["check"])
+    rewritten_raised = False
+    try:
+        rewritten_func()
+    except AssertionError:
+        rewritten_raised = True
+
+    assert plain_raised == rewritten_raised, (
+        f"Semantic mismatch: plain {'raised' if plain_raised else 'passed'}, "
+        f"rewritten {'raised' if rewritten_raised else 'passed'}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Smoke tests for the helpers themselves
+# ---------------------------------------------------------------------------
+
+
+class TestHelpersSmokeTest:
+    """Verify the test helpers work correctly."""
+
+    def test_get_failure_message_returns_message(self) -> None:
+        msg = get_failure_message("""
+def check():
+    assert 1 == 2
+""")
+        assert "assert 1 == 2" in msg
+
+    def test_get_failure_message_fails_on_passing_assert(self) -> None:
+        with pytest.raises(pytest.fail.Exception, match="did not raise"):
+            get_failure_message("""
+def check():
+    assert 1 == 1
+""")
+
+    def test_assert_introspects_succeeds(self) -> None:
+        assert_introspects(
+            """
+def check():
+    x = 3
+    assert x == 5
+""",
+            must_contain=["assert 3 == 5"],
+        )
+
+    def test_assert_introspects_fails_on_missing(self) -> None:
+        with pytest.raises(AssertionError, match=r"Expected.*in failure"):
+            assert_introspects(
+                """
+def check():
+    assert 1 == 2
+""",
+                must_contain=["this is not in the message"],
+            )
+
+    def test_assert_single_evaluation(self) -> None:
+        assert_single_evaluation("""
+def check():
+    def inc():
+        counter[0] += 1
+        return False
+    assert inc()
+""")
+
+    def test_assert_passes_when_true(self) -> None:
+        assert_passes_when_true("""
+def check():
+    assert 1 == 1
+""")
+
+    def test_assert_semantically_equivalent_passing(self) -> None:
+        assert_semantically_equivalent("""
+def check():
+    assert 1 == 1
+""")
+
+    def test_assert_semantically_equivalent_failing(self) -> None:
+        assert_semantically_equivalent("""
+def check():
+    assert 1 == 2
+""")
+
+    def test_assert_semantically_equivalent_detects_mismatch(self) -> None:
+        # This would only trigger on a bug in the rewriter itself;
+        # for now just verify both paths execute without error.
+        assert_semantically_equivalent("""
+def check():
+    x = [1, 2, 3]
+    assert len(x) == 3
+""")

--- a/testing/test_assertrewrite_coverage.py
+++ b/testing/test_assertrewrite_coverage.py
@@ -576,17 +576,16 @@ def check():
 
 
 class TestIntrospectionIfExp:
-    """Ternary / if-expression — currently hits generic_visit."""
+    """Ternary / if-expression — now has dedicated visitor."""
 
-    @pytest.mark.xfail(reason="IfExp not introspected: blind spot")
-    def test_ifexp_shows_condition_and_branch(self) -> None:
+    def test_ifexp_shows_condition_value(self) -> None:
         assert_introspects(
             """
 def check():
     flag = True
     assert (0 if flag else 1) == 1
 """,
-            must_contain=["flag", "True"],
+            must_contain=["if True else"],
         )
 
     def test_ifexp_semantics_preserved(self) -> None:
@@ -603,8 +602,24 @@ def check():
     flag = True
     assert (0 if flag else 1) == 99
 """,
-            must_contain=["assert 0 == 99"],
+            must_contain=["assert 0 == 99", "if True else"],
         )
+
+    def test_ifexp_short_circuit_true(self) -> None:
+        """Orelse branch must NOT be evaluated when condition is True."""
+        assert_passes_when_true("""
+def check():
+    flag = True
+    assert (1 if flag else (1/0)) == 1
+""")
+
+    def test_ifexp_short_circuit_false(self) -> None:
+        """Body branch must NOT be evaluated when condition is False."""
+        assert_passes_when_true("""
+def check():
+    flag = False
+    assert (1/0 if flag else 1) == 1
+""")
 
 
 class TestIntrospectionContainerLiteral:

--- a/testing/test_assertrewrite_coverage.py
+++ b/testing/test_assertrewrite_coverage.py
@@ -947,3 +947,193 @@ def check():
         return [1, 2, 3]
     assert [x * 2 for x in items()] == [2, 4, 7]
 """)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases: combinations of new visitors with existing ones
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Regression and edge-case tests combining multiple expression types."""
+
+    def test_subscript_with_variable_key(self) -> None:
+        """Subscript where the key is a variable (not constant)."""
+        assert_introspects(
+            """
+def check():
+    d = {"hello": 42}
+    key = "hello"
+    assert d[key] == 100
+""",
+            must_contain=["where 42 = ", "['hello']"],
+        )
+
+    def test_subscript_with_call_key(self) -> None:
+        """Subscript where the key is a function call."""
+        assert_introspects(
+            """
+def check():
+    d = {0: "zero", 1: "one"}
+    def get_key():
+        return 0
+    assert d[get_key()] == "wrong"
+""",
+            must_contain=["'zero'", "'wrong'"],
+        )
+
+    def test_nested_subscript(self) -> None:
+        """Nested subscript: d[k1][k2]."""
+        assert_introspects(
+            """
+def check():
+    d = {"a": {"b": 42}}
+    assert d["a"]["b"] == 100
+""",
+            must_contain=["42", "100"],
+        )
+
+    def test_method_call_with_args(self) -> None:
+        """Method call with arguments shows flat format."""
+        assert_introspects(
+            """
+def check():
+    class Calculator:
+        def add(self, a, b):
+            return a + b
+        def __repr__(self):
+            return "Calc()"
+    c = Calculator()
+    assert c.add(2, 3) == 10
+""",
+            must_contain=["where 5 = Calc().add(2, 3)"],
+        )
+
+    def test_chained_method_calls(self) -> None:
+        """Chained method call: obj.method1().method2()."""
+        assert_introspects(
+            """
+def check():
+    class Builder:
+        def __init__(self, val=0):
+            self.val = val
+        def add(self, n):
+            return Builder(self.val + n)
+        def result(self):
+            return self.val
+        def __repr__(self):
+            return f"Builder({self.val})"
+    b = Builder()
+    assert b.add(5).result() == 100
+""",
+            must_contain=["where 5 = ", ".result()"],
+        )
+
+    def test_subscript_on_method_result(self) -> None:
+        """Subscript on method return value: obj.method()[key]."""
+        assert_introspects(
+            """
+def check():
+    class Store:
+        def get_data(self):
+            return {"x": 42}
+        def __repr__(self):
+            return "Store()"
+    s = Store()
+    assert s.get_data()["x"] == 100
+""",
+            must_contain=["42", "100"],
+        )
+
+    def test_ifexp_with_call_condition(self) -> None:
+        """IfExp where condition is a function call."""
+        assert_introspects(
+            """
+def check():
+    def is_ready():
+        return False
+    assert (1 if is_ready() else 0) == 1
+""",
+            must_contain=["if False else"],
+        )
+
+    def test_walrus_in_subscript(self) -> None:
+        """Walrus operator used as subscript key."""
+        assert_semantically_equivalent("""
+def check():
+    d = {1: "one", 2: "two"}
+    x = 1
+    assert d[(y := x + 1)] == "wrong"
+""")
+
+    def test_method_call_single_evaluation(self) -> None:
+        """Method with side effects is only called once."""
+        assert_single_evaluation("""
+def check():
+    class Obj:
+        def compute(self):
+            counter[0] += 1
+            return 42
+    obj = Obj()
+    assert obj.compute() == 100
+""")
+
+    def test_subscript_single_evaluation(self) -> None:
+        """Custom __getitem__ with side effects is only called once."""
+        assert_single_evaluation("""
+def check():
+    class CountingList:
+        def __init__(self, items):
+            self.items = items
+        def __getitem__(self, idx):
+            counter[0] += 1
+            return self.items[idx]
+        def __repr__(self):
+            return repr(self.items)
+    lst = CountingList([10, 20, 30])
+    assert lst[1] == 99
+""")
+
+    def test_ifexp_condition_single_evaluation(self) -> None:
+        """IfExp condition with side effects is only evaluated once."""
+        assert_single_evaluation("""
+def check():
+    def check_flag():
+        counter[0] += 1
+        return True
+    assert (0 if check_flag() else 1) == 99
+""")
+
+    def test_complex_assertion_semantics(self) -> None:
+        """Complex assertion combining multiple new visitors."""
+        assert_semantically_equivalent("""
+def check():
+    class Config:
+        def __init__(self):
+            self.data = {"timeout": 30}
+        def get(self, key):
+            return self.data[key]
+    cfg = Config()
+    flag = True
+    assert (cfg.get("timeout") if flag else 0) > 60
+""")
+
+    def test_assert_with_message_still_works(self) -> None:
+        """Assert with a custom message still works with new visitors."""
+        msg = get_failure_message("""
+def check():
+    d = {"key": 42}
+    assert d["key"] == 100, "custom failure message"
+""")
+        assert "custom failure message" in msg
+
+    def test_method_call_on_global(self) -> None:
+        """Method call on a global/module-level object."""
+        assert_introspects(
+            """
+items = [1, 2, 3]
+def check():
+    assert items.count(99) == 1
+""",
+            must_contain=["where 0 = [1, 2, 3].count(99)"],
+        )

--- a/testing/test_assertrewrite_coverage.py
+++ b/testing/test_assertrewrite_coverage.py
@@ -691,9 +691,10 @@ def check():
 
 
 class TestIntrospectionMethodCall:
-    """Method calls — bound method intermediate display."""
+    """Method calls — flat obj.method() display without bound-method noise."""
 
-    def test_method_call_result_shown(self) -> None:
+    def test_method_call_flat_format(self) -> None:
+        """Method calls show 'where result = obj.method()' in one line."""
         assert_introspects(
             """
 def check():
@@ -705,14 +706,11 @@ def check():
     obj = Obj()
     assert obj.compute() == 100
 """,
-            must_contain=["where 42 = "],
+            must_contain=["where 42 = Obj().compute()"],
         )
 
-    @pytest.mark.xfail(
-        reason="Method call shows noisy bound-method intermediate: blind spot"
-    )
     def test_method_call_no_bound_method_noise(self) -> None:
-        """The 'where method = obj.method' line is noisy and unhelpful."""
+        """No separate 'where compute = obj.compute' line."""
         msg = get_failure_message("""
 def check():
     class Obj:
@@ -724,8 +722,6 @@ def check():
     assert obj.compute() == 100
 """)
         lines = msg.splitlines()
-        # Ideally the message should NOT have a separate "where compute = ..."
-        # line showing the bound method object — it adds noise without value
         for line in lines:
             assert "where compute = " not in line, (
                 f"Noisy bound-method intermediate found:\n{msg}"

--- a/testing/test_assertrewrite_coverage.py
+++ b/testing/test_assertrewrite_coverage.py
@@ -766,3 +766,175 @@ def check():
     x = 10
     assert (y := x * 2) == 100
 """)
+
+
+# ---------------------------------------------------------------------------
+# Single-evaluation tests: ensure no expression is evaluated multiple times
+# ---------------------------------------------------------------------------
+
+
+class TestSingleEvaluation:
+    """Verify the rewriter doesn't cause double-evaluation of side effects.
+
+    Each test uses a counter to track how many times a side-effecting
+    expression is evaluated. The rewritten assert should evaluate each
+    expression exactly once, regardless of whether the assertion passes or fails.
+    """
+
+    def test_call_in_compare_evaluated_once(self) -> None:
+        assert_single_evaluation("""
+def check():
+    def side_effect():
+        counter[0] += 1
+        return 42
+    assert side_effect() == 100
+""")
+
+    def test_call_in_boolean_and_evaluated_once(self) -> None:
+        assert_single_evaluation("""
+def check():
+    def side_effect():
+        counter[0] += 1
+        return True
+    assert side_effect() and False
+""")
+
+    def test_call_in_boolean_or_short_circuit(self) -> None:
+        # With `or`, if first is truthy, second is NOT evaluated
+        assert_single_evaluation(
+            """
+def check():
+    def first():
+        counter[0] += 1
+        return False
+    def second():
+        counter[0] += 1
+        return False
+    assert first() or second()
+""",
+            expected_call_count=2,
+        )
+
+    def test_call_in_unary_evaluated_once(self) -> None:
+        assert_single_evaluation("""
+def check():
+    def side_effect():
+        counter[0] += 1
+        return True
+    assert not side_effect()
+""")
+
+    def test_call_in_binop_evaluated_once(self) -> None:
+        assert_single_evaluation("""
+def check():
+    def side_effect():
+        counter[0] += 1
+        return 5
+    assert side_effect() + 1 == 100
+""")
+
+    def test_attribute_access_evaluated_once(self) -> None:
+        assert_single_evaluation("""
+def check():
+    class Obj:
+        @property
+        def prop(self):
+            counter[0] += 1
+            return 42
+    obj = Obj()
+    assert obj.prop == 100
+""")
+
+    def test_subscript_evaluated_once(self) -> None:
+        assert_single_evaluation("""
+def check():
+    class CountingDict(dict):
+        def __getitem__(self, key):
+            counter[0] += 1
+            return super().__getitem__(key)
+    d = CountingDict(a=1)
+    assert d["a"] == 100
+""")
+
+    def test_walrus_in_compare_evaluated_once(self) -> None:
+        assert_single_evaluation("""
+def check():
+    def side_effect():
+        counter[0] += 1
+        return 42
+    assert (x := side_effect()) == 100
+""")
+
+    def test_walrus_in_boolean_evaluated_once(self) -> None:
+        assert_single_evaluation("""
+def check():
+    def side_effect():
+        counter[0] += 1
+        return 42
+    assert (x := side_effect()) and False
+""")
+
+    def test_walrus_in_chained_compare_evaluated_once(self) -> None:
+        assert_single_evaluation("""
+def check():
+    def side_effect():
+        counter[0] += 1
+        return 5
+    assert 1 < (x := side_effect()) < 3
+""")
+
+    def test_method_call_evaluated_once(self) -> None:
+        assert_single_evaluation("""
+def check():
+    class Obj:
+        def compute(self):
+            counter[0] += 1
+            return 42
+    obj = Obj()
+    assert obj.compute() == 100
+""")
+
+    def test_nested_calls_each_evaluated_once(self) -> None:
+        assert_single_evaluation(
+            """
+def check():
+    def outer(x):
+        counter[0] += 1
+        return x + 1
+    def inner():
+        counter[0] += 1
+        return 5
+    assert outer(inner()) == 100
+""",
+            expected_call_count=2,
+        )
+
+    def test_multiple_comparators_evaluated_once_each(self) -> None:
+        assert_single_evaluation(
+            """
+def check():
+    def make_val(n):
+        counter[0] += 1
+        return n
+    assert make_val(1) < make_val(5) < make_val(3)
+""",
+            expected_call_count=3,
+        )
+
+    def test_ifexp_condition_evaluated_once(self) -> None:
+        assert_single_evaluation("""
+def check():
+    def cond():
+        counter[0] += 1
+        return True
+    assert (0 if cond() else 1) == 1
+""")
+
+    def test_comprehension_generator_evaluated_once(self) -> None:
+        assert_single_evaluation("""
+def check():
+    def items():
+        counter[0] += 1
+        return [1, 2, 3]
+    assert [x * 2 for x in items()] == [2, 4, 7]
+""")

--- a/testing/test_assertrewrite_coverage.py
+++ b/testing/test_assertrewrite_coverage.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import ast
 from collections.abc import Callable
 from collections.abc import Mapping
+import copy
 import sys
 import textwrap
 from typing import cast
@@ -185,11 +186,11 @@ def assert_semantically_equivalent(
     """
     src = textwrap.dedent(src)
 
-    # Run without rewriting
+    # Run without rewriting — use deepcopy of extra_ns to isolate mutable state
     plain_code = compile(src, "<test-plain>", "exec")
     plain_ns: dict[str, object] = {}
     if extra_ns is not None:
-        plain_ns.update(extra_ns)
+        plain_ns.update(copy.deepcopy(dict(extra_ns)))
     exec(plain_code, plain_ns)
     plain_func = cast(Callable[[], None], plain_ns["check"])
     plain_raised = False
@@ -198,12 +199,12 @@ def assert_semantically_equivalent(
     except AssertionError:
         plain_raised = True
 
-    # Run with rewriting
+    # Run with rewriting — fresh deepcopy so mutations from first run don't leak
     mod = _rewrite_source(src)
     rewritten_code = compile(mod, "<test-rewritten>", "exec")
     rewritten_ns: dict[str, object] = {}
     if extra_ns is not None:
-        rewritten_ns.update(extra_ns)
+        rewritten_ns.update(copy.deepcopy(dict(extra_ns)))
     exec(rewritten_code, rewritten_ns)
     rewritten_func = cast(Callable[[], None], rewritten_ns["check"])
     rewritten_raised = False

--- a/testing/test_assertrewrite_coverage.py
+++ b/testing/test_assertrewrite_coverage.py
@@ -534,9 +534,8 @@ def check():
 
 
 class TestIntrospectionSubscript:
-    """Subscript / indexing — currently hits generic_visit."""
+    """Subscript / indexing — now has dedicated visitor."""
 
-    @pytest.mark.xfail(reason="Subscript not introspected: blind spot")
     def test_dict_subscript_shows_key_and_container(self) -> None:
         assert_introspects(
             """
@@ -544,10 +543,9 @@ def check():
     d = {"a": 1, "b": 2}
     assert d["a"] == 99
 """,
-            must_contain=["where 1 = ", '["a"]'],
+            must_contain=["where 1 = ", "['a']"],
         )
 
-    @pytest.mark.xfail(reason="Subscript not introspected: blind spot")
     def test_list_subscript_shows_index_and_container(self) -> None:
         assert_introspects(
             """


### PR DESCRIPTION
## Summary

**Note: This is an AI-assisted experiment (Cursor + Claude Opus 4) that executed a plan after assessing initial details about assertion rewriting blind spots. More work is needed to make this clean and production-ready — this PR has known weaknesses and is meant as a starting point for discussion, not a final implementation.**

This PR builds on top of the walrus operator double-evaluation fix (#14445) and addresses additional blind spots in the assertion rewriter:

- Add a systematic test infrastructure for assertion rewriting coverage (`testing/test_assertrewrite_coverage.py`)
- Implement `visit_Subscript` for `container[key]` introspection (shows container and key separately in failure messages)
- Implement `visit_IfExp` for ternary expression introspection (shows condition value while preserving short-circuit semantics)
- Flatten method call display to show `where result = obj.method(args)` instead of nesting the bound-method intermediate

## Before/After

### Subscript (new)
```
# Before: assert 1 == 99
# After:  assert 1 == 99
#          +  where 1 = {'a': 1, 'b': 2}['a']
```

### IfExp (new)
```
# Before: assert 0 == 99
# After:  assert 0 == 99
#          +  where 0 = (... if True else ...)
```

### Method calls (improved)
```
# Before: assert 42 == 100
#          +  where 42 = compute()
#          +    where compute = Obj().compute
# After:  assert 42 == 100
#          +  where 42 = Obj().compute()
```

## Known weaknesses / areas for improvement

- The `visit_IfExp` only introspects the condition, not the branch values (to preserve short-circuit) — a more sophisticated implementation could emit an if/else block to get branch values too
- Container literal introspection (list, dict, set literals) is still unaddressed (xfail)
- Callable variables still show `<function ...>` repr instead of variable name (xfail)
- The method call flattening may interact unexpectedly with deeply chained attribute access patterns not yet covered
- No changelog fragment yet — this needs proper evaluation before merging
- Includes the #14445 walrus fix commits (those should be merged first or this PR rebased after)

## Test plan

- [x] 75 tests pass in `testing/test_assertrewrite_coverage.py` (61 pass + 14 edge cases)
- [x] 3 remaining xfail for lower-priority blind spots (container literals, callable variable repr)
- [x] All 132 existing `testing/test_assertrewrite.py` tests pass (no regressions)
- [x] All 162 `testing/test_assertion.py` tests pass (no regressions)
- [x] Single-evaluation guarantees verified for all new visitors
- [x] Short-circuit semantics preserved for IfExp
- [x] Pre-commit hooks pass (ruff, mypy, codespell)


Made with [Cursor](https://cursor.com)