### PR TITLE
docs: clarify subtests progress output

### DIFF
--- a/changelog/13902.doc.rst
+++ b/changelog/13902.doc.rst
@@ -1,0 +1,1 @@
+Clarified how subtest progress markers are shown in the documentation.

--- a/doc/en/how-to/subtests.rst
+++ b/doc/en/how-to/subtests.rst
@@ -26,7 +26,7 @@ Subtests are an alternative to parametrization, particularly useful when the exa
 
 Each assertion failure or error is caught by the context manager and reported individually:
 
-.. code-block:: pytest
+.. code-block:: text
 
     $ pytest -q test_subtest.py
     uuuuuF                                                               [100%]
@@ -63,6 +63,8 @@ Each assertion failure or error is caught by the context manager and reported in
 
 In the output above:
 
+* The compact progress output uses ``u`` for both passed and failed subtests;
+  see the short test summary for each failed subtest.
 * Subtest failures are reported as ``SUBFAILED``.
 * Subtests are reported first and the "top-level" test is reported at the end on its own.
 


### PR DESCRIPTION
## Summary

- Render the subtests example output as plain text so the docs do not color every `u` progress marker as passing.
- Add a short note explaining that the compact `u` marker is used for both passed and failed subtests, and that the summary shows which subtests failed.
- Add a short changelog fragment for the documentation clarification.

Closes #13902.

## Testing

- `git diff --check`
- `uv run --python 3.14 --with tox tox -e docs -- -q`

## Notes

- The commit includes an AI co-author trailer, per the project PR template.
