### PR TITLE
Fix isset() to cover dict.items() and dict.keys() in set comparisons

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -80,6 +80,7 @@ Brian Okken
 Brianna Laugher
 Bruno Oliveira
 Cal Jacobson
+croc100
 Cal Leeming
 Carl Friedrich Bolz
 Carlos Jenkins

--- a/changelog/12860.improvement.rst
+++ b/changelog/12860.improvement.rst
@@ -1,0 +1,1 @@
+Assertion diffs for ``dict.items()`` and ``dict.keys()`` comparisons (``>=``, ``<=``, ``>``, ``<``, ``==``) now show which items are missing, the same way set comparisons do.

--- a/src/_pytest/assertion/_guards.py
+++ b/src/_pytest/assertion/_guards.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import collections.abc
 from collections.abc import Mapping
+from collections.abc import Set as AbstractSet
 import dataclasses
 from typing import TypeGuard
 
@@ -18,8 +19,8 @@ def ismapping(x: object) -> TypeGuard[Mapping[object, object]]:
     return isinstance(x, Mapping)
 
 
-def isset(x: object) -> TypeGuard[set[object] | frozenset[object]]:
-    return isinstance(x, set | frozenset)
+def isset(x: object) -> TypeGuard[AbstractSet[object]]:
+    return isinstance(x, AbstractSet)
 
 
 def isnamedtuple(obj: object) -> bool:

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1870,6 +1870,38 @@ class TestSetAssertions:
             ]
         )
 
+    @pytest.mark.parametrize("op", [">=", "<="])
+    def test_dict_items_view_subset(self, op, pytester: Pytester) -> None:
+        """dict.items() supports set-like comparisons; assert diff should show the missing items."""
+        if op == ">=":
+            pytester.makepyfile(
+                """
+                def test_hello():
+                    x = {"a": 1, "b": 2}
+                    y = {"a": 1, "b": 2, "c": 3}
+                    assert x.items() >= y.items()
+            """
+            )
+        else:
+            pytester.makepyfile(
+                """
+                def test_hello():
+                    x = {"a": 1, "b": 2, "c": 3}
+                    y = {"a": 1, "b": 2}
+                    assert x.items() <= y.items()
+            """
+            )
+        result = pytester.runpytest()
+        side = "right" if op == ">=" else "left"
+        result.stdout.fnmatch_lines(
+            [
+                "*def test_hello():*",
+                f"*assert x.items() {op} y.items()*",
+                f"*E*Extra items in the {side} set:*",
+                "*E*('c', 3)*",
+            ]
+        )
+
 
 def test_assertrepr_loaded_per_dir(pytester: Pytester) -> None:
     pytester.makepyfile(test_base=["def test_base(): assert 1 == 2"])


### PR DESCRIPTION
Closes #12860.

`isset()` was checking `isinstance(x, set | frozenset)`, so `dict.items()` and `dict.keys()` — which both implement `collections.abc.Set` — never triggered the set comparison path. The result was a raw repr diff with no useful information:

```
E  AssertionError: assert dict_items([('a', 1), ('b', 2)]) >= dict_items([('a', 1), ('b', 2), ('c', 3)])
E   +  where dict_items(...) = {'a': 1, 'b': 2}.items()
E   +  and   dict_items(...) = {'a': 1, 'b': 2, 'c': 3}.items()
```

After this fix:

```
E  AssertionError: assert dict_items([('a', 1), ('b', 2)]) >= dict_items([('a', 1), ('b', 2), ('c', 3)])
E    Extra items in the right set:
E    ('c', 3)
```

The fix is to widen `isset()` to `isinstance(x, collections.abc.Set)`. This covers `set`, `frozenset`, `dict.items()`, and `dict.keys()` — all of which support `-` and the comparison operators that the set assertion path relies on. The existing `_compare_set.py` functions already type their parameters as `AbstractSet`, so no changes there were needed.