### PR TITLE
Reject sequences nested in a sequence of a different type in approx (closes #11945)

### DIFF
--- a/changelog/11945.bugfix.rst
+++ b/changelog/11945.bugfix.rst
@@ -1,0 +1,4 @@
+:func:`pytest.approx` now rejects a sequence nested inside a sequence of a different type,
+such as a tuple inside a list. Previously only same-type nesting was detected, so these
+values reached the scalar comparison and were compared exactly rather than approximately,
+which silently returned the wrong result instead of raising ``TypeError``.

--- a/src/_pytest/approx.py
+++ b/src/_pytest/approx.py
@@ -358,7 +358,14 @@ class ApproxSequenceLike(Approx[Sequence[Any]]):
         __tracebackhide__ = True
 
         for index, x in enumerate(expected):
-            if isinstance(x, type(expected)):
+            # Use the same predicate the dispatcher uses to recognise a sequence,
+            # so that nesting is rejected consistently. Comparing against
+            # `type(expected)` only caught an element of the *same* type, which let
+            # a tuple inside a list (and a list inside a tuple) through to
+            # ApproxScalar, where it was compared exactly instead of approximately.
+            # Mappings are left alone: they are not sequences, and rejecting them
+            # here would change behaviour beyond this fix.
+            if _is_sequence_like(x) and not isinstance(x, Mapping):
                 msg = "pytest.approx() does not support nested data structures: {!r} at index {}\n  full sequence: {}"
                 raise TypeError(msg.format(x, index, pprint.pformat(expected)))
 

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -924,6 +924,11 @@ class TestApprox:
         [
             pytest.param([[1]], "data structures", id="nested-list"),
             pytest.param({"key": {"key": 1}}, "dictionaries", id="nested-dict"),
+            # GH#11945: the guard compared each element against type(expected),
+            # so a sequence nested inside a sequence of a *different* type was
+            # not rejected and ended up being compared exactly.
+            pytest.param([(1,)], "data structures", id="tuple-in-list"),
+            pytest.param(([1],), "data structures", id="list-in-tuple"),
         ],
     )
     def test_expected_value_type_error(self, x, name):
@@ -932,6 +937,20 @@ class TestApprox:
             match=rf"pytest.approx\(\) does not support nested {name}:",
         ):
             approx(x)
+
+    @pytest.mark.parametrize(
+        "actual, expected",
+        [
+            pytest.param([(1.2,)], [(1.2,)], id="tuple-in-list"),
+            pytest.param(([1.2],), ([1.2],), id="list-in-tuple"),
+        ],
+    )
+    def test_nested_mixed_sequence_not_silently_compared(self, actual, expected):
+        # GH#11945: these used to return a bool from an exact comparison, so
+        # `[(1.20000000000001,)] == approx([(1.2,)])` was False while the flat
+        # `(1.20000000000001,) == approx((1.2,))` was True.
+        with pytest.raises(TypeError):
+            assert actual == approx(expected)
 
     @pytest.mark.parametrize(
         "x",


### PR DESCRIPTION
Closes #11945.

### The bug

`ApproxSequenceLike.__init__` rejects nesting with:

```python
if isinstance(x, type(expected)):
```

That only catches an element of the *same* type as its container. A tuple inside a
list, or a list inside a tuple, passes the guard, reaches `ApproxScalar`, and is
compared with `==`. So the comparison is exact, not approximate, and no error is
raised:

```python
>>> [[1.20000000000001]] == approx([[1.2]])          # same type
TypeError: pytest.approx() does not support nested data structures
>>> (1.20000000000001,) == approx((1.2,))            # flat
True
>>> [(1.20000000000001,)] == approx([(1.2,)])        # tuple in list
False
>>> ([1.20000000000001],) == approx(([1.2],))        # list in tuple
False
```

The identical-value case is the quieter half of it, because it looks like it works:

```python
>>> [(1.2,)] == approx([(1.2,)])
True
>>> ([1.2],) == approx(([1.2],))
True
```

Those return `True` from an exact comparison, so the tolerance is silently ignored.
A test written that way passes for the wrong reason and starts failing the moment a
value drifts by one ulp.

@crazymerlyn localised this in the issue.

### The fix

Use `_is_sequence_like`, the predicate `approx()` itself uses to decide whether to
dispatch to `ApproxSequenceLike`. The guard and the dispatcher then agree on what a
sequence is.

Mappings are excluded deliberately. `_is_sequence_like` is true for `dict`, since a
dict has `__getitem__` and `__len__`, so using it unqualified would newly reject
`[{"x": 1.0}] == approx([{"x": 1.0}])`, which works today. `approx()` avoids that by
checking `Mapping` before `_is_sequence_like`; the guard needs the same exclusion.
A dict nested in a sequence still gets the old exact comparison, and I have left
that alone since it is outside this issue. Happy to address it here or separately
if you would like it changed.

### Behaviour change worth flagging

`[np.array([1.0, 2.0])] == approx([np.array([1.0, 2.0])])` raised `ValueError`
("truth value of an array is ambiguous") on `main` and now raises `TypeError` with
the nested-structure message. Both are errors, and the new one names the actual
problem, but it is a different exception type.

Everything else I checked is unchanged: flat lists and tuples, `["string"]`,
`[{"x": 1.0}]`, a top-level numpy array, and same-type nesting.

### Tests

Two cases added to the existing `test_expected_value_type_error` parametrisation
(`tuple-in-list`, `list-in-tuple`), plus `test_nested_mixed_sequence_not_silently_compared`
which pins that these raise rather than returning a bool.

All four fail on `main`; the two pre-existing parametrisations pass either way.
`testing/python/approx.py`: 140 passed.
