### PR TITLE
pytester: do not fail on undecodable subprocess output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,6 +45,7 @@ Andrzej Ostrowski
 Andy Freeland
 Anita Hammer
 Anna Tasiopoulou
+Ant Newman
 Anthon van der Neut
 Anthony Shaw
 Anthony Sottile

--- a/changelog/7623.bugfix.rst
+++ b/changelog/7623.bugfix.rst
@@ -1,0 +1,1 @@
+:meth:`pytester.run <pytest.Pytester.run>` no longer raises ``UnicodeDecodeError`` when a command writes output which is not valid UTF-8, such as a Python subprocess on a host whose locale encoding is not UTF-8; the undecodable bytes are now escaped instead.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1405,7 +1405,7 @@ class Pytester:
         """Run a command with arguments.
 
         Run a process using :py:class:`subprocess.Popen` saving the stdout and
-        stderr.
+        stderr. The output is decoded as UTF-8, with undecodable bytes escaped.
 
         :param cmdargs:
             The sequence of arguments to pass to :py:class:`subprocess.Popen`,
@@ -1471,7 +1471,12 @@ class Pytester:
             f1.flush()
             f2.flush()
 
-        with p1.open(encoding="utf8") as f1, p2.open(encoding="utf8") as f2:
+        # The command may write bytes which are not valid UTF-8. Escaping them
+        # keeps the byte values, and keeps the result printable by _dump_lines.
+        with (
+            p1.open(encoding="utf8", errors="backslashreplace") as f1,
+            p2.open(encoding="utf8", errors="backslashreplace") as f2,
+        ):
             out = f1.read().splitlines()
             err = f2.read().splitlines()
 

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -704,6 +704,38 @@ def test_popen_default_stdin_stderr_and_stdin_None(pytester: Pytester) -> None:
     assert result.ret == 0
 
 
+def test_run_utf8_output(pytester: Pytester) -> None:
+    """UTF-8 output from a command is decoded as UTF-8"""
+    p1 = pytester.makepyfile(
+        r"""
+        import sys
+
+        sys.stdout.buffer.write(b"h\xc3\xb6llo\n")
+        sys.stderr.buffer.write(b"w\xc3\xb6rld\n")
+        """
+    )
+    result = pytester.runpython(p1)
+    assert result.ret == 0
+    assert result.stdout.lines == ["höllo"]
+    assert result.stderr.lines == ["wörld"]
+
+
+def test_run_undecodable_output(pytester: Pytester) -> None:
+    """Output which is not valid UTF-8 is escaped instead of raising (#7623)"""
+    p1 = pytester.makepyfile(
+        r"""
+        import sys
+
+        sys.stdout.buffer.write(b"before \xf6 after\n")
+        sys.stderr.buffer.write(b"\xf6\n")
+        """
+    )
+    result = pytester.runpython(p1)
+    assert result.ret == 0
+    assert result.stdout.lines == [r"before \xf6 after"]
+    assert result.stderr.lines == [r"\xf6"]
+
+
 def test_spawn_uses_tmphome(pytester: Pytester) -> None:
     tmphome = str(pytester.path)
     assert os.environ.get("HOME") == tmphome


### PR DESCRIPTION
Fixes #7623.

`Pytester.run()` writes the command's stdout and stderr to temp files and reads them back as strict UTF-8. Nothing constrains what the command writes, so the read can fail and take the whole run with it — output, exit code and all:

```
  File "src/_pytest/pytester.py", line 1475, in run
    out = f1.read().splitlines()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf6 in position 348: invalid start byte
```

There are two ways to get there. A Python child on a host whose locale encoding is not UTF-8 writes its redirected stdout in that encoding — the case in the issue, where cp1252 `ö` is `0xf6`. Separately, any command at all can write arbitrary bytes to its stdout, and that reproduces on every platform.

I have this on a default Windows box (cp1252, UTF-8 mode off, `PYTHONIOENCODING` unset, Python 3.13.6), so I was able to measure the behaviour rather than infer it.

## The change

Decode the captured output with `errors="backslashreplace"`.

I tried `errors="replace"` first and it is a poor fit here: U+FFFD is not encodable in cp1252, so on exactly the affected hosts `_dump_lines` raises `UnicodeEncodeError`, and because its `for` loop sits inside the `try` it then discards every remaining line. With a child writing three lines, one of them undecodable:

```
replace          -> couldn't print to <_io.TextIOWrapper ... encoding='cp1252'> because of encoding
backslashreplace -> first \xf6 line / second line / third line
```

`backslashreplace` also preserves the byte values, so a `fnmatch_lines` mismatch shows `h\xf6llo` and stays diagnosable rather than becoming a row of question marks. It is what CPython uses for `sys.stderr`.

## What this deliberately does not do

It does not make the child's output decode *correctly*: on Windows, `print("höllo")` still comes back as `h\xf6llo`. Fixing that means controlling the child's encoding, and I could not find a way to do so that is worth the cost.

- `PYTHONIOENCODING=utf-8` also forces the stdio error handler from `surrogateescape` to `strict`, and it applies to **stdin**. `Pytester.run(stdin=...)` with locale-encoded bytes goes from working to `UnicodeDecodeError`, and a child printing surrogates (routine from `os.fsdecode`) dies and loses all its output — the opposite of the intent.
- `PYTHONUTF8=1` avoids the error-handler problem but also changes the child's default `open()` encoding, which would mask the class of bug `PYTHONWARNDEFAULTENCODING=1` was enabled to surface.

PEP 686 makes UTF-8 mode the default in 3.15, which resolves the fidelity half without pytest doing anything. So this fixes the crash and leaves the child's environment alone. I am happy to go further if you would rather — #7627 has the shape, and this does not conflict with it.

## Also noticed, also left alone

`run()` opens the temp files for *writing* with `encoding="utf8"`, which is inert: `subprocess` takes only the file descriptor, so nothing is ever written through that wrapper. It makes the code look symmetric when only the read side is real, which I suspect is part of why this one is confusing. Changing it to binary mode requires widening `popen()`'s public type annotations, which does not belong in a bugfix.

Not touched either: `_dump_lines` abandoning the rest of its loop on the first `UnicodeEncodeError`, and `spawn()` bypassing `popen()`.

## Tests

`test_run_undecodable_output` fails on `main` with `UnicodeDecodeError` and needs no platform guard. `test_run_utf8_output` is a characterisation test for the happy path and passes either way.

On this machine `testing/test_assertrewrite.py::TestPyCacheDir::test_sys_pycache_prefix_integration` and `testing/test_doctest.py::TestDoctests::test_fixture_doctest_skip_has_line_number` fail identically with and without this change.
