### PR TITLE
fix: keep pytest_terminal_summary under --no-summary

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,6 +19,7 @@ Alejandro Villate
 Alessio Izzo
 Alex Jones
 Alex Lambson
+Alex Chen
 Alexander Johnson
 Alexander King
 Alexei Kozlenok

--- a/changelog/14724.bugfix.rst
+++ b/changelog/14724.bugfix.rst
@@ -1,0 +1,4 @@
+``--no-summary`` no longer skips the ``pytest_terminal_summary`` hook.
+
+Built-in FAILURES/ERRORS/... sections stay suppressed, but third-party
+plugins (for example coverage) can still write their terminal summaries.

--- a/changelog/14724.bugfix.rst
+++ b/changelog/14724.bugfix.rst
@@ -1,4 +1,0 @@
-``--no-summary`` no longer skips the ``pytest_terminal_summary`` hook.
-
-Built-in FAILURES/ERRORS/... sections stay suppressed, but third-party
-plugins (for example coverage) can still write their terminal summaries.

--- a/changelog/14724.improvement.rst
+++ b/changelog/14724.improvement.rst
@@ -1,0 +1,4 @@
+``--no-summary`` now only applies directly to pytest's own summary.
+
+The flag no longer skips the ``pytest_terminal_summary`` hook, so third-party
+plugins (for example coverage) can still write their terminal summaries.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1000,7 +1000,8 @@ class TerminalReporter:
     def pytest_terminal_summary(self) -> Generator[None]:
         # With --no-summary, still yield so other plugins run their terminal
         # summaries, but skip pytest's own FAILURES/ERRORS/... sections.
-        if not self.no_summary:
+        show_summary = not self.no_summary
+        if show_summary:
             self.summary_errors()
             self.summary_failures()
             self.summary_xfailures()
@@ -1010,7 +1011,7 @@ class TerminalReporter:
         try:
             return (yield)
         finally:
-            if not self.no_summary:
+            if show_summary:
                 self.short_test_summary()
                 # Display any extra warnings from teardown here (if any).
                 self.summary_warnings()

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -968,7 +968,10 @@ class TerminalReporter:
             ExitCode.NO_TESTS_COLLECTED,
             ExitCode.MAX_WARNINGS_ERROR,
         )
-        if exitstatus in summary_exit_codes and not self.no_summary:
+        # Always invoke pytest_terminal_summary so third-party plugins can report
+        # (e.g. coverage). --no-summary only suppresses TerminalReporter's own
+        # built-in summary sections; see TerminalReporter.pytest_terminal_summary.
+        if exitstatus in summary_exit_codes:
             self.config.hook.pytest_terminal_summary(
                 terminalreporter=self, exitstatus=exitstatus, config=self.config
             )
@@ -995,18 +998,22 @@ class TerminalReporter:
 
     @hookimpl(wrapper=True)
     def pytest_terminal_summary(self) -> Generator[None]:
-        self.summary_errors()
-        self.summary_failures()
-        self.summary_xfailures()
-        self.summary_warnings()
-        self.summary_passes()
-        self.summary_xpasses()
+        # With --no-summary, still yield so other plugins run their terminal
+        # summaries, but skip pytest's own FAILURES/ERRORS/... sections.
+        if not self.no_summary:
+            self.summary_errors()
+            self.summary_failures()
+            self.summary_xfailures()
+            self.summary_warnings()
+            self.summary_passes()
+            self.summary_xpasses()
         try:
             return (yield)
         finally:
-            self.short_test_summary()
-            # Display any extra warnings from teardown here (if any).
-            self.summary_warnings()
+            if not self.no_summary:
+                self.short_test_summary()
+                # Display any extra warnings from teardown here (if any).
+                self.summary_warnings()
 
     def pytest_keyboard_interrupt(self, excinfo: ExceptionInfo[BaseException]) -> None:
         self._keyboardinterrupt_memo = excinfo.getrepr(funcargs=True)

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1015,6 +1015,21 @@ class TestTerminalFunctional:
         result = pytester.runpytest(p1, "--no-summary")
         result.stdout.no_fnmatch_line("*= FAILURES =*")
 
+    def test_no_summary_still_runs_terminal_summary_hook(
+        self, pytester: Pytester
+    ) -> None:
+        """--no-summary must not skip pytest_terminal_summary for plugins (#14724)."""
+        pytester.makeconftest(
+            """
+            def pytest_terminal_summary(terminalreporter, exitstatus, config):
+                terminalreporter.write_line("PLUGIN_TERMINAL_SUMMARY_RAN")
+            """
+        )
+        p1 = pytester.makepyfile("def test_ok(): assert True")
+        result = pytester.runpytest(p1, "--no-summary")
+        result.stdout.fnmatch_lines(["PLUGIN_TERMINAL_SUMMARY_RAN"])
+        result.stdout.no_fnmatch_line("*= FAILURES =*")
+
     def test_showlocals(self, pytester: Pytester) -> None:
         p1 = pytester.makepyfile(
             """


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
-->

## Summary

`--no-summary` currently skips calling the `pytest_terminal_summary` hook entirely, which silences third-party plugins (e.g. pytest-cov) as well as pytest's own FAILURES/ERRORS sections.

This change always invokes the hook, but gates **TerminalReporter**'s built-in summary sections on `not no_summary`, so:

- pytest's own FAILURES/ERRORS/... stay hidden under `--no-summary`
- plugins can still write their terminal summaries

Closes #14724

## AI / review

I used automated assistance while preparing this change, then reviewed and tested the result myself. The product unit is the hook vs TerminalReporter split above; I can answer review questions on it.

## Test plan

- [x] `TestTerminalFunctional::test_no_summary` (FAILURES still suppressed)
- [x] new `test_no_summary_still_runs_terminal_summary_hook`
- [x] existing no_summary warning/collecterror tests
