### PR TITLE
docs: explain filesystem tests in frozen applications

### DIFF
--- a/changelog/14771.doc.rst
+++ b/changelog/14771.doc.rst
@@ -1,0 +1,3 @@
+Clarify that frozen applications must expose test modules as filesystem data
+for pytest to collect them; hidden imports inside an embedded archive are not
+sufficient for ``--pyargs`` collection.

--- a/doc/en/example/simple.rst
+++ b/doc/en/example/simple.rst
@@ -1048,6 +1048,32 @@ such as ``cx_freeze`` or ``py2exe``, you can use ``pytest.freeze_includes()``
 to obtain the full list of internal pytest modules. How to configure the tools
 to find the internal modules varies from tool to tool, however.
 
+Test modules must still be available as files for pytest to collect them.
+Adding a test package as a PyInstaller hidden import makes it importable from
+the embedded Python archive, but does not expose the test source files to
+pytest's filesystem-based collectors. Consequently, ``--pyargs`` cannot
+collect tests which exist only inside that archive.
+
+Package the test sources as data, or distribute them next to the frozen
+application. For example, with PyInstaller:
+
+.. code-block:: bash
+
+    pyinstaller --add-data "myapp/test:myapp/test" app_main.py
+
+The frozen application can locate data files relative to its ``__file__`` and
+pass that filesystem path to pytest:
+
+.. code-block:: python
+
+    import sys
+    from pathlib import Path
+
+    import pytest
+
+    tests = Path(__file__).resolve().parent / "myapp" / "test"
+    sys.exit(pytest.main([*sys.argv[2:], str(tests)]))
+
 Instead of freezing the pytest runner as a separate executable, you can make
 your frozen program work as the pytest runner by some clever
 argument handling during program startup. This allows you to


### PR DESCRIPTION
## Summary

- Explain why tests stored only inside a PyInstaller PYZ archive are not visible to pytest's filesystem-based collectors.
- Show how to bundle test sources as filesystem data with `--add-data`.
- Resolve the bundled test directory relative to `__file__` and pass that path to `pytest.main()`.

## Why

`--pyargs` can resolve importable packages, but pytest still needs filesystem paths when collecting Python test modules. The documentation now makes that boundary explicit and gives frozen applications a supported filesystem-backed layout.

Related to #14771.

## Validation

- `uvx tox -e docs -- --show-traceback` (256 documentation sources, warnings treated as errors)
- targeted pre-commit hooks for both changed files
- `uvx towncrier build --draft --version 9.2.0`
- `git diff --check`

## AI assistance

OpenAI Codex assisted with drafting the documentation change and running validation. The human contributor reviewed the complete diff and validation results before this draft pull request was opened and takes responsibility for the contribution.