### PR TITLE
Fix: show skip reason on a new line when it does not fit (#11146)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -135,6 +135,7 @@ David Peled
 David Szotten
 David Vierra
 Daw-Ran Liou
+deeferentleeg
 Debi Mishra
 Denis Cherednichenko
 Denis Kirisov

--- a/changelog/11146.bugfix.rst
+++ b/changelog/11146.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed skip/xfail reason being silently dropped in verbose output (``-v``) when the terminal is too narrow to fit the reason on the test line: the reason is now shown on a new line instead.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -680,8 +680,19 @@ class TerminalReporter:
                     else:
                         formatted_reason = f" ({reason})"
 
-                    if reason and formatted_reason is not None:
-                        self.wrap_write(formatted_reason)
+                    if reason:
+                        if formatted_reason is not None:
+                            self.wrap_write(formatted_reason)
+                        else:
+                            # The reason did not fit on the current line. Write
+                            # it on a new line instead of silently dropping it
+                            # (#11146), truncating it to the terminal width so a
+                            # very long reason does not wrap uncontrollably.
+                            self.ensure_newline()
+                            trimmed = _format_trimmed(
+                                "({})", reason, self._screen_width
+                            )
+                            self._tw.write(trimmed or f"({reason})")
                 if self._show_progress_info:
                     self._write_progress_information_filling_space()
             else:

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -494,9 +494,7 @@ class TestTerminal:
         # not silently dropped due to the narrow terminal.
         result.stdout.fnmatch_lines(["*no room*"])
         # The test must still be reported as SKIPPED.
-        result.stdout.fnmatch_lines(
-            ["*test_skip_with_a_very_long_name_here*SKIPPED*"]
-        )
+        result.stdout.fnmatch_lines(["*test_skip_with_a_very_long_name_here*SKIPPED*"])
 
     @pytest.mark.parametrize("isatty", [True, False])
     def test_isatty(self, pytester: Pytester, monkeypatch, isatty: bool) -> None:

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -470,6 +470,34 @@ class TestTerminal:
             ]
         )
 
+    def test_skip_reason_narrow_terminal(self, pytester: Pytester, monkeypatch) -> None:
+        """A skip reason that does not fit on the line is shown on a new line (#11146).
+
+        Regression: pytest 7.4.0 (PR #10958) silently dropped the skip reason when
+        the terminal was too narrow to fit even an ellipsis. It should instead be
+        written on a new line.
+        """
+        monkeypatch.setenv("COLUMNS", "30")
+        # Long test name so the inline skip reason cannot fit at all; short reason
+        # that does fit on its own line, so the full reason must be present.
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.skip(reason="no room")
+            def test_skip_with_a_very_long_name_here():
+                pass
+        """
+        )
+        result = pytester.runpytest("-v")
+        # The full skip reason must be present in the output (on its own line),
+        # not silently dropped due to the narrow terminal.
+        result.stdout.fnmatch_lines(["*no room*"])
+        # The test must still be reported as SKIPPED.
+        result.stdout.fnmatch_lines(
+            ["*test_skip_with_a_very_long_name_here*SKIPPED*"]
+        )
+
     @pytest.mark.parametrize("isatty", [True, False])
     def test_isatty(self, pytester: Pytester, monkeypatch, isatty: bool) -> None:
         config = pytester.parseconfig()


### PR DESCRIPTION
## What & why

Fixes #11146.

Since pytest 7.4.0 (PR #10958), when running with `-v` (verbosity < 2) in a terminal too narrow to fit the skip/xfail reason on the test line, `_format_trimmed(" ({})", reason, available_width)` returns `None` and the reason was **silently dropped**. This affects narrow terminals and CI logs (Jenkins/GitLab), where the skip reason simply vanishes — several users in the issue rely on reading these reasons by eye.

As @RonnyPfannschmidt asked in the issue: *"any idea for adding this to the output in a manner that's not completely messing it up"*. @disconnect3d traced the regression to PR #10958 and showed that the dropped reason is the problem.

This PR takes the conservative approach requested in the discussion: **when the reason cannot fit on the current line, write it on a new line** instead of losing it. It does not change the inline case (reason still appears next to the test when it fits).

## The change

`src/_pytest/terminal.py` — in `pytest_runtest_logreport`, the skipped-reason branch:

```python
if reason:
    if formatted_reason is not None:
        self.wrap_write(formatted_reason)
    else:
        # The reason did not fit on the current line. Write it on a new
        # line instead of silently dropping it (#11146), truncating it to
        # the terminal width so a very long reason does not wrap uncontrollably.
        self.ensure_newline()
        trimmed = _format_trimmed("({})", reason, self._screen_width)
        self._tw.write(trimmed or f"({reason})")
```

Only the previously-buggy case (`formatted_reason is None`, i.e. the reason could not fit even as an ellipsis) is affected. The `else` (verbosity ≥ 2) path is untouched — `formatted_reason` there is never `None`. No new option, no public-API change, no effect on normal/parseable output when the reason fits inline.

`_screen_width` is already used by `wrap_write` for the same wrapping purpose, so the new line is trimmed consistently with the rest of the verbose output. The `trimmed or f"({reason})"` fallback covers the absurd case where even an ellipsis can't fit (e.g. a 1-column terminal).

## Tests

`testing/test_terminal.py` — new `test_skip_reason_narrow_terminal`, modeled on `test_verbose_skip_reason` and the `COLUMNS`-env pattern used in `test_times_multiline`:

- Sets `COLUMNS=30` so the long test nodeid leaves no room for an inline reason (`_format_trimmed` returns `None`).
- A short reason (`"no room"`) that fits on its own 30-char line.
- Asserts the reason `*no room*` is present in the output (it would be absent pre-fix) and that the test is still reported `SKIPPED`.

Pre-fix this test fails (reason dropped); post-fix it passes (reason on a new line).

## Behavior note / alignment with the issue discussion

- @The-Compiler noted terminal output is not intended to be stable/parsable, so this is framed as a **user-readability** fix, not a parser contract.
- The fix is deliberately narrow: it only recovers the dropped reason; it does not reflow existing output or add a new option, keeping the change minimal and low-risk as requested.

## Changelog

Added `changelog/11146.bugfix.rst`.

## Checklist

- [x] Include documentation when adding new features — n/a (bug fix).
- [x] Include new tests or update existing tests when applicable — added `test_skip_reason_narrow_terminal`.
- [x] Allow maintainers to push and squash when merging my commits.
- [x] Add `closes #11146` to the PR description.
- [x] Create a new changelog file in the `changelog` directory.
- [x] Add myself to `AUTHORS` in alphabetical order.

## AI assistance disclosure

Per the pytest [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy): I used an AI assistant (Claude) to help research the issue discussion, analyze the code path, and draft this change. I have reviewed, understand, and take full responsibility for every line of this PR — the fix, the regression test (including the width arithmetic that confirms it triggers the bug condition), the changelog entry, and the rationale above. The commit credits the assistant via a `Co-authored-by` trailer. I am the human owner of this contribution and will engage substantively with any review feedback.

Happy to adjust the approach, the test, or the wording to match what the maintainers prefer — including if a different presentation (e.g. a dedicated line format, or an opt-in) is desired.