### PR TITLE
DOC: add docstring to FixtureFunctionDefinition

### DIFF
--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1454,6 +1454,8 @@ class FixtureFunctionMarker:
 
 # TODO: paramspec/return type annotation tracking and storing
 class FixtureFunctionDefinition:
+    """The object returned by :func:`pytest.fixture`, describing a fixture."""
+
     def __init__(
         self,
         *,


### PR DESCRIPTION
Add a one-line docstring to `FixtureFunctionDefinition` so the type returned by `pytest.fixture` is discoverable/documented.

Related to #14853 (Expose FixtureFunctionDefinition as part of the public API).