### PR TITLE
fix: raise TypeError for unknown kwargs passed to pytest.mark.skipif

### DIFF
--- a/changelog/14839.bugfix.rst
+++ b/changelog/14839.bugfix.rst
@@ -1,0 +1,1 @@
+:func:`pytest.mark.skipif` now raises :class:`TypeError` for unknown keyword arguments (e.g. ``strict=True``, which is only valid for :func:`pytest.mark.xfail`). Previously such arguments were silently ignored. This matches the validation already present for :func:`pytest.mark.skip`.

--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -166,9 +166,20 @@ class Skip:
     reason: str = "unconditional skip"
 
 
+_SKIPIF_KNOWN_KWARGS = frozenset({"condition", "reason"})
+
+
 def evaluate_skip_marks(item: Item) -> Skip | None:
     """Evaluate skip and skipif marks on item, returning Skip if triggered."""
     for mark in item.iter_markers(name="skipif"):
+        unknown = set(mark.kwargs) - _SKIPIF_KNOWN_KWARGS
+        if unknown:
+            formatted = ", ".join(f"{k!r}" for k in sorted(unknown))
+            raise TypeError(
+                f"pytest.mark.skipif() got unexpected keyword argument(s): {formatted}. "
+                f"Valid arguments are: condition, reason."
+            )
+
         if "condition" not in mark.kwargs:
             conditions = mark.args
         else:

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -944,9 +944,7 @@ class TestSkipif:
         )
         assert result.ret == 0
 
-    def test_skipif_unknown_kwarg_raises_type_error(
-        self, pytester: Pytester
-    ) -> None:
+    def test_skipif_unknown_kwarg_raises_type_error(self, pytester: Pytester) -> None:
         """pytest.mark.skipif() must raise TypeError for unknown kwargs.
 
         Previously extra kwargs like ``strict=True`` (a common mistake when

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -944,6 +944,47 @@ class TestSkipif:
         )
         assert result.ret == 0
 
+    def test_skipif_unknown_kwarg_raises_type_error(
+        self, pytester: Pytester
+    ) -> None:
+        """pytest.mark.skipif() must raise TypeError for unknown kwargs.
+
+        Previously extra kwargs like ``strict=True`` (a common mistake when
+        confusing skipif with xfail) were silently ignored. They now raise
+        a clear TypeError, matching the validation already present for
+        pytest.mark.skip(). Fixes #14839.
+        """
+        pytester.makepyfile(
+            """
+            import pytest
+            @pytest.mark.skipif(True, reason="r", strict=True)
+            def test_x():
+                pass
+        """
+        )
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines(
+            ["*TypeError*pytest.mark.skipif()*unexpected keyword argument*'strict'*"]
+        )
+        assert result.ret != 0
+
+    def test_skipif_multiple_unknown_kwargs_all_reported(
+        self, pytester: Pytester
+    ) -> None:
+        """All unknown kwargs are reported in a single TypeError at once."""
+        pytester.makepyfile(
+            """
+            import pytest
+            @pytest.mark.skipif(False, reason="r", strict=True, run=False)
+            def test_y():
+                pass
+        """
+        )
+        result = pytester.runpytest()
+        # Both unknown kwargs must appear in the error message.
+        result.stdout.fnmatch_lines(["*TypeError*pytest.mark.skipif()*'run'*'strict'*"])
+        assert result.ret != 0
+
 
 def test_skip_not_report_default(pytester: Pytester) -> None:
     p = pytester.makepyfile(


### PR DESCRIPTION
## Summary

Fixes #14839 — `pytest.mark.skipif()` silently ignores unknown keyword arguments, making common mistakes like `strict=True` (meant for `xfail`) invisible.

## Problem

```python
@pytest.mark.skipif(True, reason="r", strict=True)
def test_x():
    pass
```

This test is skipped. `strict=True` is silently dropped — the user gets skip behaviour, not the xfail behaviour they likely intended. There is no error, no warning.

`pytest.mark.skip()` already validates kwargs and raises a helpful `TypeError`. `skipif` was inconsistent.

## Fix

At the top of `evaluate_skip_marks()`, check `set(mark.kwargs) - {"condition", "reason"}` for each `skipif` marker. If unknown kwargs are present, raise immediately:

```
TypeError: pytest.mark.skipif() got unexpected keyword argument(s): 'strict'.
Valid arguments are: condition, reason.
```

All unknown kwargs are collected and reported in a single error (not one at a time).

## Tests

Two new tests inside `TestSkipif` in `testing/test_skipping.py`:

| Test | Covers |
|------|--------|
| `test_skipif_unknown_kwarg_raises_type_error` | Single unknown kwarg (`strict=True`) raises `TypeError` with helpful message |
| `test_skipif_multiple_unknown_kwargs_all_reported` | Multiple unknown kwargs (`run=False, strict=True`) all reported in one error |

## Changelog

`changelog/14839.bugfix.rst` added per towncrier conventions.
