### PR TITLE
testing: fix test failing when PYTHONPYCACHEPREFIX is set

### DIFF
--- a/testing/test_assertrewrite.py
+++ b/testing/test_assertrewrite.py
@@ -1484,7 +1484,7 @@ class TestAssertionRewriteHookDetails:
         assert _read_pyc(source, pyc, print) is None
 
     def test_rewrite_picks_up_edit_within_one_mtime_second(
-        self, pytester: Pytester
+        self, pytester: Pytester, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Regression test for #13292.
 
@@ -1492,6 +1492,9 @@ class TestAssertionRewriteHookDetails:
         edited twice within the same second used to be served from a stale
         pyc. Hashing the source instead sidesteps the resolution problem.
         """
+        monkeypatch.delenv("PYTHONPYCACHEPREFIX", raising=False)
+        monkeypatch.delenv("PYTHONDONTWRITEBYTECODE", raising=False)
+
         source = pytester.path / "test_edited.py"
         pyc_dir = source.parent / "__pycache__"
 


### PR DESCRIPTION
`PYTHONPYCACHEPREFIX` puts the pyc files in another directory, but this test expects them in `__pycache__`.