### PR TITLE
docs: clarify confcutdir plugin discovery cutoff

### DIFF
--- a/changelog/12857.doc.rst
+++ b/changelog/12857.doc.rst
@@ -1,0 +1,1 @@
+Documented how ``--confcutdir`` affects initial ``conftest.py`` discovery.

--- a/doc/en/how-to/writing_plugins.rst
+++ b/doc/en/how-to/writing_plugins.rst
@@ -54,8 +54,11 @@ Plugin discovery order at tool startup
      :confval:`testpaths` if defined and running from the rootdir, otherwise the
      current dir
    - for each test path, load ``conftest.py`` and ``test*/conftest.py`` relative
-     to the directory part of the test path, if exist. Before a ``conftest.py``
-     file is loaded, load ``conftest.py`` files in all of its parent directories.
+     to the directory part of the test path, if they exist. Before a ``conftest.py``
+     file is loaded, load ``conftest.py`` files in its parent directories up to
+     the :option:`--confcutdir` limit. When ``--confcutdir`` is not provided,
+     the cutoff defaults to the directory containing the config file, or to the
+     :ref:`rootdir <rootdir>` if no config file is found.
      After a ``conftest.py`` file is loaded, recursively load all plugins specified
      in its :globalvar:`pytest_plugins` variable if present.
 


### PR DESCRIPTION
## Summary
- clarify that initial `conftest.py` discovery stops at `--confcutdir`
- document the default cutoff when `--confcutdir` is not provided

## Verification
- `python -m pytest testing/test_conftest.py -k confcutdir -q --basetemp .pytest-tmp`
- `python -m sphinx -W --keep-going -b html doc/en doc/en/_build/html` (hits one pre-existing unrelated warning: `py._path.local.LocalPath` reference target not found)

Closes #12857.
