### PR TITLE
fix(mark): handle non-tuple non-list values in ParameterSet.extract_from

### DIFF
--- a/changelog/14795.bugfix.rst
+++ b/changelog/14795.bugfix.rst
@@ -1,0 +1,1 @@
+Handle non-tuple and non-list parameter items cleanly in :meth:`ParameterSet.extract_from` when single parameter names use trailing commas in :func:`pytest.mark.parametrize`.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -154,13 +154,10 @@ class ParameterSet(NamedTuple):
             return parameterset
         if force_tuple:
             return cls.param(parameterset)
+        elif isinstance(parameterset, (tuple, list)):
+            return cls(parameterset, marks=[], id=None)
         else:
-            # TODO: Refactor to fix this type-ignore. Currently the following
-            # passes type-checking but crashes:
-            #
-            #   @pytest.mark.parametrize(('x', 'y'), [1, 2])
-            #   def test_foo(x, y): pass
-            return cls(parameterset, marks=[], id=None)  # type: ignore[arg-type]
+            return cls((parameterset,), marks=[], id=None)
 
     @staticmethod
     def _parse_parametrize_args(


### PR DESCRIPTION
## Description
This PR resolves issue #14619 by wrapping non-tuple and non-list items in a 1-tuple in `ParameterSet.extract_from()` in `src/_pytest/mark/structures.py`.

## Details
- Prevents `TypeError: object of type 'NoneType' has no len()` when `None` or single non-tuple values are passed to `parametrize` with trailing-comma parameter names (e.g. `@pytest.mark.parametrize("x,", [None, ...])`).