### PR TITLE
docs: document doctest fixture parametrization limit

### DIFF
--- a/changelog/13038.doc.rst
+++ b/changelog/13038.doc.rst
@@ -1,0 +1,1 @@
+Document that doctests do not support parametrized fixtures, including parametrized autouse fixtures.

--- a/doc/en/how-to/doctest.rst
+++ b/doc/en/how-to/doctest.rst
@@ -224,6 +224,12 @@ unless explicitly configured by :confval:`python_files`.
 Also, the :ref:`usefixtures <usefixtures>` mark and fixtures marked as :ref:`autouse <autouse>` are supported
 when executing text doctest files.
 
+Doctests do not support fixtures that depend on parametrization, because doctest
+collection does not perform the same test generation as normal test functions.
+This includes parametrized autouse fixtures. If you need to run doctests against
+multiple backends or configurations, consider moving those checks into normal
+test functions or a dedicated doctest plugin.
+
 
 .. _`doctest_namespace`:
 


### PR DESCRIPTION
Document that doctests do not support fixtures that depend on parametrization, including parametrized autouse fixtures, because doctest collection does not perform normal test generation.

Closes #13038

Verification:
- `sphinx-build -W --keep-going -b html doc/en doc/en/_build/html`
- `git diff --check`
