### PR TITLE
Substitute %(default)s in ini option help text (#9244)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Alexander King
 Alexei Kozlenok
 algojogacor
 Alice Purcell
+Alim Kozak
 Allan Feldman
 Aly Sivji
 Amir Elkess

--- a/changelog/9244.improvement.rst
+++ b/changelog/9244.improvement.rst
@@ -1,0 +1,1 @@
+The ``help`` text of ini options registered with :func:`parser.addini() <pytest.Parser.addini>` now substitutes ``%(default)s`` with the option's default value, mirroring the behavior already available for command-line options added with ``addoption``.

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -194,6 +194,9 @@ class Parser:
 
         :param name:
             Name of the configuration.
+        :param help:
+            Description of the option, shown in pytest's help.
+            ``%(default)s`` in the text is replaced with the option's default value.
         :param type:
             Type of the configuration. Can be:
 

--- a/src/_pytest/helpconfig.py
+++ b/src/_pytest/helpconfig.py
@@ -197,9 +197,10 @@ def showhelp(config: Config) -> None:
     indent_len = 24  # based on argparse's max_help_position=24
     indent = " " * indent_len
     for name in config._parser._inidict:
-        help, type, _default = config._parser._inidict[name]
+        help, type, default = config._parser._inidict[name]
         if help is None:
             raise TypeError(f"help argument cannot be None for {name}")
+        help = help.replace("%(default)s", str(default))
         spec = f"{name} ({type}):"
         tw.write(f"  {spec}")
         spec_len = len(spec)

--- a/testing/test_helpconfig.py
+++ b/testing/test_helpconfig.py
@@ -84,6 +84,20 @@ def test_empty_help_param(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(lines, consecutive=True)
 
 
+def test_addini_default_substitution(pytester: Pytester) -> None:
+    """``%(default)s`` in an ini help string is replaced by its default (#9244)."""
+    pytester.makeconftest(
+        """
+        def pytest_addoption(parser):
+            parser.addini("test_ini", "Help text, defaults to %(default)s", default="hello")
+    """
+    )
+    result = pytester.runpytest("--help")
+    assert result.ret == ExitCode.OK
+    result.stdout.fnmatch_lines(["*test_ini (string):*Help text, defaults to hello*"])
+    assert "%(default)s" not in result.stdout.str()
+
+
 def test_parse_known_args_doesnt_quit_on_help(pytester: Pytester) -> None:
     """`parse_known_args` shouldn't exit on `--help`, unlike `parse`."""
     config = pytester.parseconfig()


### PR DESCRIPTION
Fixes #9244.

Command-line options added with `addoption` already expand `%(default)s` in their help to the default value (argparse does this). Ini options added with `addini` are rendered by pytest itself in `showhelp()`, so `%(default)s` showed up literally in `pytest --help`.

This PR replaces `%(default)s` with the option's default value when rendering the ini help. I used a targeted `str.replace` rather than `%`-formatting, so help texts that contain a literal `%` are not affected.

### Changes
- `helpconfig.py`: substitute `%(default)s` with the ini option's default in `showhelp()`.
- `config/argparsing.py`: document the `help` parameter of `addini`.
- `testing/test_helpconfig.py`: add a regression test.
- changelog entry (`9244.improvement.rst`).
