### PR TITLE
Fix off-by-one in trailing assertion diff skipping (#14637)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@ Abhijeet Kasurde
 Adam Johnson
 Adam Stewart
 Adam Uhlir
+Aditya Tripuraneni
 Ahn Ki-Wook
 Akhilesh Ramakrishnan
 Akiomi Kamakura

--- a/changelog/14637.bugfix.rst
+++ b/changelog/14637.bugfix.rst
@@ -1,0 +1,1 @@
+Pytest now correctly skips identical trailing characters in assertion text diffs even when the compared strings differ at the beginning.

--- a/src/_pytest/assertion/compare_text.py
+++ b/src/_pytest/assertion/compare_text.py
@@ -59,7 +59,7 @@ def _diff_text(
             left = left[i:]
             right = right[i:]
         if len(left) == len(right):
-            for i in range(len(left)):
+            for i in range(1, len(left) + 1):
                 if left[-i] != right[-i]:
                     break
             if i > 42:

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -507,6 +507,14 @@ class TestAssert_reprcompare:
         for line in lines:
             assert "z" * 50 not in line
 
+    def test_text_skipping_trailing_when_prefix_differs(self) -> None:
+        # The trailing-skip branch must still work when the first characters differ.
+        lines = callequal("x" + "z" * 50, "y" + "z" * 50)
+        assert lines is not None
+        assert any("identical trailing" in line for line in lines)
+        for line in lines:
+            assert "z" * 50 not in line
+
     def test_text_skipping_verbose(self) -> None:
         lines = callequal("a" * 50 + "spam", "a" * 50 + "eggs", verbose=1)
         assert lines is not None


### PR DESCRIPTION
Closes #14637

Fix an off-by-one in trailing text diff skipping so pytest compares from the last character first instead of accidentally checking the first character via `-0`.

This adds a regression test for the case where the compared strings differ at the beginning but share a long identical trailing suffix, and includes a changelog entry.

Thanks to @EternalRights for finding and reporting this bug.
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
