### PR TITLE
pytest.toml: treat headerless top-level keys as pytest config

### DIFF
--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -110,10 +110,7 @@ def load_config_dict_from_file(
         # since the filename already identifies the context and TOML
         # sections are optional.
         if filepath.name in ("pytest.toml", ".pytest.toml"):
-            top_config = {
-                k: v for k, v in config.items()
-                if not isinstance(v, dict)
-            }
+            top_config = {k: v for k, v in config.items() if not isinstance(v, dict)}
             pytest_config = {**top_config, **config.get("pytest", {})}
             if pytest_config:
                 # TOML mode - preserve native TOML types.

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -106,8 +106,15 @@ def load_config_dict_from_file(
             raise UsageError(f"{filepath}: {exc}") from exc
 
         # pytest.toml and .pytest.toml use [pytest] table directly.
+        # Top-level non-table keys are also treated as pytest config,
+        # since the filename already identifies the context and TOML
+        # sections are optional.
         if filepath.name in ("pytest.toml", ".pytest.toml"):
-            pytest_config = config.get("pytest", {})
+            top_config = {
+                k: v for k, v in config.items()
+                if not isinstance(v, dict)
+            }
+            pytest_config = {**top_config, **config.get("pytest", {})}
             if pytest_config:
                 # TOML mode - preserve native TOML types.
                 return {

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -217,6 +217,20 @@ class TestParseIni:
         config = pytester.parseconfig()
         assert config.inipath == pytest_toml
 
+    @pytest.mark.parametrize("name", ["pytest.toml", ".pytest.toml"])
+    def test_headerless_pytest_toml(self, pytester: Pytester, name: str) -> None:
+        """Top-level keys in pytest.toml are treated as pytest config (#14638)."""
+        pytester.path.joinpath(name).write_text(
+            textwrap.dedent(
+                """
+            minversion = "9.0"
+        """
+            ),
+            encoding="utf-8",
+        )
+        config = pytester.parseconfig()
+        assert config.getini("minversion") == "9.0"
+
     def test_pytest_toml_trumps_pyproject_toml(self, pytester: Pytester) -> None:
         """A pytest.toml always takes precedence over a pyproject.toml file."""
         pytester.makepyprojecttoml(


### PR DESCRIPTION
Closes #14638

## Problem
When a `pytest.toml` or `.pytest.toml` file contains top-level keys without a `[pytest]` section header, those keys are silently ignored. This is surprising because:
- TOML sections are optional (unlike INI files)
- The filename itself already identifies the file as pytest configuration

## Solution
Treat top-level non-table keys in `pytest.toml`/`.pytest.toml` as pytest configuration, as if they were written under `[pytest]`. If a `[pytest]` section is also present, its values are merged on top (taking precedence).

For example, this now works:
```toml
minversion = "9.0"
addopts = ["-v"]
```

## Testing
- All existing TOML config tests pass (24 tests)
- Added `test_headerless_pytest_toml` for both `pytest.toml` and `.pytest.toml`
- Verified manually that the config values are properly parsed and applied