### PR TITLE
fix(terminal): show teardown phase for xfail reports

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -420,6 +420,7 @@ Roland Puntaier
 Romain Dorgueil
 Roman Bolshakov
 Ronny Pfannschmidt
+Roqia Salah
 Ross Lawley
 Ruaridh Williamson
 Russel Winder

--- a/changelog/6997.bugfix.rst
+++ b/changelog/6997.bugfix.rst
@@ -1,0 +1,2 @@
+XFAIL reports from teardown phases now include the phase in the short test
+summary.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1328,7 +1328,12 @@ class TerminalReporter:
                 )
                 markup_word = self._tw.markup(verbose_word, **verbose_markup)
                 nodeid = _get_node_id_with_markup(self._tw, self.config, rep)
-                line = f"{markup_word} {nodeid}"
+
+                if rep.when == "call":
+                    line = f"{markup_word} {nodeid}"
+                else:
+                    line = f"{markup_word} at {rep.when} of {nodeid}"
+
                 reason = rep.wasxfail
                 if reason:
                     line += " - " + str(reason)

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -766,6 +766,56 @@ class TestXFailwithSetupTeardown:
         result = pytester.runpytest()
         result.stdout.fnmatch_lines(["*1 xfail*"])
 
+    def test_xfail_call_and_teardown_reports_show_phase(
+        self, pytester: Pytester
+    ) -> None:
+        pytester.makepyfile(
+            test_case="""
+            import pytest
+
+            @pytest.fixture
+            def my_fix():
+                yield
+                raise Exception("teardown")
+
+            @pytest.mark.xfail(reason="Some reason")
+            def test_func(my_fix):
+                raise Exception("call")
+            """
+        )
+
+        result = pytester.runpytest("-rx")
+
+        result.stdout.fnmatch_lines(
+            [
+                "*XFAIL*test_case.py::test_func*",
+                "*XFAIL at teardown of*test_case.py::test_func*",
+            ]
+        )
+
+    def test_xfail_setup_report_shows_phase(self, pytester: Pytester) -> None:
+        pytester.makepyfile(
+            test_case="""
+            import pytest
+
+            @pytest.fixture
+            def my_fix():
+                raise Exception("setup")
+
+            @pytest.mark.xfail(reason="Some reason")
+            def test_func(my_fix):
+                pass
+            """
+        )
+
+        result = pytester.runpytest("-rx")
+
+        result.stdout.fnmatch_lines(
+            [
+                "*XFAIL at setup of*test_case.py::test_func*",
+            ]
+        )
+
 
 class TestSkip:
     def test_skip_class(self, pytester: Pytester) -> None:


### PR DESCRIPTION
### What

Updates the short test summary for `xfail` reports from the `teardown` phase to include the phase in the output.
Previously, when both the test call and fixture `teardown` failed under an `xfail` marker, both reports were displayed identically:

```text
XFAIL test_case.py::test_func
XFAIL test_case.py::test_func
```

After this change:

```text
XFAIL test_case.py::test_func
XFAIL at teardown of test_case.py::test_func
```

### Why

When an `xfail`-marked test produces reports from both the `call` and `teardown` phases, the short test summary does not indicate which report came from `teardown`.
This makes the two reports appear duplicated even though they represent failures from different test phases.

### How

The `xfail` short-summary formatting now checks the report phase and adds `at teardown of` for `teardown` reports.
The existing output for call-phase `xfail` reports remains unchanged.

### Tests

Added a regression test covering an `xfail`-marked test where both the test `call` and fixture `teardown` raise exceptions.
Also verified:

```text
pytest testing/test_skipping.py -q
93 passed

pytest testing/test_terminal.py -q
220 passed, 9 skipped
```
`pre-commit run --all-files` also passes.

Closes #6997

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [X] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.
- [X] Add yourself to `AUTHORS` in alphabetical order.