### PR TITLE
recwarn: pass originating module name when re-emitting unmatched warnings (fixes #11933)

### DIFF
--- a/changelog/11933.bugfix.rst
+++ b/changelog/11933.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed :func:`pytest.warns` re-emitting unmatched warnings with the wrong
+``module`` argument, which prevented user-installed
+``warnings.filterwarnings(..., module=...)`` rules from matching the
+re-emitted warning.

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -8,6 +8,7 @@ from collections.abc import Generator
 from collections.abc import Iterator
 from pprint import pformat
 import re
+import sys
 from types import TracebackType
 from typing import Any
 from typing import final
@@ -31,6 +32,30 @@ from _pytest.outcomes import fail
 
 
 T = TypeVar("T")
+
+
+def _module_name_for_filename(filename: str | None) -> str | None:
+    """Recover the importable module name for a warning's ``filename``.
+
+    :class:`warnings.WarningMessage` does not preserve the ``module`` argument
+    that :func:`warnings.warn_explicit` was originally called with, so when
+    re-emitting an unmatched warning we cannot use ``w.__module__`` (that
+    attribute is the module *the WarningMessage class is defined in*, i.e.
+    ``"warnings"``).  As the next best thing, look up the module in
+    :data:`sys.modules` whose ``__file__`` matches the warning's filename.
+
+    Returns ``None`` if no module can be matched (for example, the warning
+    originated from ``exec``-ed code, a frozen / built-in module, or a file
+    that has since been unloaded).  In that case
+    :func:`warnings.warn_explicit` derives the module name from ``filename``
+    itself, matching its own default behavior.
+    """
+    if not filename:
+        return None
+    for name, mod in sys.modules.items():
+        if getattr(mod, "__file__", None) == filename:
+            return name
+    return None
 
 
 @fixture
@@ -347,7 +372,16 @@ class WarningsChecker(WarningsRecorder):
                         category=w.category,
                         filename=w.filename,
                         lineno=w.lineno,
-                        module=w.__module__,
+                        # ``w.__module__`` is always ``"warnings"`` (the module
+                        # ``WarningMessage`` is defined in), which causes
+                        # ``warnings.filterwarnings(..., module=...)`` rules
+                        # supplied by the user to never match this re-emit.
+                        # Recover the originating module's importable name from
+                        # its filename so the user's module-scoped filters can
+                        # still act on the re-emitted warning.  Falling back to
+                        # ``None`` lets :func:`warnings.warn_explicit` derive a
+                        # name from the filename, matching its default behavior.
+                        module=_module_name_for_filename(w.filename),
                         source=w.source,
                     )
 

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -520,7 +520,8 @@ class TestWarns:
         """
         pkg = pytester.mkpydir("regr_pkg")
         pkg.joinpath("inner.py").write_text(
-            "import warnings\ndef emit(msg):\n    warnings.warn(msg, UserWarning)\n"
+            "import warnings\ndef emit(msg):\n    warnings.warn(msg, UserWarning)\n",
+            encoding="utf-8",
         )
         pytester.makepyfile(
             test_module=r"""

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -501,6 +501,53 @@ class TestWarns:
                 warnings.warn("v1 warning", UserWarning)
                 warnings.warn("non-matching v2 warning", UserWarning)
 
+    def test_re_emit_preserves_module_name(self, pytester: Pytester) -> None:
+        r"""Regression test for #11933.
+
+        :func:`pytest.warns` re-emits unmatched warnings via
+        :func:`warnings.warn_explicit`. The ``module`` argument must reflect the
+        originating module's importable name; otherwise user-installed
+        ``warnings.filterwarnings(..., module=...)`` rules silently fail to
+        match the re-emitted warning.
+
+        The package layout below makes the importable name (``regr_pkg.inner``)
+        differ from :func:`warnings.warn_explicit`'s filename-derived default
+        (which would be ``"<...>/regr_pkg/inner"``).  The regex
+        ``^regr_pkg\.inner$`` matches the former and nothing else, so the
+        outer ``"error"`` filter fires only when re-emit passes the correct
+        module name — distinguishing the fix from both the original
+        (``module="warnings"``) and from omitting the argument entirely.
+        """
+        pkg = pytester.mkpydir("regr_pkg")
+        pkg.joinpath("inner.py").write_text(
+            "import warnings\ndef emit(msg):\n    warnings.warn(msg, UserWarning)\n"
+        )
+        pytester.makepyfile(
+            test_module=r"""
+            import warnings
+            import pytest
+            from regr_pkg import inner
+
+            def test_module_filter_applies_to_reemitted_warning():
+                with warnings.catch_warnings():
+                    warnings.resetwarnings()
+                    warnings.simplefilter("always")
+                    warnings.filterwarnings(
+                        "error",
+                        category=UserWarning,
+                        module=r"^regr_pkg\.inner$",
+                    )
+                    with pytest.raises(UserWarning, match="from inner"):
+                        with pytest.warns(UserWarning, match="other"):
+                            # Unmatched -> re-emitted on pytest.warns __exit__.
+                            inner.emit("from inner")
+                            # Matched -> satisfies the inner assertion.
+                            warnings.warn("other", UserWarning)
+            """
+        )
+        result = pytester.runpytest()
+        result.assert_outcomes(passed=1)
+
     def test_catch_warning_within_raise(self) -> None:
         # warns-in-raises works since https://github.com/pytest-dev/pytest/pull/11129
         with pytest.raises(ValueError, match="some exception"):


