### PR TITLE
Short-circuit comparison chains in rewritten asserts

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -236,6 +236,7 @@ Jeff Rackauckas
 Jeff Widman
 Jenni Rinker
 Jens Tröger
+Jhon Alvarez
 Jiajun Xu
 John Eddie Ayson
 John Litborn

--- a/changelog/14819.bugfix.rst
+++ b/changelog/14819.bugfix.rst
@@ -1,0 +1,6 @@
+Comparison chains in an ``assert`` are now evaluated lazily, as Python evaluates them.
+
+Previously the rewriter evaluated every comparator, so ``assert a < b < c`` could
+evaluate ``c`` even when ``a < b`` was false. A rewritten assertion could therefore
+call what Python would not, or fail with an unrelated exception instead of
+``AssertionError``. ``and`` and ``or`` already short-circuited; chains now do too.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -1113,21 +1113,26 @@ class AssertionRewriter(ast.NodeVisitor):
         # first inside an "if" on the previous result so the rewritten form does
         # the same, the way visit_BoolOp already does for "and" and "or".
         outer_statements = self.statements
+        outer_expl_stmts = self.expl_stmts
         # comp.left is already emitted; the chain's own work starts here.
         chain_starts_at = len(self.statements)
-        # Whatever a skipped operand would have bound is set to None up front:
-        # the explanation builds its arguments eagerly, and _call_reprcompare
-        # stops at the first false result, so it never reads those values.
-        may_be_skipped: list[str] = []
+        conditional_blocks: list[list[ast.stmt]] = []
+        fail_ifs: list[tuple[list[ast.stmt], ast.If]] = []
         for i, op, next_operand in it:
             if i:
                 inner: list[ast.stmt] = []
                 self.statements.append(ast.If(load_names[i - 1], inner, []))
                 self.statements = inner
