### PR TITLE
feat: expose FixtureFunctionDefinition for typing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -87,6 +87,7 @@ Cal Leeming
 Carl Friedrich Bolz
 Carlos Jenkins
 Ceridwen
+Chanho Lee
 Charles Cloud
 Charles Machalow
 Charles-Meldhine Madi Mnemoi (cmnemoi)

--- a/changelog/14853.feature.rst
+++ b/changelog/14853.feature.rst
@@ -1,0 +1,1 @@
+Exposed :class:`pytest.FixtureFunctionDefinition` as the type of a fixture function after decoration by :func:`pytest.fixture`, allowing fixture factories to use it in type annotations.

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -76,7 +76,6 @@ nitpick_ignore = [
     ("py:class", "_pytest._code.code.TerminalRepr"),
     ("py:class", "TerminalRepr"),
     ("py:class", "_pytest.fixtures.FixtureFunctionMarker"),
-    ("py:class", "_pytest.fixtures.FixtureFunctionDefinition"),
     ("py:class", "_pytest.logging.LogCaptureHandler"),
     ("py:class", "_pytest.mark.structures.ParameterSet"),
     # Intentionally undocumented/private

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1010,6 +1010,11 @@ FixtureDef
     :members:
     :show-inheritance:
 
+FixtureFunctionDefinition
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pytest.FixtureFunctionDefinition()
+
 MarkDecorator
 ~~~~~~~~~~~~~
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1453,12 +1453,9 @@ class FixtureFunctionMarker:
 
 
 # TODO: paramspec/return type annotation tracking and storing
+@final
 class FixtureFunctionDefinition:
-    """The type of a fixture function after decoration by :func:`pytest.fixture`.
-
-    This type is public for type annotations. It should not be instantiated
-    or subclassed by users, and its attributes are not part of the public API.
-    """
+    """The type of a fixture function after decoration by :func:`pytest.fixture`."""
 
     def __init__(
         self,

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1454,6 +1454,12 @@ class FixtureFunctionMarker:
 
 # TODO: paramspec/return type annotation tracking and storing
 class FixtureFunctionDefinition:
+    """The type of a fixture function after decoration by :func:`pytest.fixture`.
+
+    This type is public for type annotations. It should not be instantiated
+    or subclassed by users, and its attributes are not part of the public API.
+    """
+
     def __init__(
         self,
         *,

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -26,6 +26,7 @@ from _pytest.debugging import pytestPDB as __pytestPDB
 from _pytest.doctest import DoctestItem
 from _pytest.fixtures import fixture
 from _pytest.fixtures import FixtureDef
+from _pytest.fixtures import FixtureFunctionDefinition
 from _pytest.fixtures import FixtureLookupError
 from _pytest.fixtures import FixtureRequest
 from _pytest.fixtures import register_fixture
@@ -114,6 +115,7 @@ __all__ = [
     "ExitCode",
     "File",
     "FixtureDef",
+    "FixtureFunctionDefinition",
     "FixtureLookupError",
     "FixtureRequest",
     "Function",

--- a/testing/typing_checks.py
+++ b/testing/typing_checks.py
@@ -78,3 +78,12 @@ def check_scope_typing() -> None:
 @pytest.mark.parametrize("x", [ImportError, AttributeError])
 def check_mypy_bug_with_argvalues(x) -> None:
     pass
+
+
+# Issue #14853.
+def check_fixture_factory(value: str) -> pytest.FixtureFunctionDefinition:
+    @pytest.fixture
+    def generated_fixture() -> str:
+        return value
+
+    return generated_fixture


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [X] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->

Closes #14853

## Summary

`pytest.fixture` returns a `FixtureFunctionDefinition`, but users previously had to import this type from the private `_pytest.fixtures` module when annotating fixture factories.

This change exports the existing class as `pytest.FixtureFunctionDefinition` and adds it to the API reference. It does not introduce a new class or change fixture behavior at runtime. The supported public surface is limited to its use in type annotations. Direct instantiation, subclassing, and its attributes remain outside the public API.

A typing check covers fixture factories returning the public type. The obsolete Sphinx cross-reference exception is also removed now that the type has a public documentation target.