### PR TITLE
fix(rewrite): skip assertion rewriting in class bodies

### DIFF
--- a/changelog/9582.bugfix.rst
+++ b/changelog/9582.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed assertion rewriting crash in class bodies with custom metaclasses (e.g. ``Enum``) that reject duplicate namespace keys -- by :user:`mturac`.

--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -714,11 +714,21 @@ class AssertionRewriter(ast.NodeVisitor):
         while nodes:
             node = nodes.pop()
             assert isinstance(node, ast.AST)
+            # Skip assertion rewriting inside class bodies: the rewriter
+            # injects temporary variables (@py_assert0, etc.) which are
+            # then cleaned up by assigning None to the same name.  Class
+            # namespaces that reject duplicate keys (e.g. Enum) raise
+            # TypeError on the second assignment.  Methods inside the
+            # class are still rewritten because they are FunctionDef
+            # nodes whose own bodies are visited separately.
+            in_class_body = isinstance(node, ast.ClassDef)
             for name, field in ast.iter_fields(node):
                 if isinstance(field, list):
                     new: list[ast.AST] = []
                     for i, child in enumerate(field):
-                        if isinstance(child, ast.Assert):
+                        if isinstance(child, ast.Assert) and not (
+                            in_class_body and name == "body"
+                        ):
                             # Transform assert.
                             new.extend(self.visit(child))
                         else:

--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -2390,3 +2390,44 @@ def test_assertion_failure_when_terminalreporter_is_disabled(
     )
     reprec = pytester.inline_run("-p", "no:terminalreporter")
     reprec.assertoutcome(passed=1)
+
+
+def test_enum_class_body_assert_not_rewritten(pytester: Pytester) -> None:
+    """Assertion rewriting must not inject temporary variables into class
+    bodies, because class namespaces that reject duplicate keys (e.g. Enum)
+    raise TypeError on the cleanup assignment.  (#9582)"""
+    pytester.makepyfile(
+        """
+        from enum import Enum
+
+        class Color(Enum):
+            RED = 1
+            GREEN = 2
+            BLUE = 3
+            assert RED is not None
+
+        def test_enum_values():
+            assert Color.RED.value == 1
+            assert Color.BLUE.value == 3
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_class_body_assert_methods_still_rewritten(pytester: Pytester) -> None:
+    """Methods inside a class should still get assertion rewriting even
+    though class-body asserts are skipped.  (#9582)"""
+    pytester.makepyfile(
+        """
+        class TestSomething:
+            assert True  # class body -- not rewritten
+
+            def test_detailed_failure(self):
+                x = 1
+                assert x == 2
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines(["*assert 1 == 2*"])


### PR DESCRIPTION
Fixes #9582

assertion rewriting crashes with `TypeError` inside `Enum` class bodies (and any class whose metaclass rejects duplicate keys in namespace).

root cause: the rewriter injects temp variables like `@py_assert0` then sets them to `None` for cleanup. `_EnumDict.__setitem__` raises on that second assignment becuase the name is already defined.

fix: skip rewriting `assert` that sits directly in `ClassDef.body`. methods inside the class still get rewritten normally — they're seperate `FunctionDef` nodes visited on their own.

i hit this bug while working on a project that uses asserts in Enum bodies for validation. took a while to figure out it was the rewriter, not the enum itself.

ran the full `testing/test_assertrewrite.py` suite: 122 passed, 1 skipped. also added two tests — one for the Enum crash case, one to make sure methods still get assertion introspection.