### PR TITLE
Fix timing output for unittest subtests

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -269,6 +269,7 @@ Kojo Idrissa
 Kostis Anagnostopoulos
 Kristoffer Nordström
 Kyle Altendorf
+Laurentiu-Cristian Preda
 Lawrence Mitchell
 Lee Kamentsky
 Leonardus Chen

--- a/changelog/14412.bugfix.rst
+++ b/changelog/14412.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``console_output_style = times`` reporting ``0.000us`` for unittest subtests.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -660,7 +660,7 @@ class TerminalReporter:
             # printing here and not in logfinish, except for the 100% which
             # should only be printed after all teardowns are finished.
             if self._show_progress_info and not self._is_last_item:
-                self._write_progress_information_if_past_edge()
+                self._write_progress_information_if_past_edge(rep)
         else:
             line = self._locationline(rep.nodeid, *rep.location)
             running_xdist = hasattr(rep, "node")
@@ -683,13 +683,13 @@ class TerminalReporter:
                     if reason and formatted_reason is not None:
                         self.wrap_write(formatted_reason)
                 if self._show_progress_info:
-                    self._write_progress_information_filling_space()
+                    self._write_progress_information_filling_space(rep)
             else:
                 self.ensure_newline()
                 self._tw.write(f"[{rep.node.gateway.id}]")
                 if self._show_progress_info:
                     self._tw.write(
-                        self._get_progress_information_message() + " ", cyan=True
+                        self._get_progress_information_message(rep) + " ", cyan=True
                     )
                 else:
                     self._tw.write(" ")
@@ -717,7 +717,9 @@ class TerminalReporter:
 
         return result
 
-    def _get_progress_information_message(self) -> str:
+    def _get_progress_information_message(
+        self, report: TestReport | None = None
+    ) -> str:
         assert self._session
         collected = self._session.testscollected
         if self._show_progress_info == "count":
@@ -730,6 +732,8 @@ class TerminalReporter:
         if self._show_progress_info == "times":
             if not collected:
                 return ""
