### PR TITLE
[match case] Use match case in _compare_eq_any 

### DIFF
--- a/src/_pytest/assertion/_compare_any.py
+++ b/src/_pytest/assertion/_compare_any.py
@@ -40,6 +40,14 @@ def _compare_eq_any(
     from _pytest.approx import Approx
 
     match (left, right):
+        # Although the common order should be obtained == approx(...), allow both ways.
+        # ``approx()`` can wrap a string, so it comes before the ``str`` cases.
+        case (_, Approx()):
+            yield from right._repr_compare(left)
+        case (Approx(), _):
+            yield from left._repr_compare(right)
+        # ``str`` is a ``Sequence``/iterable: diff two of them as text, and stop for
+        # any other pairing before it gets diffed per character below.
         case (str(), str()):
             yield from _compare_eq_text(
                 left,
@@ -50,12 +58,6 @@ def _compare_eq_any(
                 truncation_budget,
             )
             return
-        # Although the common order should be obtained == approx(...), allow both ways.
-        case (_, Approx()):
-            yield from right._repr_compare(left)
-        case (Approx(), _):
-            yield from left._repr_compare(right)
-        # ``str`` is a ``Sequence``/iterable; stop before it gets diffed per character.
         case (str(), _) | (_, str()):
             return
         case _ if type(left) is type(right) and (

--- a/src/_pytest/assertion/_compare_any.py
+++ b/src/_pytest/assertion/_compare_any.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from collections.abc import Mapping
+from collections.abc import Sequence
 from collections.abc import Set as AbstractSet
 import dataclasses
 import pprint
@@ -15,7 +16,6 @@ from _pytest.assertion._guards import isattrs
 from _pytest.assertion._guards import isdatacls
 from _pytest.assertion._guards import isiterable
 from _pytest.assertion._guards import isnamedtuple
-from _pytest.assertion._guards import issequence
 from _pytest.assertion._typing import _AssertionTextDiffStyle
 from _pytest.assertion._typing import _HighlightFunc
 from _pytest.assertion._typing import NO_TRUNCATION_BUDGET
@@ -49,11 +49,15 @@ def _compare_eq_any(
                 assertion_text_diff_style,
                 truncation_budget,
             )
+            return
         # Although the common order should be obtained == approx(...), allow both ways.
         case (_, Approx()):
             yield from right._repr_compare(left)
         case (Approx(), _):
             yield from left._repr_compare(right)
+        # ``str`` is a ``Sequence``/iterable; stop before it gets diffed per character.
+        case (str(), _) | (_, str()):
+            return
         case _ if type(left) is type(right) and (
             isdatacls(left) or isattrs(left) or isnamedtuple(left)
         ):
@@ -68,9 +72,7 @@ def _compare_eq_any(
                 verbose,
                 assertion_text_diff_style,
             )
-        # A guard, since a ``Sequence()`` pattern would also match ``str``,
-        # which ``issequence`` excludes.
-        case _ if issequence(left) and issequence(right):
+        case (Sequence(), Sequence()):
             yield from _compare_eq_sequence(left, right, highlighter, verbose)
         case (AbstractSet(), AbstractSet()):
             yield from _compare_eq_set(left, right, highlighter, verbose)
@@ -79,7 +81,6 @@ def _compare_eq_any(
                 left, right, highlighter, verbose, truncation_budget
             )
 
-    # Note: ``isiterable`` does not apply to ``str``.
     if isiterable(left) and isiterable(right):
         yield from _compare_eq_iterable(
             left, right, highlighter, verbose, truncation_budget

--- a/src/_pytest/assertion/_compare_any.py
+++ b/src/_pytest/assertion/_compare_any.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from collections.abc import Mapping
+from collections.abc import Set as AbstractSet
 import dataclasses
 import pprint
 
@@ -12,11 +14,8 @@ from _pytest.assertion._guards import has_default_eq
 from _pytest.assertion._guards import isattrs
 from _pytest.assertion._guards import isdatacls
 from _pytest.assertion._guards import isiterable
-from _pytest.assertion._guards import ismapping
 from _pytest.assertion._guards import isnamedtuple
 from _pytest.assertion._guards import issequence
-from _pytest.assertion._guards import isset
-from _pytest.assertion._guards import istext
 from _pytest.assertion._typing import _AssertionTextDiffStyle
 from _pytest.assertion._typing import _HighlightFunc
 from _pytest.assertion._typing import NO_TRUNCATION_BUDGET
@@ -38,24 +37,24 @@ def _compare_eq_any(
     can stream the output and bail out early (e.g. for truncation) without
     materialising the entire diff first.
     """
-    if istext(left) and istext(right):
-        yield from _compare_eq_text(
-            left,
-            right,
-            highlighter,
-            verbose,
-            assertion_text_diff_style,
-            truncation_budget,
-        )
-    else:
-        from _pytest.approx import Approx
+    from _pytest.approx import Approx
 
+    match (left, right):
+        case (str(), str()):
+            yield from _compare_eq_text(
+                left,
+                right,
+                highlighter,
+                verbose,
+                assertion_text_diff_style,
+                truncation_budget,
+            )
         # Although the common order should be obtained == approx(...), allow both ways.
-        if isinstance(right, Approx):
+        case (_, Approx()):
             yield from right._repr_compare(left)
-        elif isinstance(left, Approx):
+        case (Approx(), _):
             yield from left._repr_compare(right)
-        elif type(left) is type(right) and (
+        case _ if type(left) is type(right) and (
             isdatacls(left) or isattrs(left) or isnamedtuple(left)
         ):
             # Note: unlike dataclasses/attrs, namedtuples compare only the
@@ -69,19 +68,22 @@ def _compare_eq_any(
                 verbose,
                 assertion_text_diff_style,
             )
-        elif issequence(left) and issequence(right):
+        # A guard, since a ``Sequence()`` pattern would also match ``str``,
+        # which ``issequence`` excludes.
+        case _ if issequence(left) and issequence(right):
             yield from _compare_eq_sequence(left, right, highlighter, verbose)
-        elif isset(left) and isset(right):
+        case (AbstractSet(), AbstractSet()):
             yield from _compare_eq_set(left, right, highlighter, verbose)
-        elif ismapping(left) and ismapping(right):
+        case (Mapping(), Mapping()):
             yield from _compare_eq_mapping(
                 left, right, highlighter, verbose, truncation_budget
             )
 
-        if isiterable(left) and isiterable(right):
-            yield from _compare_eq_iterable(
-                left, right, highlighter, verbose, truncation_budget
-            )
+    # Note: ``isiterable`` does not apply to ``str``.
+    if isiterable(left) and isiterable(right):
+        yield from _compare_eq_iterable(
+            left, right, highlighter, verbose, truncation_budget
+        )
 
 
 def _compare_eq_cls(

--- a/src/_pytest/assertion/_guards.py
+++ b/src/_pytest/assertion/_guards.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import collections.abc
-from collections.abc import Mapping
-from collections.abc import Set as AbstractSet
 import dataclasses
 from typing import TypeGuard
 
@@ -13,14 +11,6 @@ def issequence(x: object) -> TypeGuard[collections.abc.Sequence[object]]:
 
 def istext(x: object) -> TypeGuard[str]:
     return isinstance(x, str)
-
-
-def ismapping(x: object) -> TypeGuard[Mapping[object, object]]:
-    return isinstance(x, Mapping)
-
-
-def isset(x: object) -> TypeGuard[AbstractSet[object]]:
-    return isinstance(x, AbstractSet)
 
 
 def isnamedtuple(obj: object) -> bool:

--- a/src/_pytest/assertion/_guards.py
+++ b/src/_pytest/assertion/_guards.py
@@ -5,10 +5,6 @@ import dataclasses
 from typing import TypeGuard
 
 
-def issequence(x: object) -> TypeGuard[collections.abc.Sequence[object]]:
-    return isinstance(x, collections.abc.Sequence) and not isinstance(x, str)
-
-
 def isnamedtuple(obj: object) -> bool:
     return isinstance(obj, tuple) and getattr(obj, "_fields", None) is not None
 
@@ -23,7 +19,7 @@ def isattrs(obj: object) -> bool:
 def isiterable(obj: object) -> TypeGuard[collections.abc.Iterable[object]]:
     try:
         iter(obj)  # type: ignore[call-overload]
-        return not isinstance(obj, str)
+        return True
     except Exception:
         return False
 

--- a/src/_pytest/assertion/_guards.py
+++ b/src/_pytest/assertion/_guards.py
@@ -9,10 +9,6 @@ def issequence(x: object) -> TypeGuard[collections.abc.Sequence[object]]:
     return isinstance(x, collections.abc.Sequence) and not isinstance(x, str)
 
 
-def istext(x: object) -> TypeGuard[str]:
-    return isinstance(x, str)
-
-
 def isnamedtuple(obj: object) -> bool:
     return isinstance(obj, tuple) and getattr(obj, "_fields", None) is not None
 
@@ -27,7 +23,7 @@ def isattrs(obj: object) -> bool:
 def isiterable(obj: object) -> TypeGuard[collections.abc.Iterable[object]]:
     try:
         iter(obj)  # type: ignore[call-overload]
-        return not istext(obj)
+        return not isinstance(obj, str)
     except Exception:
         return False
 

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -2675,7 +2675,7 @@ def test_exit_from_assertrepr_compare(monkeypatch) -> None:
     def raise_exit(obj):
         outcomes.exit("Quitting debugger")
 
-    monkeypatch.setattr(_compare_any, "istext", raise_exit)
+    monkeypatch.setattr(_compare_any, "isdatacls", raise_exit)
 
     with pytest.raises(outcomes.Exit, match="Quitting debugger"):
         callequal(1, 1)
@@ -2762,9 +2762,9 @@ def test_exception_before_first_yield_emits_summary_and_notice(monkeypatch) -> N
     def raise_value_error(obj):
         raise ValueError("synthetic repr failure")
 
-    # ``istext`` is called before the first yield, so this triggers the
+    # ``isdatacls`` is called before the first yield, so this triggers the
     # failure path on the very first ``next()``.
-    monkeypatch.setattr(_compare_any, "istext", raise_value_error)
+    monkeypatch.setattr(_compare_any, "isdatacls", raise_value_error)
 
     expl = callequal(1, 1)
     assert expl is not None

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -499,6 +499,39 @@ class TestAssert_reprcompare:
             "+ spam",
         ]
 
+    @pytest.mark.parametrize(
+        "left, right",
+        [("cat", pytest.approx(3)), (pytest.approx(3), "cat")],
+        ids=["str-on-the-left", "str-on-the-right"],
+    )
+    def test_approx_wins_over_text(self, left: Any, right: Any) -> None:
+        """``approx`` explains itself even when the other operand is a string.
+
+        The ``approx`` cases are matched before the ``str`` ones, which stop
+        the dispatch; swapping that order silently drops this explanation.
+        """
+        lines = callequal(left, right)
+        assert lines is not None
+        assert lines[1:] == [
+            "",
+            "comparison failed",
+            "Obtained: cat",
+            "Expected: 3 ± 3.0e-06",
+        ]
+
+    @pytest.mark.parametrize(
+        "left, right",
+        [("cat", ["c", "a", "t"]), (["c", "a", "t"], "cat")],
+        ids=["str-on-the-left", "str-on-the-right"],
+    )
+    def test_no_sequence_diff_against_text(self, left: Any, right: Any) -> None:
+        """A string compared to another sequence gets no explanation.
+
+        ``str`` is a ``Sequence``, so the ``str`` cases have to stop the
+        dispatch before the sequence one describes the string per character.
+        """
+        assert callequal(left, right) is None
+
     def test_text_diff_ndiff_style(self) -> None:
         assert list(
             _compare_eq_text(


### PR DESCRIPTION
Use match case in _compare_eq_any and also explicitely return on string so we don't have to implicitely deal with string that are also iterable later on.