### PR TITLE
Fix monkeypatch.setattr/delattr binding descriptors when raising=False

### DIFF
--- a/changelog/10646.bugfix.rst
+++ b/changelog/10646.bugfix.rst
@@ -1,0 +1,4 @@
+``monkeypatch.setattr`` and ``monkeypatch.delattr`` called with
+``raising=False`` no longer bind descriptors when probing for the attribute's
+existence: the check now reads the attribute statically, so descriptor
+``__get__`` methods are no longer invoked with their side effects.

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -251,9 +251,15 @@ class MonkeyPatch:
                     "import string"
                 )
 
-        oldval = getattr(target, name, NOTSET)
-        if raising and oldval is NOTSET:
-            raise AttributeError(f"{target!r} has no attribute {name!r}")
+        if raising:
+            oldval = getattr(target, name, NOTSET)
+            if oldval is NOTSET:
+                raise AttributeError(f"{target!r} has no attribute {name!r}")
+        else:
+            # When raising is disabled, probe the attribute statically so that
+            # descriptors are not bound (no ``__get__`` side effects) just to
+            # check for existence.
+            oldval = inspect.getattr_static(target, name, NOTSET)
 
         # avoid class descriptors like staticmethod/classmethod
         if inspect.isclass(target):
@@ -298,16 +304,22 @@ class MonkeyPatch:
                 )
             name, target = derive_importpath(target, raising)
 
-        if not hasattr(target, name):
-            if raising:
+        if raising:
+            if not hasattr(target, name):
                 raise AttributeError(name)
-        else:
             oldval = getattr(target, name, NOTSET)
-            # Avoid class descriptors like staticmethod/classmethod.
-            if inspect.isclass(target):
-                oldval = target.__dict__.get(name, NOTSET)
-            delattr(target, name)
-            self._setattr.append((target, name, oldval))
+        else:
+            # When raising is disabled, probe the attribute statically so that
+            # descriptors are not bound (no ``__get__`` side effects) just to
+            # check for existence.
+            oldval = inspect.getattr_static(target, name, NOTSET)
+            if oldval is NOTSET:
+                return
+        # Avoid class descriptors like staticmethod/classmethod.
+        if inspect.isclass(target):
+            oldval = target.__dict__.get(name, NOTSET)
+        delattr(target, name)
+        self._setattr.append((target, name, oldval))
 
     def setitem(self, dic: Mapping[K, V], name: K, value: V) -> None:
         """Set dictionary entry ``name`` to value."""

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -52,6 +52,55 @@ def test_setattr() -> None:
         monkeypatch.setattr(A, "y")  # type: ignore[call-overload]
 
 
+class RaisingDescriptor:
+    """A descriptor whose binding always fails, to detect unwanted ``__get__`` calls."""
+
+    def __get__(self, instance, owner=None):
+        raise AssertionError("descriptor was bound")
+
+
+def test_setattr_raising_does_not_bind_descriptors() -> None:
+    class A:
+        z = RaisingDescriptor()
+
+    # With raising=True the existence check binds descriptors on purpose.
+    monkeypatch = MonkeyPatch()
+    with pytest.raises(AssertionError, match="descriptor was bound"):
+        monkeypatch.setattr(A, "z", 2)
+    with pytest.raises(AssertionError, match="descriptor was bound"):
+        monkeypatch.setattr(A(), "z", 2)
+
+    # With raising=False the attribute must be probed statically, without
+    # binding descriptors (gh-10646).
+    monkeypatch = MonkeyPatch()
+    monkeypatch.setattr(A, "z", 2, raising=False)
+    assert A.z == 2
+    monkeypatch.undo()
+    assert isinstance(A.__dict__["z"], RaisingDescriptor)
+
+    monkeypatch = MonkeyPatch()
+    monkeypatch.setattr(A(), "z", 2, raising=False)
+    monkeypatch.undo()
+
+
+def test_delattr_raising_does_not_bind_descriptors() -> None:
+    class A:
+        z = RaisingDescriptor()
+
+    # With raising=True the existence check binds descriptors on purpose.
+    monkeypatch = MonkeyPatch()
+    with pytest.raises(AssertionError, match="descriptor was bound"):
+        monkeypatch.delattr(A, "z")
+
+    # With raising=False the attribute must be probed statically, without
+    # binding descriptors (gh-10646).
+    monkeypatch = MonkeyPatch()
+    monkeypatch.delattr(A, "z", raising=False)
+    assert "z" not in A.__dict__
+    monkeypatch.undo()
+    assert isinstance(A.__dict__["z"], RaisingDescriptor)
+
+
 class TestSetattrWithImportPath:
     def test_string_expression(self, monkeypatch: MonkeyPatch) -> None:
         with monkeypatch.context() as mp:


### PR DESCRIPTION
Fixes #10646.

When `monkeypatch.setattr`/`monkeypatch.delattr` are called with `raising=False`, the attribute existence check currently uses `getattr`/`hasattr`, which binds descriptors on the target. This can cause unwanted side effects (e.g. a descriptor `__get__` raising, running setup code, or mutating state) even though the caller explicitly disabled the check.

This change makes the `raising=False` path probe the attribute with `inspect.getattr_static`, which reads the attribute from the object/class dicts without invoking `__get__`. The `raising=True` path is unchanged: it still binds descriptors on purpose, since it needs to detect descriptors that raise `AttributeError` on access.

Red/green verified: with the new tests (a `RaisingDescriptor` whose `__get__` always fails), `raising=True` still binds as before while `raising=False` no longer does, for both `setattr` and `delattr` on classes and instances; `undo` restores the original descriptor. Full `test_monkeypatch.py` plus `test_main`/`test_collection`/`test_assertion` pass (377 passed), ruff and mypy clean.

### AI Disclosure

This PR was developed with the assistance of an AI agent; the account owner verified the root-cause analysis, the red/green test results, and the full test-suite run before submitting.