### PR TITLE
fix(config): load rootdir conftest initially

### DIFF
--- a/changelog/11071.bugfix.rst
+++ b/changelog/11071.bugfix.rst
@@ -1,0 +1,2 @@
+Conftest files directly in an explicitly configured root directory are now
+loaded as initial conftests.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -666,6 +666,10 @@ class PytestPluginManager(PluginManager):
             anchors.append(invocation_dir)
             anchors.extend(x for x in invocation_dir.glob("test*") if x.is_dir())
 
+        root_anchor = absolutepath(invocation_dir / rootpath)
+        if root_anchor not in anchors:
+            anchors.append(root_anchor)
+
         for anchor in anchors:
             self._loadconftestmodules(
                 anchor,

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -959,6 +959,30 @@ def test_rootdir_conftest_visible_outside_rootdir(pytester: Pytester) -> None:
     result.stdout.fnmatch_lines(["*test_uses_rootdir*PASSED*", "*1 passed*"])
 
 
+def test_rootdir_conftest_with_pytest_plugins_is_initial(
+    pytester: Pytester,
+) -> None:
+    """A conftest directly in an explicit rootdir is an initial conftest.
+
+    Regression test for #11071.
+    """
+    root = pytester.path
+    package_root = root / "package_root"
+    package_root.mkdir()
+
+    package_root.joinpath("conftest.py").write_text(
+        'pytest_plugins = ""\n',
+        encoding="utf-8",
+    )
+
+    result = pytester.runpytest(
+        "--rootdir",
+        str(package_root),
+    )
+
+    assert result.ret == ExitCode.NO_TESTS_COLLECTED
+
+
 def test_fixture_closure_order_independence_with_parametrize(
     pytester: Pytester,
 ) -> None:


### PR DESCRIPTION
### What

Adds the configured `rootpath` as an initial `conftest` discovery anchor.
This allows a `conftest.py` located directly in an explicitly configured `--rootdir` to be loaded as an initial conftest.

### Why

When running `pytest` from a directory above the configured `--rootdir`, a `conftest.py` located directly inside that root directory could be discovered too late.
In that case, `pytest` reported it as a `non-top-level conftest` even though the file was already located directly in the configured `rootdir`.

### How

I traced the behavior through `_check_non_top_pytest_plugins()` and found that the error is triggered when the `conftest` is imported after `_configured` becomes `True`, rather than by directly checking whether the file is physically located outside the root directory.
Then I followed the initial `conftest` discovery logic in `_set_initial_conftests()`. The discovery `anchors` are built from the collection arguments, and when no suitable arguments are present, discovery falls back to `invocation_dir`.
I also reviewed `_decide_args()`, where, when `cwd != rootpath` and no file or directory arguments are given, the selected path falls back to `invocation_dir`. As a result, `rootdir/conftest.py` is not loaded during the initial configuration stage.
The fix adds the normalized `rootpath` as an additional initial `conftest` discovery `anchor` when it is not already present.

### Tests

Added a regression test for the `--rootdir` case and verified the related `conftest` and plugin behavior with:
```text
pytest testing/test_conftest.py::test_rootdir_conftest_with_pytest_plugins_is_initial -q

pytest testing/test_conftest.py -q
59 passed, 1 skipped

pytest testing/test_config.py::TestPytestPluginsVariable -q
5 passed

pre-commit run --all-files
```

Closes #11071

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.
- [X] If AI agents were used, they are credited in `Co-authored-by` commit trailers.
- [X] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.
- [X] Add yourself to `AUTHORS` in alphabetical order.