### PR TITLE
[refactor] Use match case in ``_get_auto_indent``

### DIFF
--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -180,27 +180,24 @@ class PercentStyleMultiline(logging.PercentStyle):
             0 (auto-indent turned off) or
             >0 (explicitly set indentation position).
         """
-        if auto_indent_option is None:
-            return 0
-        elif isinstance(auto_indent_option, bool):
-            if auto_indent_option:
+        match auto_indent_option:
+            case None | False:
+                return 0
+            case True:
                 return -1
-            else:
-                return 0
-        elif isinstance(auto_indent_option, int):
-            return int(auto_indent_option)
-        elif isinstance(auto_indent_option, str):
-            try:
+            case int():
                 return int(auto_indent_option)
-            except ValueError:
-                pass
-            try:
-                if _strtobool(auto_indent_option):
-                    return -1
-            except ValueError:
+            case str():
+                try:
+                    return int(auto_indent_option)
+                except ValueError:
+                    pass
+                try:
+                    if _strtobool(auto_indent_option):
+                        return -1
+                except ValueError:
+                    return 0
                 return 0
-
-        return 0
 
     def format(self, record: logging.LogRecord) -> str:
         if "\n" in record.message:

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -186,7 +186,7 @@ class PercentStyleMultiline(logging.PercentStyle):
             case True:
                 return -1
             case int():
-                return int(auto_indent_option)
+                return auto_indent_option
             case str():
                 try:
                     return int(auto_indent_option)


### PR DESCRIPTION
Convert the ``isinstance`` chain in the ``--log-auto-indent`` value parser. ``case None | False:`` consolidates the two "off" cases and ``case True:`` replaces the nested ``if auto_indent_option: ... else: ...`` so the bool/None dispatch is fully declarative. ``case True:`` must come before ``case int():`` because ``bool`` subclasses ``int``.

The trailing ``return 0`` is dropped because the parameter is typed ``int | str | bool | None`` and the cases are exhaustive.
