### PR TITLE
Improve parametrize error for scalar parameter sets

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -333,6 +333,7 @@ Mihail Milushev
 Mike Fiedler (miketheman)
 Mike Hoyle (hoylemd)
 Mike Lundy
+Mike Ma
 Milan Lesnek
 minbang930
 Miro Hrončok

--- a/changelog/14619.bugfix.rst
+++ b/changelog/14619.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a crash in ``pytest.mark.parametrize`` when a non-sequence value is passed for a parameter set. It now provides a clear error message during collection.

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -221,6 +221,8 @@ class ParameterSet(NamedTuple):
                 if values_len is None:
                     fail(
                         f'{nodeid}: in "parametrize" expected a sequence of values, '
+                        "for a single value use a one-element tuple like "
+                        "('value',), "
                         f"got {type(param.values).__name__}:\n"
                         f"  {param.values}",
                         pytrace=False,

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -214,7 +214,18 @@ class ParameterSet(NamedTuple):
         if parameters:
             # Check all parameter sets have the correct number of values.
             for param in parameters:
-                if len(param.values) != len(argnames):
+                try:
+                    values_len = len(param.values)
+                except TypeError:
+                    values_len = None
+                if values_len is None:
+                    fail(
+                        f'{nodeid}: in "parametrize" expected a sequence of values, '
+                        f"got {type(param.values).__name__}:\n"
+                        f"  {param.values}",
+                        pytrace=False,
+                    )
+                if values_len != len(argnames):
                     msg = (
                         '{nodeid}: in "parametrize" the number of names ({names_len}):\n'
                         "  {names}\n"
@@ -227,7 +238,7 @@ class ParameterSet(NamedTuple):
                             values=param.values,
                             names=argnames,
                             names_len=len(argnames),
-                            values_len=len(param.values),
+                            values_len=values_len,
                         ),
                         pytrace=False,
                     )

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -495,6 +495,28 @@ def test_parametrized_collect_with_wrong_args(pytester: Pytester) -> None:
     )
 
 
+def test_parametrized_collect_with_non_sequence_values(pytester: Pytester) -> None:
+    """Test collect parametrized func with tuple-style argnames and scalar values."""
+    py_file = pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.parametrize("x,", [None])
+        def test_func(x):
+            pass
+    """
+    )
+
+    result = pytester.runpytest(py_file)
+    result.stdout.fnmatch_lines(
+        [
+            "test_parametrized_collect_with_non_sequence_values.py::test_func: "
+            'in "parametrize" expected a sequence of values, got NoneType:',
+            "  None",
+        ]
+    )
+
+
 def test_parametrized_with_kwargs(pytester: Pytester) -> None:
     """Test collect parametrized func with wrong number of args."""
     py_file = pytester.makepyfile(

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -511,7 +511,9 @@ def test_parametrized_collect_with_non_sequence_values(pytester: Pytester) -> No
     result.stdout.fnmatch_lines(
         [
             "test_parametrized_collect_with_non_sequence_values.py::test_func: "
-            'in "parametrize" expected a sequence of values, got NoneType:',
+            'in "parametrize" expected a sequence of values, '
+            "for a single value use a one-element tuple like ('value',), "
+            "got NoneType:",
             "  None",
         ]
     )


### PR DESCRIPTION
Replaces #14621, whose source repository was deleted. The original commits by @mike-lmctl are preserved unchanged (no rebase, original authorship intact); this branch merely pins them on a fork so the work is not lost.

Closes #14619.

Original description:

> This turns a `TypeError` during collection into a normal `parametrize` collection error when tuple-style argnames receive a scalar parameter set.
>
> For example, `@pytest.mark.parametrize("x,", [None])` now points at the offending test and reports that the parameter set should be a sequence, instead of showing an internal `len(None)` crash.

- [x] Include new tests or update existing tests when applicable — regression test added in `testing/test_mark.py`.
- [x] Allow maintainers to push and squash when merging my commits.
- [x] `closes #14619`.
- [x] If AI agents were used, they are credited in `Co-authored-by` commit trailers — the original commit carries a `Co-authored-by: OpenAI Codex` trailer.
- [x] Changelog file `changelog/14619.bugfix.rst`.
- [x] Author added to `AUTHORS`.

Note: the branch is not rebased onto current `main`, so the commits sit on the older base they were written against. It merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfh2rhAows1TAEodU7B3AV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cfh2rhAows1TAEodU7B3AV)_