### PR TITLE
Restore precedence of indirect parametrize over fixture params

### DIFF
--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -64,6 +64,7 @@ from _pytest.deprecated import FIXTUREDEF_HAS_LOCATION_DEPRECATED
 from _pytest.deprecated import PARSEFACTORIES_NODEID_DEPRECATED
 from _pytest.deprecated import YIELD_FIXTURE
 from _pytest.main import Session
+from _pytest.mark import Mark
 from _pytest.mark import ParameterSet
 from _pytest.mark.structures import MarkDecorator
 from _pytest.outcomes import fail
@@ -1898,9 +1899,22 @@ class FixtureManager:
 
     def pytest_generate_tests(self, metafunc: Metafunc) -> None:
         """Generate new tests based on parametrized fixtures used by the given metafunc"""
+
+        def get_parametrize_mark_argnames(mark: Mark) -> Sequence[str]:
+            args, _ = ParameterSet._parse_parametrize_args(*mark.args, **mark.kwargs)
+            return args
+
         for argname in metafunc.fixturenames:
             # Get the FixtureDefs for the argname.
             fixture_defs = metafunc._arg2fixturedefs.get(argname, ())
+
+            # If the test itself parametrizes using this argname, give it
+            # precedence.
+            if any(
+                argname in get_parametrize_mark_argnames(mark)
+                for mark in metafunc.definition.iter_markers("parametrize")
+            ):
+                continue
 
             # In the common case we only look at the fixture def with the
             # closest scope (last in the list). But if the fixture overrides

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -4970,6 +4970,39 @@ def test_fixture_param_shadowing(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(["*::test_indirect[[]1[]]*"])
 
 
+def test_indirect_parametrize_overrides_fixture_params(pytester: Pytester) -> None:
+    """Indirect parametrization should override fixture params (#14591)."""
+    pytester.makepyfile(
+        """
+        import pytest
+
+        class MyFixture:
+            def __init__(self, mode):
+                self.mode = mode
+
+        @pytest.fixture(params=['first_mode', 'second_mode'])
+        def myfixture(request):
+            yield MyFixture(request.param)
+
+        def test_myfixture_default(myfixture):
+            assert isinstance(myfixture, MyFixture)
+            assert myfixture.mode in {'first_mode', 'second_mode'}
+
+        @pytest.mark.parametrize('myfixture', ['first_mode'], indirect=True)
+        def test_myfixture_single_mode1(myfixture):
+            assert isinstance(myfixture, MyFixture)
+            assert myfixture.mode == 'first_mode'
+
+        @pytest.mark.parametrize('myfixture', ['second_mode'], indirect=True)
+        def test_myfixture_single_mode2(myfixture):
+            assert isinstance(myfixture, MyFixture)
+            assert myfixture.mode == 'second_mode'
+        """
+    )
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(passed=4)
+
+
 def test_fixture_named_request(pytester: Pytester) -> None:
     pytester.copy_example("fixtures/test_fixture_named_request.py")
     result = pytester.runpytest()


### PR DESCRIPTION
Fixes #14591

## Problem

In pytest 9.1.0, using `@pytest.mark.parametrize(..., indirect=True)` to override the parameters of a fixture that already has `params=[...]` raises `duplicate parametrization of {fixture_name}` during collection. This worked in previous releases.

The regression was introduced by d56b1af52, which removed a special case in `pytest_generate_tests` that skipped applying fixture params when the test already parametrizes the same argument.

## Fix

Restore the precedence check in `FixtureManager.pytest_generate_tests`: when a test has a `parametrize` mark for an argument name, do not also apply that fixture's `params` via `pytest_generate_tests`.

## Test plan

- Added `test_indirect_parametrize_overrides_fixture_params` based on the minimal reproducer from the issue
- Verified `testing/python/fixtures.py::test_fixture_param_shadowing` still passes
- Ran the fixtures test module (336 passed)