### PR TITLE
Fix AttributeError crash in Argument.dest on invalid option strings

### DIFF
--- a/changelog/14773.bugfix.rst
+++ b/changelog/14773.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a crash in ``Argument.dest`` when accessing an option with an invalid option string (for example, one that starts with a digit). Previously, this would raise an ``AttributeError`` because the underlying ``argparse.Action`` may not have a ``dest`` attribute when initialization fails.

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -302,7 +302,7 @@ class Argument:
 
     @property
     def dest(self) -> str:
-        return self._action.dest
+        return getattr(self._action, "dest", "<missing>")
 
     @property
     def default(self) -> Any:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -2487,6 +2487,21 @@ def test_help_formatter_uses_py_get_terminal_width(monkeypatch: MonkeyPatch) -> 
     assert formatter._width == 42
 
 
+def test_argument_dest_does_not_crash_on_invalid_option() -> None:
+    """``Argument.dest`` should not raise ``AttributeError`` when accessed on an
+    Action that failed to initialize (e.g. with an invalid option string)."""
+    from _pytest.config.argparsing import Argument
+
+    # Simulate the crash path: an option name that fails _set_opt_strings
+    # may result in an Action without a `dest` attribute.
+    class BrokenAction:
+        pass
+
+    action = BrokenAction()
+    arg = Argument(action)  # type: ignore[arg-type]
+    assert arg.dest == "<missing>"
+
+
 def test_config_does_not_load_blocked_plugin_from_args(pytester: Pytester) -> None:
     """This tests that pytest's config setup handles "-p no:X"."""
     p = pytester.makepyfile("def test(capfd): pass")


### PR DESCRIPTION
Fix AttributeError crash in Argument.dest on invalid option strings

When pytest_addoption registers an option name that argparse rejects
(e.g. one starting with a digit), Action.__init__ fails during
_set_opt_strings before self.dest is set. If Argument.dest then
reads self._action.dest, the secondary AttributeError hides the
original argparse error.

Fixed by using getattr(self._action, "dest", "<missing>") in the
dest property so a missing dest attribute does not cause a second
crash.

This complements #14429 by completing the fix RonnyPfannschmidt
originally requested on #13817.

Closes #13817
