### PR TITLE
fix: prevent NOTSET sentinel leaking as test ID in parametrize with callable ids

### DIFF
--- a/changelog/13235.bugfix.rst
+++ b/changelog/13235.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed :func:`pytest.mark.parametrize` with an empty ``argvalues`` list and a
+callable ``ids`` parameter leaking the internal ``NOTSET`` string as the test
+ID (e.g. ``test_foo[NOTSET]``). The callable is no longer invoked for the
+placeholder parameterset, and the generated ID now follows the standard
+auto-naming convention (e.g. ``test_foo[x0]``).

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -238,7 +238,7 @@ class ParameterSet(NamedTuple):
             mark = get_empty_parameterset_mark(config, argnames, func)
             parameters.append(
                 ParameterSet(
-                    values=(NOTSET,) * len(argnames), marks=[mark], id="NOTSET"
+                    values=(NOTSET,) * len(argnames), marks=[mark], id=None
                 )
             )
         return argnames, parameters

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -237,9 +237,7 @@ class ParameterSet(NamedTuple):
             # parameter set with NOTSET values, with the "empty parameter set" mark applied to it.
             mark = get_empty_parameterset_mark(config, argnames, func)
             parameters.append(
-                ParameterSet(
-                    values=(NOTSET,) * len(argnames), marks=[mark], id=None
-                )
+                ParameterSet(values=(NOTSET,) * len(argnames), marks=[mark], id=None)
             )
         return argnames, parameters
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1013,6 +1013,8 @@ class IdMaker:
         user-provided id callable, if given."""
         if self.idfn is None:
             return None
+        if val is NOTSET:
+            return None
         try:
             id = self.idfn(val)
         except Exception as e:

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -1475,6 +1475,21 @@ class TestMetafuncFunctional:
         result = pytester.runpytest()
         result.stdout.fnmatch_lines(["* 1 skipped *"])
 
+    def test_parametrize_empty_argvalues_callable_ids(self, pytester: Pytester) -> None:
+        """Callable ids with empty argvalues must not crash or leak 'NOTSET' (#13235)."""
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.parametrize("x", [], ids=lambda x: x.id)
+            def test_foo(x):
+                pass
+        """
+        )
+        result = pytester.runpytest("-v")
+        result.stdout.no_fnmatch_line("*NOTSET*")
+        result.stdout.fnmatch_lines(["* 1 skipped *"])
+
     def test_parametrized_ids_invalid_type(self, pytester: Pytester) -> None:
         """Test error with non-strings/non-ints, without generator (#1857)."""
         pytester.makepyfile(


### PR DESCRIPTION
## Summary

Fixes #13235

When `@pytest.mark.parametrize` is used with an empty `argvalues` list and a **callable** `ids` parameter, two bugs occur:

1. The internal `NOTSET` sentinel string leaks into test output as `test_foo[NOTSET]`
2. The user's `ids` callable gets invoked with the `NOTSET` sentinel, causing an `AttributeError` or `ValueError`

```python
@pytest.mark.parametrize("matrix", [], ids=lambda m: m.id)
def test_foo(matrix):
    pass
```

**Before:** `test_foo[NOTSET]` in output (string leaks) or crash

**After:** `test_foo[matrix0]` — clean, matches the auto-naming convention

## Root Cause

In `ParameterSet._for_parametrize()`, when `argvalues=[]`, a placeholder `ParameterSet` is created with `id="NOTSET"`. This string was then yielded verbatim in `_resolve_ids()` (since `id is not None`), leaking the internal name. If the user provided a callable `ids`, it was also called on the `NOTSET` sentinel value before `id="NOTSET"` was set (in older versions) or was bypassed (current main), but the string still leaked.

## Fix

**`src/_pytest/mark/structures.py`** — use `id=None` for the placeholder `ParameterSet` so standard ID generation runs:

```python
# Before
ParameterSet(values=(NOTSET,) * len(argnames), marks=[mark], id="NOTSET")

# After
ParameterSet(values=(NOTSET,) * len(argnames), marks=[mark], id=None)
```

**`src/_pytest/python.py`** — guard `_idval_from_function` to skip calling the user's callable when `val is NOTSET`:

```python
def _idval_from_function(self, val, argname, idx):
    if self.idfn is None:
        return None
    if val is NOTSET:      # ← new guard
        return None
    ...
```

This follows the existing pattern in `_idval_from_value` which already has a special case for `NOTSET`.

## Test

Added `TestMetafuncFunctional::test_parametrize_empty_argvalues_callable_ids` in `testing/python/metafunc.py` verifying:
- No `NOTSET` appears in output
- The test is properly skipped (1 skipped)

## Checklist

- [x] Changelog entry added (`changelog/13235.bugfix.rst`)
- [x] Test added covering the reported scenario
- [x] Fix verified manually against the reproduction case from #13235