### PR TITLE
Introduce a legend for - and + in diff outputs

### DIFF
--- a/changelog/14743.feature.rst
+++ b/changelog/14743.feature.rst
@@ -1,0 +1,1 @@
+`Full diff:` now contains a legend explaining the `+` & `-` symbols in diff output.

--- a/src/_pytest/assertion/_compare_sequence.py
+++ b/src/_pytest/assertion/_compare_sequence.py
@@ -26,7 +26,7 @@ def _compare_eq_iterable(
     right_formatting = PrettyPrinter().pformat(right).splitlines()
 
     yield ""
-    yield "Full diff:"
+    yield "Full diff: (-: missing in left side, +: extra in left side)"
     # "right" is the expected base against which we compare "left",
     # see https://github.com/pytest-dev/pytest/issues/3333
     yield from highlighter(

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -601,7 +601,7 @@ class TestAssert_reprcompare:
             "",
             "At index 0 diff: b's' != b'e'",
             "",
-            "Full diff:",
+            "Full diff: (-: missing in left side, +: extra in left side)",
             "- b'eggs'",
             "+ b'spam'",
         ]
@@ -618,7 +618,7 @@ class TestAssert_reprcompare:
                 [0, 1],
                 [0, 2],
                 """
-                Full diff:
+                Full diff: (-: missing in left side, +: extra in left side)
                   [
                       0,
                 -     2,
@@ -633,7 +633,7 @@ class TestAssert_reprcompare:
                 {0: 1},
                 {0: 2},
                 """
-                Full diff:
+                Full diff: (-: missing in left side, +: extra in left side)
                   {
                 -     0: 2,
                 ?        ^
@@ -647,7 +647,7 @@ class TestAssert_reprcompare:
                 {0, 1},
                 {0, 2},
                 """
-                Full diff:
+                Full diff: (-: missing in left side, +: extra in left side)
                   {
                       0,
                 -     2,
@@ -695,7 +695,9 @@ class TestAssert_reprcompare:
         )
         monkeypatch.setenv("CI", "true")
         result = pytester.runpytest()
-        result.stdout.fnmatch_lines(["E         Full diff:"])
+        result.stdout.fnmatch_lines(
+            ["E         Full diff: (-: missing in left side, +: extra in left side)"]
+        )
 
         # Setting CI to empty string is same as having it undefined
         monkeypatch.setenv("CI", "")
@@ -724,7 +726,7 @@ class TestAssert_reprcompare:
             "",
             "Right contains one more item: '" + long_d + "'",
             "",
-            "Full diff:",
+            "Full diff: (-: missing in left side, +: extra in left side)",
             "  [",
             "      'a',",
             "      'b',",
@@ -739,7 +741,7 @@ class TestAssert_reprcompare:
             "",
             "Left contains one more item: '" + long_d + "'",
             "",
-            "Full diff:",
+            "Full diff: (-: missing in left side, +: extra in left side)",
             "  [",
             "      'a',",
             "      'b',",
@@ -760,7 +762,7 @@ class TestAssert_reprcompare:
             "",
             "At index 0 diff: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' != 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'",
             "",
-            "Full diff:",
+            "Full diff: (-: missing in left side, +: extra in left side)",
             "  [",
             "+     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',",
             "      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',",
@@ -780,7 +782,7 @@ class TestAssert_reprcompare:
             "At index 0 diff: 'a' != 'should not get wrapped'",
             "Left contains 7 more items, first extra item: 'aaaaaaaaaa'",
             "",
-            "Full diff:",
+            "Full diff: (-: missing in left side, +: extra in left side)",
             "  [",
             "-     'should not get wrapped',",
             "+     'a',",
@@ -806,7 +808,7 @@ class TestAssert_reprcompare:
             "Differing items:",
             "{'env': {'env1': 1, 'env2': 2}} != {'env': {'env1': 1}}",
             "",
-            "Full diff:",
+            "Full diff: (-: missing in left side, +: extra in left side)",
             "  {",
             "      'common': 1,",
             "      'env': {",
@@ -828,7 +830,7 @@ class TestAssert_reprcompare:
             "Right contains 1 more item:",
             "{'new': 1}",
             "",
-            "Full diff:",
+            "Full diff: (-: missing in left side, +: extra in left side)",
             "  {",
             "      'env': {",
             "          'sub': {",
@@ -883,7 +885,7 @@ class TestAssert_reprcompare:
             "Right contains 2 more items:",
             "{'b': 1, 'c': 2}",
             "",
-            "Full diff:",
+            "Full diff: (-: missing in left side, +: extra in left side)",
             "  {",
             "-     'b': 1,",
             "?      ^   ^",
@@ -901,7 +903,7 @@ class TestAssert_reprcompare:
             "Right contains 1 more item:",
             "{'a': 0}",
             "",
-            "Full diff:",
+            "Full diff: (-: missing in left side, +: extra in left side)",
             "  {",
             "-     'a': 0,",
             "?      ^   ^",
@@ -951,7 +953,7 @@ class TestAssert_reprcompare:
             "At index 0 diff: 1 != 3",
             "Right contains one more item: 5",
             "",
-            "Full diff:",
+            "Full diff: (-: missing in left side, +: extra in left side)",
             "  (",
             "-     3,",
             "?     ^",
@@ -971,7 +973,7 @@ class TestAssert_reprcompare:
             "At index 0 diff: 1 != 4",
             "Left contains 2 more items, first extra item: 2",
             "",
-            "Full diff:",
+            "Full diff: (-: missing in left side, +: extra in left side)",
             "  (",
             "-     4,",
             "?     ^",
@@ -987,7 +989,7 @@ class TestAssert_reprcompare:
             "",
             "At index 1 diff: 2 != 20",
             "",
-            "Full diff:",
+            "Full diff: (-: missing in left side, +: extra in left side)",
             "  (",
             "      1,",
             "-     20,",
@@ -2402,7 +2404,7 @@ def test_fine_grained_assertion_verbosity(pytester: Pytester):
         [
             f"{p.name} .FFF                            [100%]",
             "E         At index 2 diff: 'grapes' != 'orange'",
-            "E         Full diff:",
+            "E         Full diff: (-: missing in left side, +: extra in left side)",
             "E           [",
             "E               'banana',",
             "E               'apple',",
@@ -2413,7 +2415,7 @@ def test_fine_grained_assertion_verbosity(pytester: Pytester):
             "E               'melon',",
             "E               'kiwi',",
             "E           ]",
-            "E         Full diff:",
+            "E         Full diff: (-: missing in left side, +: extra in left side)",
             "E           {",
             "E               '0': 0,",
             "E         -     '10': 10,",
@@ -2575,7 +2577,7 @@ def test_dict_extra_items_preserve_insertion_order(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(
         [
             "*Left contains 5 more items:*",
-            "*Full diff:",
+            "*Full diff: (-: missing in left side, +: extra in left side)",
             "* + *'b': 2,",
             "* + *'a': 1,",
             "* + *'d': 4,",

--- a/testing/test_error_diffs.py
+++ b/testing/test_error_diffs.py
@@ -23,7 +23,7 @@ TESTCASES = [
         >       assert result == expected
         E       assert [1, 4, 3] == [1, 2, 3]
         E         At index 1 diff: 4 != 2
-        E         Full diff:
+        E         Full diff: (-: missing in left side, +: extra in left side)
         E           [
         E               1,
         E         -     2,
@@ -46,7 +46,7 @@ TESTCASES = [
         >       assert result == expected
         E       assert [1, 2, 3] == [1, 2]
         E         Left contains one more item: 3
-        E         Full diff:
+        E         Full diff: (-: missing in left side, +: extra in left side)
         E           [
         E               1,
         E               2,
@@ -67,7 +67,7 @@ TESTCASES = [
         E       assert [1, 3] == [1, 2, 3]
         E         At index 1 diff: 3 != 2
         E         Right contains one more item: 3
-        E         Full diff:
+        E         Full diff: (-: missing in left side, +: extra in left side)
         E           [
         E               1,
         E         -     2,
@@ -87,7 +87,7 @@ TESTCASES = [
         >       assert result == expected
         E       assert (1, 4, 3) == (1, 2, 3)
         E         At index 1 diff: 4 != 2
-        E         Full diff:
+        E         Full diff: (-: missing in left side, +: extra in left side)
         E           (
         E               1,
         E         -     2,
@@ -113,7 +113,7 @@ TESTCASES = [
         E         4
         E         Extra items in the right set:
         E         2
-        E         Full diff:
+        E         Full diff: (-: missing in left side, +: extra in left side)
         E           {
         E               1,
         E         -     2,
@@ -139,7 +139,7 @@ TESTCASES = [
         E         {3: 'eggs'}
         E         Right contains 1 more item:
         E         {2: 'eggs'}
-        E         Full diff:
+        E         Full diff: (-: missing in left side, +: extra in left side)
         E           {
         E               1: 'spam',
         E         -     2: 'eggs',
@@ -164,7 +164,7 @@ TESTCASES = [
         E         {1: 'spam'}
         E         Differing items:
         E         {2: 'eggs'} != {2: 'bacon'}
-        E         Full diff:
+        E         Full diff: (-: missing in left side, +: extra in left side)
         E           {
         E               1: 'spam',
         E         -     2: 'bacon',
@@ -189,7 +189,7 @@ TESTCASES = [
         E         {2: 'eggs'}
         E         Right contains 1 more item:
         E         {3: 'bacon'}
-        E         Full diff:
+        E         Full diff: (-: missing in left side, +: extra in left side)
         E           {
         E               1: 'spam',
         E         -     3: 'bacon',


### PR DESCRIPTION
Now:

```console
test_hello_2 - assert [1, 2, 3, 40, 5, 6] == [1, 2, 3, 4, 5, 6, 7]

  At index 3 diff: 40 != 4
  Right contains one more item: 7

  Full diff: (-: missing in left side, +: extra in left side)
    [
        1,
        2,
        3,
  -     4,
  +     40,
  ?      +
        5,
        6,
  -     7,
    ]

```

Before:

```console
test_hello_2 - assert [1, 2, 3, 40, 5, 6] == [1, 2, 3, 4, 5, 6, 7]

  At index 3 diff: 40 != 4
  Right contains one more item: 7

  Full diff:
    [
        1,
        2,
        3,
  -     4,
  +     40,
  ?      +
        5,
        6,
  -     7,
    ]

```

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
