### PR TITLE
Fix dotted test filenames in importlib mode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -302,6 +302,7 @@ Mark Abramowitz
 Mark Dickinson
 Mark Vong
 Marko Pacak
+marko1olo
 Markus Unterwaditzer
 Martijn Faassen
 Martin Altmayer

--- a/changelog/14514.bugfix.rst
+++ b/changelog/14514.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed importlib-mode module names for dotted test filenames such as ``foo.test.py`` so they are imported as valid Python module names.

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -931,6 +931,7 @@ def compute_module_name(root: Path, module_path: Path) -> str | None:
         return None
     if names[-1] == "__init__":
         names.pop()
+    names = [x.replace(".", "_") for x in names]
     return ".".join(names)
 
 

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -809,8 +809,7 @@ class TestImportLibMode:
         (tmp_path / "pkg/foo.py").write_text("value = 1\n", encoding="ascii")
         foo_test_py = tmp_path / "pkg/foo.test.py"
         foo_test_py.write_text(
-            "import pkg.foo\n"
-            "imported_value = pkg.foo.value\n",
+            "import pkg.foo\nimported_value = pkg.foo.value\n",
             encoding="ascii",
         )
 

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -788,6 +788,42 @@ class TestImportLibMode:
             "app.core.models",
         )
 
+    def test_resolve_pkg_root_and_module_name_dotted_filename(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "pkg").mkdir()
+        (tmp_path / "pkg/__init__.py").touch()
+        foo_test_py = tmp_path / "pkg/foo.test.py"
+        foo_test_py.touch()
+
+        assert resolve_pkg_root_and_module_name(foo_test_py) == (
+            tmp_path,
+            "pkg.foo_test",
+        )
+
+    def test_import_path_importlib_dotted_filename_in_package(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "pkg").mkdir()
+        (tmp_path / "pkg/__init__.py").write_text("", encoding="ascii")
+        (tmp_path / "pkg/foo.py").write_text("value = 1\n", encoding="ascii")
+        foo_test_py = tmp_path / "pkg/foo.test.py"
+        foo_test_py.write_text(
+            "import pkg.foo\n"
+            "imported_value = pkg.foo.value\n",
+            encoding="ascii",
+        )
+
+        mod = import_path(
+            foo_test_py,
+            mode="importlib",
+            root=tmp_path,
+            consider_namespace_packages=False,
+        )
+
+        assert mod.__name__ == "pkg.foo_test"
+        assert mod.imported_value == 1
+
     def test_insert_missing_modules(
         self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> None:
@@ -1732,6 +1768,9 @@ def test_compute_module_name(tmp_path: Path) -> None:
     assert (
         compute_module_name(tmp_path, tmp_path / "src/app/bar/__init__.py")
         == "src.app.bar"
+    )
+    assert compute_module_name(tmp_path, tmp_path / "src/app/foo.test.py") == (
+        "src.app.foo_test"
     )
 
 


### PR DESCRIPTION
Closes #14514.

Summary:
- Sanitizes dotted path components in `compute_module_name()` so importlib mode derives valid module names for files like `foo.test.py`.
- Adds package-resolution and import-path regression coverage for dotted test filenames.
- Adds the required changelog fragment and AUTHORS entry.

Tests:
- `PYTHONPATH=src python -m pytest testing/test_pathlib.py -q`
- `python -m py_compile src\_pytest\pathlib.py testing\test_pathlib.py`
- `git diff --check HEAD~1 HEAD`

Checklist:
- [x] Include new tests or update existing tests when applicable.
- [x] Add text like `closes #XYZW` to the PR description and/or commits.
- [x] If AI agents were used, they are credited in `Co-authored-by` commit trailers.
- [x] Create a new changelog file in the `changelog` directory.
- [x] Add yourself to `AUTHORS` in alphabetical order.

AI assistance disclosure:
- OpenAI Codex assisted with this change; the commit includes `Co-authored-by: OpenAI Codex <codex@openai.com>`.