### PR TITLE
Fix unittest.addModuleCleanup having no effect under pytest

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -449,6 +449,7 @@ Serhii Mozghovyi
 Seth Junot
 Shantanu Jain
 Sharad Nair
+Shamik Basu
 Shaygan Hooshyari
 Shubham Adep
 Simon Blanchard

--- a/changelog/14958.bugfix.rst
+++ b/changelog/14958.bugfix.rst
@@ -1,0 +1,4 @@
+Module cleanups registered with :func:`unittest.addModuleCleanup` (and
+:func:`unittest.enterModuleContext`) are now executed. Cleanups registered
+during a module visit run after ``tearDownModule`` (or when ``setUpModule``
+fails); import-time registrations are drained at session end.

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -604,12 +604,29 @@ class Module(nodes.File, PyCollector):
             return
 
         def xunit_setup_module_fixture(request) -> Generator[None]:
+            # Mark-and-drain unittest module cleanups around this module visit
+            # (#14958). Import-time registrations sit below the mark and are
+            # handled by the session-end backstop in _pytest.unittest.
+            from _pytest.unittest import drain_module_cleanups_to
+            from _pytest.unittest import module_cleanup_mark
+
             module = request.module
+            mark = module_cleanup_mark()
             if setup_module is not None:
-                _call_with_optional_argument(setup_module, module)
-            yield
-            if teardown_module is not None:
-                _call_with_optional_argument(teardown_module, module)
+                try:
+                    _call_with_optional_argument(setup_module, module)
+                # Match unittest / class-fixture: only Exception, not BaseException.
+                except Exception:
+                    drain_module_cleanups_to(mark)
+                    raise
+            try:
+                yield
+            finally:
+                try:
+                    if teardown_module is not None:
+                        _call_with_optional_argument(teardown_module, module)
+                finally:
+                    drain_module_cleanups_to(mark)
 
         fixtures.register_fixture(
             # Use a unique name to speed up lookup.

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -50,6 +50,68 @@ if TYPE_CHECKING:
     import twisted.trial.unittest
 
 
+def module_cleanup_mark() -> int:
+    """Return the current length of unittest's process-global module cleanups.
+
+    Used to attribute cleanups registered during a module visit (see #14958).
+    Relies on ``unittest.case._module_cleanups``; see
+    ``test_unittest_module_cleanups_private_api_contract``.
+    """
+    import unittest.case
+
+    return len(unittest.case._module_cleanups)
+
+
+def drain_module_cleanups_to(mark: int) -> None:
+    """Run module cleanups down to ``mark`` (LIFO), leaving older entries intact.
+
+    Unlike :func:`unittest.case.doModuleCleanups`, this does not drain the entire
+    process-global list — required because pytest may interleave and re-enter
+    modules (#14958). Multiple cleanup failures are raised as an
+    :class:`ExceptionGroup`, matching class-cleanup handling.
+    """
+    import unittest.case
+
+    cleanups = unittest.case._module_cleanups
+    exceptions: list[Exception] = []
+    while len(cleanups) > mark:
+        function, args, kwargs = cleanups.pop()
+        try:
+            function(*args, **kwargs)
+        except Exception as exc:
+            exceptions.append(exc)
+    if not exceptions:
+        return
+    if len(exceptions) == 1:
+        raise exceptions[0]
+    raise ExceptionGroup("Unittest module cleanup errors", exceptions)
+
+
+def drain_remaining_module_cleanups() -> None:
+    """Session-end backstop for cleanups left below every module mark (#14958).
+
+    Import-time ``addModuleCleanup`` registrations are recorded before any
+    module fixture can take a mark, so they are drained here rather than at an
+    arbitrary module boundary.
+    """
+    case = sys.modules.get("unittest.case")
+    if case is None:
+        return
+    cleanups = getattr(case, "_module_cleanups", None)
+    if not cleanups:
+        return
+    # Use the public drain for leftovers; attribution no longer applies.
+    case.doModuleCleanups()
+
+
+@hookimpl(trylast=True)
+def pytest_sessionfinish() -> None:
+    # Runs after the last item's teardown (module mark-and-drain already done).
+    # Session.addfinalizer cannot be used from sessionstart — the session is not
+    # on the SetupState stack yet (#14958).
+    drain_remaining_module_cleanups()
+
+
 _SysExcInfoType = (
     tuple[type[BaseException], BaseException, types.TracebackType]
     | tuple[None, None, None]

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -50,29 +50,34 @@ if TYPE_CHECKING:
     import twisted.trial.unittest
 
 
-def module_cleanup_mark() -> int:
-    """Return the current length of unittest's process-global module cleanups.
+def _unittest_module_cleanups() -> list:
+    """Return unittest's process-global module cleanup list (#14958).
 
-    Used to attribute cleanups registered during a module visit (see #14958).
-    Relies on ``unittest.case._module_cleanups``; see
+    Relies on the private ``unittest.case._module_cleanups`` attribute; see
     ``test_unittest_module_cleanups_private_api_contract``.
     """
     import unittest.case
 
-    return len(unittest.case._module_cleanups)
+    return getattr(unittest.case, "_module_cleanups")
+
+
+def module_cleanup_mark() -> int:
+    """Return the current length of unittest's process-global module cleanups.
+
+    Used to attribute cleanups registered during a module visit (see #14958).
+    """
+    return len(_unittest_module_cleanups())
 
 
 def drain_module_cleanups_to(mark: int) -> None:
     """Run module cleanups down to ``mark`` (LIFO), leaving older entries intact.
 
     Unlike :func:`unittest.case.doModuleCleanups`, this does not drain the entire
-    process-global list — required because pytest may interleave and re-enter
+    process-global list. That matters because pytest may interleave and re-enter
     modules (#14958). Multiple cleanup failures are raised as an
     :class:`ExceptionGroup`, matching class-cleanup handling.
     """
-    import unittest.case
-
-    cleanups = unittest.case._module_cleanups
+    cleanups = _unittest_module_cleanups()
     exceptions: list[Exception] = []
     while len(cleanups) > mark:
         function, args, kwargs = cleanups.pop()

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
     import twisted.trial.unittest
 
 
-def _unittest_module_cleanups() -> list:
+def _unittest_module_cleanups() -> list[Any]:
     """Return unittest's process-global module cleanup list (#14958).
 
     Relies on the private ``unittest.case._module_cleanups`` attribute; see
@@ -58,7 +58,9 @@ def _unittest_module_cleanups() -> list:
     """
     import unittest.case
 
-    return getattr(unittest.case, "_module_cleanups")
+    cleanups = getattr(unittest.case, "_module_cleanups")
+    assert isinstance(cleanups, list)
+    return cleanups
 
 
 def module_cleanup_mark() -> int:
@@ -112,7 +114,7 @@ def drain_remaining_module_cleanups() -> None:
 @hookimpl(trylast=True)
 def pytest_sessionfinish() -> None:
     # Runs after the last item's teardown (module mark-and-drain already done).
-    # Session.addfinalizer cannot be used from sessionstart — the session is not
+    # Session.addfinalizer cannot be used from sessionstart: the session is not
     # on the SetupState stack yet (#14958).
     drain_remaining_module_cleanups()
 

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1573,6 +1573,366 @@ def test_do_cleanups_on_teardown_failure(pytester: Pytester) -> None:
     assert passed == 1
 
 
+def test_unittest_module_cleanups_private_api_contract() -> None:
+    """Pin the private unittest API mark-and-drain relies on (#14958)."""
+    import unittest.case
+
+    assert hasattr(unittest.case, "_module_cleanups")
+    assert isinstance(unittest.case._module_cleanups, list)
+
+    seen: list[str] = []
+
+    def cleanup() -> None:
+        seen.append("ran")
+
+    unittest.addModuleCleanup(cleanup)
+    assert len(unittest.case._module_cleanups) >= 1
+    unittest.case.doModuleCleanups()
+    assert seen == ["ran"]
+    assert unittest.case._module_cleanups == []
+
+
+def test_module_cleanups_import_time_run_at_session_end(pytester: Pytester) -> None:
+    """Import-time addModuleCleanup runs via the session-end backstop (#14958)."""
+    events_file = pytester.path / "events.txt"
+    testpath = pytester.makepyfile(
+        f"""
+        import unittest
+
+        def cleanup():
+            with open(r"{events_file}", "a") as f:
+                f.write("cleanup\\n")
+
+        unittest.addModuleCleanup(cleanup)
+
+        def setUpModule():
+            with open(r"{events_file}", "a") as f:
+                f.write("setUpModule\\n")
+
+        def tearDownModule():
+            with open(r"{events_file}", "a") as f:
+                f.write("tearDownModule\\n")
+
+        class MyTestCase(unittest.TestCase):
+            def test_one(self):
+                with open(r"{events_file}", "a") as f:
+                    f.write("test\\n")
+    """
+    )
+    result = pytester.runpytest(testpath)
+    result.assert_outcomes(passed=1)
+    assert events_file.read_text().splitlines() == [
+        "setUpModule",
+        "test",
+        "tearDownModule",
+        "cleanup",
+    ]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="enterModuleContext was added in Python 3.11"
+)
+def test_enter_module_context_runs_exit(pytester: Pytester) -> None:
+    events_file = pytester.path / "events.txt"
+    testpath = pytester.makepyfile(
+        f"""
+        from contextlib import contextmanager
+        import unittest
+
+        @contextmanager
+        def module_cm():
+            with open(r"{events_file}", "a") as f:
+                f.write("cm-enter\\n")
+            yield
+            with open(r"{events_file}", "a") as f:
+                f.write("cm-exit\\n")
+
+        unittest.enterModuleContext(module_cm())
+
+        def setUpModule():
+            pass
+
+        def tearDownModule():
+            with open(r"{events_file}", "a") as f:
+                f.write("tearDownModule\\n")
+
+        class MyTestCase(unittest.TestCase):
+            def test_one(self):
+                pass
+    """
+    )
+    result = pytester.runpytest(testpath)
+    result.assert_outcomes(passed=1)
+    assert events_file.read_text().splitlines() == [
+        "cm-enter",
+        "tearDownModule",
+        "cm-exit",
+    ]
+
+
+def test_module_cleanups_registered_in_setup_run_after_teardown(
+    pytester: Pytester,
+) -> None:
+    events_file = pytester.path / "events.txt"
+    testpath = pytester.makepyfile(
+        f"""
+        import unittest
+
+        def cleanup():
+            with open(r"{events_file}", "a") as f:
+                f.write("cleanup\\n")
+
+        def setUpModule():
+            unittest.addModuleCleanup(cleanup)
+            with open(r"{events_file}", "a") as f:
+                f.write("setUpModule\\n")
+
+        def tearDownModule():
+            with open(r"{events_file}", "a") as f:
+                f.write("tearDownModule\\n")
+
+        class MyTestCase(unittest.TestCase):
+            @classmethod
+            def setUpClass(cls):
+                def class_cleanup():
+                    with open(r"{events_file}", "a") as f:
+                        f.write("class-cleanup\\n")
+                cls.addClassCleanup(class_cleanup)
+
+            def test_one(self):
+                pass
+    """
+    )
+    result = pytester.runpytest(testpath)
+    result.assert_outcomes(passed=1)
+    assert events_file.read_text().splitlines() == [
+        "setUpModule",
+        "class-cleanup",
+        "tearDownModule",
+        "cleanup",
+    ]
+
+
+def test_module_cleanups_run_when_setup_module_fails(pytester: Pytester) -> None:
+    events_file = pytester.path / "events.txt"
+    testpath = pytester.makepyfile(
+        f"""
+        import unittest
+
+        def cleanup():
+            with open(r"{events_file}", "a") as f:
+                f.write("cleanup\\n")
+
+        def setUpModule():
+            unittest.addModuleCleanup(cleanup)
+            raise Exception("setupModule boom")
+
+        class MyTestCase(unittest.TestCase):
+            def test_one(self):
+                pass
+    """
+    )
+    result = pytester.runpytest(testpath)
+    result.assert_outcomes(errors=1)
+    assert events_file.read_text().splitlines() == ["cleanup"]
+
+
+def test_module_cleanups_run_when_teardown_module_fails(pytester: Pytester) -> None:
+    events_file = pytester.path / "events.txt"
+    testpath = pytester.makepyfile(
+        f"""
+        import unittest
+
+        def cleanup():
+            with open(r"{events_file}", "a") as f:
+                f.write("cleanup\\n")
+
+        def setUpModule():
+            unittest.addModuleCleanup(cleanup)
+
+        def tearDownModule():
+            raise RuntimeError("teardown boom")
+
+        class MyTestCase(unittest.TestCase):
+            def test_one(self):
+                pass
+    """
+    )
+    result = pytester.runpytest(testpath)
+    result.assert_outcomes(passed=1, errors=1)
+    assert events_file.read_text().splitlines() == ["cleanup"]
+
+
+def test_module_cleanup_failure_reported(pytester: Pytester) -> None:
+    testpath = pytester.makepyfile(
+        """
+        import unittest
+
+        def boom():
+            raise Exception("cleanup boom")
+
+        def setUpModule():
+            unittest.addModuleCleanup(boom)
+
+        class MyTestCase(unittest.TestCase):
+            def test_one(self):
+                pass
+    """
+    )
+    result = pytester.runpytest("-s", testpath)
+    result.assert_outcomes(passed=1, errors=1)
+    result.stdout.fnmatch_lines(["*ERROR at teardown*", "*cleanup boom*"])
+
+
+def test_module_cleanup_and_setup_errors_both_visible(pytester: Pytester) -> None:
+    testpath = pytester.makepyfile(
+        """
+        import unittest
+
+        def boom():
+            raise RuntimeError("CLEANUP-ERROR")
+
+        def setUpModule():
+            unittest.addModuleCleanup(boom)
+            raise ValueError("SETUPMODULE-ERROR")
+
+        class MyTestCase(unittest.TestCase):
+            def test_one(self):
+                pass
+    """
+    )
+    result = pytester.runpytest("-s", testpath)
+    result.assert_outcomes(errors=1)
+    # Cleanup runs in the except handler; setup remains visible as __context__.
+    result.stdout.fnmatch_lines(["*SETUPMODULE-ERROR*", "*CLEANUP-ERROR*"])
+
+
+def test_module_cleanups_mark_and_drain_isolates_modules(pytester: Pytester) -> None:
+    """Import-time cleanups of other modules must not drain at our teardown.
+
+    ``unittest.case._module_cleanups`` is process-global. A naive
+    ``doModuleCleanups()`` at module A's teardown would also run B's
+    import-time registrations (already collected), before B's tests run.
+    Mark-and-drain keeps those for the session-end backstop (#14958).
+    """
+    events_file = pytester.path / "events.txt"
+    pytester.makepyfile(
+        test_a=f"""
+        import unittest
+
+        def cleanup_a_import():
+            with open(r"{events_file}", "a") as f:
+                f.write("cleanup-a-import\\n")
+
+        def cleanup_a_setup():
+            with open(r"{events_file}", "a") as f:
+                f.write("cleanup-a-setup\\n")
+
+        unittest.addModuleCleanup(cleanup_a_import)
+
+        def setUpModule():
+            unittest.addModuleCleanup(cleanup_a_setup)
+            with open(r"{events_file}", "a") as f:
+                f.write("setup-a\\n")
+
+        def tearDownModule():
+            with open(r"{events_file}", "a") as f:
+                f.write("teardown-a\\n")
+
+        class TestA(unittest.TestCase):
+            def test_a(self):
+                with open(r"{events_file}", "a") as f:
+                    f.write("test-a\\n")
+        """,
+        test_b=f"""
+        import unittest
+
+        def cleanup_b_import():
+            with open(r"{events_file}", "a") as f:
+                f.write("cleanup-b-import\\n")
+
+        unittest.addModuleCleanup(cleanup_b_import)
+
+        def setUpModule():
+            with open(r"{events_file}", "a") as f:
+                f.write("setup-b\\n")
+
+        def tearDownModule():
+            with open(r"{events_file}", "a") as f:
+                f.write("teardown-b\\n")
+
+        class TestB(unittest.TestCase):
+            def test_b(self):
+                with open(r"{events_file}", "a") as f:
+                    f.write("test-b\\n")
+        """,
+    )
+    result = pytester.runpytest("-qs", "test_a.py", "test_b.py")
+    result.assert_outcomes(passed=2)
+    lines = events_file.read_text().splitlines()
+    assert lines.index("teardown-a") < lines.index("cleanup-a-setup")
+    # B must start only after A's visit-scoped cleanup — and B's import-time
+    # cleanup must not have been eaten during A's teardown.
+    assert lines.index("cleanup-a-setup") < lines.index("setup-b")
+    assert lines.index("setup-b") < lines.index("cleanup-b-import")
+    assert lines.index("teardown-b") < lines.index("cleanup-b-import")
+    assert lines.index("teardown-b") < lines.index("cleanup-a-import")
+
+
+def test_module_cleanups_multiple_failures_exception_group(
+    pytester: Pytester,
+) -> None:
+    testpath = pytester.makepyfile(
+        """
+        import unittest
+
+        def boom(n):
+            raise Exception(f"fail {n}")
+
+        def setUpModule():
+            unittest.addModuleCleanup(boom, 2)
+            unittest.addModuleCleanup(boom, 1)
+
+        class MyTestCase(unittest.TestCase):
+            def test_one(self):
+                pass
+    """
+    )
+    result = pytester.runpytest("-s", testpath)
+    result.assert_outcomes(passed=1, errors=1)
+    result.stdout.fnmatch_lines(
+        [
+            "*Unittest module cleanup errors *2 sub-exceptions*",
+            "*Exception: fail 1",
+            "*Exception: fail 2",
+        ]
+    )
+
+
+def test_module_cleanups_without_setup_module_still_run(pytester: Pytester) -> None:
+    """Modules without setUpModule still get import-time cleanups at session end."""
+    events_file = pytester.path / "events.txt"
+    testpath = pytester.makepyfile(
+        f"""
+        import unittest
+
+        def cleanup():
+            with open(r"{events_file}", "a") as f:
+                f.write("cleanup\\n")
+
+        unittest.addModuleCleanup(cleanup)
+
+        class MyTestCase(unittest.TestCase):
+            def test_one(self):
+                with open(r"{events_file}", "a") as f:
+                    f.write("test\\n")
+    """
+    )
+    result = pytester.runpytest(testpath)
+    result.assert_outcomes(passed=1)
+    assert events_file.read_text().splitlines() == ["test", "cleanup"]
+
+
 class TestClassCleanupErrors:
     """
     Make sure to show exceptions raised during class cleanup function (those registered

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1600,28 +1600,28 @@ def test_module_cleanups_import_time_run_at_session_end(pytester: Pytester) -> N
         import unittest
 
         def cleanup():
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("cleanup\\n")
 
         unittest.addModuleCleanup(cleanup)
 
         def setUpModule():
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("setUpModule\\n")
 
         def tearDownModule():
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("tearDownModule\\n")
 
         class MyTestCase(unittest.TestCase):
             def test_one(self):
-                with open(r"{events_file}", "a") as f:
+                with open(r"{events_file}", "a", encoding="utf-8") as f:
                     f.write("test\\n")
     """
     )
     result = pytester.runpytest(testpath)
     result.assert_outcomes(passed=1)
-    assert events_file.read_text().splitlines() == [
+    assert events_file.read_text(encoding="utf-8").splitlines() == [
         "setUpModule",
         "test",
         "tearDownModule",
@@ -1641,10 +1641,10 @@ def test_enter_module_context_runs_exit(pytester: Pytester) -> None:
 
         @contextmanager
         def module_cm():
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("cm-enter\\n")
             yield
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("cm-exit\\n")
 
         unittest.enterModuleContext(module_cm())
@@ -1653,7 +1653,7 @@ def test_enter_module_context_runs_exit(pytester: Pytester) -> None:
             pass
 
         def tearDownModule():
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("tearDownModule\\n")
 
         class MyTestCase(unittest.TestCase):
@@ -1663,7 +1663,7 @@ def test_enter_module_context_runs_exit(pytester: Pytester) -> None:
     )
     result = pytester.runpytest(testpath)
     result.assert_outcomes(passed=1)
-    assert events_file.read_text().splitlines() == [
+    assert events_file.read_text(encoding="utf-8").splitlines() == [
         "cm-enter",
         "tearDownModule",
         "cm-exit",
@@ -1679,23 +1679,23 @@ def test_module_cleanups_registered_in_setup_run_after_teardown(
         import unittest
 
         def cleanup():
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("cleanup\\n")
 
         def setUpModule():
             unittest.addModuleCleanup(cleanup)
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("setUpModule\\n")
 
         def tearDownModule():
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("tearDownModule\\n")
 
         class MyTestCase(unittest.TestCase):
             @classmethod
             def setUpClass(cls):
                 def class_cleanup():
-                    with open(r"{events_file}", "a") as f:
+                    with open(r"{events_file}", "a", encoding="utf-8") as f:
                         f.write("class-cleanup\\n")
                 cls.addClassCleanup(class_cleanup)
 
@@ -1705,7 +1705,7 @@ def test_module_cleanups_registered_in_setup_run_after_teardown(
     )
     result = pytester.runpytest(testpath)
     result.assert_outcomes(passed=1)
-    assert events_file.read_text().splitlines() == [
+    assert events_file.read_text(encoding="utf-8").splitlines() == [
         "setUpModule",
         "class-cleanup",
         "tearDownModule",
@@ -1720,7 +1720,7 @@ def test_module_cleanups_run_when_setup_module_fails(pytester: Pytester) -> None
         import unittest
 
         def cleanup():
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("cleanup\\n")
 
         def setUpModule():
@@ -1734,7 +1734,7 @@ def test_module_cleanups_run_when_setup_module_fails(pytester: Pytester) -> None
     )
     result = pytester.runpytest(testpath)
     result.assert_outcomes(errors=1)
-    assert events_file.read_text().splitlines() == ["cleanup"]
+    assert events_file.read_text(encoding="utf-8").splitlines() == ["cleanup"]
 
 
 def test_module_cleanups_run_when_teardown_module_fails(pytester: Pytester) -> None:
@@ -1744,7 +1744,7 @@ def test_module_cleanups_run_when_teardown_module_fails(pytester: Pytester) -> N
         import unittest
 
         def cleanup():
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("cleanup\\n")
 
         def setUpModule():
@@ -1760,7 +1760,7 @@ def test_module_cleanups_run_when_teardown_module_fails(pytester: Pytester) -> N
     )
     result = pytester.runpytest(testpath)
     result.assert_outcomes(passed=1, errors=1)
-    assert events_file.read_text().splitlines() == ["cleanup"]
+    assert events_file.read_text(encoding="utf-8").splitlines() == ["cleanup"]
 
 
 def test_module_cleanup_failure_reported(pytester: Pytester) -> None:
@@ -1821,55 +1821,55 @@ def test_module_cleanups_mark_and_drain_isolates_modules(pytester: Pytester) -> 
         import unittest
 
         def cleanup_a_import():
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("cleanup-a-import\\n")
 
         def cleanup_a_setup():
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("cleanup-a-setup\\n")
 
         unittest.addModuleCleanup(cleanup_a_import)
 
         def setUpModule():
             unittest.addModuleCleanup(cleanup_a_setup)
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("setup-a\\n")
 
         def tearDownModule():
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("teardown-a\\n")
 
         class TestA(unittest.TestCase):
             def test_a(self):
-                with open(r"{events_file}", "a") as f:
+                with open(r"{events_file}", "a", encoding="utf-8") as f:
                     f.write("test-a\\n")
         """,
         test_b=f"""
         import unittest
 
         def cleanup_b_import():
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("cleanup-b-import\\n")
 
         unittest.addModuleCleanup(cleanup_b_import)
 
         def setUpModule():
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("setup-b\\n")
 
         def tearDownModule():
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("teardown-b\\n")
 
         class TestB(unittest.TestCase):
             def test_b(self):
-                with open(r"{events_file}", "a") as f:
+                with open(r"{events_file}", "a", encoding="utf-8") as f:
                     f.write("test-b\\n")
         """,
     )
     result = pytester.runpytest("-qs", "test_a.py", "test_b.py")
     result.assert_outcomes(passed=2)
-    lines = events_file.read_text().splitlines()
+    lines = events_file.read_text(encoding="utf-8").splitlines()
     assert lines.index("teardown-a") < lines.index("cleanup-a-setup")
     # B must start only after A's visit-scoped cleanup — and B's import-time
     # cleanup must not have been eaten during A's teardown.
@@ -1917,20 +1917,20 @@ def test_module_cleanups_without_setup_module_still_run(pytester: Pytester) -> N
         import unittest
 
         def cleanup():
-            with open(r"{events_file}", "a") as f:
+            with open(r"{events_file}", "a", encoding="utf-8") as f:
                 f.write("cleanup\\n")
 
         unittest.addModuleCleanup(cleanup)
 
         class MyTestCase(unittest.TestCase):
             def test_one(self):
-                with open(r"{events_file}", "a") as f:
+                with open(r"{events_file}", "a", encoding="utf-8") as f:
                     f.write("test\\n")
     """
     )
     result = pytester.runpytest(testpath)
     result.assert_outcomes(passed=1)
-    assert events_file.read_text().splitlines() == ["test", "cleanup"]
+    assert events_file.read_text(encoding="utf-8").splitlines() == ["test", "cleanup"]
 
 
 class TestClassCleanupErrors:


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

> [!IMPORTANT]
> **Unsupervised agentic contributions are not accepted**. See our [AI/LLM-Assisted Contributions Policy](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst#aillm-assisted-contributions-policy).

- [X] If AI agents were used, they are credited in `Co-authored-by` commit trailers.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->

closes #14958

### Summary

`unittest.addModuleCleanup` / `enterModuleContext` had no effect under pytest because we wired `setUpModule`/`tearDownModule` but never ran module cleanups. A prior attempt (#14959) drained the process-global `_module_cleanups` list at each module boundary; that is only correct under unittest's contiguous scheduling and is unsafe when pytest interleaves or re-enters modules.

This follows the approach discussed on the issue:

1. **Mark-and-drain** in the xunit module fixture (`_register_setup_module_fixture`): record `len(unittest.case._module_cleanups)` at setup, LIFO-drain down to that mark after `tearDownModule` (in a `finally`, and also when `setUpModule` fails). Cleanups registered during a module visit therefore stay attributed to that visit.
2. **Session-end backstop**: import-time registrations sit below every module mark; they are drained via a session finalizer attached from `pytest_runtest_setup` once the session is on the SetupState stack.
3. Multiple cleanup failures raise an `ExceptionGroup`, matching class-cleanup handling (stdlib keeps only the first).

Deliberate deviations from stdlib (also noted on the issue): import-time registrations run at session end rather than at an arbitrary first module boundary; package/`__init__.py` parity and unconditional fixture registration for modules without `setUpModule`/`tearDownModule` are left for follow-ups (session backstop already covers the no-setup case).

### AI disclosure

Implementation was assisted by Cursor. I reviewed the approach against the issue discussion and the closed #14959 feedback, own the change, and will handle review feedback.

### Test plan

- [x] New tests in `testing/test_unittest.py` covering import-time + setup-time cleanups, `enterModuleContext`, setup/teardown failure paths, cross-module isolation, ExceptionGroup on multiple cleanup failures, private-API contract, and modules without `setUpModule`
- [x] Related existing cleanup / `setUpModule` tests pass locally
- [ ] CI on the PR