### PR TITLE
Give back the stream that was in place when capturing was suspended

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -486,6 +486,7 @@ Thomas Grainger
 Thomas Hisch
 Tianyu Dongfang
 Tim Hoffmann
+Tim Perkins
 Tim Strazny
 TJ Bruno
 Tobias Diez

--- a/changelog/14995.bugfix.rst
+++ b/changelog/14995.bugfix.rst
@@ -1,0 +1,9 @@
+Suspending capture no longer discards a stream installed after capturing started.
+
+``SysCaptureBase.resume`` reinstated the stream capture installed at ``start``, so anything
+that replaced ``sys.stdout`` afterwards -- ``contextlib.redirect_stdout``,
+``click.testing.CliRunner.isolation``, a fixture of one's own -- lost that stream on the first
+suspend/resume cycle, and subsequent writes went to pytest's buffer instead. Under
+``log_cli = true`` the live-log handler suspends capturing around every record, so a single
+log record was enough. ``suspend`` now records the stream that is in place and ``resume``
+returns it; teardown is unchanged.

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -415,6 +415,12 @@ class SysCaptureBase(CaptureBase[AnyStr]):
 
     def suspend(self) -> None:
         self._assert_state("suspend", ("started", "suspended"))
+        # Give back whatever is installed now, not `tmpfile`: something may have
+        # swapped the stream after `start`, and `resume` owes it that stream
+        # back. Suspending while suspended is legal, and what sits there then is
+        # what `suspend` itself installed rather than a swap to remember.
+        if self._state == "started":
+            self._swapped_in = getattr(sys, self.name)
         setattr(sys, self.name, self._old)
         self._state = "suspended"
 
@@ -422,7 +428,7 @@ class SysCaptureBase(CaptureBase[AnyStr]):
         self._assert_state("resume", ("started", "suspended"))
         if self._state == "started":
             return
-        setattr(sys, self.name, self.tmpfile)
+        setattr(sys, self.name, getattr(self, "_swapped_in", self.tmpfile))
         self._state = "started"
 
 

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1125,8 +1125,96 @@ class TestFDCapture:
                 f"<SysCapture stdout _old=<UNSET> _state='done' tmpfile={cap.syscapture.tmpfile!r}>"
             )
 
+    def test_resume_gives_back_a_stream_swapped_in_after_start(self) -> None:
+        """`resume` owes back whatever was installed when `suspend` ran.
+
+        Anything may swap the stream once capturing has started -- a test using
+        `contextlib.redirect_stdout`, `click.testing.CliRunner.isolation`, a
+        fixture of its own. Handing `tmpfile` back instead drops that swap, and
+        everything written afterwards goes to the capture buffer rather than to
+        the caller that installed it.
+        """
+        cap = capture.SysCapture(1)
+        cap.start()
+        try:
+            swapped_in = io.StringIO()
+            sys.stdout = swapped_in
+
+            cap.suspend()
+            cap.resume()
+
+            assert sys.stdout is swapped_in
+        finally:
+            cap.done()
+
+    def test_resume_gives_back_tmpfile_when_nothing_swapped_it(self) -> None:
+        cap = capture.SysCapture(1)
+        cap.start()
+        try:
+            cap.suspend()
+            cap.resume()
+
+            assert sys.stdout is cap.tmpfile
+        finally:
+            cap.done()
+
+    def test_suspending_twice_keeps_the_swapped_stream(self) -> None:
+        cap = capture.SysCapture(1)
+        cap.start()
+        try:
+            swapped_in = io.StringIO()
+            sys.stdout = swapped_in
+
+            cap.suspend()
+            cap.suspend()
+            cap.resume()
+
+            assert sys.stdout is swapped_in
+        finally:
+            cap.done()
+
+    def test_done_restores_the_stream_capture_replaced(self) -> None:
+        """A swap left behind by a test does not outlive the capture."""
+        original = sys.stdout
+        cap = capture.SysCapture(1)
+        cap.start()
+        sys.stdout = io.StringIO()
+
+        cap.done()
+
+        assert sys.stdout is original
+
     def test_capfd_sys_stdout_mode(self, capfd) -> None:
         assert "b" not in sys.stdout.mode
