### PR TITLE
Don't trust a zero Windows file ID in samefile_nofollow

### DIFF
--- a/changelog/14864.bugfix.rst
+++ b/changelog/14864.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed collection on Windows collecting the whole suite instead of the given path, on file systems which do not support file IDs (``st_ino`` is ``0`` for every file, as seen for example on ``sshfs-win``/WinFsp mounts).

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -1095,4 +1095,12 @@ def samefile_nofollow(p1: Path, p2: Path) -> bool:
 
     Unlike Path.samefile(), does not resolve symlinks.
     """
-    return os.path.samestat(p1.lstat(), p2.lstat())
+    s1, s2 = p1.lstat(), p2.lstat()
+    # On Windows st_ino is the file ID, which file systems are free to not support,
+    # in which case it is 0 for every file -- WinFsp mounts such as sshfs-win are one
+    # example. os.path.samestat() would then consider any two files on the volume to
+    # be the same (python/cpython#78116), so treat a zero file ID as "unknown" and
+    # leave the caller with plain path comparison (#14864).
+    if s1.st_ino == 0 or s2.st_ino == 0:
+        return False
+    return os.path.samestat(s1, s2)

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -38,6 +38,7 @@ from _pytest.pathlib import module_name_from_path
 from _pytest.pathlib import resolve_package_path
 from _pytest.pathlib import resolve_pkg_root_and_module_name
 from _pytest.pathlib import safe_exists
+from _pytest.pathlib import samefile_nofollow
 from _pytest.pathlib import scandir
 from _pytest.pathlib import spec_matches_module_path
 from _pytest.pathlib import symlink_or_skip
@@ -568,6 +569,38 @@ def test_samefile_false_negatives(tmp_path: Path, monkeypatch: MonkeyPatch) -> N
             module_path, root=tmp_path, consider_namespace_packages=False
         )
     assert getattr(module, "foo")() == 42
+
+
+def test_samefile_nofollow(tmp_path: Path) -> None:
+    p1 = tmp_path / "test_one.py"
+    p2 = tmp_path / "test_two.py"
+    p1.touch()
+    p2.touch()
+
+    assert samefile_nofollow(p1, p1)
+    assert not samefile_nofollow(p1, p2)
+
+
+def test_samefile_nofollow_zero_file_id(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """On Windows file systems which do not support file IDs, st_ino is 0 for every
+    file, which must not make two distinct files compare equal (#14864)."""
+    p1 = tmp_path / "test_one.py"
+    p2 = tmp_path / "test_two.py"
+    p1.touch()
+    p2.touch()
+
+    # st_dev is a real value (the volume serial number), only the file ID is missing.
+    zero_file_id = os.stat_result((0o100644, 0, 3816903231, 1, 0, 0, 0, 0, 0, 0))
+    with monkeypatch.context() as mp:
+        # Use a context to narrow the patch as much as possible, given how central
+        # Path.lstat() is.
+        mp.setattr(Path, "lstat", lambda self: zero_file_id)
+
+        assert not samefile_nofollow(p1, p2)
+        # Also for the same file -- the caller compares paths first anyway.
+        assert not samefile_nofollow(p1, p1)
 
 
 def test_scandir_with_non_existent_directory() -> None:


### PR DESCRIPTION
Fixes #14864.

On Windows, when a collection argument's path does not compare equal to a collected node's path, `Session.collect()` falls back to `samefile_nofollow()` to account for 8.3 short paths (#11895). That fallback uses `os.path.samestat()`, i.e. it compares `(st_dev, st_ino)`.

On Windows `st_ino` is the file ID, and support for file IDs is file-system specific — a file system that has none reports `0` for every file, the same convention the neighbouring `BY_HANDLE_FILE_INFORMATION` fields use for unsupported values. The reporter's drive is an sshfs (WinFsp) mount, where the chain is:

* SFTP v3's `ATTRS` has no inode field, so [sshfs](https://github.com/libfuse/sshfs/blob/master/sshfs.c) never fills `st_ino` (the identifier does not appear in `sshfs.c` at all).
* On Linux this is invisible because libfuse's `set_stat()` overwrites `st_ino` with its own node id unless `use_ino` is given. WinFsp's FUSE layer has no such fallback: it discards `use_ino` and assigns [`FileInfo->IndexNumber = stbuf.st_ino`](https://github.com/winfsp/winfsp/blob/master/src/dll/fuse/fuse_intf.c#L540) verbatim.
* `FILE_ID_INFO.FileId` and `nFileIndexHigh/Low` are therefore both `0`, and CPython passes that straight through to `st_ino`.

So `os.path.samestat()` reports every pair of files on the volume as the same file, every node matched, nothing got pruned, and passing a single file collected the whole suite. This is the long-standing python/cpython#78116 (`samefile()` should not use zero-valued `st_dev` and `st_ino`), which also affects Google Drive File Stream and WebDAV volumes.

Fixed by treating a zero file ID as "unknown" in the Windows version of `samefile_nofollow()`, so the caller falls back to plain path comparison — which is what every non-Windows platform does anyway, since the `samestat()` fallback is win32-only. The short-path case from #11895 is local NTFS with real file IDs and keeps working; 8.3 short names are an NTFS/FAT feature that the affected mounts do not generate in the first place.

Note that `_is_same()` in the same module has the same weakness, but there a bogus `True` only makes the import-mismatch check miss a mismatch rather than break collection, so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)