### PR TITLE
docs: clarify stdlib monkeypatch guidance

### DIFF
--- a/changelog/11022.doc.rst
+++ b/changelog/11022.doc.rst
@@ -1,0 +1,1 @@
+Document safer alternatives and scope guidance for monkeypatching standard library functions.

--- a/doc/en/how-to/monkeypatch.rst
+++ b/doc/en/how-to/monkeypatch.rst
@@ -241,7 +241,14 @@ so that any attempts within tests to create http requests will fail.
 .. note::
 
     Mind that patching ``stdlib`` functions and some third-party libraries used by pytest
-    might break pytest itself, therefore in those cases it is recommended to use
+    might break pytest itself. Prefer patching the reference that your code uses
+    instead of patching the original object in the standard library. For example,
+    if your module does ``from os import getcwd``, patch ``mymodule.getcwd``
+    rather than ``os.getcwd``.
+
+    For code that you control, a safer long-term pattern is to make dependencies
+    explicit so they can be passed into the code under test instead of patched
+    globally. When patching a stdlib object is unavoidable, use
     :meth:`MonkeyPatch.context` to limit the patching to the block you want tested:
 
     .. code-block:: python


### PR DESCRIPTION
Document safer patterns for monkeypatching standard library functions:

- prefer patching the reference used by the code under test
- prefer explicit dependencies for code users control
- use `MonkeyPatch.context()` to keep unavoidable stdlib patches narrowly scoped

Closes #11022

Verification:
- `sphinx-build -W --keep-going -b html doc/en doc/en/_build/html`
- `git diff --check`
