### PR TITLE
Report security vulnerabilities using GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_security_vulnerability.md
+++ b/.github/ISSUE_TEMPLATE/3_security_vulnerability.md
@@ -1,0 +1,8 @@
+---
+name: Security Vulnerability
+about: Report security vulnerabilities
+---
+
+**Do not submit security vulnerabilities as issues**.
+
+Create a [new Security Advisory](https://github.com/pytest-dev/pytest/security/advisories/new) instead.

--- a/README.rst
+++ b/README.rst
@@ -149,9 +149,7 @@ Save time, reduce risk, and improve code health, while paying the maintainers of
 Security
 ^^^^^^^^
 
-pytest has never been associated with a security vulnerability, but in any case, to report a
-security vulnerability please use the `Tidelift security contact <https://tidelift.com/security>`_.
-Tidelift will coordinate the fix and disclosure.
+If you have found an issue that you believe is a security vulnerability, please do not create an issue -- instead, report it via a `new security advisory <https://github.com/pytest-dev/pytest/security/advisories/new>`__.
 
 
 License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+Security vulnerabilities in pytest are rare, given it is a testing framework used for development, not used in production.
+
+However, if you find an issue that you believe is a security risk, please report a [new Security Advisory](https://github.com/pytest-dev/pytest/security/advisories/new).

--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -151,6 +151,4 @@ Save time, reduce risk, and improve code health, while paying the maintainers of
 Security
 ~~~~~~~~
 
-pytest has never been associated with a security vulnerability, but in any case, to report a
-security vulnerability please use the `Tidelift security contact <https://tidelift.com/security>`_.
-Tidelift will coordinate the fix and disclosure.
+If you have found an issue that you believe is a security vulnerability, please do not create an issue -- instead, report it via a `new security advisory <https://github.com/pytest-dev/pytest/security/advisories/new>`__.


### PR DESCRIPTION
Direct users to report security vulnerabilities using GitHub's security advisory, which I just enabled in the repository.

