### PR TITLE
fix mark expression scanner: search for backslash in string value, not entire input

### DIFF
--- a/changelog/14474.bugfix.rst
+++ b/changelog/14474.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed a regression where ``-k`` and ``-m`` expressions containing both backslash characters in identifiers and string literal arguments would incorrectly raise a ``SyntaxError`` about escaping -- the backslash check was searching the entire input instead of only the string literal value.
+Fixed a regression where ``-k`` and ``-m`` expressions containing both backslash characters in identifiers and string literal arguments would incorrectly raise a ``SyntaxError`` about escaping.

--- a/changelog/14474.bugfix.rst
+++ b/changelog/14474.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a regression where ``-k`` and ``-m`` expressions containing both backslash characters in identifiers and string literal arguments would incorrectly raise a ``SyntaxError`` about escaping -- the backslash check was searching the entire input instead of only the string literal value.

--- a/src/_pytest/mark/expression.py
+++ b/src/_pytest/mark/expression.py
@@ -102,10 +102,10 @@ class Scanner:
                         (FILE_NAME, 1, pos + 1, input),
                     )
                 value = input[pos : end_quote_pos + 1]
-                if (backslash_pos := input.find("\\")) != -1:
+                if (backslash_pos := value.find("\\")) != -1:
                     raise SyntaxError(
                         r'escaping with "\" not supported in marker expression',
-                        (FILE_NAME, 1, backslash_pos + 1, input),
+                        (FILE_NAME, 1, pos + backslash_pos + 1, input),
                     )
                 yield Token(TokenType.STRING, value, pos)
                 pos += len(value)

--- a/testing/test_mark_expression.py
+++ b/testing/test_mark_expression.py
@@ -86,6 +86,20 @@ def test_backslash_not_treated_specially() -> None:
         evaluate("\nfoo\n", matcher)
 
 
+def test_backslash_in_identifier_with_string_literal() -> None:
+    r"""Backslashes in identifiers should not cause false rejections when the
+    expression also contains string literals. Regression test for a bug where
+    the scanner searched the entire input for backslashes instead of only the
+    current string literal value."""
+
+    def matcher(name: str, /, **kwargs: str | int | bool | None) -> bool:
+        return {r"\nfoo\n"}.__contains__(name)
+
+    assert evaluate(r'\nfoo\n and mark(x="y")', matcher)
+    assert evaluate(r'mark(x="y") and \nfoo\n', matcher)
+    assert evaluate(r'test\case and mark(x="y")', matcher)
+
+
 @pytest.mark.parametrize(
     ("expr", "column", "message"),
     (

--- a/testing/test_mark_expression.py
+++ b/testing/test_mark_expression.py
@@ -93,7 +93,7 @@ def test_backslash_in_identifier_with_string_literal() -> None:
     current string literal value."""
 
     def matcher(name: str, /, **kwargs: str | int | bool | None) -> bool:
-        return {r"\nfoo\n"}.__contains__(name)
+        return {r"\nfoo\n", r"test\case", "mark"}.__contains__(name)
 
     assert evaluate(r'\nfoo\n and mark(x="y")', matcher)
     assert evaluate(r'mark(x="y") and \nfoo\n', matcher)


### PR DESCRIPTION
The backslash check in the string literal lexer was searching the entire input expression (input.find("\\")) instead of only the current string value (value.find("\\")). This caused false rejections when an identifier containing a backslash appeared in the same expression as a string literal.

For example, pytest -k 'test\nfoo\n and mark(x="y")' would fail with "escaping not supported" even though the backslash is in the identifier, not the string.

The fix:
- Changed input.find("\\") to value.find("\\") so we only check for backslashes inside the string literal
- Adjusted the column offset from backslash_pos + 1 to pos + backslash_pos + 1 so error positions point to the right place

Added a regression test for the case where backslashes in identifiers coexist with string literals in the same expression.

Closes #14474