### PR TITLE
Fix bare except clause in testing/test_unittest.py

### DIFF
--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -393,7 +393,7 @@ def test_testcase_adderrorandfailure_defers(pytester: Pytester, type: str) -> No
                     result.add{type}(self, excinfo._excinfo)
                 except KeyboardInterrupt:
                     raise
-                except:
+                except Exception:
                     pytest.fail("add{type} should not raise")
             def test_hello(self):
                 pass


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in `testing/test_unittest.py`.

The existing code already catches `KeyboardInterrupt` explicitly and re-raises it, then uses a bare `except:` to catch everything else and call `pytest.fail()`. Since `KeyboardInterrupt` is already handled, the remaining bare `except:` should be `except Exception:` — which covers all normal exception types while making the intent clear.