### PR TITLE
Fix collection with inode 0 on Windows network drives

### DIFF
--- a/changelog/14864.bugfix.rst
+++ b/changelog/14864.bugfix.rst
@@ -1,0 +1,1 @@
+Fix collection on Windows when a file path is given on the command line and the file system reports an inode number of 0 (e.g. some network drives), which previously caused the whole suite to be collected instead of the specified file.

--- a/src/_pytest/pathlib.py
+++ b/src/_pytest/pathlib.py
@@ -1095,4 +1095,10 @@ def samefile_nofollow(p1: Path, p2: Path) -> bool:
 
     Unlike Path.samefile(), does not resolve symlinks.
     """
-    return os.path.samestat(p1.lstat(), p2.lstat())
+    s1, s2 = p1.lstat(), p2.lstat()
+    if not s1.st_ino or not s2.st_ino:
+        # On some filesystems (e.g. some network drives on Windows), st_ino is
+        # always 0, in which case samestat() would consider any two paths to
+        # be the same file, causing incorrect matches when collecting (#14864).
+        return False
+    return os.path.samestat(s1, s2)

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -38,6 +38,7 @@ from _pytest.pathlib import module_name_from_path
 from _pytest.pathlib import resolve_package_path
 from _pytest.pathlib import resolve_pkg_root_and_module_name
 from _pytest.pathlib import safe_exists
+from _pytest.pathlib import samefile_nofollow
 from _pytest.pathlib import scandir
 from _pytest.pathlib import spec_matches_module_path
 from _pytest.pathlib import symlink_or_skip
@@ -1237,6 +1238,38 @@ def test_safe_exists(tmp_path: Path) -> None:
         side_effect=ValueError("name too long"),
     ):
         assert safe_exists(p) is False
+
+
+def test_samefile_nofollow_zero_inode(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Regression test for #14864.
+
+    On some filesystems (e.g. network drives on Windows), ``st_ino`` is always
+    0, which made ``os.path.samestat()`` consider any two paths to be the same
+    file, causing pytest to collect the whole suite instead of just the
+    specified file.
+    """
+    p1 = tmp_path.joinpath("a.py")
+    p2 = tmp_path.joinpath("b.py")
+    p1.touch()
+    p2.touch()
+
+    monkeypatch.setattr(
+        Path,
+        "lstat",
+        lambda self: os.stat_result((0,) * 10),
+    )
+
+    assert samefile_nofollow(p1, p2) is False
+    assert samefile_nofollow(p1, p1) is False
+
+
+def test_samefile_nofollow_real_files(tmp_path: Path) -> None:
+    p1 = tmp_path.joinpath("a.py")
+    p2 = tmp_path.joinpath("b.py")
+    p1.touch()
+    p2.touch()
+    assert samefile_nofollow(p1, p2) is False
+    assert samefile_nofollow(p1, p1) is True
 
 
 def test_import_sets_module_as_attribute(pytester: Pytester) -> None:


### PR DESCRIPTION
Fixes #14864

## Problem

On Windows, when collecting with a file path given on the command line and the
filesystem reports `st_ino` as `0` for every file (e.g. sshfs network drives),
`samefile_nofollow()` falls back to `os.path.samestat()`, which only compares
`st_ino` and `st_dev`. Since `0 == 0`, *any* two files are considered the same,
so the whole suite gets collected instead of just the specified file.

## Fix

Bail out early in `samefile_nofollow()` when either inode is `0` and return
`False`, falling back to plain path comparison (which is what other platforms
do anyway). The Windows short-path case (#11895) keeps working because local
NTFS provides real inode numbers.

## Tests

- `test_samefile_nofollow_zero_inode`: mocks `Path.lstat()` with an all-zero
  stat result, verifying the function returns `False` (previously `True`).
- `test_samefile_nofollow_real_files`: verifies real files still compare
  correctly.