### PR TITLE
docs: endorse pytest-skip-slow plugin

### DIFF
--- a/changelog/14834.doc.rst
+++ b/changelog/14834.doc.rst
@@ -1,0 +1,1 @@
+Added :pypi:`pytest-skip-slow` to the annotated list of third-party plugins.

--- a/doc/en/how-to/plugins.rst
+++ b/doc/en/how-to/plugins.rst
@@ -45,6 +45,10 @@ Here is a little annotated list for some popular plugins:
 * :pypi:`pytest-timeout`:
   to timeout tests based on function marks or global definitions.
 
+* :pypi:`pytest-skip-slow`:
+  to skip tests marked ``@pytest.mark.slow`` by default, and run them with
+  ``--slow``.
+
 * :pypi:`pytest-pep8`:
   a ``--pep8`` option to enable PEP8 compliance checking.
 


### PR DESCRIPTION
## Summary

* Add `pytest-skip-slow` to pytest's annotated third-party plugin list.
* Document that it skips tests marked `@pytest.mark.slow` by default and allows them to run with `--slow`.

## Context

This follows the direction discussed in #14834 to endorse the existing plugin before considering slow-marker functionality in pytest core.

## Testing

* `tox -e docs`
* `tox -e linting`
* `pre-commit run --files doc/en/how-to/plugins.rst`

Closes #14834