### PR TITLE
[ai rejected] Run unittest module cleanups after module tests

### DIFF
--- a/changelog/14958.bugfix.rst
+++ b/changelog/14958.bugfix.rst
@@ -1,0 +1,1 @@
+Module cleanups registered with :func:`unittest.addModuleCleanup` are now executed after the module's tests finish, matching the standard library behavior.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -606,10 +606,24 @@ class Module(nodes.File, PyCollector):
         def xunit_setup_module_fixture(request) -> Generator[None]:
             module = request.module
             if setup_module is not None:
-                _call_with_optional_argument(setup_module, module)
+                try:
+                    _call_with_optional_argument(setup_module, module)
+                except BaseException:
+                    # unittest.suite._handleModuleFixture also runs module
+                    # cleanups when setUpModule fails (#14958).
+                    import unittest.case
+
+                    unittest.case.doModuleCleanups()
+                    raise
             yield
             if teardown_module is not None:
                 _call_with_optional_argument(teardown_module, module)
+            # Run cleanups registered via unittest.addModuleCleanup after
+            # tearDownModule, matching unittest.suite._handleModuleTearDown
+            # (#14958).
+            import unittest.case
+
+            unittest.case.doModuleCleanups()
 
         fixtures.register_fixture(
             # Use a unique name to speed up lookup.

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -31,6 +31,7 @@ from _pytest.outcomes import exit
 from _pytest.outcomes import fail
 from _pytest.outcomes import skip
 from _pytest.outcomes import xfail
+from _pytest.python import _get_first_non_fixture_func
 from _pytest.python import Class
 from _pytest.python import Function
 from _pytest.python import Module
@@ -72,8 +73,46 @@ def pytest_pycollect_makeitem(
     # Abstract classes can't be instantiated so no point collecting them.
     if inspect.isabstract(obj):
         return None
+    if isinstance(collector, Module):
+        _register_unittest_module_cleanup_fixture(collector)
     # Yes, so let's collect it.
     return UnitTestCase.from_parent(collector, name=name, obj=obj)
+
+
+def _register_unittest_module_cleanup_fixture(collector: Module) -> None:
+    """Register an autouse, module-scoped fixture that runs cleanups
+    registered via ``unittest.addModuleCleanup`` (#14958).
+
+    Modules defining ``setUpModule``/``tearDownModule`` are handled by the
+    xunit module fixture in ``_pytest.python`` (which runs the cleanups after
+    ``tearDownModule``, matching ``unittest.suite._handleModuleTearDown``);
+    this fixture covers all other modules.
+    """
+    if getattr(collector, "_unittest_module_cleanup_registered", False):
+        return
+    module = collector.obj
+    setup_module = _get_first_non_fixture_func(module, ("setUpModule", "setup_module"))
+    teardown_module = _get_first_non_fixture_func(
+        module, ("tearDownModule", "teardown_module")
+    )
+    if setup_module is not None or teardown_module is not None:
+        return
+
+    def unittest_module_cleanup_fixture() -> Generator[None]:
+        yield
+        import unittest.case
+
+        unittest.case.doModuleCleanups()
+
+    fixtures.register_fixture(
+        # Use a unique name to speed up lookup.
+        name=f"_xunit_unittest_module_cleanup_fixture_{module.__name__}",
+        func=unittest_module_cleanup_fixture,
+        node=collector,
+        scope="module",
+        autouse=True,
+    )
+    setattr(collector, "_unittest_module_cleanup_registered", True)
 
 
 class UnitTestCase(Class):

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1573,6 +1573,180 @@ def test_do_cleanups_on_teardown_failure(pytester: Pytester) -> None:
     assert passed == 1
 
 
+def test_module_cleanups_run_after_module_tests(pytester: Pytester) -> None:
+    events_file = pytester.path / "events.txt"
+    testpath = pytester.makepyfile(
+        f"""
+        import unittest
+
+        def cleanup():
+            with open(r"{events_file}", "a") as f:
+                f.write("cleanup\\n")
+
+        unittest.addModuleCleanup(cleanup)
+
+        class MyTestCase(unittest.TestCase):
+            def test_one(self):
+                with open(r"{events_file}", "a") as f:
+                    f.write("test-one\\n")
+
+        def test_not_yet():
+            with open(r"{events_file}", "a") as f:
+                f.write("last-test\\n")
+    """
+    )
+    result = pytester.runpytest(testpath)
+    result.assert_outcomes(passed=2)
+    # Module cleanups run only after all tests of the module (#14958).
+    assert events_file.read_text().splitlines() == [
+        "test-one",
+        "last-test",
+        "cleanup",
+    ]
+
+
+def test_module_cleanups_run_after_teardown_module(pytester: Pytester) -> None:
+    events_file = pytester.path / "events.txt"
+    testpath = pytester.makepyfile(
+        f"""
+        import unittest
+
+        def cleanup():
+            with open(r"{events_file}", "a") as f:
+                f.write("cleanup\\n")
+
+        unittest.addModuleCleanup(cleanup)
+
+        def setUpModule():
+            pass
+
+        def tearDownModule():
+            with open(r"{events_file}", "a") as f:
+                f.write("tearDownModule\\n")
+
+        class MyTestCase(unittest.TestCase):
+            @classmethod
+            def setUpClass(cls):
+                def class_cleanup():
+                    with open(r"{events_file}", "a") as f:
+                        f.write("class-cleanup\\n")
+
+                cls.addClassCleanup(class_cleanup)
+
+            def test_one(self):
+                pass
+    """
+    )
+    result = pytester.runpytest(testpath)
+    result.assert_outcomes(passed=1)
+    # Matches unittest.suite._handleModuleTearDown ordering: class cleanups,
+    # then tearDownModule, then module cleanups.
+    assert events_file.read_text().splitlines() == [
+        "class-cleanup",
+        "tearDownModule",
+        "cleanup",
+    ]
+
+
+def test_module_cleanups_run_when_setup_module_fails(pytester: Pytester) -> None:
+    events_file = pytester.path / "events.txt"
+    testpath = pytester.makepyfile(
+        f"""
+        import unittest
+
+        def cleanup():
+            with open(r"{events_file}", "a") as f:
+                f.write("cleanup\\n")
+
+        unittest.addModuleCleanup(cleanup)
+
+        def setUpModule():
+            raise Exception("setupModule boom")
+
+        class MyTestCase(unittest.TestCase):
+            def test_one(self):
+                pass
+    """
+    )
+    result = pytester.runpytest(testpath)
+    result.assert_outcomes(errors=1)
+    # unittest.suite._handleModuleFixture runs module cleanups when
+    # setUpModule fails (#14958).
+    assert events_file.read_text().splitlines() == ["cleanup"]
+
+
+def test_module_cleanup_failure_reported(pytester: Pytester) -> None:
+    testpath = pytester.makepyfile(
+        """
+        import unittest
+
+        def boom():
+            raise Exception("cleanup boom")
+
+        unittest.addModuleCleanup(boom)
+
+        class MyTestCase(unittest.TestCase):
+            def test_one(self):
+                pass
+    """
+    )
+    result = pytester.runpytest("-s", testpath)
+    result.assert_outcomes(passed=1, errors=1)
+    result.stdout.fnmatch_lines(["*ERROR at teardown*", "*cleanup boom*"])
+
+
+def test_module_cleanups_run_once_for_multiple_test_classes(
+    pytester: Pytester,
+) -> None:
+    events_file = pytester.path / "events.txt"
+    testpath = pytester.makepyfile(
+        f"""
+        import unittest
+
+        def cleanup():
+            with open(r"{events_file}", "a") as f:
+                f.write("cleanup\\n")
+
+        unittest.addModuleCleanup(cleanup)
+
+        class TestOne(unittest.TestCase):
+            def test_a(self):
+                pass
+
+        class TestTwo(unittest.TestCase):
+            def test_b(self):
+                pass
+    """
+    )
+    result = pytester.runpytest(testpath)
+    result.assert_outcomes(passed=2)
+    # Two test classes in the same module -> cleanups run exactly once.
+    assert events_file.read_text().splitlines() == ["cleanup"]
+
+
+def test_module_cleanups_run_when_class_skipped(pytester: Pytester) -> None:
+    events_file = pytester.path / "events.txt"
+    testpath = pytester.makepyfile(
+        f"""
+        import unittest
+
+        def cleanup():
+            with open(r"{events_file}", "a") as f:
+                f.write("cleanup\\n")
+
+        unittest.addModuleCleanup(cleanup)
+
+        @unittest.skip("skip all")
+        class MyTestCase(unittest.TestCase):
+            def test_one(self):
+                pass
+    """
+    )
+    result = pytester.runpytest(testpath)
+    result.assert_outcomes(skipped=1)
+    assert events_file.read_text().splitlines() == ["cleanup"]
+
+
 class TestClassCleanupErrors:
     """
     Make sure to show exceptions raised during class cleanup function (those registered


### PR DESCRIPTION
Fixes #14958

`unittest.addModuleCleanup` cleanups are never executed by pytest, because `_pytest/unittest.py` only calls `doClassCleanups` (added in #8033) and has no equivalent for module-level cleanups. The standard library runs them in `unittest.suite._handleModuleTearDown` — after `tearDownModule`, and also when `setUpModule` fails (`_handleModuleFixture`).

**Changes**

* `src/_pytest/python.py` — the xunit module fixture (which handles `setUpModule`/`tearDownModule`) now calls `unittest.case.doModuleCleanups()` after `tearDownModule`, and also on `setUpModule` failure, matching stdlib ordering.
* `src/_pytest/unittest.py` — modules that don't define `setUpModule`/`tearDownModule` get a module-scoped autouse fixture that runs `doModuleCleanups()` at teardown. It is registered on the `Module` collector (once per module) so the cleanups run after all tests of the module, including module-level test functions.

**Tests** — six new pytester tests in `testing/test_unittest.py` covering:
* cleanup runs after all tests of the module,
* ordering relative to class cleanups / `tearDownModule`,
* `setUpModule` failure,
* cleanup failure is reported as an error,
* exactly one run for multiple test classes,
* skipped test class.

**Verification**

* new tests fail without the change and pass with it,
* full test suite: 4511 passed, 53 skipped, 15 xfailed, 5 xpassed,
* `ruff` clean, `mypy` reports no new errors.

Note: since Python 3.11 `unittest.case._module_cleanups` is a process-wide list, so calling `doModuleCleanups()` at the end of each module matches stdlib behavior.