### PR TITLE
Defer assertion-diff highlighting so JUnit XML stays free of ANSI

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,6 +58,7 @@ Ariel Pillemer
 Armin Rigo
 Aron Coyle
 Aron Curzon
+Arron Zou
 Arthur Richard
 Ashish Kurmi
 Ashley Whetter

--- a/changelog/12365.bugfix.rst
+++ b/changelog/12365.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ANSI escape sequences from colored assertion diffs leaking into JUnit XML reports when running with verbosity and Pygments installed.

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -1030,6 +1030,16 @@ class ExceptionInfoFormatter:
         indentstr = " " * indent
         # Get the real exception information out.
         exlines = excinfo.exconly(tryshort=True).split("\n")
+        # Swap in the marked-up explanation (same text, with highlight spans)
+        # so terminal output can still apply Pygments later.
+        from _pytest.assertion.highlight import DEFERRED_HL_ATTR
+
+        tagged = getattr(excinfo.value, DEFERRED_HL_ATTR, None)
+        if isinstance(tagged, str):
+            plain = str(excinfo.value)
+            text = "\n".join(exlines)
+            if plain and plain in text:
+                exlines = text.replace(plain, tagged, 1).split("\n")
         failindent = self.fail_marker + indentstr[1:]
         for line in exlines:
             lines.append(failindent + line)
@@ -1424,7 +1434,10 @@ class ReprEntry(TerminalRepr):
             # Using tw.write instead of tw.line for testing purposes due to TWMock implementation;
             # lines written with TWMock.line and TWMock._write_source cannot be distinguished
             # from each other, whereas lines written with TWMock.write are marked with TWMock.WRITE
-            for line in self.lines:
+            from _pytest.assertion.highlight import resolve_highlight_for_writer
+
+            resolved = resolve_highlight_for_writer("\n".join(self.lines), tw)
+            for line in resolved.splitlines():
                 tw.write(line)
                 tw.write("\n")
             return
@@ -1450,8 +1463,12 @@ class ReprEntry(TerminalRepr):
         tw._write_source(source_lines, indents)
 
         # failure lines are always completely red and bold
-        for line in failure_lines:
-            tw.line(line, bold=True, red=True)
+        from _pytest.assertion.highlight import resolve_highlight_for_writer
+
+        if failure_lines:
+            resolved = resolve_highlight_for_writer("\n".join(failure_lines), tw)
+            for line in resolved.splitlines():
+                tw.line(line, bold=True, red=True)
 
     def toterminal(self, tw: TerminalWriter) -> None:
         if self.style == "short":
@@ -1476,8 +1493,12 @@ class ReprEntry(TerminalRepr):
             self.reprfileloc.toterminal(tw)
 
     def __str__(self) -> str:
+        from _pytest.assertion.highlight import strip_deferred_highlight
+
         return "{}\n{}\n{}".format(
-            "\n".join(self.lines), self.reprlocals, self.reprfileloc
+            "\n".join(strip_deferred_highlight(line) for line in self.lines),
+            self.reprlocals,
+            self.reprfileloc,
         )
 
 

--- a/src/_pytest/assertion/__init__.py
+++ b/src/_pytest/assertion/__init__.py
@@ -15,6 +15,7 @@ from _pytest.assertion import util
 from _pytest.assertion._typing import _AssertionTextDiffStyle
 from _pytest.assertion._typing import NO_TRUNCATION_BUDGET
 from _pytest.assertion._typing import TruncationBudget
+from _pytest.assertion.highlight import deferred_highlighter
 from _pytest.assertion.rewrite import assertstate_key
 from _pytest.config import Config
 from _pytest.config import hookimpl
@@ -225,11 +226,11 @@ def pytest_sessionfinish(session: Session) -> None:
 def pytest_assertrepr_compare(
     config: Config, op: str, left: Any, right: Any
 ) -> list[str] | None:
