### PR TITLE
Make `Metafunc.parametrize` keyword-only from indirect onwards

### DIFF
--- a/changelog/8593.breaking.rst
+++ b/changelog/8593.breaking.rst
@@ -1,0 +1,3 @@
+The ``indirect``, ``ids`` and ``scope`` arguments of :func:`Metafunc.parametrize() <pytest.Metafunc.parametrize>` -- and therefore of :ref:`@pytest.mark.parametrize <pytest.mark.parametrize ref>` -- are now keyword-only.
+
+Passing them positionally was a common source of confusing errors, e.g. ``parametrize("arg1", "arg2", [(1, 2)])`` made the argvalues land in ``indirect`` and failed with ``indirect fixture '(1, 2)' doesn't exist``; such mistakes now fail with an understandable ``TypeError``. The type annotations have always declared these arguments as keyword-only.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1294,10 +1294,10 @@ class Metafunc:
         self,
         argnames: str | Sequence[str],
         argvalues: Iterable[ParameterSet | Sequence[object] | object],
+        *,
         indirect: bool | Sequence[str] = False,
         ids: Iterable[object | None] | Callable[[Any], object | None] | None = None,
         scope: ScopeName | None = None,
-        *,
         _param_mark: Mark | None = None,
     ) -> None:
         """Add new invocations to the underlying test function using the list
@@ -1372,6 +1372,10 @@ class Metafunc:
             The scope is used for grouping tests by parameter instances.
             It will also override any fixture-function defined scope, allowing
             to set a dynamic scope using test context or configuration.
+
+        .. versionchanged:: 9.1
+
+            ``indirect``, ``ids`` and ``scope`` are now keyword-only.
         """
         nodeid = self.definition.nodeid
 

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -936,7 +936,7 @@ class TestMetafunc:
         an understandable TypeError rather than being silently interpreted."""
 
         def func(x, y):
-            pass
+            raise NotImplementedError()
 
         metafunc = self.Metafunc(func)
         with pytest.raises(TypeError, match="positional arguments"):

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -930,6 +930,18 @@ class TestMetafunc:
         ):
             metafunc.parametrize("x, y", [("a", "b")], indirect={})  # type: ignore[arg-type]
 
+    def test_parametrize_positional_indirect_error(self) -> None:
+        """`indirect` and later arguments are keyword-only, so that extra
+        positional arguments (e.g. several argname strings, #8593) fail with
+        an understandable TypeError rather than being silently interpreted."""
+
+        def func(x, y):
+            pass
+
+        metafunc = self.Metafunc(func)
+        with pytest.raises(TypeError, match="positional arguments"):
+            metafunc.parametrize("x, y", [("a", "b")], ["x"])  # type: ignore[misc]
+
     def test_parametrize_indirect_list_functional(self, pytester: Pytester) -> None:
         """
         #714
@@ -2330,6 +2342,7 @@ class TestMarkersWithParametrization:
         )
 
     def test_parametrize_positional_args(self, pytester: Pytester) -> None:
+        """`indirect` and later arguments are keyword-only."""
         pytester.makepyfile(
             """
             import pytest
@@ -2340,7 +2353,8 @@ class TestMarkersWithParametrization:
         """
         )
         result = pytester.runpytest()
-        result.assert_outcomes(passed=1)
+        result.stdout.fnmatch_lines(["*TypeError*positional argument*"])
+        result.assert_outcomes(errors=1)
 
     def test_parametrize_iterator(self, pytester: Pytester) -> None:
         pytester.makepyfile(

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -940,7 +940,7 @@ class TestMetafunc:
 
         metafunc = self.Metafunc(func)
         with pytest.raises(TypeError, match="positional arguments"):
-            metafunc.parametrize("x, y", [("a", "b")], ["x"])  # type: ignore[misc]
+            metafunc.parametrize("x, y", [("a", "b")], ["x"])  # type: ignore[call-arg]
 
     def test_parametrize_indirect_list_functional(self, pytester: Pytester) -> None:
         """


### PR DESCRIPTION
Passing indirect/ids/scope positionally was a common source of confusing errors -- most notably `parametrize("arg1", "arg2", [(1, 2)])` sending the argvalues into indirect and failing with "indirect fixture '(1, 2)' doesn't exist" (closes #8593). 

The type annotations for the `pytest.mark.parametrize` stub have declared these arguments keyword-only all along; this aligns the runtime signature.

Technically a breaking change, but I think the overwhelmingly common case is that it was a confusing error, not a deliberate positional use.