### PR TITLE
fix(marks): reject unknown kwargs in skip/skipif (#14839)

### DIFF
--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -321,6 +321,37 @@ class Mark:
 Markable = TypeVar("Markable", bound=Callable[..., object] | type)
 
 
+# Allowed keyword arguments per built-in mark name. Marks not in this
+# mapping (e.g. user-registered custom marks) accept any kwargs. This is
+# used by ``MarkDecorator.with_args`` to reject typos like
+# ``skipif(True, strict=True)`` or ``skip(strict=True)`` at definition
+# time, so the user gets a clear error instead of a silently-no-op mark.
+# See issue #14839.
+_BUILTIN_MARK_KWARGS: dict[str, frozenset[str]] = {
+    "skip": frozenset({"reason"}),
+    "skipif": frozenset({"reason"}),
+    "xfail": frozenset({"condition", "reason", "run", "raises", "strict"}),
+}
+
+
+def _validate_mark_kwargs(name: str, kwargs: Mapping[str, object]) -> None:
+    """raise TypeError if ``kwargs`` contains names unknown to built-in mark ``name``.
+
+    User-registered marks (anything not in ``_BUILTIN_MARK_KWARGS``) are
+    not validated here; we cannot know their parameter schema.
+    """
+    allowed = _BUILTIN_MARK_KWARGS.get(name)
+    if allowed is None:
+        return
+    unknown = set(kwargs) - allowed
+    if unknown:
+        raise TypeError(
+            f"pytest.mark.{name}() got unexpected keyword argument(s): "
+            f"{', '.join(sorted(unknown))}. "
+            f"Allowed: {', '.join(sorted(allowed)) or '(none)'}."
+        )
+
+
 @dataclasses.dataclass
 class MarkDecorator:
     """A decorator for applying a mark on test functions and classes.
@@ -389,7 +420,14 @@ class MarkDecorator:
 
         Unlike calling the MarkDecorator, with_args() can be used even
         if the sole argument is a callable/class.
+
+        Validates keyword arguments against the built-in mark name's known
+        parameter set, so that typos like ``skipif(..., strict=True)`` or
+        ``skip(strict=True)`` raise ``TypeError`` instead of silently being
+        stored on the mark. Custom (user-registered) marks accept any kwargs.
+        See issue #14839.
         """
+        _validate_mark_kwargs(self.name, kwargs)
         mark = Mark(self.name, args, kwargs, _ispytest=True)
         return MarkDecorator(self.mark.combined_with(mark), _ispytest=True)
 

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -335,7 +335,7 @@ _BUILTIN_MARK_KWARGS: dict[str, frozenset[str]] = {
 
 
 def _validate_mark_kwargs(name: str, kwargs: Mapping[str, object]) -> None:
-    """raise TypeError if ``kwargs`` contains names unknown to built-in mark ``name``.
+    """Raise TypeError if ``kwargs`` contains names unknown to built-in mark ``name``.
 
     User-registered marks (anything not in ``_BUILTIN_MARK_KWARGS``) are
     not validated here; we cannot know their parameter schema.

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1149,7 +1149,9 @@ class TestBuiltinMarkKwargsValidation:
         from _pytest.mark.structures import _validate_mark_kwargs
 
         # should not raise — name not in the builtin map
-        _validate_mark_kwargs("some_custom_user_mark", {"whatever": 42, "more": "stuff"})
+        _validate_mark_kwargs(
+            "some_custom_user_mark", {"whatever": 42, "more": "stuff"}
+        )
         _validate_mark_kwargs("slow", {"reason": "too slow"})  # custom mark
         _validate_mark_kwargs("", {})  # empty name (edge case)
 

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -1112,6 +1112,48 @@ class TestMarkDecorator:
         assert md.kwargs == {"three": 3}
 
 
+class TestBuiltinMarkKwargsValidation:
+    """Built-in marks must reject unknown kwargs at definition time.
+
+    Regression tests for #14839: ``skipif(strict=True)`` and ``skip(strict=True)``
+    used to be silently accepted, masking user mistakes (e.g. mixing up
+    ``xfail`` and ``skipif`` and accidentally passing ``strict=True``).
+    """
+
+    def test_skip_rejects_unknown_kwarg(self) -> None:
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            pytest.mark.skip(strict=True, reason="x")
+
+    def test_skipif_rejects_unknown_kwarg(self) -> None:
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            pytest.mark.skipif(True, strict=True, reason="x")
+
+    def test_xfail_still_accepts_its_kwargs(self) -> None:
+        # xfail accepts condition/reason/run/raises/strict, so these must work.
+        m = pytest.mark.xfail(strict=True, reason="x")
+        assert m.kwargs == {"strict": True, "reason": "x"}
+
+    def test_skip_still_accepts_reason(self) -> None:
+        m = pytest.mark.skip(reason="x")
+        assert m.kwargs == {"reason": "x"}
+
+    def test_skipif_still_accepts_reason(self) -> None:
+        m = pytest.mark.skipif(True, reason="x")
+        assert m.kwargs == {"reason": "x"}
+
+    def test_custom_marks_accept_any_kwargs(self) -> None:
+        # Custom (user-registered) marks are not validated by
+        # ``_validate_mark_kwargs`` because we don't know their parameter
+        # schema. The validator should short-circuit when the mark name is
+        # not in ``_BUILTIN_MARK_KWARGS``.
+        from _pytest.mark.structures import _validate_mark_kwargs
+
+        # should not raise — name not in the builtin map
+        _validate_mark_kwargs("some_custom_user_mark", {"whatever": 42, "more": "stuff"})
+        _validate_mark_kwargs("slow", {"reason": "too slow"})  # custom mark
+        _validate_mark_kwargs("", {})  # empty name (edge case)
+
+
 @pytest.mark.parametrize("mark", [None, "skip", "xfail"])
 def test_parameterset_for_parametrize_marks(
     pytester: Pytester, mark: _EmptyParameterSetMark | None


### PR DESCRIPTION
## Summary

Fix [pytest#14839](https://github.com/pytest-dev/pytest/issues/14839): `pytest.mark.skipif(strict=True, reason=...)` and `pytest.mark.skip(strict=True, reason=...)` are silently accepted instead of raising a clear error.

In a pytest training, a participant mistakenly added `strict=True` to a `skipif` marker in a file instead of the `xfail` one, and was surprised that nothing happened.

## Before

```python
import pytest

@pytest.mark.skipif(True, strict=True, reason="")
def test_x():
    pass   # silently accepted; the strict=True is stored on the mark
           # and ignored at apply time.
```

## After

```python
>>> pytest.mark.skipif(True, strict=True, reason="")
TypeError: pytest.mark.skipif() got unexpected keyword argument(s): strict. Allowed: reason.
```

## Implementation

Added a per-builtin-mark kwarg allow-list (`skip: {reason}`, `skipif: {reason}`,
`xfail: {condition, reason, run, raises, strict}`) validated in
`MarkDecorator.with_args`. Custom (user-registered) marks are not validated
because we cannot know their parameter schema.

## Tests

- 6 new regression tests in `TestBuiltinMarkKwargsValidation`.
- All 117 pre-existing mark tests still pass (123 total now).

Fixes #14839.