### PR TITLE
fixtures: fix quadratic collection slowdown from visibility-ordered override chains

### DIFF
--- a/changelog/14942.bugfix.rst
+++ b/changelog/14942.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a large collection slowdown, introduced in pytest 9.1.0, for test suites which define the same fixture name on very many nodes -- for example a fixture inherited from a base class by thousands of test classes.
+
+Ordering the fixture override chain by visibility scanned all previously registered fixturedefs of that name on every registration, making collection quadratic in the number of definitions.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -161,6 +161,16 @@ def is_visibility_more_specific(
     )
 
 
+def _node_depth(node: nodes.Node) -> int:
+    """Return the distance of ``node`` from the root of the collection tree."""
+    depth = 0
+    parent = node.parent
+    while parent is not None:
+        depth += 1
+        parent = parent.parent
+    return depth
+
+
 def get_scope_node(node: nodes.Node, scope: Scope) -> nodes.Node | None:
     """Get the closest parent node (including self) which matches the given
     scope.
@@ -1156,6 +1166,14 @@ class FixtureDef(Generic[FixtureValue]):
         #
         # Deprecated: replaced by ``node``.
         self.baseid: Final = node.nodeid if node is not NOTSET else (baseid or "")
+        # Precomputed key for visibility matching, see
+        # `FixtureManager._matchfactories`. `id()` of the node for node-based
+        # fixtures (nodes compare by identity, and `self.node` keeps the node --
+        # and hence its id -- alive), the baseid string for legacy ones. The two
+        # kinds can never compare equal, so a single set can hold both.
+        self._match_key: Final[int | str] = (
+            id(node) if node is not NOTSET else self.baseid
+        )
         # Whether the fixture was found from a node or a conftest in the
         # collection tree. Will be false for fixtures defined in non-conftest
         # plugins.
@@ -1792,6 +1810,11 @@ class FixtureManager:
         # TODO: The order of the FixtureDefs list of each arg is significant,
         #       explain.
         self._arg2fixturedefs: Final[dict[str, list[FixtureDef[Any]]]] = {}
+        # Maps a fixture name to the maximum collection-tree depth of the
+        # fixturedefs registered for it so far, or None if any of them has no
+        # node (legacy string baseid) and depths are therefore not conclusive.
+        # Used to skip the visibility scan in _register_fixture().
+        self._arg2maxdepth: Final[dict[str, int | None]] = {}
         # A mapping from a node to a list of autouse fixture names it defines.
         # The Session entry holds global usefixtures from config.
         self._node_autousenames: Final[dict[nodes.Node, list[str]]] = {
@@ -2107,12 +2130,29 @@ class FixtureManager:
         # cannot be visible together.
         # The idea is that a fixture that is defined closer to the item should
         # take precedence.
-        for i, existing in enumerate(faclist):
-            if is_visibility_more_specific(existing, fixture_def):
-                faclist.insert(i, fixture_def)
-                break
+        #
+        # Scanning `faclist` is O(len(faclist)) per registration, which becomes
+        # quadratic for a fixture name that is registered on very many nodes
+        # (e.g. a fixture inherited from a base class by thousands of test
+        # classes). An existing fixturedef can only be more specific than the
+        # new one if it is defined strictly deeper in the collection tree, so
+        # remember the deepest registration for this name and skip the scan
+        # when no existing fixturedef can possibly be deeper (#14942).
+        depth = _node_depth(fixture_def.node) if fixture_def.node is not None else None
+        max_depth = self._arg2maxdepth.get(name, 0)
+        if depth is None or max_depth is None or max_depth > depth:
+            for i, existing in enumerate(faclist):
+                if is_visibility_more_specific(existing, fixture_def):
+                    faclist.insert(i, fixture_def)
+                    break
+            else:
+                faclist.append(fixture_def)
         else:
+            # No existing fixturedef can be more specific, skip the scan.
             faclist.append(fixture_def)
+        self._arg2maxdepth[name] = (
+            None if depth is None or max_depth is None else max(max_depth, depth)
+        )
         if autouse:
             if node is not NOTSET:
                 self._node_autousenames.setdefault(node, []).append(name)
@@ -2361,17 +2401,18 @@ class FixtureManager:
     def _matchfactories(
         self, fixturedefs: Iterable[FixtureDef[Any]], node: nodes.Node
     ) -> Iterator[FixtureDef[Any]]:
-        # Collect parent nodes and their IDs for matching
-        parent_nodes = set(node.iter_parents())
-        parentnodeids = {n.nodeid for n in parent_nodes}
+        # Match against the parent nodes by identity (`id()`) for node-based
+        # fixturedefs, and against their nodeids for legacy string-baseid ones.
+        # This loop runs once per fixturedef per lookup, so it is kept to a
+        # single set lookup per fixturedef -- in particular it avoids hashing
+        # `Node`s, whose `__hash__` is a Python-level function (#14942).
+        match_keys: set[int | str] = set()
+        for parent in node.iter_parents():
+            match_keys.add(id(parent))
+            match_keys.add(parent.nodeid)
 
         for fixturedef in fixturedefs:
-            if fixturedef.node is not None:
-                # Node-based matching: check if fixture's node is a parent
-                if fixturedef.node in parent_nodes:
-                    yield fixturedef
-            elif fixturedef.baseid in parentnodeids:
-                # Fallback to string-based matching for legacy/plugins
+            if fixturedef._match_key in match_keys:
                 yield fixturedef
 
 


### PR DESCRIPTION
Fixes #14942.

**AI-assisted:** the analysis, patch and benchmarks were produced by Claude Opus 5 via Claude Code, driven and reviewed by me. Attribution is in the commit trailers. Detailed profiling writeup in https://github.com/pytest-dev/pytest/issues/14942#issuecomment-5454638951.

## The regressions

Two, both introduced in 9.1.0.

**1. `_register_fixture` scans the whole list on every registration.**

Ordering the override chain by visibility (7186cd465, #14513) inserts by scanning:

```python
for i, existing in enumerate(faclist):
    if is_visibility_more_specific(existing, fixture_def):
        faclist.insert(i, fixture_def)
        break
else:
    faclist.append(fixture_def)
```

For a fixture name registered on very many nodes — a fixture inherited from a base class by thousands of test classes, which is the reporter's layout — that is O(n²) `is_visibility_more_specific()` calls, each walking `iter_parents()`. With 4000 such classes: 7,998,000 calls, all returning `False`, 11.5s of a 16.2s profiled run.

An existing fixturedef can only be *more specific* than the new one if its node is strictly **deeper** in the collection tree. So track the deepest registration per fixture name and skip the scan when nothing registered so far can be deeper. Fixturedefs with a legacy string baseid have no node, so a name that has seen one keeps doing the full scan.

Collection is top-down, so the scan effectively only fires for plugins that register fixtures out of tree order — which is what `test_register_fixture_ordered_by_visibility` exercises (`node=item` before `node=session` ⇒ `max_depth > depth` ⇒ scan runs). Ordering behaviour is unchanged.

**2. `Node.__hash__` in `_matchfactories`.**

With (1) fixed, 4000 classes is still 4.62s profiled against 9.0.3's 2.13s. `_matchfactories` is O(defs-with-that-name) per lookup in *both* versions — that quadratic is not new — but node-based matching made the inner loop much more expensive:

```python
parent_nodes = set(node.iter_parents())
...
if fixturedef.node in parent_nodes:
```

`Node.__hash__` is a Python-level function (`hash(self._nodeid)`), so each of the 8M iterations now costs a Python call, where 9.0.3 did one attribute access and one `str` set lookup. 0.363s → 1.080s.

Precompute a `_match_key` on `FixtureDef`: `id(node)` for node-based defs, the baseid string for legacy ones. Nodes compare by identity and the fixturedef holds its node alive, so the id cannot be reused; `int` and `str` never compare equal, so a single set holds both kinds and the loop is one set lookup again.

## Numbers

`--collect-only` over N sibling classes each defining the same fixture name, CPython 3.10, wall clock, no profiler ([reproducer](https://github.com/pytest-dev/pytest/issues/14942#issuecomment-5454638951)):

| N classes | 9.0.3 | main | this PR |
|---|---|---|---|
| 1000 | 0.38s | 0.98s | 0.56s |
| 2000 | 0.67s | 2.22s | 0.94s |
| 4000 | 1.53s | 7.41s | 1.83s |

## Deliberately not in this PR

`_matchfactories` is still O(defs-with-that-name) per lookup, in 9.0.3 and after this PR alike. Removing that means indexing `_arg2fixturedefs[name]` by node and iterating the short parent chain instead of the long fixturedef list — which would also subsume the `_register_fixture` ordering, since the fixturedefs visible to a node form a chain and are therefore totally ordered. That is a behaviour-shaped change rather than a pure optimisation, so it gets its own draft PR; this one stays a regression fix.
