### PR TITLE
approx: expose `pytest.Approx` as the return type of `pytest.approx`

### DIFF
--- a/changelog/14164.improvement.rst
+++ b/changelog/14164.improvement.rst
@@ -1,0 +1,2 @@
+Exposed :class:`pytest.Approx` as the type of the return value of :func:`pytest.approx()`.
+This can be used in type annotations and ``isinstance`` checks.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -951,6 +951,11 @@ Objects
 Objects accessible from :ref:`fixtures <fixture>` or :ref:`hooks <hook-reference>`
 or importable from ``pytest``.
 
+Approx
+~~~~~~
+
+.. autoclass:: pytest.Approx()
+    :members:
 
 CallInfo
 ~~~~~~~~

--- a/src/_pytest/approx.py
+++ b/src/_pytest/approx.py
@@ -1,3 +1,5 @@
+"""The implementation of pytest.approx()."""
+
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
@@ -26,9 +28,6 @@ if TYPE_CHECKING:
     from numpy import ndarray
 else:
     ndarray = object
-
-
-# builtin pytest.approx helper
 
 
 def _compare_approx(

--- a/src/_pytest/approx.py
+++ b/src/_pytest/approx.py
@@ -116,9 +116,6 @@ class Approx(abc.ABC, Generic[ExpectedT]):
     # Ignore type because of https://github.com/python/mypy/issues/4266.
     __hash__ = None  # type: ignore
 
-    def __ne__(self, actual: object) -> bool:
-        return not (actual == self)
-
     def _approx_scalar(self, x) -> ApproxScalar[Any] | ApproxTimedelta:
         if isinstance(x, Decimal):
             return ApproxDecimal(x, rel=self.rel, abs=self.abs, nan_ok=self.nan_ok)

--- a/src/_pytest/assertion/_compare_any.py
+++ b/src/_pytest/assertion/_compare_any.py
@@ -44,7 +44,7 @@ def _compare_eq_any(
             assertion_text_diff_style,
         )
     else:
-        from _pytest.python_api import Approx
+        from _pytest.approx import Approx
 
         # Although the common order should be obtained == approx(...), allow both ways.
         if isinstance(right, Approx):

--- a/src/_pytest/assertion/_compare_any.py
+++ b/src/_pytest/assertion/_compare_any.py
@@ -44,12 +44,12 @@ def _compare_eq_any(
             assertion_text_diff_style,
         )
     else:
-        from _pytest.python_api import ApproxBase
+        from _pytest.python_api import Approx
 
         # Although the common order should be obtained == approx(...), allow both ways.
-        if isinstance(right, ApproxBase):
+        if isinstance(right, Approx):
             yield from right._repr_compare(left)
-        elif isinstance(left, ApproxBase):
+        elif isinstance(left, Approx):
             yield from left._repr_compare(right)
         elif type(left) is type(right) and (
             isdatacls(left) or isattrs(left) or isnamedtuple(left)

--- a/src/_pytest/doctest.py
+++ b/src/_pytest/doctest.py
@@ -27,6 +27,7 @@ from _pytest._code.code import ExceptionInfo
 from _pytest._code.code import ReprFileLocation
 from _pytest._code.code import TerminalRepr
 from _pytest._io import TerminalWriter
+from _pytest.approx import approx
 from _pytest.compat import safe_getattr
 from _pytest.config import Config
 from _pytest.config.argparsing import Parser
@@ -38,7 +39,6 @@ from _pytest.outcomes import OutcomeException
 from _pytest.outcomes import skip
 from _pytest.pathlib import fnmatch_ex
 from _pytest.python import Module
-from _pytest.python_api import approx
 from _pytest.warning_types import PytestWarning
 
 

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -409,7 +409,7 @@ class ApproxScalar(ApproxBase):
         # tolerances, i.e. non-numerics and infinities. Need to call abs to
         # handle complex numbers, e.g. (inf + 1j).
         if (
-            isinstance(self.expected, bool)
+            _is_bool(self.expected)
             or (not isinstance(self.expected, Complex | Decimal))
             or math.isinf(abs(self.expected))
         ):
@@ -437,15 +437,6 @@ class ApproxScalar(ApproxBase):
     def __eq__(self, actual) -> bool:
         """Return whether the given value is equal to the expected value
         within the pre-specified tolerance."""
-
-        def is_bool(val: Any) -> bool:
-            # Check if `val` is a native bool or numpy bool.
-            if isinstance(val, bool):
-                return True
-            if np := sys.modules.get("numpy"):
-                return isinstance(val, np.bool_)
-            return False
-
         asarray = _as_numpy_array(actual)
         if asarray is not None:
             # Call ``__eq__()`` manually to prevent infinite-recursion with
@@ -453,7 +444,7 @@ class ApproxScalar(ApproxBase):
             return all(self.__eq__(a) for a in asarray.flat)
 
         # Short-circuit exact equality, except for bool and np.bool_
-        if is_bool(self.expected) and not is_bool(actual):
+        if _is_bool(self.expected) and not _is_bool(actual):
             return False
         elif actual == self.expected:
             return True
@@ -462,7 +453,7 @@ class ApproxScalar(ApproxBase):
         # NB: we need Complex, rather than just Number, to ensure that __abs__,
         # __sub__, and __float__ are defined. Also, consider bool to be
         # non-numeric, even though it has the required arithmetic.
-        if is_bool(self.expected) or not (
+        if _is_bool(self.expected) or not (
             isinstance(self.expected, Complex | Decimal)
             and isinstance(actual, Complex | Decimal)
         ):
@@ -920,3 +911,12 @@ def _as_numpy_array(obj: object) -> ndarray | None:
         elif hasattr(obj, "__array__") or hasattr(obj, "__array_interface__"):
             return np.asarray(obj)
     return None
+
+
+def _is_bool(val: Any) -> bool:
+    # Check if `val` is a native bool or numpy bool.
+    if isinstance(val, bool):
+        return True
+    if np := sys.modules.get("numpy"):
+        return isinstance(val, np.bool_)
+    return False

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -483,13 +483,11 @@ class ApproxScalar(ApproxBase):
         This could be either an absolute tolerance or a relative tolerance,
         depending on what the user specified or which would be larger.
         """
-
-        def set_default(x, default):
-            return x if x is not None else default
-
         # Figure out what the absolute tolerance should be.  ``self.abs`` is
         # either None or a value specified by the user.
-        absolute_tolerance = set_default(self.abs, self.DEFAULT_ABSOLUTE_TOLERANCE)
+        absolute_tolerance = (
+            self.abs if self.abs is not None else self.DEFAULT_ABSOLUTE_TOLERANCE
+        )
 
         if absolute_tolerance < 0:
             raise ValueError(
@@ -509,8 +507,8 @@ class ApproxScalar(ApproxBase):
         # we've made sure the user didn't ask for an absolute tolerance only,
         # because we don't want to raise errors about the relative tolerance if
         # we aren't even going to use it.
-        relative_tolerance = set_default(
-            self.rel, self.DEFAULT_RELATIVE_TOLERANCE
+        relative_tolerance = (
+            self.rel if self.rel is not None else self.DEFAULT_RELATIVE_TOLERANCE
         ) * abs(self.expected)
 
         if relative_tolerance < 0:

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
+import abc
 import builtins
 from collections.abc import Collection
 from collections.abc import Mapping
@@ -14,11 +15,20 @@ from numbers import Complex
 import pprint
 import sys
 from typing import Any
+from typing import Generic
+from typing import SupportsAbs
 from typing import TYPE_CHECKING
+from typing import TypeGuard
+from typing import TypeVar
 
 
 if TYPE_CHECKING:
     from numpy import ndarray
+else:
+    ndarray = object
+
+
+# builtin pytest.approx helper
 
 
 def _compare_approx(
@@ -47,10 +57,11 @@ def _compare_approx(
     return explanation
 
 
-# builtin pytest.approx helper
+T = TypeVar("T")
+ExpectedT = TypeVar("ExpectedT", covariant=True)
 
 
-class ApproxBase:
+class ApproxBase(abc.ABC, Generic[ExpectedT]):
     """Provide shared utilities for making approximate comparisons between
     numbers or sequences of numbers."""
 
@@ -58,16 +69,23 @@ class ApproxBase:
     __array_ufunc__ = None
     __array_priority__ = 100
 
-    def __init__(self, expected, rel=None, abs=None, nan_ok: bool = False) -> None:
+    def __init__(
+        self,
+        expected: ExpectedT,
+        rel: float | Decimal | timedelta | None,
+        abs: float | Decimal | timedelta | None,
+        nan_ok: bool,
+    ) -> None:
         self.expected = expected
         self.abs = abs
         self.rel = rel
         self.nan_ok = nan_ok
 
+    @abc.abstractmethod
     def __repr__(self) -> str:
         raise NotImplementedError
 
-    def _repr_compare(self, other_side: Any) -> list[str]:
+    def _repr_compare(self, other_side) -> list[str]:
         return [
             "comparison failed",
             f"Obtained: {other_side}",
@@ -88,17 +106,17 @@ class ApproxBase:
     # Ignore type because of https://github.com/python/mypy/issues/4266.
     __hash__ = None  # type: ignore
 
-    def __ne__(self, actual) -> bool:
+    def __ne__(self, actual: object) -> bool:
         return not (actual == self)
 
-    def _approx_scalar(self, x) -> ApproxBase:
+    def _approx_scalar(self, x) -> ApproxScalar[Any] | ApproxTimedelta:
         if isinstance(x, Decimal):
             return ApproxDecimal(x, rel=self.rel, abs=self.abs, nan_ok=self.nan_ok)
         if isinstance(x, (datetime, timedelta)):
             return ApproxTimedelta(x, rel=self.rel, abs=self.abs, nan_ok=self.nan_ok)
         return ApproxScalar(x, rel=self.rel, abs=self.abs, nan_ok=self.nan_ok)
 
-    def _yield_comparisons(self, actual):
+    def _yield_comparisons(self, actual: object):
         """Yield all the pairs of numbers to be compared.
 
         This is used to implement the `__eq__` method.
@@ -117,7 +135,7 @@ def _recursive_sequence_map(f, x):
         return f(x)
 
 
-class ApproxNumpy(ApproxBase):
+class ApproxNumpy(ApproxBase[ndarray]):
     """Perform approximate comparisons where the expected value is numpy array."""
 
     def __repr__(self) -> str:
@@ -221,11 +239,17 @@ class ApproxNumpy(ApproxBase):
                 yield actual[i].item(), self.expected[i].item()
 
 
-class ApproxMapping(ApproxBase):
+class ApproxMapping(ApproxBase[Mapping[Any, Any]]):
     """Perform approximate comparisons where the expected value is a mapping
     with numeric values (the keys can be anything)."""
 
-    def __init__(self, expected, rel=None, abs=None, nan_ok: bool = False) -> None:
+    def __init__(
+        self,
+        expected: Mapping[Any, Any],
+        rel: float | Decimal | timedelta | None,
+        abs: float | Decimal | timedelta | None,
+        nan_ok: bool,
+    ) -> None:
         __tracebackhide__ = True
 
         for key, value in expected.items():
@@ -267,7 +291,9 @@ class ApproxMapping(ApproxBase):
                 if approx_value.expected is not None and other_value is not None:
                     try:
                         max_abs_diff = max(
-                            max_abs_diff, abs(approx_value.expected - other_value)
+                            max_abs_diff,
+                            # TODO: The type error here seems correct.
+                            abs(approx_value.expected - other_value),  # type: ignore[operator]
                         )
                         if approx_value.expected == 0.0:
                             max_rel_diff = math.inf
@@ -275,7 +301,8 @@ class ApproxMapping(ApproxBase):
                             max_rel_diff = max(
                                 max_rel_diff,
                                 abs(
-                                    (approx_value.expected - other_value)
+                                    # TODO: The type error here seems correct.
+                                    (approx_value.expected - other_value)  # type: ignore[operator]
                                     / approx_value.expected
                                 ),
                             )
@@ -311,10 +338,16 @@ class ApproxMapping(ApproxBase):
             yield actual[k], self.expected[k]
 
 
-class ApproxSequenceLike(ApproxBase):
+class ApproxSequenceLike(ApproxBase[Sequence[Any]]):
     """Perform approximate comparisons where the expected value is a sequence of numbers."""
 
-    def __init__(self, expected, rel=None, abs=None, nan_ok: bool = False) -> None:
+    def __init__(
+        self,
+        expected: Sequence[Any],
+        rel: float | Decimal | timedelta | None,
+        abs: float | Decimal | timedelta | None,
+        nan_ok: bool,
+    ) -> None:
         __tracebackhide__ = True
 
         for index, x in enumerate(expected):
@@ -387,13 +420,41 @@ class ApproxSequenceLike(ApproxBase):
         return zip(actual, self.expected, strict=True)
 
 
-class ApproxScalar(ApproxBase):
+class ApproxScalar(ApproxBase[ExpectedT]):
     """Perform approximate comparisons where the expected value is a single number."""
 
     # Using Real should be better than this Union, but not possible yet:
     # https://github.com/python/typeshed/pull/3108
     DEFAULT_ABSOLUTE_TOLERANCE: float | Decimal = 1e-12
     DEFAULT_RELATIVE_TOLERANCE: float | Decimal = 1e-6
+    rel: float | Decimal | None
+    abs: float | Decimal | None
+
+    def __init__(
+        self,
+        expected: ExpectedT,
+        rel: float | Decimal | timedelta | None,
+        abs: float | Decimal | timedelta | None,
+        nan_ok: bool,
+    ) -> None:
+        __tracebackhide__ = True
+        if rel is not None:
+            if not isinstance(rel, (int, float, Decimal)):
+                raise TypeError(
+                    f"relative tolerance for a scalar value must be an int, float or Decimal, "
+                    f"got {type(rel).__name__}"
+                )
+            if not isinstance(expected, SupportsAbs):
+                raise TypeError(
+                    f"expected value must support abs(...) when relative tolerance is used, "
+                    f"got {type(expected).__name__}"
+                )
+        if abs is not None and not isinstance(abs, (int, float, Decimal)):
+            raise TypeError(
+                f"absolute tolerance for a scalar value must be an int, float or Decimal, "
+                f"got {type(abs).__name__}"
+            )
+        super().__init__(expected, rel=rel, abs=abs, nan_ok=nan_ok)
 
     def __repr__(self) -> str:
         """Return a string communicating both the expected value and the
@@ -507,9 +568,11 @@ class ApproxScalar(ApproxBase):
         # we've made sure the user didn't ask for an absolute tolerance only,
         # because we don't want to raise errors about the relative tolerance if
         # we aren't even going to use it.
-        relative_tolerance = (
-            self.rel if self.rel is not None else self.DEFAULT_RELATIVE_TOLERANCE
-        ) * abs(self.expected)
+        rel = self.rel if self.rel is not None else self.DEFAULT_RELATIVE_TOLERANCE
+        # expected is SupportAbs, checked in __init__.
+        # The typing here is not exact...
+        abs_expected: ExpectedT = abs(self.expected)  # type: ignore[arg-type]
+        relative_tolerance: float | Decimal = rel * abs_expected  # type: ignore[operator]
 
         if relative_tolerance < 0:
             raise ValueError(
@@ -522,33 +585,42 @@ class ApproxScalar(ApproxBase):
         return max(relative_tolerance, absolute_tolerance)
 
 
-class ApproxDecimal(ApproxScalar):
+class ApproxDecimal(ApproxScalar[Decimal]):
     """Perform approximate comparisons where the expected value is a Decimal."""
 
     DEFAULT_ABSOLUTE_TOLERANCE = Decimal("1e-12")
     DEFAULT_RELATIVE_TOLERANCE = Decimal("1e-6")
+    rel: Decimal | None
+    abs: Decimal | None
+
+    def __init__(
+        self,
+        expected: Decimal,
+        rel: float | Decimal | timedelta | None,
+        abs: float | Decimal | timedelta | None,
+        nan_ok: bool,
+    ) -> None:
+        if isinstance(rel, (float, int)):
+            rel_: Decimal | timedelta | None = Decimal.from_float(rel)
+        else:
+            rel_ = rel
+        if isinstance(abs, (float, int)):
+            abs_: Decimal | timedelta | None = Decimal.from_float(abs)
+        else:
+            abs_ = abs
+        super().__init__(expected, rel_, abs_, nan_ok)
 
     def __repr__(self) -> str:
-        if isinstance(self.rel, float):
-            rel = Decimal.from_float(self.rel)
-        else:
-            rel = self.rel
-
-        if isinstance(self.abs, float):
-            abs_ = Decimal.from_float(self.abs)
-        else:
-            abs_ = self.abs
-
         tol_str = "???"
-        if rel is not None and Decimal("1e-3") <= rel <= Decimal("1e3"):
-            tol_str = f"{rel:.1e}"
-        elif abs_ is not None:
-            tol_str = f"{abs_:.1e}"
+        if self.rel is not None and Decimal("1e-3") <= self.rel <= Decimal("1e3"):
+            tol_str = f"{self.rel:.1e}"
+        elif self.abs is not None:
+            tol_str = f"{self.abs:.1e}"
 
         return f"{self.expected} ± {tol_str}"
 
 
-class ApproxTimedelta(ApproxBase):
+class ApproxTimedelta(ApproxBase[datetime | timedelta]):
     """Perform approximate comparisons where the expected value is a
     datetime or timedelta.
 
@@ -556,7 +628,13 @@ class ApproxTimedelta(ApproxBase):
     Relative tolerance is not supported for datetime comparisons.
     """
 
-    def __init__(self, expected, rel=None, abs=None, nan_ok: bool = False) -> None:
+    def __init__(
+        self,
+        expected: datetime | timedelta,
+        rel: float | Decimal | timedelta | None,
+        abs: float | Decimal | timedelta | None,
+        nan_ok: bool,
+    ) -> None:
         __tracebackhide__ = True
         if isinstance(expected, datetime) and rel is not None:
             raise TypeError(
@@ -595,9 +673,14 @@ class ApproxTimedelta(ApproxBase):
         # Compute the effective tolerance. abs_tolerance is a timedelta, rel * expected
         # gives a timedelta (timedelta * float works in Python).
         abs_tolerance = abs
-        rel_tolerance = rel * builtins.abs(expected) if rel is not None else None
+        if rel is None:
+            rel_tolerance = None
+        else:
+            # Checked above.
+            assert not isinstance(expected, datetime)
+            rel_tolerance = rel * builtins.abs(expected)
         if abs_tolerance is not None and rel_tolerance is not None:
-            tolerance = max(abs_tolerance, rel_tolerance)
+            tolerance: timedelta | None = max(abs_tolerance, rel_tolerance)
         else:
             tolerance = abs_tolerance if abs_tolerance is not None else rel_tolerance
         super().__init__(expected, rel=rel, abs=tolerance, nan_ok=False)
@@ -611,7 +694,7 @@ class ApproxTimedelta(ApproxBase):
         except (TypeError, OverflowError):
             return False
 
-    def _yield_comparisons(self, actual):
+    def _yield_comparisons(self, actual: object):
         yield actual, self.expected
 
     def _repr_compare(self, other_side: Any) -> list[str]:
@@ -629,11 +712,11 @@ class ApproxTimedelta(ApproxBase):
 
 
 def approx(
-    expected: Any,
+    expected: T,
     rel: float | Decimal | timedelta | None = None,
     abs: float | Decimal | timedelta | None = None,
     nan_ok: bool = False,
-) -> ApproxBase:
+) -> ApproxBase[T]:
     """Assert that two numbers (or two ordered sequences of numbers) are equal to each other
     within some tolerance.
 
@@ -863,26 +946,23 @@ def approx(
     __tracebackhide__ = True
 
     if isinstance(expected, Decimal):
-        cls: type[ApproxBase] = ApproxDecimal
+        return ApproxDecimal(expected, rel=rel, abs=abs, nan_ok=nan_ok)  # type: ignore[return-value]
     elif isinstance(expected, Mapping):
-        cls = ApproxMapping
+        return ApproxMapping(expected, rel=rel, abs=abs, nan_ok=nan_ok)  # type: ignore[return-value]
     elif (np_array := _as_numpy_array(expected)) is not None:
-        expected = np_array
-        cls = ApproxNumpy
+        return ApproxNumpy(np_array, rel=rel, abs=abs, nan_ok=nan_ok)
     elif _is_sequence_like(expected):
-        cls = ApproxSequenceLike
+        return ApproxSequenceLike(expected, rel=rel, abs=abs, nan_ok=nan_ok)  # type: ignore[return-value]
     elif isinstance(expected, Collection) and not isinstance(expected, str | bytes):
         msg = f"pytest.approx() only supports ordered sequences, but got: {expected!r}"
         raise TypeError(msg)
     elif isinstance(expected, (datetime, timedelta)):
-        cls = ApproxTimedelta
+        return ApproxTimedelta(expected, rel=rel, abs=abs, nan_ok=nan_ok)  # type: ignore[return-value]
     else:
-        cls = ApproxScalar
-
-    return cls(expected, rel, abs, nan_ok)
+        return ApproxScalar(expected, rel=rel, abs=abs, nan_ok=nan_ok)
 
 
-def _is_sequence_like(expected: object) -> bool:
+def _is_sequence_like(expected: object) -> TypeGuard[Sequence[Any]]:
     return (
         hasattr(expected, "__getitem__")
         and isinstance(expected, Sized)

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -411,7 +411,7 @@ class ApproxScalar(ApproxBase):
         if (
             isinstance(self.expected, bool)
             or (not isinstance(self.expected, Complex | Decimal))
-            or math.isinf(abs(self.expected) or isinstance(self.expected, bool))
+            or math.isinf(abs(self.expected))
         ):
             return str(self.expected)
 

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -61,9 +61,16 @@ T = TypeVar("T")
 ExpectedT = TypeVar("ExpectedT", covariant=True)
 
 
-class ApproxBase(abc.ABC, Generic[ExpectedT]):
-    """Provide shared utilities for making approximate comparisons between
-    numbers or sequences of numbers."""
+class Approx(abc.ABC, Generic[ExpectedT]):
+    """The return type of :func:`pytest.approx`.
+
+    ``Approx`` objects support (approximate) equality comparisons and ``repr``,
+    and can also be used with ``isinstance(..., pytest.Approx)``.
+
+    .. versionadded:: 9.2
+    """
+
+    __module__ = "pytest"
 
     # Tell numpy to use our `__eq__` operator instead of its.
     __array_ufunc__ = None
@@ -76,9 +83,13 @@ class ApproxBase(abc.ABC, Generic[ExpectedT]):
         abs: float | Decimal | timedelta | None,
         nan_ok: bool,
     ) -> None:
+        #: The expected value passed.
         self.expected = expected
-        self.abs = abs
+        #: The relative tolerance.
         self.rel = rel
+        #: The absolute tolerance.
+        self.abs = abs
+        #: Whether NaNs compare equal to NaN.
         self.nan_ok = nan_ok
 
     @abc.abstractmethod
@@ -135,7 +146,7 @@ def _recursive_sequence_map(f, x):
         return f(x)
 
 
-class ApproxNumpy(ApproxBase[ndarray]):
+class ApproxNumpy(Approx[ndarray]):
     """Perform approximate comparisons where the expected value is numpy array."""
 
     def __repr__(self) -> str:
@@ -239,7 +250,7 @@ class ApproxNumpy(ApproxBase[ndarray]):
                 yield actual[i].item(), self.expected[i].item()
 
 
-class ApproxMapping(ApproxBase[Mapping[Any, Any]]):
+class ApproxMapping(Approx[Mapping[Any, Any]]):
     """Perform approximate comparisons where the expected value is a mapping
     with numeric values (the keys can be anything)."""
 
@@ -338,7 +349,7 @@ class ApproxMapping(ApproxBase[Mapping[Any, Any]]):
             yield actual[k], self.expected[k]
 
 
-class ApproxSequenceLike(ApproxBase[Sequence[Any]]):
+class ApproxSequenceLike(Approx[Sequence[Any]]):
     """Perform approximate comparisons where the expected value is a sequence of numbers."""
 
     def __init__(
@@ -420,7 +431,7 @@ class ApproxSequenceLike(ApproxBase[Sequence[Any]]):
         return zip(actual, self.expected, strict=True)
 
 
-class ApproxScalar(ApproxBase[ExpectedT]):
+class ApproxScalar(Approx[ExpectedT]):
     """Perform approximate comparisons where the expected value is a single number."""
 
     # Using Real should be better than this Union, but not possible yet:
@@ -620,7 +631,7 @@ class ApproxDecimal(ApproxScalar[Decimal]):
         return f"{self.expected} ± {tol_str}"
 
 
-class ApproxTimedelta(ApproxBase[datetime | timedelta]):
+class ApproxTimedelta(Approx[datetime | timedelta]):
     """Perform approximate comparisons where the expected value is a
     datetime or timedelta.
 
@@ -716,7 +727,7 @@ def approx(
     rel: float | Decimal | timedelta | None = None,
     abs: float | Decimal | timedelta | None = None,
     nan_ok: bool = False,
-) -> ApproxBase[T]:
+) -> Approx[T]:
     """Assert that two numbers (or two ordered sequences of numbers) are equal to each other
     within some tolerance.
 

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -59,12 +59,10 @@ class ApproxBase:
     __array_priority__ = 100
 
     def __init__(self, expected, rel=None, abs=None, nan_ok: bool = False) -> None:
-        __tracebackhide__ = True
         self.expected = expected
         self.abs = abs
         self.rel = rel
         self.nan_ok = nan_ok
-        self._check_type()
 
     def __repr__(self) -> str:
         raise NotImplementedError
@@ -106,14 +104,6 @@ class ApproxBase:
         This is used to implement the `__eq__` method.
         """
         raise NotImplementedError
-
-    def _check_type(self) -> None:
-        """Raise a TypeError if the expected value is not a valid type."""
-        # This is only a concern if the expected value is a sequence.  In every
-        # other case, the approx() function ensures that the expected value has
-        # a numeric type.  For this reason, the default is to do nothing.  The
-        # classes that deal with sequences should reimplement this method to
-        # raise if there are any non-numeric elements in the sequence.
 
 
 def _recursive_sequence_map(f, x):
@@ -235,6 +225,16 @@ class ApproxMapping(ApproxBase):
     """Perform approximate comparisons where the expected value is a mapping
     with numeric values (the keys can be anything)."""
 
+    def __init__(self, expected, rel=None, abs=None, nan_ok: bool = False) -> None:
+        __tracebackhide__ = True
+
+        for key, value in expected.items():
+            if isinstance(value, type(expected)):
+                msg = "pytest.approx() does not support nested dictionaries: key={!r} value={!r}\n  full mapping={}"
+                raise TypeError(msg.format(key, value, pprint.pformat(expected)))
+
+        super().__init__(expected, rel=rel, abs=abs, nan_ok=nan_ok)
+
     def __repr__(self) -> str:
         return f"approx({ ({k: self._approx_scalar(v) for k, v in self.expected.items()})!r})"
 
@@ -310,16 +310,19 @@ class ApproxMapping(ApproxBase):
         for k in self.expected.keys():
             yield actual[k], self.expected[k]
 
-    def _check_type(self) -> None:
-        __tracebackhide__ = True
-        for key, value in self.expected.items():
-            if isinstance(value, type(self.expected)):
-                msg = "pytest.approx() does not support nested dictionaries: key={!r} value={!r}\n  full mapping={}"
-                raise TypeError(msg.format(key, value, pprint.pformat(self.expected)))
-
 
 class ApproxSequenceLike(ApproxBase):
     """Perform approximate comparisons where the expected value is a sequence of numbers."""
+
+    def __init__(self, expected, rel=None, abs=None, nan_ok: bool = False) -> None:
+        __tracebackhide__ = True
+
+        for index, x in enumerate(expected):
+            if isinstance(x, type(expected)):
+                msg = "pytest.approx() does not support nested data structures: {!r} at index {}\n  full sequence: {}"
+                raise TypeError(msg.format(x, index, pprint.pformat(expected)))
+
+        super().__init__(expected, rel=rel, abs=abs, nan_ok=nan_ok)
 
     def __repr__(self) -> str:
         seq_type = type(self.expected)
@@ -382,13 +385,6 @@ class ApproxSequenceLike(ApproxBase):
 
     def _yield_comparisons(self, actual):
         return zip(actual, self.expected, strict=True)
-
-    def _check_type(self) -> None:
-        __tracebackhide__ = True
-        for index, x in enumerate(self.expected):
-            if isinstance(x, type(self.expected)):
-                msg = "pytest.approx() does not support nested data structures: {!r} at index {}\n  full sequence: {}"
-                raise TypeError(msg.format(x, index, pprint.pformat(self.expected)))
 
 
 class ApproxScalar(ApproxBase):

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 from _pytest import __version__
 from _pytest import version_tuple
 from _pytest._code import ExceptionInfo
+from _pytest.approx import Approx
+from _pytest.approx import approx
 from _pytest.assertion import register_assert_rewrite
 from _pytest.cacheprovider import Cache
 from _pytest.capture import CaptureFixture
@@ -60,8 +62,6 @@ from _pytest.python import Function
 from _pytest.python import Metafunc
 from _pytest.python import Module
 from _pytest.python import Package
-from _pytest.python_api import Approx
-from _pytest.python_api import approx
 from _pytest.raises import raises
 from _pytest.raises import RaisesExc
 from _pytest.raises import RaisesGroup

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -60,6 +60,7 @@ from _pytest.python import Function
 from _pytest.python import Metafunc
 from _pytest.python import Module
 from _pytest.python import Package
+from _pytest.python_api import Approx
 from _pytest.python_api import approx
 from _pytest.raises import raises
 from _pytest.raises import RaisesExc
@@ -98,6 +99,7 @@ set_trace = __pytestPDB.set_trace
 
 __all__ = [
     "HIDDEN_PARAM",
+    "Approx",
     "Cache",
     "CallInfo",
     "CaptureFixture",

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -14,8 +14,8 @@ from operator import eq
 from operator import ne
 import re
 
+from _pytest.approx import _recursive_sequence_map
 from _pytest.pytester import Pytester
-from _pytest.python_api import _recursive_sequence_map
 import pytest
 from pytest import approx
 

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+import datetime
 import decimal
 from decimal import Decimal
 from fractions import Fraction
@@ -1034,6 +1035,16 @@ class TestApprox:
         approx_obj = pytest.approx(decimal.Decimal("2.60"))
         assert decimal.Decimal("2.600001") == approx_obj
 
+    def test_decimal_approx_float_rel(self) -> None:
+        approx_obj = pytest.approx(decimal.Decimal("2.60"), rel=0.01)
+        assert decimal.Decimal("2.600001") == approx_obj
+        assert repr(approx_obj) == "2.60 ± 1.0e-2"
+
+    def test_decimal_approx_float_abs(self) -> None:
+        approx_obj = pytest.approx(decimal.Decimal("2.60"), abs=0.01)
+        assert decimal.Decimal("2.600001") == approx_obj
+        assert repr(approx_obj) == "2.60 ± 1.0e-2"
+
     def test_allow_ordered_sequences_only(self) -> None:
         """pytest.approx() should raise an error on unordered sequences (#9692)."""
         with pytest.raises(TypeError, match="only supports ordered sequences"):
@@ -1116,6 +1127,25 @@ class TestApprox:
             "  Obtained: 2",
             "  Expected: 1 ± 1.0e-06",
         ]
+
+    def test_scalar_rel_type_validation(self) -> None:
+        with pytest.raises(
+            TypeError, match=r"relative tolerance for a scalar value must"
+        ):
+            pytest.approx(0, rel=datetime.timedelta(1))
+
+    def test_scalar_rel_abs_expected_validation(self) -> None:
+        with pytest.raises(
+            TypeError,
+            match=re.escape("expected value must support abs(...) when relative"),
+        ):
+            pytest.approx(object(), rel=1)
+
+    def test_scalar_abs_type_validation(self) -> None:
+        with pytest.raises(
+            TypeError, match=r"absolute tolerance for a scalar value must"
+        ):
+            pytest.approx(0, abs=datetime.timedelta(1))
 
 
 class TestApproxDatetime:

--- a/testing/test_reports.py
+++ b/testing/test_reports.py
@@ -5,9 +5,9 @@ from collections.abc import Sequence
 
 from _pytest._code.code import ExceptionChainRepr
 from _pytest._code.code import ExceptionRepr
+from _pytest.approx import approx
 from _pytest.config import Config
 from _pytest.pytester import Pytester
-from _pytest.python_api import approx
 from _pytest.reports import CollectReport
 from _pytest.reports import TestReport
 import pytest


### PR DESCRIPTION
As requested in #14164 (part of #7469).

There are some initial commits that are prerequisites or small cleanups/refactors to the code.