### PR TITLE
config: deprecate non-string values for string-typed ini options in ini mode

### DIFF
--- a/changelog/14808.deprecation.rst
+++ b/changelog/14808.deprecation.rst
@@ -1,0 +1,4 @@
+In ini mode (``.ini`` files and ``[tool.pytest.ini_options]`` in ``pyproject.toml``),
+reading a non-string value for a :confval:`string`-typed ini option (including
+options registered without an explicit type, which default to ``"string"``) is now
+deprecated and will raise a ``TypeError`` in pytest 10.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -79,6 +79,7 @@ from _pytest.pathlib import resolve_package_path
 from _pytest.pathlib import safe_exists
 from _pytest.stash import Stash
 from _pytest.warning_types import PytestConfigWarning
+from _pytest.warning_types import PytestDeprecationWarning
 from _pytest.warning_types import warn_explicit_for
 
 
@@ -1949,6 +1950,15 @@ class Config:
         elif type == "bool":
             return _strtobool(str(value).strip())
         elif type == "string":
+            if not isinstance(value, str):
+                warnings.warn(
+                    PytestDeprecationWarning(
+                        f"{self.inipath}: config option '{name}' expects a string value, "
+                        f"got {builtins.type(value).__name__}: {value!r}. This will raise "
+                        "a TypeError in pytest 10."
+                    ),
+                    stacklevel=2,
+                )
             return value
         elif type == "int":
             if not isinstance(value, str):

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -949,6 +949,29 @@ class TestConfigAPI:
         with pytest.raises(ValueError):
             config.getini("other")
 
+    def test_addini_string_type_toml_list_deprecated(self, pytester: Pytester) -> None:
+        # https://github.com/pytest-dev/pytest/issues/14808
+        pytester.makeconftest(
+            """
+            def pytest_addoption(parser):
+                parser.addini("mystr", "a string option", type="string")
+                parser.addini("myuntyped", "an untyped option")
+        """
+        )
+        pytester.makepyprojecttoml(
+            """
+            [tool.pytest.ini_options]
+            mystr = ["a", "b"]
+            myuntyped = ["c", "d"]
+        """
+        )
+        config = pytester.parseconfig()
+        with pytest.warns(pytest.PytestDeprecationWarning, match="expects a string value"):
+            assert config.getini("mystr") == ["a", "b"]
+        # Options registered without an explicit type default to "string".
+        with pytest.warns(pytest.PytestDeprecationWarning, match="expects a string value"):
+            assert config.getini("myuntyped") == ["c", "d"]
+
     @pytest.mark.parametrize("config_type", ["ini", "pyproject"])
     def test_addini_paths(self, pytester: Pytester, config_type: str) -> None:
         pytester.makeconftest(

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -966,10 +966,14 @@ class TestConfigAPI:
         """
         )
         config = pytester.parseconfig()
-        with pytest.warns(pytest.PytestDeprecationWarning, match="expects a string value"):
+        with pytest.warns(
+            pytest.PytestDeprecationWarning, match="expects a string value"
+        ):
             assert config.getini("mystr") == ["a", "b"]
         # Options registered without an explicit type default to "string".
-        with pytest.warns(pytest.PytestDeprecationWarning, match="expects a string value"):
+        with pytest.warns(
+            pytest.PytestDeprecationWarning, match="expects a string value"
+        ):
             assert config.getini("myuntyped") == ["c", "d"]
 
     @pytest.mark.parametrize("config_type", ["ini", "pyproject"])


### PR DESCRIPTION
## Description

`_getini_ini` returned any value as-is for `type="string"` ini options (the default when `addini()` is called without `type=`), while `_getini_toml` strictly validates. A TOML array in `[tool.pytest.ini_options]` therefore silently became a `list` for a string-typed option:

```toml
[tool.pytest.ini_options]
mystr = ["a", "b"]     # getini("mystr") == ['a', 'b'], silent
```

while the same array under `[tool.pytest]` raises `TypeError`. The strict side is new (native TOML work in 9.1); the lax `return value` dates to 2010.

## Approach

As suggested by @RonnyPfannschmidt in #14808, this takes the deprecation path rather than an immediate hard error, because every untyped plugin option is string-typed and some may (deliberately or not) accept list shapes today:

- ini mode + non-`str` value on a `"string"`-typed option → `PytestDeprecationWarning` now, `TypeError` in pytest 10.
- `make_scalar` in `findpaths.py` is intentionally untouched: it keeps lists as lists so `args`/`linelist`/`paths` get their lists through; the decision belongs with the consumer that knows the declared type.

## Changelog

`changelog/14808.deprecation.rst` added.

## Testing

New test `test_addini_string_type_toml_list_deprecated` covers both an explicitly `type="string"` option and an untyped one:

```
testing/test_config.py::TestConfigAPI::test_addini_string_type_toml_list_deprecated PASSED
```

Full `testing/test_config.py`: 281 passed, 5 failed — the 5 failures reproduce identically on a clean checkout of `main` on this machine (Windows/Python 3.14 environment issues in `TestConfigFromdictargs`/`TestOverrideIniArgs`, unrelated to this change; verified via `git stash`).

Fixes #14808