### PR TITLE
Accept integer TOML truncation limits

### DIFF
--- a/changelog/14675.improvement.rst
+++ b/changelog/14675.improvement.rst
@@ -1,0 +1,1 @@
+Native TOML integer values are now accepted for the :confval:`truncation_limit_lines` and :confval:`truncation_limit_chars` configuration options.

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -51,11 +51,13 @@ def pytest_addoption(parser: Parser) -> None:
 
     parser.addini(
         "truncation_limit_lines",
+        type=int | str,
         default=None,
         help="Set threshold of LINES after which truncation will take effect",
     )
     parser.addini(
         "truncation_limit_chars",
+        type=int | str,
         default=None,
         help=("Set threshold of CHARS after which truncation will take effect"),
     )

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1796,10 +1796,12 @@ class TestTruncateExplanation:
             (1000, 0, 0),
         ),
     )
-    def test_truncation_with_ini(
+    @pytest.mark.parametrize("config_format", ["ini", "toml"])
+    def test_truncation_with_config(
         self,
         monkeypatch,
         pytester: Pytester,
+        config_format: str,
         truncation_lines: int | None,
         truncation_chars: int | None,
         expected_lines_hidden: int,
@@ -1820,12 +1822,15 @@ class TestTruncateExplanation:
 
         monkeypatch.delenv("CI", raising=False)
 
-        ini = "[pytest]\n"
+        ini = "[pytest]\n" if config_format == "ini" else "[tool.pytest]\n"
         if truncation_lines is not None:
             ini += f"truncation_limit_lines = {truncation_lines}\n"
         if truncation_chars is not None:
             ini += f"truncation_limit_chars = {truncation_chars}\n"
-        pytester.makeini(ini)
+        if config_format == "ini":
+            pytester.makeini(ini)
+        else:
+            pytester.makepyprojecttoml(ini)
 
         result = pytester.runpytest()
 


### PR DESCRIPTION
Fixes #14675.

Register `truncation_limit_lines` and `truncation_limit_chars` as `int | str`. This accepts native TOML integers while preserving existing string-based configuration formats and `-o` overrides.

The truncation consumer already converts both values with `int()`. The regression test now runs the existing threshold cases against both INI and native TOML configuration.

Tests:
- `PYTHONPATH=src python -m pytest -q testing/test_assertion.py::TestTruncateExplanation::test_truncation_with_config`