### PR TITLE
Update assertion to check for subclass of RuntimeError

### DIFF
--- a/doc/en/how-to/assert.rst
+++ b/doc/en/how-to/assert.rst
@@ -137,7 +137,7 @@ If you want to check if a block of code is raising an exact exception type, you 
 
         with pytest.raises(RuntimeError) as excinfo:
             foo()
-        assert excinfo.type is RuntimeError
+        assert issubclass(excinfo.type, RuntimeError)
 
 The :func:`pytest.raises` call will succeed, even though the function raises :class:`NotImplementedError`, because
 :class:`NotImplementedError` is a subclass of :class:`RuntimeError`; however the following `assert` statement will


### PR DESCRIPTION
This pull request makes a minor update to the documentation to clarify how to check for exception types in pytest. The assertion now uses `issubclass` instead of `is` to correctly verify that the raised exception is a subclass of the expected type.

- Documentation update:
  * Changed the assertion in the pytest example from `excinfo.type is RuntimeError` to `issubclass(excinfo.type, RuntimeError)` in `doc/en/how-to/assert.rst` to accurately check for subclass relationships when verifying raised exceptions.Change assertion to check for subclass of RuntimeError.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