-    if config.pluginmanager.has_plugin("terminalreporter"):
-        highlighter = config.get_terminal_writer()._highlight
-    else:
-        # Keep it plaintext when not using terminalrepoterer (#14377).
-        highlighter = util.dummy_highlighter
+    # Mark highlight spans instead of applying Pygments now. Terminal output
+    # resolves the markers later; JUnit XML and ``str(exc)`` stay plain (#12365).
+    # Never touch the terminal writer here so this works without terminalreporter
+    # (#14377).
+    highlighter = deferred_highlighter
     # When truncation is going to clip the explanation downstream, cap the
     # comparison helpers' formatting at what the truncator will actually pull
     # (the raw limits plus the footer slack) so no effort is spent formatting

--- a/src/_pytest/assertion/highlight.py
+++ b/src/_pytest/assertion/highlight.py
@@ -1,6 +1,38 @@
+"""Highlighting helpers for assertion explanations.
+
+Pygments markup is applied at terminal-display time, not when the explanation
+is first built.  Comparison helpers wrap highlighted spans in private markers
+so JUnit XML and other plain-text consumers can recover the original source
+(including any escape sequences that belong to the values under test).
+"""
+
 from __future__ import annotations
 
+import re
 from typing import Literal
+
+from _pytest.assertion._typing import _HighlightFunc
+
+
+# Attribute set on AssertionError to keep the marked-up explanation after the
+# public exception message has been stripped to plain text.
+DEFERRED_HL_ATTR = "_pytest_deferred_hl"
+
+# Marker protocol (SOH-delimited):
+#   \x01p<source>\x01 / \x01d<source>\x01   start of a python/diff span
+#   \x01P<source>\x01 / \x01D<source>\x01   continuation of the previous span
+# A literal SOH in *source* is escaped as \x01\x02.
+# Continuations exist so a multi-line ``highlighter()`` call can be split into
+# lines and later re-joined, matching Pygments' whole-block colouring.
+_START_CODE = {"python": "p", "diff": "d"}
+_CONT_CODE = {"python": "P", "diff": "D"}
+_CODE_TO_LEXER: dict[str, Literal["python", "diff"]] = {
+    "p": "python",
+    "P": "python",
+    "d": "diff",
+    "D": "diff",
+}
+_TAG_RE = re.compile(r"\x01([pdPD])((?:\x01\x02|[^\x01])*)\x01")
 
 
 def dummy_highlighter(source: str, lexer: Literal["diff", "python"] = "python") -> str:
