### PR TITLE
raises: Fix KeyError when caplog handler is missing

### DIFF
--- a/changelog/14488.bugfix.rst
+++ b/changelog/14488.bugfix.rst
@@ -1,0 +1,1 @@
+Raise a descriptive :class:`RuntimeError` instead of a :class:`KeyError` when accessing ``caplog.handler`` before it has been initialized.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -449,7 +449,10 @@ class LogCaptureFixture:
     @property
     def handler(self) -> LogCaptureHandler:
         """Get the logging handler used by the fixture."""
-        return self._item.stash[caplog_handler_key]
+        handler = self._item.stash.get(caplog_handler_key, None)
+        if handler is None:
+            raise RuntimeError("caplog handler was not initialized for this test item")
+        return handler
 
     def get_records(
         self, when: Literal["setup", "call", "teardown"]

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -511,7 +511,7 @@ def test_log_report_captures_according_to_config_option_upon_failure(
     assert result.ret == 1
 
 
-def test_caplog_missing_handler_raises_error(caplog):
+def test_caplog_missing_handler_raises_error(caplog: pytest.LogCaptureFixture) -> None:
     del caplog._item.stash[caplog_handler_key]
 
     with pytest.raises(RuntimeError, match="caplog handler was not initialized"):

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from collections.abc import Iterator
 import logging
 
-from _pytest.logging import caplog_handler_key, caplog_records_key
+from _pytest.logging import caplog_handler_key
+from _pytest.logging import caplog_records_key
 from _pytest.pytester import Pytester
 import pytest
 
@@ -508,6 +509,7 @@ def test_log_report_captures_according_to_config_option_upon_failure(
         ["*Print message*", "*INFO log message*", "*WARNING log message*"]
     )
     assert result.ret == 1
+
 
 def test_caplog_missing_handler_raises_error(caplog):
     del caplog._item.stash[caplog_handler_key]

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 import logging
 
-from _pytest.logging import caplog_records_key
+from _pytest.logging import caplog_handler_key, caplog_records_key
 from _pytest.pytester import Pytester
 import pytest
 
@@ -508,3 +508,9 @@ def test_log_report_captures_according_to_config_option_upon_failure(
         ["*Print message*", "*INFO log message*", "*WARNING log message*"]
     )
     assert result.ret == 1
+
+def test_caplog_missing_handler_raises_error(caplog):
+    del caplog._item.stash[caplog_handler_key]
+
+    with pytest.raises(RuntimeError, match="caplog handler was not initialized"):
+        _ = caplog.handler


### PR DESCRIPTION
# Summary
Closes #14436

Raise a descriptive `RuntimeError` instead of an opaque `KeyError` when accessing `caplog.handler` before it has been initialised.

## Problem

Accessing `caplog.handler` when the handler has not been set up raised a confusing `KeyError` with a raw `StashKey` object address:


This gives users no useful information about what went wrong.

## Solution

Modified `LogCaptureFixture.handler` to use `.get()` on the stash and raise a descriptive `RuntimeError` if the handler is `None`:

```python
@property
def handler(self) -> LogCaptureHandler:
    """Get the logging handler used by the fixture."""
    handler = self._item.stash.get(caplog_handler_key, None)
    if handler is None:
        raise RuntimeError("caplog handler was not initialized for this test item")
    return handler
```

## Test Cases

Test that accessing caplog.handler after manually removing it from the stash raises a RuntimeError with a descriptive message:

```python 
def test_caplog_missing_handler_raises_error(caplog):
    del caplog._item.stash[caplog_handler_key]

    with pytest.raises(RuntimeError, match="caplog handler was not initialized"):
        _ = caplog.handler
