### PR TITLE
docs: clarify hookimpl specname limitation

### DIFF
--- a/changelog/11307.doc.rst
+++ b/changelog/11307.doc.rst
@@ -1,0 +1,1 @@
+Document that ``@pytest.hookimpl(specname=...)`` only works for function names starting with ``pytest_``.

--- a/doc/en/how-to/writing_hook_functions.rst
+++ b/doc/en/how-to/writing_hook_functions.rst
@@ -161,6 +161,16 @@ Here is the order of execution:
 It's possible to use ``tryfirst`` and ``trylast`` also on hook wrappers
 in which case it will influence the ordering of hook wrappers among each other.
 
+.. note::
+
+    pytest only searches for hook implementations whose names start with
+    ``pytest_``.  The ``specname`` argument to ``@pytest.hookimpl`` can be used
+    to give an implementation a different suffix, for example
+    ``pytest_collection_modifyitems_tryfirst``, but the function name still
+    needs to start with ``pytest_``.  A hook implementation named
+    ``my_collection_modifyitems`` is ignored even if it is decorated with
+    ``@pytest.hookimpl(specname="pytest_collection_modifyitems")``.
+
 .. _`declaringhooks`:
 
 Declaring new hooks


### PR DESCRIPTION
Add a note to the hook ordering documentation explaining that `@pytest.hookimpl(specname=...)` still requires implementation function names to start with `pytest_`. This documents the current limitation discussed in gh-11307 and points users toward suffixed hook names such as `pytest_collection_modifyitems_tryfirst`.

Closes #11307

Verification:
- `sphinx-build -W --keep-going -b html doc/en doc/en/_build/html`
- `git diff --check`
