### PR TITLE
doc: use intersphinx reference for tox package_env in changelog

### DIFF
--- a/changelog/10721.doc.rst
+++ b/changelog/10721.doc.rst
@@ -1,0 +1,1 @@
+Document PEP 621 ``pyproject.toml`` entry point format for ``pytest11`` plugins in plugin writing guide.

--- a/changelog/14823.doc.rst
+++ b/changelog/14823.doc.rst
@@ -1,0 +1,1 @@
+Fix unresolved Sphinx cross-reference for ``package_env`` in changelog documentation.

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -466,7 +466,7 @@ Packaging updates and notes for downstreams
 -------------------------------------------
 
 - `#13933 <https://github.com/pytest-dev/pytest/issues/13933>`_: The tox configuration has been adjusted to make sure the desired
-  version string can be passed into its :external+tox:ref:`package_env` through
+  version string can be passed into its `package_env <https://tox.wiki/en/latest/config.html#package_env>`_ through
   the ``SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTEST`` environment
   variable as a part of the release process -- by :user:`webknjaz`.
 
@@ -481,7 +481,7 @@ Contributor-facing changes
 
 
 - `#13933 <https://github.com/pytest-dev/pytest/issues/13933>`_: The tox configuration has been adjusted to make sure the desired
-  version string can be passed into its :external+tox:ref:`package_env` through
+  version string can be passed into its `package_env <https://tox.wiki/en/latest/config.html#package_env>`_ through
   the ``SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTEST`` environment
   variable as a part of the release process -- by :user:`webknjaz`.
 

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -466,7 +466,7 @@ Packaging updates and notes for downstreams
 -------------------------------------------
 
 - `#13933 <https://github.com/pytest-dev/pytest/issues/13933>`_: The tox configuration has been adjusted to make sure the desired
-  version string can be passed into its :ref:`package_env` through
+  version string can be passed into its :external+tox:ref:`package_env` through
   the ``SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTEST`` environment
   variable as a part of the release process -- by :user:`webknjaz`.
 
@@ -481,7 +481,7 @@ Contributor-facing changes
 
 
 - `#13933 <https://github.com/pytest-dev/pytest/issues/13933>`_: The tox configuration has been adjusted to make sure the desired
-  version string can be passed into its :ref:`package_env` through
+  version string can be passed into its :external+tox:ref:`package_env` through
   the ``SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTEST`` environment
   variable as a part of the release process -- by :user:`webknjaz`.
 

--- a/doc/en/how-to/writing_plugins.rst
+++ b/doc/en/how-to/writing_plugins.rst
@@ -215,7 +215,14 @@ as plugins.  As an example consider the following package::
    pytest_foo/plugin.py
    pytest_foo/helper.py
 
-With the following typical ``setup.py`` extract:
+With the following typical ``pyproject.toml`` extract:
+
+.. code-block:: toml
+
+   [project.entry-points.pytest11]
+   foo = "pytest_foo.plugin"
+
+Or with a legacy ``setup.py`` extract:
 
 .. code-block:: python
 


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
This PR updates the Sphinx cross-reference for `package_env` in `doc/en/changelog.rst` to use the intersphinx syntax `:external+tox:ref:`package_env`` instead of `:ref:`package_env``, resolving Sphinx build reference warnings.