### PR TITLE
Fix monkeypatch undo of inherited attributes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,6 +55,7 @@ Antony Lee
 Arel Cordero
 Arias Emmanuel
 Ariel Pillemer
+Arpan Sahu
 Armin Rigo
 Aron Coyle
 Aron Curzon

--- a/changelog/10644.bugfix.rst
+++ b/changelog/10644.bugfix.rst
@@ -1,0 +1,1 @@
+Fix :class:`pytest.MonkeyPatch` restoring inherited attributes into an instance's ``__dict__`` after undoing ``setattr`` on an object.

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -244,6 +244,14 @@ class MonkeyPatch:
         # avoid class descriptors like staticmethod/classmethod
         if inspect.isclass(target):
             oldval = target.__dict__.get(name, NOTSET)
+        else:
+            try:
+                target_vars = vars(target)
+            except TypeError:
+                pass
+            else:
+                if name not in target_vars:
+                    oldval = NOTSET
         setattr(target, name, value)
         self._setattr.append((target, name, oldval))
 

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+import inspect
 import os
 from pathlib import Path
 import re
@@ -49,6 +50,28 @@ def test_setattr() -> None:
 
     with pytest.raises(TypeError):
         monkeypatch.setattr(A, "y")  # type: ignore[call-overload]
+
+
+def test_setattr_inherited_attribute_undo_restores_instance_dict() -> None:
+    class Descriptor:
+        def __get__(self, obj, objtype=None):
+            return 1
+
+    class Parent:
+        x = 1
+        descriptor = Descriptor()
+
+    for name in ("x", "descriptor"):
+        target = Parent()
+        monkeypatch = MonkeyPatch()
+        assert name not in vars(target)
+        assert isinstance(inspect.getattr_static(target, "descriptor"), Descriptor)
+
+        monkeypatch.setattr(target, name, 2)
+        monkeypatch.undo()
+
+        assert name not in vars(target)
+        assert isinstance(inspect.getattr_static(target, "descriptor"), Descriptor)
 
 
 class TestSetattrWithImportPath:


### PR DESCRIPTION
﻿### Problem

When `MonkeyPatch.setattr()` patches an inherited attribute on an instance, undo restores the inherited value into the instance `__dict__`. This leaves the object in a different state after cleanup; for descriptors, it also shadows future descriptor lookup. Closes #10644.

### Reproducer

```py
from _pytest.monkeypatch import MonkeyPatch

class Parent:
    x = 1

target = Parent()
mp = MonkeyPatch()
mp.setattr(target, "x", 2)
mp.undo()
print(vars(target))
# current: {'x': 1}
# expected: {}
```

### Fix

For non-class targets, record `NOTSET` when the patched name is not present in the instance dictionary. `undo()` then deletes the temporary instance attribute and exposes the inherited attribute again, matching the original object state.

### Testing

- Added `testing/test_monkeypatch.py::test_setattr_inherited_attribute_undo_restores_instance_dict`.
- Before fix: the new test failed with `AssertionError: assert 'x' not in {'x': 1}`.
- After fix: `1 passed`.
- `python -m pytest testing/test_monkeypatch.py -q` → `36 passed, 1 skipped`.
- `python -m ruff check src/_pytest/monkeypatch.py testing/test_monkeypatch.py` → `All checks passed!`.
- `python -m ruff format --check src/_pytest/monkeypatch.py testing/test_monkeypatch.py` → `2 files already formatted`.

Full suite note: `python -m pytest testing/ -q --tb=short --maxfail=1` reaches a pre-existing Windows failure in `testing/acceptance_test.py::TestGeneralUsage::test_file_not_found_unconfigure_issue143` (`ExitCode.INTERNAL_ERROR` vs `ExitCode.USAGE_ERROR`) after `1769 passed`.

Checklist:

- [x] Include new tests or update existing tests when applicable.
- [x] Allow maintainers to push and squash when merging my commits.
- [x] Add text like `closes #XYZW` to the PR description and/or commits.
- [x] If AI agents were used, they are credited in `Co-authored-by` commit trailers.
- [x] Create a new changelog file in the `changelog` directory.
- [x] Add yourself to `AUTHORS` in alphabetical order.
