### PR TITLE
Fix junitxml count for teardown errors

### DIFF
--- a/changelog/3850.bugfix.rst
+++ b/changelog/3850.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the JUnit XML ``tests`` count for tests that pass during call but fail during teardown.

--- a/changelog/3850.bugfix.rst
+++ b/changelog/3850.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed the JUnit XML ``tests`` count for tests that pass during call but fail during teardown.
+Fixed JUnit XML report: the ``tests`` attribute of the ``<testsuite>`` element now always matches the number of ``<testcase>`` elements in the file. In some cases (test passes but fails during teardown) the ``tests`` attribute would report an incorrect number of testcases in the XML file.

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -579,6 +579,11 @@ class LogXML:
                     # schema.
                     self.finalize(close_report)
                     self.cnt_double_fail_tests += 1
+                elif (
+                    report.nodeid,
+                    getattr(report, "node", None),
+                ) in self.node_reporters:
+                    self.cnt_double_fail_tests += 1
             reporter = self._opentestcase(report)
             if report.when == "call":
                 reporter.append_failure(report)

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -578,14 +578,17 @@ class LogXML:
                     # call and error in teardown in order to follow junit
                     # schema.
                     self.finalize(close_report)
-                elif (
-                    report.nodeid,
-                    getattr(report, "node", None),
-                ) in self.node_reporters:
+                else:
                     # A passing call with a teardown error creates separate
                     # terminal reports, but JUnit XML keeps one testcase
                     # element for that item (#3850).
-                    self.cnt_double_fail_tests += 1
+                    self.cnt_double_fail_tests += int(
+                        (
+                            report.nodeid,
+                            getattr(report, "node", None),
+                        )
+                        in self.node_reporters
+                    )
             reporter = self._opentestcase(report)
             if report.when == "call":
                 reporter.append_failure(report)

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -582,8 +582,9 @@ class LogXML:
                     report.nodeid,
                     getattr(report, "node", None),
                 ) in self.node_reporters:
-                    # A passing call with a teardown error creates two terminal
-                    # reports, but they share one testcase element (#3850).
+                    # A passing call with a teardown error creates separate
+                    # terminal reports, but JUnit XML keeps one testcase
+                    # element for that item (#3850).
                     self.cnt_double_fail_tests += 1
             reporter = self._opentestcase(report)
             if report.when == "call":

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -578,11 +578,12 @@ class LogXML:
                     # call and error in teardown in order to follow junit
                     # schema.
                     self.finalize(close_report)
-                    self.cnt_double_fail_tests += 1
                 elif (
                     report.nodeid,
                     getattr(report, "node", None),
                 ) in self.node_reporters:
+                    # A passing call with a teardown error creates two terminal
+                    # reports, but they share one testcase element (#3850).
                     self.cnt_double_fail_tests += 1
             reporter = self._opentestcase(report)
             if report.when == "call":

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -52,6 +52,8 @@ class RunAndParse:
             with xml_path.open(encoding="utf-8") as f:
                 self.schema.validate(f)
         xmldoc = minidom.parse(str(xml_path))
+        # Ensure the tests attribute of the ``<testsuite>`` element
+        # always matches the number of ``<testcase>`` elements (#3580). 
         doc = DomDocument(xmldoc)
         testcase_nodes = doc.find_by_tag("testcase")
         test_suite_node = doc.get_first_by_tag("testsuite")

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -39,7 +39,10 @@ class RunAndParse:
         self.schema = schema
 
     def __call__(
-        self, *args: str | os.PathLike[str], family: str | None = "xunit1"
+        self,
+        *args: str | os.PathLike[str],
+        family: str | None = "xunit1",
+        suite_name: str = "pytest",
     ) -> tuple[RunResult, DomDocument]:
         if family:
             args = ("-o", "junit_family=" + family, *args)
@@ -52,7 +55,7 @@ class RunAndParse:
         doc = DomDocument(xmldoc)
         testcase_nodes = doc.find_by_tag("testcase")
         test_suite_node = doc.get_first_by_tag("testsuite")
-        test_suite_node.assert_attr(tests=len(testcase_nodes))
+        test_suite_node.assert_attr(name=suite_name, tests=len(testcase_nodes))
         return result, doc
 
 
