### PR TITLE
Fix _as_numpy_array: use variable obj instead of string literal "obj"

### DIFF
--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -906,6 +906,6 @@ def _as_numpy_array(obj: object) -> ndarray | None:
             return None
         elif isinstance(obj, np.ndarray):
             return obj
-        elif hasattr(obj, "__array__") or hasattr("obj", "__array_interface__"):
+        elif hasattr(obj, "__array__") or hasattr(obj, "__array_interface__"):
             return np.asarray(obj)
     return None

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -993,6 +993,30 @@ class TestApprox:
         with pytest.raises(TypeError):
             op(1, approx(1, rel=1e-6, abs=1e-12))
 
+    def test_numpy_array_via_interface_protocol(self):
+        """Objects implementing __array_interface__ without __array__ should work (#14456)."""
+        np = pytest.importorskip("numpy")
+
+        class ArrayViaInterface:
+            def __init__(self, value):
+                self.value = value
+
+            @property
+            def __array_interface__(self):
+                return {
+                    "shape": (),
+                    "typestr": "<f8",
+                    "data": (np.array(self.value).ctypes.data, False),
+                    "version": 3,
+                }
+
+        expected = 1.0
+        actual = 1.0 + 1e-7
+        assert ArrayViaInterface(actual) == approx(expected, rel=1e-6, abs=0)
+
+        # Also works on the left side of the comparison
+        assert approx(expected, rel=1e-6, abs=0) == ArrayViaInterface(actual)
+
     def test_numpy_array_with_scalar(self):
         np = pytest.importorskip("numpy")
 


### PR DESCRIPTION
## Describe your changes

Fixes a bug in `_as_numpy_array` where `hasattr` was called with the string literal `"obj"` instead of the variable `obj` for the `__array_interface__` check.

```python
# Before (bug):
elif hasattr(obj, "__array__") or hasattr("obj", "__array_interface__"):
# After (fix):
elif hasattr(obj, "__array__") or hasattr(obj, "__array_interface__"):
```

This meant any object implementing `__array_interface__` without also implementing `__array__` would not be recognized as a numpy-like array by `_as_numpy_array`, causing it to fall through to `ApproxSequenceLike` instead of `ApproxNumpy`. In practice this could affect users with custom array types or libraries that only implement `__array_interface__`.

## GitHub Issue Link

- Closes #14456

## Testing Plan

- [x] Added `test_numpy_array_via_interface_protocol` which creates a class implementing `__array_interface__` without `__array__` and verifies it works with `approx()`
- [x] Existing `test_numpy_array_implicit_conversion` and `test_numpy_array_protocol` continue to pass (they test `__array__` path)