-                first_new_variable = len(self.variables)
-                # format_variables only exists with the assertion_pass hook on.
-                format_variables = getattr(self, "format_variables", None)
-                first_new_format_variable = len(format_variables or ())
+                # An operand can also contribute statements that run only when
+                # the assertion fails, such as a nested boolop appending to its
+                # explanation list. Skip those too, or they run against names
+                # the skipped operand never bound.
+                fail_inner: list[ast.stmt] = []
+                fail_if = ast.If(load_names[i - 1], fail_inner, [])
+                fail_ifs.append((self.expl_stmts, fail_if))
+                self.expl_stmts.append(fail_if)
+                self.expl_stmts = fail_inner
+                conditional_blocks += (inner, fail_inner)
             match (next_operand, left_res):
                 case (
                     ast.NamedExpr(target=ast.Name(id=target_id)),
@@ -1146,13 +1151,25 @@ class AssertionRewriter(ast.NodeVisitor):
             expls.append(ast.Constant(expl))
             res_expr = ast.copy_location(ast.Compare(left_res, [op], [next_res]), comp)
             self.statements.append(ast.Assign([store_names[i]], res_expr))
-            if i:
-                may_be_skipped.append(res_variables[i])
-                may_be_skipped.extend(self.variables[first_new_variable:])
-                if format_variables is not None:
-                    may_be_skipped.extend(format_variables[first_new_format_variable:])
             left_res, left_expl = next_res, next_expl
         self.statements = outer_statements
+        self.expl_stmts = outer_expl_stmts
+        # Most operands contribute nothing to the explanation, and an "if" with
+        # an empty body is not valid ast.
+        for parent, fail_if in reversed(fail_ifs):  # innermost first
+            if not fail_if.body:
+                parent.remove(fail_if)
+        # The explanation builds its arguments eagerly, so whatever the skipped
+        # statements would have bound is set to None first. Nothing reads those
+        # values: _call_reprcompare stops at the first false result, and a chain
+        # only short-circuits after one.
+        may_be_skipped = dict.fromkeys(
+            node.id
+            for block in conditional_blocks
+            for stmt in block
+            for node in ast.walk(stmt)
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store)
+        )
         if may_be_skipped:
             self.statements.insert(
                 chain_starts_at,

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -1108,7 +1108,25 @@ class AssertionRewriter(ast.NodeVisitor):
         expls: list[ast.expr] = []
         syms: list[ast.expr] = []
         results = [left_res]
+        # Python evaluates a comparison chain lazily: in "a < b < c", "c" is
+        # never evaluated when "a < b" is false. Nest every comparison after the
+        # first inside an "if" on the previous result so the rewritten form does
+        # the same, the way visit_BoolOp already does for "and" and "or".
+        outer_statements = self.statements
+        # comp.left is already emitted; the chain's own work starts here.
+        chain_starts_at = len(self.statements)
+        # Whatever a skipped operand would have bound is set to None up front:
+        # the explanation builds its arguments eagerly, and _call_reprcompare
+        # stops at the first false result, so it never reads those values.
+        may_be_skipped: list[str] = []
         for i, op, next_operand in it:
+            if i:
+                self.statements.append(ast.If(load_names[i - 1], (inner := []), []))
+                self.statements = inner
+                first_new_variable = len(self.variables)
+                # format_variables only exists with the assertion_pass hook on.
+                format_variables = getattr(self, "format_variables", None)
+                first_new_format_variable = len(format_variables or ())
             match (next_operand, left_res):
                 case (
                     ast.NamedExpr(target=ast.Name(id=target_id)),
@@ -1127,7 +1145,21 @@ class AssertionRewriter(ast.NodeVisitor):
             expls.append(ast.Constant(expl))
             res_expr = ast.copy_location(ast.Compare(left_res, [op], [next_res]), comp)
             self.statements.append(ast.Assign([store_names[i]], res_expr))
+            if i:
+                may_be_skipped.append(res_variables[i])
+                may_be_skipped.extend(self.variables[first_new_variable:])
+                if format_variables is not None:
+                    may_be_skipped.extend(format_variables[first_new_format_variable:])
             left_res, left_expl = next_res, next_expl
+        self.statements = outer_statements
+        if may_be_skipped:
+            self.statements.insert(
+                chain_starts_at,
+                ast.Assign(
+                    [ast.Name(name, ast.Store()) for name in may_be_skipped],
+                    ast.Constant(None),
+                ),
+            )
         # Use pytest.assertion.util._reprcompare if that's available.
         expl_call = self.helper(
             "_call_reprcompare",

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -1121,7 +1121,8 @@ class AssertionRewriter(ast.NodeVisitor):
         may_be_skipped: list[str] = []
         for i, op, next_operand in it:
             if i:
-                self.statements.append(ast.If(load_names[i - 1], (inner := []), []))
+                inner: list[ast.stmt] = []
+                self.statements.append(ast.If(load_names[i - 1], inner, []))
                 self.statements = inner
                 first_new_variable = len(self.variables)
                 # format_variables only exists with the assertion_pass hook on.

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -889,6 +889,35 @@ class TestAssertionRewrite:
 
         getmsg(f5, must_pass=True)
 
+    def test_comparison_chain_short_circuits(self) -> None:
+        def f1() -> None:
+            assert 1 < 0 < 1 / 0
+
+        # Not a ZeroDivisionError: Python never evaluates the last comparator.
+        assert getmsg(f1) == """assert 1 < 0"""
+
+        def f2() -> None:
+            calls = []
+
+            def sentinel() -> int:
+                calls.append("called")
+                return 5
+
+            try:
+                assert 1 < 0 < sentinel()
+            except AssertionError:
+                pass
+            assert calls == []
+
+        getmsg(f2, must_pass=True)
+
+        def f3() -> None:
+            a, b, c = range(3)
+            assert c < b < a < 1 / 0  # type: ignore[operator]
+
+        # The chain is walked left to right, so the failure at "2 < 1" stops it.
+        assert getmsg(f3) == """assert 2 < 1"""
+
     def test_len(self, request) -> None:
         def f():
             values = list(range(10))

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -918,6 +918,14 @@ class TestAssertionRewrite:
         # The chain is walked left to right, so the failure at "2 < 1" stops it.
         assert getmsg(f3) == """assert 2 < 1"""
 
+        def f4() -> None:
+            a = b = 0
+            # A boolop in a skipped comparator also contributes statements that
+            # only run when the assertion fails. Those have to be skipped too.
+            assert 1 < 0 < (a or b)
+
+        assert getmsg(f4) == """assert 1 < 0"""
+
     def test_len(self, request) -> None:
         def f():
             values = list(range(10))

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -913,7 +913,7 @@ class TestAssertionRewrite:
 
         def f3() -> None:
             a, b, c = range(3)
-            assert c < b < a < 1 / 0  # type: ignore[operator]
+            assert c < b < a < 1 / 0
 
         # The chain is walked left to right, so the failure at "2 < 1" stops it.
         assert getmsg(f3) == """assert 2 < 1"""


### PR DESCRIPTION
Closes #14819.

## The problem

Python evaluates a comparison chain lazily: in `a < b < c`, `c` is never evaluated when `a < b` is false. `visit_Compare` walked the comparators in a loop, assigning every result, and only combined them with an `and` afterwards — by which point everything had already run.

```python
def test_raises_the_wrong_error():
    assert 1 < 0 < 1 / 0        # rewritten: ZeroDivisionError, not AssertionError

def test_calls_what_it_should_not():
    calls = []
    def boom():
        calls.append("boom")
        return 5
    try:
        assert 1 < 0 < boom()
    except AssertionError:
        pass
    assert calls == []          # rewritten: calls == ["boom"]
```

Both pass under `--assert=plain` and fail when rewritten.

## The change

Each comparison after the first is nested inside an `if` on the previous result — what `visit_BoolOp` has done for `and`/`or` since #57. For `assert 1 < 0 < boom()`:

```python
 @py_assert0 = 1
 @py_assert4 = 0
+@py_assert3 = @py_assert7 = None
 @py_assert2 = @py_assert0 < @py_assert4
-@py_assert7 = boom()
-@py_assert3 = @py_assert4 < @py_assert7
+if @py_assert2:
+    @py_assert7 = boom()
+    @py_assert3 = @py_assert4 < @py_assert7
 if not (@py_assert2 and @py_assert3):
```

The `and` in the guard already short-circuits, so `res` is safe. The explanation is not: it builds its arguments eagerly, and a skipped operand would leave an unbound name for `_saferepr` to read. Everything a skipped operand would have bound is set to `None` before the chain.

Nothing ever reads those `None`s. `_call_reprcompare` breaks at the first falsy result and reports only that pair — which is exactly where the chain stopped, since a chain only short-circuits *after* a false comparison. That is also why the messages do not change: `assert 1 < 3 < 5 <= 4 < 7` still reports `assert 5 <= 4`.

## Notes for review

- The `None` assignment is inserted after `comp.left`'s own statements, so a compound left operand is still evaluated exactly once and in place. With `assert len(v) < g() < h()` the generated code keeps `@py_assert2 = len(v)` first and only calls `h()` inside the guard.
- `format_variables` only exists when the `pytest_assertion_pass` hook is enabled, so it is read through `getattr`.

## Tests

`test_comparison_chain_short_circuits` covers the wrong-exception case, the unwanted-call case, and that a chain which fails partway still reports the failing pair. `test_comparisons` and `test_custom_reprcompare` pin the existing messages and are unchanged.

Full suite: **4359 passed, 97 skipped, 14 xfailed**.

## Checklist

- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [x] If AI agents were used, they are credited in `Co-authored-by` commit trailers.
- [x] Create a new changelog file in the `changelog` directory.
- [x] Add yourself to `AUTHORS` in alphabetical order.

Claude (Opus 5) was used; it is credited in the `Co-authored-by` trailers. I read the generated code with `ast.unparse` before and after, and I can answer questions on any part of it.
