### PR TITLE
Move fixture hooks to runtest docs section

### DIFF
--- a/changelog/12658.doc.rst
+++ b/changelog/12658.doc.rst
@@ -1,0 +1,1 @@
+Moved the fixture setup and finalizer hooks to the test running hooks section in the reference documentation.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -786,6 +786,10 @@ All runtest related hooks receive a :py:class:`pytest.Item <pytest.Item>` object
 .. autofunction:: pytest_runtest_teardown
 .. hook:: pytest_runtest_makereport
 .. autofunction:: pytest_runtest_makereport
+.. hook:: pytest_fixture_setup
+.. autofunction:: pytest_fixture_setup
+.. hook:: pytest_fixture_post_finalizer
+.. autofunction:: pytest_fixture_post_finalizer
 
 For deeper understanding you may look at the default implementation of
 these hooks in ``_pytest.runner`` and maybe also
@@ -823,10 +827,6 @@ Session related reporting hooks:
 .. autofunction:: pytest_report_from_serializable
 .. hook:: pytest_terminal_summary
 .. autofunction:: pytest_terminal_summary
-.. hook:: pytest_fixture_setup
-.. autofunction:: pytest_fixture_setup
-.. hook:: pytest_fixture_post_finalizer
-.. autofunction:: pytest_fixture_post_finalizer
 .. hook:: pytest_warning_recorded
 .. autofunction:: pytest_warning_recorded
 


### PR DESCRIPTION
## Summary
- Move pytest_fixture_setup and pytest_fixture_post_finalizer from Reporting hooks to Test running (runtest) hooks.
- Keep pytest_runtest_logreport in Reporting hooks, matching the maintainer guidance in #12658.

Fixes part of #12658.

## Testing
- Verified the two fixture hook entries now appear in the runtest section only.
- Ran git diff --check for doc/en/reference/reference.rst.

I did not run the full docs build locally because the available repo-local venv does not include Sphinx or Docutils.
