### PR TITLE
Fix marker precedence for parametrized tests

### DIFF
--- a/changelog/10406.bugfix.rst
+++ b/changelog/10406.bugfix.rst
@@ -1,0 +1,1 @@
+Parameter-set marks now take precedence over less specific function, class, and module marks when pytest resolves markers and per-test ``filterwarnings`` overrides.

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -344,9 +344,17 @@ class Node(abc.ABC, metaclass=NodeMeta):
         :returns: An iterator of (node, mark) tuples.
         """
         for node in self.iter_parents():
-            for mark in node.own_markers:
+            for mark in node._iter_own_markers_closest_first():
                 if name is None or getattr(mark, "name", None) == name:
                     yield node, mark
+
+    def _iter_own_markers_closest_first(self) -> Iterator[Mark]:
+        """Iterate this node's markers from closest to farthest."""
+        yield from self.own_markers
+
+    def _iter_own_markers_farthest_first(self) -> Iterator[Mark]:
+        """Iterate this node's markers from farthest to closest."""
+        yield from self.own_markers
 
     @overload
     def get_closest_marker(self, name: str) -> Mark | None: ...

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1706,10 +1706,14 @@ class Function(PyobjMixin, nodes.Item):
         # Note: when FunctionDefinition is introduced, we should change ``originalname``
         # to a readonly property that returns FunctionDefinition.name.
 
+        self._prepended_mark_count = 0
         self.own_markers.extend(get_unpacked_marks(self.obj))
+        self._static_function_mark_count = len(self.own_markers)
+        self._callspec_mark_count = 0
         if callspec:
             self.callspec = callspec
             self.own_markers.extend(callspec.marks)
+            self._callspec_mark_count = len(callspec.marks)
 
         # todo: this is a hell of a hack
         # https://github.com/pytest-dev/pytest/issues/4569
@@ -1733,6 +1737,39 @@ class Function(PyobjMixin, nodes.Item):
     def from_parent(cls, parent, **kw) -> Self:
         """The public constructor."""
         return super().from_parent(parent=parent, **kw)
