### PR TITLE
fix: update xdist newhooks.py link in hooks how-to docs

### DIFF
--- a/changelog/14465.doc.rst
+++ b/changelog/14465.doc.rst
@@ -1,0 +1,1 @@
+Updated the xdist ``newhooks.py`` link in the hooks how-to documentation to point to the current ``master`` branch with the updated ``src`` layout.

--- a/doc/en/how-to/writing_hook_functions.rst
+++ b/doc/en/how-to/writing_hook_functions.rst
@@ -205,7 +205,7 @@ class or module can then be passed to the ``pluginmanager`` using the ``pytest_a
 
 For a real world example, see `newhooks.py`_ from `xdist <https://github.com/pytest-dev/pytest-xdist>`_.
 
-.. _`newhooks.py`: https://github.com/pytest-dev/pytest-xdist/blob/974bd566c599dc6a9ea291838c6f226197208b46/xdist/newhooks.py
+.. _`newhooks.py`: https://github.com/pytest-dev/pytest-xdist/blob/master/src/xdist/newhooks.py
 
 Hooks may be called both from fixtures or from other hooks. In both cases, hooks are called
 through the ``hook`` object, available in the ``config`` object. Most hooks receive a


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [x] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

## Description

The hooks how-to documentation ("Declaring new hooks" section) links to an example `newhooks.py` file in pytest-xdist. The link pointed to a specific old commit (`974bd566`) that predates the `src` layout migration in pytest-xdist.

This PR updates the link to point to the current `master` branch with the correct `src/xdist/newhooks.py` path.

Closes #14465

## Changes

- `doc/en/how-to/writing_hook_functions.rst`: Updated the `newhooks.py` reference URL from a pinned old commit to the `master` branch with the updated `src` layout path.
- Added changelog entry `changelog/14465.doc.rst`.