### PR TITLE
[ai dupe] Run unittest module cleanups after module tests (#14958)

### DIFF
--- a/changelog/14958.bugfix.rst
+++ b/changelog/14958.bugfix.rst
@@ -1,0 +1,3 @@
+Module-level cleanups registered via :func:`unittest.addModuleCleanup` -- including
+:func:`unittest.enterModuleContext` -- now run after ``tearDownModule`` (or when
+``setUpModule`` fails), instead of being silently dropped.

--- a/doc/en/how-to/unittest.rst
+++ b/doc/en/how-to/unittest.rst
@@ -26,6 +26,8 @@ Almost all ``unittest`` features are supported:
 * :meth:`unittest.TestCase.setUp`/:meth:`unittest.TestCase.tearDown`
 * :meth:`unittest.TestCase.setUpClass`/:meth:`unittest.TestCase.tearDownClass`
 * :func:`unittest.setUpModule`/:func:`unittest.tearDownModule`
+* :func:`unittest.addModuleCleanup`/:func:`unittest.doModuleCleanups`
+  (since version ``9.2``, with the deviations noted below)
 * :meth:`unittest.TestCase.subTest` (since version ``9.0``)
 
 .. _`load_tests protocol`: https://docs.python.org/3/library/unittest.html#load-tests-protocol
@@ -33,6 +35,27 @@ Almost all ``unittest`` features are supported:
 Up to this point pytest does not have support for the following features:
 
 * `load_tests protocol`_;
+
+Module-level cleanups
+---------------------
+
+Module cleanups registered via :func:`unittest.addModuleCleanup` (and
+:func:`unittest.enterModuleContext`, which is built on top of it) run after
+``tearDownModule`` -- or when ``setUpModule`` fails -- matching the stdlib
+ordering.
+
+Deviations from :mod:`unittest`:
+
+* Cleanups registered at module import time run at the end of the session,
+  not at the end of the first module to finish: pytest imports all modules
+  during collection, before any test runs, so per-module attribution is not
+  possible for them.
+* Cleanups run once per module *visit*: if pytest runs a module, runs other
+  modules, and comes back to it, each visit drains the cleanups registered
+  during that visit.
+* Errors raised by cleanup functions are aggregated and reported as an
+  :class:`ExceptionGroup`; stdlib's ``doModuleCleanups`` swallows all but the
+  first.
 
 Benefits out of the box
 -----------------------

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -22,6 +22,7 @@ import itertools
 import os
 from pathlib import Path
 import re
+import sys
 import textwrap
 import types
 from typing import Any
@@ -31,6 +32,7 @@ from typing import get_args
 from typing import Literal
 from typing import NoReturn
 from typing import TYPE_CHECKING
+import unittest
 import warnings
 
 import _pytest
@@ -83,6 +85,9 @@ from _pytest.stash import StashKey
 from _pytest.warning_types import PytestCollectionWarning
 from _pytest.warning_types import PytestReturnNotNoneWarning
 
+
+if sys.version_info[:2] < (3, 11):
+    from exceptiongroup import ExceptionGroup
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -600,16 +605,33 @@ class Module(nodes.File, PyCollector):
             self.obj, ("tearDownModule", "teardown_module")
         )
 
-        if setup_module is None and teardown_module is None:
+        if (
+            setup_module is None
+            and teardown_module is None
+            and not unittest.case._module_cleanups
+        ):
             return
 
         def xunit_setup_module_fixture(request) -> Generator[None]:
             module = request.module
-            if setup_module is not None:
-                _call_with_optional_argument(setup_module, module)
+            # Mark the current stack height of the process-global
+            # unittest.case._module_cleanups list: entries registered by the
+            # module import (or by other modules) sit below the mark and are
+            # left alone -- a session-end drain catches those (see
+            # _pytest.unittest.pytest_sessionfinish).
+            mark = len(unittest.case._module_cleanups)
+            try:
+                if setup_module is not None:
+                    _call_with_optional_argument(setup_module, module)
+            except Exception:
+                _drain_module_cleanups(mark)
+                raise
             yield
