### PR TITLE
docs: document multiple positional conditions for skipif/xfail

### DIFF
--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -228,10 +228,14 @@ pytest.mark.skipif
 
 Skip a test function if a condition is ``True``.
 
-.. py:function:: pytest.mark.skipif(condition, *, reason=None)
+.. py:function:: pytest.mark.skipif(condition, *conditions, reason=None)
 
     :type condition: bool or str
     :param condition: ``True/False`` if the condition should be skipped or a :ref:`condition string <string conditions>`.
+    :type conditions: bool or str
+    :param conditions:
+        Additional conditions, evaluated the same way as ``condition``. The test is
+        skipped if *any* of the conditions evaluate to ``True``.
     :keyword str reason: Reason why the test function is being skipped.
 
 
@@ -266,12 +270,15 @@ pytest.mark.xfail
 
 Marks a test function as *expected to fail*.
 
-.. py:function:: pytest.mark.xfail(condition=True, *, reason=None, raises=None, run=True, strict=strict_xfail)
+.. py:function:: pytest.mark.xfail(condition=True, *conditions, reason=None, raises=None, run=True, strict=strict_xfail)
 
     :keyword Union[bool, str] condition:
         Condition for marking the test function as xfail (``True/False`` or a
         :ref:`condition string <string conditions>`). If a ``bool``, you also have
         to specify ``reason`` (see :ref:`condition string <string conditions>`).
+    :keyword Union[bool, str] conditions:
+        Additional conditions, evaluated the same way as ``condition``. The test is
+        marked as xfail if *any* of the conditions evaluate to ``True``.
     :keyword str reason:
         Reason why the test function is marked as xfail.
     :keyword raises:

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -70,6 +70,43 @@ class TestEvaluation:
         assert skipped
         assert skipped.reason == "hello world"
 
+    def test_marked_multiple_args_skipif(self, pytester: Pytester) -> None:
+        item = pytester.getitem(
+            """
+            import pytest
+            @pytest.mark.skipif(False, True, reason="hello world")
+            def test_func():
+                pass
+        """
+        )
+        skipped = evaluate_skip_marks(item)
+        assert skipped
+        assert skipped.reason == "hello world"
+
+    def test_marked_multiple_args_skipif_all_false(self, pytester: Pytester) -> None:
+        item = pytester.getitem(
+            """
+            import pytest
+            @pytest.mark.skipif(False, False, reason="hello world")
+            def test_func():
+                pass
+        """
+        )
+        assert evaluate_skip_marks(item) is None
+
+    def test_marked_multiple_args_xfail(self, pytester: Pytester) -> None:
+        item = pytester.getitem(
+            """
+            import pytest
+            @pytest.mark.xfail(False, True, reason="hello world")
+            def test_func():
+                pass
+        """
+        )
+        xfailed = evaluate_xfail_marks(item)
+        assert xfailed
+        assert xfailed.reason == "hello world"
+
     def test_marked_one_arg_twice(self, pytester: Pytester) -> None:
         lines = [
             """@pytest.mark.skipif("not hasattr(os, 'murks')")""",


### PR DESCRIPTION
This PR fixes the documented signatures for pytest.mark.skipif and pytest.mark.xfail to reflect the codebase: both accept multiple positional condition arguments, not just one, and the test is skipped/xfailed if any of them evaluate to True.

- pytest.mark.skipif(condition, *conditions, reason=None), was missing *conditions.
- pytest.mark.xfail(condition=True, *conditions, reason=None, raises=None, run=True, strict=strict_xfail), same.

The behavior already existed (evaluate_skip_marks/evaluate_xfail_marks in src/_pytest/skipping.py loop over mark.args), it just wasn't documented, and no existing test called either mark with more than one positional condition in a single invocation, so I added regression tests for that in testing/test_skipping.py.

No changelog entry, per CONTRIBUTING.rst's exemption for doc-only fixes that don't change documented behavior.

I used AI assistance (Claude) to research this repo and prepare the change, then reviewed the diff, reproduced the behavior myself, and ran the full test_skipping.py suite plus a local docs build before opening this. Happy to answer questions on any part of it.