+            if report is not None and self._is_subtest_report(report):
+                return format_node_duration(report.duration)
             all_reports = (
                 self._get_reports_to_display("passed")
                 + self._get_reports_to_display("xpassed")
@@ -762,7 +766,15 @@ class TerminalReporter:
             return f" [{self.reported_progress * 100 // collected:3d}%]"
         return " [100%]"
 
-    def _write_progress_information_if_past_edge(self) -> None:
+    @staticmethod
+    def _is_subtest_report(report: TestReport) -> bool:
+        from _pytest.subtests import SubtestReport
+
+        return isinstance(report, SubtestReport)
+
+    def _write_progress_information_if_past_edge(
+        self, report: TestReport | None = None
+    ) -> None:
         w = self._width_of_current_line
         if self._show_progress_info == "count":
             assert self._session
@@ -775,12 +787,14 @@ class TerminalReporter:
         past_edge = w + progress_length + 1 >= self._screen_width
         if past_edge:
             main_color, _ = self._get_main_color()
-            msg = self._get_progress_information_message()
+            msg = self._get_progress_information_message(report)
             self._tw.write(msg + "\n", **{main_color: True})
 
-    def _write_progress_information_filling_space(self) -> None:
+    def _write_progress_information_filling_space(
+        self, report: TestReport | None = None
+    ) -> None:
         color, _ = self._get_main_color()
-        msg = self._get_progress_information_message()
+        msg = self._get_progress_information_message(report)
         w = self._width_of_current_line
         fill = self._tw.fullwidth - w - 1
         self.write(msg.rjust(fill), flush=True, **{color: True})

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -3,10 +3,12 @@
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Callable
 from collections.abc import Generator
 from collections.abc import Iterable
 from collections.abc import Iterator
+from contextlib import contextmanager
 from enum import auto
 from enum import Enum
 import inspect
@@ -17,6 +19,7 @@ from typing import Any
 from typing import TYPE_CHECKING
 from unittest import TestCase
 
+from _pytest import timing
 import _pytest._code
 from _pytest._code import ExceptionInfo
 from _pytest.compat import assert_never
@@ -224,6 +227,7 @@ class TestCaseFunction(Function):
     def setup(self) -> None:
         # A bound method to be called during teardown() if set (see 'runtest()').
         self._explicit_tearDown: Callable[[], None] | None = None
+        self._subtest_durations: deque[timing.Duration] = deque()
         super().setup()
         if sys.version_info < (3, 11):
             # A cache of the subTest errors and non-subtest skips in self._outcome.
@@ -365,30 +369,52 @@ class TestCaseFunction(Function):
 
         maybe_wrap_pytest_function_for_tracing(self)
 
-        # Let the unittest framework handle async functions.
-        if is_async_function(self.obj):
-            testcase(result=self)
-        else:
-            # When --pdb is given, we want to postpone calling tearDown() otherwise
-            # when entering the pdb prompt, tearDown() would have probably cleaned up
-            # instance variables, which makes it difficult to debug.
-            # Arguably we could always postpone tearDown(), but this changes the moment where the
-            # TestCase instance interacts with the results object, so better to only do it
-            # when absolutely needed.
-            # We need to consider if the test itself is skipped, or the whole class.
-            assert isinstance(self.parent, UnitTestCase)
-            skipped = _is_skipped(self.obj) or _is_skipped(self.parent.obj)
-            if self.config.getoption("usepdb") and not skipped:
-                self._explicit_tearDown = testcase.tearDown
-                setattr(testcase, "tearDown", lambda *args: None)
+        original_subtest = testcase.subTest
+        had_instance_subtest = "subTest" in testcase.__dict__
+        original_instance_subtest = testcase.__dict__.get("subTest")
 
-            # We need to update the actual bound method with self.obj, because
-            # wrap_pytest_function_for_tracing replaces self.obj by a wrapper.
-            setattr(testcase, self.name, self.obj)
-            try:
+        # unittest only reports subtests after they finish, so measure the public
+        # subTest() context manager boundary to provide accurate SubtestReport durations.
+        @contextmanager
+        def timed_subtest(*args, **kwargs):
+            instant = timing.Instant()
+            with original_subtest(*args, **kwargs) as subtest:
+                try:
+                    yield subtest
+                finally:
+                    self._subtest_durations.append(instant.elapsed())
+
+        setattr(testcase, "subTest", timed_subtest)
+        try:
+            # Let the unittest framework handle async functions.
+            if is_async_function(self.obj):
                 testcase(result=self)
-            finally:
-                delattr(testcase, self.name)
+            else:
+                # When --pdb is given, we want to postpone calling tearDown() otherwise
+                # when entering the pdb prompt, tearDown() would have probably cleaned up
+                # instance variables, which makes it difficult to debug.
+                # Arguably we could always postpone tearDown(), but this changes the moment where the
+                # TestCase instance interacts with the results object, so better to only do it
+                # when absolutely needed.
+                # We need to consider if the test itself is skipped, or the whole class.
+                assert isinstance(self.parent, UnitTestCase)
+                skipped = _is_skipped(self.obj) or _is_skipped(self.parent.obj)
+                if self.config.getoption("usepdb") and not skipped:
+                    self._explicit_tearDown = testcase.tearDown
+                    setattr(testcase, "tearDown", lambda *args: None)
+
+                # We need to update the actual bound method with self.obj, because
+                # wrap_pytest_function_for_tracing replaces self.obj by a wrapper.
+                setattr(testcase, self.name, self.obj)
+                try:
+                    testcase(result=self)
+                finally:
+                    delattr(testcase, self.name)
+        finally:
+            if had_instance_subtest:
+                setattr(testcase, "subTest", original_instance_subtest)
+            else:
+                delattr(testcase, "subTest")
 
     def _traceback_filter(
         self, excinfo: _pytest._code.ExceptionInfo[BaseException]
@@ -422,12 +448,22 @@ class TestCaseFunction(Function):
             case unreachable:
                 assert_never(unreachable)
 
+        if self._subtest_durations:
+            duration = self._subtest_durations.popleft()
+            start = duration.start.time
+            stop = duration.stop.time
+            duration_seconds = duration.seconds
+        else:
+            start = 0
+            stop = 0
+            duration_seconds = 0
+
         call_info = CallInfo[None](
             None,
             exception_info,
-            start=0,
-            stop=0,
-            duration=0,
+            start=start,
+            stop=stop,
+            duration=duration_seconds,
             when="call",
             _ispytest=True,
         )

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -2324,6 +2324,37 @@ class TestProgressOutputStyle:
             ]
         )
 
