### PR TITLE
Fix reporting for teardown errors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@ Aaron Coleman
 Abdeali JK
 Abdelrahman Elbehery
 Abhijeet Kasurde
+ace2016
 Adam Johnson
 Adam Stewart
 Adam Uhlir

--- a/changelog/1004.bugfix.rst
+++ b/changelog/1004.bugfix.rst
@@ -1,0 +1,2 @@
+Tests which pass their call phase but fail during teardown are now reported only
+as errors instead of being reported as both passed and errored.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -409,6 +409,7 @@ class TerminalReporter:
         self.isatty = compat.CallableBool(file.isatty())
         self._progress_nodeids_reported: set[str] = set()
         self._timing_nodeids_reported: set[str] = set()
+        self._pending_passed_reports: dict[str, list[tuple[str, TestReport]]] = {}
         self._show_progress_info = self._determine_show_progress_info()
         self._collect_report_last_write = timing.Instant()
         self._already_displayed_warnings: int | None = None
@@ -634,6 +635,26 @@ class TerminalReporter:
 
     def pytest_runtest_logreport(self, report: TestReport) -> None:
         self._tests_ran = True
+
+        if report.when == "call" and report.passed:
+            category = self._process_test_report(report)
+            self._pending_passed_reports.setdefault(report.nodeid, []).append(
+                (category, report)
+            )
+            return
+
+        if report.when == "teardown":
+            pending_passed = self._pending_passed_reports.pop(report.nodeid, [])
+            if report.failed:
+                for category, passed_report in pending_passed:
+                    reports = self.stats.get(category, [])
+                    self.stats[category] = [
+                        rep for rep in reports if rep is not passed_report
+                    ]
+
+        self._process_test_report(report)
+
+    def _process_test_report(self, report: TestReport) -> str:
         rep = report
 
         res = TestShortLogReport(
@@ -647,7 +668,7 @@ class TerminalReporter:
         self._add_stats(category, [rep])
         if not letter and not word:
             # Probably passed setup/teardown.
-            return
+            return category
         if markup is None:
             was_xfail = hasattr(report, "wasxfail")
             if rep.passed and not was_xfail:
@@ -707,6 +728,7 @@ class TerminalReporter:
                 self._tw.write(" " + line)
                 self.currentfspath = -2
         self.flush()
+        return category
 
     @property
     def _is_last_item(self) -> bool:

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1623,13 +1623,13 @@ def test_stop_iteration_runtest_protocol(pytester: Pytester) -> None:
     )
     result = pytester.runpytest()
     assert result.ret == ExitCode.TESTS_FAILED
-    result.assert_outcomes(failed=1, passed=1, errors=2)
+    result.assert_outcomes(failed=1, errors=2)
     result.stdout.fnmatch_lines(
         [
             "=* short test summary info =*",
             "FAILED test_it.py::test_fail_call - StopIteration: 3",
             "ERROR test_it.py::test_fail_setup - StopIteration: 1",
             "ERROR test_it.py::test_fail_teardown - StopIteration: 2",
-            "=* 1 failed, 1 passed, 2 errors in * =*",
+            "=* 1 failed, 2 errors in * =*",
         ]
     )

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -949,7 +949,7 @@ class TestRequestBasic:
             """
         )
         result = pytester.runpytest()
-        result.assert_outcomes(passed=1, errors=1)
+        result.assert_outcomes(errors=1)
         result.stdout.fnmatch_lines(
             [
                 (
@@ -971,7 +971,7 @@ class TestRequestBasic:
             """
         )
         result = pytester.runpytest()
