### PR TITLE
docs: update 'Twitter' to 'social media' in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -11,7 +11,7 @@ so do not hesitate!
 Feature requests and feedback
 -----------------------------
 
-Do you like pytest?  Share some love on Twitter or in your blog posts!
+Do you like pytest?  Share some love on social media or in your blog posts!
 
 We'd also like to hear about your propositions and suggestions.  Feel free to
 `submit them as issues <https://github.com/pytest-dev/pytest/issues>`_ and:

--- a/changelog/14804.doc.rst
+++ b/changelog/14804.doc.rst
@@ -1,0 +1,1 @@
+Updated outdated "Twitter" reference to "social media" in ``CONTRIBUTING.rst`` to align with the contact page which lists Bluesky, Mastodon, and Twitter/X.

--- a/changelog/14804.doc.rst
+++ b/changelog/14804.doc.rst
@@ -1,1 +1,0 @@
-Updated outdated "Twitter" reference to "social media" in ``CONTRIBUTING.rst`` to align with the contact page which lists Bluesky, Mastodon, and Twitter/X.


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
## Summary

Update outdated "Twitter" reference in `CONTRIBUTING.rst` to "social media".

## Details

The `contact.rst` page has already been updated to list Bluesky, Mastodon, 
and Twitter/X under "Microblogging". However, `CONTRIBUTING.rst` line 14 
still only mentions "Twitter". This PR updates it to use the more inclusive 
term "social media" to match the rest of the documentation.

## Change

- `CONTRIBUTING.rst`: "Share some love on Twitter" → "Share some love on social media"