### PR TITLE
fix: avoid zero-inode samefile matches on network filesystems

### DIFF
--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -1095,4 +1095,10 @@ def samefile_nofollow(p1: Path, p2: Path) -> bool:
 
     Unlike Path.samefile(), does not resolve symlinks.
     """
-    return os.path.samestat(p1.lstat(), p2.lstat())
+    s1, s2 = p1.lstat(), p2.lstat()
+    # Some network filesystems report a zero inode for every path. In that
+    # case samestat() cannot distinguish different files and would make every
+    # collected path match the requested one.
+    if not s1.st_ino or not s2.st_ino:
+        return False
+    return os.path.samestat(s1, s2)

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -38,8 +38,8 @@ from _pytest.pathlib import module_name_from_path
 from _pytest.pathlib import resolve_package_path
 from _pytest.pathlib import resolve_pkg_root_and_module_name
 from _pytest.pathlib import safe_exists
-from _pytest.pathlib import scandir
 from _pytest.pathlib import samefile_nofollow
+from _pytest.pathlib import scandir
 from _pytest.pathlib import spec_matches_module_path
 from _pytest.pathlib import symlink_or_skip
 from _pytest.pathlib import visit

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -39,6 +39,7 @@ from _pytest.pathlib import resolve_package_path
 from _pytest.pathlib import resolve_pkg_root_and_module_name
 from _pytest.pathlib import safe_exists
 from _pytest.pathlib import scandir
+from _pytest.pathlib import samefile_nofollow
 from _pytest.pathlib import spec_matches_module_path
 from _pytest.pathlib import symlink_or_skip
 from _pytest.pathlib import visit
@@ -568,6 +569,20 @@ def test_samefile_false_negatives(tmp_path: Path, monkeypatch: MonkeyPatch) -> N
             module_path, root=tmp_path, consider_namespace_packages=False
         )
     assert getattr(module, "foo")() == 42
+
+
+@pytest.mark.parametrize("inodes", [(0, 0), (0, 1), (1, 0)])
+def test_samefile_nofollow_rejects_zero_inodes(
+    inodes: tuple[int, int], monkeypatch: MonkeyPatch
+) -> None:
+    stats = [unittest.mock.Mock(st_ino=inode) for inode in inodes]
+    lstat = unittest.mock.Mock(side_effect=stats)
+    samestat = unittest.mock.Mock(return_value=True)
+    monkeypatch.setattr(Path, "lstat", lstat)
+    monkeypatch.setattr(os.path, "samestat", samestat)
+
+    assert not samefile_nofollow(Path("first"), Path("second"))
+    samestat.assert_not_called()
 
 
 def test_scandir_with_non_existent_directory() -> None:


### PR DESCRIPTION
Fixes #14864

Some network filesystems report `st_ino == 0` for every path. `samefile_nofollow()` now avoids calling `samestat()` when either inode is zero, preventing unrelated paths from being treated as the same file. Added regression coverage for all zero-inode combinations.

Testing:
- `PYTHONPATH=src uv run --no-project --python 3.13 --with pytest --with pluggy --with iniconfig --with packaging python -m pytest -q testing/test_pathlib.py -k "samefile_nofollow or samefile_false_negatives"`

Prepared with AI assistance; maintainer review is requested.