### PR TITLE
ci: bump PyPy 3.10 to 3.11 for hypothesis wheel build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,7 +223,7 @@ jobs:
             use_coverage: true
 
           - name: "ubuntu-pypy3-xdist"
-            python: "pypy-3.10"
+            python: "pypy-3.11"
             os: ubuntu-latest
             tox_env: "pypy3-xdist"
 

--- a/testing/_py/test_local.py
+++ b/testing/_py/test_local.py
@@ -1464,7 +1464,7 @@ class TestPOSIXLocalPath:
                 x.chmod(y)
 
     def test_copy_archiving(self, tmpdir):
-        unicode_fn = "something-\342\200\223.txt"
+        unicode_fn = "something-\xe2\x80\x93.txt"
         f = tmpdir.ensure("a", unicode_fn)
         a = f.dirpath()
         oldmode = f.stat().mode


### PR DESCRIPTION
hypothesis 6.156.6 ships a Rust/pyo3 0.29 component whose minimum supported PyPy is 3.11. With no prebuilt wheel for pypy-3.10, pip builds from sdist and maturin fails with:

    the configured PyPy interpreter version (3.10) is lower than PyO3's
    minimum supported version (3.11)

The pin, to keep PyPy 3.10  would be 

  hypothesis>=3.56,<6.156; platform_python_implementation == "PyPy"

(6.155.7 is the last pure-Python release). No need for a changelog because this affect our test suite not pytest itself.