### PR DESCRIPTION
## Problem

`pytest.warns` re-emits unmatched warnings on `__exit__` via
`warnings.warn_explicit(..., module=w.__module__, ...)`. But `w` is a
`warnings.WarningMessage` instance, so `w.__module__` evaluates to
`"warnings"` (the module that the `WarningMessage` class is defined in) for
*every* re-emitted warning, regardless of where the warning actually came from.

The visible consequence: a user-installed filter such as

```python
warnings.filterwarnings("ignore", category=UserWarning, module=r"my_module")
```

matches the *original* warning fine, but silently fails to match its re-emit.
Code that should be quiet around `pytest.warns(...)` blocks gets noisy
(or, with `"error"` filters, raises unexpectedly).

This is #11933, reported by @Zac-HD with a precise diagnosis: `module=w.__module__`
should be the importable module name of the call site, not the home module of
`WarningMessage`.

## Approach

`WarningMessage` does not preserve the `module` argument originally passed to
`warn_explicit`, so we can't read it off `w`. The next best thing is to look up
`sys.modules` by `__file__` to find the module whose source file matches
`w.filename`, and fall back to `None` when nothing matches. `warn_explicit`'s
documented behavior with `module=None` is to derive a name from `filename`
itself, which matches what plain `warnings.warn(...)` would have produced if
called from outside any `pytest.warns` context — so the fallback is a clean
degenerate, not a regression.

The fix is contained to two spots in `src/_pytest/recwarn.py`: a helper
`_module_name_for_filename`, and replacing the `module=w.__module__` argument
in the re-emit call.

## Why this PR re-opens ground covered by #12898

The earlier attempt (#12898, by @reaganjlee, closed for inactivity) landed
on essentially the same shape of fix but was closed because the regression test
@nicoddemus asked for was inadequate — specifically, the test passed even when
`module=` was set to `None` instead of the recovered name, so it pinned the
wrong invariant.

This PR addresses that directly. The new test
`test_re_emit_preserves_module_name` uses a packaged module
(`regr_pkg/inner.py`) so the importable name (`regr_pkg.inner`) differs from
`warn_explicit`'s filename-derived default (`<...>/regr_pkg/inner`). The
filter regex `^regr_pkg\.inner$` matches **only** the importable form and
nothing else. Concretely, the test:

- **passes** with the fix (module recovered to `"regr_pkg.inner"`),
- **fails** with the original bug (module `"warnings"` doesn't match),
- **fails** with `module=None` (filename-derived `"<...>/regr_pkg/inner"` doesn't match).

So the test pins down "recover the correct module name", not the looser
"don't pass `\"warnings\"`".

## Verification

- `testing/test_recwarn.py` — 67 passed (66 existing + 1 new)
- `testing/test_recwarn.py testing/test_warnings.py` — 119 passed, 4 skipped
- Full `testing/` suite (excluding `test_recwarn.py`, kept separate above) —
  3974 passed, 124 skipped, 12 xfailed, 1 xpassed; no failures introduced.
- `ruff check`, `ruff format --check`, `mypy` on the touched files — all clean.

I also confirmed end-to-end by reverting the fix locally and re-running the
new test: it fails as designed. With the `module=None` "looser" fix it also
fails, which is what nicoddemus wanted from a regression test.

Fixes #11933.