### PR TITLE
Allow dotted test filenames (*.test.py) via dot-escape in compute_module_name

### DIFF
--- a/changelog/14514.bugfix.rst
+++ b/changelog/14514.bugfix.rst
@@ -1,0 +1,1 @@
+Dots in test module filenames are now escaped with underscores to prevent ``pytest`` from misinterpreting them as package notation when computing the module name.

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -931,6 +931,7 @@ def compute_module_name(root: Path, module_path: Path) -> str | None:
         return None
     if names[-1] == "__init__":
         names.pop()
+    names = [p.replace(".", "_") for p in names]
     return ".".join(names)
 
 

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -1734,6 +1734,15 @@ def test_compute_module_name(tmp_path: Path) -> None:
         == "src.app.bar"
     )
 
+    assert (
+        compute_module_name(tmp_path, tmp_path / "foo.test.py")
+        == "foo_test"
+    )
+    assert (
+        compute_module_name(tmp_path, tmp_path / "src/app/foo.test.py")
+        == "src.app.foo_test"
+    )
+
 
 def validate_namespace_package(
     pytester: Pytester, paths: Sequence[Path], modules: Sequence[str]

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -1734,10 +1734,7 @@ def test_compute_module_name(tmp_path: Path) -> None:
         == "src.app.bar"
     )
 
-    assert (
-        compute_module_name(tmp_path, tmp_path / "foo.test.py")
-        == "foo_test"
-    )
+    assert compute_module_name(tmp_path, tmp_path / "foo.test.py") == "foo_test"
     assert (
         compute_module_name(tmp_path, tmp_path / "src/app/foo.test.py")
         == "src.app.foo_test"


### PR DESCRIPTION
Escape dots inside path parts in `compute_module_name`, the same way `module_name_from_path` already does. This maps `pkg/foo.test.py` to module `pkg.foo_test` instead of the invalid `pkg.foo.test`.

The change is one line — the same `p.replace(., _)` pattern already used by the sibling `module_name_from_path` fallback.

closes: #14514