### PR TITLE
Collect sibling tests when parent and subfolder are both given

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,6 +58,7 @@ Ariel Pillemer
 Armin Rigo
 Aron Coyle
 Aron Curzon
+Arron Zou
 Arthur Richard
 Ashish Kurmi
 Ashley Whetter

--- a/changelog/13319.bugfix.rst
+++ b/changelog/13319.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed test collection when both a parent directory and one of its subfolders are specified on the command line, so tests in sibling folders are collected as well.

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -2038,7 +2038,7 @@ def test_namespace_packages(pytester: Pytester, import_mode: str):
 
 class TestOverlappingCollectionArguments:
     """Test that overlapping collection arguments (e.g. `pytest a/b a
-    a/c::TestIt) are handled correctly (#12083)."""
+    a/c::TestIt) are handled correctly (#12083, #13319)."""
 
     @pytest.mark.parametrize("args", [("a", "a/b"), ("a/b", "a")])
     def test_parent_child(self, pytester: Pytester, args: tuple[str, ...]) -> None:
@@ -2069,6 +2069,51 @@ class TestOverlappingCollectionArguments:
                 "    <Module test_a.py>",
                 "      <Function test_a1>",
                 "      <Function test_a2>",
+                "",
+            ],
+            consecutive=True,
+        )
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ("parent/sub1", "parent/"),
+            ("parent/", "parent/sub1"),
+            ("parent/sub1", "parent"),
+            ("parent", "parent/sub1"),
+        ],
+    )
+    def test_parent_and_subfolder_collects_sibling_dirs(
+        self, pytester: Pytester, args: tuple[str, ...]
+    ) -> None:
+        """Collecting a parent dir plus one subfolder must include sibling folders.
+
+        The parent directory has no tests of its own — only tests in subfolders.
+        Regression test for #13319.
+        """
+        pytester.makepyfile(
+            **{
+                "parent/sub1/test_sub1.py": "def test_sub1(): pass",
+                "parent/sub2/test_sub2.py": "def test_sub2(): pass",
+                "parent/sub3/test_sub3.py": "def test_sub3(): pass",
+            }
+        )
+
+        result = pytester.runpytest("--collect-only", *args)
+
+        result.stdout.fnmatch_lines(
+            [
+                "<Dir *>",
+                "  <Dir parent>",
+                "    <Dir sub1>",
+                "      <Module test_sub1.py>",
+                "        <Function test_sub1>",
+                "    <Dir sub2>",
+                "      <Module test_sub2.py>",
+                "        <Function test_sub2>",
+                "    <Dir sub3>",
+                "      <Module test_sub3.py>",
+                "        <Function test_sub3>",
                 "",
             ],
             consecutive=True,

--- a/testing/test_main.py
+++ b/testing/test_main.py
@@ -9,6 +9,7 @@ import re
 from _pytest.config import ExitCode
 from _pytest.config import UsageError
 from _pytest.main import CollectionArgument
+from _pytest.main import normalize_collection_arguments
 from _pytest.main import resolve_collection_argument
 from _pytest.main import validate_basetemp
 from _pytest.pytester import Pytester
@@ -300,6 +301,41 @@ class TestResolveCollectionArgument:
             module_name=None,
             original_index=0,
         )
+
+
+class TestNormalizeCollectionArguments:
+    def _arg(
+        self, path: Path, index: int, parts: tuple[str, ...] = ()
+    ) -> CollectionArgument:
+        return CollectionArgument(
+            path=path,
+            parts=parts,
+            parametrization=None,
+            module_name=None,
+            original_index=index,
+        )
+
+    def test_parent_dir_subsumes_child_dir(self, tmp_path: Path) -> None:
+        """A parent directory argument must replace a more specific subfolder.
+
+        Regression test for #13319: `pytest parent/sub1 parent/` should collect
+        as if only `parent/` was given, so sibling folders are not skipped.
+        """
+        parent = tmp_path / "parent"
+        child = parent / "sub1"
+        args = [self._arg(child, 0), self._arg(parent, 1)]
+        assert normalize_collection_arguments(args) == [self._arg(parent, 1)]
+
+        args = [self._arg(parent, 0), self._arg(child, 1)]
+        assert normalize_collection_arguments(args) == [self._arg(parent, 0)]
+
+    def test_sibling_dirs_are_kept(self, tmp_path: Path) -> None:
+        parent = tmp_path / "parent"
+        args = [
+            self._arg(parent / "sub1", 0),
+            self._arg(parent / "sub2", 1),
+        ]
+        assert normalize_collection_arguments(args) == args
 
 
 def test_module_full_path_without_drive(pytester: Pytester) -> None:


### PR DESCRIPTION
Passing both a parent directory and one of its subfolders collected only the named subfolder:

```
pytest --collect-only -q parent/sub1 parent/
```

expected every test under `parent/`, but only `parent/sub1` ran.

Collection arguments are already normalized so a parent path replaces an overlapping child (`normalize_collection_arguments`, added for #12083 / #13704). This keeps that behavior covered for the layout in #13319: tests only in sibling subfolders, none in the parent directory itself, including a trailing slash on the parent.

Fixes #13319