### PR TITLE
Improve assertion diffs for mapping objects

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -205,6 +205,7 @@ Hugo van Kemenade
 Hui Wang (coldnight)
 Ian Bicking
 Ian Lesperance
+Ilya Abdolmanafi
 Ilya Konstantinov
 Ionuț Turturică
 Isaac Virshup

--- a/changelog/14461.improvement.rst
+++ b/changelog/14461.improvement.rst
@@ -1,0 +1,1 @@
+Improved assertion failure explanations for equality comparisons between mapping objects that are not ``dict`` instances.

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -156,8 +156,8 @@ def istext(x: object) -> TypeGuard[str]:
     return isinstance(x, str)
 
 
-def isdict(x: object) -> TypeGuard[dict[object, object]]:
-    return isinstance(x, dict)
+def ismapping(x: object) -> TypeGuard[Mapping[object, object]]:
+    return isinstance(x, Mapping)
 
 
 def isset(x: object) -> TypeGuard[set[object] | frozenset[object]]:
@@ -323,8 +323,8 @@ def _compare_eq_any(
             explanation = _compare_eq_sequence(left, right, highlighter, verbose)
         elif isset(left) and isset(right):
             explanation = _compare_eq_set(left, right, highlighter, verbose)
-        elif isdict(left) and isdict(right):
-            explanation = _compare_eq_dict(left, right, highlighter, verbose)
+        elif ismapping(left) and ismapping(right):
+            explanation = _compare_eq_mapping(left, right, highlighter, verbose)
 
         if isiterable(left) and isiterable(right):
             expl = _compare_eq_iterable(left, right, highlighter, verbose)
@@ -576,7 +576,7 @@ def _set_one_sided_diff(
     return explanation
 
 
-def _compare_eq_dict(
+def _compare_eq_mapping(
     left: Mapping[object, object],
     right: Mapping[object, object],
     highlighter: _HighlightFunc,

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -899,7 +899,7 @@ class TestAssert_reprcompare:
             def __iter__(self) -> Iterator[str]:
                 return iter(self._values)
 
-            def __len__(self) -> int:
+            def __len__(self) -> int:  # pragma: no cover
                 return len(self._values)
 
             def __repr__(self) -> str:

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1,6 +1,8 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
+from collections.abc import Iterator
+from collections.abc import Mapping
 from collections.abc import MutableSequence
 import sys
 import textwrap
@@ -884,6 +886,38 @@ class TestAssert_reprcompare:
             "?      ^   ^",
             "+     'c': 2,",
             "  }",
+        ]
+
+    def test_mapping_different_items(self) -> None:
+        class SimpleMapping(Mapping[str, int]):
+            def __init__(self, values: dict[str, int]) -> None:
+                self._values = values
+
+            def __getitem__(self, key: str) -> int:
+                return self._values[key]
+
+            def __iter__(self) -> Iterator[str]:
+                return iter(self._values)
+
+            def __len__(self) -> int:
+                return len(self._values)
+
+            def __repr__(self) -> str:
+                return f"SimpleMapping({self._values!r})"
+
+        lines = callequal(
+            SimpleMapping({"a": 0, "b": 1}),
+            SimpleMapping({"a": 1, "b": 1, "c": 2}),
+        )
+
+        assert lines is not None
+        assert lines[2:] == [
+            "Omitting 1 identical items, use -vv to show",
+            "Differing items:",
+            "{'a': 0} != {'a': 1}",
+            "Right contains 1 more item:",
+            "{'c': 2}",
+            "Use -v to get more diff",
         ]
 
     def test_sequence_different_items(self) -> None:


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
Summary:
Improve equality assertion explanations for objects implementing `collections.abc.Mapping`, not only concrete `dict` instances.

Previously, non-dict mapping objects could fall through to the generic iterable comparison path, even though the existing mapping comparison logic already works with the `Mapping` protocol. This updates the dispatch check accordingly and renames the internal helper from dict-specific wording to mapping-specific wording.

Closes #14461.

Details:
This keeps the change intentionally narrow:

- use `Mapping` for the assertion comparison dispatch
- rename the internal helper to match the broader behavior
- add a focused regression test with a small custom `Mapping`
- add a changelog fragment
- add myself to `AUTHORS`

I avoided adding coverage for third-party mapping libraries here, since those can have different key/value semantics and would make this PR broader than necessary.

Tests:
```bash
PYTHONPATH=src .venv/bin/python -m pytest \
  testing/test_assertion.py::TestAssert_reprcompare::test_dict \
  testing/test_assertion.py::TestAssert_reprcompare::test_dict_omitting \
  testing/test_assertion.py::TestAssert_reprcompare::test_dict_omitting_with_verbosity_1 \
  testing/test_assertion.py::TestAssert_reprcompare::test_dict_omitting_with_verbosity_2 \
  testing/test_assertion.py::TestAssert_reprcompare::test_dict_different_items \
  testing/test_assertion.py::TestAssert_reprcompare::test_mapping_different_items \
  -q -s
```

Result: 6 passed

```bash
PYTHONPATH=src .venv/bin/python -m pytest \
  testing/test_assertion.py::TestAssert_reprcompare \
  -k "dict or mapping" \
  -q -s
```

Result: 8 passed, 34 deselected