### PR TITLE
monkeypatch: annotate the path parameter of syspath_prepend

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Abdeali JK
 Abdelrahman Elbehery
 Abhijeet Kasurde
 ace2016
+Adam Dangoor
 Adam Johnson
 Adam Stewart
 Adam Uhlir

--- a/changelog/14988.improvement.rst
+++ b/changelog/14988.improvement.rst
@@ -1,0 +1,1 @@
+:meth:`MonkeyPatch.syspath_prepend <pytest.MonkeyPatch.syspath_prepend>` now annotates its ``path`` parameter as ``str | os.PathLike[str]``, so strict type checkers no longer report calls to it as having an unknown type.

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -360,7 +360,7 @@ class MonkeyPatch:
         environ: MutableMapping[str, str] = os.environ
         self.delitem(environ, name, raising=raising)
 
-    def syspath_prepend(self, path) -> None:
+    def syspath_prepend(self, path: str | os.PathLike[str]) -> None:
         """Prepend ``path`` to ``sys.path`` list of import locations."""
         if self._savesyspath is None:
             self._savesyspath = sys.path[:]


### PR DESCRIPTION
`MonkeyPatch.syspath_prepend` had no annotation on its `path` parameter. Under a strict type checker such as pyright, every call in a user's test suite is then reported as `reportUnknownMemberType`, so each call needs an ignore comment.

This annotates it as `str | os.PathLike[str]`, matching `MonkeyPatch.chdir` next to it. The method already converts the argument with `str()`, so behaviour is unchanged.

- [x] Add yourself to `AUTHORS`
- [x] Changelog entry (added as `changelog/<PR number>.improvement.rst` once the number was known)