### PR TITLE
compat: add pformat helper using expand=True on Python 3.15+

### DIFF
--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -337,4 +337,3 @@ else:
     import pprint
 
     pformat = pprint.pformat
-

--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -327,3 +327,14 @@ else:
                 return func
 
             return decorator
+
+
+if sys.version_info >= (3, 15):
+    import pprint
+
+    pformat = functools.partial(pprint.pformat, expand=True)
+else:
+    import pprint
+
+    pformat = pprint.pformat
+

--- a/testing/test_compat.py
+++ b/testing/test_compat.py
@@ -202,3 +202,13 @@ def test_deprecated() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
         assert old_way() == "human intelligence"  # type: ignore[deprecated]
+
+
+def test_pformat() -> None:
+    from _pytest.compat import pformat
+
+    data = {"key": "value", "items": [1, 2, 3]}
+    result = pformat(data)
+    assert "key" in result
+    assert "value" in result
+

--- a/testing/test_compat.py
+++ b/testing/test_compat.py
@@ -211,4 +211,3 @@ def test_pformat() -> None:
     result = pformat(data)
     assert "key" in result
     assert "value" in result
-


### PR DESCRIPTION
Fixes #14859

### Summary
Adds a \pformat\ compatibility helper in \src/_pytest/compat.py\ that uses \xpand=True\ when running on Python 3.15+ (where supported by standard library \pprint.pformat\), falling back to standard \pprint.pformat\ on earlier Python versions.

### Changes
- \src/_pytest/compat.py\: Added \pformat = functools.partial(pprint.pformat, expand=True)\ for Python 3.15+.
- \	esting/test_compat.py\: Added \	est_pformat\ unit test verifying \_pytest.compat.pformat\ formatting.