### PR TITLE
Add `ordered` parameter to `RaisesGroup`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,6 +42,7 @@ Andrzej Ostrowski
 Andy Freeland
 Anita Hammer
 Anna Tasiopoulou
+Anneheartrecord
 Anthon van der Neut
 Anthony Shaw
 Anthony Sottile

--- a/changelog/14580.feature.rst
+++ b/changelog/14580.feature.rst
@@ -1,0 +1,7 @@
+Added an ``ordered`` parameter to :class:`pytest.RaisesGroup`.
+
+By default :class:`~pytest.RaisesGroup` ignores the order of the exceptions in the
+group. Passing ``ordered=True`` makes it match the expected exceptions against the
+raised exceptions positionally, so the order is asserted. This also sidesteps the
+greedy matching algorithm, which can otherwise fail to find a valid pairing even when
+one exists.

--- a/doc/en/how-to/assert.rst
+++ b/doc/en/how-to/assert.rst
@@ -210,6 +210,16 @@ It is strict about structure and unwrapped exceptions, unlike :ref:`except* <exc
         with pytest.RaisesGroup(ValueError, allow_unwrapped=True):
             raise ValueError
 
+By default the order of the contained exceptions does not matter. If you need to assert
+that the exceptions are raised in a particular order you can pass ``ordered=True``, which
+matches the expected exceptions against the raised exceptions positionally.
+
+.. code-block:: python
+
+    def test_ordered():
+        with pytest.RaisesGroup(ValueError, TypeError, ordered=True):
+            raise ExceptionGroup("msg", [ValueError("foo"), TypeError("bar")])
+
 To specify more details about the contained exception you can use :class:`pytest.RaisesExc`
 
 .. code-block:: python

--- a/src/_pytest/raises.py
+++ b/src/_pytest/raises.py
@@ -773,6 +773,15 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
         inside any nested groups, before matching. Without this it expects you to
         fully specify the nesting structure by passing :class:`RaisesGroup` as expected
         parameter.
+    :kwparam bool ordered:
+        .. versionadded:: 8.4
+
+        By default the order of the exceptions does not matter, and the matching
+        algorithm is greedy (see the note below). When ``ordered=True`` the expected
+        exceptions must match the raised exceptions *in order*: the first expected
+        exception is matched against the first raised exception, and so on. This
+        disables the reordering done by the greedy algorithm, so it both asserts the
+        order and avoids the greedy-algorithm pitfall described below.
 
     Examples::
 
@@ -812,6 +821,10 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
         with RaisesGroup(ValueError, allow_unwrapped=True):
             raise ValueError
 
+        # ordered
+        with RaisesGroup(ValueError, TypeError, ordered=True):
+            raise ExceptionGroup("", (ValueError(), TypeError()))
+
 
     :meth:`RaisesGroup.matches` can also be used directly to check a standalone exception group.
 
@@ -822,7 +835,8 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
             raise ExceptionGroup("", (ValueError("hello"), ValueError("goodbye")))
 
     even though it generally does not care about the order of the exceptions in the group.
-    To avoid the above you should specify the first :exc:`ValueError` with a :class:`RaisesExc` as well.
+    To avoid the above you should specify the first :exc:`ValueError` with a :class:`RaisesExc` as well,
+    or pass ``ordered=True`` to disable the greedy reordering and match positionally.
 
     .. note::
         When raised exceptions don't match the expected ones, you'll get a detailed error
@@ -855,6 +869,7 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
         flatten_subgroups: Literal[True],
         match: str | Pattern[str] | None = None,
         check: Callable[[BaseExceptionGroup[BaseExcT_co]], bool] | None = None,
+        ordered: bool = False,
     ) -> None: ...
 
     # simplify the typevars if possible (the following 3 are equivalent but go simpler->complicated)
@@ -870,6 +885,7 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
         *other_exceptions: type[ExcT_1] | RaisesExc[ExcT_1],
         match: str | Pattern[str] | None = None,
         check: Callable[[ExceptionGroup[ExcT_1]], bool] | None = None,
+        ordered: bool = False,
     ) -> None: ...
 
     @overload
@@ -880,6 +896,7 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
         *other_exceptions: RaisesGroup[ExcT_2],
         match: str | Pattern[str] | None = None,
         check: Callable[[ExceptionGroup[ExceptionGroup[ExcT_2]]], bool] | None = None,
+        ordered: bool = False,
     ) -> None: ...
 
     @overload
@@ -892,6 +909,7 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
         check: (
             Callable[[ExceptionGroup[ExcT_1 | ExceptionGroup[ExcT_2]]], bool] | None
         ) = None,
+        ordered: bool = False,
     ) -> None: ...
 
     # same as the above 3 but handling BaseException
@@ -903,6 +921,7 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
         *other_exceptions: type[BaseExcT_1] | RaisesExc[BaseExcT_1],
         match: str | Pattern[str] | None = None,
         check: Callable[[BaseExceptionGroup[BaseExcT_1]], bool] | None = None,
+        ordered: bool = False,
     ) -> None: ...
 
     @overload
@@ -915,6 +934,7 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
         check: (
             Callable[[BaseExceptionGroup[BaseExceptionGroup[BaseExcT_2]]], bool] | None
         ) = None,
+        ordered: bool = False,
     ) -> None: ...
 
     @overload
@@ -935,6 +955,7 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
             ]
             | None
         ) = None,
+        ordered: bool = False,
     ) -> None: ...
 
     def __init__(
@@ -954,6 +975,7 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
             | Callable[[ExceptionGroup[ExcT_1]], bool]
             | None
         ) = None,
+        ordered: bool = False,
     ):
         # The type hint on the `self` and `check` parameters uses different formats
         # that are *very* hard to reconcile while adhering to the overloads, so we cast
@@ -965,6 +987,7 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
         super().__init__(match=match, check=check)
         self.allow_unwrapped = allow_unwrapped
         self.flatten_subgroups: bool = flatten_subgroups
+        self.ordered = ordered
         self.is_baseexception = False
 
         if allow_unwrapped and other_exceptions:
@@ -1057,6 +1080,8 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
             reqs.append(f"allow_unwrapped={self.allow_unwrapped}")
         if self.flatten_subgroups:
             reqs.append(f"flatten_subgroups={self.flatten_subgroups}")
+        if self.ordered:
+            reqs.append(f"ordered={self.ordered}")
         if self.match is not None:
             # If no flags were specified, discard the redundant re.compile() here.
             reqs.append(f"match={_match_pattern(self.match)!r}")
@@ -1260,6 +1285,9 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
         """Helper method for RaisesGroup.matches that attempts to pair up expected and actual exceptions"""
         # The _exception parameter is not used, but necessary for the TypeGuard
 
+        if self.ordered:
+            return self._check_exceptions_ordered(actual_exceptions)
+
         # full table with all results
         results = ResultHolder(self.expected_exceptions, actual_exceptions)
 
@@ -1394,6 +1422,37 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
             )
         self._fail_reason = s
         return False
+
+    def _check_exceptions_ordered(
+        self,
+        actual_exceptions: Sequence[BaseException],
+    ) -> bool:
+        """Helper method for ``RaisesGroup._check_exceptions`` used when
+        ``ordered=True``. Each expected exception is matched against the actual
+        exception at the same position, without any reordering. Sets
+        ``self._fail_reason`` and returns ``False`` on the first mismatch."""
+        if len(actual_exceptions) != len(self.expected_exceptions):
+            self._fail_reason = (
+                f"Expected {len(self.expected_exceptions)} exceptions in ordered group, "
+                f"but got {len(actual_exceptions)}: {list(actual_exceptions)!r}"
+            )
+            return False
+
+        for i, (expected, actual) in enumerate(
+            zip(self.expected_exceptions, actual_exceptions, strict=True)
+        ):
+            res = self._check_expected(expected, actual)
+            if res is not None:
+                # only prefix with the position when there's more than one
+                # exception, to keep single-exception messages identical to the
+                # unordered case.
+                if len(self.expected_exceptions) == 1:
+                    self._fail_reason = res
+                else:
+                    prefix = "\n" if res.startswith("\n") else " "
+                    self._fail_reason = f"At index {i}:{prefix}{res}"
+                return False
+        return True
 
     def __exit__(
         self,

--- a/testing/python/raises_group.py
+++ b/testing/python/raises_group.py
@@ -963,6 +963,117 @@ def test_misordering_example() -> None:
         )
 
 
+def test_ordered() -> None:
+    # by default the order of the exceptions does not matter
+    with RaisesGroup(ValueError, TypeError):
+        raise ExceptionGroup("", [TypeError(), ValueError()])
+
+    # with ordered=True the exceptions must be in the specified order
+    with RaisesGroup(ValueError, TypeError, ordered=True):
+        raise ExceptionGroup("", [ValueError(), TypeError()])
+
+    # a group in the wrong order fails to match when ordered=True, and the failure
+    # message points at the offending position.
+    with (
+        fails_raises_group(
+            "At index 0: `TypeError()` is not an instance of `ValueError`",
+        ),
+        RaisesGroup(ValueError, TypeError, ordered=True),
+    ):
+        raise ExceptionGroup("", [TypeError(), ValueError()])
+
+    # a wrong number of exceptions also fails with ordered=True
+    with (
+        fails_raises_group(
+            "Expected 2 exceptions in ordered group, but got 1: [ValueError()]",
+        ),
+        RaisesGroup(ValueError, TypeError, ordered=True),
+    ):
+        raise ExceptionGroup("", [ValueError()])
+
+    # ordered=True does positional matching so it disables the greedy-algorithm
+    # reordering that test_misordering_example relies on. Here the first expected
+    # matches the first raised positionally, so it succeeds where the unordered
+    # greedy algorithm would have failed.
+    with RaisesGroup(RaisesExc(ValueError, match="foo"), ValueError, ordered=True):
+        raise ExceptionGroup("", [ValueError("foo"), ValueError("bar")])
+
+    # ordered=True also works with nested groups and RaisesExc
+    with RaisesGroup(
+        RaisesExc(ValueError, match="a"),
+        RaisesGroup(TypeError),
+        ordered=True,
+    ):
+        raise ExceptionGroup(
+            "",
+            [ValueError("a"), ExceptionGroup("", [TypeError()])],
+        )
+
+    # with a single expected exception the failure message is identical to the
+    # unordered single-exception case (no "At index" prefix)
+    with (
+        fails_raises_group("`TypeError()` is not an instance of `ValueError`"),
+        RaisesGroup(ValueError, ordered=True),
+    ):
+        raise ExceptionGroup("", [TypeError()])
+
+    # when an expected entry produces a multi-line failure (e.g. a nested
+    # RaisesGroup that fails to match), the "At index N" prefix goes on its own
+    # line so the nested report stays readable
+    with (
+        fails_raises_group(
+            "At index 0:\n"
+            "\n"
+            "RaisesGroup(ValueError, ValueError): \n"
+            "  The following expected exceptions did not find a match:\n"
+            "    ValueError\n"
+            "    ValueError\n"
+            "  The following raised exceptions did not find a match\n"
+            "    TypeError():\n"
+            "      `TypeError()` is not an instance of `ValueError`\n"
+            "      `TypeError()` is not an instance of `ValueError`\n"
+            "    KeyError():\n"
+            "      `KeyError()` is not an instance of `ValueError`\n"
+            "      `KeyError()` is not an instance of `ValueError`"
+        ),
+        RaisesGroup(RaisesGroup(ValueError, ValueError), KeyError, ordered=True),
+    ):
+        raise ExceptionGroup(
+            "", [ExceptionGroup("inner", [TypeError(), KeyError()]), KeyError()]
+        )
+
+
+def test_ordered_nested_toggles() -> None:
+    # a nested RaisesGroup enforces its own `ordered` independently of the outer
+    # group: inner ordered=True with the right order passes
+    with RaisesGroup(RaisesGroup(ValueError, TypeError, ordered=True), ordered=True):
+        raise ExceptionGroup("", [ExceptionGroup("", [ValueError(), TypeError()])])
+
+    # inner ordered=True with the wrong order fails, even though the outer group matches
+    with (
+        fails_raises_group(
+            "RaisesGroup(ValueError, TypeError, ordered=True): "
+            "At index 0: `TypeError()` is not an instance of `ValueError`"
+        ),
+        RaisesGroup(RaisesGroup(ValueError, TypeError, ordered=True), ordered=True),
+    ):
+        raise ExceptionGroup("", [ExceptionGroup("", [TypeError(), ValueError()])])
+
+    # inner group left unordered (the default): its order does not matter even when
+    # the outer group is ordered
+    with RaisesGroup(RaisesGroup(ValueError, TypeError), ordered=True):
+        raise ExceptionGroup("", [ExceptionGroup("", [TypeError(), ValueError()])])
+
+
+def test_ordered_repr() -> None:
+    assert (
+        repr(RaisesGroup(ValueError, ordered=True))
+        == "RaisesGroup(ValueError, ordered=True)"
+    )
+    # ordered=False is the default and should not show up in the repr
+    assert repr(RaisesGroup(ValueError, ordered=False)) == "RaisesGroup(ValueError)"
+
+
 def test_brief_error_on_one_fail() -> None:
     """If only one raised and one expected fail to match up, we print a full table iff
     the raised exception would match one of the expected that previously got matched"""

--- a/testing/python/raises_group.py
+++ b/testing/python/raises_group.py
@@ -1064,6 +1064,91 @@ def test_ordered_nested_toggles() -> None:
     with RaisesGroup(RaisesGroup(ValueError, TypeError), ordered=True):
         raise ExceptionGroup("", [ExceptionGroup("", [TypeError(), ValueError()])])
 
+    # outer ordered=True with multiple entries: the nested group must sit at the
+    # expected position, so swapping the subgroups fails at the outer level even
+    # though both inner groups are unordered
+    with (
+        fails_raises_group(
+            "At index 0: RaisesGroup(ValueError): "
+            "`TypeError()` is not an instance of `ValueError`"
+        ),
+        RaisesGroup(RaisesGroup(ValueError), RaisesGroup(TypeError), ordered=True),
+    ):
+        raise ExceptionGroup(
+            "", [ExceptionGroup("", [TypeError()]), ExceptionGroup("", [ValueError()])]
+        )
+
+    # outer ordered=True and inner ordered=True fail independently: here the outer
+    # position is correct, so the failure is reported by the inner ordered check
+    with (
+        fails_raises_group(
+            "At index 0: RaisesGroup(ValueError, TypeError, ordered=True): "
+            "At index 0: `TypeError()` is not an instance of `ValueError`"
+        ),
+        RaisesGroup(
+            RaisesGroup(ValueError, TypeError, ordered=True),
+            RaisesExc(ValueError, match="a"),
+            ordered=True,
+        ),
+    ):
+        raise ExceptionGroup(
+            "",
+            [
+                ExceptionGroup("", [TypeError(), ValueError()]),
+                ValueError("a"),
+            ],
+        )
+
+    # outer group left unordered: the outer entries may be reordered freely, while
+    # an inner ordered=True group still enforces the order within its subgroup
+    with RaisesGroup(
+        RaisesGroup(ValueError, TypeError, ordered=True), RaisesGroup(KeyError)
+    ):
+        raise ExceptionGroup(
+            "",
+            [
+                ExceptionGroup("", [KeyError()]),
+                ExceptionGroup("", [ValueError(), TypeError()]),
+            ],
+        )
+
+    # ... and the inner ordered=True group fails on wrong inner order even though
+    # the unordered outer group would have been free to reorder
+    with (
+        fails_raises_group(
+            "RaisesGroup(ValueError, TypeError, ordered=True): "
+            "At index 0: `TypeError()` is not an instance of `ValueError`"
+        ),
+        RaisesGroup(RaisesGroup(ValueError, TypeError, ordered=True)),
+    ):
+        raise ExceptionGroup("", [ExceptionGroup("", [TypeError(), ValueError()])])
+
+    # with an unordered outer group, inner ordered=True constrains which subgroup
+    # each expected group can pair up with: two ordered groups with opposite orders
+    # each find their (only) fitting counterpart
+    with RaisesGroup(
+        RaisesGroup(ValueError, TypeError, ordered=True),
+        RaisesGroup(TypeError, ValueError, ordered=True),
+    ):
+        raise ExceptionGroup(
+            "",
+            [
+                ExceptionGroup("", [TypeError(), ValueError()]),
+                ExceptionGroup("", [ValueError(), TypeError()]),
+            ],
+        )
+
+    # fully unordered baseline: with both toggles at the default, both the outer
+    # entries and the inner exceptions may be arbitrarily reordered
+    with RaisesGroup(RaisesGroup(ValueError, TypeError), RaisesGroup(KeyError)):
+        raise ExceptionGroup(
+            "",
+            [
+                ExceptionGroup("", [KeyError()]),
+                ExceptionGroup("", [TypeError(), ValueError()]),
+            ],
+        )
+
 
 def test_ordered_repr() -> None:
     assert (

--- a/testing/typing_raises_group.py
+++ b/testing/typing_raises_group.py
@@ -223,6 +223,14 @@ def check_raisesgroup_overloads() -> None:
     RaisesGroup(ValueError, flatten_subgroups=True)
     RaisesGroup(RaisesExc(ValueError), flatten_subgroups=True)
 
+    # ordered is accepted alongside the other parameters
+    RaisesGroup(ValueError, TypeError, ordered=True)
+    RaisesGroup(ValueError, match="foo", ordered=True)
+    RaisesGroup(ValueError, check=bool, ordered=True)
+    RaisesGroup(RaisesExc(ValueError), ordered=True)
+    RaisesGroup(RaisesGroup(ValueError), ordered=True)
+    RaisesGroup(ValueError, flatten_subgroups=True, ordered=True)
+
     # if they're both false we can of course specify nested raisesgroup
     RaisesGroup(RaisesGroup(ValueError))
 


### PR DESCRIPTION
## Summary

Closes #14580.

`pytest.RaisesGroup` currently ignores the order of the exceptions in a group and pairs them up with a greedy matching algorithm. This PR adds an opt-in `ordered: bool = False` parameter. When `ordered=True`, the expected exceptions are matched against the raised exceptions **positionally** (expected[i] vs actual[i]), which:

- lets you assert that exceptions were raised in a particular order (the feature request in #14580), and
- side-steps the documented greedy-algorithm pitfall, where a valid pairing exists but the greedy algorithm fails to find it.

The default (`ordered=False`) preserves the existing order-insensitive behavior, so this is fully backwards compatible.

## Example

```python
# order is asserted
with pytest.RaisesGroup(ValueError, TypeError, ordered=True):
    raise ExceptionGroup("msg", [ValueError("foo"), TypeError("bar")])

