### PR TITLE
Improve parametrize error for non-sequence values

### DIFF
--- a/changelog/14619.bugfix.rst
+++ b/changelog/14619.bugfix.rst
@@ -1,0 +1,1 @@
+Parametrization now reports a clear collection error when a trailing-comma argument receives a non-sequence value, instead of raising an internal ``TypeError``.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -214,7 +214,16 @@ class ParameterSet(NamedTuple):
         if parameters:
             # Check all parameter sets have the correct number of values.
             for param in parameters:
-                if len(param.values) != len(argnames):
+                try:
+                    values_len = len(param.values)
+                except TypeError:
+                    fail(
+                        f'{nodeid}: in "parametrize" expected a sequence of values, '
+                        f"got {param.values!r}",
+                        pytrace=False,
+                    )
+
+                if values_len != len(argnames):
                     msg = (
                         '{nodeid}: in "parametrize" the number of names ({names_len}):\n'
                         "  {names}\n"
@@ -227,7 +236,7 @@ class ParameterSet(NamedTuple):
                             values=param.values,
                             names=argnames,
                             names_len=len(argnames),
-                            values_len=len(param.values),
+                            values_len=values_len,
                         ),
                         pytrace=False,
                     )

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -495,6 +495,26 @@ def test_parametrized_collect_with_wrong_args(pytester: Pytester) -> None:
     )
 
 
+def test_parametrized_collect_with_non_sequence_value(pytester: Pytester) -> None:
+    """Test parametrization reports non-sequence values without crashing."""
+    py_file = pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.parametrize("value,", [None])
+        def test_func(value):
+            pass
+    """
+    )
+
+    result = pytester.runpytest(py_file)
+    result.stdout.fnmatch_lines(
+        [
+            '*in "parametrize" expected a sequence of values, got None',
+        ]
+    )
+
+
 def test_parametrized_with_kwargs(pytester: Pytester) -> None:
     """Test collect parametrized func with wrong number of args."""
     py_file = pytester.makepyfile(


### PR DESCRIPTION
Fixes #14619.

When a trailing-comma parametrization receives a scalar value such as `None`, collection currently raises an unhandled `TypeError` while checking `len(param.values)`. Report a normal, actionable parametrization error instead, and add a regression test.

Tests:
- `python -m pytest testing/test_mark.py -q`
- `python -m compileall -q src/_pytest/mark testing/test_mark.py`