### PR TITLE
Fix automatic parameter IDs for broken __name__ lookup

### DIFF
--- a/changelog/14560.bugfix.rst
+++ b/changelog/14560.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed automatic parametrization ID generation crashing when a parameter object raises an exception while accessing ``__name__``.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1048,10 +1048,11 @@ class IdMaker:
             pass
         elif isinstance(val, enum.Enum):
             return str(val)
-        elif isinstance(getattr(val, "__name__", None), str):
-            # Name of a class, function, module, etc.
-            name: str = getattr(val, "__name__")
-            return name
+        else:
+            name: str | None = safe_getattr(val, "__name__", None)
+            if isinstance(name, str):
+                # Name of a class, function, module, etc.
+                return name
         return None
 
     def _idval_from_value_required(self, val: object, idx: int) -> str:

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -425,6 +425,18 @@ class TestMetafunc:
                 IdMaker([], [], None, None, None, None)._idval(val, "a", 6) == expected
             )
 
+    def test_idval_ignores_broken_name_attribute(self) -> None:
+        """Use the fallback ID for values that reject __name__ lookup."""
+
+        class DictWrapper(dict[str, object]):
+            def __getattr__(self, name: str) -> object:
+                return self[name]
+
+        assert (
+            IdMaker([], [], None, None, None, None)._idval(DictWrapper(), "a", 6)
+            == "a6"
+        )
+
     def test_notset_idval(self) -> None:
         """Test that a NOTSET value (used by an empty parameterset) generates
         a proper ID.


### PR DESCRIPTION
Fixes #14560.

## Summary
- use pytest's defensive `safe_getattr` helper when automatic parametrization ID generation probes `__name__`
- fall back to the argument/index ID when a parameter value raises during `__name__` lookup
- add a regression test and changelog fragment

## Verification
- red before fix: `python -m pytest testing\python\metafunc.py::TestMetafunc::test_idval_ignores_broken_name_attribute -q` failed with `KeyError: '__name__'`
- `python -m pytest testing\python\metafunc.py::TestMetafunc::test_idval_ignores_broken_name_attribute -q`
- `python -m pytest testing\python\metafunc.py -q`
- `python -m ruff check src\_pytest\python.py testing\python\metafunc.py`
- `python -m ruff format --check src\_pytest\python.py testing\python\metafunc.py`
- `git diff --check`