### PR TITLE
fix: use node= instead of deprecated nodeid= in unittest skip fixture

### DIFF
--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -190,7 +190,7 @@ class UnitTestCase(Class):
         self.session._fixturemanager._register_fixture(
             name=f"_unittest_skip_fixture_{cls.__qualname__}",
             func=unittest_skip_fixture,
-            nodeid=self.nodeid,
+            node=self,
             scope="class",
             autouse=True,
         )


### PR DESCRIPTION
## Summary

`main` is red on every platform since #14210 landed. The PR was written in February against the old `_register_fixture(nodeid=...)` API, but commit 121d7a42a deprecated that path yesterday in favor of `node=`. The PR was approved before that refactor and never re-rebased, so the regression landed unseen — its own CI run was cancelled by the doc-PR merges that immediately followed.

## Root cause

`_register_unittest_skip_fixture` registers an autouse fixture with `nodeid=self.nodeid`, which now hits the legacy string-baseid path. That path scopes the fixture by string prefix and mis-attributes it relative to subclasses of a `@unittest.skip`-decorated class — so the skip fixture never preempts the inherited `setUp` / `setUpClass`, and tests that should report `1 skipped` instead error out.

Three existing tests are broken on every Python/OS:

- `test_setup_inheritance_skipping[test_setup_skip.py-1 skipped]`
- `test_setup_inheritance_skipping[test_setup_skip_class.py-1 skipped]`
- `test_pdb_teardown_skipped_for_classes[@unittest.skip]`

The two existing `_register_unittest_setUp*` fixtures in the same file already use `node=self`. This PR aligns the new fixture with that convention.

## Test plan

- [x] `pytest testing/test_unittest.py` — 71 passed, 9 skipped locally
- [x] The three previously failing tests now pass
- [x] No changelog entry — fixes an unreleased regression from #14210 (per CONTRIBUTING: "may skip … if the change doesn't affect the documented behaviour of pytest")

🤖 Generated with [Claude Code](https://claude.com/claude-code)