### PR TITLE
Improve pytester outcome parsing error

### DIFF
--- a/changelog/13369.improvement.rst
+++ b/changelog/13369.improvement.rst
@@ -1,0 +1,1 @@
+Improved the error from :meth:`pytest.RunResult.assert_outcomes` when a plugin changes or removes pytest's standard terminal summary, and documented how to isolate output-changing plugins.

--- a/doc/en/how-to/writing_plugins.rst
+++ b/doc/en/how-to/writing_plugins.rst
@@ -425,6 +425,14 @@ return a result object, with which we can assert the tests' outcomes.
         # check that all 4 tests passed
         result.assert_outcomes(passed=4)
 
+.. note::
+
+    :meth:`pytest.RunResult.assert_outcomes` parses pytest's standard terminal
+    summary. A plugin that changes or removes that summary can make outcome
+    parsing fail. Disable the output-changing plugin for the nested run with
+    ``-p no:<plugin>``, or set ``PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`` when the
+    nested run should not discover third-party plugins.
+
 
 Additionally it is possible to copy examples to the ``pytester``'s isolated environment
 before running pytest on it. This way we can abstract the tested logic to separate files,

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -563,6 +563,9 @@ class RunResult:
             ======= 1 failed, 1 passed, 1 warning, 1 error in 0.13s ====
 
         Will return ``{"failed": 1, "passed": 1, "warnings": 1, "errors": 1}``.
+
+        This method parses pytest's standard terminal summary. Plugins that
+        modify or remove that summary can make the outcomes unavailable.
         """
         return self.parse_summary_nouns(self.outlines)
 
@@ -582,7 +585,13 @@ class RunResult:
                 ret = {noun: int(count) for (count, noun) in outcomes}
                 break
         else:
-            raise ValueError("Pytest terminal summary report not found")
+            raise ValueError(
+                "Pytest terminal summary report not found. "
+                "Plugins that modify pytest's terminal output can break outcome "
+                "parsing. Disable the plugin for the test run, for example with "
+                "`-p no:<plugin>`, or disable plugin autoloading with "
+                "`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`."
+            )
 
         to_plural = {
             "warning": "warnings",
@@ -606,6 +615,9 @@ class RunResult:
         numbers (0 means it didn't occur) in the text output from a test run.
 
         ``warnings`` and ``deselected`` are only checked if not None.
+
+        This method requires pytest's standard terminal summary; see
+        :meth:`parseoutcomes`.
         """
         __tracebackhide__ = True
         from _pytest.pytester_assertions import assert_outcomes

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -299,8 +299,12 @@ def test_assert_outcomes_after_pytest_error(pytester: Pytester) -> None:
     pytester.makepyfile("def test_foo(): assert True")
 
     result = pytester.runpytest("--unexpected-argument")
-    with pytest.raises(ValueError, match="Pytest terminal summary report not found"):
+    with pytest.raises(ValueError) as exc_info:
         result.assert_outcomes(passed=0)
+
+    message = str(exc_info.value)
+    assert "Plugins that modify pytest's terminal output" in message
+    assert "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1" in message
 
 
 class TestSysModulesSnapshot:


### PR DESCRIPTION
Closes #13369

`RunResult.assert_outcomes()` depends on pytest's standard terminal summary. If
an auto-loaded plugin replaces or removes that summary, the previous exception
did not explain the likely cause.

This change:

- makes the missing-summary error point to output-changing plugins;
- names `-p no:<plugin>` and `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` as isolation options;
- documents that `assert_outcomes()` parses the standard terminal summary; and
- adds a focused regression assertion and changelog entry.

This documents the current behavior; it does not introduce a new reporting
interface or change plugin loading.

Validation:

- `testing/test_pytester.py`: 51 passed, 1 skipped, 1 xfailed
- all applicable changed-file pre-commit hooks passed
- `git diff --check`

AI assistance: OpenAI Codex helped draft the code, tests, documentation, and PR
description. I reviewed the complete diff and validation evidence, understand
the change, and take responsibility for the contribution and follow-up review.