### PR TITLE
Fix caplog access during teardown report creation

### DIFF
--- a/changelog/14436.bugfix.rst
+++ b/changelog/14436.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``KeyError`` from the ``caplog`` fixture when a plugin accesses
+``caplog.text`` during teardown report creation.

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -422,6 +422,8 @@ class LogCaptureFixture:
     def __init__(self, item: nodes.Node, *, _ispytest: bool = False) -> None:
         check_ispytest(_ispytest)
         self._item = item
+        self._handler = item.stash[caplog_handler_key]
+        self._records = item.stash[caplog_records_key]
         self._initial_handler_level: int | None = None
         # Dict of log name -> log level.
         self._initial_logger_levels: dict[str | None, int] = {}
@@ -446,7 +448,7 @@ class LogCaptureFixture:
     @property
     def handler(self) -> LogCaptureHandler:
         """Get the logging handler used by the fixture."""
-        return self._item.stash[caplog_handler_key]
+        return self._handler
 
     def get_records(
         self, when: Literal["setup", "call", "teardown"]
@@ -461,7 +463,7 @@ class LogCaptureFixture:
 
         .. versionadded:: 3.4
         """
-        return self._item.stash[caplog_records_key].get(when, [])
+        return self._records.get(when, [])
 
     @property
     def text(self) -> str:

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -508,3 +508,31 @@ def test_log_report_captures_according_to_config_option_upon_failure(
         ["*Print message*", "*INFO log message*", "*WARNING log message*"]
     )
     assert result.ret == 1
+
+
+def test_caplog_text_access_from_teardown_makereport(pytester: Pytester) -> None:
+    """Regression test for #14436."""
+    pytester.makeconftest(
+        """
+        def pytest_runtest_makereport(item, call):
+            if call.when == "teardown" and "caplog" in item.funcargs:
+                caplog = item.funcargs["caplog"]
+                caplog.text
+                assert [r.getMessage() for r in caplog.get_records("call")] == [
+                    "call log"
+                ]
+        """
+    )
+    pytester.makepyfile(
+        """
+        import logging
+
+        def test_uses_caplog(caplog):
+            caplog.set_level(logging.INFO)
+            logging.info("call log")
+        """
+    )
+
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+    result.stdout.no_fnmatch_line("*KeyError*")


### PR DESCRIPTION
Fixes #14436.

"LogCaptureFixture" now retains the logging handler and per-phase records mapping created for its test item, instead of retrieving them from "item.stash" on every access.

The logging plugin removes those stash entries at the end of teardown. However, teardown "pytest_runtest_makereport" consumers may still retain the fixture through "item.funcargs". Accessing "caplog.text" or "caplog.get_records()" at that point could therefore raise "KeyError".

The regression test covers both access paths during teardown report creation.