### PR TITLE
Do not derive rootdir from a non-regular config file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,6 +50,7 @@ Anton Grinevich
 Anton Lodder
 Anton Zhilin
 Antony Lee
+Apoorv Darshan
 Arel Cordero
 Arias Emmanuel
 Ariel Pillemer

--- a/changelog/11502.bugfix.rst
+++ b/changelog/11502.bugfix.rst
@@ -1,0 +1,1 @@
+When an explicitly given config file is not a regular file (e.g. ``--config-file=/dev/null`` to disable config file loading), the rootdir is no longer derived from its parent directory. Previously this caused a confusing ``PytestCacheWarning`` as the cache plugin attempted to write to e.g. ``/dev/.pytest_cache``.

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -316,7 +316,17 @@ def determine_setup(
         inipath: Path | None = inipath_
         inicfg = load_config_dict_from_file(inipath_) or {}
         if rootdir_cmd_arg is None:
-            rootdir = inipath_.parent
+            if inipath_.is_file():
+                rootdir = inipath_.parent
+            else:
+                # The given config file is not a regular file (e.g.
+                # `--config-file=/dev/null` to disable config file loading):
+                # its location is unrelated to the project, so do not derive
+                # the rootdir from it -- the cache plugin would attempt to
+                # write to e.g. `/dev/.pytest_cache` otherwise (#11502).
+                rootdir = get_common_ancestor(invocation_dir, dirs)
+                if is_fs_root(rootdir):
+                    rootdir = invocation_dir
     else:
         ancestor = get_common_ancestor(invocation_dir, dirs)
         rootdir, inipath, inicfg, ignored_config_files = locate_config(

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -2090,6 +2090,27 @@ class TestRootdir:
         assert rootpath == tmp_path
         assert found_inipath == inipath
 
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="requires a /dev/null-like character device"
+    )
+    def test_explicit_config_file_non_regular_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicitly given config file which is not a regular file (e.g.
+        `--config-file=/dev/null` to disable config file loading) does not
+        make its parent directory the rootdir (#11502)."""
+        monkeypatch.chdir(tmp_path)
+
+        rootpath, found_inipath, *_ = determine_setup(
+            inifile=os.devnull,
+            override_ini=None,
+            args=[str(tmp_path)],
+            rootdir_cmd_arg=None,
+            invocation_dir=Path.cwd(),
+        )
+        assert rootpath == tmp_path
+        assert found_inipath == Path(os.devnull)
+
     def test_with_arg_outside_cwd_without_inifile(
         self, tmp_path: Path, monkeypatch: MonkeyPatch
     ) -> None:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -2111,6 +2111,26 @@ class TestRootdir:
         assert rootpath == tmp_path
         assert found_inipath == Path(os.devnull)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="requires a /dev/null-like character device"
+    )
+    def test_explicit_config_file_non_regular_file_fs_root_args(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same as above, but when the common ancestor of the arguments is the
+        filesystem root, fall back to the invocation directory (#11502)."""
+        monkeypatch.chdir(tmp_path)
+
+        rootpath, found_inipath, *_ = determine_setup(
+            inifile=os.devnull,
+            override_ini=None,
+            args=["/"],
+            rootdir_cmd_arg=None,
+            invocation_dir=Path.cwd(),
+        )
+        assert rootpath == tmp_path
+        assert found_inipath == Path(os.devnull)
+
     def test_with_arg_outside_cwd_without_inifile(
         self, tmp_path: Path, monkeypatch: MonkeyPatch
     ) -> None:


### PR DESCRIPTION
Closes #11502

## Problem

Passing a non-regular file as the config file — the common case being `--config-file=/dev/null` to deliberately disable config file loading — made pytest derive the rootdir from its parent directory. This resulted in `rootdir: /dev`, and the cache plugin then emitted a confusing warning on every run when it failed to create the cache directory there:

```
PytestCacheWarning: could not create cache path /dev/.pytest_cache/v/cache/nodeids: [Errno 1] Operation not permitted
```

Reproduced on current `main` (9.2.0.dev) on macOS; same behavior as originally reported in #11502.

## Fix

In `determine_setup()`, only derive the rootdir from the config file's parent directory when the given config file is a **regular file**. For non-regular files (character devices like `/dev/null`, FIFOs), fall back to the common-ancestor logic already used elsewhere in the function (with the existing filesystem-root guard). The explicitly given config file is still honored as `inipath` — only the rootdir derivation changes.

With the fix, `pytest --config-file=/dev/null` run from a project directory yields `rootdir: <project dir>` and no cache warning.

## Checklist

- [x] Regression test added (`TestRootdir::test_explicit_config_file_non_regular_file`, skipped on Windows).
- [x] Changelog entry: `changelog/11502.bugfix.rst`.
- [x] Added myself to `AUTHORS`.
- [x] Ran `testing/test_config.py`, `testing/test_findpaths.py` (278 passed) and `testing/test_cacheprovider.py` (58 passed) locally; ruff check/format clean.
- [x] Allow maintainers to push and squash when merging my commits.

## AI disclosure

Per the project's AI/LLM-Assisted Contributions Policy: this fix was developed with the assistance of an AI tool (Claude Code). I have reviewed the change, reproduced the bug and verified the fix locally, and I take responsibility for the contribution and will respond to review feedback personally.
