### PR TITLE
Keep --log-cli-level from increasing verbosity

### DIFF
--- a/changelog/13612.bugfix.rst
+++ b/changelog/13612.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``--log-cli-level`` increasing test progress verbosity.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -807,10 +807,7 @@ class LoggingPlugin:
         if session.config.option.collectonly:
             return (yield)
 
-        if (
-            self._log_cli_enabled()
-            and self._config.get_verbosity() < 1
-        ):
+        if self._log_cli_enabled() and self._config.get_verbosity() < 1:
             if self._config.getoption("--log-cli-level") is None:
                 # The verbose flag is needed to avoid messy test progress output.
                 self._config.option.verbose = 1
@@ -945,9 +942,7 @@ class _LiveLoggingStreamHandler(logging_StreamHandler):
     def set_show_test_item(self, show_test_item: bool) -> None:
         self._show_test_item = show_test_item
 
-    def set_test_item(
-        self, nodeid: str, location: tuple[str, int | None, str]
-    ) -> None:
+    def set_test_item(self, nodeid: str, location: tuple[str, int | None, str]) -> None:
         fspath, lineno, domain = location
         self._test_item_line = self.stream._locationline(nodeid, fspath, lineno, domain)
 
@@ -998,9 +993,7 @@ class _LiveLoggingNullHandler(logging.NullHandler):
     def set_show_test_item(self, show_test_item: bool) -> None:
         pass
 
-    def set_test_item(
-        self, nodeid: str, location: tuple[str, int | None, str]
-    ) -> None:
+    def set_test_item(self, nodeid: str, location: tuple[str, int | None, str]) -> None:
         pass
 
     def set_when(self, when: str) -> None:

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -807,7 +807,11 @@ class LoggingPlugin:
         if session.config.option.collectonly:
             return (yield)
 
-        if self._log_cli_enabled() and self._config.get_verbosity() < 1:
+        if (
+            self._log_cli_enabled()
+            and self._config.get_verbosity() < 1
+            and self._config.getoption("--log-cli-level") is None
+        ):
             # The verbose flag is needed to avoid messy test progress output.
             self._config.option.verbose = 1
 

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -810,18 +810,23 @@ class LoggingPlugin:
         if (
             self._log_cli_enabled()
             and self._config.get_verbosity() < 1
-            and self._config.getoption("--log-cli-level") is None
         ):
-            # The verbose flag is needed to avoid messy test progress output.
-            self._config.option.verbose = 1
+            if self._config.getoption("--log-cli-level") is None:
+                # The verbose flag is needed to avoid messy test progress output.
+                self._config.option.verbose = 1
+            else:
+                self.log_cli_handler.set_show_test_item(True)
 
         with catching_logs(self.log_cli_handler, level=self.log_cli_level):
             with catching_logs(self.log_file_handler, level=self.log_file_level):
                 return (yield)  # Run all the tests.
 
     @hookimpl
-    def pytest_runtest_logstart(self) -> None:
+    def pytest_runtest_logstart(
+        self, nodeid: str, location: tuple[str, int | None, str]
+    ) -> None:
         self.log_cli_handler.reset()
+        self.log_cli_handler.set_test_item(nodeid, location)
         self.log_cli_handler.set_when("start")
 
     @hookimpl
@@ -929,10 +934,22 @@ class _LiveLoggingStreamHandler(logging_StreamHandler):
         self.reset()
         self.set_when(None)
         self._test_outcome_written = False
+        self._show_test_item = False
+        self._test_item_line: str | None = None
 
     def reset(self) -> None:
         """Reset the handler; should be called before the start of each test."""
         self._first_record_emitted = False
+        self._test_item_written = False
+
+    def set_show_test_item(self, show_test_item: bool) -> None:
+        self._show_test_item = show_test_item
+
+    def set_test_item(
+        self, nodeid: str, location: tuple[str, int | None, str]
+    ) -> None:
+        fspath, lineno, domain = location
+        self._test_item_line = self.stream._locationline(nodeid, fspath, lineno, domain)
 
     def set_when(self, when: str | None) -> None:
         """Prepare for the given test phase (setup/call/teardown)."""
