### PR TITLE
pastebin: deprecate `--pastebin`

### DIFF
--- a/changelog/14434.deprecation.rst
+++ b/changelog/14434.deprecation.rst
@@ -1,0 +1,3 @@
+The :option:`--pastebin` option is now deprecated.
+The same functionality is now available in an external plugin, :pypi:`pytest-pastebin`.
+See :ref:`pastebin-deprecated` for more details.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -15,6 +15,19 @@ Below is a complete list of all pytest features which are considered deprecated.
 :class:`~pytest.PytestWarning` or subclasses, which can be filtered using :ref:`standard warning filters <warnings>`.
 
 
+.. _pastebin-deprecated:
+
+The ``--pastebin`` option
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 9.1
+
+The :option:`--pastebin` option has been deprecated due to being very niche, being the only feature in core pytest relying on an external service and having low usage.
+
+The plugin which implements ``--pastebin`` has been extracted to a separate package, :pypi:`pytest-pastebin`.
+Please install ``pytest-pastebin`` if you want to keep using ``--pastebin``.
+
+
 .. _dynamic-fixture-request-during-teardown:
 
 ``request.getfixturevalue()`` during fixture teardown

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -75,6 +75,12 @@ FIXTURE_GETFIXTUREVALUE_DURING_TEARDOWN = UnformattedWarning(
     "See https://docs.pytest.org/en/stable/deprecations.html#dynamic-fixture-request-during-teardown",
 )
 
+PASTEBIN = PytestRemovedIn10Warning(
+    "The --pastebin option is deprecated. "
+    "The functionality is now available in an external plugin package, pytest-pastebin.\n"
+    "See https://docs.pytest.org/en/stable/deprecations.html#the-pastebin-option"
+)
+
 # You want to make some `__init__` or function "private".
 #
 #   def my_private_function(some, args):

--- a/src/_pytest/pastebin.py
+++ b/src/_pytest/pastebin.py
@@ -10,6 +10,7 @@ from typing import IO
 from _pytest.config import Config
 from _pytest.config import create_terminal_writer
 from _pytest.config.argparsing import Parser
+from _pytest.deprecated import PASTEBIN
 from _pytest.stash import StashKey
 from _pytest.terminal import TerminalReporter
 import pytest
@@ -33,6 +34,9 @@ def pytest_addoption(parser: Parser) -> None:
 
 @pytest.hookimpl(trylast=True)
 def pytest_configure(config: Config) -> None:
+    if config.option.pastebin:
+        config.issue_config_time_warning(PASTEBIN, 2)
+
     if config.option.pastebin == "all":
         tr = config.pluginmanager.getplugin("terminalreporter")
         # If no terminal reporter plugin is present, nothing we can do here;

--- a/testing/test_pastebin.py
+++ b/testing/test_pastebin.py
@@ -5,6 +5,7 @@ import email.message
 import io
 from unittest import mock
 
+from _pytest.config import ExitCode
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pytester import Pytester
 import pytest
@@ -50,7 +51,13 @@ class TestPasteCapture:
                 pytest.skip("")
         """
         )
-        reprec = pytester.inline_run(testpath, "--pastebin=all", "-v")
+        reprec = pytester.inline_run(
+            testpath,
+            "--pastebin=all",
+            "-v",
+            "-W",
+            "ignore:The --pastebin:DeprecationWarning",
+        )
         assert reprec.countoutcomes() == [1, 1, 1]
         assert len(pastebinlist) == 1
         contents = pastebinlist[0].decode("utf-8")
@@ -74,7 +81,11 @@ class TestPasteCapture:
                 assert '☺' == 1
             """
         )
-        result = pytester.runpytest("--pastebin=all")
+        result = pytester.runpytest(
+            "--pastebin=all",
+            "-W",
+            "ignore:The --pastebin:DeprecationWarning",
+        )
         expected_msg = "*assert '☺' == 1*"
         result.stdout.fnmatch_lines(
             [
@@ -84,6 +95,12 @@ class TestPasteCapture:
             ]
         )
         assert len(pastebinlist) == 1
+
+    def test_deprecated(self, pytester: Pytester, pastebinlist) -> None:
+        result = pytester.runpytest("--pastebin=failed")
+        assert result.ret == ExitCode.NO_TESTS_COLLECTED
+        result.assert_outcomes()
+        result.stdout.fnmatch_lines(["*The --pastebin option is deprecated*"])
 
 
 class TestPaste:


### PR DESCRIPTION
Fix #14434
