### PR TITLE
fix(skipping): raise TypeError on unexpected keyword args in pytest.mark.skipif (#14839)

### DIFF
--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -169,6 +169,11 @@ class Skip:
 def evaluate_skip_marks(item: Item) -> Skip | None:
     """Evaluate skip and skipif marks on item, returning Skip if triggered."""
     for mark in item.iter_markers(name="skipif"):
+        unexpected_kwargs = set(mark.kwargs) - {"condition", "reason"}
+        if unexpected_kwargs:
+            raise TypeError(
+                f"Unexpected keyword argument(s) for skipif mark: {', '.join(sorted(unexpected_kwargs))}"
+            )
         if "condition" not in mark.kwargs:
             conditions = mark.args
         else:

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -196,8 +196,9 @@ class TestEvaluation:
         )
         res = pytester.runpytest(p)
         assert res.ret != 0
-        res.stdout.fnmatch_lines(["*Unexpected keyword argument(s) for skipif mark: unexpected_arg*"])
-
+        res.stdout.fnmatch_lines(
+            ["*Unexpected keyword argument(s) for skipif mark: unexpected_arg*"]
+        )
 
     def test_skipif_markeval_namespace_multiple(self, pytester: Pytester) -> None:
         """Keys defined by ``pytest_markeval_namespace()`` in nested plugins override top-level ones."""

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -184,6 +184,21 @@ class TestEvaluation:
         res.stdout.fnmatch_lines(["*1 skipped*"])
         res.stdout.fnmatch_lines(["*1 passed*"])
 
+    def test_skipif_unexpected_keyword_args(self, pytester: Pytester) -> None:
+        p = pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.skipif(True, unexpected_arg=123)
+            def test_func():
+                pass
+            """
+        )
+        res = pytester.runpytest(p)
+        assert res.ret != 0
+        res.stdout.fnmatch_lines(["*Unexpected keyword argument(s) for skipif mark: unexpected_arg*"])
+
+
     def test_skipif_markeval_namespace_multiple(self, pytester: Pytester) -> None:
         """Keys defined by ``pytest_markeval_namespace()`` in nested plugins override top-level ones."""
         root = pytester.mkdir("root")


### PR DESCRIPTION
### Summary of Changes

Fixes #14839 where `pytest.mark.skipif` silently ignores extra/unexpected keyword arguments passed to the mark constructor (such as `@pytest.mark.skipif(True, unexpected_arg=123)`).

- Updated `evaluate_skip_marks` in `src/_pytest/skipping.py` to validate `mark.kwargs` against allowed keys (`condition`, `reason`), raising a clear `TypeError` if unexpected keyword arguments are supplied.
- Added unit test `test_skipif_unexpected_keyword_args` in `testing/test_skipping.py`.