@@ -1712,7 +1715,7 @@ def test_set_suite_name(
             pass
     """
     )
-    result, dom = run_and_parse(family=xunit_family)
+    result, dom = run_and_parse(family=xunit_family, suite_name=expected)
     assert result.ret == 0
     node = dom.get_first_by_tag("testsuite")
     node.assert_attr(name=expected)

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -53,7 +53,7 @@ class RunAndParse:
                 self.schema.validate(f)
         xmldoc = minidom.parse(str(xml_path))
         # Ensure the tests attribute of the ``<testsuite>`` element
-        # always matches the number of ``<testcase>`` elements (#3580). 
+        # always matches the number of ``<testcase>`` elements (#3580).
         doc = DomDocument(xmldoc)
         testcase_nodes = doc.find_by_tag("testcase")
         test_suite_node = doc.get_first_by_tag("testsuite")

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -383,6 +383,7 @@ class TestPython:
         result, dom = run_and_parse(family=xunit_family)
         assert result.ret
         node = dom.get_first_by_tag("testsuite")
+        node.assert_attr(errors=1, tests=1)
         tnode = node.get_first_by_tag("testcase")
         tnode.assert_attr(classname="test_teardown_error", name="test_function")
         fnode = tnode.get_first_by_tag("error")

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -49,7 +49,11 @@ class RunAndParse:
             with xml_path.open(encoding="utf-8") as f:
                 self.schema.validate(f)
         xmldoc = minidom.parse(str(xml_path))
-        return result, DomDocument(xmldoc)
+        doc = DomDocument(xmldoc)
+        testcase_nodes = doc.find_by_tag("testcase")
+        test_suite_node = doc.get_first_by_tag("testsuite")
+        test_suite_node.assert_attr(tests=len(testcase_nodes))
+        return result, doc
 
 
 @pytest.fixture
@@ -390,58 +394,26 @@ class TestPython:
         fnode.assert_attr(message='failed on teardown with "ValueError: Error reason"')
         assert "ValueError" in fnode.toxml()
 
+    @parametrize_families
     def test_teardown_error_after_pass_counts_as_one_test(
-        self, pytester: Pytester
+        self, pytester: Pytester, run_and_parse: RunAndParse, xunit_family: str
     ) -> None:
-        path = pytester.path.joinpath("test_teardown_error_after_pass.xml")
-        log = LogXML(str(path), None)
-        call_report = TestReport(
-            nodeid="test_mod.py::test_function",
-            location=("test_mod.py", 1, "test_function"),
-            keywords={},
-            outcome="passed",
-            longrepr=None,
-            when="call",
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.fixture
+            def arg():
+                yield
+                raise ValueError('Error reason')
+            def test_function(arg):
+                pass
+        """
         )