# wrong order now fails
with pytest.RaisesGroup(ValueError, TypeError, ordered=True):
    raise ExceptionGroup("msg", [TypeError("bar"), ValueError("foo")])
# -> Raised exception group did not match: At index 0: `TypeError()` is not an instance of `ValueError`
```

## Implementation notes

- Added `ordered` to all `RaisesGroup.__init__` overloads and the runtime signature, stored as `self.ordered`.
- New focused helper `RaisesGroup._check_exceptions_ordered` does the positional matching and produces failure messages that point at the offending index (`At index N: ...`) and report length mismatches.
- `RaisesGroup._check_exceptions` short-circuits to the ordered path when `ordered=True`; the greedy path is untouched.
- `__repr__` shows `ordered=True` only when set (parallel to `flatten_subgroups`).
- Docstring, `doc/en/how-to/assert.rst`, and a `changelog/14580.feature.rst` newsfragment updated; added myself to `AUTHORS`.

## Testing

- `testing/python/raises_group.py`: new `test_ordered` (success in/out of order, wrong order, wrong length, nested groups + `RaisesExc`, greedy-pitfall case) and `test_ordered_repr`.
- `testing/typing_raises_group.py`: `ordered=` accepted alongside the other parameters.
- `uv run pytest testing/python/raises_group.py testing/python/raises.py` → 67 passed; with `--doctest-modules src/_pytest/raises.py` → 68 passed.
- `ruff check` / `ruff format --check` clean on all touched files.
