### PR TITLE
Allow int for max_warnings in TOML

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -87,6 +87,7 @@ croc100
 Cal Leeming
 Carl Friedrich Bolz
 Carlos Jenkins
+Cen Fangyu (Dmao233)
 Ceridwen
 Charles Cloud
 Charles Machalow

--- a/changelog/14953.bugfix.rst
+++ b/changelog/14953.bugfix.rst
@@ -1,0 +1,1 @@
+The :confval:`max_warnings` configuration option now accepts integer values in TOML configuration files, while still accepting strings for backward compatibility.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1705,9 +1705,11 @@ passed multiple times. The expected format is ``name=value``. For example::
 
 
 .. confval:: max_warnings
-   :type: ``int``
+   :type: ``int | str``
 
    .. versionadded:: 9.1
+   .. versionchanged:: 9.2
+        Added support for specifying the value as an integer in TOML configuration.
 
    Maximum number of warnings allowed before the test run is considered a failure.
    When all tests pass, but the total number of warnings exceeds this value, pytest exits with
@@ -3671,7 +3673,7 @@ All the command-line flags can also be obtained by running ``pytest --help``::
                             Each line specifies a pattern for
                             warnings.filterwarnings. Processed after
                             -W/--pythonwarnings.
-      max_warnings (string):
+      max_warnings (int | string):
                             Exit with error if all tests pass but the number of
                             warnings exceeds this threshold
       norecursedirs (args): Directory patterns to avoid for recursion

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -144,6 +144,8 @@ def pytest_addoption(parser: Parser) -> None:
     parser.addini(
         "max_warnings",
         help="Exit with error if all tests pass but the number of warnings exceeds this threshold",
+        type=int | str,
+        default=None,
     )
 
     group = parser.getgroup("collect", "collection")

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1092,10 +1092,10 @@ class TerminalReporter:
         value = self.config.option.max_warnings
         if value is not None:
             return int(value)
-        ini_value = self.config.getini("max_warnings")
-        if ini_value:
+        ini_value: int | str | None = self.config.getini("max_warnings")
+        if isinstance(ini_value, str):
             return int(ini_value)
-        return None
+        return ini_value
 
     #
     # Summaries for sessionfinish.

--- a/testing/test_warnings.py
+++ b/testing/test_warnings.py
@@ -1066,6 +1066,23 @@ class TestMaxWarnings:
         assert result.ret == ExitCode.MAX_WARNINGS_ERROR
 
     @pytest.mark.filterwarnings("default::UserWarning")
+    @pytest.mark.parametrize("value", ["1", '"1"'])
+    def test_max_warnings_toml_option(self, pytester: Pytester, value: str) -> None:
+        """max_warnings can be set via TOML configuration.
+
+        Supports both int and str (for backward compat).
+        """
+        pytester.maketoml(
+            f"""
+            [pytest]
+            max_warnings = {value}
+            """
+        )
+        pytester.makepyfile(self.PYFILE)
+        result = pytester.runpytest()
+        assert result.ret == ExitCode.MAX_WARNINGS_ERROR
+
+    @pytest.mark.filterwarnings("default::UserWarning")
     def test_max_warnings_with_test_failure(self, pytester: Pytester) -> None:
         """When tests fail AND warnings exceed max, TESTS_FAILED takes priority."""
         pytester.makepyfile(


### PR DESCRIPTION
Closes #14953

`max_warnings` was registered without a type, so native TOML integers (`max_warnings = 0`) were rejected even though the docs show an unquoted int.

Register it as `int | str` the same way as `truncation_limit_*`. `_get_max_warnings()` treats `None` as unset so an explicit `0` is not the empty default.

## Checklist

- [x] Include new tests or update existing tests when applicable.
- [x] Allow maintainers to push and squash when merging my commits.
- [x] `closes #14953` in the PR description and the commit.
- [x] Changelog file `changelog/14953.bugfix.rst`.
- [x] Added myself to `AUTHORS` in alphabetical order.
- [x] AI assistance is credited in a `Co-authored-by` trailer.