### PR TITLE
terminal: add --name-only option to show only names of failed tests

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -503,6 +503,7 @@ Warren Markham
 Wei Lin
 Wil Cooley
 Will Riley
+Willem Adnet
 William Lee
 Wim Glenn
 Wouter van Ackooy

--- a/changelog/14443.feature.rst
+++ b/changelog/14443.feature.rst
@@ -1,0 +1,1 @@
+Added new CLI argument ``--name-only`` to only display the name of the test when it fails, suppressing tracebacks and other detailed information.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -3074,6 +3074,10 @@ Output and Reporting
     * ``log``: show captured logging
     * ``all`` (default): show all captured output
 
+.. option:: --name-only
+
+    Only display the name of the test when it fails, suppressing tracebacks and other detailed information.
+
 .. option:: --color=WHEN
 
     Color terminal output:

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1218,10 +1218,14 @@ class TerminalReporter:
                 self.write_sep("=", sep_title)
                 if style == "line":
                     for rep in reports:
-                        line = self._getcrashline(rep)
                         if not self.config.option.name_only:
+                            line = self._getcrashline(rep)
                             self._outrep_summary(rep)
-                        self.write_line(line)
+                            self.write_line(line)
+                        else:
+                            self._tw.line(
+                                self._getfailureheadline(rep), red=True, bold=True
+                            )
                 else:
                     for rep in reports:
                         msg = self._getfailureheadline(rep)

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -248,6 +248,13 @@ def pytest_addoption(parser: Parser) -> None:
         "Default: all.",
     )
     group.addoption(
+        "--name-only",
+        action="store_true",
+        default=False,
+        dest="name_only",
+        help="Only display the name of the test when it fails.",
+    )
+    group.addoption(
         "--fulltrace",
         "--full-trace",
         action="store_true",
@@ -1212,14 +1219,18 @@ class TerminalReporter:
                 if style == "line":
                     for rep in reports:
                         line = self._getcrashline(rep)
-                        self._outrep_summary(rep)
+                        if not self.config.option.name_only:
+                            self._outrep_summary(rep)
                         self.write_line(line)
                 else:
                     for rep in reports:
                         msg = self._getfailureheadline(rep)
-                        self.write_sep("_", msg, red=True, bold=True)
-                        self._outrep_summary(rep)
-                        self._handle_teardown_sections(rep.nodeid)
+                        if self.config.option.name_only:
+                            self._tw.line(msg, red=True, bold=True)
+                        else:
+                            self.write_sep("_", msg, red=True, bold=True)
+                            self._outrep_summary(rep)
+                            self._handle_teardown_sections(rep.nodeid)
 
     def summary_errors(self) -> None:
         if self.config.option.tbstyle != "no":
@@ -1233,8 +1244,11 @@ class TerminalReporter:
                     msg = "ERROR collecting " + msg
                 else:
                     msg = f"ERROR at {rep.when} of {msg}"
-                self.write_sep("_", msg, red=True, bold=True)
-                self._outrep_summary(rep)
+                if self.config.option.name_only:
+                    self._tw.line(msg, red=True, bold=True)
+                else:
+                    self.write_sep("_", msg, red=True, bold=True)
+                    self._outrep_summary(rep)
 
     def _outrep_summary(self, rep: BaseReport) -> None:
         rep.toterminal(self._tw)

--- a/testing/test_name_only.py
+++ b/testing/test_name_only.py
@@ -89,6 +89,52 @@ class TestNameOnly:
         result.stdout.fnmatch_lines(
             [
                 "=* FAILURES *=",
-                "*test_name_only_with_tb_line.py*: assert False",
+                "test_fail",
             ]
         )
+        output = result.stdout.str()
+        failures_part = output.split("FAILURES")[1].split("short test summary info")[0]
+        assert "test_fail" in failures_part
+        assert "assert False" not in failures_part
+
+    def test_name_only_with_verbose(self, pytester: pytest.Pytester) -> None:
+        pytester.makepyfile(
+            """
+            def test_fail():
+                assert False
+            """
+        )
+        result = pytester.runpytest("--name-only", "-v")
+        result.stdout.fnmatch_lines(
+            [
+                "=* FAILURES *=",
+                "test_fail",
+                "=* short test summary info *=",
+            ]
+        )
+        output = result.stdout.str()
+        failures_part = output.split("FAILURES")[1].split("short test summary info")[0]
+        assert "test_fail" in failures_part
+        assert "assert False" not in failures_part
+
+    def test_name_only_with_show_capture_no(self, pytester: pytest.Pytester) -> None:
+        pytester.makepyfile(
+            """
+            def test_fail():
+                print("captured output")
+                assert False
+            """
+        )
+        result = pytester.runpytest("--name-only", "--show-capture=no")
+        result.stdout.fnmatch_lines(
+            [
+                "=* FAILURES *=",
+                "test_fail",
+                "=* short test summary info *=",
+            ]
+        )
+        output = result.stdout.str()
+        failures_part = output.split("FAILURES")[1].split("short test summary info")[0]
+        assert "test_fail" in failures_part
+        assert "assert False" not in failures_part
+        assert "captured output" not in failures_part

--- a/testing/test_name_only.py
+++ b/testing/test_name_only.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import pytest
+
 
 class TestNameOnly:
     def test_name_only_failures(self, pytester: pytest.Pytester) -> None:
@@ -13,13 +16,15 @@ class TestNameOnly:
             """
         )
         result = pytester.runpytest("--name-only")
-        result.stdout.fnmatch_lines([
-            "=* FAILURES *=",
-            "test_fail1",
-            "test_fail2",
-            "=* short test summary info *=",
-        ])
-        
+        result.stdout.fnmatch_lines(
+            [
+                "=* FAILURES *=",
+                "test_fail1",
+                "test_fail2",
+                "=* short test summary info *=",
+            ]
+        )
+
         output = result.stdout.str()
         failures_part = output.split("FAILURES")[1].split("short test summary info")[0]
         assert "test_fail1" in failures_part
@@ -28,21 +33,25 @@ class TestNameOnly:
         assert "E       assert False" not in failures_part
 
     def test_name_only_errors(self, pytester: pytest.Pytester) -> None:
-        p = pytester.makepyfile(test_error="""
+        p = pytester.makepyfile(
+            test_error="""
             import pytest
             @pytest.fixture
             def bad_fixture():
                 raise RuntimeError("error in fixture")
             def test_error(bad_fixture):
                 pass
-        """)
+        """
+        )
         result = pytester.runpytest(p, "--name-only")
-        result.stdout.fnmatch_lines([
-            "=* ERRORS *=",
-            "ERROR at setup of test_error",
-            "=* short test summary info *=",
-            "ERROR test_error.py::test_error - RuntimeError: error in fixture",
-        ])
+        result.stdout.fnmatch_lines(
+            [
+                "=* ERRORS *=",
+                "ERROR at setup of test_error",
+                "=* short test summary info *=",
+                "ERROR test_error.py::test_error - RuntimeError: error in fixture",
+            ]
+        )
         output = result.stdout.str()
         errors_part = output.split("ERRORS")[1].split("short test summary info")[0]
         assert "ERROR at setup of test_error" in errors_part
@@ -56,12 +65,14 @@ class TestNameOnly:
             """
         )
         result = pytester.runpytest("--name-only")
