### PR TITLE
Lazily import pygments in TerminalWriter

### DIFF
--- a/changelog/14948.improvement.rst
+++ b/changelog/14948.improvement.rst
@@ -1,0 +1,6 @@
+``pygments`` is no longer imported when the ``_pytest._io.TerminalWriter``
+module is loaded. It is now imported lazily, only when source code is actually
+syntax-highlighted (e.g. when rendering a traceback with color output enabled).
+This avoids importing the relatively heavy ``pygments`` package on runs that
+don't need it (notably runs without markup, such as most CI executions),
+slightly reducing pytest's startup time.

--- a/src/_pytest/_io/terminalwriter.py
+++ b/src/_pytest/_io/terminalwriter.py
@@ -9,15 +9,15 @@ import sys
 from typing import final
 from typing import Literal
 from typing import TextIO
-
-import pygments
-from pygments.formatters.terminal import TerminalFormatter
-from pygments.lexer import Lexer
-from pygments.lexers.diff import DiffLexer
-from pygments.lexers.python import PythonLexer
+from typing import TYPE_CHECKING
 
 from ..compat import assert_never
 from .wcwidth import wcswidth
+
+
+if TYPE_CHECKING:
+    from pygments.formatters.terminal import TerminalFormatter
+    from pygments.lexer import Lexer
 
 
 # This code was initially copied from py 1.8.1, file _io/terminalwriter.py.
@@ -206,6 +206,9 @@ class TerminalWriter:
             self.line(indent + new_line)
 
     def _get_pygments_lexer(self, lexer: Literal["python", "diff"]) -> Lexer:
+        from pygments.lexers.diff import DiffLexer
+        from pygments.lexers.python import PythonLexer
+
         if lexer == "python":
             return PythonLexer()
         elif lexer == "diff":
@@ -214,6 +217,9 @@ class TerminalWriter:
             assert_never(lexer)
 
     def _get_pygments_formatter(self) -> TerminalFormatter:
+        import pygments
+        from pygments.formatters.terminal import TerminalFormatter
+
         from _pytest.config.exceptions import UsageError
 
         theme = os.getenv("PYTEST_THEME")
@@ -238,6 +244,8 @@ class TerminalWriter:
         """Highlight the given source if we have markup support."""
         if not source or not self.hasmarkup or not self.code_highlight:
             return source
+
+        import pygments
 
         pygments_lexer = self._get_pygments_lexer(lexer)
         pygments_formatter = self._get_pygments_formatter()

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -2909,6 +2909,29 @@ class TestCodeHighlight:
         )
 
 
+def test_terminalwriter_import_does_not_import_pygments() -> None:
+    """Importing the module must not eagerly import pygments.
+
+    pygments is imported lazily only when source is actually highlighted,
+    so pytest startup (including runs without markup) should not pay the
+    cost of importing it.
+    """
+    import subprocess
+
+    code = (
+        "import sys; "
+        "import _pytest._io.terminalwriter; "
+        "print('pygments' in sys.modules)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "False"
+
+
 def test_raw_skip_reason_skipped() -> None:
     report = SimpleNamespace()
     report.skipped = True


### PR DESCRIPTION
## Summary

`pygments` is no longer imported at module load of `_pytest/_io/terminalwriter.py`.
It is imported lazily, only when source is actually syntax-highlighted (e.g. when
rendering a traceback with color output). This avoids importing the relatively heavy
`pygments` package on runs that don't need it — notably runs without markup, such as
most CI executions — slightly reducing pytest's startup time.

## Risk analysis / considerations

- The function return annotations (`Lexer`, `TerminalFormatter`) are only needed for
  type checkers; the module already uses `from __future__ import annotations`, so they
  are never evaluated at runtime. They are imported under `TYPE_CHECKING`.
- Highlighting remains gated by `hasmarkup` / `code_highlight`, so behavior is
  unchanged: runs without color output (typical CI) never import `pygments`, while
  color runs import it once on first traceback, as before.
- No public API is changed. All `pygments` imports were moved into the methods that
  use them. Because `pygments` is no longer imported at module level, the previously
  qualified references (`pygments.util.ClassNotFound`, `pygments.util.OptionError`,
  `pygments.highlight`) could only be reached via the `pygments` module object, which
  would mean importing the whole `pygments` package inside each of those methods — the
  very thing this change is trying to avoid. So the names are imported directly (e.g.
  `from pygments.util import ClassNotFound`, `from pygments import highlight`) and used
  unqualified. This is a naming-only change — the caught exceptions and the highlighted
  output are identical.
- A regression test asserts `pygments` is not imported when the module is loaded.

## Notes on Python versions

- pytest's minimum supported Python is 3.10, so we cannot use the 3.15 `lazy` import
  keyword (PEP 810, *Final*, shipped in 3.15): it is a 3.15-only soft keyword and would
  be a `SyntaxError` on older interpreters.
- PEP 810 also offers a `__lazy_modules__` module-level opt-in that is a no-op before
  3.15, but moving the imports into the functions that use them is simpler, works
  uniformly across all supported versions, and matches the approach already used in this
  codebase (e.g. `unittest` in `debugging`).
- This change is also robust under the global `PYTHON_LAZY_IMPORTS=all` mode (already
  exercised by `testing/test_assertrewrite.py`): a function-local import resolves at
  first use regardless of the global lazy-import setting.

## Checklist

- [x] Include new tests or update existing tests when applicable
      (added `test_terminalwriter_import_does_not_import_pygments`)
- [x] Create a new changelog file (`changelog/14948.improvement.rst`)
- [ ] Add yourself to `AUTHORS` in alphabetical order — skipped (minor/internal change)
- [ ] Documentation for new features — N/A (behavior-preserving refactor, no new feature)