### PR TITLE
[rejected  autonomous ai] Raise ValueError for non-option names in addoption()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,6 +58,7 @@ Ariel Pillemer
 Armin Rigo
 Aron Coyle
 Aron Curzon
+Arron Zou
 Arthur Richard
 Ashish Kurmi
 Ashley Whetter

--- a/changelog/13817.bugfix.rst
+++ b/changelog/13817.bugfix.rst
@@ -1,0 +1,2 @@
+``parser.addoption()`` now raises a clear ``ValueError`` when given a name that is not an option
+(for example ``addoption("shuffle")`` instead of ``addoption("--shuffle")``).

--- a/src/_pytest/config/argparsing.py
+++ b/src/_pytest/config/argparsing.py
@@ -107,6 +107,16 @@ def _get_argparse_dest(opts: Sequence[str]) -> str:
     return opt.lstrip("-").replace("-", "_")
 
 
+def _check_option_names(opts: Sequence[str]) -> None:
+    for opt in opts:
+        if not opt.startswith("-"):
+            hint = f". Did you mean '--{opt}'?" if opt else ""
+            raise ValueError(
+                f"invalid option name {opt!r}: addoption() registers options only; "
+                f"names must start with '-' or '--'{hint}"
+            )
+
+
 @final
 class Parser:
     """Parser for command line arguments and config-file values.
@@ -192,7 +202,8 @@ class Parser:
         """Register a command line option.
 
         :param opts:
-            Option names, can be short or long options.
+            Option names, can be short or long options (must start with
+            ``-`` or ``--``).
         :param attrs:
             Same attributes as the argparse library's :meth:`add_argument()
             <argparse.ArgumentParser.add_argument>` function accepts.
@@ -444,12 +455,14 @@ class OptionGroup:
         accepted **and** the automatic destination is in ``args.twowords``.
 
         :param opts:
-            Option names, can be short or long options.
+            Option names, can be short or long options (must start with
+            ``-`` or ``--``).
             Note that lower-case short options (e.g. `-x`) are reserved.
         :param attrs:
             Same attributes as the argparse library's :meth:`add_argument()
             <argparse.ArgumentParser.add_argument>` function accepts.
         """
+        _check_option_names(opts)
         conflict = set(opts).intersection(
             name for opt in self.options for name in opt.names()
         )
@@ -477,6 +490,7 @@ class OptionGroup:
     def _addoption_inner(
         self, opts: tuple[str, ...], attrs: dict[str, Any], allow_reserved: bool
     ) -> None:
+        _check_option_names(opts)
         if not allow_reserved:
             for opt in opts:
                 if len(opt) >= 2 and opt[0] == "-" and opt[1].islower():

--- a/testing/test_parseopt.py
+++ b/testing/test_parseopt.py
@@ -128,6 +128,30 @@ class TestParser:
         group.addoption("--option1", action="store_true")
         assert len(group.options) == 1
 
+    def test_addoption_rejects_non_option_name(self, parser: parseopt.Parser) -> None:
+        """addoption() must not treat a missing ``--`` as a positional argument."""
+        with pytest.raises(
+            ValueError,
+            match=r"invalid option name 'shuffle'.*Did you mean '--shuffle'\?",
+        ):
+            parser.addoption("shuffle")
+        assert parser._anonymous.options == []
+
+        group = parser.getgroup("hello")
+        with pytest.raises(ValueError, match="invalid option name 'foo-bar'"):
+            group.addoption("foo-bar")
+        assert group.options == []
+
+        with pytest.raises(ValueError, match="invalid option name ''"):
+            parser.addoption("")
+
+        parser.addoption("--shuffle", action="store_true")
+        parser.addoption("-S", action="store_true")
+        assert [list(opt.names()) for opt in parser._anonymous.options] == [
+            ["--shuffle"],
+            ["-S"],
+        ]
+
     def test_group_addoption_rejects_implicit_dest_conflict(
         self, parser: parseopt.Parser
     ) -> None:
@@ -372,6 +396,19 @@ def test_argcomplete(pytester: Pytester, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("COMP_POINT", str(len("pytest " + arg)))
     result = pytester.run("bash", str(script), arg)
     result.stdout.fnmatch_lines(["test_argcomplete", "test_argcomplete.d/"])
+
+
+def test_addoption_invalid_flag_from_conftest(pytester: Pytester) -> None:
+    """Invalid flags in pytest_addoption should fail clearly (issue #13817)."""
+    pytester.makeconftest(
+        """
+        def pytest_addoption(parser):
+            parser.addoption("shuffle")
+        """
+    )
+    result = pytester.runpytest()
+    assert result.ret != 0
+    result.stderr.fnmatch_lines(["*invalid option name 'shuffle'*"])
 
 
 def test_argument_repr_uninitialized() -> None:


### PR DESCRIPTION
`parser.addoption("shuffle")` (missing `--`) is treated by argparse as a required positional argument. The original report was a secondary `AttributeError` while formatting that failure; after the argparse rewrite the same call still fails later with a dest-conflict or "arguments are required" error.

Reject names that do not start with `-` or `--` at registration time, and suggest the `--name` form when the missing prefix is the likely typo.

Fixes #13817