+    def test_verbose_times_with_duplicate_unittest_subtests(
+        self, pytester: Pytester
+    ) -> None:
+        pytester.makepyfile(
+            """
+            import time
+            import unittest
+
+
+            class Test(unittest.TestCase):
+                def test_subtests(self):
+                    for _ in range(2):
+                        with self.subTest():
+                            time.sleep(0.05)
+            """
+        )
+        pytester.makeini(
+            """
+            [pytest]
+            console_output_style = times
+            """
+        )
+        output = pytester.runpytest("-v")
+        duration_re = r"(?!0\.000us)(?:\d+(\.\d+)?(?:us|ms|s)|\d+m \d+s|\d+h \d+m)"
+        output.stdout.re_match_lines(
+            [
+                rf".*::Test::test_subtests SUBPASSED\(<subtest>\)\s+{duration_re}",
+                rf".*::Test::test_subtests SUBPASSED\(<subtest>\)\s+{duration_re}",
+            ]
+        )
+
     def test_xdist_normal(
         self, many_tests_files, pytester: Pytester, monkeypatch
     ) -> None:

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -6,6 +6,7 @@ import sys
 from _pytest.config import ExitCode
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pytester import Pytester
+from _pytest.subtests import SubtestReport
 import pytest
 
 
@@ -47,6 +48,72 @@ def test_runTest_method(pytester: Pytester) -> None:
         *2 passed*
     """
     )
+
+
+def test_restores_instance_level_subtest(pytester: Pytester) -> None:
+    pytester.makeconftest(
+        """
+        import pytest
+
+
+        @pytest.hookimpl(wrapper=True)
+        def pytest_runtest_call(item):
+            yield
+            original_subtest = item.instance.__dict__["subTest"]
+            assert original_subtest._pytest_test_restored
+        """
+    )
+    testpath = pytester.makepyfile(
+        """
+        import unittest
+
+
+        class MyTestCase(unittest.TestCase):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+                def custom_subtest(*args, **kwargs):
+                    return unittest.TestCase.subTest(self, *args, **kwargs)
+
+                custom_subtest._pytest_test_restored = True
+                self.subTest = custom_subtest
+
+            def test_subtest(self):
+                with self.subTest():
+                    pass
+        """
+    )
+    reprec = pytester.inline_run(testpath)
+    reprec.assertoutcome(passed=2)
+
+
+def test_addsubtest_without_recorded_duration_uses_zero_duration(
+    pytester: Pytester,
+) -> None:
+    testpath = pytester.makepyfile(
+        """
+        import unittest
+
+
+        class ManualSubTest:
+            _message = "manual"
+            params = {}
+
+
+        class MyTestCase(unittest.TestCase):
+            def test_subtest(self):
+                self._outcome.result.addSubTest(self, ManualSubTest(), None)
+        """
+    )
+    reprec = pytester.inline_run(testpath)
+    reports = [
+        report
+        for report in reprec.getreports("pytest_runtest_logreport")
+        if isinstance(report, SubtestReport)
+    ]
+    assert len(reports) == 1
+    assert reports[0].duration == 0
+    reprec.assertoutcome(passed=2)
 
 
 def test_isclasscheck_issue53(pytester: Pytester) -> None:


### PR DESCRIPTION
Fixes #14412.

When `console_output_style = times` was used with unittest subtests, subtest rows could display `0.000us`.

There turned out to be two separate issues behind this:

* terminal timing aggregation tracked displayed timing by `nodeid`, but unittest subtest reports all share the same parent test `nodeid`
* unittest `SubtestReport` instances were created with `duration=0`

This PR changes terminal timing so that `SubtestReport` rows display their own report duration directly, while normal test reports continue using the existing node-level aggregation logic.

On the unittest side the problem was that stdlib `unittest` only calls `addSubTest()` after a subtest has already completed, so pytest does not receive a start timestamp for the subtest body. My approach measures the public `subTest()` context manager boundary during `TestCaseFunction.runtest()` and restores the original method in `finally`.

This seemed like the narrowest approach that could provide accurate per-subtest durations while staying within the public unittest API surface.

A regression test was added using duplicate `subTest()` contexts so the fix does not rely on subtest context text being unique.

Tests run locally:

```text
.\.venv\Scripts\pytest.exe testing/test_terminal.py testing/test_subtests.py -q -p no:cacheprovider --basetemp=C:\tmp\pytest-14412-final
```

Result:

```text
254 passed, 9 skipped
```

I also ran pre-commit on the changed files during commit.
