### PR TITLE
[ai clone] Fix monkeypatch recording failed mutations

### DIFF
--- a/changelog/14927.bugfix.rst
+++ b/changelog/14927.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes MonkeyPatch so failed mutations are not recorded for undo.

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -282,14 +282,15 @@ class MonkeyPatch:
             # Avoid class descriptors like staticmethod/classmethod.
             if inspect.isclass(target):
                 oldval = target.__dict__.get(name, NOTSET)
-            self._setattr.append((target, name, oldval))
             delattr(target, name)
+            self._setattr.append((target, name, oldval))
 
     def setitem(self, dic: Mapping[K, V], name: K, value: V) -> None:
         """Set dictionary entry ``name`` to value."""
-        self._setitem.append((dic, name, dic.get(name, NOTSET)))
+        oldval = dic.get(name, NOTSET)
         # Not all Mapping types support indexing, but MutableMapping doesn't support TypedDict
         dic[name] = value  # type: ignore[index]
+        self._setitem.append((dic, name, oldval))
 
     def delitem(self, dic: Mapping[K, V], name: K, raising: bool = True) -> None:
         """Delete ``name`` from dict.
@@ -301,9 +302,10 @@ class MonkeyPatch:
             if raising:
                 raise KeyError(name)
         else:
-            self._setitem.append((dic, name, dic.get(name, NOTSET)))
+            oldval = dic.get(name, NOTSET)
             # Not all Mapping types support indexing, but MutableMapping doesn't support TypedDict
             del dic[name]  # type: ignore[attr-defined]
+            self._setitem.append((dic, name, oldval))
 
     def setenv(self, name: str, value: str, prepend: str | None = None) -> None:
         """Set environment variable ``name`` to ``value``.

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -135,6 +135,22 @@ def test_delattr() -> None:
     assert A.x == 1
 
 
+def test_delattr_does_not_record_failed_mutation() -> None:
+    class BrokenDelete:
+        value = 1
+
+        def __delattr__(self, name: str) -> None:
+            raise RuntimeError("delete failed")
+
+    monkeypatch = MonkeyPatch()
+    obj = BrokenDelete()
+
+    with pytest.raises(RuntimeError, match="delete failed"):
+        monkeypatch.delattr(obj, "value")
+
+    monkeypatch.undo()
+
+
 def test_setitem() -> None:
     d = {"x": 1}
     monkeypatch = MonkeyPatch()
@@ -160,6 +176,23 @@ def test_setitem_deleted_meanwhile() -> None:
     del d["x"]
     monkeypatch.undo()
     assert not d
+
+
+def test_setitem_does_not_record_failed_mutation() -> None:
+    class BrokenDict(dict[str, object]):
+        def __setitem__(self, key: str, value: object) -> None:
+            raise RuntimeError("set failed")
+
+        def __delitem__(self, key: str) -> None:
+            raise RuntimeError("delete failed")
+
+    monkeypatch = MonkeyPatch()
+    d = BrokenDict()
+
+    with pytest.raises(RuntimeError, match="set failed"):
+        monkeypatch.setitem(d, "x", 1)
+
+    monkeypatch.undo()
 
 
 @pytest.mark.parametrize("before", [True, False])
@@ -194,6 +227,23 @@ def test_delitem() -> None:
     assert d["x"] == 1500
     monkeypatch.undo()
     assert d == {"hello": "world", "x": 1}
+
+
+def test_delitem_does_not_record_failed_mutation() -> None:
+    class BrokenDict(dict[str, object]):
+        def __setitem__(self, key: str, value: object) -> None:
+            raise RuntimeError("set failed")
+
+        def __delitem__(self, key: str) -> None:
+            raise RuntimeError("delete failed")
+
+    monkeypatch = MonkeyPatch()
+    d = BrokenDict({"x": 1})
+
+    with pytest.raises(RuntimeError, match="delete failed"):
+        monkeypatch.delitem(d, "x")
+
+    monkeypatch.undo()
 
 
 def test_setenv() -> None:


### PR DESCRIPTION
## Summary

Fix `MonkeyPatch` methods recording undo state before the underlying mutation succeeds.

Previously, `delattr`, `setitem`, and `delitem` recorded their undo information before performing the mutation. If the mutation raised an exception, the failed operation was still recorded and later replayed by `undo()`, which could raise a second unexpected exception.

This change records the undo state only after the mutation succeeds.

## Changes

- Record `delattr` undo state after successful deletion.
- Record `setitem` undo state after successful assignment.
- Record `delitem` undo state after successful deletion.
- Add regression tests covering failed mutations for all three operations.

## Testing

```text
python -m pytest testing/test_monkeypatch.py -q
37 passed, 2 skipped

also verified git diff --check with no errors

### 4. Before clicking **Create pull request**

Look at the **Files changed** tab.

You should see only:

```text
src/_pytest/monkeypatch.py
testing/test_monkeypatch.py