### PR TITLE
[refactor] Avoid calling ``_as_numpy_array`` twice in ``approx``

### DIFF
--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -881,8 +881,8 @@ def approx(
         cls: type[ApproxBase] = ApproxDecimal
     elif isinstance(expected, Mapping):
         cls = ApproxMapping
-    elif _is_numpy_array(expected):
-        expected = _as_numpy_array(expected)
+    elif (np_array := _as_numpy_array(expected)) is not None:
+        expected = np_array
         cls = ApproxNumpy
     elif _is_sequence_like(expected):
         cls = ApproxSequenceLike
@@ -903,14 +903,6 @@ def _is_sequence_like(expected: object) -> bool:
         and isinstance(expected, Sized)
         and not isinstance(expected, str | bytes)
     )
-
-
-def _is_numpy_array(obj: object) -> bool:
-    """
-    Return true if the given object is implicitly convertible to ndarray,
-    and numpy is already imported.
-    """
-    return _as_numpy_array(obj) is not None
 
 
 def _as_numpy_array(obj: object) -> ndarray | None:


### PR DESCRIPTION
``_is_numpy_array`` was a thin wrapper around ``_as_numpy_array(obj) is not None`` with a single caller in ``approx``. The caller then immediately called ``_as_numpy_array(expected)`` again to get the converted array, doing the work twice.

Inline the check with a walrus assignment so the conversion runs once, and drop ``_is_numpy_array`` since the only caller is gone.

(Discovered while searching for possible conversion to match case.)