### PR TITLE
Improve parametrize error for scalar parameter sets

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -333,6 +333,7 @@ Mihail Milushev
 Mike Fiedler (miketheman)
 Mike Hoyle (hoylemd)
 Mike Lundy
+Mike Ma
 Milan Lesnek
 minbang930
 Miro Hrončok

--- a/changelog/14619.bugfix.rst
+++ b/changelog/14619.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a crash in ``pytest.mark.parametrize`` when a non-sequence value is passed for a parameter set. It now provides a clear error message during collection.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -221,6 +221,8 @@ class ParameterSet(NamedTuple):
                 if values_len is None:
                     fail(
                         f'{nodeid}: in "parametrize" expected a sequence of values, '
+                        "for a single value use a one-element tuple like "
+                        "('value',), "
                         f"got {type(param.values).__name__}:\n"
                         f"  {param.values}",
                         pytrace=False,

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -214,7 +214,18 @@ class ParameterSet(NamedTuple):
         if parameters:
             # Check all parameter sets have the correct number of values.
             for param in parameters:
-                if len(param.values) != len(argnames):
+                try:
+                    values_len = len(param.values)
+                except TypeError:
+                    values_len = None
+                if values_len is None:
+                    fail(
+                        f'{nodeid}: in "parametrize" expected a sequence of values, '
+                        f"got {type(param.values).__name__}:\n"
+                        f"  {param.values}",
+                        pytrace=False,
+                    )
+                if values_len != len(argnames):
                     msg = (
                         '{nodeid}: in "parametrize" the number of names ({names_len}):\n'
                         "  {names}\n"
@@ -227,7 +238,7 @@ class ParameterSet(NamedTuple):
                             values=param.values,
                             names=argnames,
                             names_len=len(argnames),
-                            values_len=len(param.values),
+                            values_len=values_len,
                         ),
                         pytrace=False,
                     )

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -495,6 +495,28 @@ def test_parametrized_collect_with_wrong_args(pytester: Pytester) -> None:
     )
 
 
+def test_parametrized_collect_with_non_sequence_values(pytester: Pytester) -> None:
+    """Test collect parametrized func with tuple-style argnames and scalar values."""
+    py_file = pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.parametrize("x,", [None])
+        def test_func(x):
+            pass
+    """
+    )
+
+    result = pytester.runpytest(py_file)
+    result.stdout.fnmatch_lines(
+        [
+            "test_parametrized_collect_with_non_sequence_values.py::test_func: "
+            'in "parametrize" expected a sequence of values, got NoneType:',
+            "  None",
+        ]
+    )
+
+
 def test_parametrized_with_kwargs(pytester: Pytester) -> None:
     """Test collect parametrized func with wrong number of args."""
     py_file = pytester.makepyfile(

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -511,7 +511,9 @@ def test_parametrized_collect_with_non_sequence_values(pytester: Pytester) -> No
     result.stdout.fnmatch_lines(
         [
             "test_parametrized_collect_with_non_sequence_values.py::test_func: "
-            'in "parametrize" expected a sequence of values, got NoneType:',
+            'in "parametrize" expected a sequence of values, '
+            "for a single value use a one-element tuple like ('value',), "
+            "got NoneType:",
             "  None",
         ]
     )


### PR DESCRIPTION
Closes #14619.

This turns a `TypeError` during collection into a normal `parametrize` collection error when tuple-style argnames receive a scalar parameter set.

For example, `@pytest.mark.parametrize("x,", [None])` now points at the offending test and reports that the parameter set should be a sequence, instead of showing an internal `len(None)` crash.

I added a regression test for the `None` case and a changelog entry.

I used AI assistance while preparing this change, reviewed the patch locally, and take responsibility for the contribution.

Checks run locally:

```text
PYTHONPATH=src python3 -m pytest testing/test_mark.py::test_parametrized_collect_with_non_sequence_values testing/test_mark.py::test_parametrized_collect_with_wrong_args -q
PYTHONPATH=src python3 -m pytest testing/test_mark.py -q
git diff --check -- src/_pytest/mark/structures.py testing/test_mark.py changelog/14619.bugfix.rst AUTHORS
python3 -m py_compile src/_pytest/mark/structures.py testing/test_mark.py
```

`testing/python/metafunc.py` was not run locally because `hypothesis` is not installed in this environment.

Checklist:

- [x] New regression test added.
- [x] Maintainers may push to and squash this branch when merging.
- [x] Closes #14619.
- [x] AI assistance is credited in the commit trailer.
- [x] Changelog fragment added in `changelog/14619.bugfix.rst`.
- [x] Added myself to `AUTHORS`.