### PR TITLE
Docs: Document that pytest_assertrepr_compare is called on passing asserts

### DIFF
--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -941,6 +941,11 @@ def pytest_assertrepr_compare(
     *in* a string will be escaped. Note that all but the first line will
     be indented slightly, the intention is for the first line to be a summary.
 
+    .. note::
+
+        This hook is also called for passing assertions if the
+        :func:`pytest_assertion_pass` hook is implemented.
+
     :param config: The pytest config object.
     :param op: The operator, e.g. `"=="`, `"!="`, `"not in"`.
     :param left: The left operand.


### PR DESCRIPTION
- [x] closes #12062

This PR documents the behavior where `pytest_assertrepr_compare` is also executed on passing assertions if a `pytest_assertion_pass` hook is defined, as reported in #12062.