### PR TITLE
docs: group collection reporting hooks

### DIFF
--- a/changelog/12658.doc.rst
+++ b/changelog/12658.doc.rst
@@ -1,1 +1,1 @@
-Moved the fixture setup and finalizer hooks to the test running hooks section in the reference documentation.
+Grouped collection reporting hooks with the other collection hooks in the reference documentation.

--- a/changelog/12658.doc.rst
+++ b/changelog/12658.doc.rst
@@ -1,3 +1,1 @@
 Moved the fixture setup and finalizer hooks to the test running hooks section in the reference documentation.
-
-Grouped collection reporting hooks with the other collection hooks in the reference documentation.

--- a/changelog/12658.doc.rst
+++ b/changelog/12658.doc.rst
@@ -1,1 +1,3 @@
+Moved the fixture setup and finalizer hooks to the test running hooks section in the reference documentation.
+
 Grouped collection reporting hooks with the other collection hooks in the reference documentation.

--- a/changelog/15000.doc.rst
+++ b/changelog/15000.doc.rst
@@ -1,0 +1,1 @@
+Grouped collection reporting hooks with the other collection hooks in the reference documentation.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -765,6 +765,19 @@ items, delete or otherwise amend the test items:
 .. hook:: pytest_collection_finish
 .. autofunction:: pytest_collection_finish
 
+Collection reporting hooks:
+
+.. hook:: pytest_collectstart
+.. autofunction:: pytest_collectstart
+.. hook:: pytest_make_collect_report
+.. autofunction:: pytest_make_collect_report
+.. hook:: pytest_itemcollected
+.. autofunction:: pytest_itemcollected
+.. hook:: pytest_collectreport
+.. autofunction:: pytest_collectreport
+.. hook:: pytest_deselected
+.. autofunction:: pytest_deselected
+
 Test running (runtest) hooks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -805,16 +818,6 @@ Reporting hooks
 
 Session related reporting hooks:
 
-.. hook:: pytest_collectstart
-.. autofunction:: pytest_collectstart
-.. hook:: pytest_make_collect_report
-.. autofunction:: pytest_make_collect_report
-.. hook:: pytest_itemcollected
-.. autofunction:: pytest_itemcollected
-.. hook:: pytest_collectreport
-.. autofunction:: pytest_collectreport
-.. hook:: pytest_deselected
-.. autofunction:: pytest_deselected
 .. hook:: pytest_report_header
 .. autofunction:: pytest_report_header
 .. hook:: pytest_report_collectionfinish


### PR DESCRIPTION
## Summary

Move the collection lifecycle reporting hooks into the Collection hooks section so plugin authors can find them with the phase they describe.

Fixes #12658

## Verification

- uv run --frozen --with tox --with tox-uv tox -e docs
- git diff --check

## Checklist

- [x] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [x] Allow maintainers to push and squash when merging my commits.
- [x] Add text like closes #12658 to the PR description.
- [x] AI assistance was used and the commits include Co-authored-by trailers; the change was human-reviewed and verified.
- [x] Create a new changelog entry in changelog/12658.doc.1.rst.
- [ ] Add yourself to AUTHORS (this is a small documentation fix).
