### PR TITLE
Cache fixture setup failures that happen before the fixture function runs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -276,6 +276,7 @@ Kojo Idrissa
 Kostis Anagnostopoulos
 Kristoffer Nordström
 Kyle Altendorf
+Kyue
 Lawrence Mitchell
 Lee Kamentsky
 Leonardus Chen

--- a/changelog/14775.bugfix.rst
+++ b/changelog/14775.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an internal ``AssertionError`` that could occur when a fixture's setup fails before its underlying function is even called (e.g. when the class-scoped-fixture-as-instance-method deprecation warning is turned into an error via ``-W error``). The failure is now cached like any other setup error instead of leaking finalizer state into the next test.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1320,21 +1320,22 @@ def pytest_fixture_setup(
     for argname in fixturedef.argnames:
         kwargs[argname] = request.getfixturevalue(argname)
 
-    fixturefunc = resolve_fixture_function(fixturedef, request)
     my_cache_key = fixturedef.cache_key(request)
 
-    if inspect.isasyncgenfunction(fixturefunc) or inspect.iscoroutinefunction(
-        fixturefunc
-    ):
-        auto_str = " with autouse=True" if fixturedef._autouse else ""
-        fail(
-            f"{request.node.name!r} requested an async fixture {request.fixturename!r}{auto_str}, "
-            "with no plugin or hook that handled it. This is an error, as pytest does not natively support it.\n"
-            "See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture",
-            pytrace=False,
-        )
-
     try:
+        fixturefunc = resolve_fixture_function(fixturedef, request)
+
+        if inspect.isasyncgenfunction(fixturefunc) or inspect.iscoroutinefunction(
+            fixturefunc
+        ):
+            auto_str = " with autouse=True" if fixturedef._autouse else ""
+            fail(
+                f"{request.node.name!r} requested an async fixture {request.fixturename!r}{auto_str}, "
+                "with no plugin or hook that handled it. This is an error, as pytest does not natively support it.\n"
+                "See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture",
+                pytrace=False,
+            )
+
         result = call_fixture_func(fixturefunc, request, kwargs)
     except TEST_OUTCOME as e:
         if isinstance(e, skip.Exception):

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -3801,6 +3801,42 @@ class TestErrors:
         lines2 = failures[2].longrepr.reprtraceback.reprentries[0].lines
         assert len(lines1) == len(lines2)
 
+    def test_exception_before_fixture_func_called_is_cached(
+        self, pytester: Pytester
+    ) -> None:
+        """A failure that happens while resolving the fixture function itself
+        (e.g. a deprecation warning promoted to an error by ``-W error``, before
+        the fixture body ever runs) must be cached on the FixtureDef like any
+        other setup failure. Otherwise leftover finalizer state leaks into the
+        next test using the same class-scoped fixture and crashes pytest
+        internals instead of reporting the (repeated) original error (#14775).
+        """
+        pytester.makepyfile(
+            """
+            import pytest
+
+            class TestFixt:
+                @pytest.fixture(scope="class")
+                def fixt(self):
+                    yield
+
+                def test_1(self, fixt):
+                    pass
+
+                def test_2(self, fixt):
+                    pass
+            """
+        )
+        result = pytester.runpytest("-Werror")
+        result.assert_outcomes(errors=2)
+        assert "AssertionError" not in result.stdout.str()
+        result.stdout.fnmatch_lines(
+            [
+                "*PytestRemovedIn10Warning: Class-scoped fixtures defined as "
+                "instance methods are deprecated.*",
+            ]
+        )
+
 
 class TestShowFixtures:
     def test_funcarg_compat(self, pytester: Pytester) -> None:


### PR DESCRIPTION
yeah this one's a real crash, not just a bad error message.

`execute()` in `fixtures.py` registers the `pytest_fixture_post_finalizer` callback into `self._finalizers` (around line 1223) *before* calling `pytest_fixture_setup()`. But `pytest_fixture_setup()` only wraps `call_fixture_func()` in `try/except TEST_OUTCOME` — `resolve_fixture_function()` and the async-fixture `fail()` check both run *outside* that block. So if either of those raises, `cached_result` never gets set, and the finalizer already sitting in `self._finalizers` never gets popped (that only happens via `finish()`, which for a class-scoped fixture doesn't run until the class itself tears down, i.e. after the *next* test in the class already tried to set the fixture up again).

Next test hits `assert not self._finalizers` in `execute()` and pytest crashes internally instead of reporting the actual problem.

Easiest way to hit this right now: a class-scoped fixture defined as an instance method warns (the new deprecation from #14764), and under `-W error` that warning becomes an exception inside `resolve_fixture_function()`, before `call_fixture_func()` is ever reached. Repro is basically verbatim from the issue.

Fix: move `fixturefunc = resolve_fixture_function(...)` and the async check inside the existing `try/except`, so any setup failure — not just ones from inside the fixture body — gets cached the same way `call_fixture_func` failures already are. The second test then correctly re-raises the cached failure instead of tripping the assert.

Added a regression test in `TestErrors` (`testing/python/fixtures.py`) using the exact repro from the issue, asserting two clean errors instead of one clean error + one internal `AssertionError`. Checked it fails on main and passes with the fix by stashing/unstashing the fixtures.py change.

Ran `testing/python/` and `testing/deprecated_test.py` locally, all green. Didn't run the full tox suite (mypy/pyright not installed here) — the diff is just a reindent/reorder of existing statements into the try block, no new types involved, but flagging that I haven't run those specific checks.

Fixes #14775