### PR TITLE
Use expanded pformat on Python 3.15

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -276,6 +276,7 @@ Kojo Idrissa
 Kostis Anagnostopoulos
 Kristoffer Nordström
 Kyle Altendorf
+Langning Zhang
 Lawrence Mitchell
 Lee Kamentsky
 Leonardus Chen

--- a/changelog/14859.improvement.rst
+++ b/changelog/14859.improvement.rst
@@ -1,0 +1,1 @@
+Used Python 3.15's expanded pretty-printing for clearer multiline output.

--- a/src/_pytest/_io/saferepr.py
+++ b/src/_pytest/_io/saferepr.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from itertools import islice
-import pprint
 import reprlib
+
+from _pytest.compat import pformat
 
 
 def _try_repr_or_str(obj: object) -> str:
@@ -112,7 +113,7 @@ def safeformat(obj: object) -> str:
     with a short exception info.
     """
     try:
-        return pprint.pformat(obj)
+        return pformat(obj)
     except Exception as exc:
         return _format_repr_exception(exc, obj)
 

--- a/src/_pytest/approx.py
+++ b/src/_pytest/approx.py
@@ -14,7 +14,6 @@ from datetime import timedelta
 from decimal import Decimal
 import math
 from numbers import Complex
-import pprint
 import sys
 from typing import Any
 from typing import Generic
@@ -22,6 +21,8 @@ from typing import SupportsAbs
 from typing import TYPE_CHECKING
 from typing import TypeGuard
 from typing import TypeVar
+
+from _pytest.compat import pformat
 
 
 if TYPE_CHECKING:
@@ -262,7 +263,7 @@ class ApproxMapping(Approx[Mapping[Any, Any]]):
         for key, value in expected.items():
             if isinstance(value, type(expected)):
                 msg = "pytest.approx() does not support nested dictionaries: key={!r} value={!r}\n  full mapping={}"
-                raise TypeError(msg.format(key, value, pprint.pformat(expected)))
+                raise TypeError(msg.format(key, value, pformat(expected)))
 
         super().__init__(expected, rel=rel, abs=abs, nan_ok=nan_ok)
 
@@ -360,7 +361,7 @@ class ApproxSequenceLike(Approx[Sequence[Any]]):
         for index, x in enumerate(expected):
             if isinstance(x, type(expected)):
                 msg = "pytest.approx() does not support nested data structures: {!r} at index {}\n  full sequence: {}"
-                raise TypeError(msg.format(x, index, pprint.pformat(expected)))
+                raise TypeError(msg.format(x, index, pformat(expected)))
 
         super().__init__(expected, rel=rel, abs=abs, nan_ok=nan_ok)
 

--- a/src/_pytest/assertion/_compare_any.py
+++ b/src/_pytest/assertion/_compare_any.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 import dataclasses
-import pprint
 
 from _pytest.assertion._compare_mapping import _compare_eq_mapping
 from _pytest.assertion._compare_sequence import _compare_eq_iterable
@@ -22,6 +21,7 @@ from _pytest.assertion._typing import _HighlightFunc
 from _pytest.assertion._typing import NO_TRUNCATION_BUDGET
 from _pytest.assertion._typing import TruncationBudget
 from _pytest.assertion.compare_text import _compare_eq_text
+from _pytest.compat import pformat
 
 
 def _compare_eq_any(
@@ -119,10 +119,10 @@ def _compare_eq_cls(
         yield f"Omitting {len(same)} identical items, use -vv to show"
     elif same:
         yield "Matching attributes:"
-        yield from highlighter(pprint.pformat(same)).splitlines()
+        yield from highlighter(pformat(same)).splitlines()
     if diff:
         yield "Differing attributes:"
-        yield from highlighter(pprint.pformat(diff)).splitlines()
+        yield from highlighter(pformat(diff)).splitlines()
         for field in diff:
             field_left = getattr(left, field)
             field_right = getattr(right, field)

--- a/src/_pytest/assertion/_compare_mapping.py
+++ b/src/_pytest/assertion/_compare_mapping.py
@@ -4,13 +4,13 @@ from collections.abc import Collection
 from collections.abc import Iterator
 from collections.abc import Mapping
 import heapq
-import pprint
 
 from _pytest._io.pprint import _safe_key
 from _pytest._io.saferepr import saferepr
 from _pytest.assertion._typing import _HighlightFunc
 from _pytest.assertion._typing import NO_TRUNCATION_BUDGET
 from _pytest.assertion._typing import TruncationBudget
+from _pytest.compat import pformat
 
 
 def _compare_eq_mapping(
@@ -28,7 +28,7 @@ def _compare_eq_mapping(
         yield f"Omitting {len(same)} identical items, use -vv to show"
     elif same:
         yield "Common items:"
-        yield from highlighter(pprint.pformat(same)).splitlines()
+        yield from highlighter(pformat(same)).splitlines()
     diff = {k for k in common if left[k] != right[k]}
     if diff:
         yield "Differing items:"
@@ -62,9 +62,7 @@ def _format_extra_items(
     max_lines = truncation_budget.max_lines
     if max_lines == 0 or len(keys) <= max_lines:
         # If no need to truncate, let pprint handle it.
-        yield from highlighter(
-            pprint.pformat({k: mapping[k] for k in keys})
-        ).splitlines()
+        yield from highlighter(pformat({k: mapping[k] for k in keys})).splitlines()
     else:
         # To avoid spending effort on formatting entries that would be truncated,
         # only format the needed entries, keeping the sorting that pprint would use.

--- a/src/_pytest/cacheprovider.py
+++ b/src/_pytest/cacheprovider.py
@@ -21,6 +21,7 @@ from .pathlib import rm_rf
 from .reports import CollectReport
 from _pytest import nodes
 from _pytest._io import TerminalWriter
+from _pytest.compat import pformat
 from _pytest.config import Config
 from _pytest.config import ExitCode
 from _pytest.config import hookimpl
@@ -599,8 +600,6 @@ def cacheshow(config: Config, session: Session) -> int:
     :param session: pytest session object.
     :returns: Exit code (0 for success).
     """