@@ -9,3 +41,158 @@ def dummy_highlighter(source: str, lexer: Literal["diff", "python"] = "python") 
     Needed for _notin_text, as the diff gets post-processed to only show the "+" part.
     """
     return source
+
+
+def deferred_highlighter(
+    source: str, lexer: Literal["diff", "python"] = "python"
+) -> str:
+    """Wrap *source* in deferred-highlight markers instead of applying Pygments.
+
+    Multi-line input is tagged per line (first line starts a span, the rest
+    continue it) so later ``splitlines()`` keeps enough information to rebuild
+    the original block.
+    """
+    if not source:
+        return source
+    try:
+        start = _START_CODE[lexer]
+        cont = _CONT_CODE[lexer]
+    except KeyError:
+        raise ValueError(f"unknown lexer: {lexer!r}") from None
+    keep_nl = source.endswith("\n")
+    tagged_lines: list[str] = []
+    for i, line in enumerate(source.splitlines()):
+        code = start if i == 0 else cont
+        tagged_lines.append(f"\x01{code}{line.replace(chr(1), chr(1) + chr(2))}\x01")
+    tagged = "\n".join(tagged_lines)
+    if keep_nl:
+        tagged += "\n"
+    return tagged
+
+
+def contains_deferred_highlight(text: str) -> bool:
+    """Return whether *text* contains a highlight marker."""
+    return "\x01" in text and _TAG_RE.search(text) is not None
+
+
+def _unescape_source(escaped: str) -> str:
+    return escaped.replace("\x01\x02", "\x01")
+
+
+def strip_deferred_highlight(text: str) -> str:
+    """Return *text* with deferred-highlight markers removed."""
+    if "\x01" not in text:
+        return text
+    return _TAG_RE.sub(lambda m: _unescape_source(m.group(2)), text)
+
+
+def resolve_highlight(text: str, highlighter: _HighlightFunc | None) -> str:
+    """Replace deferred-highlight markers in *text*.
+
+    If *highlighter* is ``None``, emit the original source of each span.
+    Otherwise apply ``highlighter(source, lexer)`` to each span.  Consecutive
+    continuation lines of the same lexer are highlighted as one block so the
+    colours match a single original ``highlighter()`` call.
+    """
+    if "\x01" not in text:
+        return text
+    if highlighter is None:
+        return strip_deferred_highlight(text)
+    return _resolve_with_highlighter(text, highlighter)
+
+
+def _resolve_with_highlighter(text: str, highlighter: _HighlightFunc) -> str:
+    # Fast path: no multi-line continuation, highlight each span in place.
+    if "\x01P" not in text and "\x01D" not in text:
+        return _TAG_RE.sub(
+            lambda m: highlighter(
+                _unescape_source(m.group(2)), _CODE_TO_LEXER[m.group(1)]
+            ),
+            text,
+        )
+
+    lines = text.splitlines(keepends=True)
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        start = _first_tag(line)
+        if start is None or start.isupper():
+            out.append(_resolve_line(line, highlighter))
+            i += 1
+            continue
+        lexer = _CODE_TO_LEXER[start]
+        cont = _CONT_CODE[lexer]
+        group = [line]
+        i += 1
+        while i < len(lines) and _first_tag(lines[i]) == cont:
+            group.append(lines[i])
+            i += 1
+        out.append(_highlight_group(group, highlighter, lexer))
+    return "".join(out)
+
+
+def _first_tag(line: str) -> str | None:
+    match = _TAG_RE.search(line)
+    return match.group(1) if match else None
+
+
+def _resolve_line(line: str, highlighter: _HighlightFunc) -> str:
+    return _TAG_RE.sub(
+        lambda m: highlighter(_unescape_source(m.group(2)), _CODE_TO_LEXER[m.group(1)]),
+        line,
+    )
+
+
+def _highlight_group(
+    lines: list[str], highlighter: _HighlightFunc, lexer: Literal["python", "diff"]
+) -> str:
+    """Highlight a start+continuation group as one Pygments input."""
+    prefixes: list[str] = []
+    bodies: list[str] = []
+    suffixes: list[str] = []
+    newlines: list[str] = []
+    for line in lines:
+        nl = "\n" if line.endswith("\n") else ""
+        core = line[:-1] if nl else line
+        match = _TAG_RE.search(core)
+        if match is None:
+            prefixes.append(core)
+            bodies.append("")
+            suffixes.append("")
+            newlines.append(nl)
+            continue
+        prefixes.append(core[: match.start()])
+        bodies.append(_unescape_source(match.group(2)))
+        suffixes.append(core[match.end() :])
+        newlines.append(nl)
+
+    highlighted = highlighter("\n".join(bodies), lexer)
+    hl_lines = highlighted.splitlines()
+    rendered: list[str] = []
+    for idx, (prefix, suffix, nl) in enumerate(
+        zip(prefixes, suffixes, newlines, strict=True)
+    ):
+        hl = hl_lines[idx] if idx < len(hl_lines) else ""
+        rendered.append(f"{prefix}{hl}{suffix}{nl}")
+    if len(hl_lines) > len(lines):
+        prefix = prefixes[-1] if prefixes else ""
+        nl = newlines[-1] if newlines else "\n"
+        for hl in hl_lines[len(lines) :]:
+            rendered.append(f"{prefix}{hl}{nl}")
+    return "".join(rendered)
+
+
+def resolve_highlight_for_writer(text: str, tw: object) -> str:
+    """Resolve markers for a terminal writer, or strip them for plain output.
+
+    ``tw`` is untyped so tests can pass the lightweight ``TWMock``.
+    """
+    if not contains_deferred_highlight(text):
+        return text
+    hasmarkup = getattr(tw, "hasmarkup", False)
+    code_highlight = getattr(tw, "code_highlight", True)
+    highlight = getattr(tw, "_highlight", None)
+    if hasmarkup and code_highlight and highlight is not None:
+        return resolve_highlight(text, highlight)
+    return strip_deferred_highlight(text)

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -42,6 +42,8 @@ from _pytest._io.saferepr import saferepr
 from _pytest._io.saferepr import saferepr_unlimited
 from _pytest._version import version
 from _pytest.assertion import util
+from _pytest.assertion.highlight import DEFERRED_HL_ATTR
+from _pytest.assertion.highlight import strip_deferred_highlight
 from _pytest.config import Config
 from _pytest.fixtures import FixtureFunctionDefinition
 from _pytest.main import Session
@@ -503,7 +505,20 @@ def _call_reprcompare(
 
 def _call_assertion_pass(lineno: int, orig: str, expl: str) -> None:
     if util._assertion_pass is not None:
-        util._assertion_pass(lineno, orig, expl)
+        util._assertion_pass(lineno, orig, strip_deferred_highlight(expl))
+
+
+def _assertion_error(msg: str) -> AssertionError:
+    """Build an AssertionError whose public message has no highlight markers.
+
+    The marked-up explanation is kept on the exception so traceback formatting
+    can still apply Pygments when writing to a color terminal.
+    """
+    plain = strip_deferred_highlight(msg)
+    err = AssertionError(plain)
+    if msg != plain:
+        setattr(err, DEFERRED_HL_ATTR, msg)
+    return err
 
 
 def _check_if_assertion_pass_impl() -> bool:
@@ -893,9 +908,8 @@ class AssertionRewriter(ast.NodeVisitor):
                 gluestr = "assert "
             err_explanation = ast.BinOp(ast.Constant(gluestr), ast.Add(), msg)
             err_msg = ast.BinOp(assertmsg, ast.Add(), err_explanation)
-            err_name = ast.Name("AssertionError", ast.Load())
             fmt = self.helper("_format_explanation", err_msg)
-            exc = ast.Call(err_name, [fmt], [])
+            exc = self.helper("_assertion_error", fmt)
             raise_ = ast.Raise(exc, None)
             statements_fail = []
             statements_fail.extend(self.expl_stmts)
@@ -943,8 +957,7 @@ class AssertionRewriter(ast.NodeVisitor):
             template = ast.BinOp(assertmsg, ast.Add(), ast.Constant(explanation))
             msg = self.pop_format_context(template)
             fmt = self.helper("_format_explanation", msg)
-            err_name = ast.Name("AssertionError", ast.Load())
-            exc = ast.Call(err_name, [fmt], [])
+            exc = self.helper("_assertion_error", fmt)
             raise_ = ast.Raise(exc, None)
 
             body.append(raise_)

--- a/src/_pytest/assertion/truncate.py
+++ b/src/_pytest/assertion/truncate.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable
 
 from _pytest.assertion._typing import NO_TRUNCATION_BUDGET
 from _pytest.assertion._typing import TruncationBudget
+from _pytest.assertion.highlight import strip_deferred_highlight
 from _pytest.compat import running_on_ci
 from _pytest.config import Config
 
@@ -46,7 +47,7 @@ def materialize_with_truncation(lines: Iterable[str], config: Config) -> list[st
     char_count = 0
     for line in lines:
         buffered.append(line)
-        char_count += len(line)
+        char_count += _visible_len(line)
         if line_cap is not None and len(buffered) >= line_cap:
             break
         if budget.max_chars > 0 and char_count > tolerable_max_chars:
@@ -117,7 +118,7 @@ def _truncate_explanation(
     ):
         if (
             budget.max_chars == 0
-            or sum(len(s) for s in input_lines) <= tolerable_max_chars
+            or sum(_visible_len(s) for s in input_lines) <= tolerable_max_chars
         ):
             return input_lines
         truncated_explanation = input_lines
@@ -127,7 +128,7 @@ def _truncate_explanation(
     # We reevaluate the need to truncate chars following removal of some lines
     if (
         budget.max_chars > 0
-        and sum(len(e) for e in truncated_explanation) > tolerable_max_chars
+        and sum(_visible_len(e) for e in truncated_explanation) > tolerable_max_chars
     ):
         truncated_explanation = _truncate_by_char_count(
             truncated_explanation, budget.max_chars
@@ -141,19 +142,26 @@ def _truncate_explanation(
     ]
 
 
+def _visible_len(line: str) -> int:
+    """Character length of a line as the user will see it (no highlight markers)."""
+    return len(strip_deferred_highlight(line))
+
+
 def _truncate_by_char_count(input_lines: list[str], max_chars: int) -> list[str]:
     # Find point at which input length exceeds total allowed length
     iterated_char_count = 0
     for iterated_index, input_line in enumerate(input_lines):
-        if iterated_char_count + len(input_line) > max_chars:
+        if iterated_char_count + _visible_len(input_line) > max_chars:
             break
-        iterated_char_count += len(input_line)
+        iterated_char_count += _visible_len(input_line)
 
     # Create truncated explanation with modified final line
     truncated_result = input_lines[:iterated_index]
     final_line = input_lines[iterated_index]
     if final_line:
         final_line_truncate_point = max_chars - iterated_char_count
-        final_line = final_line[:final_line_truncate_point]
+        # Slice the visible text so markers cannot shift the cut point.
+        visible = strip_deferred_highlight(final_line)
+        final_line = visible[:final_line_truncate_point]
     truncated_result.append(final_line)
     return truncated_result

--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -22,6 +22,7 @@ from _pytest import nodes
 from _pytest import timing
 from _pytest._code.code import ExceptionRepr
 from _pytest._code.code import ReprFileLocation
+from _pytest.assertion.highlight import strip_deferred_highlight
 from _pytest.config import Config
 from _pytest.config import filename_arg
 from _pytest.config.argparsing import Parser
@@ -61,7 +62,9 @@ def bin_xml_escape(arg: object) -> str:
     # Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
     # For an unknown(?) reason, we disallow #x7F (DEL) as well.
     illegal_xml_re = "[^\u0009\u000a\u000d\u0020-\u007e\u0080-\ud7ff\ue000-\ufffd\U00010000-\U0010ffff]"
-    return re.sub(illegal_xml_re, repl, str(arg))
+    # Drop pytest highlight markers before escaping so they cannot leak as #x01.
+    text = strip_deferred_highlight(str(arg))
+    return re.sub(illegal_xml_re, repl, text)
 
 
 def merge_family(left, right) -> None:

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -17,6 +17,7 @@ from _pytest import outcomes
 import _pytest.assertion as plugin
 from _pytest.assertion import truncate
 from _pytest.assertion import util
+from _pytest.assertion.highlight import strip_deferred_highlight
 from _pytest.assertion._compare_any import _compare_eq_cls
 from _pytest.assertion._compare_mapping import _compare_eq_mapping
 from _pytest.assertion._typing import _AssertionTextDiffStyle
@@ -463,7 +464,12 @@ def callop(
         verbose=verbose,
         assertion_text_diff_style=assertion_text_diff_style,
     )
-    return plugin.pytest_assertrepr_compare(config, op, left, right)
+    result = plugin.pytest_assertrepr_compare(config, op, left, right)
+    if result is None:
+        return None
+    # Explanations are stored with deferred-highlight markers; tests assert
+    # the visible text.
+    return [strip_deferred_highlight(line) for line in result]
 
 
 def callequal(
@@ -2147,8 +2153,8 @@ class TestAssertReprCompareDispatcher:
         assert any("truncated" in line for line in result)
 
     def test_no_terminalreporter_uses_plaintext_highlighter(self) -> None:
-        """Without the terminalreporter plugin the dispatcher uses the
-        plaintext highlighter and never touches a terminal writer (#14377)."""
+        """Explanations are built with deferred markers and never touch a
+        terminal writer, even when terminalreporter is absent (#14377)."""
         config = mock_config(has_terminalreporter=False)
         result = plugin.pytest_assertrepr_compare(config, "==", {1, 2}, {1, 3})
         assert result is not None
@@ -2868,6 +2874,21 @@ def test_comparisons_handle_colors(
     )
 
     result.stdout.fnmatch_lines(formatter(expected_lines), consecutive=False)
+
+
+def test_raises_match_ignores_highlight_markers(pytester: Pytester) -> None:
+    """pytest.raises matches the plain assertion message, not highlight markers (#12365)."""
+    pytester.makepyfile(
+        """
+        import pytest
+
+        def test_match():
+            with pytest.raises(AssertionError, match=r"At index 0 diff: 1 != 3"):
+                assert [1, 2, 3] == [3, 2, 1]
+        """
+    )
+    result = pytester.runpytest("--color=yes", "-vv")
+    result.assert_outcomes(passed=1)
 
 
 def test_fine_grained_assertion_verbosity(pytester: Pytester):

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -17,7 +17,6 @@ from _pytest import outcomes
 import _pytest.assertion as plugin
 from _pytest.assertion import truncate
 from _pytest.assertion import util
-from _pytest.assertion.highlight import strip_deferred_highlight
 from _pytest.assertion._compare_any import _compare_eq_cls
 from _pytest.assertion._compare_mapping import _compare_eq_mapping
 from _pytest.assertion._typing import _AssertionTextDiffStyle
@@ -25,6 +24,7 @@ from _pytest.assertion._typing import NO_TRUNCATION_BUDGET
 from _pytest.assertion._typing import TruncationBudget
 from _pytest.assertion.compare_text import _compare_eq_text
 from _pytest.assertion.compare_text import _notin_text
+from _pytest.assertion.highlight import strip_deferred_highlight
 from _pytest.config import Config as _Config
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pytester import Pytester

--- a/testing/test_assertion_highlight.py
+++ b/testing/test_assertion_highlight.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from _pytest.assertion.highlight import contains_deferred_highlight
+from _pytest.assertion.highlight import deferred_highlighter
+from _pytest.assertion.highlight import resolve_highlight
+from _pytest.assertion.highlight import resolve_highlight_for_writer
+from _pytest.assertion.highlight import strip_deferred_highlight
+from _pytest.assertion.rewrite import _assertion_error
+
+
+def test_deferred_roundtrip_plain() -> None:
+    tagged = deferred_highlighter("1 != 2")
+    assert tagged != "1 != 2"
+    assert contains_deferred_highlight(tagged)
+    assert strip_deferred_highlight(tagged) == "1 != 2"
+
+
+def test_deferred_preserves_escape_in_source() -> None:
+    source = "\x1b[31mred\x1b[0m"
+    tagged = deferred_highlighter(source)
+    assert strip_deferred_highlight(tagged) == source
+    assert "\x1b[31m" in strip_deferred_highlight(tagged)
+
+
+def test_deferred_escapes_soh_in_source() -> None:
+    source = "pre\x01post"
+    tagged = deferred_highlighter(source)
+    assert strip_deferred_highlight(tagged) == source
+
+
+def test_deferred_tags_each_line() -> None:
+    tagged = deferred_highlighter("- eggs\n+ spam", lexer="diff")
+    assert strip_deferred_highlight(tagged) == "- eggs\n+ spam"
+    assert tagged.count("\x01d") == 1
+    assert tagged.count("\x01D") == 1
+
+
+def test_resolve_highlight_applies_highlighter() -> None:
+    seen: list[tuple[str, str]] = []
+
+    def hl(source: str, lexer: Literal["diff", "python"] = "python") -> str:
+        seen.append((source, lexer))
+        return f"<{lexer}:{source}>"
+
+    tagged = deferred_highlighter("1", lexer="python")
+    assert resolve_highlight(tagged, hl) == "<python:1>"
+    assert seen == [("1", "python")]
+
+
+def test_resolve_highlights_multiline_as_one_block() -> None:
+    seen: list[str] = []
+
+    def hl(source: str, lexer: str = "python") -> str:
+        seen.append(source)
+        return "\n".join(f"<{line}>" for line in source.splitlines())
+
+    tagged = deferred_highlighter("- eggs\n+ spam", lexer="diff")
+    assert resolve_highlight(tagged, hl) == "<- eggs>\n<+ spam>"
+    assert seen == ["- eggs\n+ spam"]
+
+
+def test_assertion_error_message_is_plain() -> None:
+    tagged = f"assert 1 == 2\n\n  At index 0 diff: {deferred_highlighter('1')} != {deferred_highlighter('2')}"
+    err = _assertion_error(tagged)
+    assert str(err) == "assert 1 == 2\n\n  At index 0 diff: 1 != 2"
+    assert "\x01" not in str(err)
+
+
+def test_resolve_for_writer_strips_without_markup() -> None:
+    class Tw:
+        hasmarkup = False
+        code_highlight = True
+
+        def _highlight(self, source: str, lexer: str = "python") -> str:
+            return f"HL:{source}"
+
+    tagged = deferred_highlighter("1")
+    assert resolve_highlight_for_writer(tagged, Tw()) == "1"
+
+
+def test_resolve_for_writer_highlights_with_markup() -> None:
+    class Tw:
+        hasmarkup = True
+        code_highlight = True
+
+        def _highlight(self, source: str, lexer: str = "python") -> str:
+            return f"HL:{source}"
+
+    tagged = deferred_highlighter("1")
+    assert resolve_highlight_for_writer(tagged, Tw()) == "HL:1"

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -1779,6 +1779,45 @@ def test_escaped_setup_teardown_error(
     assert "#x1B[31mred#x1B[m" in snode.text
 
 
+def test_verbose_assertion_diff_does_not_leak_ansi(
+    pytester: Pytester, run_and_parse: RunAndParse
+) -> None:
+    """Pygments colors in verbose assertion diffs must not appear in JUnit XML (#12365)."""
+    pytester.makepyfile(
+        """
+        def test_foo():
+            assert [1, 2, 3] == [3, 2, 1]
+        """
+    )
+    _, dom = run_and_parse("--color=yes", "-vv")
+    failure = dom.get_first_by_tag("testcase").get_first_by_tag("failure")
+    for part in (failure.text, failure["message"]):
+        assert "\x1b" not in part
+        assert "#x1B" not in part
+    assert "At index 0 diff: 1 != 3" in failure.text
+    assert "+     1," in failure.text
+
+
+def test_user_ansi_in_compared_strings_is_preserved(
+    pytester: Pytester, run_and_parse: RunAndParse
+) -> None:
+    """Escape sequences that belong to the values under test stay visible in XML (#12365)."""
+    pytester.makepyfile(
+        r"""
+        def test_color():
+            assert "\x1b[31mred\x1b[0m" == "\x1b[32mgreen\x1b[0m"
+        """
+    )
+    _, dom = run_and_parse("--color=yes", "-vv")
+    failure = dom.get_first_by_tag("testcase").get_first_by_tag("failure")
+    # Pytest's own Pygments reset sequence must not be baked in.
+    assert "#x1B[39;49;00m" not in failure.text
+    assert "\x1b" not in failure.text
+    # The compared strings still show the user's color codes (repr or raw).
+    assert "\\x1b[31m" in failure.text or "#x1B[31m" in failure.text
+    assert "\\x1b[32m" in failure.text or "#x1B[32m" in failure.text
+
+
 @parametrize_families
 def test_logging_passing_tests_disabled_does_not_log_test_output(
     pytester: Pytester, run_and_parse: RunAndParse, xunit_family: _JunitFamily


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!
-->

- [x] Include new tests or update existing tests when applicable.
- [x] Allow maintainers to push and squash when merging my commits.
- [x] Add text like ``closes #XYZW`` to the PR description and/or commits.
- [x] Create a new changelog file in the `changelog` directory.
- [x] Add yourself to `AUTHORS` in alphabetical order.

Fixes #12365.

## Problem

With Pygments installed, verbose assertion diffs (`-v`/`-vv`) bake SGR escape sequences into the explanation strings at comparison time. `--junitxml` then writes those codes through `bin_xml_escape()`, which turns ESC into `#x1B` and leaves fragments like `#x1B[94m1#x1B[39;49;00m` in both the failure `message` attribute and the failure body.

A previous attempt (#14605) stripped ANSI from `TerminalRepr.__str__`. That was the wrong layer: it also removed escape sequences that belong to the values under test (for example `assert render() == "\x1b[31mred\x1b[0m"`), and it never touched `reprcrash.message`.

## Solution

Do not apply Pygments when building the explanation. Wrap highlighted spans in private markers, keep the public `AssertionError` message plain, and resolve the markers only when writing to a color terminal. JUnit XML and other plain-text consumers see the original source, so pytest-generated colors disappear from the report while user-provided escape sequences remain visible.