### PR TITLE
docs: clarify recwarn resets warnings filter after tests

### DIFF
--- a/changelog/14653.doc.rst
+++ b/changelog/14653.doc.rst
@@ -1,0 +1,1 @@
+Clarified that :fixture:`recwarn` resets the warnings filter after each test.

--- a/changelog/14653.doc.rst
+++ b/changelog/14653.doc.rst
@@ -1,1 +1,0 @@
-Clarified that :fixture:`recwarn` resets the warnings filter after each test.

--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -429,8 +429,7 @@ Alternatively, you can examine raised warnings in detail using the
 :fixture:`recwarn` fixture (see :ref:`below <recwarn>`).
 
 
-The :fixture:`recwarn` fixture automatically ensures to reset the warnings
-filter at the end of the test, so no global state is leaked.
+The :fixture:`recwarn` fixture automatically resets the warnings filter at the end of the test, so no global state is leaked.
 
 .. _`recording warnings`:
 


### PR DESCRIPTION
﻿## Summary
- Rephrase recwarn documentation to state that the fixture resets the warnings filter after each test.

## Test plan
- [x] Docs-only change.
