### PR TITLE
fix junitxml bin_xml_escape: supplementary plane characters incorrectly escaped

### DIFF
--- a/changelog/14483.bugfix.rst
+++ b/changelog/14483.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``bin_xml_escape`` in junitxml incorrectly escaping supplementary plane characters (U+10000 and above, including emoji) due to using ``\u`` instead of ``\U`` for the supplementary plane range in the ``illegal_xml_re`` regex.

--- a/changelog/14483.bugfix.rst
+++ b/changelog/14483.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed ``bin_xml_escape`` in junitxml incorrectly escaping supplementary plane characters (U+10000 and above, including emoji) due to using ``\u`` instead of ``\U`` for the supplementary plane range in the ``illegal_xml_re`` regex.
+Fixed JUnit XML report incorrectly escaping high Unicode codepoints (supplementary plane characters like emoji) in test failure messages. -- by :user:`EternalRights`

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -55,9 +55,7 @@ def bin_xml_escape(arg: object) -> str:
     # The spec range of valid chars is:
     # Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
     # For an unknown(?) reason, we disallow #x7F (DEL) as well.
-    illegal_xml_re = (
-        "[^\u0009\u000a\u000d\u0020-\u007e\u0080-\ud7ff\ue000-\ufffd\U00010000-\U0010ffff]"
-    )
+    illegal_xml_re = "[^\u0009\u000a\u000d\u0020-\u007e\u0080-\ud7ff\ue000-\ufffd\U00010000-\U0010ffff]"
     return re.sub(illegal_xml_re, repl, str(arg))
 
 

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -56,7 +56,7 @@ def bin_xml_escape(arg: object) -> str:
     # Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
     # For an unknown(?) reason, we disallow #x7F (DEL) as well.
     illegal_xml_re = (
-        "[^\u0009\u000a\u000d\u0020-\u007e\u0080-\ud7ff\ue000-\ufffd\u10000-\u10ffff]"
+        "[^\u0009\u000a\u000d\u0020-\u007e\u0080-\ud7ff\ue000-\ufffd\U00010000-\U0010ffff]"
     )
     return re.sub(illegal_xml_re, repl, str(arg))
 

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1104,9 +1104,6 @@ def test_invalid_xml_escape() -> None:
     # Test some more invalid xml chars, the full range should be
     # tested really but let's just test the edges of the ranges
     # instead.
-    # XXX This only tests low unicode character points for now as
-    #     there are some issues with the testing infrastructure for
-    #     the higher ones.
     # XXX Testing 0xD (\r) is tricky as it overwrites the just written
     #     line in the output, so we skip it too.
     invalid = (
@@ -1121,7 +1118,7 @@ def test_invalid_xml_escape() -> None:
         0xDFFF,
         0xFFFE,
         0x0FFFF,
-    )  # , 0x110000)
+    )
     valid = (0x9, 0xA, 0x20, 0xD, 0xD7FF, 0xE000, 0xFFFD, 0x10000, 0x10FFFF)
 
     for i in invalid:

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1135,13 +1135,6 @@ def test_invalid_xml_escape() -> None:
         assert chr(i) == bin_xml_escape(chr(i))
 
 
-def test_bin_xml_escape_supplementary_plane() -> None:
-    assert bin_xml_escape(chr(0x1F600)) == chr(0x1F600)
-    assert bin_xml_escape("test_😀") == "test_😀"
-    assert bin_xml_escape("test_𠀀") == "test_𠀀"
-    assert bin_xml_escape("test_𝄞") == "test_𝄞"
-
-
 def test_logxml_path_expansion(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     home_tilde = Path(os.path.expanduser("~")).joinpath("test.xml")
     xml_tilde = LogXML(Path("~", "test.xml"), None)

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1122,8 +1122,7 @@ def test_invalid_xml_escape() -> None:
         0xFFFE,
         0x0FFFF,
     )  # , 0x110000)
-    valid = (0x9, 0xA, 0x20)
-    # 0xD, 0xD7FF, 0xE000, 0xFFFD, 0x10000, 0x10FFFF)
+    valid = (0x9, 0xA, 0x20, 0xD, 0xD7FF, 0xE000, 0xFFFD, 0x10000, 0x10FFFF)
 
     for i in invalid:
         got = bin_xml_escape(chr(i))
@@ -1134,6 +1133,13 @@ def test_invalid_xml_escape() -> None:
         assert got == expected
     for i in valid:
         assert chr(i) == bin_xml_escape(chr(i))
+
+
+def test_bin_xml_escape_supplementary_plane() -> None:
+    assert bin_xml_escape(chr(0x1F600)) == chr(0x1F600)
+    assert bin_xml_escape("test_😀") == "test_😀"
+    assert bin_xml_escape("test_𠀀") == "test_𠀀"
+    assert bin_xml_escape("test_𝄞") == "test_𝄞"
 
 
 def test_logxml_path_expansion(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
The `illegal_xml_re` regex in `bin_xml_escape` was using `\u10000-\u10ffff` to cover the supplementary plane range, but Python's `\u` escape only takes 4 hex digits. So `\u10000` was parsed as `\u1000` + `0` and `\u10ffff` as `\u10ff` + `ff`, meaning the entire supplementary plane (U+10000 to U+10FFFF) was missing from the "valid" character set.

This caused all supplementary plane characters to be incorrectly escaped in JUnit XML output -- emoji, CJK Extension B-F, mathematical symbols, etc. For example `bin_xml_escape("test_😀")` returned `"test_#x1F600"` instead of `"test_😀"`.

The fix: change `\u10000-\u10ffff` to `\U00010000-\U0010ffff` (8-digit unicode escape).

Also uncommented the supplementary plane code points in the existing `test_bin_xml_escape` test, and added a dedicated `test_bin_xml_escape_supplementary_plane` test with emoji, CJK Ext B, and musical symbol cases.

Closes #14483