### PR TITLE
Support generic mappings in assertion comparison

### DIFF
--- a/changelog/14461.bugfix.rst
+++ b/changelog/14461.bugfix.rst
@@ -1,0 +1,2 @@
+Assertion diffs now use mapping-specific output for objects implementing
+:class:`collections.abc.Mapping`, not only concrete :class:`dict` instances.

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -127,8 +127,8 @@ def istext(x: object) -> TypeGuard[str]:
     return isinstance(x, str)
 
 
-def isdict(x: object) -> TypeGuard[dict[object, object]]:
-    return isinstance(x, dict)
+def isdict(x: object) -> TypeGuard[Mapping[object, object]]:
+    return isinstance(x, Mapping)
 
 
 def isset(x: object) -> TypeGuard[set[object] | frozenset[object]]:

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1,7 +1,9 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
+from collections.abc import Mapping
 from collections.abc import MutableSequence
+
 import sys
 import textwrap
 from typing import Any
@@ -718,6 +720,34 @@ class TestAssert_reprcompare:
             "-     'new': 1,",
             "  }",
         ]
+
+    def test_Mapping(self) -> None:
+        # Test comparing with a Mapping implementation that is not a dict subclass.
+        class TestMapping(Mapping[str, int]):
+            def __init__(self, values: dict[str, int]) -> None:
+                self.values = values
+
+            def __getitem__(self, key: str) -> int:
+                return self.values[key]
+
+            def __iter__(self):
+                return iter(self.values)
+
+            def __len__(self) -> int:
+                return len(self.values)
+
+        lines = callequal(
+            TestMapping({"a": 0, "b": 1}),
+            TestMapping({"a": 1, "b": 1}),
+        )
+
+        assert lines is not None
+        assert any(
+            line.startswith("Omitting 1 identical item")
+            for line in lines
+        )
+        assert "Differing items:" in lines
+        assert "{'a': 0} != {'a': 1}" in lines
 
     def test_dict(self) -> None:
         expl = callequal({"a": 0}, {"a": 1})

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from collections.abc import MutableSequence
-
 import sys
 import textwrap
 from typing import Any
@@ -742,10 +741,7 @@ class TestAssert_reprcompare:
         )
 
         assert lines is not None
-        assert any(
-            line.startswith("Omitting 1 identical item")
-            for line in lines
-        )
+        assert any(line.startswith("Omitting 1 identical item") for line in lines)
         assert "Differing items:" in lines
         assert "{'a': 0} != {'a': 1}" in lines
 


### PR DESCRIPTION
## Summary

Support rich assertion comparison output for objects implementing
`collections.abc.Mapping`, not only concrete `dict` instances.

## Motivation

`_compare_eq_dict()` already accepts `Mapping[object, object]`, but the
dispatch logic only recognized actual `dict` instances. As a result,
custom mapping implementations fell back to generic iterable diff output
instead of the more useful mapping-specific explanation.

## Changes

- Broaden the mapping guard in `isdict()` from `dict` to `Mapping`
- Add a regression test using a custom `Mapping` implementation that is
  not a `dict` subclass
- Verify that mapping-specific assertion details are rendered

## Tests

```bash
python -m pytest testing/test_assertion.py -k Mapping
python -m pytest testing/test_assertion.py -k "Mapping or dict"
```

Fixes #14461