### PR TITLE
python: rename CallSpec2 -> CallSpec

### DIFF
--- a/changelog/14742.deprecation.rst
+++ b/changelog/14742.deprecation.rst
@@ -1,0 +1,2 @@
+The private ``_pytest.python.CallSpec2`` name has been renamed to ``CallSpec``.
+The old name remains available as a deprecated alias.

--- a/changelog/14742.deprecation.rst
+++ b/changelog/14742.deprecation.rst
@@ -1,2 +1,2 @@
 The private ``_pytest.python.CallSpec2`` name has been renamed to ``CallSpec``.
-The old name remains available as a deprecated alias.
+The old ``CallSpec2`` alias remains available for now and will be removed in pytest 10.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -24,8 +24,8 @@ Below is a complete list of all pytest features which are considered deprecated.
 
 The private ``_pytest.python.CallSpec2`` name has been renamed to ``CallSpec``.
 
-Plugins that import ``CallSpec2`` should update to ``CallSpec``. The old name
-remains available as a deprecated alias for a transitional period.
+Plugins that import ``CallSpec2`` should update to ``CallSpec``. The old
+``CallSpec2`` alias remains available for now and will be removed in pytest 10.
 
 
 .. _fixture-nodeid-deprecated:

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -15,6 +15,19 @@ Below is a complete list of all pytest features which are considered deprecated.
 :class:`~pytest.PytestWarning` or subclasses, which can be filtered using :ref:`standard warning filters <warnings>`.
 
 
+.. _callspec2-renamed:
+
+``_pytest.python.CallSpec2`` renamed to ``CallSpec``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 9.1
+
+The private ``_pytest.python.CallSpec2`` name has been renamed to ``CallSpec``.
+
+Plugins that import ``CallSpec2`` should update to ``CallSpec``. The old name
+remains available as a deprecated alias for a transitional period.
+
+
 .. _fixture-nodeid-deprecated:
 
 Passing ``baseid``/``nodeid`` strings to fixture registration APIs

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -133,6 +133,12 @@ PARSEFACTORIES_NODEID_DEPRECATED = PytestRemovedIn10Warning(
     "Use parsefactories(holder=obj, node=node) instead."
 )
 
