### PR TITLE
Slate yield_fixture decorator for removal in pytest 10

### DIFF
--- a/changelog/14755.deprecation.rst
+++ b/changelog/14755.deprecation.rst
@@ -1,0 +1,1 @@
+Schedule *yield_fixture* decorator for removal in pytest 10.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -435,7 +435,7 @@ The ``yield_fixture`` function/decorator
 
 .. deprecated:: 6.2
 
-``pytest.yield_fixture`` is a deprecated alias for :func:`pytest.fixture`.
+``pytest.yield_fixture`` is a deprecated alias for :func:`pytest.fixture` and will be removed in pytest 10.
 
 It has been so for a very long time, so it can be searched/replaced safely.
 

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -29,7 +29,7 @@ DEPRECATED_EXTERNAL_PLUGINS = {
 
 
 # This could have been removed pytest 8, but it's harmless and common, so no rush to remove.
-YIELD_FIXTURE = PytestDeprecationWarning(
+YIELD_FIXTURE = PytestRemovedIn10Warning(
     "@pytest.yield_fixture is deprecated.\n"
     "Use @pytest.fixture instead; they are the same."
 )

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -5,6 +5,7 @@ from _pytest import deprecated
 from _pytest.pytester import Pytester
 import pytest
 from pytest import PytestDeprecationWarning
+from pytest import PytestRemovedIn10Warning
 
 
 @pytest.mark.parametrize("plugin", sorted(deprecated.DEPRECATED_EXTERNAL_PLUGINS))
@@ -66,7 +67,7 @@ def test_hookimpl_via_function_attributes_are_deprecated():
 
 
 def test_yield_fixture_is_deprecated() -> None:
-    with pytest.warns(DeprecationWarning, match=r"yield_fixture is deprecated"):
+    with pytest.warns(PytestRemovedIn10Warning, match=r"yield_fixture is deprecated"):
 
         @pytest.yield_fixture  # type: ignore[deprecated]
         def fix():


### PR DESCRIPTION
Schedules the deprecated *yield_fixture* decorator for removal in pytest 10.
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
