### PR TITLE
fix(monkeypatch): don't leave inherited attrs in instance __dict__ after undo

### DIFF
--- a/changelog/10644.bugfix.rst
+++ b/changelog/10644.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :func:`monkeypatch.setattr` leaving inherited attributes in the target's own ``__dict__`` after undo, which shadowed class-level descriptors -- by :user:`mturac`.

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -241,9 +241,19 @@ class MonkeyPatch:
         if raising and oldval is NOTSET:
             raise AttributeError(f"{target!r} has no attribute {name!r}")
 
-        # avoid class descriptors like staticmethod/classmethod
+        # Store the value from the target's own namespace so that undo()
+        # restores the exact prior state.  For classes this avoids
+        # unwrapping descriptors (staticmethod/classmethod).  For instances
+        # it prevents an inherited attribute from being written into the
+        # instance __dict__ during undo, which would shadow the class-level
+        # attribute (including descriptors) after cleanup.  (#10644)
         if inspect.isclass(target):
             oldval = target.__dict__.get(name, NOTSET)
+        else:
+            try:
+                oldval = vars(target).get(name, NOTSET)
+            except TypeError:
+                pass
         setattr(target, name, value)
         self._setattr.append((target, name, oldval))
 
@@ -279,9 +289,15 @@ class MonkeyPatch:
                 raise AttributeError(name)
         else:
             oldval = getattr(target, name, NOTSET)
-            # Avoid class descriptors like staticmethod/classmethod.
+            # Use the target's own namespace for the same reasons as
+            # setattr — see the comment there.  (#10644)
             if inspect.isclass(target):
                 oldval = target.__dict__.get(name, NOTSET)
+            else:
+                try:
+                    oldval = vars(target).get(name, NOTSET)
+                except TypeError:
+                    pass
             self._setattr.append((target, name, oldval))
             delattr(target, name)
 

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -499,3 +499,58 @@ def test_syspath_prepend_with_namespace_packages(
 
     modules_tmpdir.joinpath("main_app.py").write_text("app = True", encoding="utf-8")
     from main_app import app  # noqa: F401
+
+
+class TestSetAttrInheritedAttribute:
+    """Regression tests for #10644: setattr on inherited attributes should
+    not leave items in vars(target) after undo."""
+
+    def test_inherited_attr_not_left_in_instance_dict(self, mp: MonkeyPatch):
+        class Base:
+            x = "base"
+
+        class Child(Base):
+            pass
+
+        obj = Child()
+        assert "x" not in vars(obj)
+        mp.setattr(obj, "x", "patched")
+        assert obj.x == "patched"
+        assert "x" in vars(obj)
+        mp.undo()
+        assert obj.x == "base"
+        assert "x" not in vars(obj)
+
+    def test_own_attr_restored_after_undo(self, mp: MonkeyPatch):
+        class Base:
+            x = "base"
+
+        class Child(Base):
+            x = "child"
+
+        obj = Child()
+        obj.x = "instance"
+        mp.setattr(obj, "x", "patched")
+        mp.undo()
+        assert obj.x == "instance"
+        assert vars(obj)["x"] == "instance"
+
+    def test_inherited_descriptor_not_shadowed(self, mp: MonkeyPatch):
+        """A class-level descriptor patched on a subclass should not
+        leave a bound result in the subclass __dict__ after undo."""
+
+        class Base:
+            @property
+            def val(self):
+                return "dynamic"
+
+        class Child(Base):
+            pass
+
+        assert "val" not in Child.__dict__
+        mp.setattr(Child, "val", "static")
+        assert Child().val == "static"
+        mp.undo()
+        assert isinstance(Base.__dict__["val"], property)
+        assert "val" not in Child.__dict__
+        assert Child().val == "dynamic"


### PR DESCRIPTION
fixes #10644

`monkeypatch.setattr` on an inherited attribute records the value from `getattr()` — wich is the class-level value. on undo it does `setattr(target, name, old)`, writing that into the instance's own `__dict__`. after that the class attribute (including descriptors) is permanently shadowed.

fix: check `vars(target)` first. if the name isnt in the instance's own namespace, store the sentinel so undo uses `delattr` instead of `setattr`. same logic for `delattr` path.

three regression tests:
- inherited attr not left in instance dict after undo
- own instance attr still restored correctly
- class-level descriptor not shadowed on subclass after undo

ran full `testing/test_monkeypatch.py` + `testing/test_unittest.py`: 109 passed, 10 skipped, 0 failed.