### PR TITLE
doc: fix pytest_load_initial_conftests example referring to conftest.py

### DIFF
--- a/changelog/4482.doc.rst
+++ b/changelog/4482.doc.rst
@@ -1,0 +1,5 @@
+Corrected the "Dynamically adding command line options" example so it no longer
+refers to the ``pytest_load_initial_conftests`` hook as living in a
+``conftest.py``. As noted in the hook reference, ``pytest_load_initial_conftests``
+is not called for ``conftest.py`` files and must be provided by an installable
+plugin.

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -229,7 +229,7 @@ the command line arguments before they get processed:
 If you have the :pypi:`xdist plugin <pytest-xdist>` installed
 you will now always perform test runs using a number
 of subprocesses close to your CPU. Running in an empty
-directory with the above conftest.py:
+directory with the above plugin:
 
 .. code-block:: pytest
 


### PR DESCRIPTION
Closes #4482.

The "Dynamically adding command line options" example in `doc/en/example/simple.rst` defines `pytest_load_initial_conftests` under a `# installable external plugin` comment, but the following prose referred to it as *"the above conftest.py"*. That contradicts the hook reference in `_pytest/hookspec.py`, which states:

> This hook is not called for conftest files.

@RonnyPfannschmidt confirmed in the issue that this is "indeed a mistake". This changes the wording to "the above plugin" so the example is consistent with the hook's documented behavior (it only runs from an installable plugin, not a project `conftest.py`).

Docs-only change; added a `changelog/4482.doc.rst` entry.

<sub>This documentation fix was prepared with the assistance of Claude Code and verified against the hook reference and the issue.</sub>
