### PR TITLE
Fix finalizer state after fixture setup errors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -143,6 +143,7 @@ Denivy Braiam Rück
 Deysha Rivera
 Dheeraj C K
 Dhiren Serai
+Dresden
 Diego Russo
 Dima Gerasimov
 Dmitry Dygalo

--- a/changelog/14775.bugfix.rst
+++ b/changelog/14775.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an internal ``AssertionError`` that could occur when a class-scoped fixture defined as an instance method raised its deprecation warning as an error.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1205,11 +1205,6 @@ class FixtureDef(Generic[FixtureValue]):
         self._finalizers.append(finalizer)
 
     def finish(self, request: SubRequest) -> None:
-        if self.cached_result is None:
-            # Already finished. It is assumed that finalizers cannot be added in
-            # this state.
-            return
-
         exceptions: list[BaseException] = []
         while self._finalizers:
             fin = self._finalizers.pop()
@@ -1280,11 +1275,11 @@ class FixtureDef(Generic[FixtureValue]):
         # Register the pytest_fixture_post_finalizer as the first finalizer,
         # which is executed last.
         assert not self._finalizers
-        self.addfinalizer(
-            lambda: request.node.ihook.pytest_fixture_post_finalizer(
+        def post_finalizer() -> None:
+            request.node.ihook.pytest_fixture_post_finalizer(
                 fixturedef=self, request=request
             )
-        )
+        self.addfinalizer(post_finalizer)
 
         ihook = request.node.ihook
         try:
@@ -1293,6 +1288,9 @@ class FixtureDef(Generic[FixtureValue]):
             result: FixtureValue = ihook.pytest_fixture_setup(
                 fixturedef=self, request=request
             )
+        except BaseException:
+            self._finalizers.remove(post_finalizer)
+            raise
         finally:
             # Schedule our finalizer, even if the setup failed.
             request.node.addfinalizer(finalizer)

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1275,10 +1275,12 @@ class FixtureDef(Generic[FixtureValue]):
         # Register the pytest_fixture_post_finalizer as the first finalizer,
         # which is executed last.
         assert not self._finalizers
+
         def post_finalizer() -> None:
             request.node.ihook.pytest_fixture_post_finalizer(
                 fixturedef=self, request=request
             )
+
         self.addfinalizer(post_finalizer)
 
         ihook = request.node.ihook

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -99,15 +99,19 @@ def test_class_scope_instance_method_is_deprecated(pytester: Pytester) -> None:
 
             def test_foo(self, fix):
                 pass
+
+            def test_bar(self, fix):
+                pass
         """
     )
     result = pytester.runpytest("-Werror::pytest.PytestRemovedIn10Warning")
-    result.assert_outcomes(errors=1)
+    result.assert_outcomes(errors=2)
     result.stdout.fnmatch_lines(
         [
             "*PytestRemovedIn10Warning: Class-scoped fixtures defined as instance methods*"
         ]
     )
+    result.stdout.no_fnmatch_line("*AssertionError*")
 
 
 def test_class_scope_classmethod_fixture_not_deprecated(pytester: Pytester) -> None:


### PR DESCRIPTION
Fixes #14775.

When fixture setup raises before `cached_result` is set, the fixture post-finalizer remains in `_finalizers`. A later request for the same class-scoped fixture then trips the internal assertion.

Clear the fixture-local finalizers on setup failure and add a regression case with two tests under `-Werror`.

Tests:
- `python -m pytest testing/deprecated_test.py::test_class_scope_instance_method_is_deprecated -q`