### PR TITLE
fix: validate keyword arguments for pytest.mark.skipif (#14839)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -475,6 +475,7 @@ Tarcisio Fischer
 Tareq Alayan
 Tatiana Ovary
 Ted Xiao
+The-Habib
 Terje Runde
 Thomas Grainger
 Thomas Hisch

--- a/changelog/14839.bugfix.rst
+++ b/changelog/14839.bugfix.rst
@@ -1,0 +1,1 @@
+:func:`pytest.mark.skipif` now validates its keyword arguments and raises a :xcp:`TypeError` when unexpected keyword arguments (such as ``strict``) are passed.

--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -169,6 +169,14 @@ class Skip:
 def evaluate_skip_marks(item: Item) -> Skip | None:
     """Evaluate skip and skipif marks on item, returning Skip if triggered."""
     for mark in item.iter_markers(name="skipif"):
+        unexpected_kwargs = set(mark.kwargs) - {"condition", "reason"}
+        if unexpected_kwargs:
+            unexpected = sorted(unexpected_kwargs)[0]
+            msg = f"skipif() got an unexpected keyword argument {unexpected!r}"
+            if unexpected == "strict":
+                msg += " - maybe you meant pytest.mark.xfail?"
+            raise TypeError(msg)
+
         if "condition" not in mark.kwargs:
             conditions = mark.args
         else:

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -61,7 +61,7 @@ class TestEvaluation:
         item = pytester.getitem(
             """
             import pytest
-            @pytest.mark.skipif("hasattr(os, 'sep')", attr=2, reason="hello world")
+            @pytest.mark.skipif("hasattr(os, 'sep')", reason="hello world")
             def test_func():
                 pass
         """
@@ -69,6 +69,33 @@ class TestEvaluation:
         skipped = evaluate_skip_marks(item)
         assert skipped
         assert skipped.reason == "hello world"
+
+    def test_marked_skipif_unexpected_kwarg(self, pytester: Pytester) -> None:
+        item = pytester.getitem(
+            """
+            import pytest
+            @pytest.mark.skipif("hasattr(os, 'sep')", invalid=123, reason="hello world")
+            def test_func():
+                pass
+        """
+        )
+        with pytest.raises(TypeError, match=r"skipif\(\) got an unexpected keyword argument 'invalid'"):
+            evaluate_skip_marks(item)
+
+    def test_marked_skipif_strict_kwarg(self, pytester: Pytester) -> None:
+        item = pytester.getitem(
+            """
+            import pytest
+            @pytest.mark.skipif(True, strict=True, reason="hello world")
+            def test_func():
+                pass
+        """
+        )
+        with pytest.raises(
+            TypeError,
+            match=r"skipif\(\) got an unexpected keyword argument 'strict' - maybe you meant pytest.mark.xfail\?",
+        ):
+            evaluate_skip_marks(item)
 
     def test_marked_one_arg_twice(self, pytester: Pytester) -> None:
         lines = [

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -79,7 +79,9 @@ class TestEvaluation:
                 pass
         """
         )
-        with pytest.raises(TypeError, match=r"skipif\(\) got an unexpected keyword argument 'invalid'"):
+        with pytest.raises(
+            TypeError, match=r"skipif\(\) got an unexpected keyword argument 'invalid'"
+        ):
             evaluate_skip_marks(item)
 
     def test_marked_skipif_strict_kwarg(self, pytester: Pytester) -> None:


### PR DESCRIPTION
### Summary
This PR adds keyword argument validation for `pytest.mark.skipif`. Previously, any unsupported keyword argument passed to `@pytest.mark.skipif` (such as `strict=True`) was silently ignored. Now, `evaluate_skip_marks` validates keyword arguments and raises a `TypeError` when unexpected arguments are passed (including a helpful hint when `strict` is passed).

Closes #14839

### Problem
When a user mistakenly writes `@pytest.mark.skipif(True, strict=True, reason="")` instead of `pytest.mark.xfail`, `pytest.mark.skipif` silently ignores `strict=True`. In contrast, `pytest.mark.skip` validates its arguments.

### Solution
In `src/_pytest/skipping.py` (`evaluate_skip_marks`), validate that `mark.kwargs` only contains `"condition"` and `"reason"`. If unexpected keyword arguments are present, raise a `TypeError`. If `strict` is passed, append a helpful hint `- maybe you meant pytest.mark.xfail?`.

### Testing
- Updated existing `test_marked_one_arg_with_reason` in `testing/test_skipping.py`.
- Added unit tests `test_marked_skipif_unexpected_kwarg` and `test_marked_skipif_strict_kwarg` in `testing/test_skipping.py`.
- Verified all tests in `testing/test_skipping.py` and `testing/test_mark.py` pass.
- Added news fragment `changelog/14839.bugfix.rst`.
- Added entry to `AUTHORS`.