### PR TITLE
mark/structures: undo non-collection-argvalues type-check time deprecation due to mypy bug

### DIFF
--- a/changelog/14606.bugfix.rst
+++ b/changelog/14606.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``list-item`` typing errors from mypy in :ref:`@pytest.mark.parametrize <pytest.mark.parametrize ref>` ``argvalues`` parameter.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -21,7 +21,6 @@ from typing import TypeVar
 import warnings
 
 from .._code import getfslineno
-from ..compat import deprecated
 from ..compat import NOTSET
 from ..compat import NotSetType
 from _pytest.config import Config
@@ -537,31 +536,16 @@ if TYPE_CHECKING:
         ) -> MarkDecorator: ...
 
     class _ParametrizeMarkDecorator(MarkDecorator):
-        @overload  # type: ignore[override,no-overload-impl]
-        def __call__(
-            self,
-            argnames: str | Sequence[str],
-            argvalues: Collection[ParameterSet | Sequence[object] | object],
-            *,
-            indirect: bool | Sequence[str] = ...,
-            ids: Iterable[None | str | float | int | bool | _HiddenParam]
-            | Callable[[Any], object | None]
-            | None = ...,
-            scope: ScopeName | None = ...,
-        ) -> MarkDecorator: ...
-
-        @overload
-        @deprecated(
-            "Passing a non-Collection iterable to the 'argvalues' parameter of @pytest.mark.parametrize is deprecated. "
-            "Convert argvalues to a list or tuple.",
-        )
-        def __call__(
+        def __call__(  # type: ignore[override]
             self,
             argnames: str | Sequence[str],
             argvalues: Iterable[ParameterSet | Sequence[object] | object],
+            # TODO(pytest10): Change to below after PARAMETRIZE_NON_COLLECTION_ITERABLE deprecation.
+            #                 Overload doesn't work, see #14606.
+            # argvalues: Collection[ParameterSet | Sequence[object] | object],
             *,
             indirect: bool | Sequence[str] = ...,
-            ids: Iterable[None | str | float | int | bool]
+            ids: Iterable[None | str | float | int | bool | _HiddenParam]
             | Callable[[Any], object | None]
             | None = ...,
             scope: ScopeName | None = ...,

--- a/testing/typing_checks.py
+++ b/testing/typing_checks.py
@@ -67,15 +67,14 @@ def test_hidden_param(x: int) -> None:
     pass
 
 
-# Test @pytest.mark.parametrize iterator argvalues deprecation.
-# Will be complain about unused type ignore if doesn't work.
-@pytest.mark.parametrize("x", iter(range(10)))  # type: ignore[deprecated]
-def test_it(x: int) -> None:
-    pass
-
-
 # Issue #14137.
 def check_scope_typing() -> None:
 
     custom_scope: ScopeName = "function"
     assert_type(custom_scope, ScopeName)
+
+
+# Issue #14606.
+@pytest.mark.parametrize("x", [ImportError, AttributeError])
+def check_mypy_bug_with_argvalues(x) -> None:
+    pass


### PR DESCRIPTION
Please see the issue for details. The runtime deprecation remains.

Fix #14606