### PR TITLE
fix: propagate pytestmark from __init__.py to Package collector

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -696,6 +696,12 @@ class Package(nodes.Directory):
     def setup(self) -> None:
         init_mod = importtestmodule(self.path / "__init__.py", self.config)
 
+        # Read pytestmark from the __init__.py module.
+        init_marks = get_unpacked_marks(init_mod)
+        if init_marks:
+            self.own_markers.extend(init_marks)
+            self.keywords.update((mark.name, mark) for mark in init_marks)
+
         # Not using fixtures to call setup_module here because autouse fixtures
         # from packages are not called automatically (#4085).
         setup_module = _get_first_non_fixture_func(


### PR DESCRIPTION
## Fixes #14737

### Problem
When a `pytestmark` is defined in a package's `__init__.py`, it is no longer propagated to tests within that package. This worked in earlier versions but was broken by a refactoring.

### Root Cause
`Package.setup()` imports the `__init__.py` module via `importtestmodule()` but never reads the `pytestmark` attribute from it. The `get_unpacked_marks()` function (already imported) is used elsewhere (e.g., in `PyobjMixin._filter_with_own_markers`) to extract marks from module objects, but was never called for the `__init__.py` module in `Package.setup()`.

### Fix
Added `get_unpacked_marks(init_mod)` call in `Package.setup()` after importing the `__init__.py` module. The extracted marks are added to `self.own_markers` and `self.keywords`, which is consistent with how other collectors handle marks (see `PyobjMixin` at line 313 and `FunctionDefinition.__init__` at line 1709).

### Testing
- `pytestmark = pytest.mark.skip(reason="package skip")` in `__init__.py` now correctly skips tests in the package
- `iter_markers()` on package-level markers now includes marks from `__init__.py`
- All existing tests should pass as this is purely additive