### PR TITLE
Fix module fixtures with --doctest-modules

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -334,6 +334,7 @@ Mike Fiedler (miketheman)
 Mike Hoyle (hoylemd)
 Mike Lundy
 Milan Lesnek
+minbang930
 Miro Hrončok
 Mulat Mekonen
 mrbean-bremen

--- a/changelog/14533.breaking.rst
+++ b/changelog/14533.breaking.rst
@@ -1,0 +1,8 @@
+When using :option:`--doctest-modules`, autouse fixtures with ``module``, ``package`` or ``session`` scope that are defined inline in Python test modules (not plugins or conftests) will now possibly execute twice.
+
+If this is undesirable, move the fixture definition to a ``conftest.py`` file if possible.
+
+Technical explanation for those interested:
+When using `--doctest-modules`, pytest possibly collects Python modules twice, once as :class:`pytest.Module` and once as a ``DoctestModule`` (depending on the configuration).
+Due to improvements in pytest's fixture implementation, if e.g. the ``DoctestModule`` collects a fixture, it is now visible to it only, and not to the ``Module``.
+This means that both need to register the fixtures independently.

--- a/doc/en/how-to/doctest.rst
+++ b/doc/en/how-to/doctest.rst
@@ -42,7 +42,7 @@ By default, pytest will collect ``test*.txt`` files looking for doctest directiv
 can pass additional globs using the :option:`--doctest-glob` option (multi-allowed).
 
 In addition to text files, you can also execute doctests directly from docstrings of your classes
-and functions, including from test modules:
+and functions, including from test modules, using the :option:`--doctest-modules` option:
 
 .. code-block:: python
 
@@ -223,6 +223,9 @@ unless explicitly configured by :confval:`python_files`.
 
 Also, the :ref:`usefixtures <usefixtures>` mark and fixtures marked as :ref:`autouse <autouse>` are supported
 when executing text doctest files.
