### PR TITLE
docs: fix tox package_env references

### DIFF
--- a/changelog/14818.doc.rst
+++ b/changelog/14818.doc.rst
@@ -1,1 +1,0 @@
-Corrected the Tox ``package_env`` references in the changelog so they resolve to the external Tox documentation.

--- a/changelog/14818.doc.rst
+++ b/changelog/14818.doc.rst
@@ -1,0 +1,1 @@
+Corrected the Tox ``package_env`` references in the changelog so they resolve to the external Tox documentation.

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -466,7 +466,7 @@ Packaging updates and notes for downstreams
 -------------------------------------------
 
 - `#13933 <https://github.com/pytest-dev/pytest/issues/13933>`_: The tox configuration has been adjusted to make sure the desired
-  version string can be passed into its :ref:`package_env` through
+  version string can be passed into its :external+tox:ref:`package_env` through
   the ``SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTEST`` environment
   variable as a part of the release process -- by :user:`webknjaz`.
 
@@ -481,7 +481,7 @@ Contributor-facing changes
 
 
 - `#13933 <https://github.com/pytest-dev/pytest/issues/13933>`_: The tox configuration has been adjusted to make sure the desired
-  version string can be passed into its :ref:`package_env` through
+  version string can be passed into its :external+tox:ref:`package_env` through
   the ``SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTEST`` environment
   variable as a part of the release process -- by :user:`webknjaz`.
 


### PR DESCRIPTION
## Summary

- Replace both unresolved local `:ref:`package_env`` references in the changelog with the existing external Tox intersphinx role.
- Keep the duplicate generated changelog entries consistent.
- Add the required `changelog/14818.doc.rst` fragment.

Closes #14818

## Validation

- `git diff --check`
- `git show --check HEAD`
- Confirmed `doc/en/conf.py` already defines the `tox` intersphinx mapping.
- The external Chronographer changelog check initially required a news fragment; `changelog/14818.doc.rst` was added and pushed in `c1dd525`.
- The full docs build was not run because the host ran out of temporary disk space while provisioning tox; no temporary build artifacts remain.

## Contribution policy

This is a small documentation fix. I personally reviewed the diff and existing Sphinx configuration, understand why the external role is required, and will respond to review feedback. AI assistance was used and is credited by the `Co-authored-by: OpenAI Codex <noreply@openai.com>` commit trailer.