### PR TITLE
Reject negative log_auto_indent values

### DIFF
--- a/changelog/14586.bugfix.rst
+++ b/changelog/14586.bugfix.rst
@@ -1,0 +1,1 @@
+Negative values passed to ``log_auto_indent`` now correctly fall back to no indentation, matching the documented behavior.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -186,10 +186,10 @@ class PercentStyleMultiline(logging.PercentStyle):
             case True:
                 return -1
             case int():
-                return auto_indent_option
+                return max(auto_indent_option, 0)
             case str():
                 try:
-                    return int(auto_indent_option)
+                    return max(int(auto_indent_option), 0)
                 except ValueError:
                     pass
                 try:

--- a/testing/logging/test_formatter.py
+++ b/testing/logging/test_formatter.py
@@ -149,6 +149,18 @@ def test_multiline_message() -> None:
         "dummypath                   10 INFO     Test Message line1\n     line2"
     )
 
+    record.auto_indent = "-5"
+    output = ai_off_style.format(record)
+    assert output == (
+        "dummypath                   10 INFO     Test Message line1\nline2"
+    )
+
+    record.auto_indent = -5
+    output = ai_off_style.format(record)
+    assert output == (
+        "dummypath                   10 INFO     Test Message line1\nline2"
+    )
+
 
 def test_colored_short_level() -> None:
     logfmt = "%(levelname).1s %(message)s"


### PR DESCRIPTION
Negative values passed to ```log_auto_indent``` were treated as dynamic indentation, even though the documentation and docstring mention that only positive integers are valid and that invalid values should fall back to the default behavior.

This change normalizes negative integer values to 0, disabling auto-indentation as documented.


Added necessary tests and verified that all the relevant test cases pass locally.