### PR TITLE
Improve error for mistaken self fixture

### DIFF
--- a/changelog/12907.improvement.rst
+++ b/changelog/12907.improvement.rst
@@ -1,0 +1,1 @@
+The missing fixture error for bare test functions which mistakenly declare a ``self`` parameter now suggests removing it.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1009,6 +1009,11 @@ class FixtureLookupError(LookupError):
                 )
             else:
                 msg = f"fixture '{self.argname}' not found"
+                if self.argname == "self":
+                    msg += (
+                        "\n hint: remove 'self' from the function definition if this "
+                        "is not a method"
+                    )
             msg += "\n available fixtures: {}".format(", ".join(sorted(available)))
             msg += "\n use 'pytest --fixtures [testpath]' for help on them."
 

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -687,6 +687,23 @@ class TestFillFixtures:
         )
         result.stdout.no_fnmatch_line("*INTERNAL*")
 
+    def test_funcarg_lookup_error_self_hint(self, pytester: Pytester) -> None:
+        pytester.makepyfile(
+            """
+            def test_something(self):
+                pass
+            """
+        )
+        result = pytester.runpytest()
+        result.stdout.fnmatch_lines(
+            [
+                "*ERROR at setup of test_something*",
+                "E       fixture 'self' not found",
+                ">       hint: remove 'self' from the function definition if this is not a method",
+            ]
+        )
+        result.assert_outcomes(errors=1)
+
     def test_fixture_excinfo_leak(self, pytester: Pytester) -> None:
         # on python2 sys.excinfo would leak into fixture executions
         pytester.makepyfile(


### PR DESCRIPTION
## Summary

- add a targeted hint when a bare test function mistakenly declares `self` and pytest reports it as a missing fixture
- add a regression test for the rendered error
- add a changelog entry

This addresses the maintainer-approved first case in #12907. It deliberately leaves the more complex missing-`self` method case unchanged.

## Why

The existing `fixture 'self' not found` message assumes the reader already understands pytest fixtures. For beginners who accidentally write a standalone test like `def test_something(self)`, a short hint points directly to the likely mistake without changing fixture discovery or execution.

The hint is emitted only for the normal missing-fixture path when the unresolved name is exactly `self`; recursive fixture dependency errors are unaffected.

## Validation

- focused fixture lookup tests: 2 passed
- complete `testing/python/fixtures.py` module: 241 passed, 3 xfailed
- repository changed-files pre-commit suite: passed, including Ruff, formatting, codespell, and mypy

## AI assistance

Codex assisted with issue research and implementation. I reviewed and understand the complete change and will own the contribution and follow-up discussion.
