### PR TITLE
Handle RaisesGroup check errors during suggestions

### DIFF
--- a/changelog/14324.bugfix.rst
+++ b/changelog/14324.bugfix.rst
@@ -1,0 +1,1 @@
+``pytest.RaisesGroup`` no longer raises an exception from the internal suggestion path when a ``check`` callable expects an exception group and cannot handle a contained exception.

--- a/src/_pytest/raises.py
+++ b/src/_pytest/raises.py
@@ -1196,12 +1196,20 @@ class RaisesGroup(AbstractRaises[BaseExceptionGroup[BaseExcT_co]]):
             reason = (
                 cast(str, self._fail_reason) + f" on the {type(exception).__name__}"
             )
-            if (
-                len(actual_exceptions) == len(self.expected_exceptions) == 1
-                and isinstance(expected := self.expected_exceptions[0], type)
-                # we explicitly break typing here :)
-                and self._check_check(actual_exceptions[0])  # type: ignore[arg-type]
-            ):
+            check_matched_expected = False
+            if len(actual_exceptions) == len(
+                self.expected_exceptions
+            ) == 1 and isinstance(expected := self.expected_exceptions[0], type):
+                try:
+                    # we explicitly break typing here :)
+                    check_matched_expected = self._check_check(
+                        actual_exceptions[0]  # type: ignore[arg-type]
+                    )
+                except Exception:
+                    self._fail_reason = reason
+                    return False
+            if check_matched_expected:
+                assert isinstance(expected, type)
                 self._fail_reason = reason + (
                     f", but did return True for the expected {self._repr_expected(expected)}."
                     f" You might want RaisesGroup(RaisesExc({expected.__name__}, check=<...>))"

--- a/testing/python/raises_group.py
+++ b/testing/python/raises_group.py
@@ -435,6 +435,19 @@ def test_check() -> None:
     ):
         raise ExceptionGroup("", (ValueError(),))
 
+    def has_multiple_exceptions(e: ExceptionGroup[ValueError]) -> bool:
+        return len(e.exceptions) > 1
+
+    with (
+        fails_raises_group(
+            "check "
+            f"{repr_callable(has_multiple_exceptions)} did not return True "
+            "on the ExceptionGroup"
+        ),
+        RaisesGroup(ValueError, check=has_multiple_exceptions),
+    ):
+        raise ExceptionGroup("", (ValueError(),))
+
 
 def test_unwrapped_match_check() -> None:
     def my_check(e: object) -> bool:  # pragma: no cover

--- a/testing/python/raises_group.py
+++ b/testing/python/raises_group.py
@@ -448,6 +448,18 @@ def test_check() -> None:
     ):
         raise ExceptionGroup("", (ValueError(),))
 
+    def check_returns_false(e: ExceptionGroup[ValueError]) -> bool:
+        return False
+
+    with (
+        fails_raises_group(
+            f"check {repr_callable(check_returns_false)} did not return True "
+            "on the ExceptionGroup"
+        ),
+        RaisesGroup(RaisesExc(ValueError), check=check_returns_false),
+    ):
+        raise ExceptionGroup("", (ValueError(),))
+
 
 def test_unwrapped_match_check() -> None:
     def my_check(e: object) -> bool:  # pragma: no cover


### PR DESCRIPTION
## Summary
- prevent the speculative `RaisesGroup` suggestion check from surfacing exceptions raised by a group-level `check` callable
- keep the existing helpful suggestion when the callable can safely evaluate the contained exception
- add regression coverage for a `check` callable that expects an `ExceptionGroup`

## Testing
- `python -m pytest testing/python/raises_group.py::test_check -q` failed before the implementation with `AttributeError: ValueError object has no attribute exceptions`
- `python -m pytest testing/python/raises_group.py::test_check -q`
- `python -m pytest testing/python/raises_group.py -q`
- `ruff check src/_pytest/raises.py testing/python/raises_group.py`
- `ruff format --check src/_pytest/raises.py testing/python/raises_group.py`

Closes #14324