### PR TITLE
Apply warning filters to `pytest_configure`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -486,6 +486,7 @@ Tom Most
 Tom Viner
 Tomáš Gavenčiak
 Tomer Keren
+Tom Kuson
 Tony Narlock
 Tor Colvin
 Trevor Bekolay

--- a/changelog/10128.bugfix.rst
+++ b/changelog/10128.bugfix.rst
@@ -1,0 +1,1 @@
+Configured warning filters now apply to warnings emitted by ``pytest_configure`` hooks.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1199,9 +1199,37 @@ class Config:
         """
         self._cleanup_stack.callback(func)
 
+    @contextlib.contextmanager
+    def _catch_configured_warnings(
+        self,
+        *,
+        record: bool,
+    ) -> Generator[list[warnings.WarningMessage] | None]:
+        config_filters = self.getini("filterwarnings")
+        cmdline_filters = self.known_args_namespace.pythonwarnings or []
+        with warnings.catch_warnings(record=record) as log:
+            if not sys.warnoptions:
+                # If user is not explicitly configuring warning filters, show deprecation warnings by default (#2908).
+                warnings.filterwarnings("always", category=DeprecationWarning)
+                warnings.filterwarnings("always", category=PendingDeprecationWarning)
+
+            # To be enabled in pytest 10.0.0.
+            # warnings.filterwarnings("error", category=pytest.PytestRemovedIn10Warning)
+
+            apply_warning_filters(config_filters, cmdline_filters)
+            yield log
+
     def _do_configure(self) -> None:
         assert not self._configured
         self._configured = True
+        if self.pluginmanager.hasplugin("warnings"):
+            with contextlib.ExitStack() as stack:
+                # this disables recording because the terminalreporter has
+                # finished by the time it comes to reporting logged warnings
+                # from the end of config cleanup. So for now, this is only
+                # useful for setting a warning filter with an 'error' action.
+                stack.enter_context(self._catch_configured_warnings(record=False))
+                self.add_cleanup(stack.pop_all().close)
         self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
 
     def _ensure_unconfigure(self) -> None:

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1205,6 +1205,12 @@ class Config:
         *,
         record: bool,
     ) -> Generator[list[warnings.WarningMessage] | None]:
+        """Apply configured filters in a warnings-catching context.
+
+        Defined here instead of _pytest.warnings as _do_configure uses
+        it before the warnings module's pytest_configure hook runs, and
+        defining it there would create an import cycle.
+        """
         config_filters = self.getini("filterwarnings")
         cmdline_filters = self.known_args_namespace.pythonwarnings or []
         with warnings.catch_warnings(record=record) as log:

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -3,12 +3,9 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from contextlib import contextmanager
-from contextlib import ExitStack
-import sys
 from typing import Literal
 import warnings
 
-from _pytest.config import apply_warning_filters
 from _pytest.config import Config
 from _pytest.config import parse_warning_filter
 from _pytest.main import Session
@@ -33,19 +30,7 @@ def catch_warnings_for_item(
 
     Each warning captured triggers the ``pytest_warning_recorded`` hook.
     """
-    config_filters = config.getini("filterwarnings")
-    cmdline_filters = config.known_args_namespace.pythonwarnings or []
-    with warnings.catch_warnings(record=record) as log:
-        if not sys.warnoptions:
-            # If user is not explicitly configuring warning filters, show deprecation warnings by default (#2908).
-            warnings.filterwarnings("always", category=DeprecationWarning)
-            warnings.filterwarnings("always", category=PendingDeprecationWarning)
-
-        # To be enabled in pytest 10.0.0.
-        # warnings.filterwarnings("error", category=pytest.PytestRemovedIn10Warning)
-
-        apply_warning_filters(config_filters, cmdline_filters)
-
+    with config._catch_configured_warnings(record=record) as log:
         # apply filters from "filterwarnings" marks
         nodeid = "" if item is None else item.nodeid
         if item is not None:
@@ -130,23 +115,8 @@ def pytest_load_initial_conftests(
 
 
 def pytest_configure(config: Config) -> None:
-    with ExitStack() as stack:
-        stack.enter_context(
-            catch_warnings_for_item(
-                config=config,
-                ihook=config.hook,
-                when="config",
-                item=None,
-                # this disables recording because the terminalreporter has
-                # finished by the time it comes to reporting logged warnings
-                # from the end of config cleanup. So for now, this is only
-                # useful for setting a warning filter with an 'error' action.
-                record=False,
-            )
-        )
-        config.addinivalue_line(
-            "markers",
-            "filterwarnings(warning): add a warning filter to the given test. "
-            "see https://docs.pytest.org/en/stable/how-to/capture-warnings.html#pytest-mark-filterwarnings ",
-        )
-        config.add_cleanup(stack.pop_all().close)
+    config.addinivalue_line(
+        "markers",
+        "filterwarnings(warning): add a warning filter to the given test. "
+        "see https://docs.pytest.org/en/stable/how-to/capture-warnings.html#pytest-mark-filterwarnings ",
+    )

--- a/testing/plugins_integration/pytest.ini
+++ b/testing/plugins_integration/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 strict_markers = True
 asyncio_mode = strict
+asyncio_default_fixture_loop_scope = function
 filterwarnings =
     error::pytest.PytestWarning
     ignore:usefixtures.* without arguments has no effect:pytest.PytestWarning

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -702,7 +702,11 @@ def test_pytest_configure_warning(pytester: Pytester, recwarn) -> None:
 
 @pytest.mark.parametrize("tryfirst", [True, False])
 def test_pytest_configure_warning_filter(pytester: Pytester, tryfirst: bool) -> None:
-    """Issue 10128."""
+    """Issue 10128.
+
+    Parametrize over ``tryfirst`` to guard against hooks that run early
+    from avoiding the filterwarnings configuration.
+    """
     pytester.makeini(
         """
         [pytest]

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -700,6 +700,35 @@ def test_pytest_configure_warning(pytester: Pytester, recwarn) -> None:
     assert str(warning.message) == "from pytest_configure"
 
 
+@pytest.mark.parametrize("tryfirst", [True, False])
+def test_pytest_configure_warning_filter(pytester: Pytester, tryfirst: bool) -> None:
+    """Issue 10128."""
+    pytester.makeini(
+        """
+        [pytest]
+        filterwarnings =
+            ignore::UserWarning
+        """
+    )
+    pytester.makeconftest(
+        f"""
+        import warnings
+        import pytest
+
+        @pytest.hookimpl(tryfirst={tryfirst})
+        def pytest_configure():
+            warnings.warn("from pytest_configure", UserWarning)
+        """
+    )
+    pytester.makepyfile("def test_it(): pass")
+
+    result = pytester.runpytest_subprocess()
+
+    result.assert_outcomes(passed=1)
+    result.stdout.no_fnmatch_line("*from pytest_configure*")
+    result.stderr.no_fnmatch_line("*from pytest_configure*")
+
+
 class TestStackLevel:
     @pytest.fixture
     def capwarn(self, pytester: Pytester):


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [x] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [x] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [x] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [x] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [x] Add yourself to `AUTHORS` in alphabetical order.
-->

Apply warning filters to warnings emitted by `pytest_configure` hooks.

This affects users of pytest-asyncio as the plugin implements a `pytest_configure` hook that issues a warning. This also means we have to update the plugin integration test as now that warning is converted into an error (the fix is to specify a default fixture loop scope).

Closes #10128