### PR TITLE
Fix missing traceback source for code with cwd-relative filenames

### DIFF
--- a/changelog/1139.bugfix.rst
+++ b/changelog/1139.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed tracebacks showing ``???`` instead of source lines for code compiled with a filename relative to a directory other than the current working directory -- e.g. compiled Cython modules, when running pytest from a subdirectory of the project root.
+The source lookup now falls back to searching ``sys.path`` for such filenames, as the standard :mod:`traceback` module does.

--- a/src/_pytest/_code/source.py
+++ b/src/_pytest/_code/source.py
@@ -6,6 +6,7 @@ from bisect import bisect_right
 from collections.abc import Iterable
 from collections.abc import Iterator
 import inspect
+import linecache
 import textwrap
 import tokenize
 import types
@@ -126,7 +127,20 @@ def findsource(obj) -> tuple[Source | None, int]:
     try:
         sourcelines, lineno = inspect.findsource(obj)
     except Exception:
-        return None, -1
+        # inspect.findsource() fails for code objects whose co_filename is
+        # relative to a directory other than the cwd, e.g. compiled Cython
+        # modules when running pytest from a subdirectory (#1139).
+        # Fall back to linecache, which also searches sys.path for bare
+        # filenames, as the standard traceback module does.
+        code = (
+            obj if isinstance(obj, types.CodeType) else getattr(obj, "__code__", None)
+        )
+        if code is None:
+            return None, -1
+        sourcelines = linecache.getlines(code.co_filename)
+        if not sourcelines:
+            return None, -1
+        lineno = code.co_firstlineno - 1
     source = Source()
     source.lines = [line.rstrip() for line in sourcelines]
     source.raw_lines = sourcelines

--- a/testing/code/test_source.py
+++ b/testing/code/test_source.py
@@ -344,6 +344,37 @@ def test_findsource(monkeypatch) -> None:
     assert src[lineno] == "    def x():"
 
 
+def test_findsource_filename_relative_to_syspath_entry(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """findsource() falls back to searching sys.path for code objects whose
+    co_filename is relative to a directory other than the cwd, like the
+    standard traceback module does (#1139).
+
+    This happens e.g. with compiled Cython modules, whose code objects
+    carry paths relative to the project root, when pytest is run from a
+    subdirectory.
+    """
+    from _pytest._code.source import findsource
+
+    filename = "findsource_syspath_demo.py"
+    lines = ["def f():\n", "    return 1\n"]
+    (tmp_path / filename).write_text("".join(lines), encoding="utf-8")
+    co = compile("".join(lines), filename, "exec")
+    d: dict[str, Any] = {}
+    eval(co, d)
+
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.chdir(empty)
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    src, lineno = findsource(d["f"].__code__)
+    assert src is not None
+    assert lineno == 0
+    assert src[lineno] == "def f():"
+
+
 def test_getfslineno() -> None:
     def f(x) -> None:
         raise NotImplementedError()


### PR DESCRIPTION
inspect.findsource() fails for code objects whose co_filename is relative to a directory other than the current working directory - e.g. compiled Cython modules when pytest is run from a subdirectory of the project root - causing tracebacks to show `???` instead of the source lines.

Fall back to linecache.getlines(), which additionally searches sys.path for bare filenames, matching the behavior of the standard traceback module (which displays these sources correctly).

Fixes #1139