### PR TITLE
Reopen sys.__std*__ on Windows consoles so they follow fd capture

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@ Aaron Coleman
 Abdeali JK
 Abdelrahman Elbehery
 Abhijeet Kasurde
+Abhishek Kumar Roy
 Adam Johnson
 Adam Stewart
 Adam Uhlir

--- a/changelog/12349.bugfix.rst
+++ b/changelog/12349.bugfix.rst
@@ -1,0 +1,3 @@
+On Windows, ``sys.__stdout__``, ``sys.__stderr__`` and ``sys.__stdin__`` are now reopened to be backed by their file descriptors when attached to a console and capturing is enabled (``--capture=fd``, the default).
+
+Previously they remained backed by the console handle, so while output was being captured ``sys.__stdout__.isatty()`` incorrectly returned ``True`` (unlike on POSIX systems, where it returns ``False``), and writes to ``sys.__stdout__`` either escaped capturing and were printed to the terminal or failed with ``OSError: [WinError 6] The handle is invalid``.

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -147,9 +147,41 @@ def _windowsconsoleio_workaround(stream: TextIO) -> None:
             f.line_buffering,
         )
 
+    def _reopen_dunder(f, mode):
+        # Build the raw stream explicitly: ``open()`` on a console fd would
+        # produce another ``_WindowsConsoleIO``, which writes through the
+        # console handle rather than the fd.
+        raw = io.FileIO(f.fileno(), mode, closefd=False)
+        buffer = io.BufferedReader(raw) if mode == "r" else io.BufferedWriter(raw)
+        return io.TextIOWrapper(
+            buffer,
+            f.encoding,
+            f.errors,
+            f.newlines,
+            f.line_buffering,
+        )
+
     sys.stdin = _reopen_stdio(sys.stdin, "rb")
     sys.stdout = _reopen_stdio(sys.stdout, "wb")
     sys.stderr = _reopen_stdio(sys.stderr, "wb")
+
+    # The original sys.__std*__ streams are backed by the console handle
+    # rather than by their file descriptor, so while ``FDCapture`` has
+    # redirected the fd they keep reporting ``isatty() == True`` and their
+    # writes bypass the capture file entirely (or fail with EBADF once the
+    # console handle has been closed by ``dup2``) (#12349).
+    # Reopen them backed by their original file descriptors, so that they
+    # follow fd redirection just like on POSIX systems.
+    # The assignments are intentional, hence the type ignores: typeshed marks
+    # these as Final because they normally hold the interpreter's original
+    # streams, but the original console-backed streams misbehave under fd
+    # capturing, as described above.
+    if sys.__stdin__ is not None:
+        sys.__stdin__ = _reopen_dunder(sys.__stdin__, "r")  # type: ignore[misc]
+    if sys.__stdout__ is not None:
+        sys.__stdout__ = _reopen_dunder(sys.__stdout__, "w")  # type: ignore[misc]
+    if sys.__stderr__ is not None:
+        sys.__stderr__ = _reopen_dunder(sys.__stderr__, "w")  # type: ignore[misc]
 
 
 @hookimpl(wrapper=True)

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -6,10 +6,12 @@ import contextlib
 import io
 from io import UnsupportedOperation
 import os
+from pathlib import Path
 import re
 import subprocess
 import sys
 import textwrap
+from types import SimpleNamespace
 from typing import BinaryIO
 from typing import cast
 from typing import TextIO
@@ -1526,6 +1528,83 @@ def test_windowsconsoleio_workaround_non_standard_streams() -> None:
 
     stream = cast(TextIO, DummyStream())
     _windowsconsoleio_workaround(stream)
