### PR TITLE
Expose CaptureManager as public API (#14186)

### DIFF
--- a/changelog/14186.improvement.rst
+++ b/changelog/14186.improvement.rst
@@ -1,0 +1,4 @@
+Expose `CaptureManager` as a public API type.
+
+Plugin authors can now annotate capture-manager lookups with
+`pytest.CaptureManager` instead of importing from `_pytest.capture`.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -417,6 +417,9 @@ capsys
 .. autoclass:: pytest.CaptureFixture()
     :members:
 
+.. autoclass:: pytest.CaptureManager()
+    :members:
+
 .. fixture:: capteesys
 
 capteesys

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -11,6 +11,7 @@ from _pytest.approx import approx
 from _pytest.assertion import register_assert_rewrite
 from _pytest.cacheprovider import Cache
 from _pytest.capture import CaptureFixture
+from _pytest.capture import CaptureManager
 from _pytest.config import cmdline
 from _pytest.config import Config
 from _pytest.config import console_main
@@ -103,6 +104,7 @@ __all__ = [
     "Cache",
     "CallInfo",
     "CaptureFixture",
+    "CaptureManager",
     "Class",
     "CollectReport",
     "Collector",

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -30,6 +30,10 @@ import pytest
 # pylib 1.4.20.dev2 (rev 13d9af95547e)
 
 
+def test_capture_manager_is_public_api() -> None:
+    assert pytest.CaptureManager is CaptureManager
+
+
 def StdCaptureFD(
     out: bool = True, err: bool = True, in_: bool = True
 ) -> MultiCapture[str]:

--- a/testing/typing_checks.py
+++ b/testing/typing_checks.py
@@ -8,11 +8,13 @@ none of the code triggers any mypy errors.
 from __future__ import annotations
 
 import contextlib
+from typing import cast
 from typing import Literal
 
 from typing_extensions import assert_type
 
 import pytest
+from pytest import CaptureManager
 from pytest import MonkeyPatch
 from pytest import ScopeName
 from pytest import TestReport
@@ -53,6 +55,17 @@ def check_raises_is_a_context_manager(val: bool) -> None:
     with pytest.raises(RuntimeError) if val else contextlib.nullcontext() as excinfo:
         pass
     assert_type(excinfo, pytest.ExceptionInfo[RuntimeError] | None)
+
+
+# Issue #14186.
+def check_capture_manager_typing(
+    request: pytest.FixtureRequest,
+) -> None:
+    capture_manager = cast(
+        CaptureManager | None,
+        request.config.pluginmanager.getplugin("capturemanager"),
+    )
+    assert_type(capture_manager, CaptureManager | None)
 
 
 # Issue #12941.


### PR DESCRIPTION
Expose `CaptureManager` as a public API type.

  This exposes `CaptureManager` via `pytest.CaptureManager` so plugin authors can annotate capture-manager lookups without importing from
  `_pytest.capture`.

  Tests and validation:
  - Added a runtime API test in `testing/test_capture.py` to verify `pytest.CaptureManager is CaptureManager`.
  - Added a typing regression check in `testing/typing_checks.py` to verify plugin-style annotation with `pytest.CaptureManager`.
  - Verified with `uv run --python 3.10 pytest testing/test_capture.py -k capture_manager_is_public_api`.
  - Verified with `uv run --python 3.10 --with mypy mypy testing/typing_checks.py`.

  Closes #14186