### PR TITLE
chore: drop duplicate PLR1714 ruff rule

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -513,6 +513,7 @@ Vivaan Verma
 Vlad Dragos
 Vlad Radziuk
 Vladyslav Rachek
+Vladimir Roshchin
 Volodymyr Kochetkov
 Volodymyr Piskun
 Warren Markham

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,24 +114,23 @@ src = [
 ]
 format.docstring-code-format = true
 lint.extend-select = [
-    "B",       # bugbear
-    "D",       # pydocstyle
-    "E",       # pycodestyle
-    "F",       # pyflakes
-    "FA100",   # add future annotations
-    "I",       # isort
-    "PGH004",  # pygrep-hooks - Use specific rule codes when using noqa
-    "PIE",     # flake8-pie
-    "PLC",     # pylint convention
-    "PLE",     # pylint error
-    "PLR",     # pylint refactor
-    "PLR1714", # Consider merging multiple comparisons
-    "PLW",     # pylint warning
-    "PYI",     # flake8-pyi
-    "RUF",     # ruff
-    "T100",    # flake8-debugger
-    "UP",      # pyupgrade
-    "W",       # pycodestyle
+    "B",      # bugbear
+    "D",      # pydocstyle
+    "E",      # pycodestyle
+    "F",      # pyflakes
+    "FA100",  # add future annotations
+    "I",      # isort
+    "PGH004", # pygrep-hooks - Use specific rule codes when using noqa
+    "PIE",    # flake8-pie
+    "PLC",    # pylint convention
+    "PLE",    # pylint error
+    "PLR",    # pylint refactor
+    "PLW",    # pylint warning
+    "PYI",    # flake8-pyi
+    "RUF",    # ruff
+    "T100",   # flake8-debugger
+    "UP",     # pyupgrade
+    "W",      # pycodestyle
 ]
 lint.ignore = [
     # flake8-async ignore


### PR DESCRIPTION
## Problem
after https://github.com/pytest-dev/pytest/pull/12622/changes#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R107 "PLR1714" ruff rule doesn't need. "PLR1714" include in "PLR" ruff rules.

## Fix

delete twice "PLR1714" 

## Tests
<img width="724" height="317" alt="Снимок экрана 2026-08-25 в 00 51 53" src="https://github.com/user-attachments/assets/4f0eb2b9-02ad-4472-b780-4ebc06b11dee" />


Also: after delete PLR1714 pyproject-fmt was formatting lint.extend-select block.  