### PR TITLE
fix: deduplicate Directory nodes on re-collection to preserve fixture identity (backport #14635)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -512,6 +512,7 @@ Will Riley
 William Lee
 Wim Glenn
 Wouter van Ackooy
+Wahaj Ahmed
 Xixi Zhao
 Xuan Luong
 Xuecong Liao

--- a/changelog/14964.bugfix.rst
+++ b/changelog/14964.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed conftest fixtures being silently missing for tests collected after a file argument from an ancestor directory (regression from #14004 in pytest 9.1.0+).

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -893,6 +893,23 @@ class Session(nodes.Collector):
             return rep, True
         else:
             rep = collect_one_node(node)
+            if rep.passed and node in self._collection_cache:
+                # Re-collection (handle_dupes=False) creates fresh child nodes.
+                # Reuse previously-seen Directory children so that fixture
+                # registration (keyed by node identity) remains valid. (#14635)
+                prev_result = self._collection_cache[node].result
+                prev_dirs = {
+                    child.path: child
+                    for child in prev_result
+                    if isinstance(child, nodes.Directory)
+                }
+                if prev_dirs:
+                    rep.result = [
+                        prev_dirs.get(child.path, child)
+                        if isinstance(child, nodes.Directory)
+                        else child
+                        for child in rep.result
+                    ]
             self._collection_cache[node] = rep
             return rep, False
 


### PR DESCRIPTION
## Summary

Backport of #14635 to the 9.1.x branch to fix #14964.

When a test file is passed directly on the command line (e.g. pytest tests/a.py test_x.py tests/b.py), Session.collect re-collects the parent Directory with handle_dupes=False, which previously created fresh child Directory nodes. Since fixture registration in 9.1.x+ uses node identity for matching, fixtures registered against the original Directory instance became invisible to items collected under the new one, causing conftest fixtures to be silently missing.

## Reproduction (from #14964)

```
pytest tests/a.py test_x.py tests/b.py
```

Expected: test_a and test_b both fail during setup because of the autouse=True guard fixture in tests/conftest.py.
Observed on 9.1.1: only test_a errors; test_b passes — the conftest fixtures were missing from its fixture closure.

## Fix

This is the backport of commit fc8f56b from main (#14635):

When _collect_one_node re-collects a parent Directory that is already in _collection_cache, reuse the previously-seen Directory children by path. Module/File nodes are still recreated to preserve --keep-duplicates behavior.

## Changelog

Added changelog/14964.bugfix.rst per the contribution guidelines.

Fixes #14964