### PR TITLE
Clarify request fixture in indirect parametrization docs

### DIFF
--- a/changelog/13155.doc.rst
+++ b/changelog/13155.doc.rst
@@ -1,0 +1,1 @@
+Clarified how the ``request`` fixture provides indirect parametrization values via ``request.param``.

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -370,6 +370,11 @@ test:
     def test_indirect(fixt):
         assert len(fixt) == 3
 
+The ``request`` argument used by the fixture is pytest's built-in
+:py:class:`FixtureRequest <pytest.FixtureRequest>` fixture. For indirect
+parametrization, the value supplied to the test parameter is passed to the
+fixture and made available as ``request.param``.
+
 This can be used, for example, to do more expensive setup at test run time in
 the fixture, rather than having to run those setup steps at collection time.
 

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -370,13 +370,18 @@ test:
     def test_indirect(fixt):
         assert len(fixt) == 3
 
-The ``request`` argument used by the fixture is pytest's built-in
-:py:class:`FixtureRequest <pytest.FixtureRequest>` fixture. For indirect
-parametrization, the value supplied to the test parameter is passed to the
-fixture and made available as ``request.param``.
 
 This can be used, for example, to do more expensive setup at test run time in
 the fixture, rather than having to run those setup steps at collection time.
+
+.. note::
+
+    The ``request`` argument used by the fixture is pytest's built-in
+    :py:class:`FixtureRequest <pytest.FixtureRequest>` fixture. For indirect
+    parametrization, the value supplied to the test parameter is passed to the
+    fixture and made available as ``request.param``.
+
+    For more information, see :ref:`fixture-parametrize`.
 
 .. regendoc:wipe
 


### PR DESCRIPTION
## Summary
- clarify that `request` in the indirect parametrization example is pytest's built-in `FixtureRequest` fixture
- explain that indirect parameter values are exposed to the fixture via `request.param`

Closes #13155.

## Checks
- `git diff --check`
- `uvx tox -e docs -- doc/en/example/parametrize.rst`