### PR TITLE
Fix parameter mark precedence

### DIFF
--- a/changelog/10406.bugfix.rst
+++ b/changelog/10406.bugfix.rst
@@ -1,0 +1,3 @@
+Parameter-set marks now take precedence over marks on the test function,
+class, or module. This also fixes ``filterwarnings`` precedence across those
+levels while preserving the documented ordering of filters defined together.

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -344,9 +344,13 @@ class Node(abc.ABC, metaclass=NodeMeta):
         :returns: An iterator of (node, mark) tuples.
         """
         for node in self.iter_parents():
-            for mark in node.own_markers:
+            for mark in node._iter_own_markers_closest_first():
                 if name is None or getattr(mark, "name", None) == name:
                     yield node, mark
+
+    def _iter_own_markers_closest_first(self) -> Iterable[Mark]:
+        """Iterate over this node's markers from closest to farthest."""
+        return self.own_markers
 
     @overload
     def get_closest_marker(self, name: str) -> Mark | None: ...

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1634,7 +1634,10 @@ class Function(PyobjMixin, nodes.Item):
         # Note: when FunctionDefinition is introduced, we should change ``originalname``
         # to a readonly property that returns FunctionDefinition.name.
 
-        self.own_markers.extend(get_unpacked_marks(self.obj))
+        function_markers = get_unpacked_marks(self.obj)
+        self.own_markers.extend(function_markers)
+        self._function_markers_count = len(function_markers)
+        self._prepended_markers_count = 0
         if callspec:
             self.callspec = callspec
             self.own_markers.extend(callspec.marks)
@@ -1655,6 +1658,26 @@ class Function(PyobjMixin, nodes.Item):
         self._fixtureinfo: FuncFixtureInfo = fixtureinfo
         self.fixturenames = fixtureinfo.names_closure
         self._initrequest()
+
+    def add_marker(self, marker: str | MarkDecorator, append: bool = True) -> None:
+        super().add_marker(marker, append=append)
+        if not append:
+            self._prepended_markers_count += 1
+
+    def _iter_own_markers_closest_first(self) -> Iterator[Mark]:
+        """Yield parameter-set marks before function-level marks."""
+        if not hasattr(self, "callspec"):
+            yield from self.own_markers
+            return
+
+        function_start = self._prepended_markers_count
+        function_end = function_start + self._function_markers_count
+        callspec_end = function_end + len(self.callspec.marks)
+
+        yield from self.own_markers[:function_start]
+        yield from self.own_markers[function_end:callspec_end]
+        yield from self.own_markers[function_start:function_end]
+        yield from self.own_markers[callspec_end:]
 
     # todo: determine sound type limitations
     @classmethod

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -49,9 +49,13 @@ def catch_warnings_for_item(
         # apply filters from "filterwarnings" marks
         nodeid = "" if item is None else item.nodeid
         if item is not None:
-            for mark in item.iter_markers(name="filterwarnings"):
-                for arg in mark.args:
-                    warnings.filterwarnings(*parse_warning_filter(arg, escape=False))
+            for node in reversed(list(item.iter_parents())):
+                for mark in node.own_markers:
+                    if mark.name == "filterwarnings":
+                        for arg in mark.args:
+                            warnings.filterwarnings(
+                                *parse_warning_filter(arg, escape=False)
+                            )
 
         try:
             yield

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1133,6 +1133,7 @@ def test_mark_expressions_no_smear(pytester: Pytester) -> None:
 def test_addmarker_order(pytester) -> None:
     session = mock.Mock()
     session.own_markers = []
+    session._iter_own_markers_closest_first.return_value = session.own_markers
     session.parent = None
     session.nodeid = ""
     session.path = pytester.path
@@ -1180,6 +1181,39 @@ def test_markers_from_parametrize(pytester: Pytester) -> None:
 
     result = pytester.runpytest()
     result.assert_outcomes(passed=4)
+
+
+def test_parametrize_mark_is_closest(pytester: Pytester) -> None:
+    """Marks on a parameter set take precedence over function marks (#10406)."""
+    pytester.makepyfile(
+        """
+        import pytest
+
+        pytestmark = pytest.mark.priority("module")
+
+        @pytest.mark.priority("class")
+        class TestMarkers:
+            @pytest.mark.priority("function")
+            @pytest.mark.parametrize(
+                "value",
+                [pytest.param(None, marks=pytest.mark.priority("parametrize"))],
+            )
+            def test_mark_order(self, value, request):
+                priorities = [
+                    mark.args[0]
+                    for mark in request.node.iter_markers("priority")
+                ]
+                assert priorities == [
+                    "parametrize",
+                    "function",
+                    "class",
+                    "module",
+                ]
+        """
+    )
+
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
 
 
 def test_pytest_param_id_requires_string() -> None:

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -425,6 +425,54 @@ def test_option_precedence_mark(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(["* 1 failed in*"])
 
 
+def test_filterwarnings_mark_hierarchy_precedence(pytester: Pytester) -> None:
+    """The closest filterwarnings mark should take precedence (#10406)."""
+    pytester.makepyfile(
+        """
+        import warnings
+
+        import pytest
+
+
+        @pytest.mark.filterwarnings("error")
+        class TestWarnings:
+            @pytest.mark.parametrize(
+                "value",
+                [
+                    pytest.param(
+                        None,
+                        marks=pytest.mark.filterwarnings("ignore"),
+                    )
+                ],
+            )
+            def test_parametrize_over_class(self, value):
+                warnings.warn("parametrize over class")
+
+            @pytest.mark.filterwarnings("error")
+            @pytest.mark.parametrize(
+                "value",
+                [
+                    pytest.param(
+                        None,
+                        marks=pytest.mark.filterwarnings("ignore"),
+                    )
+                ],
+            )
+            def test_parametrize_over_function(self, value):
+                warnings.warn("parametrize over function")
+
+
+        @pytest.mark.filterwarnings("ignore:specific")
+        @pytest.mark.filterwarnings("error")
+        def test_same_level_decorator_order():
+            warnings.warn("specific")
+        """
+    )
+
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=3)
+
+
 def test_accept_unknown_category(pytester: Pytester) -> None:
     """Category types that can't be imported don't cause failure (#13732)."""
     pytester.makeini(


### PR DESCRIPTION
Closes #10406.

## Summary

Parameter-set marks should be more specific than marks applied to the test function, class, or module.

This change:

- makes `iter_markers()` yield callspec/parameter-set marks before function-level marks;
- preserves the existing `own_markers` storage order for compatibility;
- applies `filterwarnings` marks from farthest to closest so the most specific filter wins;
- preserves documented ordering between filters defined at the same level;
- adds regression tests and a changelog entry.

## Root cause

`Function.own_markers` stores function marks before callspec marks, causing `iter_markers()` to report the function mark as more specific.

Additionally, `warnings.filterwarnings()` inserts filters at the front. Processing closest marks first therefore allowed farther class or module filters to override them. In some function-level cases, these two ordering errors accidentally cancelled each other.

## Testing

- `testing/test_mark.py` and `testing/test_warnings.py`: 164 passed, 4 skipped, 1 xfailed
- `testing/test_nodes.py` and `testing/python`: 660 passed, 6 skipped, 3 xfailed
- Ruff, formatting, mypy, codespell, and the changed-file pre-commit checks passed
- `git diff --check` passed

## Checklist

- [x] Added regression tests.
- [x] Added a changelog entry.
- [x] Included `Closes #10406`.
- [x] Credited AI assistance using a `Co-authored-by` commit trailer.
- [x] Maintainers may push changes and squash when merging.
