### PR TITLE
Handle brackets in collection paths

### DIFF
--- a/changelog/10329.bugfix.rst
+++ b/changelog/10329.bugfix.rst
@@ -1,0 +1,1 @@
+Collection arguments now support existing file system paths containing square brackets.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -1125,11 +1125,25 @@ def resolve_collection_argument(
     If the path doesn't exist, raise UsageError.
     If the path is a directory and selection parts are present, raise UsageError.
     """
-    base, squacket, rest = arg.partition("[")
-    strpath, *parts = base.split("::")
-    if squacket and not parts:
-        raise UsageError(f"path cannot contain [] parametrization: {arg}")
-    parametrization = f"{squacket}{rest}" if squacket else None
+    strpath, *parts = arg.split("::")
+    fspath = absolutepath(invocation_path / strpath)
+
+    if "[" in strpath and safe_exists(fspath):
+        parametrization = None
+
+        if parts:
+            part, squacket, rest = parts[-1].partition("[")
+            if squacket:
+                parts[-1] = part
+                parametrization = f"{squacket}{rest}"
+    else:
+        base, squacket, rest = arg.partition("[")
+        strpath, *parts = base.split("::")
+        if squacket and not parts:
+            raise UsageError(f"path cannot contain [] parametrization: {arg}")
+        parametrization = f"{squacket}{rest}" if squacket else None
+        fspath = absolutepath(invocation_path / strpath)
+
     module_name = None
     if as_pypath:
         pyarg_strpath = search_pypath(
@@ -1138,8 +1152,7 @@ def resolve_collection_argument(
         if pyarg_strpath is not None:
             module_name = strpath
             strpath = pyarg_strpath
-    fspath = invocation_path / strpath
-    fspath = absolutepath(fspath)
+            fspath = absolutepath(invocation_path / strpath)
     if not safe_exists(fspath):
         msg = (
             "module or package not found: {arg} (missing __init__.py?)"

--- a/testing/test_main.py
+++ b/testing/test_main.py
@@ -188,6 +188,21 @@ class TestResolveCollectionArgument:
         ):
             resolve_collection_argument(invocation_path, "src/pkg::foo::bar", 0)
 
+    def test_dir_with_square_bracket(self, invocation_path: Path) -> None:
+        """Existing directories may contain square brackets in their path."""
+        dirname = invocation_path / "src/pkg[special]"
+        dirname.mkdir()
+
+        assert resolve_collection_argument(
+            invocation_path, "src/pkg[special]", 0
+        ) == CollectionArgument(
+            path=dirname,
+            parts=[],
+            parametrization=None,
+            module_name=None,
+            original_index=0,
+        )
+
     @pytest.mark.parametrize("namespace_package", [False, True])
     def test_pypath(self, namespace_package: bool, invocation_path: Path) -> None:
         """Dotted name and parts."""


### PR DESCRIPTION
Fixes #10329.

Pytest treated `[` in a collection path as the start of a parametrized node id, even when the argument pointed to an existing file system path like `simple[hard]/`.

This keeps existing paths with square brackets as normal collection paths, while preserving parametrized node selection for arguments like `test_file.py::test_name[param]`.

Tests cover resolving an existing directory with square brackets in its name.