### PR TITLE
Keep usefixtures fixtures ahead of autouse dependencies

### DIFF
--- a/changelog/14992.bugfix.rst
+++ b/changelog/14992.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed fixture setup order so fixtures requested by ``usefixtures`` remain ahead of dependencies of earlier autouse fixtures.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1985,14 +1985,18 @@ class FixtureManager:
             else:
                 return fixturedefs[-1]._scope
 
-        fixturenames_closure = sorted(
-            traverse_fixture_closure(
+        # Keep the initial fixtures at the front of the closure. Their order
+        # is observable by hooks such as pytest_generate_tests.
+        fixturenames_closure = list(initialnames)
+        fixturenames_closure.extend(
+            argname
+            for argname in traverse_fixture_closure(
                 initialnames,
                 getfixturedefs=getfixturedefs,
-            ),
-            key=sort_by_scope,
-            reverse=True,
+            )
+            if argname not in initialnames
         )
+        fixturenames_closure.sort(key=sort_by_scope, reverse=True)
 
         return fixturenames_closure, arg2fixturedefs
 

--- a/testing/example_scripts/fixtures/test_getfixturevalue_dynamic.py
+++ b/testing/example_scripts/fixtures/test_getfixturevalue_dynamic.py
@@ -20,4 +20,4 @@ def b(a):
 
 
 def test(b, request):
-    assert request.fixturenames == ["b", "a", "request", "dynamic"]
+    assert request.fixturenames == ["b", "request", "a", "dynamic"]

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -2529,6 +2529,49 @@ class TestAutouseManagement:
         reprec = pytester.inline_run()
         reprec.assertoutcome(passed=1)
 
+    def test_usefixtures_before_autouse_dependencies(self, pytester: Pytester) -> None:
+        pytester.makepyfile(
+            """
+            import pytest
+
+            order = []
+
+            @pytest.fixture
+            def precondition():
+                order.append("precondition")
+
+            @pytest.fixture
+            def subject_deps(precondition):
+                order.append("subject_deps")
+
+            @pytest.fixture(autouse=True)
+            def subject(subject_deps):
+                order.append("subject")
+
+            @pytest.fixture
+            def guard():
+                order.append("guard")
+
+            def pytest_generate_tests(metafunc):
+                names = metafunc.fixturenames
+                if "subject" in names:
+                    names.remove("subject")
+                    names.append("subject")
+
+            @pytest.mark.usefixtures("guard")
+            class TestOrdering:
+                def test_guard_is_set_up_first(self):
+                    assert order == [
+                        "guard",
+                        "precondition",
+                        "subject_deps",
+                        "subject",
+                    ]
+        """
+        )
+        result = pytester.runpytest()
+        result.assert_outcomes(passed=1)
+
     @pytest.mark.parametrize("param1", ["", "params=[1]"], ids=["p00", "p01"])
     @pytest.mark.parametrize("param2", ["", "params=[1]"], ids=["p10", "p11"])
     def test_ordering_dependencies_torndown_first(
@@ -4673,8 +4716,8 @@ class TestScopeOrdering:
                 # Actual fixture execution differs from static order: dependent
                 # fixtures must be created first ("my_tmp_path").
                 assert fixture_order == [
-                    "my_tmp_path_factory",
                     "s1",
+                    "my_tmp_path_factory",
                     "p1",
                     "m1",
                     "my_tmp_path",
@@ -4689,13 +4732,13 @@ class TestScopeOrdering:
         # Static order of fixtures based on their scope and position in the
         # parameter list.
         assert request.fixturenames == [
-            "my_tmp_path_factory",
             "s1",
+            "my_tmp_path_factory",
             "p1",
             "m1",
             "f1",
-            "my_tmp_path",
             "f2",
+            "my_tmp_path",
         ]
         result = pytester.runpytest("-vv")
         result.assert_outcomes(passed=1)
@@ -5871,7 +5914,7 @@ def test_fixture_closure_handles_circular_dependencies(pytester: Pytester) -> No
     )
     items, _hookrec = pytester.inline_genitems()
     assert isinstance(items[0], Function)
-    assert items[0].fixturenames == ["fix_a", "fix_b", "fix_x", "fix_y", "fix_z"]
+    assert items[0].fixturenames == ["fix_a", "fix_x", "fix_b", "fix_y", "fix_z"]
 
 
 def test_fixture_closure_handles_diamond_dependencies(pytester: Pytester) -> None:


### PR DESCRIPTION
Closes #14992.

Pytest 9.1 changed fixture-closure construction so a fixture requested with
``usefixtures`` can be set up after the dependencies of an earlier autouse
fixture. This can move a guard or other setup action after the work it was
intended to protect.

The regression came from traversing every initial fixture name depth-first
before honoring the established order of the initial requests. The fix keeps
the initial fixture names ahead of their transitive dependencies, preserves
scope ordering for the expanded closure, updates the affected order
expectations, adds a regression test for the reported setup order, and records
the behavior in a bug-fix changelog entry.

### How this was tested

At the reported base commit ``3fd8675d6d798507c06cf9c60753be6d9d7b0e17``, the
machine-checked reproduction failed with the observed order
``['precondition', 'subject_deps', 'guard', 'subject']``. After the change, the
final independent fixture-suite verification reported ``241 passed, 3
xfailed``.

The checks ran on Windows 11. Mailman recorded Python 3.14.3 for the host
command metadata. A separate reviewer probe of nested pytester invocations
encountered existing Windows cache-permission failures in unrelated cases; the
issue-specific regression passed independently.

### An alternative not taken

The implementation could special-case only ``usefixtures`` names after the
depth-first traversal. Restoring the initial-name prefix keeps the established
precedence rule in the shared closure algorithm and avoids a second ordering
mechanism, while the existing scope sort still handles the expanded fixture
set.

### AI disclosure

This change was drafted with AI assistance: codex (``gpt-5.6-luna``) wrote the
patch and codex (``gpt-5.6-luna``) reviewed it under Mailman. The test results
above were executed by the Mailman harness. Human review and filing remain
pending.