+
+
+def test_live_logging_does_not_cost_a_test_its_redirected_stream(
+    pytester: Pytester,
+) -> None:
+    """`--log-cli` suspends capturing around every record it writes.
+
+    The handler sits on the root logger, so a record written from anywhere
+    inside a redirect passes through `suspend`/`resume`; the redirect has to
+    survive it.
+    """
+    pytester.makepyfile(
+        """
+        import contextlib
+        import io
+        import logging
+
+        def test_redirect_stdout_survives_a_log_record():
+            captured = io.StringIO()
+            with contextlib.redirect_stdout(captured):
+                logging.getLogger("some.library").warning("reaches the root logger")
+                print("inside the redirect")
+            assert captured.getvalue() == "inside the redirect\\n"
+        """
+    )
+
+    result = pytester.runpytest_subprocess("-o", "log_cli=true")
+
+    result.assert_outcomes(passed=1)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Fixes #14995.

`SysCaptureBase.suspend` handed `sys.stdout` back to the stream saved before capturing started, and `resume` reinstated `tmpfile`, the stream capture installed at `start`. Neither read what was actually there, so a stream installed after `start` — `contextlib.redirect_stdout`, `click.testing.CliRunner.isolation`, a fixture of one's own — was discarded on the first suspend/resume cycle, and everything written afterwards went to pytest's buffer rather than to the caller that installed it.

Under `log_cli = true` that is a per-record event: the live-log handler sits on the root logger and suspends capturing around every record it writes, so one log record emitted at any depth costs a test its redirect. The failure is silent, and assertions about absent output pass vacuously.

## The change

```python
def suspend(self) -> None:
    self._assert_state("suspend", ("started", "suspended"))
    if self._state == "started":
        self._swapped_in = getattr(sys, self.name)
    setattr(sys, self.name, self._old)
    self._state = "suspended"

def resume(self) -> None:
    self._assert_state("resume", ("started", "suspended"))
    if self._state == "started":
        return
    setattr(sys, self.name, getattr(self, "_swapped_in", self.tmpfile))
    self._state = "started"
```

Suspending while suspended is left alone, since what sits there then is what `suspend` itself installed rather than a stream worth remembering. `done` is unchanged and still restores the stream capture replaced, so a swap left behind by a test cannot outlive it.

## Tests

Five added to `testing/test_capture.py`. Four sit beside `test_simple_resume_suspend` and drive `SysCapture` directly; one uses `pytester` to cover the `log_cli` path this actually reaches users through.

Three of the five fail without the change. The two that pass either way are the ones asserting existing behaviour is preserved — `resume` returning `tmpfile` when nothing swapped it, and `done` restoring the original stream.

## Verification

Against `main` at 3fd8675d6:

| | baseline | with this change |
|---|---|---|
| full suite | 1 failed, 4549 passed, 51 skipped, 15 xfailed, 5 xpassed, 1 error | 1 failed, **4554** passed, 51 skipped, 15 xfailed, 5 xpassed, 1 error |
| `testing/test_capture.py` + `testing/logging/` | 219 passed, 1 skipped, 1 xfailed | unchanged |
| `pre-commit` | — | all hooks pass |

The only delta is the five added tests. The failure and error are present on `main` beforehand and are unrelated to capture: `testing/test_doctest.py::TestDoctests::test_fixture_doctest_skip_has_line_number` and `testing/test_legacypath.py::test_cache_makedir`.

## On the "pytest owns the streams" reading

The one counter-argument is that pytest owns `sys.stdout` for the duration of a test, so anything swapping it underneath is unsupported and `resume` is entitled to reset. Three things stand against it.

`contextlib.redirect_stdout` is standard library. Under that reading it is unsupported inside any test run with `--log-cli`, which is documented nowhere and is unlikely to be the intent. No third-party code is required to hit this.

pytest's own design already separates the two operations. `done` restores the pre-capture stream; `resume` restores `tmpfile`. That distinction only makes sense if `resume` is the inverse of `suspend` rather than a reset — and `global_and_fixture_disabled`, the caller that produces this, describes itself as *temporarily* disabling capture.

There is precedent in the same context manager. #7148 was an imbalance in `global_and_fixture_disabled` — resuming capture it had not suspended — and was accepted and fixed in #7651. This is the same shape: a pair that does not restore what it displaced.

The change is four lines and moves nothing else. The full suite is unchanged apart from the tests added here, so correctness here costs nothing elsewhere.

