### PR TITLE
Move fixture cache from FixtureDef to SetupState

### DIFF
--- a/changelog/14770.misc.rst
+++ b/changelog/14770.misc.rst
@@ -1,1 +1,3 @@
-Move fixture cache from *FixtureDef* to *SetupState*.
+Moved `FixtureDef.cached_result` to `SetupState`.
+
+This is part of the effort to add thread safety in pytest.

--- a/changelog/14770.misc.rst
+++ b/changelog/14770.misc.rst
@@ -1,0 +1,1 @@
+Move fixture cache from *FixtureDef* to *SetupState*.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -480,7 +480,7 @@ exclude_lines = [
     '^\s*assert False(,|$)',
     '^\s*case unreachable:',
     '^\s*assert_never\(',
-    '^\s*if TYPE_CHECKING:',
+    '^\s*if TYPE_CHECKING\s*.*',
     '^\s*(el)?if TYPE_CHECKING:',
     '^\s*@overload( |$)',
     '^\s*def .+: \.\.\.$',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -488,7 +488,7 @@ exclude_lines = [
     '^\s*assert False(,|$)',
     '^\s*case unreachable:',
     '^\s*assert_never\(',
-    '^\s*if TYPE_CHECKING:',
+    '^\s*if TYPE_CHECKING\s*.*',
     '^\s*(el)?if TYPE_CHECKING:',
     '^\s*@overload( |$)',
     '^\s*def .+: \.\.\.$',

--- a/src/_pytest/fixture_cache.py
+++ b/src/_pytest/fixture_cache.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+from typing import Generic
+from typing import NamedTuple
+from typing import TYPE_CHECKING
+from typing import TypeVar
+
+
+if TYPE_CHECKING:
+    from _pytest.fixtures import FixtureDef
+
+
+FixtureValue = TypeVar("FixtureValue")
+
+# NamedTuples cannot take generic arguments before Python 3.11
+if TYPE_CHECKING and sys.version_info >= (3, 11):
+
+    class _FixtureResult(NamedTuple, Generic[FixtureValue]):
+        value: FixtureValue
+        param: object
+        exception_and_traceback: None
+else:
+
+    class _FixtureResult(NamedTuple):
+        value: Any
+        param: object
+        exception_and_traceback: None
+
+
+class _FixtureException(NamedTuple):
+    value: None
+    param: object
+    exception_and_traceback: tuple[BaseException, types.TracebackType | None]
+
+
+_FixtureCachedResult = _FixtureResult[FixtureValue] | _FixtureException  # type: ignore[type-arg]
+
+
+class FixtureCache:
+    """
+    Temporarily stores the results of FixtureDefs.
+
+    Conceptually, the entries of this cache should be indexed by a tuple of FixtureDef and param. However,
+    the param used by the previous test may no longer be known when retrieving the value of a FixtureDef.
+    Therefore, we store the param as part of the result to detect a cache miss.
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[FixtureDef[Any], Any] = {}
+
+    def get(
+        self, fixturedef: FixtureDef[FixtureValue]
+    ) -> _FixtureCachedResult[FixtureValue] | None:
+        """Retrieve the result for the specified fixture definition or ``None``."""
+        return self._cache.get(fixturedef)
+
+    def set_value(
+        self,
+        fixturedef: FixtureDef[FixtureValue],
+        param: object,
+        value: FixtureValue,
+    ) -> None:
+        """Write a value into the cache for a fixture definition and the specified fixture parameter."""
+        self._cache[fixturedef] = _FixtureResult(value, param, None)
+
+    def set_exception(
+        self,
+        fixturedef: FixtureDef[FixtureValue],
+        param: object,
+        exception: BaseException,
+    ) -> None:
+        """Write an exception result into the cache for a fixture definition and the specified fixture parameter."""
+        self._cache[fixturedef] = _FixtureException(
+            None, param, (exception, exception.__traceback__)
+        )
+
+    def invalidate(self, fixturedef: FixtureDef[FixtureValue]) -> None:
+        """Remove the entry for the specified fixture definition."""
+        del self._cache[fixturedef]

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -122,7 +122,6 @@ class _FixtureException(NamedTuple):
     exception_and_traceback: tuple[BaseException, types.TracebackType | None]
 
 
-# The type of FixtureDef.cached_result (type alias generic in fixture value).
 _FixtureCachedResult = _FixtureResult[FixtureValue] | _FixtureException  # type: ignore[type-arg]
 
 
@@ -1216,7 +1215,8 @@ class FixtureDef(Generic[FixtureValue]):
         # This needs to be done before checking if we have a cached value, since
         # if a dependent fixture has their cache invalidated, e.g. due to
         # parametrization, they finalize themselves and fixtures depending on it
-        # (which will likely include this fixture) setting `self.cached_result = None`.
+        # (which will likely include this fixture), invalidating the respective
+        # cached values.
         # See #4871
         requested_fixtures_that_should_finalize_us = []
         for argname in self.argnames:

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -644,16 +644,23 @@ class FixtureRequest(abc.ABC):
     def _set_cached_result(
         self,
         fixturedef: FixtureDef[FixtureValue],
-        value: _FixtureResult[FixtureValue],
+        value: FixtureValue,  # type: ignore[misc]
     ) -> None:
-        self.session._setupstate.fixture_cache[fixturedef] = value
+        self.session._setupstate.fixture_cache[fixturedef] = _FixtureResult(
+            value, self._cache_key(), None
+        )
 
     def _set_cached_exception(
         self,
         fixturedef: FixtureDef[FixtureValue],
-        value: _FixtureException,
+        exception_and_traceback: tuple[BaseException, types.TracebackType | None],
     ) -> None:
-        self.session._setupstate.fixture_cache[fixturedef] = value
+        self.session._setupstate.fixture_cache[fixturedef] = _FixtureException(
+            None, self._cache_key(), exception_and_traceback
+        )
+
+    def _cache_key(self) -> object:
+        return getattr(self, "param", None)
 
     def _invalidate_fixture_cache(self, fixturedef: FixtureDef[FixtureValue]) -> None:
         del self.session._setupstate.fixture_cache[fixturedef]
@@ -918,9 +925,6 @@ class SubRequest(FixtureRequest):
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         self._fixturedef.addfinalizer(finalizer)
-
-    def cache_key(self) -> object:
-        return getattr(self, "param", None)
 
 
 @final
@@ -1212,7 +1216,7 @@ class FixtureDef(Generic[FixtureValue]):
 
         # Check for (and return) cached value/exception.
         if (fixture_result := request._get_cached_result(self)) is not None:
-            request_cache_key = request.cache_key()
+            request_cache_key = request._cache_key()
             cache_key = fixture_result.cache_key
             try:
                 # Attempt to make a normal == check: this might fail for objects
@@ -1282,7 +1286,7 @@ class RequestFixtureDef(FixtureDef[FixtureRequest]):
             node=request.node,
             _ispytest=True,
         )
-        request._set_cached_result(self, _FixtureResult(request, [0], None))
+        request._set_cached_result(self, request)
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         pass
@@ -1340,7 +1344,6 @@ def pytest_fixture_setup(
         kwargs[argname] = request.getfixturevalue(argname)
 
     fixturefunc = resolve_fixture_function(fixturedef, request)
-    my_cache_key = request.cache_key()
 
     if inspect.isasyncgenfunction(fixturefunc) or inspect.iscoroutinefunction(
         fixturefunc
@@ -1363,10 +1366,10 @@ def pytest_fixture_setup(
             e._use_item_location = True
         request._set_cached_exception(
             fixturedef,
-            _FixtureException(None, my_cache_key, (e, e.__traceback__)),
+            (e, e.__traceback__),
         )
         raise
-    request._set_cached_result(fixturedef, _FixtureResult(result, my_cache_key, None))
+    request._set_cached_result(fixturedef, result)
     return result
 
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -101,10 +101,19 @@ _FixtureFunc = Callable[..., FixtureValue] | Callable[..., Generator[FixtureValu
 _NO_PARAM = object()
 
 
-class _FixtureResult(NamedTuple, Generic[FixtureValue]):
-    value: FixtureValue
-    param: object
-    exception_and_traceback: None
+# NamedTuples cannot take generic arguments before Python 3.11
+if TYPE_CHECKING and sys.version_info >= (3, 11):
+
+    class _FixtureResult(NamedTuple, Generic[FixtureValue]):
+        value: FixtureValue
+        param: object
+        exception_and_traceback: None
+else:
+
+    class _FixtureResult(NamedTuple):
+        value: Any
+        param: object
+        exception_and_traceback: None
 
 
 class _FixtureException(NamedTuple):
@@ -114,7 +123,7 @@ class _FixtureException(NamedTuple):
 
 
 # The type of FixtureDef.cached_result (type alias generic in fixture value).
-_FixtureCachedResult = _FixtureResult[FixtureValue] | _FixtureException
+_FixtureCachedResult = _FixtureResult[FixtureValue] | _FixtureException  # type: ignore[type-arg]
 
 
 def pytest_sessionstart(session: Session) -> None:
@@ -1236,7 +1245,7 @@ class FixtureDef(Generic[FixtureValue]):
                     exc, exc_tb = cached_result.exception_and_traceback
                     raise exc.with_traceback(exc_tb)
                 else:
-                    return cached_result.value
+                    return cached_result.value  # type: ignore[no-any-return]
             # We have a previous but differently parametrized fixture instance
             # so we need to tear it down before creating a new one.
             self.finish(request)

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -26,6 +26,7 @@ from typing import Final
 from typing import final
 from typing import Generic
 from typing import Literal
+from typing import NamedTuple
 from typing import NoReturn
 from typing import overload
 from typing import TYPE_CHECKING
@@ -96,23 +97,22 @@ FixtureValue = TypeVar("FixtureValue", covariant=True)
 FixtureFunction = Callable[..., object]
 # The type of a fixture function (type alias generic in fixture value).
 _FixtureFunc = Callable[..., FixtureValue] | Callable[..., Generator[FixtureValue]]
+
+
+class _FixtureResult(NamedTuple, Generic[FixtureValue]):
+    value: FixtureValue
+    cache_key: object
+    exception_and_traceback: None
+
+
+class _FixtureException(NamedTuple):
+    value: None
+    cache_key: object
+    exception_and_traceback: tuple[BaseException, types.TracebackType | None]
+
+
 # The type of FixtureDef.cached_result (type alias generic in fixture value).
-_FixtureCachedResult = (
-    tuple[
-        # The result.
-        FixtureValue,
-        # Cache key.
-        object,
-        None,
-    ]
-    | tuple[
-        None,
-        # Cache key.
-        object,
-        # The exception and the original traceback.
-        tuple[BaseException, types.TracebackType | None],
-    ]
-)
+_FixtureCachedResult = _FixtureResult[FixtureValue] | _FixtureException
 
 
 def pytest_sessionstart(session: Session) -> None:
@@ -634,7 +634,7 @@ class FixtureRequest(abc.ABC):
             f'The fixture value for "{argname}" is not available.  '
             "This can happen when the fixture has already been torn down."
         )
-        return fixture_result[0]
+        return fixture_result.value
 
     def _iter_chain(self) -> Iterator[SubRequest]:
         """Yield all SubRequests in the chain, from self up.
@@ -1198,7 +1198,7 @@ class FixtureDef(Generic[FixtureValue]):
         # Check for (and return) cached value/exception.
         if (fixture_result := self._get_cached_result(request)) is not None:
             request_cache_key = self.cache_key(request)
-            cache_key = fixture_result[1]
+            cache_key = fixture_result.cache_key
             try:
                 # Attempt to make a normal == check: this might fail for objects
                 # which do not implement the standard comparison (like numpy arrays -- #6497).
@@ -1208,11 +1208,11 @@ class FixtureDef(Generic[FixtureValue]):
                 cache_hit = request_cache_key is cache_key
 
             if cache_hit:
-                if fixture_result[2] is not None:
-                    exc, exc_tb = fixture_result[2]
+                if fixture_result.exception_and_traceback is not None:
+                    exc, exc_tb = fixture_result.exception_and_traceback
                     raise exc.with_traceback(exc_tb)
                 else:
-                    return fixture_result[0]
+                    return fixture_result.value
             # We have a previous but differently parametrized fixture instance
             # so we need to tear it down before creating a new one.
             self.finish(request)
@@ -1270,7 +1270,7 @@ class RequestFixtureDef(FixtureDef[FixtureRequest]):
             node=request.node,
             _ispytest=True,
         )
-        self._set_cached_result(request, (request, [0], None))
+        self._set_cached_result(request, _FixtureResult(request, [0], None))
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         pass
@@ -1350,10 +1350,11 @@ def pytest_fixture_setup(
             # wouldn't know which test skipped.
             e._use_item_location = True
         fixturedef._set_cached_result(
-            request, (None, my_cache_key, (e, e.__traceback__))
+            request,
+            _FixtureException(None, my_cache_key, (e, e.__traceback__)),
         )
         raise
-    fixturedef._set_cached_result(request, (result, my_cache_key, None))
+    fixturedef._set_cached_result(request, _FixtureResult(result, my_cache_key, None))
     return result
 
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -653,10 +653,10 @@ class FixtureRequest(abc.ABC):
     def _set_cached_exception(
         self,
         fixturedef: FixtureDef[FixtureValue],
-        exception_and_traceback: tuple[BaseException, types.TracebackType | None],
+        exception: BaseException,
     ) -> None:
         self.session._setupstate.fixture_cache[fixturedef] = _FixtureException(
-            None, self._cache_key(), exception_and_traceback
+            None, self._cache_key(), (exception, exception.__traceback__)
         )
 
     def _cache_key(self) -> object:
@@ -1366,7 +1366,7 @@ def pytest_fixture_setup(
             e._use_item_location = True
         request._set_cached_exception(
             fixturedef,
-            (e, e.__traceback__),
+            e,
         )
         raise
     request._set_cached_result(fixturedef, result)

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -641,20 +641,22 @@ class FixtureRequest(abc.ABC):
     ) -> _FixtureCachedResult[FixtureValue] | None:
         return self.session._setupstate.fixture_cache.get(fixturedef)
 
-    def _set_cached_result(
+    def _cache_value(
         self,
         fixturedef: FixtureDef[FixtureValue],
         value: FixtureValue,  # type: ignore[misc]
     ) -> None:
+        """Write a value into the cache for a fixture definition."""
         self.session._setupstate.fixture_cache[fixturedef] = _FixtureResult(
             value, self._cache_key(), None
         )
 
-    def _set_cached_exception(
+    def _cache_exception(
         self,
         fixturedef: FixtureDef[FixtureValue],
         exception: BaseException,
     ) -> None:
+        """Write an exception result into the cache for a fixture definition."""
         self.session._setupstate.fixture_cache[fixturedef] = _FixtureException(
             None, self._cache_key(), (exception, exception.__traceback__)
         )
@@ -1286,7 +1288,7 @@ class RequestFixtureDef(FixtureDef[FixtureRequest]):
             node=request.node,
             _ispytest=True,
         )
-        request._set_cached_result(self, request)
+        request._cache_value(self, request)
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         pass
@@ -1364,12 +1366,12 @@ def pytest_fixture_setup(
             # Don't show the fixture as the skip location, as then the user
             # wouldn't know which test skipped.
             e._use_item_location = True
-        request._set_cached_exception(
+        request._cache_exception(
             fixturedef,
             e,
         )
         raise
-    request._set_cached_result(fixturedef, result)
+    request._cache_value(fixturedef, result)
     return result
 
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1135,7 +1135,7 @@ class FixtureDef(Generic[FixtureValue]):
         return request.session._setupstate.fixture_cache.get(self)
 
     def _set_cached_result(
-        self, request: FixtureRequest, value: _FixtureCachedResult[FixtureValue] | None
+        self, request: FixtureRequest, value: _FixtureCachedResult[FixtureValue]
     ) -> None:
         request.session._setupstate.fixture_cache[self] = value
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -101,13 +101,13 @@ _FixtureFunc = Callable[..., FixtureValue] | Callable[..., Generator[FixtureValu
 
 class _FixtureResult(NamedTuple, Generic[FixtureValue]):
     value: FixtureValue
-    cache_key: object
+    param: object
     exception_and_traceback: None
 
 
 class _FixtureException(NamedTuple):
     value: None
-    cache_key: object
+    param: object
     exception_and_traceback: tuple[BaseException, types.TracebackType | None]
 
 
@@ -648,7 +648,7 @@ class FixtureRequest(abc.ABC):
     ) -> None:
         """Write a value into the cache for a fixture definition."""
         self.session._setupstate.fixture_cache[fixturedef] = _FixtureResult(
-            value, self._cache_key, None
+            value, self._active_param, None
         )
 
     def _cache_exception(
@@ -658,11 +658,11 @@ class FixtureRequest(abc.ABC):
     ) -> None:
         """Write an exception result into the cache for a fixture definition."""
         self.session._setupstate.fixture_cache[fixturedef] = _FixtureException(
-            None, self._cache_key, (exception, exception.__traceback__)
+            None, self._active_param, (exception, exception.__traceback__)
         )
 
     @property
-    def _cache_key(self) -> object:
+    def _active_param(self) -> object:
         return getattr(self, "param", None)
 
     def _invalidate_fixture_cache(self, fixturedef: FixtureDef[FixtureValue]) -> None:
@@ -1218,23 +1218,23 @@ class FixtureDef(Generic[FixtureValue]):
             requested_fixtures_that_should_finalize_us.append(fixturedef)
 
         # Check for (and return) cached value/exception.
-        if (fixture_result := request._get_cached_result(self)) is not None:
-            request_cache_key = request._cache_key
-            cache_key = fixture_result.cache_key
+        if (cached_result := request._get_cached_result(self)) is not None:
+            active_param = request._active_param
+            cached_param = cached_result.param
             try:
                 # Attempt to make a normal == check: this might fail for objects
                 # which do not implement the standard comparison (like numpy arrays -- #6497).
-                cache_hit = bool(request_cache_key == cache_key)
+                cache_hit = bool(active_param == cached_param)
             except (ValueError, RuntimeError):
                 # If the comparison raises, use 'is' as fallback.
-                cache_hit = request_cache_key is cache_key
+                cache_hit = active_param is cached_param
 
             if cache_hit:
-                if fixture_result.exception_and_traceback is not None:
-                    exc, exc_tb = fixture_result.exception_and_traceback
+                if cached_result.exception_and_traceback is not None:
+                    exc, exc_tb = cached_result.exception_and_traceback
                     raise exc.with_traceback(exc_tb)
                 else:
-                    return fixture_result.value
+                    return cached_result.value
             # We have a previous but differently parametrized fixture instance
             # so we need to tear it down before creating a new one.
             self.finish(request)

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -648,7 +648,7 @@ class FixtureRequest(abc.ABC):
     ) -> None:
         """Write a value into the cache for a fixture definition."""
         self.session._setupstate.fixture_cache[fixturedef] = _FixtureResult(
-            value, self._cache_key(), None
+            value, self._cache_key, None
         )
 
     def _cache_exception(
@@ -658,9 +658,10 @@ class FixtureRequest(abc.ABC):
     ) -> None:
         """Write an exception result into the cache for a fixture definition."""
         self.session._setupstate.fixture_cache[fixturedef] = _FixtureException(
-            None, self._cache_key(), (exception, exception.__traceback__)
+            None, self._cache_key, (exception, exception.__traceback__)
         )
 
+    @property
     def _cache_key(self) -> object:
         return getattr(self, "param", None)
 
@@ -1218,7 +1219,7 @@ class FixtureDef(Generic[FixtureValue]):
 
         # Check for (and return) cached value/exception.
         if (fixture_result := request._get_cached_result(self)) is not None:
-            request_cache_key = request._cache_key()
+            request_cache_key = request._cache_key
             cache_key = fixture_result.cache_key
             try:
                 # Attempt to make a normal == check: this might fail for objects

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -97,6 +97,8 @@ FixtureValue = TypeVar("FixtureValue", covariant=True)
 FixtureFunction = Callable[..., object]
 # The type of a fixture function (type alias generic in fixture value).
 _FixtureFunc = Callable[..., FixtureValue] | Callable[..., Generator[FixtureValue]]
+# Sentinel value for unset fixture params
+_NO_PARAM = object()
 
 
 class _FixtureResult(NamedTuple, Generic[FixtureValue]):
@@ -663,7 +665,7 @@ class FixtureRequest(abc.ABC):
 
     @property
     def _active_param(self) -> object:
-        return getattr(self, "param", None)
+        return getattr(self, "param", _NO_PARAM)
 
     def _invalidate_fixture_cache(self, fixturedef: FixtureDef[FixtureValue]) -> None:
         del self.session._setupstate.fixture_cache[fixturedef]

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -629,12 +629,27 @@ class FixtureRequest(abc.ABC):
         # (using function parameters, autouse, etc).
 
         fixturedef = self._get_active_fixturedef(argname)
-        fixture_result = fixturedef._get_cached_result(self)
+        fixture_result = self._get_cached_result(fixturedef)
         assert fixture_result is not None, (
             f'The fixture value for "{argname}" is not available.  '
             "This can happen when the fixture has already been torn down."
         )
         return fixture_result.value
+
+    def _get_cached_result(
+        self, fixturedef: FixtureDef[FixtureValue]
+    ) -> _FixtureCachedResult[FixtureValue] | None:
+        return self.session._setupstate.fixture_cache.get(fixturedef)
+
+    def _set_cached_result(
+        self,
+        fixturedef: FixtureDef[FixtureValue],
+        value: _FixtureCachedResult[FixtureValue],
+    ) -> None:
+        self.session._setupstate.fixture_cache[fixturedef] = value
+
+    def _invalidate_fixture_cache(self, fixturedef: FixtureDef[FixtureValue]) -> None:
+        del self.session._setupstate.fixture_cache[fixturedef]
 
     def _iter_chain(self) -> Iterator[SubRequest]:
         """Yield all SubRequests in the chain, from self up.
@@ -1129,19 +1144,6 @@ class FixtureDef(Generic[FixtureValue]):
         # only used to emit a deprecationwarning, can be removed in pytest9
         self._autouse = _autouse
 
-    def _get_cached_result(
-        self, request: FixtureRequest
-    ) -> _FixtureCachedResult[FixtureValue] | None:
-        return request.session._setupstate.fixture_cache.get(self)
-
-    def _set_cached_result(
-        self, request: FixtureRequest, value: _FixtureCachedResult[FixtureValue]
-    ) -> None:
-        request.session._setupstate.fixture_cache[self] = value
-
-    def _invalidate_fixture_cache(self, request: FixtureRequest) -> None:
-        del request.session._setupstate.fixture_cache[self]
-
     @property
     def scope(self) -> ScopeName:
         """Scope string, one of "function", "class", "module", "package", "session"."""
@@ -1156,7 +1158,7 @@ class FixtureDef(Generic[FixtureValue]):
         self._finalizers.append(finalizer)
 
     def finish(self, request: SubRequest) -> None:
-        if self._get_cached_result(request) is None:
+        if request._get_cached_result(self) is None:
             # Already finished. It is assumed that finalizers cannot be added in
             # this state.
             return
@@ -1172,7 +1174,7 @@ class FixtureDef(Generic[FixtureValue]):
         # Even if finalization fails, we invalidate the cached fixture
         # value and remove all finalizers because they may be bound methods
         # which will keep instances alive.
-        self._invalidate_fixture_cache(request)
+        request._invalidate_fixture_cache(self)
         self._finalizers.clear()
         if len(exceptions) == 1:
             raise exceptions[0]
@@ -1199,7 +1201,7 @@ class FixtureDef(Generic[FixtureValue]):
             requested_fixtures_that_should_finalize_us.append(fixturedef)
 
         # Check for (and return) cached value/exception.
-        if (fixture_result := self._get_cached_result(request)) is not None:
+        if (fixture_result := request._get_cached_result(self)) is not None:
             request_cache_key = self.cache_key(request)
             cache_key = fixture_result.cache_key
             try:
@@ -1219,7 +1221,7 @@ class FixtureDef(Generic[FixtureValue]):
             # We have a previous but differently parametrized fixture instance
             # so we need to tear it down before creating a new one.
             self.finish(request)
-            assert self._get_cached_result(request) is None
+            assert request._get_cached_result(self) is None
 
         # Add finalizer to requested fixtures we saved previously.
         # We make sure to do this after checking for cached value to avoid
@@ -1273,7 +1275,7 @@ class RequestFixtureDef(FixtureDef[FixtureRequest]):
             node=request.node,
             _ispytest=True,
         )
-        self._set_cached_result(request, _FixtureResult(request, [0], None))
+        request._set_cached_result(self, _FixtureResult(request, [0], None))
 
     def cache_key(self, request: SubRequest) -> object:
         return [0]
@@ -1355,12 +1357,12 @@ def pytest_fixture_setup(
             # Don't show the fixture as the skip location, as then the user
             # wouldn't know which test skipped.
             e._use_item_location = True
-        fixturedef._set_cached_result(
-            request,
+        request._set_cached_result(
+            fixturedef,
             _FixtureException(None, my_cache_key, (e, e.__traceback__)),
         )
         raise
-    fixturedef._set_cached_result(request, _FixtureResult(result, my_cache_key, None))
+    request._set_cached_result(fixturedef, _FixtureResult(result, my_cache_key, None))
     return result
 
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -629,11 +629,12 @@ class FixtureRequest(abc.ABC):
         # (using function parameters, autouse, etc).
 
         fixturedef = self._get_active_fixturedef(argname)
-        assert fixturedef.cached_result is not None, (
+        fixture_result = fixturedef._get_cached_result(self)
+        assert fixture_result is not None, (
             f'The fixture value for "{argname}" is not available.  '
             "This can happen when the fixture has already been torn down."
         )
-        return fixturedef.cached_result[0]
+        return fixture_result[0]
 
     def _iter_chain(self) -> Iterator[SubRequest]:
         """Yield all SubRequests in the chain, from self up.
@@ -1123,13 +1124,20 @@ class FixtureDef(Generic[FixtureValue]):
         self.ids: Final = ids
         # The names requested by the fixtures.
         self.argnames: Final = getfuncargnames(func, name=argname)
-        # If the fixture was executed, the current value of the fixture.
-        # Can change if the fixture is executed with different parameters.
-        self.cached_result: _FixtureCachedResult[FixtureValue] | None = None
         self._finalizers: Final[list[Callable[[], object]]] = []
 
         # only used to emit a deprecationwarning, can be removed in pytest9
         self._autouse = _autouse
+
+    def _get_cached_result(
+        self, request: FixtureRequest
+    ) -> _FixtureCachedResult[FixtureValue] | None:
+        return request.session._setupstate.fixture_cache.get(self)
+
+    def _set_cached_result(
+        self, request: FixtureRequest, value: _FixtureCachedResult[FixtureValue] | None
+    ) -> None:
+        request.session._setupstate.fixture_cache[self] = value
 
     @property
     def scope(self) -> ScopeName:
@@ -1145,7 +1153,7 @@ class FixtureDef(Generic[FixtureValue]):
         self._finalizers.append(finalizer)
 
     def finish(self, request: SubRequest) -> None:
-        if self.cached_result is None:
+        if self._get_cached_result(request) is None:
             # Already finished. It is assumed that finalizers cannot be added in
             # this state.
             return
@@ -1161,7 +1169,7 @@ class FixtureDef(Generic[FixtureValue]):
         # Even if finalization fails, we invalidate the cached fixture
         # value and remove all finalizers because they may be bound methods
         # which will keep instances alive.
-        self.cached_result = None
+        self._set_cached_result(request, None)
         self._finalizers.clear()
         if len(exceptions) == 1:
             raise exceptions[0]
@@ -1188,9 +1196,9 @@ class FixtureDef(Generic[FixtureValue]):
             requested_fixtures_that_should_finalize_us.append(fixturedef)
 
         # Check for (and return) cached value/exception.
-        if self.cached_result is not None:
+        if (fixture_result := self._get_cached_result(request)) is not None:
             request_cache_key = self.cache_key(request)
-            cache_key = self.cached_result[1]
+            cache_key = fixture_result[1]
             try:
                 # Attempt to make a normal == check: this might fail for objects
                 # which do not implement the standard comparison (like numpy arrays -- #6497).
@@ -1200,15 +1208,15 @@ class FixtureDef(Generic[FixtureValue]):
                 cache_hit = request_cache_key is cache_key
 
             if cache_hit:
-                if self.cached_result[2] is not None:
-                    exc, exc_tb = self.cached_result[2]
+                if fixture_result[2] is not None:
+                    exc, exc_tb = fixture_result[2]
                     raise exc.with_traceback(exc_tb)
                 else:
-                    return self.cached_result[0]
+                    return fixture_result[0]
             # We have a previous but differently parametrized fixture instance
             # so we need to tear it down before creating a new one.
             self.finish(request)
-            assert self.cached_result is None
+            assert self._get_cached_result(request) is None
 
         # Add finalizer to requested fixtures we saved previously.
         # We make sure to do this after checking for cached value to avoid
@@ -1229,7 +1237,6 @@ class FixtureDef(Generic[FixtureValue]):
         ihook = request.node.ihook
         try:
             # Setup the fixture, run the code in it, and cache the value
-            # in self.cached_result.
             result: FixtureValue = ihook.pytest_fixture_setup(
                 fixturedef=self, request=request
             )
@@ -1263,7 +1270,7 @@ class RequestFixtureDef(FixtureDef[FixtureRequest]):
             node=request.node,
             _ispytest=True,
         )
-        self.cached_result = (request, [0], None)
+        self._set_cached_result(request, (request, [0], None))
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         pass
@@ -1342,9 +1349,11 @@ def pytest_fixture_setup(
             # Don't show the fixture as the skip location, as then the user
             # wouldn't know which test skipped.
             e._use_item_location = True
-        fixturedef.cached_result = (None, my_cache_key, (e, e.__traceback__))
+        fixturedef._set_cached_result(
+            request, (None, my_cache_key, (e, e.__traceback__))
+        )
         raise
-    fixturedef.cached_result = (result, my_cache_key, None)
+    fixturedef._set_cached_result(request, (result, my_cache_key, None))
     return result
 
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1139,6 +1139,9 @@ class FixtureDef(Generic[FixtureValue]):
     ) -> None:
         request.session._setupstate.fixture_cache[self] = value
 
+    def _invalidate_fixture_cache(self, request: FixtureRequest) -> None:
+        del request.session._setupstate.fixture_cache[self]
+
     @property
     def scope(self) -> ScopeName:
         """Scope string, one of "function", "class", "module", "package", "session"."""
@@ -1169,7 +1172,7 @@ class FixtureDef(Generic[FixtureValue]):
         # Even if finalization fails, we invalidate the cached fixture
         # value and remove all finalizers because they may be bound methods
         # which will keep instances alive.
-        self._set_cached_result(request, None)
+        self._invalidate_fixture_cache(request)
         self._finalizers.clear()
         if len(exceptions) == 1:
             raise exceptions[0]

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1275,6 +1275,9 @@ class RequestFixtureDef(FixtureDef[FixtureRequest]):
         )
         self._set_cached_result(request, _FixtureResult(request, [0], None))
 
+    def cache_key(self, request: SubRequest) -> object:
+        return [0]
+
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         pass
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -644,7 +644,14 @@ class FixtureRequest(abc.ABC):
     def _set_cached_result(
         self,
         fixturedef: FixtureDef[FixtureValue],
-        value: _FixtureCachedResult[FixtureValue],
+        value: _FixtureResult[FixtureValue],
+    ) -> None:
+        self.session._setupstate.fixture_cache[fixturedef] = value
+
+    def _set_cached_exception(
+        self,
+        fixturedef: FixtureDef[FixtureValue],
+        value: _FixtureException,
     ) -> None:
         self.session._setupstate.fixture_cache[fixturedef] = value
 
@@ -1354,7 +1361,7 @@ def pytest_fixture_setup(
             # Don't show the fixture as the skip location, as then the user
             # wouldn't know which test skipped.
             e._use_item_location = True
-        request._set_cached_result(
+        request._set_cached_exception(
             fixturedef,
             _FixtureException(None, my_cache_key, (e, e.__traceback__)),
         )

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -912,6 +912,9 @@ class SubRequest(FixtureRequest):
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         self._fixturedef.addfinalizer(finalizer)
 
+    def cache_key(self) -> object:
+        return getattr(self, "param", None)
+
 
 @final
 class FixtureLookupError(LookupError):
@@ -1202,7 +1205,7 @@ class FixtureDef(Generic[FixtureValue]):
 
         # Check for (and return) cached value/exception.
         if (fixture_result := request._get_cached_result(self)) is not None:
-            request_cache_key = self.cache_key(request)
+            request_cache_key = request.cache_key()
             cache_key = fixture_result.cache_key
             try:
                 # Attempt to make a normal == check: this might fail for objects
@@ -1251,9 +1254,6 @@ class FixtureDef(Generic[FixtureValue]):
 
         return result
 
-    def cache_key(self, request: SubRequest) -> object:
-        return getattr(request, "param", None)
-
     def __repr__(self) -> str:
         return f"<FixtureDef argname={self.argname!r} scope={self.scope!r} baseid={self.baseid!r}>"
 
@@ -1276,9 +1276,6 @@ class RequestFixtureDef(FixtureDef[FixtureRequest]):
             _ispytest=True,
         )
         request._set_cached_result(self, _FixtureResult(request, [0], None))
-
-    def cache_key(self, request: SubRequest) -> object:
-        return [0]
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         pass
@@ -1336,7 +1333,7 @@ def pytest_fixture_setup(
         kwargs[argname] = request.getfixturevalue(argname)
 
     fixturefunc = resolve_fixture_function(fixturedef, request)
-    my_cache_key = fixturedef.cache_key(request)
+    my_cache_key = request.cache_key()
 
     if inspect.isasyncgenfunction(fixturefunc) or inspect.iscoroutinefunction(
         fixturefunc

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1335,6 +1335,9 @@ class RequestFixtureDef(FixtureDef[FixtureRequest]):
         )
         self._set_cached_result(request, _FixtureResult(request, [0], None))
 
+    def cache_key(self, request: SubRequest) -> object:
+        return [0]
+
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         pass
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -704,7 +704,14 @@ class FixtureRequest(abc.ABC):
     def _set_cached_result(
         self,
         fixturedef: FixtureDef[FixtureValue],
-        value: _FixtureCachedResult[FixtureValue],
+        value: _FixtureResult[FixtureValue],
+    ) -> None:
+        self.session._setupstate.fixture_cache[fixturedef] = value
+
+    def _set_cached_exception(
+        self,
+        fixturedef: FixtureDef[FixtureValue],
+        value: _FixtureException,
     ) -> None:
         self.session._setupstate.fixture_cache[fixturedef] = value
 
@@ -1414,7 +1421,7 @@ def pytest_fixture_setup(
             # Don't show the fixture as the skip location, as then the user
             # wouldn't know which test skipped.
             e._use_item_location = True
-        request._set_cached_result(
+        request._set_cached_exception(
             fixturedef,
             _FixtureException(None, my_cache_key, (e, e.__traceback__)),
         )

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1199,6 +1199,9 @@ class FixtureDef(Generic[FixtureValue]):
     ) -> None:
         request.session._setupstate.fixture_cache[self] = value
 
+    def _invalidate_fixture_cache(self, request: FixtureRequest) -> None:
+        del request.session._setupstate.fixture_cache[self]
+
     @property
     def scope(self) -> ScopeName:
         """Scope string, one of "function", "class", "module", "package", "session"."""
@@ -1229,7 +1232,7 @@ class FixtureDef(Generic[FixtureValue]):
         # Even if finalization fails, we invalidate the cached fixture
         # value and remove all finalizers because they may be bound methods
         # which will keep instances alive.
-        self._set_cached_result(request, None)
+        self._invalidate_fixture_cache(request)
         self._finalizers.clear()
         if len(exceptions) == 1:
             raise exceptions[0]

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -701,20 +701,22 @@ class FixtureRequest(abc.ABC):
     ) -> _FixtureCachedResult[FixtureValue] | None:
         return self.session._setupstate.fixture_cache.get(fixturedef)
 
-    def _set_cached_result(
+    def _cache_value(
         self,
         fixturedef: FixtureDef[FixtureValue],
         value: FixtureValue,  # type: ignore[misc]
     ) -> None:
+        """Write a value into the cache for a fixture definition."""
         self.session._setupstate.fixture_cache[fixturedef] = _FixtureResult(
             value, self._cache_key(), None
         )
 
-    def _set_cached_exception(
+    def _cache_exception(
         self,
         fixturedef: FixtureDef[FixtureValue],
         exception: BaseException,
     ) -> None:
+        """Write an exception result into the cache for a fixture definition."""
         self.session._setupstate.fixture_cache[fixturedef] = _FixtureException(
             None, self._cache_key(), (exception, exception.__traceback__)
         )
@@ -1346,7 +1348,7 @@ class RequestFixtureDef(FixtureDef[FixtureRequest]):
             node=request.node,
             _ispytest=True,
         )
-        request._set_cached_result(self, request)
+        request._cache_value(self, request)
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         pass
@@ -1424,12 +1426,12 @@ def pytest_fixture_setup(
             # Don't show the fixture as the skip location, as then the user
             # wouldn't know which test skipped.
             e._use_item_location = True
-        request._set_cached_exception(
+        request._cache_exception(
             fixturedef,
             e,
         )
         raise
-    request._set_cached_result(fixturedef, result)
+    request._cache_value(fixturedef, result)
     return result
 
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -26,7 +26,6 @@ from typing import Final
 from typing import final
 from typing import Generic
 from typing import Literal
-from typing import NamedTuple
 from typing import NoReturn
 from typing import overload
 from typing import TYPE_CHECKING
@@ -99,30 +98,6 @@ FixtureFunction = Callable[..., object]
 _FixtureFunc = Callable[..., FixtureValue] | Callable[..., Generator[FixtureValue]]
 # Sentinel value for unset fixture params
 _NO_PARAM = object()
-
-
-# NamedTuples cannot take generic arguments before Python 3.11
-if TYPE_CHECKING and sys.version_info >= (3, 11):
-
-    class _FixtureResult(NamedTuple, Generic[FixtureValue]):
-        value: FixtureValue
-        param: object
-        exception_and_traceback: None
-else:
-
-    class _FixtureResult(NamedTuple):
-        value: Any
-        param: object
-        exception_and_traceback: None
-
-
-class _FixtureException(NamedTuple):
-    value: None
-    param: object
-    exception_and_traceback: tuple[BaseException, types.TracebackType | None]
-
-
-_FixtureCachedResult = _FixtureResult[FixtureValue] | _FixtureException  # type: ignore[type-arg]
 
 
 def pytest_sessionstart(session: Session) -> None:
@@ -699,44 +674,17 @@ class FixtureRequest(abc.ABC):
         # (using function parameters, autouse, etc).
 
         fixturedef = self._get_active_fixturedef(argname)
-        fixture_result = self._get_cached_result(fixturedef)
+        fixture_cache = self.session._setupstate.fixture_cache
+        fixture_result = fixture_cache.get(fixturedef)
         assert fixture_result is not None, (
             f'The fixture value for "{argname}" is not available.  '
             "This can happen when the fixture has already been torn down."
         )
         return fixture_result.value
 
-    def _get_cached_result(
-        self, fixturedef: FixtureDef[FixtureValue]
-    ) -> _FixtureCachedResult[FixtureValue] | None:
-        return self.session._setupstate.fixture_cache.get(fixturedef)
-
-    def _cache_value(
-        self,
-        fixturedef: FixtureDef[FixtureValue],
-        value: FixtureValue,  # type: ignore[misc]
-    ) -> None:
-        """Write a value into the cache for a fixture definition."""
-        self.session._setupstate.fixture_cache[fixturedef] = _FixtureResult(
-            value, self._active_param, None
-        )
-
-    def _cache_exception(
-        self,
-        fixturedef: FixtureDef[FixtureValue],
-        exception: BaseException,
-    ) -> None:
-        """Write an exception result into the cache for a fixture definition."""
-        self.session._setupstate.fixture_cache[fixturedef] = _FixtureException(
-            None, self._active_param, (exception, exception.__traceback__)
-        )
-
     @property
     def _active_param(self) -> object:
         return getattr(self, "param", _NO_PARAM)
-
-    def _invalidate_fixture_cache(self, fixturedef: FixtureDef[FixtureValue]) -> None:
-        del self.session._setupstate.fixture_cache[fixturedef]
 
     def _iter_chain(self) -> Iterator[SubRequest]:
         """Yield all SubRequests in the chain, from self up.
@@ -1245,7 +1193,8 @@ class FixtureDef(Generic[FixtureValue]):
         self._finalizers.append(finalizer)
 
     def finish(self, request: SubRequest) -> None:
-        if request._get_cached_result(self) is None:
+        fixture_cache = request.session._setupstate.fixture_cache
+        if fixture_cache.get(self) is None:
             # Already finished. It is assumed that finalizers cannot be added in
             # this state.
             return
@@ -1261,7 +1210,7 @@ class FixtureDef(Generic[FixtureValue]):
         # Even if finalization fails, we invalidate the cached fixture
         # value and remove all finalizers because they may be bound methods
         # which will keep instances alive.
-        request._invalidate_fixture_cache(self)
+        fixture_cache.invalidate(self)
         self._finalizers.clear()
         if len(exceptions) == 1:
             raise exceptions[0]
@@ -1289,7 +1238,8 @@ class FixtureDef(Generic[FixtureValue]):
             requested_fixtures_that_should_finalize_us.append(fixturedef)
 
         # Check for (and return) cached value/exception.
-        if (cached_result := request._get_cached_result(self)) is not None:
+        fixture_cache = request.session._setupstate.fixture_cache
+        if (cached_result := fixture_cache.get(self)) is not None:
             active_param = request._active_param
             cached_param = cached_result.param
             try:
@@ -1309,7 +1259,7 @@ class FixtureDef(Generic[FixtureValue]):
             # We have a previous but differently parametrized fixture instance
             # so we need to tear it down before creating a new one.
             self.finish(request)
-            assert request._get_cached_result(self) is None
+            assert fixture_cache.get(self) is None
 
         # Add finalizer to requested fixtures we saved previously.
         # We make sure to do this after checking for cached value to avoid
@@ -1360,7 +1310,8 @@ class RequestFixtureDef(FixtureDef[FixtureRequest]):
             node=request.node,
             _ispytest=True,
         )
-        request._cache_value(self, request)
+        fixture_cache = request.session._setupstate.fixture_cache
+        fixture_cache.set_value(self, request._active_param, request)
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         pass
@@ -1430,6 +1381,7 @@ def pytest_fixture_setup(
             pytrace=False,
         )
 
+    fixture_cache = request.session._setupstate.fixture_cache
     try:
         result = call_fixture_func(fixturefunc, request, kwargs)
     except TEST_OUTCOME as e:
@@ -1438,12 +1390,13 @@ def pytest_fixture_setup(
             # Don't show the fixture as the skip location, as then the user
             # wouldn't know which test skipped.
             e._use_item_location = True
-        request._cache_exception(
+        fixture_cache.set_exception(
             fixturedef,
+            request._active_param,
             e,
         )
         raise
-    request._cache_value(fixturedef, result)
+    fixture_cache.set_value(fixturedef, request._active_param, result)
     return result
 
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -972,6 +972,9 @@ class SubRequest(FixtureRequest):
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         self._fixturedef.addfinalizer(finalizer)
 
+    def cache_key(self) -> object:
+        return getattr(self, "param", None)
+
 
 @final
 class FixtureLookupError(LookupError):
@@ -1262,7 +1265,7 @@ class FixtureDef(Generic[FixtureValue]):
 
         # Check for (and return) cached value/exception.
         if (fixture_result := request._get_cached_result(self)) is not None:
-            request_cache_key = self.cache_key(request)
+            request_cache_key = request.cache_key()
             cache_key = fixture_result.cache_key
             try:
                 # Attempt to make a normal == check: this might fail for objects
@@ -1311,9 +1314,6 @@ class FixtureDef(Generic[FixtureValue]):
 
         return result
 
-    def cache_key(self, request: SubRequest) -> object:
-        return getattr(request, "param", None)
-
     def __repr__(self) -> str:
         return f"<FixtureDef argname={self.argname!r} scope={self.scope!r} baseid={self.baseid!r}>"
 
@@ -1336,9 +1336,6 @@ class RequestFixtureDef(FixtureDef[FixtureRequest]):
             _ispytest=True,
         )
         request._set_cached_result(self, _FixtureResult(request, [0], None))
-
-    def cache_key(self, request: SubRequest) -> object:
-        return [0]
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         pass
@@ -1396,7 +1393,7 @@ def pytest_fixture_setup(
         kwargs[argname] = request.getfixturevalue(argname)
 
     fixturefunc = resolve_fixture_function(fixturedef, request)
-    my_cache_key = fixturedef.cache_key(request)
+    my_cache_key = request.cache_key()
 
     if inspect.isasyncgenfunction(fixturefunc) or inspect.iscoroutinefunction(
         fixturefunc

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -708,7 +708,7 @@ class FixtureRequest(abc.ABC):
     ) -> None:
         """Write a value into the cache for a fixture definition."""
         self.session._setupstate.fixture_cache[fixturedef] = _FixtureResult(
-            value, self._cache_key(), None
+            value, self._cache_key, None
         )
 
     def _cache_exception(
@@ -718,9 +718,10 @@ class FixtureRequest(abc.ABC):
     ) -> None:
         """Write an exception result into the cache for a fixture definition."""
         self.session._setupstate.fixture_cache[fixturedef] = _FixtureException(
-            None, self._cache_key(), (exception, exception.__traceback__)
+            None, self._cache_key, (exception, exception.__traceback__)
         )
 
+    @property
     def _cache_key(self) -> object:
         return getattr(self, "param", None)
 
@@ -1278,7 +1279,7 @@ class FixtureDef(Generic[FixtureValue]):
 
         # Check for (and return) cached value/exception.
         if (fixture_result := request._get_cached_result(self)) is not None:
-            request_cache_key = request._cache_key()
+            request_cache_key = request._cache_key
             cache_key = fixture_result.cache_key
             try:
                 # Attempt to make a normal == check: this might fail for objects

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -122,7 +122,6 @@ class _FixtureException(NamedTuple):
     exception_and_traceback: tuple[BaseException, types.TracebackType | None]
 
 
-# The type of FixtureDef.cached_result (type alias generic in fixture value).
 _FixtureCachedResult = _FixtureResult[FixtureValue] | _FixtureException  # type: ignore[type-arg]
 
 
@@ -1276,7 +1275,8 @@ class FixtureDef(Generic[FixtureValue]):
         # This needs to be done before checking if we have a cached value, since
         # if a dependent fixture has their cache invalidated, e.g. due to
         # parametrization, they finalize themselves and fixtures depending on it
-        # (which will likely include this fixture) setting `self.cached_result = None`.
+        # (which will likely include this fixture), invalidating the respective
+        # cached values.
         # See #4871
         requested_fixtures_that_should_finalize_us = []
         for argname in self.argnames:

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -101,13 +101,13 @@ _FixtureFunc = Callable[..., FixtureValue] | Callable[..., Generator[FixtureValu
 
 class _FixtureResult(NamedTuple, Generic[FixtureValue]):
     value: FixtureValue
-    cache_key: object
+    param: object
     exception_and_traceback: None
 
 
 class _FixtureException(NamedTuple):
     value: None
-    cache_key: object
+    param: object
     exception_and_traceback: tuple[BaseException, types.TracebackType | None]
 
 
@@ -708,7 +708,7 @@ class FixtureRequest(abc.ABC):
     ) -> None:
         """Write a value into the cache for a fixture definition."""
         self.session._setupstate.fixture_cache[fixturedef] = _FixtureResult(
-            value, self._cache_key, None
+            value, self._active_param, None
         )
 
     def _cache_exception(
@@ -718,11 +718,11 @@ class FixtureRequest(abc.ABC):
     ) -> None:
         """Write an exception result into the cache for a fixture definition."""
         self.session._setupstate.fixture_cache[fixturedef] = _FixtureException(
-            None, self._cache_key, (exception, exception.__traceback__)
+            None, self._active_param, (exception, exception.__traceback__)
         )
 
     @property
-    def _cache_key(self) -> object:
+    def _active_param(self) -> object:
         return getattr(self, "param", None)
 
     def _invalidate_fixture_cache(self, fixturedef: FixtureDef[FixtureValue]) -> None:
@@ -1278,23 +1278,23 @@ class FixtureDef(Generic[FixtureValue]):
             requested_fixtures_that_should_finalize_us.append(fixturedef)
 
         # Check for (and return) cached value/exception.
-        if (fixture_result := request._get_cached_result(self)) is not None:
-            request_cache_key = request._cache_key
-            cache_key = fixture_result.cache_key
+        if (cached_result := request._get_cached_result(self)) is not None:
+            active_param = request._active_param
+            cached_param = cached_result.param
             try:
                 # Attempt to make a normal == check: this might fail for objects
                 # which do not implement the standard comparison (like numpy arrays -- #6497).
-                cache_hit = bool(request_cache_key == cache_key)
+                cache_hit = bool(active_param == cached_param)
             except (ValueError, RuntimeError):
                 # If the comparison raises, use 'is' as fallback.
-                cache_hit = request_cache_key is cache_key
+                cache_hit = active_param is cached_param
 
             if cache_hit:
-                if fixture_result.exception_and_traceback is not None:
-                    exc, exc_tb = fixture_result.exception_and_traceback
+                if cached_result.exception_and_traceback is not None:
+                    exc, exc_tb = cached_result.exception_and_traceback
                     raise exc.with_traceback(exc_tb)
                 else:
-                    return fixture_result.value
+                    return cached_result.value
             # We have a previous but differently parametrized fixture instance
             # so we need to tear it down before creating a new one.
             self.finish(request)

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -97,6 +97,8 @@ FixtureValue = TypeVar("FixtureValue", covariant=True)
 FixtureFunction = Callable[..., object]
 # The type of a fixture function (type alias generic in fixture value).
 _FixtureFunc = Callable[..., FixtureValue] | Callable[..., Generator[FixtureValue]]
+# Sentinel value for unset fixture params
+_NO_PARAM = object()
 
 
 class _FixtureResult(NamedTuple, Generic[FixtureValue]):
@@ -723,7 +725,7 @@ class FixtureRequest(abc.ABC):
 
     @property
     def _active_param(self) -> object:
-        return getattr(self, "param", None)
+        return getattr(self, "param", _NO_PARAM)
 
     def _invalidate_fixture_cache(self, fixturedef: FixtureDef[FixtureValue]) -> None:
         del self.session._setupstate.fixture_cache[fixturedef]

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -713,10 +713,10 @@ class FixtureRequest(abc.ABC):
     def _set_cached_exception(
         self,
         fixturedef: FixtureDef[FixtureValue],
-        exception_and_traceback: tuple[BaseException, types.TracebackType | None],
+        exception: BaseException,
     ) -> None:
         self.session._setupstate.fixture_cache[fixturedef] = _FixtureException(
-            None, self._cache_key(), exception_and_traceback
+            None, self._cache_key(), (exception, exception.__traceback__)
         )
 
     def _cache_key(self) -> object:
@@ -1426,7 +1426,7 @@ def pytest_fixture_setup(
             e._use_item_location = True
         request._set_cached_exception(
             fixturedef,
-            (e, e.__traceback__),
+            e,
         )
         raise
     request._set_cached_result(fixturedef, result)

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1195,7 +1195,7 @@ class FixtureDef(Generic[FixtureValue]):
         return request.session._setupstate.fixture_cache.get(self)
 
     def _set_cached_result(
-        self, request: FixtureRequest, value: _FixtureCachedResult[FixtureValue] | None
+        self, request: FixtureRequest, value: _FixtureCachedResult[FixtureValue]
     ) -> None:
         request.session._setupstate.fixture_cache[self] = value
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -26,6 +26,7 @@ from typing import Final
 from typing import final
 from typing import Generic
 from typing import Literal
+from typing import NamedTuple
 from typing import NoReturn
 from typing import overload
 from typing import TYPE_CHECKING
@@ -96,23 +97,22 @@ FixtureValue = TypeVar("FixtureValue", covariant=True)
 FixtureFunction = Callable[..., object]
 # The type of a fixture function (type alias generic in fixture value).
 _FixtureFunc = Callable[..., FixtureValue] | Callable[..., Generator[FixtureValue]]
+
+
+class _FixtureResult(NamedTuple, Generic[FixtureValue]):
+    value: FixtureValue
+    cache_key: object
+    exception_and_traceback: None
+
+
+class _FixtureException(NamedTuple):
+    value: None
+    cache_key: object
+    exception_and_traceback: tuple[BaseException, types.TracebackType | None]
+
+
 # The type of FixtureDef.cached_result (type alias generic in fixture value).
-_FixtureCachedResult = (
-    tuple[
-        # The result.
-        FixtureValue,
-        # Cache key.
-        object,
-        None,
-    ]
-    | tuple[
-        None,
-        # Cache key.
-        object,
-        # The exception and the original traceback.
-        tuple[BaseException, types.TracebackType | None],
-    ]
-)
+_FixtureCachedResult = _FixtureResult[FixtureValue] | _FixtureException
 
 
 def pytest_sessionstart(session: Session) -> None:
@@ -694,7 +694,7 @@ class FixtureRequest(abc.ABC):
             f'The fixture value for "{argname}" is not available.  '
             "This can happen when the fixture has already been torn down."
         )
-        return fixture_result[0]
+        return fixture_result.value
 
     def _iter_chain(self) -> Iterator[SubRequest]:
         """Yield all SubRequests in the chain, from self up.
@@ -1258,7 +1258,7 @@ class FixtureDef(Generic[FixtureValue]):
         # Check for (and return) cached value/exception.
         if (fixture_result := self._get_cached_result(request)) is not None:
             request_cache_key = self.cache_key(request)
-            cache_key = fixture_result[1]
+            cache_key = fixture_result.cache_key
             try:
                 # Attempt to make a normal == check: this might fail for objects
                 # which do not implement the standard comparison (like numpy arrays -- #6497).
@@ -1268,11 +1268,11 @@ class FixtureDef(Generic[FixtureValue]):
                 cache_hit = request_cache_key is cache_key
 
             if cache_hit:
-                if fixture_result[2] is not None:
-                    exc, exc_tb = fixture_result[2]
+                if fixture_result.exception_and_traceback is not None:
+                    exc, exc_tb = fixture_result.exception_and_traceback
                     raise exc.with_traceback(exc_tb)
                 else:
-                    return fixture_result[0]
+                    return fixture_result.value
             # We have a previous but differently parametrized fixture instance
             # so we need to tear it down before creating a new one.
             self.finish(request)
@@ -1330,7 +1330,7 @@ class RequestFixtureDef(FixtureDef[FixtureRequest]):
             node=request.node,
             _ispytest=True,
         )
-        self._set_cached_result(request, (request, [0], None))
+        self._set_cached_result(request, _FixtureResult(request, [0], None))
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         pass
@@ -1410,10 +1410,11 @@ def pytest_fixture_setup(
             # wouldn't know which test skipped.
             e._use_item_location = True
         fixturedef._set_cached_result(
-            request, (None, my_cache_key, (e, e.__traceback__))
+            request,
+            _FixtureException(None, my_cache_key, (e, e.__traceback__)),
         )
         raise
-    fixturedef._set_cached_result(request, (result, my_cache_key, None))
+    fixturedef._set_cached_result(request, _FixtureResult(result, my_cache_key, None))
     return result
 
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -704,16 +704,23 @@ class FixtureRequest(abc.ABC):
     def _set_cached_result(
         self,
         fixturedef: FixtureDef[FixtureValue],
-        value: _FixtureResult[FixtureValue],
+        value: FixtureValue,  # type: ignore[misc]
     ) -> None:
-        self.session._setupstate.fixture_cache[fixturedef] = value
+        self.session._setupstate.fixture_cache[fixturedef] = _FixtureResult(
+            value, self._cache_key(), None
+        )
 
     def _set_cached_exception(
         self,
         fixturedef: FixtureDef[FixtureValue],
-        value: _FixtureException,
+        exception_and_traceback: tuple[BaseException, types.TracebackType | None],
     ) -> None:
-        self.session._setupstate.fixture_cache[fixturedef] = value
+        self.session._setupstate.fixture_cache[fixturedef] = _FixtureException(
+            None, self._cache_key(), exception_and_traceback
+        )
+
+    def _cache_key(self) -> object:
+        return getattr(self, "param", None)
 
     def _invalidate_fixture_cache(self, fixturedef: FixtureDef[FixtureValue]) -> None:
         del self.session._setupstate.fixture_cache[fixturedef]
@@ -978,9 +985,6 @@ class SubRequest(FixtureRequest):
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         self._fixturedef.addfinalizer(finalizer)
-
-    def cache_key(self) -> object:
-        return getattr(self, "param", None)
 
 
 @final
@@ -1272,7 +1276,7 @@ class FixtureDef(Generic[FixtureValue]):
 
         # Check for (and return) cached value/exception.
         if (fixture_result := request._get_cached_result(self)) is not None:
-            request_cache_key = request.cache_key()
+            request_cache_key = request._cache_key()
             cache_key = fixture_result.cache_key
             try:
                 # Attempt to make a normal == check: this might fail for objects
@@ -1342,7 +1346,7 @@ class RequestFixtureDef(FixtureDef[FixtureRequest]):
             node=request.node,
             _ispytest=True,
         )
-        request._set_cached_result(self, _FixtureResult(request, [0], None))
+        request._set_cached_result(self, request)
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         pass
@@ -1400,7 +1404,6 @@ def pytest_fixture_setup(
         kwargs[argname] = request.getfixturevalue(argname)
 
     fixturefunc = resolve_fixture_function(fixturedef, request)
-    my_cache_key = request.cache_key()
 
     if inspect.isasyncgenfunction(fixturefunc) or inspect.iscoroutinefunction(
         fixturefunc
@@ -1423,10 +1426,10 @@ def pytest_fixture_setup(
             e._use_item_location = True
         request._set_cached_exception(
             fixturedef,
-            _FixtureException(None, my_cache_key, (e, e.__traceback__)),
+            (e, e.__traceback__),
         )
         raise
-    request._set_cached_result(fixturedef, _FixtureResult(result, my_cache_key, None))
+    request._set_cached_result(fixturedef, result)
     return result
 
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -689,12 +689,27 @@ class FixtureRequest(abc.ABC):
         # (using function parameters, autouse, etc).
 
         fixturedef = self._get_active_fixturedef(argname)
-        fixture_result = fixturedef._get_cached_result(self)
+        fixture_result = self._get_cached_result(fixturedef)
         assert fixture_result is not None, (
             f'The fixture value for "{argname}" is not available.  '
             "This can happen when the fixture has already been torn down."
         )
         return fixture_result.value
+
+    def _get_cached_result(
+        self, fixturedef: FixtureDef[FixtureValue]
+    ) -> _FixtureCachedResult[FixtureValue] | None:
+        return self.session._setupstate.fixture_cache.get(fixturedef)
+
+    def _set_cached_result(
+        self,
+        fixturedef: FixtureDef[FixtureValue],
+        value: _FixtureCachedResult[FixtureValue],
+    ) -> None:
+        self.session._setupstate.fixture_cache[fixturedef] = value
+
+    def _invalidate_fixture_cache(self, fixturedef: FixtureDef[FixtureValue]) -> None:
+        del self.session._setupstate.fixture_cache[fixturedef]
 
     def _iter_chain(self) -> Iterator[SubRequest]:
         """Yield all SubRequests in the chain, from self up.
@@ -1189,19 +1204,6 @@ class FixtureDef(Generic[FixtureValue]):
         # only used to emit a deprecationwarning, can be removed in pytest9
         self._autouse = _autouse
 
-    def _get_cached_result(
-        self, request: FixtureRequest
-    ) -> _FixtureCachedResult[FixtureValue] | None:
-        return request.session._setupstate.fixture_cache.get(self)
-
-    def _set_cached_result(
-        self, request: FixtureRequest, value: _FixtureCachedResult[FixtureValue]
-    ) -> None:
-        request.session._setupstate.fixture_cache[self] = value
-
-    def _invalidate_fixture_cache(self, request: FixtureRequest) -> None:
-        del request.session._setupstate.fixture_cache[self]
-
     @property
     def scope(self) -> ScopeName:
         """Scope string, one of "function", "class", "module", "package", "session"."""
@@ -1216,7 +1218,7 @@ class FixtureDef(Generic[FixtureValue]):
         self._finalizers.append(finalizer)
 
     def finish(self, request: SubRequest) -> None:
-        if self._get_cached_result(request) is None:
+        if request._get_cached_result(self) is None:
             # Already finished. It is assumed that finalizers cannot be added in
             # this state.
             return
@@ -1232,7 +1234,7 @@ class FixtureDef(Generic[FixtureValue]):
         # Even if finalization fails, we invalidate the cached fixture
         # value and remove all finalizers because they may be bound methods
         # which will keep instances alive.
-        self._invalidate_fixture_cache(request)
+        request._invalidate_fixture_cache(self)
         self._finalizers.clear()
         if len(exceptions) == 1:
             raise exceptions[0]
@@ -1259,7 +1261,7 @@ class FixtureDef(Generic[FixtureValue]):
             requested_fixtures_that_should_finalize_us.append(fixturedef)
 
         # Check for (and return) cached value/exception.
-        if (fixture_result := self._get_cached_result(request)) is not None:
+        if (fixture_result := request._get_cached_result(self)) is not None:
             request_cache_key = self.cache_key(request)
             cache_key = fixture_result.cache_key
             try:
@@ -1279,7 +1281,7 @@ class FixtureDef(Generic[FixtureValue]):
             # We have a previous but differently parametrized fixture instance
             # so we need to tear it down before creating a new one.
             self.finish(request)
-            assert self._get_cached_result(request) is None
+            assert request._get_cached_result(self) is None
 
         # Add finalizer to requested fixtures we saved previously.
         # We make sure to do this after checking for cached value to avoid
@@ -1333,7 +1335,7 @@ class RequestFixtureDef(FixtureDef[FixtureRequest]):
             node=request.node,
             _ispytest=True,
         )
-        self._set_cached_result(request, _FixtureResult(request, [0], None))
+        request._set_cached_result(self, _FixtureResult(request, [0], None))
 
     def cache_key(self, request: SubRequest) -> object:
         return [0]
@@ -1415,12 +1417,12 @@ def pytest_fixture_setup(
             # Don't show the fixture as the skip location, as then the user
             # wouldn't know which test skipped.
             e._use_item_location = True
-        fixturedef._set_cached_result(
-            request,
+        request._set_cached_result(
+            fixturedef,
             _FixtureException(None, my_cache_key, (e, e.__traceback__)),
         )
         raise
-    fixturedef._set_cached_result(request, _FixtureResult(result, my_cache_key, None))
+    request._set_cached_result(fixturedef, _FixtureResult(result, my_cache_key, None))
     return result
 
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -689,11 +689,12 @@ class FixtureRequest(abc.ABC):
         # (using function parameters, autouse, etc).
 
         fixturedef = self._get_active_fixturedef(argname)
-        assert fixturedef.cached_result is not None, (
+        fixture_result = fixturedef._get_cached_result(self)
+        assert fixture_result is not None, (
             f'The fixture value for "{argname}" is not available.  '
             "This can happen when the fixture has already been torn down."
         )
-        return fixturedef.cached_result[0]
+        return fixture_result[0]
 
     def _iter_chain(self) -> Iterator[SubRequest]:
         """Yield all SubRequests in the chain, from self up.
@@ -1183,13 +1184,20 @@ class FixtureDef(Generic[FixtureValue]):
         self.ids: Final = ids
         # The names requested by the fixtures.
         self.argnames: Final = getfuncargnames(func, name=argname)
-        # If the fixture was executed, the current value of the fixture.
-        # Can change if the fixture is executed with different parameters.
-        self.cached_result: _FixtureCachedResult[FixtureValue] | None = None
         self._finalizers: Final[list[Callable[[], object]]] = []
 
         # only used to emit a deprecationwarning, can be removed in pytest9
         self._autouse = _autouse
+
+    def _get_cached_result(
+        self, request: FixtureRequest
+    ) -> _FixtureCachedResult[FixtureValue] | None:
+        return request.session._setupstate.fixture_cache.get(self)
+
+    def _set_cached_result(
+        self, request: FixtureRequest, value: _FixtureCachedResult[FixtureValue] | None
+    ) -> None:
+        request.session._setupstate.fixture_cache[self] = value
 
     @property
     def scope(self) -> ScopeName:
@@ -1205,7 +1213,7 @@ class FixtureDef(Generic[FixtureValue]):
         self._finalizers.append(finalizer)
 
     def finish(self, request: SubRequest) -> None:
-        if self.cached_result is None:
+        if self._get_cached_result(request) is None:
             # Already finished. It is assumed that finalizers cannot be added in
             # this state.
             return
@@ -1221,7 +1229,7 @@ class FixtureDef(Generic[FixtureValue]):
         # Even if finalization fails, we invalidate the cached fixture
         # value and remove all finalizers because they may be bound methods
         # which will keep instances alive.
-        self.cached_result = None
+        self._set_cached_result(request, None)
         self._finalizers.clear()
         if len(exceptions) == 1:
             raise exceptions[0]
@@ -1248,9 +1256,9 @@ class FixtureDef(Generic[FixtureValue]):
             requested_fixtures_that_should_finalize_us.append(fixturedef)
 
         # Check for (and return) cached value/exception.
-        if self.cached_result is not None:
+        if (fixture_result := self._get_cached_result(request)) is not None:
             request_cache_key = self.cache_key(request)
-            cache_key = self.cached_result[1]
+            cache_key = fixture_result[1]
             try:
                 # Attempt to make a normal == check: this might fail for objects
                 # which do not implement the standard comparison (like numpy arrays -- #6497).
@@ -1260,15 +1268,15 @@ class FixtureDef(Generic[FixtureValue]):
                 cache_hit = request_cache_key is cache_key
 
             if cache_hit:
-                if self.cached_result[2] is not None:
-                    exc, exc_tb = self.cached_result[2]
+                if fixture_result[2] is not None:
+                    exc, exc_tb = fixture_result[2]
                     raise exc.with_traceback(exc_tb)
                 else:
-                    return self.cached_result[0]
+                    return fixture_result[0]
             # We have a previous but differently parametrized fixture instance
             # so we need to tear it down before creating a new one.
             self.finish(request)
-            assert self.cached_result is None
+            assert self._get_cached_result(request) is None
 
         # Add finalizer to requested fixtures we saved previously.
         # We make sure to do this after checking for cached value to avoid
@@ -1289,7 +1297,6 @@ class FixtureDef(Generic[FixtureValue]):
         ihook = request.node.ihook
         try:
             # Setup the fixture, run the code in it, and cache the value
-            # in self.cached_result.
             result: FixtureValue = ihook.pytest_fixture_setup(
                 fixturedef=self, request=request
             )
@@ -1323,7 +1330,7 @@ class RequestFixtureDef(FixtureDef[FixtureRequest]):
             node=request.node,
             _ispytest=True,
         )
-        self.cached_result = (request, [0], None)
+        self._set_cached_result(request, (request, [0], None))
 
     def addfinalizer(self, finalizer: Callable[[], object]) -> None:
         pass
@@ -1402,9 +1409,11 @@ def pytest_fixture_setup(
             # Don't show the fixture as the skip location, as then the user
             # wouldn't know which test skipped.
             e._use_item_location = True
-        fixturedef.cached_result = (None, my_cache_key, (e, e.__traceback__))
+        fixturedef._set_cached_result(
+            request, (None, my_cache_key, (e, e.__traceback__))
+        )
         raise
-    fixturedef.cached_result = (result, my_cache_key, None)
+    fixturedef._set_cached_result(request, (result, my_cache_key, None))
     return result
 
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -101,10 +101,19 @@ _FixtureFunc = Callable[..., FixtureValue] | Callable[..., Generator[FixtureValu
 _NO_PARAM = object()
 
 
-class _FixtureResult(NamedTuple, Generic[FixtureValue]):
-    value: FixtureValue
-    param: object
-    exception_and_traceback: None
+# NamedTuples cannot take generic arguments before Python 3.11
+if TYPE_CHECKING and sys.version_info >= (3, 11):
+
+    class _FixtureResult(NamedTuple, Generic[FixtureValue]):
+        value: FixtureValue
+        param: object
+        exception_and_traceback: None
+else:
+
+    class _FixtureResult(NamedTuple):
+        value: Any
+        param: object
+        exception_and_traceback: None
 
 
 class _FixtureException(NamedTuple):
@@ -114,7 +123,7 @@ class _FixtureException(NamedTuple):
 
 
 # The type of FixtureDef.cached_result (type alias generic in fixture value).
-_FixtureCachedResult = _FixtureResult[FixtureValue] | _FixtureException
+_FixtureCachedResult = _FixtureResult[FixtureValue] | _FixtureException  # type: ignore[type-arg]
 
 
 def pytest_sessionstart(session: Session) -> None:
@@ -1296,7 +1305,7 @@ class FixtureDef(Generic[FixtureValue]):
                     exc, exc_tb = cached_result.exception_and_traceback
                     raise exc.with_traceback(exc_tb)
                 else:
-                    return cached_result.value
+                    return cached_result.value  # type: ignore[no-any-return]
             # We have a previous but differently parametrized fixture instance
             # so we need to tear it down before creating a new one.
             self.finish(request)

--- a/src/_pytest/hookspec.py
+++ b/src/_pytest/hookspec.py
@@ -867,8 +867,8 @@ def pytest_fixture_post_finalizer(
     fixturedef: FixtureDef[Any], request: SubRequest
 ) -> None:
     """Called after fixture teardown, but before the cache is cleared, so
-    the fixture result ``fixturedef.cached_result`` is still available (not
-    ``None``).
+    the fixture result ``request._get_cached_result(fixturedef)`` is still
+    available (not ``None``).
 
     :param fixturedef:
         The fixture definition object.

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -514,9 +514,6 @@ class SetupState:
         # Importing the appropriate types from the fixtures module lead to circular
         # imports, so we leave the cache untyped for now
         self.fixture_cache = {}  # type: ignore[var-annotated]
-        # Tracks the currently active param per fixturedef
-        # This is only used during --setup-show
-        self.active_param_by_fixture = {}  # type: ignore[var-annotated]
 
     def is_node_active(self, node: Node) -> bool:
         """Check if a node is currently active in the stack -- set up and not

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -511,6 +511,9 @@ class SetupState:
                 tuple[OutcomeException | Exception, types.TracebackType | None] | None,
             ],
         ] = {}
+        # Importing the appropriate types from the fixtures module lead to circular
+        # imports, so we leave the cache untyped for now
+        self.fixture_cache = {}  # type: ignore[var-annotated]
 
     def is_node_active(self, node: Node) -> bool:
         """Check if a node is currently active in the stack -- set up and not

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -514,6 +514,9 @@ class SetupState:
         # Importing the appropriate types from the fixtures module lead to circular
         # imports, so we leave the cache untyped for now
         self.fixture_cache = {}  # type: ignore[var-annotated]
+        # Tracks the currently active param per fixturedef
+        # This is only used during --setup-show
+        self.active_param_by_fixture = {}  # type: ignore[var-annotated]
 
     def is_node_active(self, node: Node) -> bool:
         """Check if a node is currently active in the stack -- set up and not

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -27,6 +27,7 @@ from _pytest._code.code import ExceptionInfo
 from _pytest._code.code import TerminalRepr
 from _pytest.config.argparsing import Parser
 from _pytest.deprecated import check_ispytest
+from _pytest.fixture_cache import FixtureCache
 from _pytest.nodes import Collector
 from _pytest.nodes import Directory
 from _pytest.nodes import Item
@@ -511,9 +512,7 @@ class SetupState:
                 tuple[OutcomeException | Exception, types.TracebackType | None] | None,
             ],
         ] = {}
-        # Importing the appropriate types from the fixtures module lead to circular
-        # imports, so we leave the cache untyped for now
-        self.fixture_cache = {}  # type: ignore[var-annotated]
+        self.fixture_cache = FixtureCache()
 
     def is_node_active(self, node: Node) -> bool:
         """Check if a node is currently active in the stack -- set up and not

--- a/src/_pytest/setuponly.py
+++ b/src/_pytest/setuponly.py
@@ -53,7 +53,9 @@ def pytest_fixture_setup(
                 request.session._setupstate.fixture_cache[fixturedef] = _FixtureResult(
                     None, param, None
                 )
-            _show_fixture_action(request, fixturedef, "SETUP")
+            else:
+                param = _NO_PARAM
+            _show_fixture_action(request.config, fixturedef, param, "SETUP")
 
 
 def pytest_fixture_post_finalizer(
@@ -63,13 +65,12 @@ def pytest_fixture_post_finalizer(
     assert cached_result is not None, "As per the definition of this hook the fixture cache should not have been cleared"
     config = request.config
     if config.option.setupshow:
-        _show_fixture_action(request, fixturedef, "TEARDOWN")
+        _show_fixture_action(config, fixturedef, cached_result.param, "TEARDOWN")
 
 
 def _show_fixture_action(
-    request: SubRequest, fixturedef: FixtureDef[object], msg: str
+    config: Config, fixturedef: FixtureDef[object], param: object, msg: str
 ) -> None:
-    config = request.config
     capman = config.pluginmanager.getplugin("capturemanager")
     if capman:
         capman.suspend_global_capture()
@@ -88,9 +89,8 @@ def _show_fixture_action(
         if deps:
             tw.write(" (fixtures used: {})".format(", ".join(deps)))
 
-    if cache_entry := request.session._setupstate.fixture_cache.get(fixturedef):
-        if cache_entry.param is not _NO_PARAM:
-            tw.write(f"[{saferepr(cache_entry.param, maxsize=42)}]")
+    if param is not _NO_PARAM:
+        tw.write(f"[{saferepr(param, maxsize=42)}]")
 
     tw.flush()
 

--- a/src/_pytest/setuponly.py
+++ b/src/_pytest/setuponly.py
@@ -53,7 +53,7 @@ def pytest_fixture_setup(
 def pytest_fixture_post_finalizer(
     fixturedef: FixtureDef[object], request: SubRequest
 ) -> None:
-    if fixturedef.cached_result is not None:
+    if fixturedef._get_cached_result(request) is not None:
         config = request.config
         if config.option.setupshow:
             _show_fixture_action(fixturedef, request.config, "TEARDOWN")

--- a/src/_pytest/setuponly.py
+++ b/src/_pytest/setuponly.py
@@ -6,6 +6,8 @@ from _pytest._io.saferepr import saferepr
 from _pytest.config import Config
 from _pytest.config import ExitCode
 from _pytest.config.argparsing import Parser
+from _pytest.fixtures import _FixtureResult
+from _pytest.fixtures import _NO_PARAM
 from _pytest.fixtures import FixtureDef
 from _pytest.fixtures import SubRequest
 from _pytest.scope import Scope
@@ -46,7 +48,11 @@ def pytest_fixture_setup(
                         param = fixturedef.ids[request.param_index]
                 else:
                     param = request.param
-                request.session._setupstate.active_param_by_fixture[fixturedef] = param
+                # Use None as a dummy value for resolving/caching the fixture
+                # --setup-show does not care about the actual value, only about the param
+                request.session._setupstate.fixture_cache[fixturedef] = _FixtureResult(
+                    None, param, None
+                )
             _show_fixture_action(request, fixturedef, "SETUP")
 
 
@@ -57,8 +63,6 @@ def pytest_fixture_post_finalizer(
         config = request.config
         if config.option.setupshow:
             _show_fixture_action(request, fixturedef, "TEARDOWN")
-            if fixturedef in request.session._setupstate.active_param_by_fixture:
-                del request.session._setupstate.active_param_by_fixture[fixturedef]
 
 
 def _show_fixture_action(
@@ -83,9 +87,9 @@ def _show_fixture_action(
         if deps:
             tw.write(" (fixtures used: {})".format(", ".join(deps)))
 
-    if fixturedef in request.session._setupstate.active_param_by_fixture:
-        active_param = request.session._setupstate.active_param_by_fixture[fixturedef]
-        tw.write(f"[{saferepr(active_param, maxsize=42)}]")
+    if cache_entry := request.session._setupstate.fixture_cache.get(fixturedef):
+        if cache_entry.param is not _NO_PARAM:
+            tw.write(f"[{saferepr(cache_entry.param, maxsize=42)}]")
 
     tw.flush()
 

--- a/src/_pytest/setuponly.py
+++ b/src/_pytest/setuponly.py
@@ -62,7 +62,9 @@ def pytest_fixture_post_finalizer(
     fixturedef: FixtureDef[object], request: SubRequest
 ) -> None:
     cached_result = request._get_cached_result(fixturedef)
-    assert cached_result is not None, "As per the definition of this hook the fixture cache should not have been cleared"
+    assert cached_result is not None, (
+        "As per the definition of this hook the fixture cache should not have been cleared"
+    )
     config = request.config
     if config.option.setupshow:
         _show_fixture_action(config, fixturedef, cached_result.param, "TEARDOWN")

--- a/src/_pytest/setuponly.py
+++ b/src/_pytest/setuponly.py
@@ -46,8 +46,8 @@ def pytest_fixture_setup(
                         param = fixturedef.ids[request.param_index]
                 else:
                     param = request.param
-                fixturedef.cached_param = param  # type: ignore[attr-defined]
-            _show_fixture_action(fixturedef, request.config, "SETUP")
+                request.session._setupstate.active_param_by_fixture[fixturedef] = param
+            _show_fixture_action(request, fixturedef, "SETUP")
 
 
 def pytest_fixture_post_finalizer(
@@ -56,14 +56,15 @@ def pytest_fixture_post_finalizer(
     if request._get_cached_result(fixturedef) is not None:
         config = request.config
         if config.option.setupshow:
-            _show_fixture_action(fixturedef, request.config, "TEARDOWN")
-            if hasattr(fixturedef, "cached_param"):
-                del fixturedef.cached_param
+            _show_fixture_action(request, fixturedef, "TEARDOWN")
+            if fixturedef in request.session._setupstate.active_param_by_fixture:
+                del request.session._setupstate.active_param_by_fixture[fixturedef]
 
 
 def _show_fixture_action(
-    fixturedef: FixtureDef[object], config: Config, msg: str
+    request: SubRequest, fixturedef: FixtureDef[object], msg: str
 ) -> None:
+    config = request.config
     capman = config.pluginmanager.getplugin("capturemanager")
     if capman:
         capman.suspend_global_capture()
@@ -82,8 +83,9 @@ def _show_fixture_action(
         if deps:
             tw.write(" (fixtures used: {})".format(", ".join(deps)))
 
-    if hasattr(fixturedef, "cached_param"):
-        tw.write(f"[{saferepr(fixturedef.cached_param, maxsize=42)}]")
+    if fixturedef in request.session._setupstate.active_param_by_fixture:
+        active_param = request.session._setupstate.active_param_by_fixture[fixturedef]
+        tw.write(f"[{saferepr(active_param, maxsize=42)}]")
 
     tw.flush()
 

--- a/src/_pytest/setuponly.py
+++ b/src/_pytest/setuponly.py
@@ -59,10 +59,11 @@ def pytest_fixture_setup(
 def pytest_fixture_post_finalizer(
     fixturedef: FixtureDef[object], request: SubRequest
 ) -> None:
-    if request._get_cached_result(fixturedef) is not None:
-        config = request.config
-        if config.option.setupshow:
-            _show_fixture_action(request, fixturedef, "TEARDOWN")
+    cached_result = request._get_cached_result(fixturedef)
+    assert cached_result is not None, "As per the definition of this hook the fixture cache should not have been cleared"
+    config = request.config
+    if config.option.setupshow:
+        _show_fixture_action(request, fixturedef, "TEARDOWN")
 
 
 def _show_fixture_action(

--- a/src/_pytest/setuponly.py
+++ b/src/_pytest/setuponly.py
@@ -53,7 +53,7 @@ def pytest_fixture_setup(
 def pytest_fixture_post_finalizer(
     fixturedef: FixtureDef[object], request: SubRequest
 ) -> None:
-    if fixturedef._get_cached_result(request) is not None:
+    if request._get_cached_result(fixturedef) is not None:
         config = request.config
         if config.option.setupshow:
             _show_fixture_action(fixturedef, request.config, "TEARDOWN")

--- a/src/_pytest/setuponly.py
+++ b/src/_pytest/setuponly.py
@@ -6,7 +6,6 @@ from _pytest._io.saferepr import saferepr
 from _pytest.config import Config
 from _pytest.config import ExitCode
 from _pytest.config.argparsing import Parser
-from _pytest.fixtures import _FixtureResult
 from _pytest.fixtures import _NO_PARAM
 from _pytest.fixtures import FixtureDef
 from _pytest.fixtures import SubRequest
@@ -48,11 +47,10 @@ def pytest_fixture_setup(
                         param = fixturedef.ids[request.param_index]
                 else:
                     param = request.param
+                fixture_cache = request.session._setupstate.fixture_cache
                 # Use None as a dummy value for resolving/caching the fixture
                 # --setup-show does not care about the actual value, only about the param
-                request.session._setupstate.fixture_cache[fixturedef] = _FixtureResult(
-                    None, param, None
-                )
+                fixture_cache.set_value(fixturedef, param, None)
             else:
                 param = _NO_PARAM
             _show_fixture_action(request.config, fixturedef, param, "SETUP")
@@ -61,7 +59,8 @@ def pytest_fixture_setup(
 def pytest_fixture_post_finalizer(
     fixturedef: FixtureDef[object], request: SubRequest
 ) -> None:
-    cached_result = request._get_cached_result(fixturedef)
+    fixture_cache = request.session._setupstate.fixture_cache
+    cached_result = fixture_cache.get(fixturedef)
     assert cached_result is not None, (
         "As per the definition of this hook the fixture cache should not have been cleared"
     )

--- a/src/_pytest/setupplan.py
+++ b/src/_pytest/setupplan.py
@@ -26,7 +26,7 @@ def pytest_fixture_setup(
 ) -> object | None:
     # Will return a dummy fixture if the setuponly option is provided.
     if request.config.option.setupplan:
-        my_cache_key = fixturedef.cache_key(request)
+        my_cache_key = request.cache_key()
         request._set_cached_result(fixturedef, _FixtureResult(None, my_cache_key, None))
         return request._get_cached_result(fixturedef)
     return None

--- a/src/_pytest/setupplan.py
+++ b/src/_pytest/setupplan.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from _pytest.config import Config
 from _pytest.config import ExitCode
 from _pytest.config.argparsing import Parser
+from _pytest.fixtures import _FixtureResult
 from _pytest.fixtures import FixtureDef
 from _pytest.fixtures import SubRequest
 import pytest
@@ -26,7 +27,7 @@ def pytest_fixture_setup(
     # Will return a dummy fixture if the setuponly option is provided.
     if request.config.option.setupplan:
         my_cache_key = fixturedef.cache_key(request)
-        fixturedef._set_cached_result(request, (None, my_cache_key, None))
+        fixturedef._set_cached_result(request, _FixtureResult(None, my_cache_key, None))
         return fixturedef._get_cached_result(request)
     return None
 

--- a/src/_pytest/setupplan.py
+++ b/src/_pytest/setupplan.py
@@ -25,7 +25,7 @@ def pytest_fixture_setup(
 ) -> object | None:
     # Will return a dummy fixture if the setuponly option is provided.
     if request.config.option.setupplan:
-        request._set_cached_result(fixturedef, None)
+        request._cache_value(fixturedef, None)
         return request._get_cached_result(fixturedef)
     return None
 

--- a/src/_pytest/setupplan.py
+++ b/src/_pytest/setupplan.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from _pytest.config import Config
 from _pytest.config import ExitCode
 from _pytest.config.argparsing import Parser
-from _pytest.fixtures import _FixtureResult
 from _pytest.fixtures import FixtureDef
 from _pytest.fixtures import SubRequest
 import pytest
@@ -26,8 +25,7 @@ def pytest_fixture_setup(
 ) -> object | None:
     # Will return a dummy fixture if the setuponly option is provided.
     if request.config.option.setupplan:
-        my_cache_key = request.cache_key()
-        request._set_cached_result(fixturedef, _FixtureResult(None, my_cache_key, None))
+        request._set_cached_result(fixturedef, None)
         return request._get_cached_result(fixturedef)
     return None
 

--- a/src/_pytest/setupplan.py
+++ b/src/_pytest/setupplan.py
@@ -27,8 +27,8 @@ def pytest_fixture_setup(
     # Will return a dummy fixture if the setuponly option is provided.
     if request.config.option.setupplan:
         my_cache_key = fixturedef.cache_key(request)
-        fixturedef._set_cached_result(request, _FixtureResult(None, my_cache_key, None))
-        return fixturedef._get_cached_result(request)
+        request._set_cached_result(fixturedef, _FixtureResult(None, my_cache_key, None))
+        return request._get_cached_result(fixturedef)
     return None
 
 

--- a/src/_pytest/setupplan.py
+++ b/src/_pytest/setupplan.py
@@ -26,8 +26,8 @@ def pytest_fixture_setup(
     # Will return a dummy fixture if the setuponly option is provided.
     if request.config.option.setupplan:
         my_cache_key = fixturedef.cache_key(request)
-        fixturedef.cached_result = (None, my_cache_key, None)
-        return fixturedef.cached_result
+        fixturedef._set_cached_result(request, (None, my_cache_key, None))
+        return fixturedef._get_cached_result(request)
     return None
 
 

--- a/src/_pytest/setupplan.py
+++ b/src/_pytest/setupplan.py
@@ -25,8 +25,9 @@ def pytest_fixture_setup(
 ) -> object | None:
     # Will return a dummy fixture if the setuponly option is provided.
     if request.config.option.setupplan:
-        request._cache_value(fixturedef, None)
-        return request._get_cached_result(fixturedef)
+        fixture_cache = request.session._setupstate.fixture_cache
+        fixture_cache.set_value(fixturedef, request._active_param, None)
+        return fixture_cache.get(fixturedef)
     return None
 
 

--- a/testing/test_setuponly.py
+++ b/testing/test_setuponly.py
@@ -259,6 +259,27 @@ def test_capturing(pytester: Pytester) -> None:
     )
 
 
+def test_suppress_capturing(pytester: Pytester) -> None:
+    p = pytester.makepyfile(
+        """
+        import pytest, sys
+        @pytest.fixture()
+        def one():
+            sys.stdout.write('this should not be captured')
+        @pytest.fixture()
+        def two(one):
+            assert 0
+        def test_capturing(two):
+            pass
+    """
+    )
+
+    result = pytester.runpytest("--setup-only", "-s", p)
+    result.stdout.no_fnmatch_line(
+        "this should not be captured"
+    )
+
+
 def test_show_fixtures_and_execute_test(pytester: Pytester) -> None:
     """Verify that setups are shown and tests are executed."""
     p = pytester.makepyfile(

--- a/testing/test_setuponly.py
+++ b/testing/test_setuponly.py
@@ -275,9 +275,7 @@ def test_suppress_capturing(pytester: Pytester) -> None:
     )
 
     result = pytester.runpytest("--setup-only", "-s", p)
-    result.stdout.no_fnmatch_line(
-        "this should not be captured"
-    )
+    result.stdout.no_fnmatch_line("this should not be captured")
 
 
 def test_show_fixtures_and_execute_test(pytester: Pytester) -> None:


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [X] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
This PR removes *FixtureDef.cached_result* in favor of a cache that is attached to *SetupState*. *FixtureRequest* received methods to manipulate the fixture cache.

The PR is easiest reviewed commit by commit.

# Open issues
Previously, fixture values were cached as part of *FixtureDef* objects and the cache entries contained a *cache_key*. The cache key is either *None* for non-parametrized fixtures or *SubRequest.param*. This allows invalidating cache entries when fixture parameters change.

Hoisting up the fixture cache to *SetupState* technically makes *FixtureDef* part of the cache key. This means we should use a two-dimensional index (e.g. tuple[FixtureDef, param]) to store entries in the fixture cache. Unfortunately, this is tricky, because *TopRequest* doesn't know about the current fixture param and therefore doesn't know the cache key. 

*This work has been done as part of the pytest sprint 2026, sponsored by [Omicron](https://www.omicronenergy.com).*