@@ -949,6 +966,13 @@ class _LiveLoggingStreamHandler(logging_StreamHandler):
         )
         with ctx_manager:
             if not self._first_record_emitted:
+                if (
+                    self._show_test_item
+                    and self._test_item_line
+                    and not self._test_item_written
+                ):
+                    self.stream.write_ensure_prefix(self._test_item_line, "")
+                    self._test_item_written = True
                 self.stream.write("\n")
                 self._first_record_emitted = True
             elif self._when in ("teardown", "finish"):
@@ -969,6 +993,14 @@ class _LiveLoggingNullHandler(logging.NullHandler):
     """A logging handler used when live logging is disabled."""
 
     def reset(self) -> None:
+        pass
+
+    def set_show_test_item(self, show_test_item: bool) -> None:
+        pass
+
+    def set_test_item(
+        self, nodeid: str, location: tuple[str, int | None, str]
+    ) -> None:
         pass
 
     def set_when(self, when: str) -> None:

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 import io
 import os
 import re
+from types import SimpleNamespace
 from typing import cast
 
 from _pytest.capture import CaptureManager
 from _pytest.config import ExitCode
 from _pytest.fixtures import FixtureRequest
+from _pytest.logging import LoggingPlugin
+from _pytest.main import Session
 from _pytest.pytester import Pytester
 from _pytest.terminal import TerminalReporter
 import pytest
@@ -615,13 +618,15 @@ def test_log_cli_auto_enable(pytester: Pytester, cli_args: str) -> None:
     if cli_args == "--log-cli-level=WARNING":
         result.stdout.fnmatch_lines(
             [
-                "*::test_log_1 ",
+                "test_log_cli_auto_enable.py ",
                 "*-- live log call --*",
                 "*WARNING*log message from test_log_1*",
-                "PASSED *100%*",
+                ". *100%*",
                 "=* 1 passed in *=",
             ]
         )
+        result.stdout.no_fnmatch_line("*::test_log_1*")
+        result.stdout.no_fnmatch_line("PASSED *100%*")
         assert "INFO" not in stdout
     else:
         result.stdout.fnmatch_lines(
@@ -629,6 +634,64 @@ def test_log_cli_auto_enable(pytester: Pytester, cli_args: str) -> None:
         )
         assert "INFO" not in stdout
         assert "WARNING" not in stdout
+
+
+def test_log_cli_level_does_not_increase_verbosity(pytester: Pytester) -> None:
+    pytester.makepyfile(
+        """
+        import logging
+
+        def test_log():
+            logging.getLogger(__name__).warning("visible log")
+
+        def test_quiet_progress():
+            pass
+    """
+    )
+
+    result = pytester.runpytest("--log-cli-level=WARNING")
+
+    result.stdout.fnmatch_lines(
+        [
+            "*-- live log call --*",
+            "*WARNING*visible log*",
+            "*2 passed in *",
+        ]
+    )
+    result.stdout.no_fnmatch_line("*::test_log*")
+    result.stdout.no_fnmatch_line("*::test_quiet_progress*")
+    result.stdout.no_fnmatch_line("PASSED *100%*")
+
+
+@pytest.mark.parametrize(
+    ("cli_args", "expected_verbose"),
+    [
+        (("--log-cli-level=WARNING",), 0),
+        ((), 1),
+    ],
+)
+def test_log_cli_level_option_keeps_default_verbosity(
+    pytester: Pytester, cli_args: tuple[str, ...], expected_verbose: int
+) -> None:
+    if not cli_args:
+        pytester.makeini(
+            """
+            [pytest]
+            log_cli=true
+            """
+        )
+    config = pytester.parseconfigure(*cli_args)
+    plugin = config.pluginmanager.getplugin("logging-plugin")
+    assert isinstance(plugin, LoggingPlugin)
+
+    session = cast(Session, SimpleNamespace(config=config))
+    hook = plugin.pytest_runtestloop(session)
+    try:
+        next(hook)
+    finally:
+        hook.close()
+
+    assert config.option.verbose == expected_verbose
 
 
 def test_log_file_cli(pytester: Pytester) -> None:

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import io
+import logging
 import os
 import re
 from types import SimpleNamespace
