### PR TITLE
Revert "fixtures: remove no longer needed special case in `pytest_generate_tests`"

### DIFF
--- a/changelog/14591.bugfix.rst
+++ b/changelog/14591.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a regression in pytest 9.1.0 which caused overriding a parametrized fixture with an indirect `@pytest.mark.parametrize` to fail with "duplicate parametrization of '<fixture name>'".

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -64,6 +64,7 @@ from _pytest.deprecated import FIXTUREDEF_HAS_LOCATION_DEPRECATED
 from _pytest.deprecated import PARSEFACTORIES_NODEID_DEPRECATED
 from _pytest.deprecated import YIELD_FIXTURE
 from _pytest.main import Session
+from _pytest.mark import Mark
 from _pytest.mark import ParameterSet
 from _pytest.mark.structures import MarkDecorator
 from _pytest.outcomes import fail
@@ -1898,9 +1899,22 @@ class FixtureManager:
 
     def pytest_generate_tests(self, metafunc: Metafunc) -> None:
         """Generate new tests based on parametrized fixtures used by the given metafunc"""
+
+        def get_parametrize_mark_argnames(mark: Mark) -> Sequence[str]:
+            args, _ = ParameterSet._parse_parametrize_args(*mark.args, **mark.kwargs)
+            return args
+
         for argname in metafunc.fixturenames:
             # Get the FixtureDefs for the argname.
             fixture_defs = metafunc._arg2fixturedefs.get(argname, ())
+
+            # If the test itself parametrizes using this argname, give it
+            # precedence.
+            if any(
+                argname in get_parametrize_mark_argnames(mark)
+                for mark in metafunc.definition.iter_markers("parametrize")
+            ):
+                continue
 
             # In the common case we only look at the fixture def with the
             # closest scope (last in the list). But if the fixture overrides

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -2624,6 +2624,32 @@ class TestFixtureMarker:
         reprec = pytester.inline_run()
         reprec.assertoutcome(passed=2)
 
+    def test_override_parametrized_fixture_with_indirect(
+        self, pytester: Pytester
+    ) -> None:
+        """Make sure a parametrized argument can override a parametrized fixture.
+
+        This was a regression introduced in the fix for #736.
+        """
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.fixture(params=["a"])
+            def fixt(request):
+                return request.param * 2
+
+            def test_fixt(fixt):
+                assert fixt == "aa"
+
+            @pytest.mark.parametrize("fixt", ['b'], indirect=True)
+            def test_indirect(fixt):
+                assert fixt == "bb"
+            """
+        )
+        reprec = pytester.inline_run()
+        reprec.assertoutcome(passed=2)
+
     def test_scope_session(self, pytester: Pytester) -> None:
         pytester.makepyfile(
             """


### PR DESCRIPTION
This reverts commit d56b1af5252ceb8578d6751a6b2006e79defbb08.

Seems this is still needed for the indirect case. Revert and add a regression test for now; I might look into it more later.