### PR TITLE
feat(assertion): set type='int' for truncation_limit_lines and truncation_limit_chars ini options

### DIFF
--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -51,11 +51,13 @@ def pytest_addoption(parser: Parser) -> None:
 
     parser.addini(
         "truncation_limit_lines",
+        type="int",
         default=None,
         help="Set threshold of LINES after which truncation will take effect",
     )
     parser.addini(
         "truncation_limit_chars",
+        type="int",
         default=None,
         help=("Set threshold of CHARS after which truncation will take effect"),
     )


### PR DESCRIPTION
## Description
This PR resolves issue #14675 by setting `type="int"` for `truncation_limit_lines` and `truncation_limit_chars` ini options in `src/_pytest/assertion/__init__.py`.

## Details
- Allows TOML configuration files (`pyproject.toml`, `pytest.toml`) to specify integer values for truncation limits without raising a `TypeError`.