### PR TITLE
python: minor refactor of `_find_parametrized_scope`

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1333,7 +1333,7 @@ class Metafunc:
                 scope, descr=f"parametrize() call in {self.function.__name__}"
             )
         else:
-            scope_ = _find_parametrized_scope(argnames, self._arg2fixturedefs, indirect)
+            scope_ = _infer_parametrize_scope(argnames, self._arg2fixturedefs, indirect)
 
         self._validate_if_using_arg_names(argnames, indirect)
 
@@ -1526,12 +1526,13 @@ class Metafunc:
                     callspec.indices[argname] = i
 
 
-def _find_parametrized_scope(
+def _infer_parametrize_scope(
     argnames: Sequence[str],
     arg2fixturedefs: Mapping[str, Sequence[fixtures.FixtureDef[object]]],
     indirect: bool | Sequence[str],
 ) -> Scope:
-    """Find the most appropriate scope for a parametrized call based on its arguments.
+    """Infer the most appropriate scope for a parametrize() call based on its
+    arguments, for when the scope is not explicitly specified.
 
     When there's at least one direct argument, always use "function" scope.
 
@@ -1546,13 +1547,14 @@ def _find_parametrized_scope(
         all_arguments_are_fixtures = bool(indirect)
 
     if all_arguments_are_fixtures:
-        fixturedefs = arg2fixturedefs or {}
-        used_scopes = [
-            fixturedef[-1]._scope
-            for name, fixturedef in fixturedefs.items()
-            if name in argnames
-        ]
         # Takes the most narrow scope from used fixtures.
+        used_scopes = (
+            # Higher scope can't request lower scope, so it's OK to only
+            # look at the first fixturedef in the override chain.
+            arg2fixturedefs[argname][-1]._scope
+            for argname in argnames
+            if argname in arg2fixturedefs
+        )
         return min(used_scopes, default=Scope.Function)
 
     return Scope.Function

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -192,9 +192,9 @@ class TestMetafunc:
         ):
             metafunc.parametrize("request", [1])
 
-    def test_find_parametrized_scope(self) -> None:
-        """Unit test for _find_parametrized_scope (#3941)."""
-        from _pytest.python import _find_parametrized_scope
+    def test_infer_parametrize_scope(self) -> None:
+        """Unit test for _infer_parameterize_scope (#3941)."""
+        from _pytest.python import _infer_parametrize_scope
 
         @dataclasses.dataclass
         class DummyFixtureDef:
@@ -215,7 +215,7 @@ class TestMetafunc:
         # use arguments to determine narrow scope; the cause of the bug is that it would look on all
         # fixture defs given to the method
         def find_scope(argnames, indirect):
-            return _find_parametrized_scope(argnames, fixtures_defs, indirect=indirect)
+            return _infer_parametrize_scope(argnames, fixtures_defs, indirect=indirect)
 
         assert find_scope(["func_fix"], indirect=True) == Scope.Function
         assert find_scope(["class_fix"], indirect=True) == Scope.Class


### PR DESCRIPTION
I was looking at this function when reviewing #14070 and thought some small things can be better.

- Change the name to `_infer_parametrize_scope`, I think is more descriptive.

- Remove unneeded `arg2fixturedefs or {}`.

- Change `used_scopes` from list to generator.

- Iterate over `argnames` instead of `arg2fixturedefs`, should be more efficient since `len(argnames)` <= `len(arg2fixturedefs)`.

- Comment why `-1` is OK here.