### PR TITLE
Fix __tracebackhide__ for ExceptionGroup frames sharing a source location

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,6 +28,7 @@ algojogacor
 Alice Purcell
 Allan Feldman
 Aly Sivji
+Amine-LG
 Amir Elkess
 Ammar Askar
 Anatoly Bubenkoff

--- a/changelog/14940.bugfix.rst
+++ b/changelog/14940.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``__tracebackhide__`` not hiding frames that share a source location in ``ExceptionGroup`` tracebacks.

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -1658,18 +1658,19 @@ def _filter_tracebackexception(
     objects. It recurses into exception group sub-exceptions and into
     ``__cause__`` / ``__context__`` chains.
 
-    Frames are matched by ``(filename, lineno)``: ``TracebackEntry._rawentry.tb_lineno``
-    is 1-based absolute, matching ``FrameSummary.lineno``.
+    Frames are filtered based on the identity of their corresponding raw
+    traceback entries.
     """
     if e.__traceback__ is not None:
         excinfo = ExceptionInfo.from_exception(e)
         filtered = filter_excinfo_traceback(tbfilter, excinfo)
-        kept = {
-            (str(entry.frame.code.path), entry._rawentry.tb_lineno)
-            for entry in filtered
-        }
+        kept = {id(entry._rawentry) for entry in filtered}
         tb_exc.stack = StackSummary.from_list(
-            [fs for fs in tb_exc.stack if (fs.filename, fs.lineno) in kept]
+            [
+                fs
+                for entry, fs in zip(excinfo.traceback, tb_exc.stack, strict=False)
+                if id(entry._rawentry) in kept
+            ]
         )
     if isinstance(e, BaseExceptionGroup):
         sub_tb_excs = getattr(tb_exc, "exceptions", None) or []

--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -2220,6 +2220,59 @@ def test_tracebackhide_in_exceptiongroup_is_respected(pytester: Pytester) -> Non
     result.stdout.no_fnmatch_line("*in g1*")
 
 
+def test_tracebackhide_in_exceptiongroup_distinguishes_same_line_frames(
+    pytester: Pytester,
+) -> None:
+    p = pytester.makepyfile(
+        """
+        import sys
+        if sys.version_info < (3, 11):
+            from exceptiongroup import ExceptionGroup
+
+        def fail(number):
+            __tracebackhide__ = number == 1
+            if number == 0:
+                raise ValueError("boom")
+            fail(number - 1)
+
+        def test():
+            try:
+                fail(2)
+            except ValueError as error:
+                raise ExceptionGroup("failure", [error]) from None
+        """
+    )
+    result = pytester.runpytest(str(p), "--tb=short")
+    assert result.ret == 1
+    assert result.stdout.str().count("fail(number - 1)") == 1
+
+
+def test_tracebackhide_in_exceptiongroup_with_tracebacklimit(
+    pytester: Pytester,
+) -> None:
+    p = pytester.makepyfile(
+        """
+        import sys
+        if sys.version_info < (3, 11):
+            from exceptiongroup import ExceptionGroup
+
+        def fail():
+            __tracebackhide__ = True
+            raise ValueError("boom")
+
+        def test(monkeypatch):
+            monkeypatch.setattr(sys, "tracebacklimit", 1, raising=False)
+            try:
+                fail()
+            except ValueError as error:
+                raise ExceptionGroup("failure", [error]) from None
+        """
+    )
+    result = pytester.runpytest(str(p), "--tb=short")
+    assert result.ret == 1
+    result.stdout.fnmatch_lines(["*ValueError: boom*"])
+
+
 def add_note(err: BaseException, msg: str) -> None:
     """Adds a note to an exception inplace."""
     if sys.version_info < (3, 11):


### PR DESCRIPTION
Fixes #14940.

`_filter_tracebackexception()` matched filtered traceback entries to Python's formatted frames using `(filename, line number)`. Separate traceback entries can share those values while having different `__tracebackhide__` values, causing a hidden frame to remain visible.

This change identifies each occurrence by the identity of its underlying raw traceback entry instead. Pytest's `TracebackEntry` and Python's `FrameSummary` sequences preserve traceback order, so they are walked together and only occurrences that survived filtering are kept.

The pairing is non-strict because `sys.tracebacklimit` can shorten Python's formatted traceback. A separate test protects that behavior.

This is a follow-up to the `ExceptionGroup` traceback filtering added in #14649.

### Tests

- Added a regression test for visible and hidden recursive calls from the same line.
- Added a regression test for a shortened traceback when `sys.tracebacklimit` is set.
- `python -m pytest -q testing/code`
- `pre-commit run --files AUTHORS changelog/14940.bugfix.rst src/_pytest/_code/code.py testing/code/test_excinfo.py`

### AI assistance

I used AI tools during the investigation and implementation. I manually reproduced the issue and reviewed and tested the final changes.
