### PR TITLE
fix: catch KeyError when accessing __name__ in _idval_from_value (#14560)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -352,6 +352,7 @@ Nicolas Delaby
 Nicolas Simonds
 Nico Vidal
 Nikesh Chavhan
+Nikita Zamuldinov
 Nikolay Kondratyev
 Nipunn Koorapati
 Oleg Pidsadnyi

--- a/changelog/14560.bugfix.rst
+++ b/changelog/14560.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a crash when parametrized tests used custom classes with a ``__getattr__`` that raises ``KeyError`` instead of ``AttributeError`` during test id generation.

--- a/repro_test.py
+++ b/repro_test.py
@@ -1,0 +1,15 @@
+import sys
+sys.path.insert(0, '/root/.openclaw/workspace-fork/pytest-work/src')
+
+from _pytest.python import IdMaker
+
+class CustomDict:
+    def __init__(self, data):
+        self._data = data
+    def __getattr__(self, item):
+        return self._data[item]
+
+val = CustomDict({"a": 1})
+result = IdMaker([], [], None, None, None, None)._idval(val, "a", 6)
+assert result == "a6", f"Expected 'a6', got {result!r}"
+print("Test passed!")

--- a/repro_test.py
+++ b/repro_test.py
@@ -1,13 +1,20 @@
+from __future__ import annotations
+
 import sys
-sys.path.insert(0, '/root/.openclaw/workspace-fork/pytest-work/src')
+
+
+sys.path.insert(0, "/root/.openclaw/workspace-fork/pytest-work/src")
 
 from _pytest.python import IdMaker
+
 
 class CustomDict:
     def __init__(self, data):
         self._data = data
+
     def __getattr__(self, item):
         return self._data[item]
+
 
 val = CustomDict({"a": 1})
 result = IdMaker([], [], None, None, None, None)._idval(val, "a", 6)

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1048,9 +1048,12 @@ class IdMaker:
             pass
         elif isinstance(val, enum.Enum):
             return str(val)
-        elif isinstance(getattr(val, "__name__", None), str):
+        try:
+            name = getattr(val, "__name__", None)
+        except (AttributeError, KeyError):
+            name = None
+        if isinstance(name, str):
             # Name of a class, function, module, etc.
-            name: str = getattr(val, "__name__")
             return name
         return None
 

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -425,6 +425,24 @@ class TestMetafunc:
                 IdMaker([], [], None, None, None, None)._idval(val, "a", 6) == expected
             )
 
+    def test_idval_custom_class_getattr_keyerror(self) -> None:
+        """Regression test for #14560.
+
+        Custom classes with a ``__getattr__`` that raises ``KeyError``
+        (instead of ``AttributeError``) should not crash id generation.
+        """
+
+        class CustomDict:
+            def __init__(self, data: dict) -> None:
+                self._data = data
+
+            def __getattr__(self, item: str) -> object:
+                return self._data[item]
+
+        val = CustomDict({"a": 1})
+        result = IdMaker([], [], None, None, None, None)._idval(val, "a", 6)
+        assert result == "a6"
+
     def test_notset_idval(self) -> None:
         """Test that a NOTSET value (used by an empty parameterset) generates
         a proper ID.


### PR DESCRIPTION
## Description

Fixes #14560.

Custom classes with a ``__getattr__`` that raises ``KeyError`` (instead of ``AttributeError``) would crash pytest during parameterized test id generation. This PR catches both ``AttributeError`` and ``KeyError`` when trying to access ``__name__``.

## Checklist

- [x] Include new tests or update existing tests when applicable.
- [x] Allow maintainers to push and squash when merging my commits.
- [x] Add text like ``closes #14560`` to the PR description and/or commits.
- [x] Create a new changelog file in the ``changelog`` directory.
- [x] Add yourself to ``AUTHORS`` in alphabetical order.
