### PR TITLE
[Autonomous agent]stepwise: resume after debugger quit (#10562)

### DIFF
--- a/changelog/10562.bugfix.rst
+++ b/changelog/10562.bugfix.rst
@@ -1,0 +1,1 @@
+``--stepwise`` now records the test that was running when the session was interrupted by ``pytest.exit()`` -- for example, when quitting a ``pdb`` debugging session -- as the last failed test, so the next run resumes from it.

--- a/src/_pytest/stepwise.py
+++ b/src/_pytest/stepwise.py
@@ -21,9 +21,9 @@ if TYPE_CHECKING:
 
 from collections.abc import Generator
 
+from _pytest.outcomes import Exit
 import pytest
 
-from _pytest.outcomes import Exit
 
 STEPWISE_CACHE_DIR = "cache/stepwise"
 

--- a/src/_pytest/stepwise.py
+++ b/src/_pytest/stepwise.py
@@ -18,6 +18,13 @@ from _pytest.reports import TestReport
 if TYPE_CHECKING:
     from typing_extensions import Self
 
+
+from collections.abc import Generator
+
+import pytest
+
+from _pytest.outcomes import Exit
+
 STEPWISE_CACHE_DIR = "cache/stepwise"
 
 
@@ -172,6 +179,19 @@ class StepwisePlugin:
             deselected = items[:failed_index]
             del items[:failed_index]
             config.hook.pytest_deselected(items=deselected)
+
+    @pytest.hookimpl(wrapper=True)
+    def pytest_runtest_protocol(
+        self, item: nodes.Item, nextitem: nodes.Item | None
+    ) -> Generator[None, object, object]:
+        # The Exit exception (raised e.g. by pytest.exit() when quitting a
+        # ``pdb`` session) does not produce a report, so record the interrupted
+        # test here such that the next --stepwise run resumes from it (#10562).
+        try:
+            return (yield)
+        except Exit:
+            self.cached_info.last_failed = item.id
+            raise
 
     def pytest_runtest_logreport(self, report: TestReport) -> None:
         if report.failed:

--- a/testing/test_stepwise_interrupt.py
+++ b/testing/test_stepwise_interrupt.py
@@ -7,7 +7,7 @@ from _pytest.pytester import Pytester
 
 
 def test_stepwise_continues_after_pytest_exit(pytester: Pytester) -> None:
-    """pdb quit raises pytest.exit; --stepwise should start from that test next run."""
+    """Pdb quit raises pytest.exit; --stepwise should start from that test next run."""
     pytester.makeini(
         """
         [pytest]

--- a/testing/test_stepwise_interrupt.py
+++ b/testing/test_stepwise_interrupt.py
@@ -1,0 +1,77 @@
+# mypy: disallow-untyped-defs
+"""--stepwise should resume after a debugger quit / pytest.exit (#10562)."""
+
+from __future__ import annotations
+
+from _pytest.pytester import Pytester
+
+
+def test_stepwise_continues_after_pytest_exit(pytester: Pytester) -> None:
+    """pdb quit raises pytest.exit; --stepwise should start from that test next run."""
+    pytester.makeini(
+        """
+        [pytest]
+        cache_dir = .cache
+        """
+    )
+    pytester.makepyfile(
+        """
+        def test_before():
+            assert True
+
+        def test_quit():
+            import pytest
+
+            pytest.exit("Quitting debugger")
+
+        def test_after():
+            assert True
+        """
+    )
+    first = pytester.runpytest("-v", "--stepwise")
+    stdout = first.stdout.str()
+    assert "test_before PASSED" in stdout
+    assert "test_quit" in stdout
+    assert "test_after PASSED" not in stdout
+
+    second = pytester.runpytest("-v", "--stepwise")
+    stdout = second.stdout.str()
+    assert "skipping 1 already passed items" in stdout
+    assert "test_before PASSED" not in stdout
+    assert "test_quit" in stdout
+    assert "test_after PASSED" not in stdout
+
+
+def test_stepwise_continues_after_bdbquit(pytester: Pytester) -> None:
+    """A raised BdbQuit is already a failed report; keep that resume path."""
+    pytester.makeini(
+        """
+        [pytest]
+        cache_dir = .cache
+        """
+    )
+    pytester.makepyfile(
+        """
+        def test_before():
+            assert True
+
+        def test_quit():
+            import bdb
+
+            raise bdb.BdbQuit()
+
+        def test_after():
+            assert True
+        """
+    )
+    first = pytester.runpytest("-v", "--stepwise")
+    stdout = first.stdout.str()
+    assert "test_before PASSED" in stdout
+    assert "test_quit FAILED" in stdout
+    assert "test_after PASSED" not in stdout
+
+    second = pytester.runpytest("-v", "--stepwise")
+    stdout = second.stdout.str()
+    assert "skipping 1 already passed items" in stdout
+    assert "test_before PASSED" not in stdout
+    assert "test_quit FAILED" in stdout


### PR DESCRIPTION
Fixes #10562.

`--stepwise` did not resume after `pytest.exit()` (pdb `q` uses this path). `Exit` is re-raised before a failed report, so `last_failed` stayed empty.

This records the interrupted item in a `pytest_runtest_protocol` wrapper and keeps the existing `BdbQuit` resume path.

Regression: `testing/test_stepwise_interrupt.py`.