### PR TITLE
Treat malformed unittest skips as collection errors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -529,6 +529,7 @@ Zac Palmer Laporte
 Zach Snicker
 Zachary Kneupper
 Zachary OBrien
+zhangli091011
 Zhouxin Qiu
 Zoltán Máté
 Zsolt Cserna

--- a/changelog/10821.bugfix.rst
+++ b/changelog/10821.bugfix.rst
@@ -1,0 +1,1 @@
+Malformed uses of :func:`unittest.skip` during test module import now cause a collection error instead of silently skipping the module.

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -415,7 +415,18 @@ def pytest_make_collect_report(collector: Collector) -> CollectReport:
         skip_exceptions = [Skipped]
         unittest = sys.modules.get("unittest")
         if unittest is not None:
-            skip_exceptions.append(unittest.SkipTest)
+            exception = call.excinfo.value
+            if isinstance(exception, unittest.SkipTest):
+                traceback = exception.__traceback__
+                assert traceback is not None
+                while traceback.tb_next is not None:
+                    traceback = traceback.tb_next
+                frame = traceback.tb_frame
+                if not (
+                    frame.f_code.co_name == "skip_wrapper"
+                    and frame.f_globals.get("__name__") == "unittest.case"
+                ):
+                    skip_exceptions.append(unittest.SkipTest)
         if isinstance(call.excinfo.value, tuple(skip_exceptions)):
             outcome = "skipped"
             r_ = collector._repr_failure_py(call.excinfo, "line")

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1733,7 +1733,7 @@ def test_unittest_skip_decorator_misuse_is_collection_error(
     result = pytester.runpytest()
 
     result.assert_outcomes(errors=1, skipped=0)
-    result.stdout.fnmatch_lines(["*unittest.case.SkipTest: broken*"])
+    result.stdout.fnmatch_lines(["*SkipTest: broken*"])
 
 
 def test_abstract_testcase_is_not_collected(pytester: Pytester) -> None:

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1715,6 +1715,27 @@ def test_raising_unittest_skiptest_during_collection(
     assert reprec.ret == ExitCode.NO_TESTS_COLLECTED
 
 
+def test_unittest_skip_decorator_misuse_is_collection_error(
+    pytester: Pytester,
+) -> None:
+    pytester.makepyfile(
+        """
+        import unittest
+
+        broken = unittest.skip("broken")
+
+        class TestIt(unittest.TestCase):
+            @broken("not a test")
+            def test_it(self): pass
+        """
+    )
+
+    result = pytester.runpytest()
+
+    result.assert_outcomes(errors=1, skipped=0)
+    result.stdout.fnmatch_lines(["*unittest.case.SkipTest: broken*"])
+
+
 def test_abstract_testcase_is_not_collected(pytester: Pytester) -> None:
     """Regression test for #12275."""
     pytester.makepyfile(


### PR DESCRIPTION
Closes #10821.

## Summary

Malformed use of an aliased `unittest.skip` decorator currently raises `unittest.SkipTest` from unittest's generated `skip_wrapper` while importing the test module. Pytest classifies every collection-time `unittest.SkipTest` as a module skip, so this programming error can hide all tests in that module.

This keeps legitimate unittest module skipping intact and changes only `SkipTest` whose innermost traceback frame is unittest's generated `skip_wrapper`. Such exceptions are now normal collection errors. Direct module-level `raise unittest.SkipTest(...)` remains a skipped module, matching `unittest.TestLoader.discover`, and `pytest.skip(..., allow_module_level=True)` is unaffected.

This narrower boundary addresses the compatibility concern raised on #10864 and #14415 rather than removing collection-time `SkipTest` handling wholesale.

## Tests

- `python -m pytest testing/test_unittest.py testing/test_runner.py testing/test_skipping.py` (`231 passed, 9 skipped, 1 xfailed`)
- `tox -e py310 -- testing/test_unittest.py -k "raising_unittest_skiptest_during_collection or unittest_skip_decorator_misuse_is_collection_error"` (`2 passed`)
- `python -m pytest testing/test_unittest.py -k "raising_unittest_skiptest_during_collection or unittest_skip_decorator_misuse_is_collection_error"` on Python 3.13 (`2 passed`)
- `pre-commit run --all-files --show-diff-on-failure` (passed, including Ruff, formatting, mypy, RST and policy hooks)

Current `main` was reproduced separately: the issue example reports `collected 0 items / 1 skipped` before this change.

## AI assistance

OpenCode assisted with repository inspection, implementation, and validation, and is credited by a `Co-authored-by` trailer. I reviewed the complete diff and tests, understand the traceback-based compatibility boundary, and take responsibility for this change and reviewer follow-up in accordance with pytest's AI/LLM-Assisted Contributions Policy.

- [x] Includes a regression test.
- [x] Includes a changelog entry.
- [x] Adds the contributor to `AUTHORS`.
- [x] Allows maintainers to push and squash when merging.
- [x] Credits the AI agent in the commit trailer.
