### PR TITLE
Document assertrepr compare with assertion pass hook

### DIFF
--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -934,7 +934,12 @@ def pytest_unconfigure(config: Config) -> None:
 def pytest_assertrepr_compare(
     config: Config, op: str, left: object, right: object
 ) -> list[str] | None:
-    """Return explanation for comparisons in failing assert expressions.
+    """Return explanation for comparisons in assert expressions.
+
+    By default, this hook is used only for failing assertions. It can also
+    be called for passing assertions when the :confval:`enable_assertion_pass_hook`
+    option is enabled and a :hook:`pytest_assertion_pass` hook implementation is
+    active, because pytest needs an assertion explanation to pass to that hook.
 
     Return None for no custom explanation, otherwise return a list
     of strings. The strings will be joined by newlines but any newlines

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -2097,9 +2097,10 @@ class TestAssertionPass:
         )
         result = pytester.runpytest()
         result.assert_outcomes(passed=1)
-        assert pytester.path.joinpath("reprcompare.txt").read_text(
-            encoding="utf-8"
-        ) == "==:1:1"
+        assert (
+            pytester.path.joinpath("reprcompare.txt").read_text(encoding="utf-8")
+            == "==:1:1"
+        )
         assert (
             pytester.path.joinpath("assertion-pass.txt").read_text(encoding="utf-8")
             == "custom pass comparison"

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -2072,6 +2072,39 @@ class TestAssertionPass:
         result = pytester.runpytest()
         result.stdout.fnmatch_lines("*Assertion Passed: f() 1")
 
+    def test_assertrepr_compare_called_for_pass_hook(
+        self, pytester: Pytester, flag_on
+    ) -> None:
+        pytester.makeconftest(
+            """\
+            def pytest_assertrepr_compare(config, op, left, right):
+                config.rootpath.joinpath("reprcompare.txt").write_text(
+                    f"{op}:{left}:{right}", encoding="utf-8"
+                )
+                return ["custom pass comparison"]
+
+            def pytest_assertion_pass(item, lineno, orig, expl):
+                item.config.rootpath.joinpath("assertion-pass.txt").write_text(
+                    expl, encoding="utf-8"
+                )
+            """
+        )
+        pytester.makepyfile(
+            """\
+            def test_simple():
+                assert 1 == 1
+            """
+        )
+        result = pytester.runpytest()
+        result.assert_outcomes(passed=1)
+        assert pytester.path.joinpath("reprcompare.txt").read_text(
+            encoding="utf-8"
+        ) == "==:1:1"
+        assert (
+            pytester.path.joinpath("assertion-pass.txt").read_text(encoding="utf-8")
+            == "custom pass comparison"
+        )
+
     def test_hook_not_called_without_hookimpl(
         self, pytester: Pytester, monkeypatch, flag_on
     ) -> None:


### PR DESCRIPTION
Fixes #12062.

Documents that pytest_assertrepr_compare may be called for passing assertions when pytest_assertion_pass is implemented, and adds a regression test for that interaction.

Validation:
- SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTEST=9.0.0 uv run --reinstall-package pytest --with-editable . python -m pytest testing/test_assertrewrite.py::TestAssertionPass::test_assertrepr_compare_called_for_pass_hook -q
- python -m compileall -q src\\_pytest\\hookspec.py testing\\test_assertrewrite.py
- git diff --check HEAD~1 HEAD

Not run: full pytest test suite.