### PR TITLE
Document delayed ResourceWarning filtering

### DIFF
--- a/changelog/9825.doc.rst
+++ b/changelog/9825.doc.rst
@@ -1,0 +1,1 @@
+Documented why delayed :class:`ResourceWarning` emission can require filtering :class:`pytest.PytestUnraisableExceptionWarning`.

--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -598,8 +598,7 @@ warning categories:
 
     @pytest.mark.filterwarnings("error::ResourceWarning")
     @pytest.mark.filterwarnings("error::pytest.PytestUnraisableExceptionWarning")
-    def test_resource_cleanup():
-        ...
+    def test_resource_cleanup(): ...
 
 Additional information of the source of a :class:`ResourceWarning` can be obtained when captured by pytest if
 :mod:`tracemalloc` module is enabled.

--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -585,6 +585,22 @@ The full list of warnings is listed in :ref:`the reference documentation <warnin
 Resource Warnings
 -----------------
 
+Unlike warnings emitted directly by application code, :class:`ResourceWarning` warnings for leaked resources are commonly
+emitted later, when the Python interpreter notices the leak during garbage collection. This means a warning filter such
+as ``error::ResourceWarning`` might not fail the test that created the leaked resource, because the warning does not yet
+exist while that test is running. Some Python implementations might never emit the warning.
+
+When pytest observes an unraisable exception caused by a delayed warning, it reports
+:class:`pytest.PytestUnraisableExceptionWarning`. If you want leaked resources to fail tests, consider filtering both
+warning categories:
+
+.. code-block:: python
+
+    @pytest.mark.filterwarnings("error::ResourceWarning")
+    @pytest.mark.filterwarnings("error::pytest.PytestUnraisableExceptionWarning")
+    def test_resource_cleanup():
+        ...
+
 Additional information of the source of a :class:`ResourceWarning` can be obtained when captured by pytest if
 :mod:`tracemalloc` module is enabled.
 


### PR DESCRIPTION
Closes #9825.\n\nThis adds the ResourceWarning note requested in the issue discussion: leaked-resource warnings can be emitted later during garbage collection, so an error filter for ResourceWarning alone might not fail the test that caused the leak. It also points users at the PytestUnraisableExceptionWarning filter when they want leaked resources to fail tests.\n\nValidation:\n- git diff --check\n- PYTHONPATH=src .tox/docs/bin/sphinx-build -j auto -W --keep-going -b html doc/en doc/en/_build/html\n\nNote: python -m tox -e docs could not complete on this external-drive checkout because setuptools failed while building the editable pytest wheel before Sphinx ran: FileNotFoundError for .tox/.pkg/dist/.tmp-*/pytest.egg-info. The docs tox environment and dependencies were created successfully, so I ran the equivalent Sphinx command directly with PYTHONPATH=src after installing pytest's runtime dependency into that env.