+
+Python doctest modules are collected independently from Python test files.
+Fixture scope is not shared between the two.
 
 Doctests do not support fixtures that depend on parametrization, because doctest
 collection does not perform the same test generation as normal test functions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -377,6 +377,7 @@ testpaths = [
 ]
 norecursedirs = [
     "testing/example_scripts",
+    "testing/plugins_integration",
     ".*",
     "build",
     "dist",

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -552,8 +552,7 @@ class DoctestModule(Module):
             else:
                 raise
 
-        # While doctests currently don't support fixtures directly, we still
-        # need to pick up autouse fixtures.
+        # doctests supports fixtures via `getfixture` and autouse.
         self.session._fixturemanager.parsefactories(self)
 
         # Uses internal doctest module parsing mechanism.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1707,7 +1707,6 @@ class FixtureManager:
         # TODO: The order of the FixtureDefs list of each arg is significant,
         #       explain.
         self._arg2fixturedefs: Final[dict[str, list[FixtureDef[Any]]]] = {}
-        self._holderobjseen: Final[set[object]] = set()
         # A mapping from a node to a list of autouse fixture names it defines.
         # The Session entry holds global usefixtures from config.
         self._node_autousenames: Final[dict[nodes.Node, list[str]]] = {
@@ -2070,8 +2069,6 @@ class FixtureManager:
             assert isinstance(node_or_obj, nodes.Node)
             holderobj = cast(object, node_or_obj.obj)  # type: ignore[attr-defined]
             effective_node = node_or_obj
-        if holderobj in self._holderobjseen:
-            return
 
         # Avoid accessing `@property` (and other descriptors) when iterating fixtures.
         if not safe_isclass(holderobj) and not isinstance(holderobj, types.ModuleType):
@@ -2079,7 +2076,6 @@ class FixtureManager:
         else:
             holderobj_tp = holderobj
 
-        self._holderobjseen.add(holderobj)
         for name in dir(holderobj):
             # The attribute can be an arbitrary descriptor, so the attribute
             # access below can raise. safe_getattr() ignores such exceptions.

--- a/testing/test_doctest.py
+++ b/testing/test_doctest.py
@@ -600,6 +600,37 @@ class TestDoctests:
         reprec = pytester.inline_run(p, "--doctest-modules")
         reprec.assertoutcome(passed=1)
 
+    def test_module_fixture_available_to_normal_test_with_doctestmodules(
+        self, pytester: Pytester
+    ) -> None:
+        """Regression test for #14533.
+
+        Module-level fixtures collected with ``--doctest-modules`` are available
+        both to normal tests and doctests in the same file.
+        """
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.fixture
+            def fix():
+                return "fix"
+
+            def test(fix):
+                assert fix == "fix"
+
+            def func():
+                '''My function.
+
+                >>> getfixture("fix")
+                'fix'
+                '''
+            """
+        )
+
+        result = pytester.runpytest("--doctest-modules")
+        result.assert_outcomes(passed=2)
+
     def test_doctestmodule_three_tests(self, pytester: Pytester):
         p = pytester.makepyfile(
             """
@@ -1301,6 +1332,37 @@ class TestDoctestAutoUseFixtures:
         )
         result = pytester.runpytest("--doctest-modules")
         result.stdout.fnmatch_lines(["*2 passed*"])
+
+    def test_doctest_and_python_fixtures_not_shared(self, pytester: Pytester) -> None:
+        """Fixture scopes are not shared between doctest and python modules.
+
+        This test is not meant as a hard behavioral test -- sharing scope is
+        also an acceptable behavior (see #14533). But this test ensures and
+        behavior change is done knowingly.
+        """
+        pytester.makepyfile(
+            r"""
+            import pytest
+
+            @pytest.fixture(scope="session", autouse=True)
+            def auto():
+                with open("out", "a", encoding="utf-8") as f:
+                    f.write("RUN\n")
+
+            def test():
+                pass
+
+            def func():
+                '''My function.
+
+                >>> 1 + 1
+                2
+                '''
+        """
+        )
+        result = pytester.runpytest("--doctest-modules")
+        result.assert_outcomes(passed=2)
+        assert Path("out").read_text("utf-8").split() == ["RUN"] * 2
 
     @pytest.mark.parametrize("scope", SCOPES)
     @pytest.mark.parametrize("enable_doctest", [True, False])

--- a/tox.ini
+++ b/tox.ini
@@ -182,6 +182,7 @@ description =
 pip_pre=true
 changedir = testing/plugins_integration
 deps = -rtesting/plugins_integration/requirements.txt
+allowlist_externals = pip
 setenv =
     PYTHONPATH=.
 commands =


### PR DESCRIPTION
## Summary

- Fix fixture registration when `--doctest-modules` collects a Python module before the normal module collector.
- Key parsed fixture holders by their visibility anchor, so normal tests get module-scoped `FixtureDef`s without relaxing node-based scoping.
- Add a regression test, changelog entry, and AUTHORS entry.

Closes #14533.

## Test plan

- [x] `PYTHONPATH=src python /tmp/pytest-14533-repro/run_checkout_pytest.py -q testing/test_doctest.py::TestDoctests::test_module_fixture_available_to_normal_test_with_doctestmodules testing/test_doctest.py::TestDoctests::test_doctestmodule_with_fixtures testing/test_doctest.py::TestDoctests::test_doctestmodule_three_tests testing/test_doctest.py::TestDoctestAutoUseFixtures` — `37 passed in 0.75s`
- [x] `PYTHONPATH=src python /tmp/pytest-14533-repro/run_checkout_pytest.py -q testing/test_conftest.py::test_conftest_fixture_scoping_with_testpaths_outside_rootdir testing/test_conftest.py::test_conftest_fixture_from_ancestor_above_rootdir testing/deprecated_test.py::TestFixtureNodeidDeprecations` — `6 passed in 0.14s`
- [x] `PYTHONPATH=src python /tmp/pytest-14533-repro/run_checkout_pytest.py -q testing/python/fixtures.py::TestFixtureManagerParseFactories::test_parsefactories_conftest testing/python/fixtures.py::TestFixtureManagerParseFactories::test_parsefactories_conftest_and_module_and_class testing/python/fixtures.py::TestFixtureManagerParseFactories::test_parsefactories_relative_node_ids` — `3 passed in 0.10s`
- [x] `git diff --check`
- [x] `python -m compileall -q src/_pytest/fixtures.py testing/test_doctest.py`
- [x] `python -m ruff check src/_pytest/fixtures.py testing/test_doctest.py`
- [x] `python -m ruff format --check src/_pytest/fixtures.py testing/test_doctest.py`

## AI assistance

OpenAI Codex helped reproduce the bug, draft the regression test, and prepare the initial patch. I reviewed the diff, checked the fixture scoping risk, added the changelog and AUTHORS entries, reran the targeted tests, and take responsibility for the change.

- [x] Include new tests or update existing tests when applicable.
- [x] Allow maintainers to push and squash when merging my commits.
- [x] Add `closes #14533` to the PR description and commit message.
- [x] Credit the AI agent in a `Co-authored-by` commit trailer.
- [x] Create a changelog file in `changelog/`.
- [x] Add myself to `AUTHORS` in alphabetical order.
