### PR TITLE
fix: load test* subdir conftests when initial path is missing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -89,6 +89,7 @@ Charles Machalow
 Charles-Meldhine Madi Mnemoi (cmnemoi)
 Charnjit SiNGH (CCSJ)
 Cheuk Ting Ho
+Chris Burr
 Chris Mahoney
 Chris Lamb
 Chris NeJame

--- a/changelog/14608.bugfix.rst
+++ b/changelog/14608.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a regression in pytest 9.1.0 where ``conftest.py`` files located in ``<invocation dir>/test*`` were no longer loaded as initial conftests when invoked without arguments.
+This could cause certain hooks (like :hook:`pytest_addoption`) in these files to not fire.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -645,18 +645,18 @@ class PytestPluginManager(PluginManager):
             if i != -1:
                 path = path[:i]
             anchor = absolutepath(invocation_dir / path)
-
             # Ensure we do not break if what appears to be an anchor
             # is in fact a very long option (#10169, #11394).
-            if safe_exists(anchor):
-                anchors.append(anchor)
-                # Let's also consider test* subdirs.
-                if anchor.is_dir():
-                    for x in anchor.glob("test*"):
-                        if x.is_dir():
-                            anchors.append(x)
+            if not safe_exists(anchor):
+                continue
+
+            anchors.append(anchor)
+            # Let's also consider test* subdirs.
+            if anchor.is_dir():
+                anchors.extend(x for x in anchor.glob("test*") if x.is_dir())
         if not anchors:
-            anchors = [invocation_dir]
+            anchors.append(invocation_dir)
+            anchors.extend(x for x in invocation_dir.glob("test*") if x.is_dir())
 
         for anchor in anchors:
             self._loadconftestmodules(

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -440,6 +440,28 @@ def test_conftest_existing_junitxml(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(["*--xyz*"])
 
 
+def test_conftests_in_invocation_dir_tests_is_initial(pytester: Pytester) -> None:
+    """An option registered in a conftest under ``test*`` subdir of the
+    invocation dir is loaded as initial when no command-line arguments
+    or `testpaths` are given (#14608).
+    """
+    pytester.makepyfile(
+        **{
+            "tests/conftest.py": """
+                def pytest_addoption(parser):
+                    parser.addoption("--db-url")
+            """,
+            "test_it.py": """
+                def test_it(request):
+                    assert request.config.getoption("--db-url") == "scheme://host/db"
+            """,
+        }
+    )
+    result = pytester.runpytest("--db-url", "scheme://host/db")
+    assert result.ret == ExitCode.OK
+    result.assert_outcomes(passed=1)
+
+
 def test_conftest_import_order(pytester: Pytester, monkeypatch: MonkeyPatch) -> None:
     ct1 = pytester.makeconftest("")
     sub = pytester.mkdir("sub")


### PR DESCRIPTION
This PR fixes a mistake in the 9.1.0 rewrite of `_set_initial_conftests` (#14307) that led to #14608. I saw this issue in my own project and have verified that the included test reproduces the failure and this PR then fixes it.

Closes #14608

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [X] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
