### PR TITLE
[refactor] Tighten ``SetComparisonFunction`` to ``Iterator[str]``

### DIFF
--- a/src/_pytest/assertion/_compare_set.py
+++ b/src/_pytest/assertion/_compare_set.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from collections.abc import Iterable
 from collections.abc import Iterator
 from collections.abc import Set as AbstractSet
 from typing import TypeAlias
@@ -77,14 +76,24 @@ def _compare_lt_set(
 
 SetComparisonFunction: TypeAlias = Callable[
     [AbstractSet[object], AbstractSet[object], _HighlightFunc, int],
-    Iterable[str],
+    Iterator[str],
 ]
+
+
+def _both_sets_are_equal(
+    left: AbstractSet[object],
+    right: AbstractSet[object],
+    highlighter: _HighlightFunc,
+    verbose: int = 0,
+) -> Iterator[str]:
+    yield "Both sets are equal"
+
 
 SET_COMPARISON_FUNCTIONS: dict[str, SetComparisonFunction] = {
     # == can't be done here without a prior refactor because there's an additional
     # explanation for iterable in _compare_eq_any
     # "==": _compare_eq_set,
-    "!=": lambda *a, **kw: ["Both sets are equal"],
+    "!=": _both_sets_are_equal,
     ">=": _compare_gte_set,
     "<=": _compare_lte_set,
     ">": _compare_gt_set,

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -177,7 +177,7 @@ def assertrepr_compare(
 
     try:
         if op == "==":
-            source: Iterator[str] = _compare_eq_any(
+            source = _compare_eq_any(
                 left,
                 right,
                 highlighter,
@@ -187,9 +187,7 @@ def assertrepr_compare(
         elif op == "not in" and istext(left) and istext(right):
             source = _notin_text(left, right, verbose)
         elif op in {"!=", ">=", "<=", ">", "<"} and isset(left) and isset(right):
-            source = iter(
-                SET_COMPARISON_FUNCTIONS[op](left, right, highlighter, verbose)
-            )
+            source = SET_COMPARISON_FUNCTIONS[op](left, right, highlighter, verbose)
         else:
             source = iter(())
 


### PR DESCRIPTION
Consensual changes prior to #14523:
* drop the redundant ``: Iterator[str]`` annotation on ``source``: every branch already produces an ``Iterator[str]``.
* return ``Iterator[str]`` from ``SetComparisonFunction`` instead of ``Iterable[str]`` so the call site no longer needs ``iter(...)``; the ``!=`` branch is promoted from a list-returning lambda to a named generator so the new contract holds.

