### PR TITLE
fix(config): remove `as Name` re-export pattern to support PYTHON_LAZY_IMPORTS=all (Python 3.15)

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -45,8 +45,8 @@ from pluggy import HookspecMarker
 from pluggy import HookspecOpts
 from pluggy import PluginManager
 
-from .exceptions import PrintHelp as PrintHelp
-from .exceptions import UsageError as UsageError
+from .exceptions import PrintHelp  # re-exported
+from .exceptions import UsageError  # re-exported
 from .findpaths import ConfigDict
 from .findpaths import ConfigValue
 from .findpaths import determine_setup


### PR DESCRIPTION
## Problem

`pytest` crashes when run with Python 3.15's `PYTHON_LAZY_IMPORTS=all` environment variable:

```
$ PYTHON_LAZY_IMPORTS=all pytest --help
Traceback (most recent call last):
  File ".../src/_pytest/config/__init__.py", line 50, in <module>
    from .exceptions import UsageError as UsageError
ImportError: lazy import of '_pytest.config.exceptions.UsageError' raised an exception during resolution
```

## Root cause

Python 3.15 introduces `PYTHON_LAZY_IMPORTS` (PEP 690) which defers module loading until names are first accessed. The `from module import Name as Name` pattern (where the alias repeats the original name) is a well-known mypy/pyright re-export marker — but it conflicts with the lazy import resolution mechanism in Python 3.15.

Lines 48–49 in `src/_pytest/config/__init__.py` use this pattern for `PrintHelp` and `UsageError`:

```python
# Before — breaks PYTHON_LAZY_IMPORTS=all
from .exceptions import PrintHelp as PrintHelp
from .exceptions import UsageError as UsageError
```

## Fix

Remove the redundant `as Name` alias. A `# re-exported` comment preserves the intent for human readers:

```python
# After — compatible with PYTHON_LAZY_IMPORTS=all
from .exceptions import PrintHelp  # re-exported
from .exceptions import UsageError  # re-exported
```

This is a no-op at runtime. The only practical change is that strict-mode type checkers (`mypy --no-implicit-reexport`) will no longer treat these as explicit re-exports — but since `_pytest.config` is a private namespace, this is an acceptable tradeoff for Python 3.15 forward-compatibility.

Closes #14632