### PR TITLE
Accept MarkDecorator as get_closest_marker default

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@ Aaron Coleman
 Abdeali JK
 Abdelrahman Elbehery
 Abhijeet Kasurde
+ace2016
 Adam Johnson
 Adam Stewart
 Adam Uhlir

--- a/changelog/13354.improvement.rst
+++ b/changelog/13354.improvement.rst
@@ -1,0 +1,3 @@
+:meth:`Node.get_closest_marker <_pytest.nodes.Node.get_closest_marker>` now also accepts a :class:`~pytest.MarkDecorator` as its ``default``, for example ``item.get_closest_marker("foo", pytest.mark.foo(1))``, and returns the wrapped :class:`~pytest.Mark`.
+
+Previously the only way to build a ``default`` was to instantiate :class:`~pytest.Mark` directly, which is private and warns.

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -352,15 +352,22 @@ class Node(abc.ABC, metaclass=NodeMeta):
     def get_closest_marker(self, name: str) -> Mark | None: ...
 
     @overload
-    def get_closest_marker(self, name: str, default: Mark) -> Mark: ...
+    def get_closest_marker(self, name: str, default: Mark | MarkDecorator) -> Mark: ...
 
-    def get_closest_marker(self, name: str, default: Mark | None = None) -> Mark | None:
+    def get_closest_marker(
+        self, name: str, default: Mark | MarkDecorator | None = None
+    ) -> Mark | None:
         """Return the first marker matching the name, from closest (for
         example function) to farther level (for example module level).
 
-        :param default: Fallback return value if no marker was found.
+        :param default:
+            Fallback return value if no marker was found. A
+            :class:`~pytest.MarkDecorator` such as ``pytest.mark.foo(1)`` is
+            also accepted, in which case its :class:`~pytest.Mark` is returned.
         :param name: Name to filter by.
         """
+        if isinstance(default, MarkDecorator):
+            default = default.mark
         return next(self.iter_markers(name=name), default)
 
     def listextrakeywords(self) -> set[str]:

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -657,6 +657,18 @@ class TestFunctional:
         assert has_inherited_marker.kwargs == {"location": "class"}
         assert has_own.get_closest_marker("missing") is None
 
+    def test_mark_closest_default_mark_decorator(self, pytester: Pytester) -> None:
+        p = pytester.makepyfile(
+            """
+            def test_without_mark():
+                pass
+        """
+        )
+        items, _rec = pytester.inline_genitems(p)
+        (item,) = items
+        default = pytest.mark.foo(location="default")
+        assert item.get_closest_marker("foo", default) is default.mark
+
     def test_mark_with_wrong_marker(self, pytester: Pytester) -> None:
         reprec = pytester.inline_runsource(
             """


### PR DESCRIPTION
closes #13354

## Problem

`Node.get_closest_marker(name, default)` documents and type-hints its `default` as a `Mark`:

```python
@overload
def get_closest_marker(self, name: str, default: Mark) -> Mark: ...
```

But `Mark.__init__` is private-gated — it ends in `check_ispytest(_ispytest)`, which raises a `PytestDeprecationWarning` ("A private pytest class or function was used.") when a user constructs a `Mark` directly. That leaves the public parameter with no supported way to produce a value: the API asks for a `Mark`, and the obvious way to build one warns.

## Approach
So `get_closest_marker` now also accepts a `MarkDecorator` and unwraps it:

```python
if isinstance(default, MarkDecorator):
    default = default.mark
```

```python
# now works, no warning
item.get_closest_marker("foo", pytest.mark.foo(1))
```

`pytest.mark.foo(1)` builds its `Mark` internally with `_ispytest=True`, so nothing warns.

## Changes

| File | Change |
| --- | --- |
| `src/_pytest/nodes.py` | Widen `default` to `Mark \| MarkDecorator`, unwrap to `.mark`, document it |
| `testing/test_mark.py` | Regression test alongside the existing `test_mark_closest` |
| `changelog/13354.improvement.rst` | Changelog entry |
| `AUTHORS` | Added myself |

`doc/en/reference/reference.rst` needed no edit — it autodocs the method, so the updated docstring flows through.

## Testing

- `testing/test_mark.py` and `testing/test_nodes.py` pass (124 passed, 1 xfailed).
- The new test is a genuine regression test: reverting only the `nodes.py` change makes it fail, restoring it makes it pass.
- Full `pre-commit` on all changed files passes, including `mypy`, `ruff`, `ruff format`, and `codespell`.

The new test uses the registered dummy marker `foo` from `pyproject.toml` rather than an ad-hoc name, because the decorator is constructed in the outer test process where pytest's own suite runs with `--strict-markers`.

##Checklist:

- [ ] Include documentation when adding new features.
      -> The method docstring is updated; reference docs autodoc it.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits.
- [X] Add text like ``closes #XYZW`` to the PR description and/or commits.
- [X] If AI agents were used, they are credited in `Co-authored-by` commit trailers.
- [X] Create a new changelog file in the `changelog` directory.
- [X] Add yourself to `AUTHORS` in alphabetical order.

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
