### PR TITLE
docs: improve wording and hyphenation in non-python tests documentation

### DIFF
--- a/doc/en/example/nonpython.rst
+++ b/doc/en/example/nonpython.rst
@@ -48,7 +48,7 @@ now execute the test specification:
 You get one dot for the passing ``sub1: sub1`` check and one failure.
 Obviously in the above ``conftest.py`` you'll want to implement a more
 interesting interpretation of the yaml-values.  You can easily write
-your own domain specific testing language this way.
+your own domain-specific testing language this way.
 
 .. note::
 
@@ -89,7 +89,7 @@ consulted when reporting in ``verbose`` mode. It should return a tuple
 .. regendoc:wipe
 
 While developing your custom test collection and execution it's also
-interesting to just look at the collection tree:
+interesting to look at the collection tree:
 
 .. code-block:: pytest
 


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.

## Summary

This PR makes small documentation improvements in the non-python tests documentation.

### Changes
- Hyphenated "domain-specific" when used as a compound adjective.
- Improved documentation wording for clarity and readability.

This is a documentation-only change and does not affect functionality.
-->
