### PR TITLE
fix: keep frame locations in longrepr under --tb=line/no

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,6 +17,7 @@ Akiomi Kamakura
 Alan Velasco
 Alejandro Villate
 Alessio Izzo
+Alex Chen
 Alex Jones
 Alex Lambson
 Alexander Johnson

--- a/changelog/14720.bugfix.rst
+++ b/changelog/14720.bugfix.rst
@@ -1,0 +1,1 @@
+Compact traceback styles (``--tb=line`` and ``--tb=no``) now keep frame file and line metadata on ``longrepr`` entries so reporting plugins can still read locations when terminal output is suppressed.

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -1113,9 +1113,18 @@ class ExceptionInfoFormatter:
                 lines.extend(str(excinfo.value).split("\n"))
             return ReprEntry(lines, None, None, None, style)
         else:
+            # Compact styles ("line", "no", …): still attach file/line metadata so
+            # reporting plugins can read frame locations from longrepr even when
+            # terminal display is suppressed or reduced (#14720). Display stays
+            # compact via ReprEntry.toterminal.
+            reprfileloc = None
+            if entry is not None:
+                path = self._makepath(entry.path)
+                message = (excinfo and excinfo.typename) or ""
+                reprfileloc = ReprFileLocation(path, entry.lineno + 1, message)
             if excinfo:
                 lines.extend(self.get_exconly(excinfo, indent=4))
-            return ReprEntry(lines, None, None, None, style)
+            return ReprEntry(lines, None, None, reprfileloc, style)
 
     def _makepath(self, path: Path | str) -> str:
         if not self.abspath and isinstance(path, Path):
@@ -1452,6 +1461,8 @@ class ReprEntry(TerminalRepr):
             tw.line(line, bold=True, red=True)
 
     def toterminal(self, tw: TerminalWriter) -> None:
+        # Display style is independent of the structural data we keep for plugins
+        # (reprfileloc under --tb=line/--tb=no; see #14720).
         if self.style == "short":
             if self.reprfileloc:
                 self.reprfileloc.toterminal(tw)
@@ -1468,7 +1479,10 @@ class ReprEntry(TerminalRepr):
         if self.reprlocals:
             tw.line("")
             self.reprlocals.toterminal(tw)
-        if self.reprfileloc:
+        # Compact styles keep reprfileloc for plugins/API consumers but do not
+        # dump per-frame locations into the terminal (terminal uses crashline
+        # for --tb=line and skips the FAILURES section for --tb=no).
+        if self.reprfileloc and self.style not in ("line", "no"):
             if self.lines:
                 tw.line("")
             self.reprfileloc.toterminal(tw)

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -1944,6 +1944,45 @@ def test_exceptiongroup_short_summary_info(pytester: Pytester):
     )
 
 
+@pytest.mark.parametrize("tbstyle", ("line", "no"))
+def test_compact_tb_styles_keep_reprfileloc_for_plugins(
+    pytester: Pytester, tbstyle: str
+) -> None:
+    """--tb line/no must still expose frame locations on longrepr (#14720).
+
+    Display can stay compact, but reporting plugins reading
+    ``report.longrepr.reprtraceback.reprentries`` need ``reprfileloc``.
+    """
+    pytester.makepyfile(
+        """
+        def inner():
+            raise ValueError("boom")
+
+        def middle():
+            inner()
+
+        def test_a():
+            middle()
+        """
+    )
+    reprec = pytester.inline_run(f"--tb={tbstyle}")
+    reports = [
+        r
+        for r in reprec.getreports("pytest_runtest_logreport")
+        if r.when == "call" and r.failed
+    ]
+    assert len(reports) == 1
+    longrepr = reports[0].longrepr
+    assert hasattr(longrepr, "reprtraceback")
+    entries = longrepr.reprtraceback.reprentries
+    assert len(entries) >= 1
+    located = [e for e in entries if getattr(e, "reprfileloc", None) is not None]
+    assert located, f"expected reprfileloc under --tb={tbstyle}, got {entries!r}"
+    for e in located:
+        assert e.reprfileloc.path
+        assert e.reprfileloc.lineno > 0
+
+
 @pytest.mark.parametrize("tbstyle", ("long", "short", "auto", "line", "native"))
 @pytest.mark.parametrize("group", (True, False), ids=("group", "bare"))
 def test_all_entries_hidden(pytester: Pytester, tbstyle: str, group: bool) -> None:


### PR DESCRIPTION
## Summary

`--tb=line` and `--tb=no` used to build compact `longrepr` entries **without** `reprfileloc`. Plugins that suppress pytest's own traceback via `--tb=no` still saw `reprentries`, but every frame's file/line was `None`, so custom reporters silently lost location data.

This keeps structural frame locations on compact styles. Terminal display stays compact: `ReprEntry.toterminal` still does not dump per-frame locations for `line`/`no` (the terminal plugin uses crashline / skips FAILURES as before).

## Test plan

- [x] `pytest testing/code/test_excinfo.py testing/test_terminal.py::TestGenericReporting testing/test_reports.py -q` → 230 passed, 11 skipped
- [x] New regression: `test_compact_tb_styles_keep_reprfileloc_for_plugins` for `--tb=line` and `--tb=no`
- [x] ruff check + format on touched files
- [x] changelog fragment `14720.bugfix.rst` + AUTHORS

Fixes #14720
