### PR TITLE
Handle group-only RaisesGroup checks safely

### DIFF
--- a/src/_pytest/raises.py
+++ b/src/_pytest/raises.py
@@ -1198,10 +1198,9 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
                 cast(str, self._fail_reason) + f" on the {type(exception).__name__}"
             )
             subexception_matches_check = False
-            if (
-                len(actual_exceptions) == len(self.expected_exceptions) == 1
-                and isinstance(expected := self.expected_exceptions[0], type)
-            ):
+            if len(actual_exceptions) == len(
+                self.expected_exceptions
+            ) == 1 and isinstance(expected := self.expected_exceptions[0], type):
                 old_reason = self._fail_reason
                 try:
                     # We probe the contained exception to improve the error message,

--- a/src/_pytest/raises.py
+++ b/src/_pytest/raises.py
@@ -1197,12 +1197,24 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
             reason = (
                 cast(str, self._fail_reason) + f" on the {type(exception).__name__}"
             )
+            subexception_matches_check = False
             if (
                 len(actual_exceptions) == len(self.expected_exceptions) == 1
                 and isinstance(expected := self.expected_exceptions[0], type)
-                # we explicitly break typing here :)
-                and self._check_check(actual_exceptions[0])  # type: ignore[arg-type]
             ):
+                old_reason = self._fail_reason
+                try:
+                    # We probe the contained exception to improve the error message,
+                    # but this heuristic must not break matching if the check only
+                    # supports exception groups.
+                    subexception_matches_check = self._check_check(
+                        actual_exceptions[0]  # type: ignore[arg-type]
+                    )
+                except BaseException:
+                    subexception_matches_check = False
+                finally:
+                    self._fail_reason = old_reason
+            if subexception_matches_check:
                 self._fail_reason = reason + (
                     f", but did return True for the expected {self._repr_expected(expected)}."
                     f" You might want RaisesGroup(RaisesExc({expected.__name__}, check=<...>))"

--- a/testing/python/raises_group.py
+++ b/testing/python/raises_group.py
@@ -436,6 +436,20 @@ def test_check() -> None:
         raise ExceptionGroup("", (ValueError(),))
 
 
+def test_check_does_not_probe_subexception_with_group_only_check() -> None:
+    def has_multiple_exceptions(exc_group: ExceptionGroup[ValueError]) -> bool:
+        return len(exc_group.exceptions) > 1
+
+    has_multiple_exceptions_repr = repr_callable(has_multiple_exceptions)
+    with (
+        fails_raises_group(
+            f"check {has_multiple_exceptions_repr} did not return True on the ExceptionGroup"
+        ),
+        RaisesGroup(ValueError, check=has_multiple_exceptions),
+    ):
+        raise ExceptionGroup("", (ValueError(),))
+
+
 def test_unwrapped_match_check() -> None:
     def my_check(e: object) -> bool:  # pragma: no cover
         return True


### PR DESCRIPTION
## Summary
- avoid crashing when `RaisesGroup(check=...)` uses a callable that only accepts exception groups
- keep the existing helpful suggestion when the check also matches the contained exception
- add a regression test for the reported `AttributeError` case

Closes #14324