### PR TITLE
doc: fix three dead reference links

### DIFF
--- a/changelog/14977.doc.rst
+++ b/changelog/14977.doc.rst
@@ -1,1 +1,0 @@
-Fixed three dead external reference links in the documentation: the JUnit XSD citation in the JUnit XML how-to, and the Dropbox blog post and Test and Code podcast references in the flaky tests explanation.

--- a/changelog/14977.doc.rst
+++ b/changelog/14977.doc.rst
@@ -1,0 +1,1 @@
+Fixed three dead external reference links in the documentation: the JUnit XSD citation in the JUnit XML how-to, and the Dropbox blog post and Test and Code podcast references in the flaky tests explanation.

--- a/doc/en/explanation/flaky.rst
+++ b/doc/en/explanation/flaky.rst
@@ -67,7 +67,7 @@ Rerunning any failed tests can mitigate the negative effects of flaky tests by g
 
 * `pytest-rerunfailures <https://github.com/pytest-dev/pytest-rerunfailures>`_
 * `pytest-replay <https://github.com/ESSS/pytest-replay>`_: This plugin helps to reproduce locally crashes or flaky tests observed during CI runs.
-* `pytest-flakefinder <https://github.com/dropbox/pytest-flakefinder>`_ - `blog post <https://blogs.dropbox.com/tech/2016/03/open-sourcing-pytest-tools/>`_
+* `pytest-flakefinder <https://github.com/dropbox/pytest-flakefinder>`_ - `blog post <https://web.archive.org/web/20200313031602/https://blogs.dropbox.com/tech/2016/03/open-sourcing-pytest-tools/>`_
 
 Plugins to deliberately randomize tests can help expose tests with state problems:
 
@@ -129,7 +129,7 @@ Resources
 * `Eradicating Non-Determinism in Tests <https://martinfowler.com/articles/nonDeterminism.html>`_ by Martin Fowler, 2011
 * `No more flaky tests on the Go team <https://www.thoughtworks.com/insights/blog/no-more-flaky-tests-go-team>`_ by Pavan Sudarshan, 2012
 * `The Build That Cried Broken: Building Trust in your Continuous Integration Tests <https://www.youtube.com/embed/VotJqV4n8ig>`_ talk (video) by `Angie Jones <https://angiejones.tech/>`_ at SeleniumConf Austin 2017
-* `Test and Code Podcast: Flaky Tests and How to Deal with Them <https://testandcode.com/50>`_ by Brian Okken and Anthony Shaw, 2018
+* `Test and Code Podcast: Flaky Tests and How to Deal with Them <https://web.archive.org/web/20221201011103/https://testandcode.com/50>`_ by Brian Okken and Anthony Shaw, 2018
 * Microsoft:
 
   * `How we approach testing VSTS to enable continuous delivery <https://blogs.msdn.microsoft.com/bharry/2017/06/28/testing-in-a-cloud-delivery-cadence/>`_ by Brian Harry MS, 2017

--- a/doc/en/how-to/output.rst
+++ b/doc/en/how-to/output.rst
@@ -623,7 +623,7 @@ To set the name of the root test suite xml item, you can configure the ``junit_s
 
 JUnit XML specification seems to indicate that ``"time"`` attribute
 should report total test execution times, including setup and teardown
-(`1 <http://windyroad.com.au/dl/Open%20Source/JUnit.xsd>`_, `2
+(`1 <https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd>`_, `2
 <https://www.ibm.com/support/knowledgecenter/en/SSQ2R2_14.1.0/com.ibm.rsar.analysis.codereview.cobol.doc/topics/cac_useresults_junit.html>`_).
 It is the default pytest behavior. To report just call durations
 instead, configure the ``junit_duration_report`` option like this:


### PR DESCRIPTION
Three external references in the docs no longer resolve. All checked with a browser user-agent and following redirects.

| File | Link | Status | Replacement |
| --- | --- | --- | --- |
| `doc/en/how-to/output.rst` | `windyroad.com.au/dl/Open%20Source/JUnit.xsd` | 404 | `github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd` |
| `doc/en/explanation/flaky.rst` | `blogs.dropbox.com/tech/2016/03/open-sourcing-pytest-tools/` | redirects to the dropbox.tech front page | Wayback snapshot |
| `doc/en/explanation/flaky.rst` | `testandcode.com/50` | 404 | Wayback snapshot |

Notes:

- The JUnit XSD is still published in the `windyroad/JUnit-Schema` repository, so that citation keeps pointing at the actual schema rather than an archive.
- The Dropbox post is a soft failure — the URL still returns 200 but lands on the blog's front page, so the citation no longer reaches the article it names. Neither it nor the podcast episode has a live successor URL, so both use Wayback snapshots, matching what `doc/en/history.rst` already does for older dead references.
- Per CONTRIBUTING, no changelog entry since this is a documentation fix.

I also checked the other links flagged by a scan of the docs and left them alone: `stackoverflow.com/search?q=pytest` and `bsky.app/profile/pytest.org` in `contact.rst` both resolve fine (they only appear broken to non-browser clients), and the remaining dead ones are inside `doc/en/announce/` release notes and `history.rst`, which are historical records.
