### PR TITLE
Document firstresult behavior for report (de)serialization hooks

### DIFF
--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -799,6 +799,8 @@ def pytest_report_to_serializable(
     :param config: The pytest config object.
     :param report: The report.
 
+    Stops at first non-None result, see :ref:`firstresult`.
+
     Use in conftest plugins
     =======================
 
@@ -816,6 +818,8 @@ def pytest_report_from_serializable(
     :hook:`pytest_report_to_serializable`.
 
     :param config: The pytest config object.
+
+    Stops at first non-None result, see :ref:`firstresult`.
 
     Use in conftest plugins
     =======================


### PR DESCRIPTION
Add the "Stops at first non-None result" line to the docstrings of `pytest_report_to_serializable` and `pytest_report_from_serializable`, both of which are declared with `@hookspec(firstresult=True)` but were missing the note that the other firstresult hooks carry. Closes #6787.