-        result.assert_outcomes(passed=1, errors=1)
+        result.assert_outcomes(errors=1)
         result.stdout.fnmatch_lines(
             [
                 (
@@ -1134,7 +1134,7 @@ class TestRequestBasic:
         """
         )
         result = pytester.runpytest()
-        result.assert_outcomes(passed=2, errors=1)
+        result.assert_outcomes(passed=1, errors=1)
         result.stdout.fnmatch_lines(
             [
                 '  | *ExceptionGroup: errors while tearing down fixture "subrequest" of <Function test_first> (2 sub-exceptions)',  # noqa: E501
@@ -3759,7 +3759,7 @@ class TestErrors:
             *KeyError*
             *ERROR*teardown*test_2*
             *KeyError*
-            *3 pass*2 errors*
+            *1 pass*2 errors*
         """
         )
 
@@ -4185,7 +4185,7 @@ class TestContextManagerFixtureFuncs:
         result.stdout.fnmatch_lines(
             """
             *pytest.fail*teardown*
-            *1 passed*1 error*
+            *1 error*
         """
         )
 
@@ -4511,7 +4511,7 @@ def test_fixture_post_finalizer_hook_exception(pytester: Pytester) -> None:
         """
     )
     result = pytester.runpytest("-v", "--setup-show")
-    result.assert_outcomes(passed=2, errors=1)
+    result.assert_outcomes(passed=1, errors=1)
     result.stdout.fnmatch_lines(
         [
             "*test_first*PASSED",

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -693,9 +693,10 @@ class TestFixtureReporting:
                 "*assert 0*",
                 "*Captured stdout*",
                 "*teardown func*",
-                "*1 passed*1 error*",
+                "*1 error*",
             ]
         )
+        result.stdout.no_fnmatch_line("*1 passed*")
 
     def test_teardown_fixture_error_and_test_failure(self, pytester: Pytester) -> None:
         pytester.makepyfile(
@@ -2453,7 +2454,7 @@ class TestProgressOutputStyle:
 
 
 class TestProgressWithTeardown:
-    """Ensure we show the correct percentages for tests that fail during teardown (#3088)"""
+    """Test progress for tests that fail during teardown (#1004, #3088)."""
 
     @pytest.fixture
     def contest_with_teardown_fixture(self, pytester: Pytester) -> None:
@@ -2531,9 +2532,10 @@ class TestProgressWithTeardown:
                     "test_bar.py::test_bar[0] PASSED  * [  5%]",
                     "test_bar.py::test_bar[0] ERROR   * [  5%]",
                     "test_bar.py::test_bar[4] PASSED  * [ 25%]",
+                    "test_bar.py::test_bar[4] ERROR   * [ 25%]",
                     "test_foo.py::test_foo[14] PASSED * [100%]",
                     "test_foo.py::test_foo[14] ERROR  * [100%]",
-                    "=* 20 passed, 20 errors in *",
+                    "=* 20 errors in *",
                 ]
             )
         )

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1629,7 +1629,7 @@ class TestClassCleanupErrors:
         """
         )
         result = pytester.runpytest("-s", testpath)
-        result.assert_outcomes(passed=1, errors=1)
+        result.assert_outcomes(errors=1)
         result.stdout.fnmatch_lines(
             [
                 "*Unittest class cleanup errors *2 sub-exceptions*",
@@ -1653,7 +1653,7 @@ class TestClassCleanupErrors:
         """
         )
         result = pytester.runpytest("-s", testpath)
-        result.assert_outcomes(passed=1, errors=1)
+        result.assert_outcomes(errors=1)
         result.stdout.fnmatch_lines(
             [
                 "*ERROR at teardown of MyTestCase.test*",


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
Closes #1004.

## Summary

A test whose call phase passed but whose teardown failed was previously reported as both `PASSED` and `ERROR`. This change defers successful call reporting until teardown completes. If teardown fails, only the error is reported. Call failures followed by teardown errors remain separately reported.

The internal setup, call, and teardown reports remain unchanged for plugins.

## Testing

- Focused teardown-reporting tests: `5 passed`
- Broader terminal tests: `219 passed, 2 skipped, 8 deselected`
- `python -m ruff check src/_pytest/terminal.py testing/test_terminal.py`
- `python -m ruff format --check src/_pytest/terminal.py testing/test_terminal.py`
- `git diff --check`

## Checklist

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits.
- [X] Add text like `closes #XYZW` to the PR description and/or commits.
- [X] If AI agents were used, they are credited in `Co-authored-by` commit trailers.
- [X] Create a new changelog file in the `changelog` directory.
- [X] Add yourself to `AUTHORS` in alphabetical order.