+
+
+@pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info"),
+    reason="_windowsconsoleio_workaround is a no-op on PyPy",
+)
+def test_windowsconsoleio_workaround_reopens_dunder_streams(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    """The workaround must also rebind ``sys.__std{in,out,err}__`` to streams
+    backed by their file descriptor instead of the console handle.
+
+    Otherwise ``sys.__stdout__.isatty()`` keeps returning True while
+    ``FDCapture`` has redirected the fd, and writes to it bypass capturing
+    entirely or fail with "handle is invalid" (#12349).
+
+    The console environment is faked so that this runs on all platforms.
+    """
+    from _pytest.capture import _windowsconsoleio_workaround
+
+    class FakeConsoleRaw(io.FileIO):
+        pass
+
+    with (
+        (tmp_path / "stdin").open("w+") as stdin_f,
+        (tmp_path / "stdout").open("w+") as stdout_f,
+        (tmp_path / "stderr").open("w+") as stderr_f,
+    ):
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(io, "_WindowsConsoleIO", FakeConsoleRaw, raising=False)
+        monkeypatch.setattr(sys, "stdin", stdin_f)
+        monkeypatch.setattr(sys, "stdout", stdout_f)
+        monkeypatch.setattr(sys, "stderr", stderr_f)
+        monkeypatch.setattr(sys, "__stdin__", stdin_f)
+        monkeypatch.setattr(sys, "__stdout__", stdout_f)
+        monkeypatch.setattr(sys, "__stderr__", stderr_f)
+
+        with FakeConsoleRaw(stdout_f.fileno(), "w", closefd=False) as fake_raw:
+            stream = cast(TextIO, SimpleNamespace(buffer=SimpleNamespace(raw=fake_raw)))
+            _windowsconsoleio_workaround(stream)
+
+        try:
+            assert sys.__stdin__ is not None
+            assert sys.__stdout__ is not None
+            assert sys.__stderr__ is not None
+
+            # sys.std* are reopened on duplicated fds, isolating them from
+            # dup2 over the original fds.
+            assert sys.stdout is not stdout_f
+            assert sys.stdout.fileno() != stdout_f.fileno()
+
+            # The dunder streams are reopened backed by their *original* fd
+            # (through a regular FileIO, not a console IO), so that they
+            # follow fd redirection performed by FDCapture.
+            assert sys.__stdout__ is not stdout_f
+            assert sys.__stdout__.fileno() == stdout_f.fileno()
+            dunder_buffer = sys.__stdout__.buffer
+            assert isinstance(dunder_buffer, io.BufferedWriter)
+            assert type(dunder_buffer.raw) is io.FileIO
+            assert sys.__stdin__.fileno() == stdin_f.fileno()
+            assert sys.__stderr__.fileno() == stderr_f.fileno()
+
+            # Writes through the reopened dunder stream reach the fd target.
+            sys.__stdout__.write("hello")
+            sys.__stdout__.flush()
+            assert (tmp_path / "stdout").read_text() == "hello"
+        finally:
+            for reopened in (
+                sys.stdin,
+                sys.stdout,
+                sys.stderr,
+                sys.__stdin__,
+                sys.__stdout__,
+                sys.__stderr__,
+            ):
+                if reopened is not None:
+                    reopened.close()
 
 
 def test_dontreadfrominput_has_encoding(pytester: Pytester) -> None:


### PR DESCRIPTION
Closes #12349

## The problem

On Windows, when attached to a console, `sys.__stdin__`/`sys.__stdout__`/`sys.__stderr__` are backed by `_io._WindowsConsoleIO`, which writes through the **console handle** rather than the file descriptor, and whose `isatty()` unconditionally returns `True`.

So while `FDCapture` has `dup2`-ed the fds away (`--capture=fd`, the default):

- `sys.__stdout__.isatty()` keeps returning `True`, while `os.isatty(1)` correctly returns `False` — unlike POSIX, where both return `False` (this is the exact assertion failure reported in #12349, reproduced on Windows 11);
- writes to `sys.__stdout__` either escape capturing and are printed straight to the terminal, or fail with `OSError: [WinError 6] The handle is invalid` once `dup2` has closed the console handle (the very handle instability already described in `_windowsconsoleio_workaround`'s docstring).

## The fix

Extend `_windowsconsoleio_workaround` to also reopen the dunder streams, backed by their **original** file descriptors (unlike `sys.std*`, which keep being reopened on duplicated fds for handle isolation). The raw stream is constructed explicitly with `io.FileIO`, because `open()` on a console fd produces another `_WindowsConsoleIO` and would change nothing.

After the fix the dunder streams follow fd redirection exactly like on POSIX: `isatty()` reflects the actual state of the fd, writes during capture land in the capture file, and writes outside capture reach the console. `sys.__stdin__.encoding` and `sys.__stderr__.fileno()` (used by the faulthandler plugin) are preserved.

## Verification on Windows 11

Running the reproducer from #12349 under a real console (ConPTY), before the fix:

```
FAILED - AssertionError: assert not True   (sys.__stdout__.isatty())
```

and a write probe showed `OSError(9, 'The handle is invalid')` plus output leaking to the terminal despite capture being active.

After the fix, both asserts from the issue pass, and writes to `sys.__stdout__` are captured. `testing/test_capture.py` (131 tests), `testing/test_terminal.py` and `testing/test_faulthandler.py` all pass both piped and under a real console on Windows 11.

The new regression test fakes the console environment (monkeypatched `sys.platform` and `io._WindowsConsoleIO`), so it exercises this code path on all platforms/CI runners, where no real console is available.

---

- [ ] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number).
- [x] If AI agents were used, they are credited in `Co-authored-by` commit trailers.
- [x] Create a new changelog file in the `changelog` directory (`changelog/12349.bugfix.rst`).
- [x] Add yourself to `AUTHORS` in alphabetical order.

*Disclosure per the AI/LLM-Assisted Contributions Policy: this change was developed with AI assistance (Claude Code), credited in the commit trailer. I take responsibility for the change and will respond to review feedback myself.*