### PR TITLE
docs: clarify pytest_assertrepr_compare behavior with passing assertions

### DIFF
--- a/changelog/12062.improvement.rst
+++ b/changelog/12062.improvement.rst
@@ -1,0 +1,1 @@
+Clarified that :func:`pytest_assertrepr_compare <_pytest.hookspec.pytest_assertrepr_compare>` is also invoked for passing assertions when :confval:`enable_assertion_pass_hook` is enabled.

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -941,6 +941,9 @@ def pytest_assertrepr_compare(
     *in* a string will be escaped. Note that all but the first line will
     be indented slightly, the intention is for the first line to be a summary.
 
+    If the :confval:`enable_assertion_pass_hook` configuration option is enabled,
+    this hook is also called for passing assertions.
+
     :param config: The pytest config object.
     :param op: The operator, e.g. `"=="`, `"!="`, `"not in"`.
     :param left: The left operand.


### PR DESCRIPTION
Closes #12062.

When `enable_assertion_pass_hook` is enabled, `pytest_assertrepr_compare` is also evaluated on passing assertions. This clarifies the hook's docstring to state this behavior, as previously it only mentioned failing assertions.