### PR TITLE
fix: strip ANSI escape codes from TerminalRepr.__str__ output (#12365)

### DIFF
--- a/changelog/12365.bugfix.rst
+++ b/changelog/12365.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ANSI escape codes (for example from syntax-highlighted assertion diffs produced under ``--color=yes``) leaking into JUnit XML reports and other plain-text outputs. :class:`~_pytest._code.code.TerminalRepr` now strips all ANSI escape sequences from its string representation.

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -1246,7 +1246,12 @@ class ExceptionInfoFormatter:
         return ExceptionChainRepr(repr_chain)
 
 
-_ANSI_ESCAPE_RE: Final = re.compile(r"\x1b\[[0-9;]*m")
+# Matches all ANSI escape sequences per ECMA-48: CSI sequences (SGR colour
+# codes ending in "m", but also cursor moves and line clears such as
+# "\x1b[K" / "\x1b[2K") and two-character escapes.  Plain-text consumers
+# (JUnit XML, pytest-xdist serialization, resultlog) must never receive raw
+# escape codes.  See #12365.
+_ANSI_ESCAPE_RE: Final = re.compile(r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
 
 @dataclasses.dataclass(eq=False)
@@ -1260,13 +1265,10 @@ class TerminalRepr:
         io = StringIO()
         tw = TerminalWriter(file=io)
         self.toterminal(tw)
-        text = io.getvalue().strip()
-        # Strip ANSI escape sequences that may have been pre-baked into the
-        # repr data by Pygments-highlighted assertion diffs or by a
-        # TerminalWriter running with forced markup (PY_COLORS / FORCE_COLOR).
-        # Plain-text consumers such as JUnit XML and pytest-xdist serialization
-        # should never see raw escape codes.  See #12365.
-        return _ANSI_ESCAPE_RE.sub("", text)
+        # Strip ANSI escape codes that may have been pre-baked into the repr
+        # data (e.g. by Pygments-highlighted assertion diffs under
+        # --color=yes) so plain-text consumers never see them.  See #12365.
+        return _ANSI_ESCAPE_RE.sub("", io.getvalue().strip())
 
     def __repr__(self) -> str:
         return f"<{self.__class__} instance at {id(self):0x}>"

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -1246,6 +1246,9 @@ class ExceptionInfoFormatter:
         return ExceptionChainRepr(repr_chain)
 
 
+_ANSI_ESCAPE_RE: Final = re.compile(r"\x1b\[[0-9;]*m")
+
+
 @dataclasses.dataclass(eq=False)
 class TerminalRepr:
     """Base class for terminal representations -- pieces of data that display
@@ -1257,7 +1260,13 @@ class TerminalRepr:
         io = StringIO()
         tw = TerminalWriter(file=io)
         self.toterminal(tw)
-        return io.getvalue().strip()
+        text = io.getvalue().strip()
+        # Strip ANSI escape sequences that may have been pre-baked into the
+        # repr data by Pygments-highlighted assertion diffs or by a
+        # TerminalWriter running with forced markup (PY_COLORS / FORCE_COLOR).
+        # Plain-text consumers such as JUnit XML and pytest-xdist serialization
+        # should never see raw escape codes.  See #12365.
+        return _ANSI_ESCAPE_RE.sub("", text)
 
     def __repr__(self) -> str:
         return f"<{self.__class__} instance at {id(self):0x}>"

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -2057,3 +2057,20 @@ def test_check_error_notes_failure(
     with pytest.raises(AssertionError):
         with pytest.raises(type(error), match=match):
             raise error
+
+
+def test_terminalrepr_strips_all_ansi_escape_codes() -> None:
+    r"""TerminalRepr.__str__ must strip every ANSI escape code, not just SGR.
+
+    Regression guard for #12365: a narrow ``\x1b[...m`` regex let non-SGR CSI
+    sequences (cursor moves, line clears) leak into plain-text consumers such
+    as JUnit XML.
+    """
+    from _pytest._code.code import TerminalRepr
+
+    class _Repr(TerminalRepr):
+        def toterminal(self, tw: TerminalWriter) -> None:
+            # SGR colour codes plus a line-clear and a cursor-up move.
+            tw.write("\x1b[31mred\x1b[0m \x1b[2Kcleared \x1b[1Aup")
+
+    assert str(_Repr()) == "red cleared up"

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1842,7 +1842,6 @@ def test_no_message_quiet(pytester: Pytester) -> None:
     result.stdout.no_fnmatch_line("* generated xml file: *")
 
 
-
 def test_ansi_escape_codes_stripped_from_junitxml(
     pytester: Pytester, run_and_parse: RunAndParse
 ) -> None:

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1752,7 +1752,10 @@ def test_escaped_setup_teardown_error(
     node = dom.get_first_by_tag("testcase")
     snode = node.get_first_by_tag("error")
     assert "#x1B[31mred#x1B[m" in snode["message"]
-    assert "#x1B[31mred#x1B[m" in snode.text
+    # TerminalRepr.__str__ strips ANSI escape codes before bin_xml_escape
+    # runs, so the text body contains the bare word without escape sequences.
+    assert "red" in snode.text
+    assert "#x1B" not in snode.text
 
 
 @parametrize_families
@@ -1837,3 +1840,31 @@ def test_no_message_quiet(pytester: Pytester) -> None:
 
     result = pytester.runpytest("--junitxml=pytest.xml", "--quiet")
     result.stdout.no_fnmatch_line("* generated xml file: *")
+
+
+
+def test_ansi_escape_codes_stripped_from_junitxml(
+    pytester: Pytester, run_and_parse: RunAndParse
+) -> None:
+    """ANSI escape codes from assertion diffs must not leak into JUnit XML.
+
+    Pygments-highlighted assertion diffs pre-bake ANSI escape sequences into
+    the repr data.  TerminalRepr.__str__ now strips them so that plain-text
+    consumers (JUnit XML, pytest-xdist serialization) never see raw escape
+    codes.  See #12365.
+    """
+    pytester.makepyfile(
+        """
+        def test_fail():
+            assert "hello" == "world"
+    """
+    )
+    _, dom = run_and_parse("--color=yes")
+    node = dom.get_first_by_tag("testcase")
+    fnode = node.get_first_by_tag("failure")
+    # The failure text must not contain raw ANSI escape sequences.
+    assert "\x1b[" not in fnode.text
+    assert "#x1B" not in fnode.text
+    # But the actual assertion content should still be present.
+    assert "hello" in fnode.text
+    assert "world" in fnode.text


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->

Closes #12365.

- [x] Include new tests or update existing tests when applicable.
- [ ] - [X] Allow maintainers to push and squash when merging my commits.
## Problem

When `PY_COLORS=1` or `FORCE_COLOR` is set, Pygments-highlighted assertion diffs pre-bake ANSI escape sequences (e.g. `\x1b[1m`, `\x1b[36m`) into `ReprEntry.lines` at test time.  When `TerminalRepr.__str__()` is later called by plain-text consumers such as JUnit XML (`--junitxml`) or pytest-xdist serialization, those raw escape codes leak into the output and corrupt the XML.

## Root cause

`TerminalRepr.__str__` creates a `TerminalWriter` backed by a `StringIO` and calls `self.toterminal(tw)`.  The ANSI codes already embedded in `ReprEntry.lines` are written verbatim into the `StringIO`, and `__str__` returns them unmodified.

`bin_xml_escape()` in `junitxml.py` does handle individual invalid-XML characters (including `0x1B`) by replacing them with `#xNN` references, but it cannot reassemble a multi-character ANSI sequence back into readable text, so the XML ends up containing fragments like `#x1B[31m`.

## Fix

Add a module-level compiled regex `_ANSI_ESCAPE_RE` that matches SGR escape sequences (`ESC[...m`) and strip them from the string returned by `__str__` before returning.

**Why this is safe for test data that contains real escape bytes:**  `saferepr()` escapes non-printable characters to their literal text representation (e.g. actual `0x1B` bytes become the six characters `\x1b`), so user data that happens to include ANSI codes is represented as literal backslash-x-1-b text, which does *not* match the regex (the regex matches only the actual single byte `0x1B`).

## Tests

- Updated `test_escaped_setup_teardown_error` to reflect that `snode.text` (which flows through `TerminalRepr.__str__`) no longer contains `#x1B`-escaped ANSI codes.  The `snode["message"]` assertion is unchanged because `reprcrash.message` bypasses `__str__`.
- - Added `test_ansi_escape_codes_stripped_from_junitxml` that runs a failing test with `--color=yes` and verifies no ANSI escape sequences appear in the failure element text.