### PR TITLE
Deprecate self in module, package and session scoped fixtures

### DIFF
--- a/changelog/14765.deprecation.rst
+++ b/changelog/14765.deprecation.rst
@@ -1,0 +1,6 @@
+Defining a ``module``, ``package`` or ``session``-scoped fixture as an instance method inside a
+test class is now deprecated, extending the existing ``class``-scoped deprecation.
+
+Attributes set on ``self`` in such a fixture are never visible to the tests, because each test
+runs on a new instance while the fixture runs once per module, package or session. Use a
+``@staticmethod`` and request the returned value as a fixture argument instead.

--- a/doc/en/deprecations.rst
+++ b/doc/en/deprecations.rst
@@ -277,6 +277,50 @@ Using ``@classmethod`` ensures attributes are set on the class itself, making th
 to all test methods.
 
 
+.. _wider-scoped-fixture-as-instance-method:
+
+Module, package and session-scoped fixture as instance method
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 9.2
+
+Defining a ``module``, ``package`` or ``session``-scoped fixture as an instance method is
+deprecated and will be removed in pytest 10.0.
+
+This is the same problem as :ref:`class-scoped-fixture-as-instance-method`, and for the same
+reason. pytest creates a new instance of the test class for each test method, so attributes set
+on ``self`` inside the fixture are never seen by the tests.
+
+**Before** (deprecated):
+
+.. code-block:: python
+
+    class TestExample:
+        @pytest.fixture(scope="module")
+        def setup_data(self):
+            self.data = [1, 2, 3]  # This won't be visible to tests!
+
+        def test_something(self, setup_data):
+            assert self.data == [1, 2, 3]  # AttributeError
+
+**After** (recommended):
+
+.. code-block:: python
+
+    class TestExample:
+        @pytest.fixture(scope="module")
+        @staticmethod
+        def setup_data():
+            return [1, 2, 3]
+
+        def test_something(self, setup_data):
+            assert setup_data == [1, 2, 3]  # Works correctly
+
+Unlike the class-scoped case, ``@classmethod`` is not suggested here. These scopes outlive the
+class body, so storing state on the class is rarely what you want. Return the value from a
+``@staticmethod`` and request it as a fixture argument instead.
+
+
 .. _monkeypatch-fixup-namespace-packages:
 
 ``monkeypatch.syspath_prepend`` with legacy namespace packages

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -43,6 +43,15 @@ CLASS_FIXTURE_INSTANCE_METHOD = UnformattedWarning(
     "See https://docs.pytest.org/en/stable/deprecations.html#class-scoped-fixture-as-instance-method",
 )
 
+WIDER_SCOPED_FIXTURE_INSTANCE_METHOD = UnformattedWarning(
+    PytestRemovedIn10Warning,
+    "{scope}-scoped fixtures defined as instance methods are deprecated.\n"
+    "Instance attributes set in the {fixturename!r} fixture will NOT be visible to test methods,\n"
+    "as each test gets a new instance while the fixture runs only once per {scope}.\n"
+    "Use a @staticmethod decorator below @pytest.fixture instead.\n"
+    "See https://docs.pytest.org/en/stable/deprecations.html#wider-scoped-fixture-as-instance-method",
+)
+
 # This deprecation is never really meant to be removed.
 PRIVATE = PytestDeprecationWarning("A private pytest class or function was used.")
 

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -62,6 +62,7 @@ from _pytest.deprecated import FIXTURE_GETFIXTUREVALUE_DURING_TEARDOWN
 from _pytest.deprecated import FIXTURE_NODEID_DEPRECATED
 from _pytest.deprecated import FIXTUREDEF_HAS_LOCATION_DEPRECATED
 from _pytest.deprecated import PARSEFACTORIES_NODEID_DEPRECATED
+from _pytest.deprecated import WIDER_SCOPED_FIXTURE_INSTANCE_METHOD
 from _pytest.deprecated import YIELD_FIXTURE
 from _pytest.main import Session
 from _pytest.mark import Mark
@@ -1329,6 +1330,14 @@ class RequestFixtureDef(FixtureDef[FixtureRequest]):
         pass
 
 
