### PR TITLE
perf(capture): skip reading the capture file when nothing was written

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -204,6 +204,7 @@ Hamza Mobeen
 Harald Armin Massa
 Harshna
 Henk-Jaap Wagenaar
+Henry Schreiner
 Holger Kohr
 Hugo van Kemenade
 Hui Wang (coldnight)

--- a/changelog/14687.improvement.rst
+++ b/changelog/14687.improvement.rst
@@ -1,0 +1,1 @@
+The default fd-level output capturing (``--capture=fd``) now skips reading the capture buffer for tests which produce no output, reducing per-test overhead in large test suites.

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -566,6 +566,9 @@ class FDCaptureBinary(FDCaptureBase[bytes]):
 
     def snap(self) -> bytes:
         self._assert_state("snap", ("started", "suspended"))
+        # Avoid seek/read/truncate in the common case of no output.
+        if os.fstat(self.tmpfile.fileno()).st_size == 0:
+            return self.EMPTY_BUFFER
         self.tmpfile.seek(0)
         res = self.tmpfile.buffer.read()
         self.tmpfile.seek(0)
@@ -588,6 +591,9 @@ class FDCapture(FDCaptureBase[str]):
 
     def snap(self) -> str:
         self._assert_state("snap", ("started", "suspended"))
+        # Avoid seek/read/truncate in the common case of no output.
+        if os.fstat(self.tmpfile.fileno()).st_size == 0:
+            return self.EMPTY_BUFFER
         self.tmpfile.seek(0)
         res = self.tmpfile.read()
         self.tmpfile.seek(0)


### PR DESCRIPTION
I was investigating pytest performance on pypa/packaging's test suite, which has a lot of small tests, and pytest takes quite a bit of time. I used python 3.15's new sampling profiler, setup something like this:

```
cd <pytest>
uv sync --python 3.15
uv pip install -e <packaging> hypothesis pretend tomli-w
cd <packaging>
sudo <pytest>/.venv/bin/python -m profiling.sampling run -m pytest
```

I then feed the report into Claude and had it look for spots that could be made faster. This is the first thing it found.

`FDCapture.snap()` did `seek/read/seek/truncate` even when the test produced no output. Since the tmpfile is unbuffered, a single `fstat` can prove it is empty and skip all of that.

This removes ~6 of these cycles per test (2 streams x 3 phases); on pypa/packaging (62k tests) it cuts the total runtime by about 8% (the overhead from pytest something like 25%, I think).

I used an `Assisted-by` trailer (as recommended by the linux kernel) instead of a `Co-authored-by` trailer, I can switch if you prefer; generally Co-authored-by seems to be discouraged due to the implied copyright ownership. I rewrote the comments, so it's 33/67 me and Claude.

There isn't an associated issue, so will do a changelog with the PR number if that's fine.

Assisted-by: ClaudeCode:claude-fable-5

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
