### PR TITLE
Improve parametrize error for invalid tuple-style values

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -207,6 +207,7 @@ Hugo van Kemenade
 Hui Wang (coldnight)
 Ian Bicking
 Ian Lesperance
+Ilia Sorokin
 Ilya Abdolmanafi
 Ilya Konstantinov
 Ionuț Turturică

--- a/changelog/14619.bugfix.rst
+++ b/changelog/14619.bugfix.rst
@@ -1,0 +1,1 @@
+Improved ``parametrize`` collection errors for tuple-style parameter names with invalid scalar values.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -213,8 +213,28 @@ class ParameterSet(NamedTuple):
 
         if parameters:
             # Check all parameter sets have the correct number of values.
-            for param in parameters:
-                if len(param.values) != len(argnames):
+            for i, param in enumerate(parameters):
+                try:
+                    values_len = len(param.values)
+                except TypeError:
+                    values_len = None
+
+                if values_len is None:
+                    msg = (
+                        '{nodeid}: in "parametrize" the parameter set at index {index} '
+                        "needs to be a sequence, but got {values!r}"
+                    )
+                    fail(
+                        msg.format(nodeid=nodeid, index=i, values=param.values),
+                        pytrace=False,
+                    )
+
+                if values_len != len(argnames):
+                    values = (
+                        list(param.values)
+                        if isinstance(param.values, str)
+                        else param.values
+                    )
                     msg = (
                         '{nodeid}: in "parametrize" the number of names ({names_len}):\n'
                         "  {names}\n"
@@ -224,10 +244,10 @@ class ParameterSet(NamedTuple):
                     fail(
                         msg.format(
                             nodeid=nodeid,
-                            values=param.values,
+                            values=values,
                             names=argnames,
                             names_len=len(argnames),
-                            values_len=len(param.values),
+                            values_len=values_len,
                         ),
                         pytrace=False,
                     )

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -119,6 +119,36 @@ class TestMetafunc:
         assert metafunc._calls[0].params == {"arg": "a"}
         assert metafunc._calls[1].params == {"arg": "b"}
 
+    def test_parametrize_trailing_comma_scalar_parameter_set(self) -> None:
+        def func(arg):
+            pass  # pragma: no cover
+
+        metafunc = self.Metafunc(func)
+
+        with pytest.raises(fail.Exception) as excinfo:
+            metafunc.parametrize("arg,", [None])
+
+        assert str(excinfo.value) == (
+            'mock::nodeid: in "parametrize" the parameter set at index 0 '
+            "needs to be a sequence, but got None"
+        )
+
+    def test_parametrize_string_parameter_set_error_shows_sequence(self) -> None:
+        def func(arg):
+            pass  # pragma: no cover
+
+        metafunc = self.Metafunc(func)
+
+        with pytest.raises(fail.Exception) as excinfo:
+            metafunc.parametrize("arg,", ["foo"])
+
+        assert str(excinfo.value) == (
+            'mock::nodeid: in "parametrize" the number of names (1):\n'
+            "  ['arg']\n"
+            "must be equal to the number of values (3):\n"
+            "  ['f', 'o', 'o']"
+        )
+
     def test_parametrize_error(self) -> None:
         def func(x, y):
             pass


### PR DESCRIPTION
Closes #14619.

## Summary

This improves the collection error raised when tuple-style `parametrize` argument names receive an invalid scalar parameter set.

Previously, `@pytest.mark.parametrize("x,", [None, "foo", "bar"])` crashed while formatting the validation error because pytest called `len()` on `None`. The updated validation reports the bad parameter set index directly instead.

It also makes the existing string mismatch case clearer by displaying the string as the sequence pytest counted, e.g. `['f', 'o', 'o']`, instead of `foo`.

## Test plan

- `uv run --python /opt/homebrew/bin/python3.12 --extra dev --with-editable . python -m pytest testing/python/metafunc.py::TestMetafunc::test_parametrize_trailing_comma_scalar_parameter_set testing/python/metafunc.py::TestMetafunc::test_parametrize_string_parameter_set_error_shows_sequence -q`
- `uv run --python /opt/homebrew/bin/python3.12 --extra dev --with-editable . python -m pytest testing/python/metafunc.py -q`
- `uvx pre-commit run --files src/_pytest/mark/structures.py testing/python/metafunc.py AUTHORS changelog/14619.bugfix.rst`

## Notes

Full test suite was not run locally; this change is covered by the focused parametrization tests and the full `testing/python/metafunc.py` module.

AI tooling was used while preparing this patch, and the commit includes a `Co-authored-by` trailer for attribution.
