### PR TITLE
Fix elision of long collections in assertion messages with -vv

### DIFF
--- a/changelog/12307.bugfix.rst
+++ b/changelog/12307.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed truncation of long collections (lists, dicts, sets, etc.) in the "message" part of failed assertions (as in ``assert condition, msg``) when using ``-vv``: the message now uses the same unlimited repr as the rest of the assertion output, instead of eliding collection elements with ``...``.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -456,7 +456,7 @@ def _format_assertmsg(obj: object) -> str:
     # However in either case we want to preserve the newline.
     replaces = [("\n", "\n~"), ("%", "%%")]
     if not isinstance(obj, str):
-        obj = saferepr(obj, _get_maxsize_for_saferepr(util._config))
+        obj = _saferepr(obj)
         replaces.append(("\\n", "\n~"))
 
     for r1, r2 in replaces:

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -572,6 +572,28 @@ class TestAssertionRewrite:
         assert result.ret == 1
         result.stdout.re_match_lines([r".*AssertionError: A+$", ".*assert False"])
 
+    def test_assertion_message_verbosity_collection(self, pytester: Pytester) -> None:
+        """
+        With -vv, the "message" part of assertions must not elide collection
+        elements with "..." either (#12307).
+        """
+        pytester.makepyfile(
+            """
+            def test_assertion_verbosity_collection():
+                assert False, list(range(100))
+            """
+        )
+        # Normal verbosity: collection elements are elided.
+        result = pytester.runpytest()
+        assert result.ret == 1
+        result.stdout.fnmatch_lines(["*AssertionError: [[]0, 1, 2, 3, 4, 5, ...*"])
+
+        # High-verbosity: show the collection in full.
+        result = pytester.runpytest("-vv")
+        assert result.ret == 1
+        result.stdout.fnmatch_lines(["*AssertionError: [[]0, 1, 2,*98, 99[]]*"])
+        result.stdout.no_fnmatch_line("*AssertionError: *...*")
+
     def test_boolop(self) -> None:
         def f1() -> None:
             f = g = False


### PR DESCRIPTION
The message part of `assert cond, msg` went through `saferepr(obj, maxsize)`, where `-vv` maps to `maxsize=None`. That lifts the overall string-length cap, but `SafeRepr` still inherits reprlib's per-container limits (`maxlist=6` etc.), so e.g. `assert False, dir("")` stayed elided with `...` at any verbosity — the exact reproducer from issue #12307, which #12662 only partially fixed (it covered long scalar reprs but not collections).

Use the `_saferepr` helper instead, as originally proposed in #12322: it routes `maxsize=None` to `saferepr_unlimited()`, which uses a plain `repr()`, matching how asserted expressions are already displayed at high verbosity.

Closes #12322.