-    from pprint import pformat
-
     assert config.cache is not None
 
     tw = TerminalWriter()

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -11,6 +11,7 @@ from inspect import Parameter
 from inspect import Signature
 import os
 from pathlib import Path
+import pprint
 import sys
 from typing import Any
 from typing import Final
@@ -327,3 +328,9 @@ else:
                 return func
 
             return decorator
+
+
+if sys.version_info >= (3, 15):
+    pformat = functools.partial(pprint.pformat, expand=True)
+else:
+    pformat = pprint.pformat

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from collections.abc import Generator
 from collections.abc import Iterator
-from pprint import pformat
 import re
 from types import TracebackType
 from typing import Any
@@ -24,6 +23,7 @@ if TYPE_CHECKING:
 
 import warnings
 
+from _pytest.compat import pformat
 from _pytest.deprecated import check_ispytest
 from _pytest.fixtures import fixture
 from _pytest.outcomes import Exit

--- a/testing/test_cacheprovider.py
+++ b/testing/test_cacheprovider.py
@@ -7,6 +7,7 @@ from enum import Enum
 import os
 from pathlib import Path
 import shutil
+import sys
 from typing import Any
 
 from _pytest.compat import assert_never
@@ -278,6 +279,48 @@ def test_cache_show(pytester: Pytester) -> None:
     stdout = result.stdout.str()
     assert "other/some" not in stdout
     assert "d/mydb/world" not in stdout
+    assert result.ret == 0
+
+
+@pytest.mark.skipif(sys.version_info < (3, 15), reason="requires Python 3.15+")
+def test_cache_show_uses_expanded_pformat(pytester: Pytester) -> None:
+    pytester.makeconftest(
+        """
+        def pytest_configure(config):
+            config.cache.set(
+                "nested",
+                {
+                    "a" * 12: 1,
+                    "b" * 20: 2,
+                    "c" * 30: {
+                        "d" * 5: 3,
+                        "e" * 20: 4,
+                        "f" * 10: 5,
+                        "g" * 20: 6,
+                    },
+                },
+            )
+        """
+    )
+    pytester.runpytest()
+
+    result = pytester.runpytest("--cache-show", "nested")
+
+    result.stdout.fnmatch_lines(
+        [
+            "nested contains:",
+            "  {",
+            "   'aaaaaaaaaaaa': 1,",
+            "   'bbbbbbbbbbbbbbbbbbbb': 2,",
+            "   'cccccccccccccccccccccccccccccc': {",
+            "    'ddddd': 3,",
+            "    'eeeeeeeeeeeeeeeeeeee': 4,",
+            "    'ffffffffff': 5,",
+            "    'gggggggggggggggggggg': 6,",
+            "   },",
+            "  }",
+        ]
+    )
     assert result.ret == 0
 
 


### PR DESCRIPTION
Closes #14859.

On Python 3.15 and newer, route pytest uses of pprint.pformat through a compatibility helper that enables expand=True. Earlier Python versions keep the existing formatter behavior.

The regression test exercises the public --cache-show output with nested data.

Tests:
- Python 3.15 full suite: 4370 passed, 48 skipped, 17 xfailed, 4 xpassed
- Python 3.13 affected suite: 493 passed, 1 skipped
- pre-commit run --all-files