### PR TITLE
Warn when cmdline_main raises SystemExit

### DIFF
--- a/changelog/8986.bugfix.rst
+++ b/changelog/8986.bugfix.rst
@@ -1,0 +1,2 @@
+Warn when a plugin raises :class:`SystemExit` from the
+:hook:`pytest_cmdline_main` hook.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -234,7 +234,15 @@ def _main(
             return ExitCode.USAGE_ERROR
 
         try:
-            ret: ExitCode | int = config.hook.pytest_cmdline_main(config=config)
+            try:
+                ret: ExitCode | int = config.hook.pytest_cmdline_main(config=config)
+            except SystemExit:
+                warnings.warn(
+                    PytestConfigWarning(
+                        "A plugin raised SystemExit from the pytest_cmdline_main hook"
+                    )
+                )
+                raise
             try:
                 return ExitCode(ret)
             except ValueError:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -32,6 +32,7 @@ from _pytest.config.findpaths import locate_config
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pathlib import absolutepath
 from _pytest.pytester import Pytester
+from _pytest.warning_types import PytestConfigWarning
 from _pytest.warning_types import PytestDeprecationWarning
 import pytest
 
@@ -852,6 +853,20 @@ class TestConfigCmdlineParsing:
 
 
 class TestConfigAPI:
+    @pytest.mark.parametrize("code", [0, 42])
+    def test_cmdline_main_system_exit(self, code: int) -> None:
+        class Plugin:
+            def pytest_cmdline_main(self, config: Config) -> None:
+                raise SystemExit(code)
+
+        with pytest.warns(
+            PytestConfigWarning,
+            match="plugin raised SystemExit from the pytest_cmdline_main hook",
+        ), pytest.raises(SystemExit) as exc_info:
+            pytest.main([], plugins=[Plugin()])
+
+        assert exc_info.value.code == code
+
     def test_config_trace(self, pytester: Pytester) -> None:
         config = pytester.parseconfig()
         values: list[str] = []

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -859,10 +859,13 @@ class TestConfigAPI:
             def pytest_cmdline_main(self, config: Config) -> None:
                 raise SystemExit(code)
 
-        with pytest.warns(
-            PytestConfigWarning,
-            match="plugin raised SystemExit from the pytest_cmdline_main hook",
-        ), pytest.raises(SystemExit) as exc_info:
+        with (
+            pytest.warns(
+                PytestConfigWarning,
+                match="plugin raised SystemExit from the pytest_cmdline_main hook",
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
             pytest.main([], plugins=[Plugin()])
 
         assert exc_info.value.code == code


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
## Summary

Warn when a plugin raises `SystemExit` from the `pytest_cmdline_main` hook.

Previously, this could terminate pytest during command-line startup without identifying the plugin as the source. This change emits a `PytestConfigWarning` while preserving the original `SystemExit` behavior and exit code.

Closes #8986

## Testing

- `python -m pytest testing/test_config.py -q`
- `python -m pytest testing/test_config.py testing/test_runner.py -q`

Result: `348 passed, 2 xfailed`

## Checklist

- [ ] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [x] Allow maintainers to push and squash when merging my commits.
- [x] Add `Closes #8986` to the PR description.
- [x] If AI agents were used, credit them in `Co-authored-by` commit trailers.
- [x] Add a changelog file in the `changelog` directory.
- [x] Add yourself to `AUTHORS` in alphabetical order.