### PR TITLE
parametrize: clear error for non-Sized argvalues entry

### DIFF
--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -214,6 +214,26 @@ class ParameterSet(NamedTuple):
         if parameters:
             # Check all parameter sets have the correct number of values.
             for param in parameters:
+                # A scalar argvalues entry (e.g. `None` or `42`) slips
+                # through `extract_from` as-is when argnames has a
+                # trailing comma, because the trailing comma means
+                # force_tuple=False and the value isn't a ParameterSet.
+                # `len()` then raises `TypeError: object of type
+                # 'NoneType' has no len()` from inside pytest internals,
+                # which is hard to track back to the offending test.
+                # Detect the non-Sized case explicitly and surface a
+                # clear error message that names the test and tells the
+                # user how to fix it.
+                if not isinstance(param.values, collections.abc.Sized):
+                    fail(
+                        f'{nodeid}: in "parametrize" argnames {argnames!r} declares '
+                        f'{len(argnames)} parameter(s) but argvalues contains an entry '
+                        f"of type {type(param.values).__name__} ({param.values!r}), "
+                        "which is not a sequence. Each entry of argvalues must be "
+                        "a sequence with one element per declared argname; wrap "
+                        "scalars in a tuple (e.g. `(value,)`) or use `pytest.param`.",
+                        pytrace=False,
+                    )
                 if len(param.values) != len(argnames):
                     msg = (
                         '{nodeid}: in "parametrize" the number of names ({names_len}):\n'

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -227,7 +227,7 @@ class ParameterSet(NamedTuple):
                 if not isinstance(param.values, collections.abc.Sized):
                     fail(
                         f'{nodeid}: in "parametrize" argnames {argnames!r} declares '
-                        f'{len(argnames)} parameter(s) but argvalues contains an entry '
+                        f"{len(argnames)} parameter(s) but argvalues contains an entry "
                         f"of type {type(param.values).__name__} ({param.values!r}), "
                         "which is not a sequence. Each entry of argvalues must be "
                         "a sequence with one element per declared argname; wrap "

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -15,7 +15,6 @@ from _pytest.pytester import Pytester
 from _pytest.python import Class
 from _pytest.python import Function
 import pytest
-import re
 
 
 class TestModule:

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -15,6 +15,7 @@ from _pytest.pytester import Pytester
 from _pytest.python import Class
 from _pytest.python import Function
 import pytest
+import re
 
 
 class TestModule:
@@ -822,6 +823,30 @@ class TestFunction:
                 "*= 1 passed in *",
             ]
         )
+
+    def test_parametrize_non_sized_argvalues_entry_clear_error(
+        self, pytester: Pytester
+    ) -> None:
+        """Regression test for #14619: a non-Sized entry in argvalues
+        (e.g. ``None`` from a bare scalar) used to surface as the
+        opaque ``TypeError: object of type 'NoneType' has no len()``
+        from inside pytest internals. The error must now point at
+        the offending parametrize and explain the wrapper requirement.
+        """
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.parametrize("x,", [None, "foo", "bar"])
+            def test(x): ...
+            """
+        )
+        result = pytester.runpytest("--collect-only")
+        assert result.ret != 0
+        stdout = str(result.stdout)
+        assert "in \"parametrize\" argnames ['x']" in stdout
+        assert "is not a sequence" in stdout
+        assert "NoneType (None)" in stdout
 
 
 class TestSorting:


### PR DESCRIPTION
Closes #14619

When a trailing-comma argnames string like `"x,"` is combined with
argvalues that include a bare scalar (e.g. `None` from `[None, "foo", "bar"]`),
the user gets a `TypeError: object of type 'NoneType' has no len()` from deep
inside pytest's parametrize internals. The actual cause (a non-Sized entry in
argvalues when force_tuple is False because the trailing comma is present) is
buried in a stack trace, leaving the user to bisect the whole module to find
the offending parametrize.

Fix: surface a `pytest.fail(...)` with the nodeid, the declared argnames, and
the offending entry's type and repr, plus a hint to wrap scalars in a tuple
or use `pytest.param`. The error now reads:

  test.py::test1: in "parametrize" argnames ['x'] declares 1 parameter(s) but
  argvalues contains an entry of type NoneType (None), which is not a
  sequence. Each entry of argvalues must be a sequence with one element per
  declared argname; wrap scalars in a tuple (e.g. `(value,)`) or use
  `pytest.param`.

A regression test (`test_parametrize_non_sized_argvalues_entry_clear_error`)
verifies the new behaviour and fails on the pre-fix code with the opaque
`TypeError`.
