### PR TITLE
Classify plugin startup import failures (#993)

### DIFF
--- a/changelog/993.breaking.rst
+++ b/changelog/993.breaking.rst
@@ -1,0 +1,6 @@
+Plugin import failures at startup are now reported and classified instead of escaping as a raw traceback with the accidental exit code ``1``:
+
+* a plugin that cannot be found -- via ``-p``, ``pytest_plugins`` or ``PYTEST_PLUGINS`` -- exits with :class:`pytest.ExitCode` ``USAGE_ERROR`` (``4``), like a ``conftest.py`` that fails to import;
+* a plugin that is found but raises while importing -- including a broken ``pytest11`` entry point or a missing plugin dependency -- exits with :class:`pytest.ExitCode` ``INTERNAL_ERROR`` (``3``), with the traceback preserved.
+
+:func:`pytest.main` now returns these codes instead of raising ``ImportError``. Also fixed an ``IndexError`` from pytest's own internals when the plugin raised an exception with no arguments.

--- a/changelog/993.bugfix.rst
+++ b/changelog/993.bugfix.rst
@@ -1,0 +1,15 @@
+Fixed a plugin which fails to load during startup escaping as an unhandled exception, printing a raw traceback and exiting with the accidental exit code ``1``
+-- indistinguishable from :attr:`ExitCode.TESTS_FAILED <pytest.ExitCode.TESTS_FAILED>`. The failure is now reported and classified:
+
+* A plugin which cannot be found -- requested via ``-p``, ``pytest_plugins`` or the ``PYTEST_PLUGINS`` environment variable --
+  now exits with :attr:`ExitCode.USAGE_ERROR <pytest.ExitCode.USAGE_ERROR>` (``4``), the same code already used for a ``conftest.py`` which fails to import.
+
+* A plugin which is found but raises while being imported -- including an installed plugin loaded through a ``pytest11`` entry point,
+  and a plugin whose own dependencies are missing -- now exits with :attr:`ExitCode.INTERNAL_ERROR <pytest.ExitCode.INTERNAL_ERROR>` (``3``),
+  since this is a defect in the plugin rather than a misuse of pytest. The plugin's traceback is still shown.
+
+As a consequence, :func:`pytest.main` now returns these exit codes instead of propagating the exception to its caller.
+
+A ``conftest.py`` which fails to import is unaffected and keeps returning :attr:`ExitCode.USAGE_ERROR <pytest.ExitCode.USAGE_ERROR>` (``4``).
+
+This also fixes an ``IndexError`` raised from pytest's internals when a plugin raised an exception with no arguments, such as a bare ``raise ImportError``.

--- a/doc/en/reference/exit-codes.rst
+++ b/doc/en/reference/exit-codes.rst
@@ -8,8 +8,8 @@ Running ``pytest`` can result in seven different exit codes:
 :Exit code 0: All tests were collected and passed successfully
 :Exit code 1: Tests were collected and run but some of the tests failed
 :Exit code 2: Test execution was interrupted by the user
-:Exit code 3: Internal error happened while executing tests
-:Exit code 4: pytest command line usage error
+:Exit code 3: Internal error happened while executing tests, or a plugin raised while importing
+:Exit code 4: pytest command line usage error, including a plugin that cannot be found or a ``conftest.py`` that fails to import
 :Exit code 5: No tests were collected
 :Exit code 6: Maximum number of warnings exceeded (see :option:`--max-warnings`)
 

--- a/doc/en/reference/exit-codes.rst
+++ b/doc/en/reference/exit-codes.rst
@@ -8,8 +8,8 @@ Running ``pytest`` can result in seven different exit codes:
 :Exit code 0: All tests were collected and passed successfully
 :Exit code 1: Tests were collected and run but some of the tests failed
 :Exit code 2: Test execution was interrupted by the user
-:Exit code 3: Internal error happened while executing tests
-:Exit code 4: pytest command line usage error
+:Exit code 3: Internal error happened while executing tests, or a plugin failed to load
+:Exit code 4: pytest command line usage error, including a ``conftest.py`` which fails to import or a plugin which cannot be found
 :Exit code 5: No tests were collected
 :Exit code 6: Maximum number of warnings exceeded (see :option:`--max-warnings`)
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -141,7 +141,27 @@ class ConftestImportFailure(Exception):
         return f"{type(self.cause).__name__}: {self.cause} (from {self.path})"
 
 
-def filter_traceback_for_conftest_import_failure(
+class PluginImportFailure(Exception):
+    """A plugin was found, but raised while being imported.
+
+    This is deliberately distinct from a plugin which could not be found at
+    all: not finding it means pytest was pointed at something that isn't there,
+    which is a :class:`UsageError`, while a plugin blowing up on import is a
+    defect in the plugin and reported as an internal error.
+    """
+
+    def __init__(self, modname: str, *, cause: BaseException) -> None:
+        self.modname = modname
+        self.cause = cause
+
+    def __str__(self) -> str:
+        return (
+            f"{type(self.cause).__name__}: {self.cause} "
+            f"(importing plugin {self.modname!r})"
+        )
+
+
+def filter_traceback_for_import_failure(
     entry: _pytest._code.TracebackEntry,
 ) -> bool:
     """Filter tracebacks entries which point to pytest internals or importlib.
@@ -152,13 +172,11 @@ def filter_traceback_for_conftest_import_failure(
     return filter_traceback(entry) and "importlib" not in str(entry.path).split(os.sep)
 
 
-def print_conftest_import_error(e: ConftestImportFailure, file: TextIO) -> None:
-    exc_info = ExceptionInfo.from_exception(e.cause)
+def _print_import_error(header: str, cause: BaseException, file: TextIO) -> None:
+    exc_info = ExceptionInfo.from_exception(cause)
     tw = TerminalWriter(file)
-    tw.line(f"ImportError while loading conftest '{e.path}'.", red=True)
-    exc_info.traceback = exc_info.traceback.filter(
-        filter_traceback_for_conftest_import_failure
-    )
+    tw.line(header, red=True)
+    exc_info.traceback = exc_info.traceback.filter(filter_traceback_for_import_failure)
     exc_repr = (
         exc_info.getrepr(style="short", chain=False)
         if exc_info.traceback
@@ -167,6 +185,16 @@ def print_conftest_import_error(e: ConftestImportFailure, file: TextIO) -> None:
     formatted_tb = str(exc_repr)
     for line in formatted_tb.splitlines():
         tw.line(line.rstrip(), red=True)
+
+
+def print_conftest_import_error(e: ConftestImportFailure, file: TextIO) -> None:
+    _print_import_error(
+        f"ImportError while loading conftest '{e.path}'.", e.cause, file
+    )
+
+
+def print_plugin_import_error(e: PluginImportFailure, file: TextIO) -> None:
+    _print_import_error(f'Error while loading plugin "{e.modname}".', e.cause, file)
 
 
 def print_usage_error(e: UsageError, file: TextIO) -> None:
@@ -227,6 +255,9 @@ def _main(
         except ConftestImportFailure as e:
             print_conftest_import_error(e, file=sys.stderr)
             return ExitCode.USAGE_ERROR
+        except PluginImportFailure as e:
+            print_plugin_import_error(e, file=sys.stderr)
+            return ExitCode.INTERNAL_ERROR
 
         try:
             ret: ExitCode | int = config.hook.pytest_cmdline_main(config=config)
@@ -919,15 +950,45 @@ class PytestPluginManager(PluginManager):
                 # testing/test_config.py::test_disable_plugin_autoload.
                 __import__(importspec)
                 mod = sys.modules[importspec]
-        except ImportError as e:
-            raise ImportError(
-                f'Error importing plugin "{modname}": {e.args[0]}'
-            ).with_traceback(e.__traceback__) from e
-
         except Skipped as e:
             self.skipped_plugins.append((modname, e.msg or ""))
+        except ModuleNotFoundError as e:
+            if _is_missing_module(e, importspec):
+                # The plugin itself is nowhere to be found - pytest was pointed
+                # at something which does not exist, so this is a usage error.
+                raise UsageError(f'Error importing plugin "{modname}": {e}') from e
+            # Some *other* module the plugin imports is missing: the plugin was
+            # found, so this is a defect in the plugin, not a usage error.
+            raise PluginImportFailure(modname, cause=e) from e
+        except UsageError:
+            raise
+        except Exception as e:
+            raise PluginImportFailure(modname, cause=e) from e
         else:
             self.register(mod, modname)
+
+    def load_setuptools_entrypoints(self, group: str, name: str | None = None) -> int:
+        """:meta private:"""
+        try:
+            return super().load_setuptools_entrypoints(group, name=name)
+        except UsageError:
+            raise
+        except Exception as e:
+            # An installed plugin which cannot be loaded is a defect in that
+            # plugin - the user did nothing wrong by having it installed.
+            raise PluginImportFailure(name or group, cause=e) from e
+
+
+def _is_missing_module(e: ModuleNotFoundError, importspec: str) -> bool:
+    """Whether ``e`` means that ``importspec`` itself could not be found.
+
+    A ``ModuleNotFoundError`` naming some other module means the plugin was
+    located but one of its own imports is unsatisfied.
+    """
+    if e.name is None:
+        return False
+    # A missing parent package also means importspec cannot be found.
+    return e.name == importspec or importspec.startswith(f"{e.name}.")
 
 
 def _get_plugin_specs_as_list(

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -142,7 +142,17 @@ class ConftestImportFailure(Exception):
         return f"{type(self.cause).__name__}: {self.cause} (from {self.path})"
 
 
-def filter_traceback_for_conftest_import_failure(
+class PluginImportFailure(Exception):
+    """A plugin was found, but raised while being imported.
+
+    This is deliberately distinct from a plugin which could not be found at
+    all: not finding it means pytest was pointed at something that isn't there,
+    which is a :class:`UsageError`, while a plugin blowing up on import is a
+    defect in the plugin and reported as an internal error.
+    """
+
+
+def filter_traceback_for_import_failure(
     entry: _pytest._code.TracebackEntry,
 ) -> bool:
     """Filter tracebacks entries which point to pytest internals or importlib.
@@ -153,13 +163,11 @@ def filter_traceback_for_conftest_import_failure(
     return filter_traceback(entry) and "importlib" not in str(entry.path).split(os.sep)
 
 
-def print_conftest_import_error(e: ConftestImportFailure, file: TextIO) -> None:
-    exc_info = ExceptionInfo.from_exception(e.cause)
+def _print_import_error(header: str, cause: BaseException, file: TextIO) -> None:
+    exc_info = ExceptionInfo.from_exception(cause)
     tw = TerminalWriter(file)
-    tw.line(f"ImportError while loading conftest '{e.path}'.", red=True)
-    exc_info.traceback = exc_info.traceback.filter(
-        filter_traceback_for_conftest_import_failure
-    )
+    tw.line(header, red=True)
+    exc_info.traceback = exc_info.traceback.filter(filter_traceback_for_import_failure)
     exc_repr = (
         exc_info.getrepr(style="short", chain=False)
         if exc_info.traceback
@@ -168,6 +176,17 @@ def print_conftest_import_error(e: ConftestImportFailure, file: TextIO) -> None:
     formatted_tb = str(exc_repr)
     for line in formatted_tb.splitlines():
         tw.line(line.rstrip(), red=True)
+
+
+def print_conftest_import_error(e: ConftestImportFailure, file: TextIO) -> None:
+    _print_import_error(
+        f"ImportError while loading conftest '{e.path}'.", e.cause, file
+    )
+
+
+def print_plugin_import_error(e: PluginImportFailure, file: TextIO) -> None:
+    assert e.__cause__ is not None, f"{e!r} must be raised `from` the original error"
+    _print_import_error(f'Error while loading plugin "{e}".', e.__cause__, file)
 
 
 def print_usage_error(e: UsageError, file: TextIO) -> None:
@@ -232,6 +251,9 @@ def _main(
         except ConftestImportFailure as e:
             print_conftest_import_error(e, file=sys.stderr)
             return ExitCode.USAGE_ERROR
+        except PluginImportFailure as e:
+            print_plugin_import_error(e, file=sys.stderr)
+            return ExitCode.INTERNAL_ERROR
 
         try:
             ret: ExitCode | int = config.hook.pytest_cmdline_main(config=config)
@@ -924,15 +946,45 @@ class PytestPluginManager(PluginManager):
                 # testing/test_config.py::test_disable_plugin_autoload.
                 __import__(importspec)
                 mod = sys.modules[importspec]
-        except ImportError as e:
-            raise ImportError(
-                f'Error importing plugin "{modname}": {e.args[0]}'
-            ).with_traceback(e.__traceback__) from e
-
         except Skipped as e:
             self.skipped_plugins.append((modname, e.msg or ""))
+        except ModuleNotFoundError as e:
+            if _is_missing_module(e, importspec):
+                # The plugin itself is nowhere to be found - pytest was pointed
+                # at something which does not exist, so this is a usage error.
+                raise UsageError(f'Error importing plugin "{modname}": {e}') from e
+            # Some *other* module the plugin imports is missing: the plugin was
+            # found, so this is a defect in the plugin, not a usage error.
+            raise PluginImportFailure(modname) from e
+        except UsageError:
+            raise
+        except Exception as e:
+            raise PluginImportFailure(modname) from e
         else:
             self.register(mod, modname)
+
+    def load_setuptools_entrypoints(self, group: str, name: str | None = None) -> int:
+        """:meta private:"""
+        try:
+            return super().load_setuptools_entrypoints(group, name=name)
+        except UsageError:
+            raise
+        except Exception as e:
+            # An installed plugin which cannot be loaded is a defect in that
+            # plugin - the user did nothing wrong by having it installed.
+            raise PluginImportFailure(name or group) from e
+
+
+def _is_missing_module(e: ModuleNotFoundError, importspec: str) -> bool:
+    """Whether ``e`` means that ``importspec`` itself could not be found.
+
+    A ``ModuleNotFoundError`` naming some other module means the plugin was
+    located but one of its own imports is unsatisfied.
+    """
+    if e.name is None:
+        return False
+    # A missing parent package also means importspec cannot be found.
+    return e.name == importspec or importspec.startswith(f"{e.name}.")
 
 
 def _get_plugin_specs_as_list(

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -13,6 +13,7 @@ import types
 import setuptools
 
 from _pytest.config import ExitCode
+from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pathlib import symlink_or_skip
 from _pytest.pytester import Pytester
 import pytest
@@ -510,9 +511,10 @@ class TestGeneralUsage:
     ) -> None:
         """Test that str values passed to main() as `plugins` arg are
         interpreted as module names to be imported and registered (#855)."""
-        with pytest.raises(ImportError) as excinfo:
-            pytest.main([str(pytester.path)], plugins=["invalid.module"])
-        assert "invalid" in str(excinfo.value)
+        # A plugin which cannot be found is a usage error, reported through the
+        # return value rather than raised out of pytest.main() (#993).
+        ret = pytest.main([str(pytester.path)], plugins=["invalid.module"])
+        assert ret == ExitCode.USAGE_ERROR
 
         p = pytester.path.joinpath("test_test_plugins_given_as_strings.py")
         p.write_text("def test_foo(): pass", encoding="utf-8")
@@ -1086,6 +1088,128 @@ def test_zipimport_hook(pytester: Pytester) -> None:
     assert result.ret == 0
     result.stderr.fnmatch_lines(["*not found*foo*"])
     result.stdout.no_fnmatch_line("*INTERNALERROR>*")
+
+
+class TestStartupPluginImportErrors:
+    """Exit codes for plugins which fail to load at startup (#993).
+
+    A plugin which cannot be found means pytest was pointed at something which
+    is not there, which is a usage error; a plugin which is found but blows up
+    while importing is a defect in the plugin, reported as an internal error.
+    """
+
+    @pytest.fixture
+    def broken_plugin(self, pytester: Pytester) -> Pytester:
+        pytester.syspathinsert()
+        pytester.makepyfile(myplugin="raise ValueError('plugin is broken')")
+        pytester.makepyfile("def test_foo(): pass")
+        return pytester
+
+    @pytest.fixture
+    def missing_plugin(self, pytester: Pytester) -> Pytester:
+        pytester.syspathinsert()
+        pytester.makepyfile("def test_foo(): pass")
+        return pytester
+
+    def test_missing_via_cmdline(self, missing_plugin: Pytester) -> None:
+        result = missing_plugin.runpytest("-p", "nosuchplugin")
+        assert result.ret == ExitCode.USAGE_ERROR
+        result.stderr.fnmatch_lines(['*Error importing plugin "nosuchplugin"*'])
+
+    def test_missing_via_conftest(self, missing_plugin: Pytester) -> None:
+        missing_plugin.makeconftest("pytest_plugins = ['nosuchplugin']")
+        result = missing_plugin.runpytest()
+        assert result.ret == ExitCode.USAGE_ERROR
+
+    def test_missing_via_env(
+        self, missing_plugin: Pytester, monkeypatch: MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PYTEST_PLUGINS", "nosuchplugin")
+        result = missing_plugin.runpytest()
+        assert result.ret == ExitCode.USAGE_ERROR
+
+    def test_broken_via_cmdline(self, broken_plugin: Pytester) -> None:
+        result = broken_plugin.runpytest("-p", "myplugin")
+        assert result.ret == ExitCode.INTERNAL_ERROR
+        result.stderr.fnmatch_lines(
+            [
+                'Error while loading plugin "myplugin".',
+                "*myplugin.py:1: in <module>*",
+                "E*ValueError: plugin is broken",
+            ]
+        )
+
+    def test_broken_via_conftest(self, broken_plugin: Pytester) -> None:
+        broken_plugin.makeconftest("pytest_plugins = ['myplugin']")
+        result = broken_plugin.runpytest()
+        assert result.ret == ExitCode.INTERNAL_ERROR
+
+    def test_broken_via_env(
+        self, broken_plugin: Pytester, monkeypatch: MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PYTEST_PLUGINS", "myplugin")
+        result = broken_plugin.runpytest()
+        assert result.ret == ExitCode.INTERNAL_ERROR
+
+    def test_broken_via_entry_point(
+        self, pytester: Pytester, monkeypatch: MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
+
+        class DummyEntryPoint:
+            name = "myplugin"
+            group = "pytest11"
+
+            def load(self):
+                raise ValueError("plugin is broken")
+
+        class Distribution:
+            version = "1.0"
+            files = ("foo.txt",)
+            metadata = {"name": "foo"}
+            entry_points = (DummyEntryPoint(),)
+
+        monkeypatch.setattr(
+            importlib.metadata, "distributions", lambda: (Distribution(),)
+        )
+        pytester.makepyfile("def test_foo(): pass")
+        result = pytester.runpytest()
+        assert result.ret == ExitCode.INTERNAL_ERROR
+
+    def test_import_error_without_args(self, pytester: Pytester) -> None:
+        """A bare ``raise ImportError`` used to crash with an IndexError (#993)."""
+        pytester.syspathinsert()
+        pytester.makepyfile(myplugin="raise ImportError")
+        pytester.makepyfile("def test_foo(): pass")
+        result = pytester.runpytest("-p", "myplugin")
+        assert result.ret == ExitCode.INTERNAL_ERROR
+        result.stderr.no_fnmatch_line("*IndexError*")
+        result.stderr.fnmatch_lines(['Error while loading plugin "myplugin".'])
+
+    def test_missing_dependency_is_not_a_usage_error(self, pytester: Pytester) -> None:
+        """The plugin was found; one of *its* imports is unsatisfied (#993)."""
+        pytester.syspathinsert()
+        pytester.makepyfile(myplugin="import nosuchdependency")
+        pytester.makepyfile("def test_foo(): pass")
+        result = pytester.runpytest("-p", "myplugin")
+        assert result.ret == ExitCode.INTERNAL_ERROR
+
+    def test_missing_submodule_of_existing_package(self, pytester: Pytester) -> None:
+        """The package exists but the requested plugin module within it does not."""
+        pytester.syspathinsert()
+        pytester.mkpydir("mypkg")
+        pytester.makepyfile("def test_foo(): pass")
+        result = pytester.runpytest("-p", "mypkg.nosuchmodule")
+        assert result.ret == ExitCode.USAGE_ERROR
+
+    def test_conftest_import_failure_stays_a_usage_error(
+        self, pytester: Pytester
+    ) -> None:
+        """conftest.py is not a plugin; it keeps reporting a usage error (#993)."""
+        pytester.makeconftest("raise ValueError('conftest is broken')")
+        pytester.makepyfile("def test_foo(): pass")
+        result = pytester.runpytest()
+        assert result.ret == ExitCode.USAGE_ERROR
 
 
 def test_import_plugin_unicode_name(pytester: Pytester) -> None:

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -13,6 +13,7 @@ import types
 import setuptools
 
 from _pytest.config import ExitCode
+from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pathlib import symlink_or_skip
 from _pytest.pytester import Pytester
 import pytest
@@ -510,9 +511,10 @@ class TestGeneralUsage:
     ) -> None:
         """Test that str values passed to main() as `plugins` arg are
         interpreted as module names to be imported and registered (#855)."""
-        with pytest.raises(ImportError) as excinfo:
-            pytest.main([str(pytester.path)], plugins=["invalid.module"])
-        assert "invalid" in str(excinfo.value)
+        # A plugin which cannot be found is a usage error, reported through the
+        # return value rather than raised out of pytest.main() (#993).
+        ret = pytest.main([str(pytester.path)], plugins=["invalid.module"])
+        assert ret == ExitCode.USAGE_ERROR
 
         p = pytester.path.joinpath("test_test_plugins_given_as_strings.py")
         p.write_text("def test_foo(): pass", encoding="utf-8")
@@ -1086,6 +1088,138 @@ def test_zipimport_hook(pytester: Pytester) -> None:
     assert result.ret == 0
     result.stderr.fnmatch_lines(["*not found*foo*"])
     result.stdout.no_fnmatch_line("*INTERNALERROR>*")
+
+
+class TestStartupPluginImportErrors:
+    """Exit codes for plugins which fail to load at startup (#993).
+
+    A plugin which cannot be found means pytest was pointed at something which
+    is not there, which is a usage error; a plugin which is found but blows up
+    while importing is a defect in the plugin, reported as an internal error.
+    """
+
+    @pytest.fixture
+    def broken_plugin(self, pytester: Pytester) -> Pytester:
+        pytester.syspathinsert()
+        pytester.makepyfile(myplugin="raise ValueError('plugin is broken')")
+        pytester.makepyfile("def test_foo(): pass")
+        return pytester
+
+    @pytest.fixture
+    def missing_plugin(self, pytester: Pytester) -> Pytester:
+        pytester.syspathinsert()
+        pytester.makepyfile("def test_foo(): pass")
+        return pytester
+
+    def test_missing_via_cmdline(self, missing_plugin: Pytester) -> None:
+        result = missing_plugin.runpytest("-p", "nosuchplugin")
+        assert result.ret == ExitCode.USAGE_ERROR
+        result.stderr.fnmatch_lines(['*Error importing plugin "nosuchplugin"*'])
+
+    def test_missing_via_conftest(self, missing_plugin: Pytester) -> None:
+        missing_plugin.makeconftest("pytest_plugins = ['nosuchplugin']")
+        result = missing_plugin.runpytest()
+        assert result.ret == ExitCode.USAGE_ERROR
+
+    def test_missing_via_env(
+        self, missing_plugin: Pytester, monkeypatch: MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PYTEST_PLUGINS", "nosuchplugin")
+        result = missing_plugin.runpytest()
+        assert result.ret == ExitCode.USAGE_ERROR
+
+    def test_broken_via_cmdline(self, broken_plugin: Pytester) -> None:
+        result = broken_plugin.runpytest("-p", "myplugin")
+        assert result.ret == ExitCode.INTERNAL_ERROR
+        result.stderr.fnmatch_lines(
+            [
+                'Error while loading plugin "myplugin".',
+                "*myplugin.py:1: in <module>*",
+                "E*ValueError: plugin is broken",
+            ]
+        )
+
+    def test_broken_via_conftest(self, broken_plugin: Pytester) -> None:
+        broken_plugin.makeconftest("pytest_plugins = ['myplugin']")
+        result = broken_plugin.runpytest()
+        assert result.ret == ExitCode.INTERNAL_ERROR
+
+    def test_broken_via_env(
+        self, broken_plugin: Pytester, monkeypatch: MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PYTEST_PLUGINS", "myplugin")
+        result = broken_plugin.runpytest()
+        assert result.ret == ExitCode.INTERNAL_ERROR
+
+    def test_usage_error_passes_through(self, pytester: Pytester) -> None:
+        """A plugin raising UsageError at import keeps its usage-error semantics."""
+        pytester.syspathinsert()
+        pytester.makepyfile(
+            myplugin="import pytest\nraise pytest.UsageError('config trouble')"
+        )
+        result = pytester.runpytest("-p", "myplugin")
+        assert result.ret == ExitCode.USAGE_ERROR
+        result.stderr.fnmatch_lines(["ERROR: config trouble*"])
+
+    def test_broken_via_entry_point(
+        self, pytester: Pytester, monkeypatch: MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
+
+        class DummyEntryPoint:
+            name = "myplugin"
+            group = "pytest11"
+
+            def load(self):
+                raise ValueError("plugin is broken")
+
+        class Distribution:
+            version = "1.0"
+            files = ("foo.txt",)
+            metadata = {"name": "foo"}
+            entry_points = (DummyEntryPoint(),)
+
+        monkeypatch.setattr(
+            importlib.metadata, "distributions", lambda: (Distribution(),)
+        )
+        pytester.makepyfile("def test_foo(): pass")
+        result = pytester.runpytest()
+        assert result.ret == ExitCode.INTERNAL_ERROR
+
+    def test_import_error_without_args(self, pytester: Pytester) -> None:
+        """A bare ``raise ImportError`` used to crash with an IndexError (#993)."""
+        pytester.syspathinsert()
+        pytester.makepyfile(myplugin="raise ImportError")
+        pytester.makepyfile("def test_foo(): pass")
+        result = pytester.runpytest("-p", "myplugin")
+        assert result.ret == ExitCode.INTERNAL_ERROR
+        result.stderr.no_fnmatch_line("*IndexError*")
+        result.stderr.fnmatch_lines(['Error while loading plugin "myplugin".'])
+
+    def test_missing_dependency_is_not_a_usage_error(self, pytester: Pytester) -> None:
+        """The plugin was found; one of *its* imports is unsatisfied (#993)."""
+        pytester.syspathinsert()
+        pytester.makepyfile(myplugin="import nosuchdependency")
+        pytester.makepyfile("def test_foo(): pass")
+        result = pytester.runpytest("-p", "myplugin")
+        assert result.ret == ExitCode.INTERNAL_ERROR
+
+    def test_missing_submodule_of_existing_package(self, pytester: Pytester) -> None:
+        """The package exists but the requested plugin module within it does not."""
+        pytester.syspathinsert()
+        pytester.mkpydir("mypkg")
+        pytester.makepyfile("def test_foo(): pass")
+        result = pytester.runpytest("-p", "mypkg.nosuchmodule")
+        assert result.ret == ExitCode.USAGE_ERROR
+
+    def test_conftest_import_failure_stays_a_usage_error(
+        self, pytester: Pytester
+    ) -> None:
+        """conftest.py is not a plugin; it keeps reporting a usage error (#993)."""
+        pytester.makeconftest("raise ValueError('conftest is broken')")
+        pytester.makepyfile("def test_foo(): pass")
+        result = pytester.runpytest()
+        assert result.ret == ExitCode.USAGE_ERROR
 
 
 def test_import_plugin_unicode_name(pytester: Pytester) -> None:

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import _pytest._code
 from _pytest.config import ExitCode
+from _pytest.config.exceptions import UsageError
 from _pytest.main import Session
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.nodes import Collector
@@ -80,7 +81,7 @@ class TestModule:
 
     def test_module_considers_pluginmanager_at_import(self, pytester: Pytester) -> None:
         modcol = pytester.getmodulecol("pytest_plugins='xasdlkj',")
-        with pytest.raises(ImportError):
+        with pytest.raises(UsageError):
             modcol.obj()
 
     def test_invalid_test_module_name(self, pytester: Pytester) -> None:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -22,6 +22,7 @@ from _pytest.config import ConftestImportFailure
 from _pytest.config import console_main
 from _pytest.config import ExitCode
 from _pytest.config import parse_warning_filter
+from _pytest.config import PluginImportFailure
 from _pytest.config.argparsing import get_ini_default_for_type
 from _pytest.config.argparsing import Parser
 from _pytest.config.exceptions import UsageError
@@ -1858,7 +1859,35 @@ def test_setuptools_importerror_issue1479(
         return (Distribution(),)
 
     monkeypatch.setattr(importlib.metadata, "distributions", distributions)
-    with pytest.raises(ImportError):
+    with pytest.raises(PluginImportFailure) as excinfo:
+        pytester.parseconfig()
+    assert "Don't hide me!" in str(excinfo.value.__cause__)
+
+
+def test_setuptools_usage_error_passes_through(
+    pytester: Pytester, monkeypatch: MonkeyPatch
+) -> None:
+    """A UsageError from an entry-point plugin is not reclassified (#993)."""
+    monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
+
+    class DummyEntryPoint:
+        name = "mytestplugin"
+        group = "pytest11"
+
+        def load(self):
+            raise UsageError("bad usage")
+
+    class Distribution:
+        version = "1.0"
+        files = ("foo.txt",)
+        metadata = {"name": "foo"}
+        entry_points = (DummyEntryPoint(),)
+
+    def distributions():
+        return (Distribution(),)
+
+    monkeypatch.setattr(importlib.metadata, "distributions", distributions)
+    with pytest.raises(UsageError, match="bad usage"):
         pytester.parseconfig()
 
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -22,6 +22,7 @@ from _pytest.config import ConftestImportFailure
 from _pytest.config import console_main
 from _pytest.config import ExitCode
 from _pytest.config import parse_warning_filter
+from _pytest.config import PluginImportFailure
 from _pytest.config.argparsing import get_ini_default_for_type
 from _pytest.config.argparsing import Parser
 from _pytest.config.exceptions import UsageError
@@ -1771,8 +1772,9 @@ def test_setuptools_importerror_issue1479(
         return (Distribution(),)
 
     monkeypatch.setattr(importlib.metadata, "distributions", distributions)
-    with pytest.raises(ImportError):
+    with pytest.raises(PluginImportFailure) as excinfo:
         pytester.parseconfig()
+    assert "Don't hide me!" in str(excinfo.value)
 
 
 def test_importlib_metadata_broken_distribution(

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -7,8 +7,11 @@ import shutil
 import sys
 import types
 
+from _pytest._code import ExceptionInfo
+from _pytest.config import _is_missing_module
 from _pytest.config import Config
 from _pytest.config import ExitCode
+from _pytest.config import PluginImportFailure
 from _pytest.config import PytestPluginManager
 from _pytest.config.exceptions import UsageError
 from _pytest.main import Session
@@ -252,13 +255,22 @@ def test_importplugin_error_message(
         test_traceback()
         """
     )
-    with pytest.raises(ImportError) as excinfo:
+    with pytest.raises(PluginImportFailure) as excinfo:
         pytestpm.import_plugin("qwe")
 
-    assert str(excinfo.value).endswith(
-        'Error importing plugin "qwe": Not possible to import: ☺'
-    )
-    assert "in test_traceback" in str(excinfo.traceback[-1])
+    assert excinfo.value.args == ("qwe",)
+    # The original error and traceback must stay reachable through the cause,
+    # otherwise there is no way to tell where in the plugin things went wrong.
+    assert excinfo.value.__cause__ is not None
+    assert str(excinfo.value.__cause__) == "Not possible to import: ☺"
+    cause = ExceptionInfo.from_exception(excinfo.value.__cause__)
+    assert "in test_traceback" in str(cause.traceback[-1])
+
+
+def test_is_missing_module_without_name() -> None:
+    """A ModuleNotFoundError raised without a module name cannot be attributed
+    to the requested plugin, so it counts as a defect in the plugin."""
+    assert not _is_missing_module(ModuleNotFoundError("boom"), "myplugin")
 
 
 class TestPytestPluginManager:
@@ -322,7 +334,7 @@ class TestPytestPluginManager:
         self, monkeypatch: MonkeyPatch, pytestpm: PytestPluginManager
     ) -> None:
         monkeypatch.setenv("PYTEST_PLUGINS", "nonexisting", prepend=",")
-        with pytest.raises(ImportError):
+        with pytest.raises(UsageError):
             pytestpm.consider_env()
 
     def test_consider_env_entry_point_name(
@@ -458,9 +470,9 @@ class TestPytestPluginManager:
     def test_import_plugin_importname(
         self, pytester: Pytester, pytestpm: PytestPluginManager
     ) -> None:
-        with pytest.raises(ImportError):
+        with pytest.raises(UsageError):
             pytestpm.import_plugin("qweqwex.y")
-        with pytest.raises(ImportError):
+        with pytest.raises(UsageError):
             pytestpm.import_plugin("pytest_qweqwx.y")
 
         pytester.syspathinsert()
@@ -480,9 +492,9 @@ class TestPytestPluginManager:
     def test_import_plugin_dotted_name(
         self, pytester: Pytester, pytestpm: PytestPluginManager
     ) -> None:
-        with pytest.raises(ImportError):
+        with pytest.raises(UsageError):
             pytestpm.import_plugin("qweqwex.y")
-        with pytest.raises(ImportError):
+        with pytest.raises(UsageError):
             pytestpm.import_plugin("pytest_qweqwex.y")
 
         pytester.syspathinsert()
@@ -503,17 +515,17 @@ class TestPytestPluginManager:
             root=pytester.path,
             consider_namespace_packages=False,
         )
-        with pytest.raises(ImportError):
+        with pytest.raises(UsageError):
             pytestpm.consider_conftest(mod, registration_name="unused")
 
 
 class TestPytestPluginManagerBootstrapping:
     def test_preparse_args(self, pytestpm: PytestPluginManager) -> None:
-        with pytest.raises(ImportError):
+        with pytest.raises(UsageError):
             pytestpm.consider_preparse(["xyz", "-p", "hello123"])
 
         # Handles -p without space (#3532).
-        with pytest.raises(ImportError) as excinfo:
+        with pytest.raises(UsageError) as excinfo:
             pytestpm.consider_preparse(["-phello123"])
         assert '"hello123"' in excinfo.value.args[0]
         pytestpm.consider_preparse(["-pno:hello123"])

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -7,8 +7,10 @@ import shutil
 import sys
 import types
 
+from _pytest._code import ExceptionInfo
 from _pytest.config import Config
 from _pytest.config import ExitCode
+from _pytest.config import PluginImportFailure
 from _pytest.config import PytestPluginManager
 from _pytest.config.exceptions import UsageError
 from _pytest.main import Session
@@ -252,13 +254,16 @@ def test_importplugin_error_message(
         test_traceback()
         """
     )
-    with pytest.raises(ImportError) as excinfo:
+    with pytest.raises(PluginImportFailure) as excinfo:
         pytestpm.import_plugin("qwe")
 
-    assert str(excinfo.value).endswith(
-        'Error importing plugin "qwe": Not possible to import: ☺'
+    assert str(excinfo.value) == (
+        "ImportError: Not possible to import: ☺ (importing plugin 'qwe')"
     )
-    assert "in test_traceback" in str(excinfo.traceback[-1])
+    # The original traceback must stay reachable through the cause, otherwise
+    # there is no way to tell where in the plugin things went wrong.
+    cause = ExceptionInfo.from_exception(excinfo.value.cause)
+    assert "in test_traceback" in str(cause.traceback[-1])
 
 
 class TestPytestPluginManager:
@@ -322,7 +327,7 @@ class TestPytestPluginManager:
         self, monkeypatch: MonkeyPatch, pytestpm: PytestPluginManager
     ) -> None:
         monkeypatch.setenv("PYTEST_PLUGINS", "nonexisting", prepend=",")
-        with pytest.raises(ImportError):
+        with pytest.raises(UsageError):
             pytestpm.consider_env()
 
     def test_consider_env_entry_point_name(
@@ -458,9 +463,9 @@ class TestPytestPluginManager:
     def test_import_plugin_importname(
         self, pytester: Pytester, pytestpm: PytestPluginManager
     ) -> None:
-        with pytest.raises(ImportError):
+        with pytest.raises(UsageError):
             pytestpm.import_plugin("qweqwex.y")
-        with pytest.raises(ImportError):
+        with pytest.raises(UsageError):
             pytestpm.import_plugin("pytest_qweqwx.y")
 
         pytester.syspathinsert()
@@ -480,9 +485,9 @@ class TestPytestPluginManager:
     def test_import_plugin_dotted_name(
         self, pytester: Pytester, pytestpm: PytestPluginManager
     ) -> None:
-        with pytest.raises(ImportError):
+        with pytest.raises(UsageError):
             pytestpm.import_plugin("qweqwex.y")
-        with pytest.raises(ImportError):
+        with pytest.raises(UsageError):
             pytestpm.import_plugin("pytest_qweqwex.y")
 
         pytester.syspathinsert()
@@ -503,17 +508,17 @@ class TestPytestPluginManager:
             root=pytester.path,
             consider_namespace_packages=False,
         )
-        with pytest.raises(ImportError):
+        with pytest.raises(UsageError):
             pytestpm.consider_conftest(mod, registration_name="unused")
 
 
 class TestPytestPluginManagerBootstrapping:
     def test_preparse_args(self, pytestpm: PytestPluginManager) -> None:
-        with pytest.raises(ImportError):
+        with pytest.raises(UsageError):
             pytestpm.consider_preparse(["xyz", "-p", "hello123"])
 
         # Handles -p without space (#3532).
-        with pytest.raises(ImportError) as excinfo:
+        with pytest.raises(UsageError) as excinfo:
             pytestpm.consider_preparse(["-phello123"])
         assert '"hello123"' in excinfo.value.args[0]
         pytestpm.consider_preparse(["-pno:hello123"])

--- a/testing/test_session.py
+++ b/testing/test_session.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from _pytest.config import ExitCode
+from _pytest.config.exceptions import UsageError
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pytester import Pytester
 import pytest
@@ -254,7 +255,7 @@ class TestNewSession(SessionTests):
 
 
 def test_plugin_specify(pytester: Pytester) -> None:
-    with pytest.raises(ImportError):
+    with pytest.raises(UsageError):
         pytester.parseconfig("-p", "nqweotexistent")
     # pytest.raises(ImportError,
     #    "config.do_configure(config)"


### PR DESCRIPTION
Closes #993.

On `main` a plugin failing to import at startup escapes `_main` as a plain `ImportError`: raw traceback, exit 1 — colliding with `EXIT_TESTSFAILED` by accident — and `pytest.main()` raises instead of returning its documented exit code. A bare argless `ImportError` additionally crashes pytest's own `e.args[0]` handling with `IndexError`.

#7290 stalled on whether a plugin failing under a conftest's `pytest_plugins` is a conftest problem or a plugin problem. This PR splits on what actually went wrong instead of on which mechanism asked:

- **plugin not found** (`-p`, `pytest_plugins`, `PYTEST_PLUGINS`) → misuse → `USAGE_ERROR` (4), same as a failing `conftest.py` import
- **found but raises while importing** — including a missing transitive dependency and a broken `pytest11` entry point → plugin defect → `INTERNAL_ERROR` (3), traceback preserved in the report and on the exception chain (`raise ... from`) (losing it was the other objection to #7290)

The split keys on `ModuleNotFoundError.name` matching the requested spec or a parent package, so a plugin whose own `import foo` fails is not blamed on the user. `conftest.py` import failures stay at 4, unchanged.

| | before | after |
|---|---|---|
| missing plugin via `-p` / `pytest_plugins` / `PYTEST_PLUGINS` | 1 + raw traceback | **4** |
| plugin raises at import (incl. missing dependency, broken entry point) | 1 + raw traceback | **3** + formatted traceback |
| `conftest.py` fails to import | 4 | **4** |
| `pytest.main()` in-process | raised `ImportError` | returns the exit code |

Draft because the classification is a judgement call and exit codes are observable API:

1. Is `INTERNAL_ERROR` (3) right for a broken third-party plugin, or does this warrant a new exit code? `wrap_session` already uses 3 for plugin exceptions mid-session.
2. Should `conftest.py` follow the same split? Left alone here to keep the blast radius small.
3. The `load_setuptools_entrypoints` override widens scope — but without it a broken installed plugin still exits 1 with a raw traceback.
4. ~~Changelog: `bugfix` or `breaking`?~~ Filed as `breaking` per review.

Tests: new `TestStartupPluginImportErrors` covers every entry path plus both regressions; six existing tests updated from `ImportError` to `UsageError`/`PluginImportFailure`. Full suite and pre-commit (incl. mypy) pass locally.

🤖 Written by Claude Code (Claude Fable 5); reviewed and submitted by @RonnyPfannschmidt.
