### PR TITLE
Add regression test for get_user() OSError handling

### DIFF
--- a/changelog/13835.bugfix.rst
+++ b/changelog/13835.bugfix.rst
@@ -1,1 +1,1 @@
-Added regression test ensuring :func:`get_user` returns ``None`` when :func:`getpass.getuser` raises :exc:`OSError` on Python 3.13+ -- #13835.
+Added regression test ensuring ``get_user`` returns ``None`` when ``getpass.getuser`` raises ``OSError`` on Python 3.13+ -- #13835.

--- a/changelog/13835.bugfix.rst
+++ b/changelog/13835.bugfix.rst
@@ -1,1 +1,0 @@
-Added regression test ensuring ``get_user`` returns ``None`` when ``getpass.getuser`` raises ``OSError`` on Python 3.13+ -- #13835.

--- a/changelog/13835.bugfix.rst
+++ b/changelog/13835.bugfix.rst
@@ -1,0 +1,1 @@
+Added regression test ensuring :func:`get_user` returns ``None`` when :func:`getpass.getuser` raises :exc:`OSError` on Python 3.13+ -- #13835.

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -716,6 +716,7 @@ def test_tmp_path_factory_doesnt_follow_symlinks(
     with pytest.raises(OSError, match=r"temporary directory .* is a symbolic link"):
         tmp_factory.getbasetemp()
 
+
 def test_get_user_handles_getpass_oserror(monkeypatch: MonkeyPatch) -> None:
     """Regression test: get_user() should return None when getpass.getuser()
     raises OSError (Python 3.13+ behavior, #13835)."""

--- a/testing/test_tmpdir.py
+++ b/testing/test_tmpdir.py
@@ -715,3 +715,14 @@ def test_tmp_path_factory_doesnt_follow_symlinks(
     tmp_factory = TempPathFactory(None, 3, "all", lambda *args: None, _ispytest=True)
     with pytest.raises(OSError, match=r"temporary directory .* is a symbolic link"):
         tmp_factory.getbasetemp()
+
+def test_get_user_handles_getpass_oserror(monkeypatch: MonkeyPatch) -> None:
+    """Regression test: get_user() should return None when getpass.getuser()
+    raises OSError (Python 3.13+ behavior, #13835)."""
+    import getpass
+
+    def _raise_oserror():
+        raise OSError("No username set in the environment")
+
+    monkeypatch.setattr(getpass, "getuser", _raise_oserror)
+    assert get_user() is None


### PR DESCRIPTION
Was looking at #13835 and noticed the fix was already in main from #11875 but there wasn't an explicit test for the exact scenario - getpass.getuser() raising OSError. On Python 3.13+ this is the new default behaviour when no username can be derived.

Added a quick monkeypatch test for it.