+
+    def add_marker(self, marker: str | MarkDecorator, append: bool = True) -> None:
+        super().add_marker(marker=marker, append=append)
+        if not append:
+            self._prepended_mark_count += 1
+
+    def _iter_own_markers_closest_first(self) -> Iterator[Mark]:
+        if not self._callspec_mark_count:
+            yield from self.own_markers
+            return
+
+        prepended_end = self._prepended_mark_count
+        static_end = prepended_end + self._static_function_mark_count
+        callspec_end = static_end + self._callspec_mark_count
+
+        yield from self.own_markers[:prepended_end]
+        yield from self.own_markers[static_end:callspec_end]
+        yield from self.own_markers[prepended_end:static_end]
+        yield from self.own_markers[callspec_end:]
+
+    def _iter_own_markers_farthest_first(self) -> Iterator[Mark]:
+        if not self._callspec_mark_count and not self._prepended_mark_count:
+            yield from self.own_markers
+            return
+
+        prepended_end = self._prepended_mark_count
+        static_end = prepended_end + self._static_function_mark_count
+        callspec_end = static_end + self._callspec_mark_count
+
+        yield from self.own_markers[callspec_end:]
+        yield from self.own_markers[prepended_end:static_end]
+        yield from self.own_markers[static_end:callspec_end]
+        yield from self.own_markers[:prepended_end]
 
     def _initrequest(self) -> None:
         self.funcargs: dict[str, object] = {}

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -34,9 +34,14 @@ def catch_warnings_for_item(
         # apply filters from "filterwarnings" marks
         nodeid = "" if item is None else item.nodeid
         if item is not None:
-            for mark in item.iter_markers(name="filterwarnings"):
-                for arg in mark.args:
-                    warnings.filterwarnings(*parse_warning_filter(arg, escape=False))
+            for node in reversed(list(item.iter_parents())):
+                for mark in node._iter_own_markers_farthest_first():
+                    if mark.name != "filterwarnings":
+                        continue
+                    for arg in mark.args:
+                        warnings.filterwarnings(
+                            *parse_warning_filter(arg, escape=False)
+                        )
 
         try:
             yield

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1184,26 +1184,9 @@ def test_markers_from_parametrize(pytester: Pytester) -> None:
 
 
 def test_parametrize_marks_are_closest(pytester: Pytester) -> None:
-    pytester.makepyfile(
-        """
-        import pytest
-
-        @pytest.mark.custom_mark("module")
-        class TestMarkers:
-            @pytest.mark.custom_mark("function")
-            @pytest.mark.parametrize(
-                "_",
-                [pytest.param(None, marks=pytest.mark.custom_mark("parametrize"))],
-            )
-            def test_marker_order(self, _, request):
-                assert [mark.args[0] for mark in request.node.iter_markers("custom_mark")] == [
-                    "parametrize",
-                    "function",
-                    "module",
-                ]
-                assert request.node.get_closest_marker("custom_mark").args[0] == "parametrize"
-    """
-    )
+    # fmt: off
+    pytester.makepyfile('import pytest\n@pytest.mark.custom_mark("module")\nclass TestMarkers:\n    @pytest.mark.custom_mark("function")\n    @pytest.mark.parametrize("_", [pytest.param(None, marks=pytest.mark.custom_mark("parametrize"))])\n    def test_marker_order(self, _, request):\n        assert [mark.args[0] for mark in request.node.iter_markers("custom_mark")] == ["parametrize", "function", "module"]\n        assert request.node.get_closest_marker("custom_mark").args[0] == "parametrize"\n')  # noqa: E501
+    # fmt: on
     result = pytester.runpytest()
     result.assert_outcomes(passed=1)
 

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1133,6 +1133,7 @@ def test_mark_expressions_no_smear(pytester: Pytester) -> None:
 def test_addmarker_order(pytester) -> None:
     session = mock.Mock()
     session.own_markers = []
+    session._iter_own_markers_closest_first.return_value = iter(())
     session.parent = None
     session.nodeid = ""
     session.path = pytester.path
@@ -1180,6 +1181,31 @@ def test_markers_from_parametrize(pytester: Pytester) -> None:
 
     result = pytester.runpytest()
     result.assert_outcomes(passed=4)
+
+
+def test_parametrize_marks_are_closest(pytester: Pytester) -> None:
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.custom_mark("module")
+        class TestMarkers:
+            @pytest.mark.custom_mark("function")
+            @pytest.mark.parametrize(
+                "_",
+                [pytest.param(None, marks=pytest.mark.custom_mark("parametrize"))],
+            )
+            def test_marker_order(self, _, request):
+                assert [mark.args[0] for mark in request.node.iter_markers("custom_mark")] == [
+                    "parametrize",
+                    "function",
+                    "module",
+                ]
+                assert request.node.get_closest_marker("custom_mark").args[0] == "parametrize"
+    """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
 
 
 def test_pytest_param_id_requires_string() -> None:

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -210,86 +210,27 @@ def test_filterwarnings_mark(pytester: Pytester, default_config) -> None:
 
 
 def test_filterwarnings_parametrize_mark_is_most_specific(pytester: Pytester) -> None:
-    pytester.makepyfile(
-        """
-        import pytest
-        import warnings
-
-        @pytest.mark.filterwarnings("error")
-        class TestMarkClass:
-            @pytest.mark.parametrize(
-                "_",
-                [pytest.param(None, marks=pytest.mark.filterwarnings("ignore"))],
-            )
-            def test_class_mark(self, _):
-                warnings.warn("class")
-
-        class TestMarkMethods:
-            @pytest.mark.filterwarnings("error")
-            @pytest.mark.parametrize(
-                "_",
-                [pytest.param(None, marks=pytest.mark.filterwarnings("ignore"))],
-            )
-            def test_function_mark_before_parametrize(self, _):
-                warnings.warn("function-before")
-
-            @pytest.mark.parametrize(
-                "_",
-                [pytest.param(None, marks=pytest.mark.filterwarnings("ignore"))],
-            )
-            @pytest.mark.filterwarnings("error")
-            def test_function_mark_after_parametrize(self, _):
-                warnings.warn("function-after")
-    """
-    )
-    result = pytester.runpytest_subprocess("-q")
-
+    # fmt: off
+    pytester.makepyfile('import pytest\nimport warnings\n@pytest.mark.filterwarnings("error")\nclass TestMarkClass:\n    @pytest.mark.parametrize("_", [pytest.param(None, marks=pytest.mark.filterwarnings("ignore"))])\n    def test_class_mark(self, _):\n        warnings.warn("class")\nclass TestMarkMethods:\n    @pytest.mark.filterwarnings("error")\n    @pytest.mark.parametrize("_", [pytest.param(None, marks=pytest.mark.filterwarnings("ignore"))])\n    def test_function_mark_before_parametrize(self, _):\n        warnings.warn("function-before")\n    @pytest.mark.parametrize("_", [pytest.param(None, marks=pytest.mark.filterwarnings("ignore"))])\n    @pytest.mark.filterwarnings("error")\n    def test_function_mark_after_parametrize(self, _):\n        warnings.warn("function-after")\n')  # noqa: E501
+    # fmt: on
+    result = pytester.runpytest("-q")
     result.stdout.fnmatch_lines(["*3 passed*"])
 
 
 def test_filterwarnings_mark_preserves_decorator_order(pytester: Pytester) -> None:
-    pytester.makepyfile(
-        """
-        import pytest
-        import warnings
-
-        @pytest.mark.filterwarnings("ignore:api v1")
-        @pytest.mark.filterwarnings("error")
-        def test_decorator_order():
-            warnings.warn(UserWarning("api v1"))
-    """
-    )
-    result = pytester.runpytest_subprocess("-q")
-
+    # fmt: off
+    pytester.makepyfile('import pytest\nimport warnings\n@pytest.mark.filterwarnings("ignore:api v1")\n@pytest.mark.filterwarnings("error")\ndef test_decorator_order():\n    warnings.warn(UserWarning("api v1"))\n')  # noqa: E501
+    # fmt: on
+    result = pytester.runpytest("-q")
     result.stdout.fnmatch_lines(["*1 passed*"])
 
 
 def test_filterwarnings_prepend_mark_is_most_specific(pytester: Pytester) -> None:
-    pytester.makeconftest(
-        """
-        import pytest
-
-        def pytest_collection_modifyitems(items):
-            for item in items:
-                item.add_marker(pytest.mark.filterwarnings("error"), append=False)
-    """
-    )
-    pytester.makepyfile(
-        """
-        import pytest
-        import warnings
-
-        @pytest.mark.parametrize(
-            "_",
-            [pytest.param(None, marks=pytest.mark.filterwarnings("ignore"))],
-        )
-        def test_prepend_mark(_, request):
-            assert request.node.get_closest_marker("filterwarnings").args[0] == "error"
-            warnings.warn("prepend")
-    """
-    )
-    result = pytester.runpytest_subprocess("-q")
-
+    # fmt: off
+    pytester.makeconftest('import pytest\ndef pytest_collection_modifyitems(items):\n    for item in items:\n        item.add_marker(pytest.mark.filterwarnings("error"), append=False)\n')  # noqa: E501
+    pytester.makepyfile('import pytest\nimport warnings\n@pytest.mark.parametrize("_", [pytest.param(None, marks=pytest.mark.filterwarnings("ignore"))])\ndef test_prepend_mark(_, request):\n    assert request.node.get_closest_marker("filterwarnings").args[0] == "error"\n    warnings.warn("prepend")\n')  # noqa: E501
+    # fmt: on
+    result = pytester.runpytest("-q")
     result.stdout.fnmatch_lines(["*1 failed in *"])
 
 

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -209,6 +209,90 @@ def test_filterwarnings_mark(pytester: Pytester, default_config) -> None:
     result.stdout.fnmatch_lines(["*= 1 failed, 2 passed, 1 warning in *"])
 
 
+def test_filterwarnings_parametrize_mark_is_most_specific(pytester: Pytester) -> None:
+    pytester.makepyfile(
+        """
+        import pytest
+        import warnings
+
+        @pytest.mark.filterwarnings("error")
+        class TestMarkClass:
+            @pytest.mark.parametrize(
+                "_",
+                [pytest.param(None, marks=pytest.mark.filterwarnings("ignore"))],
+            )
+            def test_class_mark(self, _):
+                warnings.warn("class")
+
+        class TestMarkMethods:
+            @pytest.mark.filterwarnings("error")
+            @pytest.mark.parametrize(
+                "_",
+                [pytest.param(None, marks=pytest.mark.filterwarnings("ignore"))],
+            )
+            def test_function_mark_before_parametrize(self, _):
+                warnings.warn("function-before")
+
+            @pytest.mark.parametrize(
+                "_",
+                [pytest.param(None, marks=pytest.mark.filterwarnings("ignore"))],
+            )
+            @pytest.mark.filterwarnings("error")
+            def test_function_mark_after_parametrize(self, _):
+                warnings.warn("function-after")
+    """
+    )
+    result = pytester.runpytest_subprocess("-q")
+
+    result.stdout.fnmatch_lines(["*3 passed*"])
+
+
+def test_filterwarnings_mark_preserves_decorator_order(pytester: Pytester) -> None:
+    pytester.makepyfile(
+        """
+        import pytest
+        import warnings
+
+        @pytest.mark.filterwarnings("ignore:api v1")
+        @pytest.mark.filterwarnings("error")
+        def test_decorator_order():
+            warnings.warn(UserWarning("api v1"))
+    """
+    )
+    result = pytester.runpytest_subprocess("-q")
+
+    result.stdout.fnmatch_lines(["*1 passed*"])
+
+
+def test_filterwarnings_prepend_mark_is_most_specific(pytester: Pytester) -> None:
+    pytester.makeconftest(
+        """
+        import pytest
+
+        def pytest_collection_modifyitems(items):
+            for item in items:
+                item.add_marker(pytest.mark.filterwarnings("error"), append=False)
+    """
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+        import warnings
+
+        @pytest.mark.parametrize(
+            "_",
+            [pytest.param(None, marks=pytest.mark.filterwarnings("ignore"))],
+        )
+        def test_prepend_mark(_, request):
+            assert request.node.get_closest_marker("filterwarnings").args[0] == "error"
+            warnings.warn("prepend")
+    """
+    )
+    result = pytester.runpytest_subprocess("-q")
+
+    result.stdout.fnmatch_lines(["*1 failed in *"])
+
+
 def test_non_string_warning_argument(pytester: Pytester) -> None:
     """Non-str argument passed to warning breaks pytest (#2956)"""
     pytester.makepyfile(


### PR DESCRIPTION
## Summary

- make callspec markers override function, class, and module markers
- apply warning filters from farthest to closest while preserving same-node decorator order
- add regression tests for parametrized marker and warning-filter precedence

## Validation

- `testing/test_mark.py testing/test_warnings.py` (168 passed, 4 skipped, 1 xfailed)
- `testing/test_recwarn.py` (67 passed)
- pre-commit on all touched files, including mypy
- full suite: 4207 passed; one unrelated Windows `pydoc` encoding failure

Closes #10406