### PR TITLE
[refactor] Drop an unreachable 'setUpClass' / 'tearDownClass' guard in 'UnitTestCase'

### DIFF
--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -129,8 +129,6 @@ class UnitTestCase(Class):
         tearDownClass (#517)."""
         setup = getattr(cls, "setUpClass", None)
         teardown = getattr(cls, "tearDownClass", None)
-        if setup is None and teardown is None:
-            return None
         cleanup = getattr(cls, "doClassCleanups", lambda: None)
 
         def process_teardown_exceptions() -> None:


### PR DESCRIPTION
unittest.TestCase has carried default no-op setUpClass/tearDownClass classmethods since Python 3.2 (https://docs.python.org/3/library/unittest.html#unittest.TestCase.setUpClass / https://github.com/python/cpython/commit/847a4110ea99). PyPy takes unittest verbatim from CPython's pure-Python stdlib. This line was introduced in pytest in https://github.com/pytest-dev/pytest/commit/a616adf3aef6057203994852a8e0ae3cef54e0e3 probably taken from https://github.com/pytest-dev/pytest/commit/0f918b1a9dd14a2d046d19be6ec239e8e2df4cb2 that was more generic (handle pytest struct too ?)

A class that nulls both hooks out ('setUpClass = tearDownClass = None') now registers the fixture instead of skipping it, and runs the same: the 'is not None' checks inside the fixture already handle that.