+CALLSPEC2_RENAMED = PytestRemovedIn10Warning(
+    "_pytest.python.CallSpec2 has been renamed to CallSpec.\n"
+    "Update imports to use CallSpec instead.\n"
+    "See https://docs.pytest.org/en/stable/deprecations.html#callspec2-renamed"
+)
+
 
 def check_ispytest(ispytest: bool) -> None:
     if not ispytest:

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -135,6 +135,7 @@ PARSEFACTORIES_NODEID_DEPRECATED = PytestRemovedIn10Warning(
 
 CALLSPEC2_RENAMED = PytestRemovedIn10Warning(
     "_pytest.python.CallSpec2 has been renamed to CallSpec.\n"
+    "The CallSpec2 alias will be removed in pytest 10.\n"
     "Update imports to use CallSpec instead.\n"
     "See https://docs.pytest.org/en/stable/deprecations.html#callspec2-renamed"
 )

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -83,7 +83,7 @@ if sys.version_info < (3, 11):
 
 
 if TYPE_CHECKING:
-    from _pytest.python import CallSpec2
+    from _pytest.python import CallSpec
     from _pytest.python import Function
     from _pytest.python import Metafunc
     from _pytest.reports import CollectReport
@@ -227,7 +227,7 @@ def get_param_argkeys(item: nodes.Item, scope: Scope) -> Iterator[ParamArgKey]:
     assert scope is not Scope.Function
 
     try:
-        callspec: CallSpec2 = item.callspec  # type: ignore[attr-defined]
+        callspec: CallSpec = item.callspec  # type: ignore[attr-defined]
     except AttributeError:
         return
 

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1090,7 +1090,7 @@ class IdMaker:
 
 @final
 @dataclasses.dataclass(frozen=True)
-class CallSpec2:
+class CallSpec:
     """A planned parameterized invocation of a test function.
 
     Calculated during collection for a given test function's Metafunc.
@@ -1120,7 +1120,7 @@ class CallSpec2:
         scope: Scope,
         param_index: int,
         nodeid: str,
-    ) -> CallSpec2:
+    ) -> CallSpec:
         params = self.params.copy()
         indices = self.indices.copy()
         arg2scope = dict(self._arg2scope)
@@ -1132,7 +1132,7 @@ class CallSpec2:
             params[arg] = val
             indices[arg] = param_index
             arg2scope[arg] = scope
-        return CallSpec2(
+        return CallSpec(
             params=params,
             indices=indices,
             _arg2scope=arg2scope,
@@ -1224,7 +1224,7 @@ class Metafunc:
         self._arg2fixturedefs = fixtureinfo.name2fixturedefs
 
         # Result of parametrize().
-        self._calls: list[CallSpec2] = []
+        self._calls: list[CallSpec] = []
 
         self._params_directness: dict[str, Literal["indirect", "direct"]] = {}
 
@@ -1408,7 +1408,7 @@ class Metafunc:
         # more than once) then we accumulate those calls generating the cartesian product
         # of all calls.
         newcalls = []
-        for callspec in self._calls or [CallSpec2()]:
+        for callspec in self._calls or [CallSpec()]:
             for param_index, (param_id, param_set) in enumerate(
                 zip(ids, parametersets, strict=True)
             ):
@@ -1610,7 +1610,7 @@ class Function(PyobjMixin, nodes.Item):
         name: str,
         parent,
         config: Config | None = None,
-        callspec: CallSpec2 | None = None,
+        callspec: CallSpec | None = None,
         callobj=NOTSET,
         keywords: Mapping[str, Any] | None = None,
         session: Session | None = None,

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -51,6 +51,7 @@ from _pytest.compat import safe_isclass
 from _pytest.config import Config
 from _pytest.config import hookimpl
 from _pytest.config.argparsing import Parser
+from _pytest.deprecated import CALLSPEC2_RENAMED
 from _pytest.deprecated import check_ispytest
 from _pytest.fixtures import _resolve_args_directness
 from _pytest.fixtures import FixtureDef
@@ -1151,6 +1152,11 @@ class CallSpec:
         return "-".join(self._idlist)
 
 
+if TYPE_CHECKING:
+    # Deprecated alias kept for type checkers; runtime access goes through __getattr__.
+    CallSpec2 = CallSpec
+
+
 def get_direct_param_fixture_func(request: FixtureRequest) -> Any:
     return request.param
 
@@ -1759,3 +1765,10 @@ class FunctionDefinition(Function):
         raise RuntimeError("function definitions are not supposed to be run as tests")
 
     setup = runtest
+
+
+def __getattr__(name: str) -> object:
+    if name == "CallSpec2":
+        warnings.warn(CALLSPEC2_RENAMED, stacklevel=2)
+        return CallSpec
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -310,3 +310,17 @@ class TestFixtureNodeidDeprecations:
         )
         result = pytester.runpytest()
         result.assert_outcomes(passed=1)
+
+
+def test_callspec2_renamed() -> None:
+    """Importing/accessing CallSpec2 warns and returns CallSpec."""
+    import _pytest.python as python_mod
+    from _pytest.python import CallSpec
+
+    with pytest.warns(pytest.PytestRemovedIn10Warning, match="CallSpec2"):
+        from _pytest.python import CallSpec2
+
+    assert CallSpec2 is CallSpec
+
+    with pytest.warns(pytest.PytestRemovedIn10Warning, match="CallSpec2"):
+        assert python_mod.CallSpec2 is CallSpec


### PR DESCRIPTION
## Summary

- Internal rename of private `CallSpec2` to `CallSpec` (no public API exposure, no behavior change).
- Preparatory cleanup to shrink the rename noise in #13242 (dependent parametrize).

## Test plan

- [ ] CI green
- [ ] Confirm no remaining `CallSpec2` references outside historical changelog entries


Made with [Cursor](https://cursor.com)