@@ -10,6 +11,8 @@ from typing import cast
 from _pytest.capture import CaptureManager
 from _pytest.config import ExitCode
 from _pytest.fixtures import FixtureRequest
+from _pytest.logging import _LiveLoggingNullHandler
+from _pytest.logging import _LiveLoggingStreamHandler
 from _pytest.logging import LoggingPlugin
 from _pytest.main import Session
 from _pytest.pytester import Pytester
@@ -692,6 +695,40 @@ def test_log_cli_level_option_keeps_default_verbosity(
         hook.close()
 
     assert config.option.verbose == expected_verbose
+
+
+def test_log_cli_level_writes_current_test_item_once(pytester: Pytester) -> None:
+    config = pytester.parseconfigure("--log-cli-level=WARNING")
+    stream = io.StringIO()
+    terminal_reporter = TerminalReporter(config, file=stream)
+    handler = _LiveLoggingStreamHandler(terminal_reporter, capture_manager=None)
+    handler.set_show_test_item(True)
+    handler.set_test_item(
+        "test_log_cli.py::test_log", ("test_log_cli.py", 2, "test_log")
+    )
+    handler.set_when("call")
+    record = logging.LogRecord(
+        "test_log_cli", logging.WARNING, "test_log_cli.py", 4, "visible log", (), None
+    )
+
+    handler.emit(record)
+    handler.emit(record)
+
+    output = stream.getvalue()
+    assert output.count("test_log_cli.py::test_log") == 1
+    assert "live log call" in output
+    assert output.count("visible log") == 2
+
+
+def test_live_logging_null_handler_accepts_test_item_hooks() -> None:
+    handler = _LiveLoggingNullHandler()
+
+    handler.reset()
+    handler.set_show_test_item(True)
+    handler.set_test_item(
+        "test_log_cli.py::test_log", ("test_log_cli.py", 2, "test_log")
+    )
+    handler.set_when("start")
 
 
 def test_log_file_cli(pytester: Pytester) -> None:

--- a/testing/logging/test_reporting.py
+++ b/testing/logging/test_reporting.py
@@ -619,13 +619,13 @@ def test_log_cli_auto_enable(pytester: Pytester, cli_args: str) -> None:
         result.stdout.fnmatch_lines(
             [
                 "test_log_cli_auto_enable.py ",
+                "*::test_log_1 ",
                 "*-- live log call --*",
                 "*WARNING*log message from test_log_1*",
                 ". *100%*",
                 "=* 1 passed in *=",
             ]
         )
-        result.stdout.no_fnmatch_line("*::test_log_1*")
         result.stdout.no_fnmatch_line("PASSED *100%*")
         assert "INFO" not in stdout
     else:
@@ -653,12 +653,12 @@ def test_log_cli_level_does_not_increase_verbosity(pytester: Pytester) -> None:
 
     result.stdout.fnmatch_lines(
         [
+            "*::test_log ",
             "*-- live log call --*",
             "*WARNING*visible log*",
             "*2 passed in *",
         ]
     )
-    result.stdout.no_fnmatch_line("*::test_log*")
     result.stdout.no_fnmatch_line("*::test_quiet_progress*")
     result.stdout.no_fnmatch_line("PASSED *100%*")
 


### PR DESCRIPTION
Fixes #13612.

`--log-cli-level` currently enables live logging and then raises the global verbosity to `1`, which makes normal test progress look like `-v` was passed. This keeps the existing verbosity bump for `log_cli=true`, but skips it when live logging is enabled only by the `--log-cli-level` command-line option.

Validation:

- `PYTHONPATH=src .venv-codex/bin/python -m pytest testing/logging/test_reporting.py -q`
- `git diff --check`
