### PR TITLE
Expose FixtureFunctionDefinition as part of the public API

### DIFF
--- a/changelog/14853.feature.rst
+++ b/changelog/14853.feature.rst
@@ -1,0 +1,1 @@
+Exposed ``pytest.FixtureFunctionDefinition`` as part of the public API, so it can be used in type annotations for the return value of functions/factories that create fixtures via ``@pytest.fixture``.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1010,6 +1010,12 @@ FixtureDef
     :members:
     :show-inheritance:
 
+FixtureFunctionDefinition
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pytest.FixtureFunctionDefinition()
+    :members:
+
 MarkDecorator
 ~~~~~~~~~~~~~
 

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -26,6 +26,7 @@ from _pytest.debugging import pytestPDB as __pytestPDB
 from _pytest.doctest import DoctestItem
 from _pytest.fixtures import fixture
 from _pytest.fixtures import FixtureDef
+from _pytest.fixtures import FixtureFunctionDefinition
 from _pytest.fixtures import FixtureLookupError
 from _pytest.fixtures import FixtureRequest
 from _pytest.fixtures import register_fixture
@@ -114,6 +115,7 @@ __all__ = [
     "ExitCode",
     "File",
     "FixtureDef",
+    "FixtureFunctionDefinition",
     "FixtureLookupError",
     "FixtureRequest",
     "Function",

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1817,7 +1817,9 @@ class TestFixtureUsages:
         result = pytester.runpytest()
         result.assert_outcomes(passed=2)
 
-    def test_fixture_function_definition_in_public_api(self, pytester: Pytester) -> None:
+    def test_fixture_function_definition_in_public_api(
+        self, pytester: Pytester
+    ) -> None:
         """FixtureFunctionDefinition is exposed as part of the public API and usable as an annotation."""
         pytester.makepyfile(
             """

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1817,6 +1817,35 @@ class TestFixtureUsages:
         result = pytester.runpytest()
         result.assert_outcomes(passed=2)
 
+    def test_fixture_function_definition_in_public_api(self, pytester: Pytester) -> None:
+        """FixtureFunctionDefinition is exposed as part of the public API and usable as an annotation."""
+        pytester.makepyfile(
+            """
+            import pytest
+
+            from pytest import FixtureFunctionDefinition
+
+            def make_fixture(value: str) -> FixtureFunctionDefinition:
+                @pytest.fixture
+                def my_fixture() -> str:
+                    return value
+
+                return my_fixture
+
+
+            def test_annotation_type():
+                result = make_fixture("hello")
+                assert isinstance(result, FixtureFunctionDefinition)
+                assert result.name == "my_fixture"
+
+
+            def test_public_namespace():
+                assert "FixtureFunctionDefinition" in pytest.__all__
+            """
+        )
+        result = pytester.runpytest()
+        result.assert_outcomes(passed=2)
+
     def test_fixture_wrapped_looks_liked_wrapped_function(
         self, pytester: Pytester
     ) -> None:


### PR DESCRIPTION
Closes #14853.

There is no public type to annotate the return value of `@pytest.fixture`-decorated functions or fixture factories; users had to reach into `_pytest.fixtures.FixtureFunctionDefinition`. This exposes it as `pytest.FixtureFunctionDefinition`.

## Changes

- `src/pytest/__init__.py`: import `FixtureFunctionDefinition` and add it to `__all__`.
- `doc/en/reference/reference.rst`: document it alongside the other fixture types.
- `testing/python/fixtures.py`: add a test covering the public import, `__all__` membership, and its use as a return annotation.
- `changelog/14853.feature.rst`: feature changelog entry.

## Verification

- `python -m pytest testing/python/fixtures.py` → 240 passed, 2 skipped, 2 xfailed (includes the new test).
- `import pytest; pytest.FixtureFunctionDefinition` resolves and is present in `pytest.__all__`.
