### PR TITLE
Error on top-level options in pytest.toml

### DIFF
--- a/changelog/14638.bugfix.rst
+++ b/changelog/14638.bugfix.rst
@@ -1,1 +1,1 @@
-Top-level options in ``pytest.toml`` and ``.pytest.toml`` files are now read as pytest configuration instead of being silently ignored.
+Top-level options in ``pytest.toml`` and ``.pytest.toml`` files now raise an error instead of being silently ignored when no ``[pytest]`` table is present.

--- a/changelog/14638.bugfix.rst
+++ b/changelog/14638.bugfix.rst
@@ -1,0 +1,1 @@
+Top-level options in ``pytest.toml`` and ``.pytest.toml`` files are now read as pytest configuration instead of being silently ignored.

--- a/doc/en/reference/customize.rst
+++ b/doc/en/reference/customize.rst
@@ -31,13 +31,13 @@ pytest.toml
 ``pytest.toml`` files take precedence over other files, even when empty.
 
 Alternatively, the hidden version ``.pytest.toml`` can be used.
-Options can be placed at the top level of the file, or under a ``[pytest]`` table.
 
 .. tab:: toml
 
     .. code-block:: toml
 
         # pytest.toml or .pytest.toml
+        [pytest]
         minversion = "9.0"
         addopts = ["-ra", "-q"]
         testpaths = [

--- a/doc/en/reference/customize.rst
+++ b/doc/en/reference/customize.rst
@@ -31,13 +31,13 @@ pytest.toml
 ``pytest.toml`` files take precedence over other files, even when empty.
 
 Alternatively, the hidden version ``.pytest.toml`` can be used.
+Options can be placed at the top level of the file, or under a ``[pytest]`` table.
 
 .. tab:: toml
 
     .. code-block:: toml
 
         # pytest.toml or .pytest.toml
-        [pytest]
         minversion = "9.0"
         addopts = ["-ra", "-q"]
         testpaths = [

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -105,20 +105,23 @@ def load_config_dict_from_file(
         except tomllib.TOMLDecodeError as exc:
             raise UsageError(f"{filepath}: {exc}") from exc
 
-        # pytest.toml and .pytest.toml use [pytest] table directly, and also
-        # allow pytest options at the top level because TOML tables are optional.
+        # pytest.toml and .pytest.toml use [pytest] table directly.
         if filepath.name in ("pytest.toml", ".pytest.toml"):
-            pytest_config = config.get("pytest", {})
-            if not pytest_config:
-                pytest_config = {
-                    k: v for k, v in config.items() if not isinstance(v, dict)
-                }
-            if pytest_config:
+            if "pytest" in config:
                 # TOML mode - preserve native TOML types.
                 return {
                     k: ConfigValue(v, origin="file", mode="toml")
-                    for k, v in pytest_config.items()
+                    for k, v in config["pytest"].items()
                 }
+            top_level_options = [
+                key for key, value in config.items() if not isinstance(value, dict)
+            ]
+            if top_level_options:
+                raise UsageError(
+                    f"{filepath}: pytest configuration must be under a "
+                    f"[pytest] table (found top-level options: "
+                    f"{', '.join(top_level_options)})"
+                )
             # "pytest.toml" files are always the source of configuration, even if empty.
             return {}
 

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -105,9 +105,14 @@ def load_config_dict_from_file(
         except tomllib.TOMLDecodeError as exc:
             raise UsageError(f"{filepath}: {exc}") from exc
 
-        # pytest.toml and .pytest.toml use [pytest] table directly.
+        # pytest.toml and .pytest.toml use [pytest] table directly, and also
+        # allow pytest options at the top level because TOML tables are optional.
         if filepath.name in ("pytest.toml", ".pytest.toml"):
             pytest_config = config.get("pytest", {})
+            if not pytest_config:
+                pytest_config = {
+                    k: v for k, v in config.items() if not isinstance(v, dict)
+                }
             if pytest_config:
                 # TOML mode - preserve native TOML types.
                 return {

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -165,7 +165,7 @@ class TestParseIni:
         assert config.getini("minversion") == "3.36"
 
     @pytest.mark.parametrize("name", ["pytest.toml", ".pytest.toml"])
-    def test_toml_config_names_without_section(
+    def test_toml_config_names_without_section_errors(
         self, pytester: Pytester, name: str
     ) -> None:
         pytester.path.joinpath(name).write_text(
@@ -177,9 +177,12 @@ class TestParseIni:
             ),
             encoding="utf-8",
         )
-        config = pytester.parseconfig()
-        assert config.getini("minversion") == "3.36"
-        assert config.getini("addopts") == ["-v"]
+        result = pytester.runpytest()
+        assert result.ret != 0
+        assert (
+            "pytest configuration must be under a [pytest] table "
+            "(found top-level options: minversion, addopts)" in result.stderr.str()
+        )
 
     def test_pyproject_toml(self, pytester: Pytester) -> None:
         pyproject_toml = pytester.makepyprojecttoml(

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -168,7 +168,8 @@ class TestParseIni:
     def test_toml_config_names_without_section_errors(
         self, pytester: Pytester, name: str
     ) -> None:
-        pytester.path.joinpath(name).write_text(
+        config_path = pytester.path.joinpath(name)
+        config_path.write_text(
             textwrap.dedent(
                 """
             minversion = "3.36"
@@ -177,11 +178,12 @@ class TestParseIni:
             ),
             encoding="utf-8",
         )
-        result = pytester.runpytest()
-        assert result.ret != 0
-        assert (
+        with pytest.raises(UsageError) as excinfo:
+            pytester.parseconfig()
+        assert str(excinfo.value) == (
+            f"{config_path}: "
             "pytest configuration must be under a [pytest] table "
-            "(found top-level options: minversion, addopts)" in result.stderr.str()
+            "(found top-level options: minversion, addopts)"
         )
 
     def test_pyproject_toml(self, pytester: Pytester) -> None:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -164,6 +164,23 @@ class TestParseIni:
         config = pytester.parseconfig()
         assert config.getini("minversion") == "3.36"
 
+    @pytest.mark.parametrize("name", ["pytest.toml", ".pytest.toml"])
+    def test_toml_config_names_without_section(
+        self, pytester: Pytester, name: str
+    ) -> None:
+        pytester.path.joinpath(name).write_text(
+            textwrap.dedent(
+                """
+            minversion = "3.36"
+            addopts = ["-v"]
+        """
+            ),
+            encoding="utf-8",
+        )
+        config = pytester.parseconfig()
+        assert config.getini("minversion") == "3.36"
+        assert config.getini("addopts") == ["-v"]
+
     def test_pyproject_toml(self, pytester: Pytester) -> None:
         pyproject_toml = pytester.makepyprojecttoml(
             """


### PR DESCRIPTION
Closes #14638.

## Summary
- Keep the `[pytest]` table required in `pytest.toml` and `.pytest.toml`.
- Raise a clear configuration error when either file contains top-level scalar options without a `[pytest]` table, instead of silently ignoring them.
- Continue allowing empty `pytest.toml` files.
- Add regression coverage and update the changelog.

## Verification
- Manually reproduced the original behavior before the change: top-level `addopts` was silently ignored.
- Verified the updated behavior with a small project: top-level `addopts = ["-v"]` exits with code 4 and reports that configuration must be under `[pytest]`.
- Verified an empty `pytest.toml` remains valid and the sample test passes.
- `SETUPTOOLS_SCM_PRETEND_VERSION=9.2.0.dev0 uv run --no-project --with-editable . --with '.[dev]' --python 3.11 python -m pytest testing/test_config.py -q` (`256 passed, 1 xfailed`)
- `uvx --from pre-commit==4.4.0 pre-commit run --files src/_pytest/config/findpaths.py testing/test_config.py doc/en/reference/customize.rst changelog/14638.bugfix.rst`