### PR TITLE
Avoid traceback formatting for xfail(run=False)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@ Aaron Coleman
 Abdeali JK
 Abdelrahman Elbehery
 Abhijeet Kasurde
+ace2016
 Adam Johnson
 Adam Stewart
 Adam Uhlir

--- a/changelog/9436.improvement.rst
+++ b/changelog/9436.improvement.rst
@@ -1,0 +1,1 @@
+Avoided formatting tracebacks for tests marked with ``xfail(run=False)``.

--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -252,7 +252,7 @@ def pytest_runtest_setup(item: Item) -> None:
 
     item.stash[xfailed_key] = xfailed = evaluate_xfail_marks(item)
     if xfailed and not item.config.option.runxfail and not xfailed.run:
-        xfail("[NOTRUN] " + xfailed.reason)
+        raise xfail.Exception("[NOTRUN] " + xfailed.reason, pytrace=False)
 
 
 @hookimpl(wrapper=True)
@@ -262,7 +262,7 @@ def pytest_runtest_call(item: Item) -> Generator[None]:
         item.stash[xfailed_key] = xfailed = evaluate_xfail_marks(item)
 
     if xfailed and not item.config.option.runxfail and not xfailed.run:
-        xfail("[NOTRUN] " + xfailed.reason)
+        raise xfail.Exception("[NOTRUN] " + xfailed.reason, pytrace=False)
 
     try:
         return (yield)

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import textwrap
 
+from _pytest._code import ExceptionInfo
 from _pytest.pytester import Pytester
 from _pytest.runner import runtestprotocol
 from _pytest.skipping import evaluate_skip_marks
@@ -452,6 +453,32 @@ class TestXFail:
                 "*1 passed*",
             ]
         )
+
+    def test_xfail_not_run_does_not_format_traceback(
+        self, pytester: Pytester, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        item = pytester.getitem(
+            """
+            import pytest
+
+            @pytest.mark.xfail(run=False, reason="noway")
+            def test_func():
+                assert 0
+            """
+        )
+        getrepr = ExceptionInfo.getrepr
+        styles = []
+
+        def spy_getrepr(self, *args, **kwargs):
+            styles.append(kwargs["style"])
+            return getrepr(self, *args, **kwargs)
+
+        monkeypatch.setattr(ExceptionInfo, "getrepr", spy_getrepr)
+
+        reports = runtestprotocol(item, log=False)
+
+        assert reports[0].skipped
+        assert styles == ["value"]
 
     def test_xfail_not_run_no_setup_run(self, pytester: Pytester) -> None:
         p = pytester.makepyfile(


### PR DESCRIPTION
Closes #9436.

## Summary

Tests marked with `xfail(run=False)` stop before execution by raising pytest's
internal xfail exception. That exception previously used `pytrace=True`, so
report generation formatted a full traceback even though the xfail report only
displays the `[NOTRUN]` reason.

Raise the same internal exception with `pytrace=False` in both the setup path
and the dynamically evaluated call path. This uses pytest's existing
value-only outcome formatting and leaves imperative `pytest.xfail()`, normal
failures, and the report pipeline unchanged.

A regression test verifies that `xfail(run=False)` requests value-only
formatting instead of long traceback formatting.

## Testing

- `python -m pytest -p no:asyncio testing/test_skipping.py testing/test_reports.py -q`
  - 116 passed
- Changed-file pre-commit hooks passed, including Ruff, formatting, codespell,
  and mypy.
- `git diff --check` passed.


## Checklist

- [x] Include documentation when adding new features.
      Not applicable because this is an internal performance improvement.
- [x] Include new tests or update existing tests when applicable.
- [x] Allow maintainers to push and squash when merging my commits.
- [x] Add `Closes #9436` to the PR description.
- [x] If AI agents were used, they are credited in `Co-authored-by` commit trailers.
- [x] Create `changelog/9436.improvement.rst`.
- [x] Add myself to `AUTHORS` in alphabetical order.