### PR TITLE
doc: add pyproject.toml entry-point example to plugin documentation (fixes #10721)

### DIFF
--- a/changelog/10721.doc.rst
+++ b/changelog/10721.doc.rst
@@ -1,0 +1,1 @@
+Replaced ``setup.py`` usage with ``pyproject.toml`` in :ref:`writing-plugins`.

--- a/doc/en/how-to/writing_plugins.rst
+++ b/doc/en/how-to/writing_plugins.rst
@@ -215,11 +215,12 @@ as plugins.  As an example consider the following package::
    pytest_foo/plugin.py
    pytest_foo/helper.py
 
-With the following typical ``setup.py`` extract:
+With the following typical ``pyproject.toml`` extract:
 
-.. code-block:: python
+.. code-block:: toml
 
-   setup(..., entry_points={"pytest11": ["foo = pytest_foo.plugin"]}, ...)
+   [project.entry-points.pytest11]
+   foo = "pytest_foo.plugin"
 
 In this case only ``pytest_foo/plugin.py`` will be rewritten.  If the
 helper module also contains assert statements which need to be


### PR DESCRIPTION
…fixes #10721)

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
Update `doc/en/how-to/writing_plugins.rst` to include a standard PEP 621 `pyproject.toml` `[project.entry-points.pytest11]` configuration example alongside the existing `setup.py` snippet.

Fixes #10721