### PR TITLE
docs: fix target of "assertraises" anchor.

### DIFF
--- a/doc/en/how-to/assert.rst
+++ b/doc/en/how-to/assert.rst
@@ -64,8 +64,6 @@ it is printed alongside the assertion introspection in the traceback.
 
 See :ref:`assert-details` for more information on assertion introspection.
 
-.. _`assertraises`:
-
 Assertions about approximate equality
 -------------------------------------
 
@@ -92,6 +90,8 @@ errors are common. Instead of using ``assert abs(a - b) < tol`` or
 It also supports comparisons involving NaNs.
 
 See :func:`pytest.approx` for details.
+
+.. _`assertraises`:
 
 Assertions about expected exceptions
 ------------------------------------------


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

Hi, this is a quick docs fix: The "raises" link [in the Getting Started guide here](https://docs.pytest.org/en/stable/getting-started.html#assert-that-a-certain-exception-is-raised) links to the section "Assertions about approximate equality" when it *should* link to "Assertions about expected exceptions".

(I built the docs locally with `tox -e docs` and verified that it works)