+# Scopes where a fixture defined as an instance method silently fails to share
+# state with tests, because the fixture and the tests run on different
+# instances. Function scope is exempt since both run on the same instance.
+_INSTANCE_METHOD_DEPRECATED_SCOPES = frozenset(
+    {Scope.Class, Scope.Module, Scope.Package, Scope.Session}
+)
+
+
 def resolve_fixture_function(
     fixturedef: FixtureDef[FixtureValue], request: FixtureRequest
 ) -> _FixtureFunc[FixtureValue]:
@@ -1344,19 +1353,25 @@ def resolve_fixture_function(
     # as expected.
     instance = request.instance
 
-    if fixturedef._scope is Scope.Class:
+    if fixturedef._scope in _INSTANCE_METHOD_DEPRECATED_SCOPES:
         # Check if fixture is an instance method (bound to instance, not class)
         if hasattr(fixturefunc, "__self__"):
             bound_to = fixturefunc.__self__
             # classmethod: bound_to is the class itself (a type)
             # instance method: bound_to is an instance (not a type)
             if not isinstance(bound_to, type):
-                warnings.warn(
-                    CLASS_FIXTURE_INSTANCE_METHOD.format(
+                if fixturedef._scope is Scope.Class:
+                    warning = CLASS_FIXTURE_INSTANCE_METHOD.format(
                         fixturename=request.fixturename
-                    ),
-                    stacklevel=2,
-                )
+                    )
+                else:
+                    # Wider scopes outlive the class body, so cls is no more
+                    # useful than self here and @staticmethod is the fix.
+                    warning = WIDER_SCOPED_FIXTURE_INSTANCE_METHOD.format(
+                        fixturename=request.fixturename,
+                        scope=fixturedef._scope.value.capitalize(),
+                    )
+                warnings.warn(warning, stacklevel=2)
 
     if instance is not None:
         # Handle the case where fixture is defined not in a test class, but some other class

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -138,6 +138,76 @@ def test_class_scope_classmethod_fixture_not_deprecated(pytester: Pytester) -> N
     result.assert_outcomes(passed=1)
 
 
+@pytest.mark.parametrize("scope", ["module", "package", "session"])
+def test_wider_scope_instance_method_is_deprecated(
+    pytester: Pytester, scope: str
+) -> None:
+    pytester.makepyfile(
+        __init__="",
+        test_it=f"""
+        import pytest
+
+        class TestClass:
+            @pytest.fixture(scope="{scope}")
+            def fix(self):
+                self.attr = True
+
+            def test_foo(self, fix):
+                pass
+        """,
+    )
+    result = pytester.runpytest("-Werror::pytest.PytestRemovedIn10Warning")
+    result.assert_outcomes(errors=1)
+    result.stdout.fnmatch_lines(
+        [
+            f"*PytestRemovedIn10Warning: {scope.capitalize()}-scoped fixtures defined "
+            "as instance methods*"
+        ]
+    )
+
+
+@pytest.mark.parametrize("scope", ["module", "package", "session"])
+def test_wider_scope_staticmethod_fixture_not_deprecated(
+    pytester: Pytester, scope: str
+) -> None:
+    pytester.makepyfile(
+        __init__="",
+        test_it=f"""
+        import pytest
+
+        class TestClass:
+            @pytest.fixture(scope="{scope}")
+            @staticmethod
+            def fix():
+                return True
+
+            def test_foo(self, fix):
+                assert fix is True
+        """,
+    )
+    result = pytester.runpytest("-Werror::pytest.PytestRemovedIn10Warning")
+    result.assert_outcomes(passed=1)
+
+
+def test_function_scope_instance_method_not_deprecated(pytester: Pytester) -> None:
+    """Function scope shares one instance with the test, so self works."""
+    pytester.makepyfile(
+        """
+        import pytest
+
+        class TestClass:
+            @pytest.fixture
+            def fix(self):
+                self.attr = True
+
+            def test_foo(self, fix):
+                assert self.attr is True
+        """
+    )
+    result = pytester.runpytest("-Werror::pytest.PytestRemovedIn10Warning")
+    result.assert_outcomes(passed=1)
+
+
 class TestFixtureNodeidDeprecations:
     """Tests for deprecated baseid/nodeid string APIs in fixture registration.
 

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1293,7 +1293,8 @@ class TestRequestBasic:
 
 class TestRequestSessionScoped:
     @pytest.fixture(scope="session")
-    def session_request(self, request):
+    @staticmethod
+    def session_request(request):
         return request
 
     @pytest.mark.parametrize("name", ["path", "module"])

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -43,7 +43,8 @@ def conftest_setinitial(
 @pytest.mark.usefixtures("_sys_snapshot")
 class TestConftestValueAccessGlobal:
     @pytest.fixture(scope="module", params=["global", "inpackage"])
-    def basedir(self, request, tmp_path_factory: TempPathFactory) -> Generator[Path]:
+    @staticmethod
+    def basedir(request, tmp_path_factory: TempPathFactory) -> Generator[Path]:
         tmp_path = tmp_path_factory.mktemp("basedir", numbered=True)
         tmp_path.joinpath("adir/b").mkdir(parents=True)
         tmp_path.joinpath("adir/conftest.py").write_text(

--- a/testing/test_legacypath.py
+++ b/testing/test_legacypath.py
@@ -102,7 +102,8 @@ def test_fixturerequest_getmodulepath(pytester: pytest.Pytester) -> None:
 
 class TestFixtureRequestSessionScoped:
     @pytest.fixture(scope="session")
-    def session_request(self, request):
+    @staticmethod
+    def session_request(request):
         return request
 
     def test_session_scoped_unavailable_attributes(self, session_request):

--- a/testing/test_pathlib.py
+++ b/testing/test_pathlib.py
@@ -130,9 +130,10 @@ class TestImportPath:
     """
 
     @pytest.fixture(scope="session")
-    def path1(self, tmp_path_factory: TempPathFactory) -> Generator[Path]:
+    @staticmethod
+    def path1(tmp_path_factory: TempPathFactory) -> Generator[Path]:
         path = tmp_path_factory.mktemp("path")
-        self.setuptestfs(path)
+        TestImportPath.setuptestfs(path)
         yield path
         assert path.joinpath("samplefile").exists()
 
@@ -142,7 +143,8 @@ class TestImportPath:
             with unittest.mock.patch.object(sys, "path", list(sys.path)):
                 yield
 
-    def setuptestfs(self, path: Path) -> None:
+    @staticmethod
+    def setuptestfs(path: Path) -> None:
         # print "setting up test fs for", repr(path)
         samplefile = path / "samplefile"
         samplefile.write_text("samplefile\n", encoding="utf-8")


### PR DESCRIPTION
Closes #14765.

#14071 deprecated instance-method fixtures at `class` scope, since attributes set on `self` never reach the tests. Each test runs on a fresh instance while the fixture runs once per class. `module`, `package` and `session` scope have exactly the same problem and were still silent, so this extends the deprecation to cover them.

Confirmed the breakage is real before writing the warning. With `scope="module"` or `scope="session"`, a fixture that sets `self.attr` leaves the test seeing nothing:

```
E       AssertionError: assert None == 'set-by-fixture'
```

The message differs from the class-scoped one. `@classmethod` is what the class-scoped warning recommends, but for these wider scopes the class body is not a useful place to hang state either, so the new message points at `@staticmethod`. Worth noting that `@classmethod` does happen to work at these scopes, so if you would rather the message mention both, that is a one-line change.

Function scope is deliberately untouched. The fixture and the test share an instance there, so `self` behaves as people expect.

Four fixtures in our own test suite matched the pattern:

- `testing/test_legacypath.py` `TestFixtureRequestSessionScoped.session_request`
- `testing/test_conftest.py` `TestConftestValueAccessGlobal.basedir`
- `testing/test_pathlib.py` `TestImportPath.path1`
- `testing/python/fixtures.py` `TestRequestSessionScoped.session_request`

Every one of them took `self` without using it, which is some evidence the deprecation catches accidental instance methods rather than deliberate ones. They are now staticmethods. `TestImportPath.path1` called `self.setuptestfs`, which does not use `self` either, so that helper became a staticmethod as well.

## Verification

- `testing/deprecated_test.py`, 23 passed, including 7 new
- Full `testing/` suite with `-n 8`, 3761 passed against 3754 on unmodified main. Same 1 failure and same 5 errors appear on both, all from optional deps missing in my environment, `attrs` among them
- `ruff check`, `ruff format --check`, and `mypy` on the changed files, all clean
- Reverted the two `src/` files and re-ran the new tests to confirm they fail without the change, rather than passing regardless