-        result.stdout.fnmatch_lines([
-            "=* ERRORS *=",
-            "ERROR collecting test_name_only_collection_error.py",
-            "=* short test summary info *=",
-            "ERROR test_name_only_collection_error.py",
-        ])
+        result.stdout.fnmatch_lines(
+            [
+                "=* ERRORS *=",
+                "ERROR collecting test_name_only_collection_error.py",
+                "=* short test summary info *=",
+                "ERROR test_name_only_collection_error.py",
+            ]
+        )
         output = result.stdout.str()
         errors_part = output.split("ERRORS")[1].split("short test summary info")[0]
         assert "ERROR collecting test_name_only_collection_error.py" in errors_part
@@ -75,7 +86,9 @@ class TestNameOnly:
             """
         )
         result = pytester.runpytest("--name-only", "--tb=line")
-        result.stdout.fnmatch_lines([
-            "=* FAILURES *=",
-            "*test_name_only_with_tb_line.py*: assert False",
-        ])
+        result.stdout.fnmatch_lines(
+            [
+                "=* FAILURES *=",
+                "*test_name_only_with_tb_line.py*: assert False",
+            ]
+        )

--- a/testing/test_name_only.py
+++ b/testing/test_name_only.py
@@ -1,0 +1,81 @@
+import pytest
+
+class TestNameOnly:
+    def test_name_only_failures(self, pytester: pytest.Pytester) -> None:
+        pytester.makepyfile(
+            """
+            def test_fail1():
+                assert False
+            def test_fail2():
+                assert False
+            def test_pass():
+                assert True
+            """
+        )
+        result = pytester.runpytest("--name-only")
+        result.stdout.fnmatch_lines([
+            "=* FAILURES *=",
+            "test_fail1",
+            "test_fail2",
+            "=* short test summary info *=",
+        ])
+        
+        output = result.stdout.str()
+        failures_part = output.split("FAILURES")[1].split("short test summary info")[0]
+        assert "test_fail1" in failures_part
+        assert "test_fail2" in failures_part
+        assert "assert False" not in failures_part
+        assert "E       assert False" not in failures_part
+
+    def test_name_only_errors(self, pytester: pytest.Pytester) -> None:
+        p = pytester.makepyfile(test_error="""
+            import pytest
+            @pytest.fixture
+            def bad_fixture():
+                raise RuntimeError("error in fixture")
+            def test_error(bad_fixture):
+                pass
+        """)
+        result = pytester.runpytest(p, "--name-only")
+        result.stdout.fnmatch_lines([
+            "=* ERRORS *=",
+            "ERROR at setup of test_error",
+            "=* short test summary info *=",
+            "ERROR test_error.py::test_error - RuntimeError: error in fixture",
+        ])
+        output = result.stdout.str()
+        errors_part = output.split("ERRORS")[1].split("short test summary info")[0]
+        assert "ERROR at setup of test_error" in errors_part
+        assert "RuntimeError: error in fixture" not in errors_part
+
+    def test_name_only_collection_error(self, pytester: pytest.Pytester) -> None:
+        pytester.makepyfile(
+            """
+            def test_syntax():
+                assert
+            """
+        )
+        result = pytester.runpytest("--name-only")
+        result.stdout.fnmatch_lines([
+            "=* ERRORS *=",
+            "ERROR collecting test_name_only_collection_error.py",
+            "=* short test summary info *=",
+            "ERROR test_name_only_collection_error.py",
+        ])
+        output = result.stdout.str()
+        errors_part = output.split("ERRORS")[1].split("short test summary info")[0]
+        assert "ERROR collecting test_name_only_collection_error.py" in errors_part
+        assert "SyntaxError" not in errors_part
+
+    def test_name_only_with_tb_line(self, pytester: pytest.Pytester) -> None:
+        pytester.makepyfile(
+            """
+            def test_fail():
+                assert False
+            """
+        )
+        result = pytester.runpytest("--name-only", "--tb=line")
+        result.stdout.fnmatch_lines([
+            "=* FAILURES *=",
+            "*test_name_only_with_tb_line.py*: assert False",
+        ])


### PR DESCRIPTION
Add --name-only option to show only names of failed tests
---
Add a new CLI argument `--name-only` that displays only the test name or collection error headline when a test fails. This is useful for quickly identifying failures in large test suites without the noise of full tracebacks or capture sections.
- Register `--name-only` in `pytest_addoption`.
- Modify `summary_failures_combined` and `summary_errors` to honor the flag.
- Add documentation in `doc/en/reference/reference.rst`.
- Add regression tests in `testing/test_name_only.py`.
- Add news fragment in `changelog/14443.feature.rst`.
- Update `AUTHORS`.
---
- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits.
---
Closes: #14452