### PR TITLE
fix(config): raise UsageError for invalid or missing -c/--config-file paths

### DIFF
--- a/changelog/14793.bugfix.rst
+++ b/changelog/14793.bugfix.rst
@@ -1,0 +1,1 @@
+Raise a clean :class:`~_pytest.config.UsageError` when explicit ``-c`` or ``--config-file`` paths do not exist or have unparseable configurations.

--- a/changelog/14793.bugfix.rst
+++ b/changelog/14793.bugfix.rst
@@ -1,1 +1,1 @@
-Raise a clean :class:`~_pytest.config.UsageError` when explicit ``-c`` or ``--config-file`` paths do not exist or have unparseable configurations.
+Raise a clean :class:`~_pytest.config.UsageError` when explicit ``-c`` or ``--config-file`` paths do not exist or have unparsable configurations.

--- a/src/_pytest/config/findpaths.py
+++ b/src/_pytest/config/findpaths.py
@@ -44,14 +44,13 @@ ConfigDict: TypeAlias = dict[str, ConfigValue]
 
 
 def _parse_ini_config(path: Path) -> iniconfig.IniConfig:
-    """Parse the given generic '.ini' file using legacy IniConfig parser, returning
-    the parsed object.
+    """Parse an ini file.
 
     Raise UsageError if the file cannot be parsed.
     """
     try:
         return iniconfig.IniConfig(str(path))
-    except iniconfig.ParseError as exc:
+    except (FileNotFoundError, iniconfig.ParseError) as exc:
         raise UsageError(str(exc)) from exc
 
 
@@ -313,8 +312,12 @@ def determine_setup(
 
     if inifile:
         inipath_ = absolutepath(inifile)
+        if not inipath_.is_file():
+            raise UsageError(f"Config file not found: {inipath_}")
         inipath: Path | None = inipath_
-        inicfg = load_config_dict_from_file(inipath_) or {}
+        inicfg = load_config_dict_from_file(inipath_)
+        if inicfg is None:
+            raise UsageError(f"Unrecognized or invalid config file: {inipath_}")
         if rootdir_cmd_arg is None:
             rootdir = inipath_.parent
     else:


### PR DESCRIPTION
## Description
This PR resolves issue #14716 by validating explicit `-c`/`--config-file` paths in `src/_pytest/config/findpaths.py`.

## Details
- Converts uncaught `FileNotFoundError` into a clean `UsageError`.
- Raises `UsageError` when an explicit `--config-file` path does not exist or has an unrecognized extension instead of silently falling back.