### PR TITLE
[ai clone] Fix stale fixture finalizers after setup errors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -311,6 +311,7 @@ Mark Dickinson
 Mark Vong
 Marko Pacak
 Markus Unterwaditzer
+Marthala Jagruthi Reddy
 Martijn Faassen
 Martin Altmayer
 Martin K. Scherer

--- a/changelog/14800.bugfix.rst
+++ b/changelog/14800.bugfix.rst
@@ -1,0 +1,2 @@
+Fixes an internal assertion when a parametrized fixture setup fails in a
+``pytest_fixture_setup`` hook, allowing subsequent parameters to run normally.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1205,9 +1205,9 @@ class FixtureDef(Generic[FixtureValue]):
         self._finalizers.append(finalizer)
 
     def finish(self, request: SubRequest) -> None:
-        if self.cached_result is None:
-            # Already finished. It is assumed that finalizers cannot be added in
-            # this state.
+        if self.cached_result is None and not self._finalizers:
+            # Already finished. If finalizers are present, fixture setup failed
+            # before the result could be cached, so they still need to run.
             return
 
         exceptions: list[BaseException] = []

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -1521,6 +1521,38 @@ def test_error_on_sync_test_async_autouse_fixture(pytester: Pytester) -> None:
     )
 
 
+def test_sync_tests_with_async_autouse_fixture_do_not_poison_later_tests(
+    pytester: Pytester,
+) -> None:
+    pytester.makepyfile(
+        test_sync="""
+            import pytest
+
+            @pytest.fixture(autouse=True)
+            async def async_fixture():
+                yield
+
+            def test_first():
+                pass
+
+            def test_second():
+                pass
+
+            def test_third():
+                pass
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(errors=3)
+    result.stdout.fnmatch_lines(
+        [
+            "*'test_first' requested an async fixture 'async_fixture' with autouse=True, *",
+            "*'test_second' requested an async fixture 'async_fixture' with autouse=True, *",
+            "*'test_third' requested an async fixture 'async_fixture' with autouse=True, *",
+        ]
+    )
+
+
 def test_pdb_can_be_rewritten(pytester: Pytester) -> None:
     pytester.makepyfile(
         **{

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -4536,6 +4536,42 @@ def test_fixture_post_finalizer_hook_exception(pytester: Pytester) -> None:
     )
 
 
+def test_fixture_setup_hook_exception_does_not_leave_stale_finalizers(
+    pytester: Pytester,
+) -> None:
+    """A fixture setup hook failure must not poison later parametrized cases (#14800)."""
+    pytester.makeconftest(
+        """
+        import pytest
+
+        @pytest.hookimpl(tryfirst=True)
+        def pytest_fixture_setup(fixturedef, request):
+            param = getattr(request, "param", None)
+            if isinstance(param, str) and param.startswith("fixture:"):
+                request.param = request.getfixturevalue(param[len("fixture:"):])
+        """
+    )
+    pytester.makepyfile(
+        test_fixtures="""
+        import pytest
+
+        @pytest.fixture
+        def skipping_base():
+            pytest.skip("backend unavailable")
+
+        @pytest.fixture
+        def derived(skipping_base):
+            return "derived"
+
+        @pytest.mark.parametrize("value", ["fixture:derived", "plain-1", "plain-2"])
+        def test_value(value):
+            assert isinstance(value, str)
+        """
+    )
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(passed=2, skipped=1)
+
+
 class TestParamValueKey:
     """Unit tests for the equivalence key used by `reorder_items` (#8914)."""
 


### PR DESCRIPTION
## Summary

When a `pytest_fixture_setup` hook raises while setting up a parametrized fixture, `FixtureDef.finish()` returned early because `cached_result` was `None`. The post-finalizer remained queued, so the next parameter hit the `assert not self._finalizers` assertion and failed internally.

The same stale-finalizer state occurs with pytest's built-in async-fixture guard, where one unsupported async fixture can turn later tests into bare internal errors. Keep the early return only when there are no pending finalizers. This allows pending cleanup to run after setup failures and lets subsequent tests report their own results.

Fixes #14800

## Tests

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --frozen pytest -o minversion=0 testing/python/fixtures.py -q` (241 passed, 3 xfailed)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --frozen pytest -o minversion=0 testing/acceptance_test.py -k 'sync_test_async_fixture or async_autouse_fixture' -q` (4 passed)
- `uvx ruff check src/_pytest/fixtures.py testing/python/fixtures.py testing/acceptance_test.py`
- `uvx ruff format --check src/_pytest/fixtures.py testing/python/fixtures.py testing/acceptance_test.py`

## Checklist

- [x] Include new tests or update existing tests when applicable.
- [x] Add text linking this PR to the issue.
- [x] Create a changelog file in `changelog/`.
- [x] Add yourself to `AUTHORS`.
- [x] Allow maintainers to push and squash when merging my commits.
- [ ] If AI agents were used, they are credited in `Co-authored-by` commit trailers.
