### PR TITLE
Fix fixture arg detection for bound methods

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -108,6 +108,7 @@ Christoph Buelter
 Christopher Dignam
 Christopher Gilling
 Christopher Head
+cjc0013
 Claire Cecil
 Claudio Madotto
 Clément M.T. Robert

--- a/changelog/6750.bugfix.rst
+++ b/changelog/6750.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed fixture argument detection for custom items whose callable is already a bound method.

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -158,13 +158,17 @@ def getfuncargnames(
     # If this function should be treated as a bound method even though
     # it's passed as an unbound method or function, and its first parameter
     # wasn't defined as positional only, remove the first parameter name.
-    if not any(p.kind is Parameter.POSITIONAL_ONLY for p in parameters) and (
-        # Not using `getattr` because we don't want to resolve the staticmethod.
-        # Not using `cls.__dict__` because we want to check the entire MRO.
+    is_bound_method = inspect.ismethod(function) and function.__self__ is not None
+    # Not using `getattr` because we don't want to resolve the staticmethod.
+    # Not using `cls.__dict__` because we want to check the entire MRO.
+    is_static_method = cls is not None and isinstance(
+        inspect.getattr_static(cls, name, default=None), staticmethod
+    )
+    if (
         cls
-        and not isinstance(
-            inspect.getattr_static(cls, name, default=None), staticmethod
-        )
+        and not is_bound_method
+        and not is_static_method
+        and not any(p.kind is Parameter.POSITIONAL_ONLY for p in parameters)
     ):
         arg_names = arg_names[1:]
     # Remove any names that will be replaced with mocks.

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -61,11 +61,18 @@ def test_getfuncargnames_methods():
         def k(self, /, arg1, *, arg2, arg3="hello"):
             raise NotImplementedError()
 
+        @classmethod
+        def cm(cls, arg1):
+            raise NotImplementedError()
+
     assert getfuncargnames(A().f) == ("arg1",)
     assert getfuncargnames(A().g) == ("arg1",)
     assert getfuncargnames(A().h) == ("arg1",)
     assert getfuncargnames(A().j) == ("arg1", "arg2")
     assert getfuncargnames(A().k) == ("arg1", "arg2")
+    assert getfuncargnames(A.f, name="f", cls=A) == ("arg1",)
+    assert getfuncargnames(A().f, name="f", cls=A) == ("arg1",)
+    assert getfuncargnames(A.cm, name="cm", cls=A) == ("arg1",)
 
 
 def test_getfuncargnames_staticmethod():


### PR DESCRIPTION
Fixes #6750.

## Summary

- keep `getfuncargnames(..., cls=...)` from removing an implicit receiver when the callable is already a bound method
- preserve existing staticmethod handling and unbound method receiver stripping
- add regression coverage for unbound, bound, and classmethod callables passed with class context

## Testing

- `python -m compileall -q src\_pytest\compat.py`
- manual reproduction for `getfuncargnames(A().run_test, name="run_test", cls=A)`
- `python -m pytest testing/python/fixtures.py::test_getfuncargnames_methods testing/python/fixtures.py::test_getfuncargnames_staticmethod testing/python/fixtures.py::test_getfuncargnames_staticmethod_inherited testing/python/fixtures.py::test_getfuncargnames_staticmethod_partial -q`
- `python -m pytest testing/python/fixtures.py -q`
- `uvx ruff check src\_pytest\compat.py testing\python\fixtures.py`
- `uvx ruff format --check src\_pytest\compat.py testing\python\fixtures.py`
- `git diff --check`

## AI Assistance

Prepared with AI assistance. I reviewed the patch and validation output and take responsibility for the submission.
