### PR TITLE
[rejected  autonomous ai]  Preserve warning filters set during collection for the test run

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,6 +58,7 @@ Ariel Pillemer
 Armin Rigo
 Aron Coyle
 Aron Curzon
+Arron Zou
 Arthur Richard
 Ashish Kurmi
 Ashley Whetter

--- a/changelog/13485.bugfix.rst
+++ b/changelog/13485.bugfix.rst
@@ -1,0 +1,3 @@
+Warning filters registered by collected modules and ``conftest.py`` files
+(for example via :func:`warnings.filterwarnings`) are now honored during
+the test run instead of being discarded when collection finishes.

--- a/doc/en/how-to/capture-warnings.rst
+++ b/doc/en/how-to/capture-warnings.rst
@@ -324,7 +324,10 @@ See :ref:`@pytest.mark.filterwarnings <filterwarnings>` and
 
     Also pytest doesn't follow :pep:`565` suggestion of resetting all warning filters because
     it might break test suites that configure warning filters themselves
-    by calling :func:`warnings.simplefilter` (see :issue:`2430` for an example of that).
+    by calling :func:`warnings.simplefilter` or :func:`warnings.filterwarnings`
+    (see :issue:`2430` and :issue:`13485`).
+    Filters installed at module level in test modules or ``conftest.py`` during
+    collection are kept for the test run.
 
 
 .. _`ensuring a function triggers a deprecation warning`:

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
+from typing import cast
 from typing import Literal
 import warnings
 
@@ -27,9 +28,14 @@ def _copy_filters() -> list[Any]:
     return list(warnings.filters)
 
 
+def _filter_list() -> list[Any]:
+    # typeshed types warnings.filters as Sequence; it is a mutable list.
+    return cast(list[Any], warnings.filters)
+
+
 def _prepend_filters(filters: list[Any]) -> None:
     if filters:
-        warnings.filters[:0] = filters
+        _filter_list()[:0] = filters
 
 
 def _filters_added(before: list[Any], after: list[Any]) -> list[Any]:

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -29,7 +29,7 @@ def _copy_filters() -> list[Any]:
 
 
 def _filter_list() -> list[Any]:
-    # typeshed types warnings.filters as Sequence; it is a mutable list.
+    # warnings.filters is a mutable list; the stub types it as Sequence.
     return cast(list[Any], warnings.filters)
 
 

--- a/src/_pytest/warnings.py
+++ b/src/_pytest/warnings.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from contextlib import contextmanager
+from typing import Any
 from typing import Literal
 import warnings
 
@@ -10,9 +11,29 @@ from _pytest.config import Config
 from _pytest.config import parse_warning_filter
 from _pytest.main import Session
 from _pytest.nodes import Item
+from _pytest.stash import StashKey
 from _pytest.terminal import TerminalReporter
 from _pytest.tracemalloc import tracemalloc_message
 import pytest
+
+
+# Filters that user code added while an earlier catching context was active
+# (initial conftest import, collection). Re-applied in later catching contexts
+# so module-level warnings.filterwarnings() is not discarded (#2430, #13485).
+_persisted_filters_key = StashKey[list[Any]]()
+
+
+def _copy_filters() -> list[Any]:
+    return list(warnings.filters)
+
+
+def _prepend_filters(filters: list[Any]) -> None:
+    if filters:
+        warnings.filters[:0] = filters
+
+
+def _filters_added(before: list[Any], after: list[Any]) -> list[Any]:
+    return [f for f in after if f not in before]
 
 
 @contextmanager
@@ -23,14 +44,23 @@ def catch_warnings_for_item(
     item: Item | None,
     *,
     record: bool = True,
+    persist_new_filters: bool = False,
 ) -> Generator[None]:
     """Context manager that catches warnings generated in the contained execution block.
 
     ``item`` can be None if we are not in the context of an item execution.
 
     Each warning captured triggers the ``pytest_warning_recorded`` hook.
+
+    If ``persist_new_filters`` is true, filters installed by the block (for
+    example ``warnings.filterwarnings`` in a collected module) are kept and
+    re-applied in later catching contexts.
     """
+    added: list[Any] = []
     with config._catch_configured_warnings(record=record) as log:
+        persisted = config.stash.get(_persisted_filters_key, None)
+        if persisted:
+            _prepend_filters(persisted)
         # apply filters from "filterwarnings" marks
         nodeid = "" if item is None else item.nodeid
         if item is not None:
@@ -38,9 +68,17 @@ def catch_warnings_for_item(
                 for arg in mark.args:
                     warnings.filterwarnings(*parse_warning_filter(arg, escape=False))
 
+        before = _copy_filters() if persist_new_filters else []
         try:
             yield
         finally:
+            if persist_new_filters:
+                added = _filters_added(before, _copy_filters())
+                if added:
+                    prev = config.stash.get(_persisted_filters_key, [])
+                    config.stash[_persisted_filters_key] = added + [
+                        f for f in prev if f not in added
+                    ]
             if record:
                 # mypy can't infer that record=True means log is not None; help it.
                 assert log is not None
@@ -54,6 +92,8 @@ def catch_warnings_for_item(
                             location=None,
                         )
                     )
+    # Promote newly added filters into the enclosing warnings context.
+    _prepend_filters(added)
 
 
 def warning_record_to_str(warning_message: warnings.WarningMessage) -> str:
@@ -79,7 +119,11 @@ def pytest_runtest_protocol(item: Item) -> Generator[None, object, object]:
 def pytest_collection(session: Session) -> Generator[None, object, object]:
     config = session.config
     with catch_warnings_for_item(
-        config=config, ihook=config.hook, when="collect", item=None
+        config=config,
+        ihook=config.hook,
+        when="collect",
+        item=None,
+        persist_new_filters=True,
     ):
         return (yield)
 
@@ -109,7 +153,11 @@ def pytest_load_initial_conftests(
     early_config: Config,
 ) -> Generator[None]:
     with catch_warnings_for_item(
-        config=early_config, ihook=early_config.hook, when="config", item=None
+        config=early_config,
+        ihook=early_config.hook,
+        when="config",
+        item=None,
+        persist_new_filters=True,
     ):
         return (yield)
 

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -150,9 +150,8 @@ def test_unicode(pytester: Pytester) -> None:
     )
 
 
-@pytest.mark.skip("issue #13485")
 def test_works_with_filterwarnings(pytester: Pytester) -> None:
-    """Ensure our warnings capture does not mess with pre-installed filters (#2430)."""
+    """Module-level warnings.filterwarnings during collection apply at run (#2430, #13485)."""
     pytester.makepyfile(
         """
         import warnings
@@ -162,7 +161,7 @@ def test_works_with_filterwarnings(pytester: Pytester) -> None:
 
         warnings.filterwarnings("error", category=MyWarning)
 
-        class TestWarnings(object):
+        class TestWarnings:
             def test_my_warning(self):
                 try:
                     warnings.warn(MyWarning("warn!"))
@@ -171,8 +170,70 @@ def test_works_with_filterwarnings(pytester: Pytester) -> None:
                     assert True
     """
     )
-    result = pytester.runpytest()
-    result.stdout.fnmatch_lines(["*== 1 passed in *"])
+    # Subprocess + -Wdefault so this does not pass only because the outer
+    # suite uses filterwarnings=error (#13480).
+    result = pytester.runpytest_subprocess("-W", "default")
+    result.assert_outcomes(passed=1)
+
+
+def test_collection_filterwarnings_ignore_during_run(pytester: Pytester) -> None:
+    """Ignore filters registered while collecting a module apply during the test run."""
+    pytester.makepyfile(
+        """
+        import warnings
+
+        warnings.filterwarnings("ignore", category=UserWarning)
+
+        def test_hidden():
+            warnings.warn(UserWarning("from collected module"))
+        """
+    )
+    result = pytester.runpytest_subprocess("-W", "always")
+    result.assert_outcomes(passed=1, warnings=0)
+    assert WARNINGS_SUMMARY_HEADER not in result.stdout.str()
+
+
+def test_collection_filterwarnings_from_conftest(pytester: Pytester) -> None:
+    """Filters set in conftest.py apply during the test run (#13485)."""
+    pytester.makeconftest(
+        """
+        import warnings
+
+        warnings.filterwarnings("ignore", category=UserWarning)
+        """
+    )
+    pytester.makepyfile(
+        """
+        import warnings
+
+        def test_hidden():
+            warnings.warn(UserWarning("from test"))
+        """
+    )
+    result = pytester.runpytest_subprocess("-W", "always")
+    result.assert_outcomes(passed=1, warnings=0)
+    assert WARNINGS_SUMMARY_HEADER not in result.stdout.str()
+
+
+def test_mark_filterwarnings_overrides_collection_filters(
+    pytester: Pytester,
+) -> None:
+    """@mark.filterwarnings still takes precedence over collection-time filters."""
+    pytester.makepyfile(
+        """
+        import warnings
+        import pytest
+
+        warnings.filterwarnings("ignore", category=UserWarning)
+
+        @pytest.mark.filterwarnings("error::UserWarning")
+        def test_mark_wins():
+            with pytest.raises(UserWarning):
+                warnings.warn(UserWarning("from test"))
+        """
+    )
+    result = pytester.runpytest_subprocess("-W", "default")
+    result.assert_outcomes(passed=1)
 
 
 @pytest.mark.parametrize("default_config", ["ini", "cmdline"])


### PR DESCRIPTION
## Summary

`pytest_collection` is wrapped in `warnings.catch_warnings`, so any `warnings.filterwarnings()` / `simplefilter()` calls made by collected modules or `conftest.py` were discarded when that context exited. The later per-test catching context then started from the pre-collection filters, which is why module-level filters had no effect during the run (regression of #2430, introduced when collection-time warning capture was added).

The existing `test_works_with_filterwarnings` did not catch this unless the suite was run with `-Wdefault`, because the in-process inner run inherited the outer suite's `filterwarnings=error`.

## Solution

Remember filters that user code adds while the initial-conftest and collection catching contexts are active. Re-apply them (in front of pytest's configured filters) in later catching contexts, and promote them into the enclosing warnings context when those phases finish. `@pytest.mark.filterwarnings` is still applied after that, so marks keep precedence.

`test_works_with_filterwarnings` now runs in a subprocess with `-Wdefault`. Additional tests cover ignore filters from a collected module and from `conftest.py`.

Fixes #13485

- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [x] Allow maintainers to push and squash when merging my commits.
- [x] Add text like `closes #XYZW` / `Fixes #13485`.
- [x] Changelog: `changelog/13485.bugfix.rst`
- [x] Added myself to `AUTHORS`