### PR TITLE
fix(monkeypatch): don't leave inherited attributes in the instance dict

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -85,6 +85,7 @@ Bruno Oliveira
 Cal Jacobson
 croc100
 Cal Leeming
+Caner
 Carl Friedrich Bolz
 Carlos Jenkins
 Ceridwen

--- a/changelog/10644.bugfix.rst
+++ b/changelog/10644.bugfix.rst
@@ -1,0 +1,3 @@
+``monkeypatch.setattr()`` no longer leaves a new entry in the instance ``__dict__`` when it patches an attribute that the instance inherits from its class.
+
+Previously ``undo()`` assigned the inherited value onto the instance, which shadowed the class attribute -- permanently freezing the result for descriptors that resolve dynamically.

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -110,6 +110,20 @@ def derive_importpath(import_path: str, raising: bool) -> tuple[str, object]:
     return attr, target
 
 
+def _is_data_descriptor(cls: type, name: str) -> bool:
+    """Return True if looking up ``name`` on ``cls`` finds a data descriptor.
+
+    Data descriptors take precedence over the instance ``__dict__``, so
+    ``setattr()`` on an instance is routed through the descriptor instead of
+    writing an entry into the instance ``__dict__``.
+    """
+    for klass in cls.__mro__:
+        if name in klass.__dict__:
+            descr_type = type(klass.__dict__[name])
+            return hasattr(descr_type, "__set__") or hasattr(descr_type, "__delete__")
+    return False
+
+
 @final
 class MonkeyPatch:
     """Helper to conveniently monkeypatch attributes/items/environment
@@ -244,6 +258,16 @@ class MonkeyPatch:
         # avoid class descriptors like staticmethod/classmethod
         if inspect.isclass(target):
             oldval = target.__dict__.get(name, NOTSET)
+        elif not _is_data_descriptor(type(target), name):
+            # With no data descriptor in the way, the `setattr()` below writes
+            # into the instance `__dict__`, so `undo()` has to restore that
+            # `__dict__` entry. Assigning an inherited `oldval` back onto the
+            # instance would instead leave behind a new entry shadowing the
+            # class attribute, which permanently freezes descriptors that
+            # resolve dynamically (#10644).
+            target_dict = getattr(target, "__dict__", None)
+            if isinstance(target_dict, Mapping):
+                oldval = target_dict.get(name, NOTSET)
         setattr(target, name, value)
         self._setattr.append((target, name, oldval))
 

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -418,6 +418,143 @@ def test_undo_class_descriptors_delattr() -> None:
     assert original_world == SampleChild.world
 
 
+def test_undo_inherited_attribute_on_instance() -> None:
+    """Undo must not leave an inherited attribute behind in the instance dict.
+
+    See #10644.
+    """
+
+    class Parent:
+        x = 1
+
+    class Child(Parent):
+        pass
+
+    obj = Child()
+    monkeypatch = MonkeyPatch()
+
+    monkeypatch.setattr(obj, "x", 2)
+    assert obj.x == 2
+    assert vars(obj)["x"] == 2
+
+    monkeypatch.undo()
+    assert obj.x == 1
+    assert "x" not in vars(obj)
+
+
+def test_undo_inherited_non_data_descriptor_on_instance() -> None:
+    """Undo must not freeze a descriptor which resolves dynamically.
+
+    See #10644.
+    """
+
+    class Dynamic:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __get__(self, instance: object, owner: type | None = None) -> int:
+            self.calls += 1
+            return self.calls
+
+    class Sample:
+        value = Dynamic()
+
+    obj = Sample()
+    first, second = obj.value, obj.value
+    assert first != second
+
+    monkeypatch = MonkeyPatch()
+    monkeypatch.setattr(obj, "value", -1)
+    assert obj.value == -1
+
+    monkeypatch.undo()
+    assert "value" not in vars(obj)
+    third, fourth = obj.value, obj.value
+    assert third != fourth
+
+
+def test_undo_inherited_method_on_instance() -> None:
+    """Patching a method on an instance must not leave a bound method behind."""
+
+    class Sample:
+        def hello(self) -> str:
+            return "hello"
+
+    obj = Sample()
+    monkeypatch = MonkeyPatch()
+
+    monkeypatch.setattr(obj, "hello", lambda: "patched")
+    assert obj.hello() == "patched"
+
+    monkeypatch.undo()
+    assert obj.hello() == "hello"
+    assert "hello" not in vars(obj)
+
+
+def test_undo_own_attribute_on_instance() -> None:
+    """An attribute owned by the instance is still restored to its old value."""
+
+    class Sample:
+        x = "class"
+
+        def __init__(self) -> None:
+            self.x = "instance"
+
+    obj = Sample()
+    monkeypatch = MonkeyPatch()
+
+    monkeypatch.setattr(obj, "x", "patched")
+    assert obj.x == "patched"
+
+    monkeypatch.undo()
+    assert vars(obj)["x"] == "instance"
+
+
+def test_undo_data_descriptor_on_instance() -> None:
+    """A data descriptor owns the attribute, so the old value is set back through it."""
+
+    class Sample:
+        def __init__(self) -> None:
+            self._x = 1
+
+        @property
+        def x(self) -> int:
+            return self._x
+
+        @x.setter
+        def x(self, value: int) -> None:
+            self._x = value
+
+    obj = Sample()
+    monkeypatch = MonkeyPatch()
+
+    monkeypatch.setattr(obj, "x", 2)
+    assert obj.x == 2
+
+    monkeypatch.undo()
+    assert obj.x == 1
+    assert "x" not in vars(obj)
+
+
+def test_undo_slot_attribute_on_instance() -> None:
+    """Slot descriptors are data descriptors, so undo restores the slot value."""
+
+    class Sample:
+        __slots__ = ("x",)
+
+        def __init__(self) -> None:
+            self.x = 1
+
+    obj = Sample()
+    monkeypatch = MonkeyPatch()
+
+    monkeypatch.setattr(obj, "x", 2)
+    assert obj.x == 2
+
+    monkeypatch.undo()
+    assert obj.x == 1
+
+
 def test_issue1338_name_resolving() -> None:
     pytest.importorskip("requests")
     monkeypatch = MonkeyPatch()


### PR DESCRIPTION
Closes #10644.

## Problem

`MonkeyPatch.setattr()` records the old value with `getattr()`, which follows the MRO. When the patched attribute is *inherited* rather than owned by the instance, `undo()` assigns that inherited value back **onto the instance**, creating a `__dict__` entry that was never there:

```python
class Parent:
    x = 1

class Child(Parent):
    pass

obj = Child()
mp.setattr(obj, "x", 2)
mp.undo()
assert "x" not in vars(obj)   # fails on main: vars(obj) == {"x": 1}
```

For a plain class attribute this only leaves the target in a different state than it was found in. For an inherited **non-data descriptor** it is worse: the value computed during teardown is stored on the instance and shadows the descriptor, so the attribute is frozen for every later lookup.

```python
class Dynamic:
    def __init__(self):
        self.calls = 0

    def __get__(self, instance, owner=None):
        self.calls += 1
        return self.calls

class Sample:
    value = Dynamic()

obj = Sample()
obj.value, obj.value      # 1, 2 -- resolves dynamically
mp.setattr(obj, "value", "patched")
mp.undo()
obj.value, obj.value      # 3, 3 -- frozen from here on, on main
```

Patching a method on an instance hits the same path, leaving a bound method behind in `vars(obj)` after teardown.

## Fix

Look the old value up in the instance `__dict__` — which is what `setattr()` and `undo()` actually operate on — mirroring the handling `setattr()` already has for classes.

The lookup is guarded by a data-descriptor check, and that guard is load-bearing. A data descriptor intercepts the assignment, so the attribute never reaches the instance `__dict__` and there is nothing there to delete on undo. Without the guard, `monkeypatch.setattr()` on a property fails during undo with `AttributeError: property 'x' of 'Sample' object has no deleter`, and `__slots__` attributes break the same way. `test_undo_data_descriptor_on_instance` and `test_undo_slot_attribute_on_instance` cover both.

## Notes

Only `setattr()` is changed. `delattr()` has the same shape but cannot reach this state: deleting an inherited attribute from an instance raises `AttributeError`, so nothing is recorded. Its separate undo-ordering issue is #14909.

Verified locally on Python 3.13 (Windows): the three new tests reproducing the bug fail without the change and pass with it, and the full test suite is unaffected.

## Checklist

- [x] Include new tests or update existing tests when applicable.
- [x] Add text like `closes #XYZW` to the PR description and/or commits.
- [x] Create a new changelog file in the `changelog` directory.
- [x] Add yourself to `AUTHORS` in alphabetical order.
- [x] Allow maintainers to push and squash when merging my commits.

## AI/LLM assistance

Per the [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy): this change was developed with AI assistance (Claude Code), credited in the `Co-authored-by` trailer on the commit. Happy to explain any part of it or adjust the approach.
