### PR TITLE
[rejected ai clone] Fix #14902: disambiguate duplicate report headings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -483,6 +483,7 @@ Terje Runde
 Thomas Grainger
 Thomas Hisch
 Tianyu Dongfang
+Tim Anderson
 Tim Hoffmann
 Tim Strazny
 TJ Bruno

--- a/changelog/14902.bugfix.rst
+++ b/changelog/14902.bugfix.rst
@@ -1,0 +1,2 @@
+Disambiguated terminal report headings for tests with the same name by including
+their node IDs when needed.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1233,8 +1233,13 @@ class TerminalReporter:
                         self._outrep_summary(rep)
                         self.write_line(line)
                 else:
+                    headline_counts = Counter(
+                        self._getfailureheadline(rep) for rep in reports
+                    )
                     for rep in reports:
                         msg = self._getfailureheadline(rep)
+                        if headline_counts[msg] > 1:
+                            msg = self.config.cwd_relative_nodeid(rep.nodeid) or msg
                         self.write_sep("_", msg, red=True, bold=True)
                         self._outrep_summary(rep)
                         self._handle_teardown_sections(rep.nodeid)
@@ -1245,8 +1250,13 @@ class TerminalReporter:
             if not reports:
                 return
             self.write_sep("=", "ERRORS")
-            for rep in self.stats["error"]:
+            headline_counts = Counter(
+                (rep.when, self._getfailureheadline(rep)) for rep in reports
+            )
+            for rep in reports:
                 msg = self._getfailureheadline(rep)
+                if headline_counts[rep.when, msg] > 1:
+                    msg = self.config.cwd_relative_nodeid(rep.nodeid) or msg
                 if rep.when == "collect":
                     msg = "ERROR collecting " + msg
                 else:

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -653,6 +653,61 @@ class TestCollectonly:
 
 
 class TestFixtureReporting:
+    def test_duplicate_setup_error_headlines_are_disambiguated(
+        self, pytester: Pytester
+    ) -> None:
+        pytester.makeconftest(
+            """
+            import pytest
+
+            @pytest.fixture
+            def fixture():
+                raise RuntimeError("fixture failed")
+            """
+        )
+        pytester.makepyfile(
+            test_1="""
+                def test(fixture):
+                    pass
+            """,
+            test_2="""
+                def test(fixture):
+                    pass
+            """,
+        )
+
+        result = pytester.runpytest("-q")
+
+        result.stdout.fnmatch_lines(
+            [
+                "*ERROR at setup of test_1.py::test*",
+                "*ERROR at setup of test_2.py::test*",
+            ]
+        )
+
+    def test_duplicate_failure_headlines_are_disambiguated(
+        self, pytester: Pytester
+    ) -> None:
+        pytester.makepyfile(
+            test_1="""
+                def test():
+                    assert False
+            """,
+            test_2="""
+                def test():
+                    assert False
+            """,
+        )
+
+        result = pytester.runpytest("-q")
+
+        result.stdout.fnmatch_lines(
+            [
+                "*_ test_1.py::test _*",
+                "*_ test_2.py::test _*",
+            ]
+        )
+
     def test_setup_fixture_error(self, pytester: Pytester) -> None:
         pytester.makepyfile(
             """


### PR DESCRIPTION
Closes #14902.

When multiple tests share the same function name, their terminal error or failure sections currently receive identical headings. This makes it difficult to tell which traceback belongs to which test.

This change counts the headings in each summary and uses the test's cwd-relative node ID only when a heading is duplicated. Unique headings retain the existing concise output. Error phases are counted separately so setup and teardown reports remain naturally distinct.

Regression coverage verifies duplicate setup-error headings and duplicate failure headings across two test files.

Validation:

* `python -m pytest -q testing/test_terminal.py` — 222 passed, 9 skipped
* `pre-commit run --files AUTHORS changelog/14902.bugfix.rst src/_pytest/terminal.py testing/test_terminal.py --show-diff-on-failure` — passed

AI assistance: Codex assisted with reproducing the issue, implementing the change, and running validation. I reviewed the resulting behavior and test evidence and take responsibility for the contribution.
