### PR TITLE
Fix assertion rewriting reordering a bare-name operand before a later call (#14820)

### DIFF
--- a/changelog/14820.bugfix.rst
+++ b/changelog/14820.bugfix.rst
@@ -1,0 +1,1 @@
+Assertion rewriting now reads a bare-name operand before evaluating a later operand that can run arbitrary code (a call or an await), preserving Python's left-to-right evaluation order when that code rebinds the name.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -519,9 +519,7 @@ def _contains_arbitrary_code(node: ast.expr) -> bool:
     operand that can run arbitrary code (a call or an await), because that
     code may rebind the name (e.g. via ``global``/``nonlocal``). See #14820.
     """
-    return any(
-        isinstance(child, ast.Call | ast.Await) for child in ast.walk(node)
-    )
+    return any(isinstance(child, ast.Call | ast.Await) for child in ast.walk(node))
 
 
 UNARY_MAP = {ast.Not: "not %s", ast.Invert: "~%s", ast.USub: "-%s", ast.UAdd: "+%s"}

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -799,11 +799,13 @@ class AssertionRewriter(ast.NodeVisitor):
         evaluates the earlier operand first. Copy the value into a temporary
         instead (see #14820).
         """
-        if not any(_contains_arbitrary_code(node) for node in later):
-            return self.visit(operand)
         specifiers = set(self.explanation_specifiers)
         res, expl = self.visit(operand)
-        if isinstance(res, ast.Name) and not res.id.startswith("@py_assert"):
+        if (
+            isinstance(res, ast.Name)
+            and not res.id.startswith("@py_assert")
+            and any(_contains_arbitrary_code(node) for node in later)
+        ):
             snapshot = self.assign(res)
             for key in set(self.explanation_specifiers) - specifiers:
                 self.explanation_specifiers[key] = self.display(snapshot)

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -512,6 +512,18 @@ def _check_if_assertion_pass_impl() -> bool:
     return True if util._assertion_pass else False
 
 
+def _contains_arbitrary_code(node: ast.expr) -> bool:
+    """Return whether evaluating *node* can run arbitrary code.
+
+    A bare name used as a left-hand operand must be read before a later
+    operand that can run arbitrary code (a call or an await), because that
+    code may rebind the name (e.g. via ``global``/``nonlocal``). See #14820.
+    """
+    return any(
+        isinstance(child, ast.Call | ast.Await) for child in ast.walk(node)
+    )
+
+
 UNARY_MAP = {ast.Not: "not %s", ast.Invert: "~%s", ast.USub: "-%s", ast.UAdd: "+%s"}
 
 BINOP_MAP = {
@@ -776,6 +788,30 @@ class AssertionRewriter(ast.NodeVisitor):
         self.statements.append(ast.Assign([ast.Name(name, ast.Store())], expr))
         return ast.copy_location(ast.Name(name, ast.Load()), expr)
 
+    def visit_operand(
+        self, operand: ast.expr, later: Sequence[ast.expr]
+    ) -> tuple[ast.expr, str]:
+        """Visit an operand, freezing it against arbitrary code in *later*.
+
+        A plain name is left as a bare load evaluated when the enclosing
+        expression is assembled, after any statements hoisted for the operands
+        that follow it. If one of those can run arbitrary code (a call or an
+        await), it may rebind the name via ``global``/``nonlocal``, so both the
+        value used and the value reported would be the post-rebind one — Python
+        evaluates the earlier operand first. Copy the value into a temporary
+        instead (see #14820).
+        """
+        if not any(_contains_arbitrary_code(node) for node in later):
+            return self.visit(operand)
+        specifiers = set(self.explanation_specifiers)
+        res, expl = self.visit(operand)
+        if isinstance(res, ast.Name) and not res.id.startswith("@py_assert"):
+            snapshot = self.assign(res)
+            for key in set(self.explanation_specifiers) - specifiers:
+                self.explanation_specifiers[key] = self.display(snapshot)
+            res = snapshot
+        return res, expl
+
     def display(self, expr: ast.expr) -> ast.expr:
         """Call saferepr on the expression."""
         return self.helper("_saferepr", expr)
@@ -1039,7 +1075,7 @@ class AssertionRewriter(ast.NodeVisitor):
 
     def visit_BinOp(self, binop: ast.BinOp) -> tuple[ast.Name, str]:
         symbol = BINOP_MAP[binop.op.__class__]
-        left_expr, left_expl = self.visit(binop.left)
+        left_expr, left_expl = self.visit_operand(binop.left, [binop.right])
         right_expr, right_expl = self.visit(binop.right)
         explanation = f"({left_expl} {symbol} {right_expl})"
         res = self.assign(
@@ -1048,25 +1084,28 @@ class AssertionRewriter(ast.NodeVisitor):
         return res, explanation
 
     def visit_Call(self, call: ast.Call) -> tuple[ast.Name, str]:
-        new_func, func_expl = self.visit(call.func)
+        # The callee and every argument are evaluated left to right, so each
+        # is frozen against arbitrary code in what follows (#14820).
+        operands = [*call.args, *(keyword.value for keyword in call.keywords)]
+        new_func, func_expl = self.visit_operand(call.func, operands)
         arg_expls = []
         new_args = []
         new_kwargs = []
-        for arg in call.args:
+        for i, arg in enumerate(call.args):
             if isinstance(arg, ast.Name) and arg.id in self.variables_overwrite.get(
                 self.scope, {}
             ):
                 arg = self.variables_overwrite[self.scope][arg.id]  # type:ignore[assignment]
-            res, expl = self.visit(arg)
+            res, expl = self.visit_operand(arg, operands[i + 1 :])
             arg_expls.append(expl)
             new_args.append(res)
-        for keyword in call.keywords:
+        for i, keyword in enumerate(call.keywords, start=len(call.args)):
             match keyword.value:
                 case ast.Name(id=id) if id in self.variables_overwrite.get(
                     self.scope, {}
                 ):
                     keyword.value = self.variables_overwrite[self.scope][id]  # type:ignore[assignment]
-            res, expl = self.visit(keyword.value)
+            res, expl = self.visit_operand(keyword.value, operands[i + 1 :])
             new_kwargs.append(ast.keyword(keyword.arg, res))
             if keyword.arg:
                 arg_expls.append(keyword.arg + "=" + expl)
@@ -1108,7 +1147,7 @@ class AssertionRewriter(ast.NodeVisitor):
                 comp.left = self.variables_overwrite[self.scope][name_id]  # type: ignore[assignment]
             case ast.NamedExpr(target=ast.Name(id=target_id)):
                 self.variables_overwrite[self.scope][target_id] = comp.left  # type: ignore[assignment]
-        left_res, left_expl = self.visit(comp.left)
+        left_res, left_expl = self.visit_operand(comp.left, comp.comparators)
         if isinstance(comp.left, ast.Compare | ast.BoolOp):
             left_expl = f"({left_expl})"
         res_variables = [self.variable() for i in range(len(comp.ops))]
@@ -1127,7 +1166,9 @@ class AssertionRewriter(ast.NodeVisitor):
                     next_operand.target.id = self.variable()
                     self.variables_overwrite[self.scope][name_id] = next_operand  # type: ignore[assignment]
 
-            next_res, next_expl = self.visit(next_operand)
+            next_res, next_expl = self.visit_operand(
+                next_operand, comp.comparators[i + 1 :]
+            )
             if isinstance(next_operand, ast.Compare | ast.BoolOp):
                 next_expl = f"({next_expl})"
             results.append(next_res)

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -685,6 +685,58 @@ class TestAssertionRewrite:
 
         getmsg(f2, must_pass=True)
 
+    def test_operand_read_order_before_later_call(self, pytester: Pytester) -> None:
+        # A bare name used as an operand must be read before a later call that
+        # rebinds it (see #14820).
+        pytester.makepyfile(
+            """
+            count = 0
+
+            def bump():
+                global count
+                count = 99
+                return 0
+
+            def test_left_operand_is_read_too_late():
+                assert count == bump()
+
+            total = 0
+
+            def bump_total():
+                global total
+                total = 99
+                return 1
+
+            def test_binop_left_operand_is_read_too_late():
+                assert total + bump_total() == 1
+
+            middle = 0
+
+            def bump_middle():
+                global middle
+                middle = 99
+                return 0
+
+            def test_chained_middle_operand_is_read_too_late():
+                assert 0 == middle == bump_middle()
+
+            argument = "x"
+
+            def bump_argument():
+                global argument
+                argument = "y"
+                return "x"
+
+            def pair(first, second):
+                return first, second
+
+            def test_earlier_argument_is_read_too_late():
+                assert pair(argument, bump_argument()) == ("x", "x")
+            """
+        )
+        result = pytester.runpytest()
+        assert result.ret == 0
+
     def test_unary_op(self) -> None:
         def f1() -> None:
             x = True


### PR DESCRIPTION
Fixes #14820

## Summary

Assertion rewriting reorders operand evaluation when a bare-name operand is
followed by a call (or an `await`) that rebinds that name via
`global`/`nonlocal`. Python evaluates operands left-to-right, so this makes the
rewritten assertion read the name *after* the rebind, producing wrong results.

```python
count = 0

def bump():
    global count
    count = 99
    return 0

def test_left_operand_is_read_too_late():
    assert count == bump()   # Python: 0 == 0 -> passes; rewritten: 99 == 0 -> fails
```

## Fix

Add a `visit_operand()` helper that freezes a bare name into a temporary when
any *later* operand can run arbitrary code (`ast.Call` or `ast.Await`). The
value is read before the later operand runs, and the failure message is
redirected to the frozen value (so it reports the value Python would have seen,
not the post-rebind one).

Applied to the operand positions where Python requires left-to-right order:

- `visit_Compare` — the left operand and each comparator (covers the chained
  comparison `a == b == bump()`)
- `visit_BinOp` — the left operand (`total + bump()`)
- `visit_Call` — the callee and each argument (`pair(a, bump())`)

Already-hoisted operands are left untouched, so `assert len(items) == expected`
is unchanged; only the bare-name-followed-by-a-call shape gains one assignment.

Walrus (`:=`) rebinding is intentionally out of scope here: it is already
handled by the existing `variables_overwrite` mechanism, and is being reworked
separately in #14447. This change only covers the `global`/`nonlocal` case that
`variables_overwrite` cannot see.

## Tests

- Added `TestAssertionRewrite.test_operand_read_order_before_later_call`
  covering the comparison, binary-op, chained-comparison, and call-argument
  shapes.
- `python -m pytest testing/test_assertrewrite.py testing/test_assertion.py -q`
  - `333 passed`
- `python -m pytest testing/test_assertrewrite.py testing/test_assertion.py testing/test_pytester.py testing/test_terminal.py testing/test_capture.py -q`
  - `745 passed, 2 skipped, 2 xfailed`

Added a changelog fragment at `changelog/14820.bugfix.rst`.
