### PR TITLE
Clarify conftest hook timing before collection

### DIFF
--- a/changelog/14557.doc.rst
+++ b/changelog/14557.doc.rst
@@ -1,0 +1,1 @@
+Clarified that conftest files discovered during collection are not available for hooks which run before collection, such as :hook:`pytest_sessionstart` and :hook:`pytest_report_header`.

--- a/doc/en/how-to/writing_plugins.rst
+++ b/doc/en/how-to/writing_plugins.rst
@@ -59,6 +59,11 @@ Plugin discovery order at tool startup
      After a ``conftest.py`` file is loaded, recursively load all plugins specified
      in its :globalvar:`pytest_plugins` variable if present.
 
+   These initial conftest files are loaded before collection starts. Conftest
+   files discovered later during collection can still implement hooks, but they
+   are not available for hooks which run before collection, such as
+   :hook:`pytest_sessionstart` and :hook:`pytest_report_header`.
+
 
 .. _`conftest.py plugins`:
 .. _`localplugin`:


### PR DESCRIPTION
## Summary

Clarify that only initial conftest files are available for hooks which run before collection, such as `pytest_sessionstart` and `pytest_report_header`.

This addresses the confusing case where a deeper conftest can still receive later/historic hooks like `pytest_configure`, but cannot affect the terminal header once `pytest_report_header` has already run.

Closes #14557.