-        teardown_report = TestReport(
-            nodeid=call_report.nodeid,
-            location=call_report.location,
-            keywords={},
-            outcome="failed",
-            longrepr="ValueError: Error reason",
-            when="teardown",
-        )
-
-        log.pytest_sessionstart()
-        log.pytest_runtest_logreport(call_report)
-        log.pytest_runtest_logreport(teardown_report)
-        log.pytest_sessionfinish()
-
-        testsuite = minidom.parse(str(path)).getElementsByTagName("testsuite")[0]
-        assert testsuite.getAttribute("errors") == "1"
-        assert testsuite.getAttribute("tests") == "1"
-
-    def test_teardown_error_without_open_report_counts_as_one_test(
-        self, pytester: Pytester
-    ) -> None:
-        path = pytester.path.joinpath("test_teardown_error_without_open_report.xml")
-        log = LogXML(str(path), None)
-        teardown_report = TestReport(
-            nodeid="test_mod.py::test_function",
-            location=("test_mod.py", 1, "test_function"),
-            keywords={},
-            outcome="failed",
-            longrepr="ValueError: Error reason",
-            when="teardown",
-        )
-
-        log.pytest_sessionstart()
-        log.pytest_runtest_logreport(teardown_report)
-        log.pytest_sessionfinish()
-
-        testsuite = minidom.parse(str(path)).getElementsByTagName("testsuite")[0]
-        assert testsuite.getAttribute("errors") == "1"
-        assert testsuite.getAttribute("tests") == "1"
+        result, dom = run_and_parse(family=xunit_family)
+        assert result.ret
+        node = dom.get_first_by_tag("testsuite")
+        node.assert_attr(errors=1, tests=1)
 
     @parametrize_families
     def test_call_failure_teardown_error(
@@ -462,7 +434,7 @@ class TestPython:
         result, dom = run_and_parse(family=xunit_family)
         assert result.ret
         node = dom.get_first_by_tag("testsuite")
-        node.assert_attr(errors=1, failures=1, tests=1)
+        node.assert_attr(errors=1, failures=1, tests=2)
         first, second = dom.find_by_tag("testcase")
         assert first
         assert second

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -390,6 +390,59 @@ class TestPython:
         fnode.assert_attr(message='failed on teardown with "ValueError: Error reason"')
         assert "ValueError" in fnode.toxml()
 
+    def test_teardown_error_after_pass_counts_as_one_test(
+        self, pytester: Pytester
+    ) -> None:
+        path = pytester.path.joinpath("test_teardown_error_after_pass.xml")
+        log = LogXML(str(path), None)
+        call_report = TestReport(
+            nodeid="test_mod.py::test_function",
+            location=("test_mod.py", 1, "test_function"),
+            keywords={},
+            outcome="passed",
+            longrepr=None,
+            when="call",
+        )
+        teardown_report = TestReport(
+            nodeid=call_report.nodeid,
+            location=call_report.location,
+            keywords={},
+            outcome="failed",
+            longrepr="ValueError: Error reason",
+            when="teardown",
+        )
+
+        log.pytest_sessionstart()
+        log.pytest_runtest_logreport(call_report)
+        log.pytest_runtest_logreport(teardown_report)
+        log.pytest_sessionfinish()
+
+        testsuite = minidom.parse(str(path)).getElementsByTagName("testsuite")[0]
+        assert testsuite.getAttribute("errors") == "1"
+        assert testsuite.getAttribute("tests") == "1"
+
+    def test_teardown_error_without_open_report_counts_as_one_test(
+        self, pytester: Pytester
+    ) -> None:
+        path = pytester.path.joinpath("test_teardown_error_without_open_report.xml")
+        log = LogXML(str(path), None)
+        teardown_report = TestReport(
+            nodeid="test_mod.py::test_function",
+            location=("test_mod.py", 1, "test_function"),
+            keywords={},
+            outcome="failed",
+            longrepr="ValueError: Error reason",
+            when="teardown",
+        )
+
+        log.pytest_sessionstart()
+        log.pytest_runtest_logreport(teardown_report)
+        log.pytest_sessionfinish()
+
+        testsuite = minidom.parse(str(path)).getElementsByTagName("testsuite")[0]
+        assert testsuite.getAttribute("errors") == "1"
+        assert testsuite.getAttribute("tests") == "1"
+
     @parametrize_families
     def test_call_failure_teardown_error(
         self, pytester: Pytester, run_and_parse: RunAndParse, xunit_family: str

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -398,27 +398,6 @@ class TestPython:
         assert "ValueError" in fnode.toxml()
 
     @parametrize_families
-    def test_teardown_error_after_pass_counts_as_one_test(
-        self, pytester: Pytester, run_and_parse: RunAndParse, xunit_family: str
-    ) -> None:
-        pytester.makepyfile(
-            """
-            import pytest
-
-            @pytest.fixture
-            def arg():
-                yield
-                raise ValueError('Error reason')
-            def test_function(arg):
-                pass
-        """
-        )
-        result, dom = run_and_parse(family=xunit_family)
-        assert result.ret
-        node = dom.get_first_by_tag("testsuite")
-        node.assert_attr(errors=1, tests=1)
-
-    @parametrize_families
     def test_call_failure_teardown_error(
         self, pytester: Pytester, run_and_parse: RunAndParse, xunit_family: str
     ) -> None:


### PR DESCRIPTION
Fixes #3850

## Summary
- correct the JUnit XML `tests` count when a test passes during call but fails during teardown
- assert in `run_and_parse` that the testsuite `tests` attribute matches the emitted `<testcase>` nodes
- keep call-failure plus teardown-error as separate testcase nodes, while the pass-plus-teardown-error path stays one testcase node
- add a changelog entry

## Tests
- `.venv/bin/python -m pytest testing/test_junitxml.py -q`
- `.venv/bin/pre-commit run --color never --files src/_pytest/junitxml.py testing/test_junitxml.py changelog/3850.bugfix.rst`
- `git diff --check`

AI assistance was used while iterating on the patch and tests. I reviewed the change and can explain it.
