### PR TITLE
fix(config): raise TypeError when string ini option receives list (_getini_ini) (#14808)

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -1949,6 +1949,10 @@ class Config:
         elif type == "bool":
             return _strtobool(str(value).strip())
         elif type == "string":
+            if not isinstance(value, str):
+                raise TypeError(
+                    f"Expected a string for option {name} of type string, but got: {value!r}"
+                ) from None
             return value
         elif type == "int":
             if not isinstance(value, str):

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -131,10 +131,12 @@ class TestParseIni:
     def test_getini_string_type_invalid_list(self, pytester: Pytester) -> None:
         config = pytester.parseconfig()
         config._parser.addini("custom_str_opt", "custom string option", type="string")
-        with pytest.raises(TypeError, match="Expected a string for option custom_str_opt"):
-            config._getini_ini("custom_str_opt", "custom_str_opt", "string", ["invalid", "list"], None)
-
-
+        with pytest.raises(
+            TypeError, match="Expected a string for option custom_str_opt"
+        ):
+            config._getini_ini(
+                "custom_str_opt", "custom_str_opt", "string", ["invalid", "list"], None
+            )
 
     @pytest.mark.parametrize(
         "section, name",

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -128,6 +128,14 @@ class TestParseIni:
             ["*tox.ini: 'minversion' requires pytest-999.0, actual pytest-*"]
         )
 
+    def test_getini_string_type_invalid_list(self, pytester: Pytester) -> None:
+        config = pytester.parseconfig()
+        config._parser.addini("custom_str_opt", "custom string option", type="string")
+        with pytest.raises(TypeError, match="Expected a string for option custom_str_opt"):
+            config._getini_ini("custom_str_opt", "custom_str_opt", "string", ["invalid", "list"], None)
+
+
+
     @pytest.mark.parametrize(
         "section, name",
         [


### PR DESCRIPTION
### Summary of Changes

Fixes #14808 where `_getini_ini` returns raw `list` objects for options registered with `type="string"` without raising `TypeError`.

- Updated `_getini_ini` in `src/_pytest/config/__init__.py` to check `isinstance(value, str)` when `type == "string"`, raising a `TypeError` if a non-string value (e.g. list from TOML) is passed.
- Added unit test `test_getini_string_type_invalid_list` in `testing/test_config.py`.
