### PR TITLE
assertion: fix crash explaining dict.items() comparisons with unhashable values

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -497,6 +497,7 @@ Victor Maryama
 Victor Rodriguez
 Victor Uriarte
 Vidar T. Fauske
+Vidit Patankar
 Vijay Arora
 Virendra Patil
 Virgil Dupras

--- a/changelog/14717.bugfix.rst
+++ b/changelog/14717.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed assertion explanation erroring with "representation of details failed" when comparing :func:`dict.items` views containing unhashable values.
+Fixed assertion explanation erroring with "representation of details failed" when comparing :meth:`dict.items` views containing unhashable values.

--- a/changelog/14717.bugfix.rst
+++ b/changelog/14717.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed assertion explanation erroring with "representation of details failed" when comparing :func:`dict.items` views containing unhashable values.

--- a/src/_pytest/assertion/_compare_set.py
+++ b/src/_pytest/assertion/_compare_set.py
@@ -15,7 +15,10 @@ def _set_one_sided_diff(
     set2: AbstractSet[object],
     highlighter: _HighlightFunc,
 ) -> Iterator[str]:
-    diff = set1 - set2
+    # Use a membership test rather than set difference: set views such as
+    # dict.items() are Sets whose elements may be unhashable, in which case
+    # computing `set1 - set2` raises TypeError.
+    diff = [item for item in set1 if item not in set2]
     if diff:
         yield f"Extra items in the {posn} set:"
         for item in diff:

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1862,6 +1862,32 @@ class TestSetAssertions:
                 ]
             )
 
+    @pytest.mark.parametrize("op", ["==", "<="])
+    def test_dict_items_view_unhashable_values(self, op, pytester: Pytester) -> None:
+        """dict.items() comparisons must not require hashable values.
+
+        The set diff previously used set difference, which raises TypeError
+        for items views whose values are unhashable.
+        """
+        pytester.makepyfile(
+            f"""
+            def test_hello():
+                x = {{"a": [1], "c": [3]}}
+                y = {{"a": [1]}}
+                assert x.items() {op} y.items()
+        """
+        )
+
+        result = pytester.runpytest()
+        result.stdout.no_fnmatch_line("*representation of details failed*")
+        result.stdout.fnmatch_lines(
+            [
+                f"*assert x.items() {op} y.items()*",
+                "*E*Extra items in the left set:*",
+                "*E*('c', [[]3])*",
+            ]
+        )
+
     @pytest.mark.parametrize("op", [">", "<", "!="])
     def test_set_proper_superset_equal(self, pytester: Pytester, op) -> None:
         pytester.makepyfile(


### PR DESCRIPTION
Comparing `dict.items()` views in an assertion crashes the explanation when any value is unhashable, e.g.:

```python
def test_hello():
    x = {"a": [1], "c": [3]}
    y = {"a": [1]}
    assert x.items() <= y.items()
```

produces on current `main`:

```
E       AssertionError: assert dict_items([('a', [1]), ('c', [3])]) <= dict_items([('a', [1])])
E         (pytest_assertion plugin: representation of details failed: .../_pytest/assertion/_compare_set.py:18: TypeError: cannot use 'tuple' as a set element (unhashable type: 'list').
E          Probably an object has a faulty __repr__.)
```

This is a regression from 9db664649 (#14675), which widened `isset()` to any `collections.abc.Set` — that admits `dict.items()` views, whose elements are `(key, value)` tuples that may hold unhashable values. The comparison operators themselves work hash-free via `__contains__`, so such asserts are legitimate; only the explanation's `set1 - set2` requires hashability. Since #14675 is unreleased, this would ship broken in 9.2 otherwise.

Fix: compute the one-sided diff with a membership test instead of set difference. This doesn't just avoid the crash — it makes the new set-diff output actually work for these views:

```
E         Extra items in the left set:
E         ('c', [3])
```

Considered `try/except TypeError` around `set1 - set2` instead, but that silently loses the diff exactly in the case the feature was added for; the membership version stays O(n) for builtin sets/views.

Includes a parametrized regression test (fails before, passes after; `testing/test_assertion.py` + `testing/test_assertrewrite.py`: 306 passed locally) and a changelog entry.

*Prepared with AI assistance; I reviewed the change and ran the repro and test suites locally.*