-            if teardown_module is not None:
-                _call_with_optional_argument(teardown_module, module)
+            try:
+                if teardown_module is not None:
+                    _call_with_optional_argument(teardown_module, module)
+            finally:
+                _drain_module_cleanups(mark)
 
         fixtures.register_fixture(
             # Use a unique name to speed up lookup.
@@ -761,6 +783,29 @@ def _get_first_non_fixture_func(obj: object, names: Iterable[str]) -> object | N
         if meth is not None and fixtures.getfixturemarker(meth) is None:
             return meth
     return None
+
+
+def _drain_module_cleanups(mark: int) -> None:
+    """Run unittest module cleanups registered since *mark* (LIFO order).
+
+    Entries at or below *mark* are left alone: ``unittest.case._module_cleanups``
+    is process-global and pytest can collect/re-enter modules in arbitrary
+    order, so only the entries a module registered during its own
+    setup/setUpModule run may be drained at its teardown (#14958).
+
+    Unlike stdlib's ``doModuleCleanups`` -- which swallows every error except
+    the first -- cleanup errors are aggregated and raised as an
+    ``ExceptionGroup``, mirroring the class-cleanup path (#8033).
+    """
+    exceptions: list[Exception] = []
+    while len(unittest.case._module_cleanups) > mark:
+        function, args, kwargs = unittest.case._module_cleanups.pop()
+        try:
+            function(*args, **kwargs)
+        except Exception as exc:
+            exceptions.append(exc)
+    if exceptions:
+        raise ExceptionGroup("Unittest module cleanup errors", exceptions)
 
 
 class Class(PyCollector):

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -31,6 +31,7 @@ from _pytest.outcomes import exit
 from _pytest.outcomes import fail
 from _pytest.outcomes import skip
 from _pytest.outcomes import xfail
+from _pytest.python import _drain_module_cleanups
 from _pytest.python import Class
 from _pytest.python import Function
 from _pytest.python import Module
@@ -48,6 +49,8 @@ if TYPE_CHECKING:
     import unittest
 
     import twisted.trial.unittest
+
+    from _pytest.main import Session
 
 
 _SysExcInfoType = (
@@ -520,6 +523,17 @@ def pytest_runtest_makereport(item: Item, call: CallInfo[None]) -> None:
         excinfo = call.excinfo
         call2 = CallInfo[None].from_call(lambda: skip(str(excinfo.value)), call.when)
         call.excinfo = call2.excinfo
+
+
+@hookimpl(tryfirst=True)
+def pytest_sessionfinish(session: Session) -> None:
+    """Drain leftover unittest module cleanups at session end (#14958).
+
+    Cleanups registered at import time sit below every per-module mark (see
+    ``_drain_module_cleanups`` in ``_pytest.python``) and are deliberately not
+    drained at module teardown -- they run here instead.
+    """
+    _drain_module_cleanups(0)
 
 
 def _is_skipped(obj) -> bool:

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1754,7 +1754,7 @@ LOG = Path({log_path!r})
 
 def setUpModule():
     def cleanup():
-        LOG.write_text((LOG.read_text() if LOG.exists() else "") + "cleanup\\n")
+        LOG.write_text((LOG.read_text(encoding="utf-8") if LOG.exists() else "") + "cleanup\\n")
     unittest.addModuleCleanup(cleanup)
 
 class MyTestCase(unittest.TestCase):
@@ -1769,7 +1769,7 @@ def test_cleanup_not_yet_run():
     passed, _skipped, failed = reprec.countoutcomes()
     assert failed == 0
     assert passed == 2
-    assert (pytester.path / "cleanup.log").read_text() == "cleanup\n"
+    assert (pytester.path / "cleanup.log").read_text(encoding="utf-8") == "cleanup\n"
 
 
 def test_module_cleanups_on_setupmodule_failure(pytester: Pytester) -> None:
@@ -1783,7 +1783,7 @@ LOG = Path({log_path!r})
 
 def setUpModule():
     def cleanup():
-        LOG.write_text("ran")
+        LOG.write_text("ran", encoding="utf-8")
     unittest.addModuleCleanup(cleanup)
     assert False
 
@@ -1796,7 +1796,7 @@ class MyTestCase(unittest.TestCase):
     passed, _skipped, failed = reprec.countoutcomes()
     assert failed == 1
     assert passed == 0
-    assert (pytester.path / "cleanup.log").read_text() == "ran"
+    assert (pytester.path / "cleanup.log").read_text(encoding="utf-8") == "ran"
 
 
 def test_module_cleanups_on_teardownmodule_failure(pytester: Pytester) -> None:
@@ -1810,7 +1810,7 @@ LOG = Path({log_path!r})
 
 def setUpModule():
     def cleanup():
-        LOG.write_text("ran")
+        LOG.write_text("ran", encoding="utf-8")
     unittest.addModuleCleanup(cleanup)
 
 def tearDownModule():
@@ -1824,7 +1824,7 @@ class MyTestCase(unittest.TestCase):
     reprec = pytester.inline_run(testpath)
     _passed, _skipped, failed = reprec.countoutcomes()
     assert failed == 1
-    assert (pytester.path / "cleanup.log").read_text() == "ran"
+    assert (pytester.path / "cleanup.log").read_text(encoding="utf-8") == "ran"
 
 
 def test_module_cleanups_run_in_lifo_order(pytester: Pytester) -> None:
@@ -1838,7 +1838,7 @@ LOG = Path({log_path!r})
 
 def setUpModule():
     def cleanup(n):
-        LOG.write_text((LOG.read_text() if LOG.exists() else "") + f"{{n}}\\n")
+        LOG.write_text((LOG.read_text(encoding="utf-8") if LOG.exists() else "") + f"{{n}}\\n")
     unittest.addModuleCleanup(cleanup, 1)
     unittest.addModuleCleanup(cleanup, 2)
 
@@ -1850,7 +1850,7 @@ class MyTestCase(unittest.TestCase):
     reprec = pytester.inline_run(testpath)
     _passed, _skipped, failed = reprec.countoutcomes()
     assert failed == 0
-    assert (pytester.path / "cleanup.log").read_text() == "2\n1\n"
+    assert (pytester.path / "cleanup.log").read_text(encoding="utf-8") == "2\n1\n"
 
 
 def test_module_cleanups_import_time_at_session_end(pytester: Pytester) -> None:
@@ -1863,7 +1863,7 @@ from pathlib import Path
 LOG = Path({log_path!r})
 
 def cleanup():
-    LOG.write_text("import-time")
+    LOG.write_text("import-time", encoding="utf-8")
 
 unittest.addModuleCleanup(cleanup)
 
@@ -1876,7 +1876,7 @@ class MyTestCase(unittest.TestCase):
     passed, _skipped, failed = reprec.countoutcomes()
     assert failed == 0
     assert passed == 1
-    assert (pytester.path / "cleanup.log").read_text() == "import-time"
+    assert (pytester.path / "cleanup.log").read_text(encoding="utf-8") == "import-time"
 
 
 def test_module_cleanups_not_stolen_across_modules(
@@ -1892,7 +1892,7 @@ LOG = Path({log_path!r})
 
 def setUpModule():
     def cleanup():
-        LOG.write_text((LOG.read_text() if LOG.exists() else "") + "a-drain\\n")
+        LOG.write_text((LOG.read_text(encoding="utf-8") if LOG.exists() else "") + "a-drain\\n")
     unittest.addModuleCleanup(cleanup)
 
 class TestA(unittest.TestCase):
@@ -1912,7 +1912,7 @@ from pathlib import Path
 LOG = Path({log_path!r})
 
 def cleanup():
-    LOG.write_text((LOG.read_text() if LOG.exists() else "") + "b-import\\n")
+    LOG.write_text((LOG.read_text(encoding="utf-8") if LOG.exists() else "") + "b-import\\n")
 
 unittest.addModuleCleanup(cleanup)
 
@@ -1933,7 +1933,7 @@ class TestB(unittest.TestCase):
     # a's cleanup drained at the end of each of a's two visits (cleanups run
     # once per module visit); b's import-time cleanup must survive both
     # module visits and drain at session end.
-    assert (pytester.path / "cleanup.log").read_text() == "a-drain\na-drain\nb-import\n"
+    assert (pytester.path / "cleanup.log").read_text(encoding="utf-8") == "a-drain\na-drain\nb-import\n"
 
 
 class TestModuleCleanupErrors:
@@ -2029,15 +2029,15 @@ LOG = Path({log_path!r})
 
 @contextmanager
 def cm():
-    LOG.write_text("enter")
+    LOG.write_text("enter", encoding="utf-8")
     yield
-    LOG.write_text("exit")
+    LOG.write_text("exit", encoding="utf-8")
 
 unittest.enterModuleContext(cm())
 
 class MyTestCase(unittest.TestCase):
     def test(self):
-        assert LOG.read_text() == "enter"
+        assert LOG.read_text(encoding="utf-8") == "enter"
 """
     )
     reprec = pytester.inline_run(testpath)
@@ -2045,4 +2045,4 @@ class MyTestCase(unittest.TestCase):
     assert failed == 0
     # enter() ran at import (asserted inside the test); exit() runs at
     # session end (import-time registrations drain at session end).
-    assert (pytester.path / "cleanup.log").read_text() == "exit"
+    assert (pytester.path / "cleanup.log").read_text(encoding="utf-8") == "exit"

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1742,6 +1742,7 @@ def test_abstract_testcase_is_not_collected(pytester: Pytester) -> None:
     assert result.ret == ExitCode.OK
     result.assert_outcomes(passed=1)
 
+
 def test_module_cleanups_on_success(pytester: Pytester) -> None:
     log_path = str(pytester.path / "cleanup.log")
     testpath = pytester.makepyfile(

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1933,7 +1933,9 @@ class TestB(unittest.TestCase):
     # a's cleanup drained at the end of each of a's two visits (cleanups run
     # once per module visit); b's import-time cleanup must survive both
     # module visits and drain at session end.
-    assert (pytester.path / "cleanup.log").read_text(encoding="utf-8") == "a-drain\na-drain\nb-import\n"
+    assert (pytester.path / "cleanup.log").read_text(
+        encoding="utf-8"
+    ) == "a-drain\na-drain\nb-import\n"
 
 
 class TestModuleCleanupErrors:

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1741,3 +1741,307 @@ def test_abstract_testcase_is_not_collected(pytester: Pytester) -> None:
     result = pytester.runpytest()
     assert result.ret == ExitCode.OK
     result.assert_outcomes(passed=1)
+
+def test_module_cleanups_on_success(pytester: Pytester) -> None:
+    log_path = str(pytester.path / "cleanup.log")
+    testpath = pytester.makepyfile(
+        f"""
+import unittest
+from pathlib import Path
+
+LOG = Path({log_path!r})
+
+def setUpModule():
+    def cleanup():
+        LOG.write_text((LOG.read_text() if LOG.exists() else "") + "cleanup\\n")
+    unittest.addModuleCleanup(cleanup)
+
+class MyTestCase(unittest.TestCase):
+    def test_one(self):
+        pass
+
+def test_cleanup_not_yet_run():
+    assert not LOG.exists()
+"""
+    )
+    reprec = pytester.inline_run(testpath)
+    passed, _skipped, failed = reprec.countoutcomes()
+    assert failed == 0
+    assert passed == 2
+    assert (pytester.path / "cleanup.log").read_text() == "cleanup\n"
+
+
+def test_module_cleanups_on_setupmodule_failure(pytester: Pytester) -> None:
+    log_path = str(pytester.path / "cleanup.log")
+    testpath = pytester.makepyfile(
+        f"""
+import unittest
+from pathlib import Path
+
+LOG = Path({log_path!r})
+
+def setUpModule():
+    def cleanup():
+        LOG.write_text("ran")
+    unittest.addModuleCleanup(cleanup)
+    assert False
+
+class MyTestCase(unittest.TestCase):
+    def test(self):
+        pass
+"""
+    )
+    reprec = pytester.inline_run(testpath)
+    passed, _skipped, failed = reprec.countoutcomes()
+    assert failed == 1
+    assert passed == 0
+    assert (pytester.path / "cleanup.log").read_text() == "ran"
+
+
+def test_module_cleanups_on_teardownmodule_failure(pytester: Pytester) -> None:
+    log_path = str(pytester.path / "cleanup.log")
+    testpath = pytester.makepyfile(
+        f"""
+import unittest
+from pathlib import Path
+
+LOG = Path({log_path!r})
+
+def setUpModule():
+    def cleanup():
+        LOG.write_text("ran")
+    unittest.addModuleCleanup(cleanup)
+
+def tearDownModule():
+    assert False
+
+class MyTestCase(unittest.TestCase):
+    def test(self):
+        pass
+"""
+    )
+    reprec = pytester.inline_run(testpath)
+    _passed, _skipped, failed = reprec.countoutcomes()
+    assert failed == 1
+    assert (pytester.path / "cleanup.log").read_text() == "ran"
+
+
+def test_module_cleanups_run_in_lifo_order(pytester: Pytester) -> None:
+    log_path = str(pytester.path / "cleanup.log")
+    testpath = pytester.makepyfile(
+        f"""
+import unittest
+from pathlib import Path
+
+LOG = Path({log_path!r})
+
+def setUpModule():
+    def cleanup(n):
+        LOG.write_text((LOG.read_text() if LOG.exists() else "") + f"{{n}}\\n")
+    unittest.addModuleCleanup(cleanup, 1)
+    unittest.addModuleCleanup(cleanup, 2)
+
+class MyTestCase(unittest.TestCase):
+    def test(self):
+        pass
+"""
+    )
+    reprec = pytester.inline_run(testpath)
+    _passed, _skipped, failed = reprec.countoutcomes()
+    assert failed == 0
+    assert (pytester.path / "cleanup.log").read_text() == "2\n1\n"
+
+
+def test_module_cleanups_import_time_at_session_end(pytester: Pytester) -> None:
+    log_path = str(pytester.path / "cleanup.log")
+    testpath = pytester.makepyfile(
+        f"""
+import unittest
+from pathlib import Path
+
+LOG = Path({log_path!r})
+
+def cleanup():
+    LOG.write_text("import-time")
+
+unittest.addModuleCleanup(cleanup)
+
+class MyTestCase(unittest.TestCase):
+    def test(self):
+        assert not LOG.exists()
+"""
+    )
+    reprec = pytester.inline_run(testpath)
+    passed, _skipped, failed = reprec.countoutcomes()
+    assert failed == 0
+    assert passed == 1
+    assert (pytester.path / "cleanup.log").read_text() == "import-time"
+
+
+def test_module_cleanups_not_stolen_across_modules(
+    pytester: Pytester, monkeypatch: MonkeyPatch
+) -> None:
+    log_path = str(pytester.path / "cleanup.log")
+    pytester.makepyfile(
+        test_a=f"""
+import unittest
+from pathlib import Path
+
+LOG = Path({log_path!r})
+
+def setUpModule():
+    def cleanup():
+        LOG.write_text((LOG.read_text() if LOG.exists() else "") + "a-drain\\n")
+    unittest.addModuleCleanup(cleanup)
+
+class TestA(unittest.TestCase):
+    def test1(self):
+        pass
+
+    def test2(self):
+        pass
+"""
+    )
+    log_path = str(pytester.path / "cleanup.log")
+    pytester.makepyfile(
+        test_b=f"""
+import unittest
+from pathlib import Path
+
+LOG = Path({log_path!r})
+
+def cleanup():
+    LOG.write_text((LOG.read_text() if LOG.exists() else "") + "b-import\\n")
+
+unittest.addModuleCleanup(cleanup)
+
+class TestB(unittest.TestCase):
+    def test1(self):
+        pass
+"""
+    )
+    monkeypatch.chdir(pytester.path)
+    reprec = pytester.inline_run(
+        "test_a.py::TestA::test1",
+        "test_b.py::TestB::test1",
+        "test_a.py::TestA::test2",
+    )
+    passed, _skipped, failed = reprec.countoutcomes()
+    assert failed == 0
+    assert passed == 3
+    # a's cleanup drained at the end of each of a's two visits (cleanups run
+    # once per module visit); b's import-time cleanup must survive both
+    # module visits and drain at session end.
+    assert (pytester.path / "cleanup.log").read_text() == "a-drain\na-drain\nb-import\n"
+
+
+class TestModuleCleanupErrors:
+    """Exceptions raised during module cleanup functions (registered via
+    addModuleCleanup()) are reported (#14958)."""
+
+    def test_module_cleanups_failure_in_setup(self, pytester: Pytester) -> None:
+        testpath = pytester.makepyfile(
+            """
+import unittest
+
+def setUpModule():
+    def cleanup(n):
+        raise Exception(f"fail {n}")
+    unittest.addModuleCleanup(cleanup, 2)
+    unittest.addModuleCleanup(cleanup, 1)
+    raise Exception("fail 0")
+
+class MyTestCase(unittest.TestCase):
+    def test(self):
+        pass
+"""
+        )
+        result = pytester.runpytest("-s", testpath)
+        result.assert_outcomes(errors=1)
+        result.stdout.fnmatch_lines(
+            [
+                "*Unittest module cleanup errors *2 sub-exceptions*",
+                "*Exception: fail 1",
+                "*Exception: fail 2",
+            ]
+        )
+
+    def test_module_cleanups_failure_in_teardown(self, pytester: Pytester) -> None:
+        testpath = pytester.makepyfile(
+            """
+import unittest
+
+def setUpModule():
+    def cleanup(n):
+        raise Exception(f"fail {n}")
+    unittest.addModuleCleanup(cleanup, 2)
+    unittest.addModuleCleanup(cleanup, 1)
+
+class MyTestCase(unittest.TestCase):
+    def test(self):
+        pass
+"""
+        )
+        result = pytester.runpytest("-s", testpath)
+        result.assert_outcomes(passed=1, errors=1)
+        result.stdout.fnmatch_lines(
+            [
+                "*Unittest module cleanup errors *2 sub-exceptions*",
+                "*Exception: fail 1",
+                "*Exception: fail 2",
+            ]
+        )
+
+
+def test_module_cleanups_stdlib_contract() -> None:
+    import unittest.case
+
+    saved = list(unittest.case._module_cleanups)
+    try:
+        unittest.case._module_cleanups.clear()
+        calls: list[int] = []
+
+        def cleanup() -> None:
+            calls.append(1)
+
+        unittest.addModuleCleanup(cleanup)
+        assert unittest.case._module_cleanups
+        unittest.case.doModuleCleanups()
+        assert calls == [1]
+        assert not unittest.case._module_cleanups
+    finally:
+        unittest.case._module_cleanups[:] = saved
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="enterModuleContext added in Python 3.11"
+)
+def test_module_cleanups_enter_module_context(pytester: Pytester) -> None:
+    log_path = str(pytester.path / "cleanup.log")
+    testpath = pytester.makepyfile(
+        f"""
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+
+LOG = Path({log_path!r})
+
+@contextmanager
+def cm():
+    LOG.write_text("enter")
+    yield
+    LOG.write_text("exit")
+
+unittest.enterModuleContext(cm())
+
+class MyTestCase(unittest.TestCase):
+    def test(self):
+        assert LOG.read_text() == "enter"
+"""
+    )
+    reprec = pytester.inline_run(testpath)
+    _passed, _skipped, failed = reprec.countoutcomes()
+    assert failed == 0
+    # enter() ran at import (asserted inside the test); exit() runs at
+    # session end (import-time registrations drain at session end).
+    assert (pytester.path / "cleanup.log").read_text() == "exit"

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1754,7 +1754,7 @@ LOG = Path({log_path!r})
 
 def setUpModule():
     def cleanup():
-        LOG.write_text((LOG.read_text(encoding="utf-8") if LOG.exists() else "") + "cleanup\\n")
+        LOG.write_text((LOG.read_text(encoding="utf-8") if LOG.exists() else "") + "cleanup\\n", encoding="utf-8")
     unittest.addModuleCleanup(cleanup)
 
 class MyTestCase(unittest.TestCase):
@@ -1838,7 +1838,7 @@ LOG = Path({log_path!r})
 
 def setUpModule():
     def cleanup(n):
-        LOG.write_text((LOG.read_text(encoding="utf-8") if LOG.exists() else "") + f"{{n}}\\n")
+        LOG.write_text((LOG.read_text(encoding="utf-8") if LOG.exists() else "") + f"{{n}}\\n", encoding="utf-8")
     unittest.addModuleCleanup(cleanup, 1)
     unittest.addModuleCleanup(cleanup, 2)
 
@@ -1892,7 +1892,7 @@ LOG = Path({log_path!r})
 
 def setUpModule():
     def cleanup():
-        LOG.write_text((LOG.read_text(encoding="utf-8") if LOG.exists() else "") + "a-drain\\n")
+        LOG.write_text((LOG.read_text(encoding="utf-8") if LOG.exists() else "") + "a-drain\\n", encoding="utf-8")
     unittest.addModuleCleanup(cleanup)
 
 class TestA(unittest.TestCase):
@@ -1912,7 +1912,7 @@ from pathlib import Path
 LOG = Path({log_path!r})
 
 def cleanup():
-    LOG.write_text((LOG.read_text(encoding="utf-8") if LOG.exists() else "") + "b-import\\n")
+    LOG.write_text((LOG.read_text(encoding="utf-8") if LOG.exists() else "") + "b-import\\n", encoding="utf-8")
 
 unittest.addModuleCleanup(cleanup)
 


### PR DESCRIPTION
Fixes #14958

## Problem

Module cleanups registered via `unittest.addModuleCleanup` (and `unittest.enterModuleContext`, built on top of it) were silently dropped: pytest wires up `setUpModule`/`tearDownModule` but never calls `doModuleCleanups()`, so the cleanups simply never run.

## Approach

The mark-and-drain scheme laid out in the issue discussion:

- The xunit module fixture marks the height of the process-global `unittest.case._module_cleanups` list at setup and drains LIFO down to that mark at teardown, in a `finally` so cleanups also run when `setUpModule`/`tearDownModule` fail (matching stdlib `_handleModuleFixture` ordering).
- Cleanups registered at import time sit below every per-module mark and are drained by a session-end backstop (`pytest_sessionfinish` in `_pytest/unittest.py`), since pytest imports all modules during collection and cannot attribute those entries to any module.
- Cleanup errors are aggregated into an `ExceptionGroup` instead of stdlib"s swallow-all-but-the-first behavior, mirroring the class cleanup path (#8033).
- A flat `doModuleCleanups()` at each module boundary (the obvious patch) was rejected in #14959 because `_module_cleanups` is process-global and pytest re-enters modules; the interleaving test below pins the mark-and-drain behavior.

## Deviations from stdlib (documented in doc/en/how-to/unittest.rst)

- Import-time registrations drain at session end.
- Cleanups run once per module *visit*.
- Errors aggregate into an `ExceptionGroup`.

## Tests

10 new pytester tests in `testing/test_unittest.py` covering: success, setUpModule failure, tearDownModule failure, LIFO order, import-time session-end drain, interleaved module visits (no stealing), error aggregation (setup + teardown), `enterModuleContext` (3.11+), and a contract test pinning the `unittest.case._module_cleanups` private-API dependency.

## Verification

- New tests fail on main, pass with the change.
- `python -m pytest testing/test_unittest.py testing/test_python_path.py testing/test_runner_xunit.py`: 100 passed, 9 skipped.
- `ruff check` clean on all touched files.