### PR TITLE
fixtures: use node-based matching in `get_scope_package` when possible

### DIFF
--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -123,8 +123,13 @@ def get_scope_package(
     from _pytest.python import Package
 
     for parent in node.iter_parents():
-        if isinstance(parent, Package) and parent.nodeid == fixturedef.baseid:
-            return parent
+        if isinstance(parent, Package):
+            if fixturedef.node is not None:
+                if parent == fixturedef.node:
+                    return parent
+            else:
+                if parent.nodeid == fixturedef.baseid:
+                    return parent
     return node.session
 
 


### PR DESCRIPTION
We are trying to move away from nodeid-based matching.