### PR TITLE
Add complete option to LineMatcher methods

### DIFF
--- a/changelog/6820.improvement.rst
+++ b/changelog/6820.improvement.rst
@@ -1,0 +1,1 @@
+Add support for asserting complete output with :class:`~pytest.LineMatcher`'s :func:`~pytest.LineMatcher.fnmatch_lines` and :func:`~pytest.LineMatcher.re_match_lines` via a new ``complete`` option.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1653,7 +1653,11 @@ class LineMatcher:
         return "\n".join(self._log_output)
 
     def fnmatch_lines(
-        self, lines2: Sequence[str], *, consecutive: bool = False
+        self,
+        lines2: Sequence[str],
+        *,
+        consecutive: bool = False,
+        complete: bool = False,
     ) -> None:
         """Check lines exist in the output (using :func:`python:fnmatch.fnmatch`).
 
@@ -1663,12 +1667,19 @@ class LineMatcher:
 
         :param lines2: String patterns to match.
         :param consecutive: Match lines consecutively?
+        :param complete: Fail if the output contains lines which were not asserted?
         """
         __tracebackhide__ = True
-        self._match_lines(lines2, fnmatch, "fnmatch", consecutive=consecutive)
+        self._match_lines(
+            lines2, fnmatch, "fnmatch", consecutive=consecutive, complete=complete
+        )
 
     def re_match_lines(
-        self, lines2: Sequence[str], *, consecutive: bool = False
+        self,
+        lines2: Sequence[str],
+        *,
+        consecutive: bool = False,
+        complete: bool = False,
     ) -> None:
         """Check lines exist in the output (using :func:`python:re.match`).
 
@@ -1679,6 +1690,7 @@ class LineMatcher:
 
         :param lines2: string patterns to match.
         :param consecutive: match lines consecutively?
+        :param complete: Fail if the output contains lines which were not asserted?
         """
         __tracebackhide__ = True
         self._match_lines(
@@ -1686,6 +1698,7 @@ class LineMatcher:
             lambda name, pat: bool(re.match(pat, name)),
             "re.match",
             consecutive=consecutive,
+            complete=complete,
         )
 
     def _match_lines(
@@ -1695,6 +1708,7 @@ class LineMatcher:
         match_nickname: str,
         *,
         consecutive: bool = False,
+        complete: bool = False,
     ) -> None:
         """Underlying implementation of ``fnmatch_lines`` and ``re_match_lines``.
 
@@ -1710,6 +1724,8 @@ class LineMatcher:
             when a match occurs.
         :param consecutive:
             Match lines consecutively?
+        :param complete:
+            Fail if the output contains lines which were not asserted?
         """
         if not isinstance(lines2, collections.abc.Sequence):
             raise TypeError(f"invalid type for lines2: {type(lines2).__name__}")
@@ -1751,6 +1767,12 @@ class LineMatcher:
                 extralines.append(nextline)
             else:
                 msg = f"remains unmatched: {line!r}"
+                self._log(msg)
+                self._fail(msg)
+        if complete:
+            unasserted = extralines + lines1
+            if unasserted:
+                msg = f"output has unasserted lines: {unasserted!r}"
                 self._log(msg)
                 self._fail(msg)
         self._log_output = []

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -549,6 +549,53 @@ def test_linematcher_consecutive() -> None:
     ]
 
 
+def test_linematcher_complete() -> None:
+    lm = LineMatcher(["1", "2", "3"])
+    lm.fnmatch_lines(["1", "2", "3"], complete=True)
+    lm.re_match_lines(["1", "2", "3"], complete=True)
+
+    lm = LineMatcher(["unexpected", "1", "2", "3"])
+    with pytest.raises(pytest.fail.Exception) as excinfo:
+        lm.fnmatch_lines(["1", "2", "3"], complete=True)
+    assert str(excinfo.value).splitlines() == [
+        "nomatch: '1'",
+        "    and: 'unexpected'",
+        "exact match: '1'",
+        "exact match: '2'",
+        "exact match: '3'",
+        "output has unasserted lines: ['unexpected']",
+    ]
+
+    lm = LineMatcher(["1", "2", "3", "trailing"])
+    with pytest.raises(pytest.fail.Exception) as excinfo:
+        lm.re_match_lines(["1", "2", "3"], complete=True)
+    assert str(excinfo.value).splitlines() == [
+        "exact match: '1'",
+        "exact match: '2'",
+        "exact match: '3'",
+        "output has unasserted lines: ['trailing']",
+    ]
+
+    lm = LineMatcher(["0", "1", "2", "3"])
+    with pytest.raises(pytest.fail.Exception) as excinfo:
+        lm.fnmatch_lines(["1", "2", "3"], consecutive=True, complete=True)
+    assert str(excinfo.value).splitlines() == [
+        "nomatch: '1'",
+        "    and: '0'",
+        "exact match: '1'",
+        "exact match: '2'",
+        "exact match: '3'",
+        "output has unasserted lines: ['0']",
+    ]
+
+    lm = LineMatcher(["x"])
+    with pytest.raises(pytest.fail.Exception) as excinfo:
+        lm.fnmatch_lines([], complete=True)
+    assert str(excinfo.value).splitlines() == [
+        "output has unasserted lines: ['x']",
+    ]
+
+
 @pytest.mark.parametrize("function", ["no_fnmatch_line", "no_re_match_line"])
 def test_linematcher_no_matching(function: str) -> None:
     if function == "no_fnmatch_line":

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -595,6 +595,14 @@ def test_linematcher_complete() -> None:
         "output has unasserted lines: ['x']",
     ]
 
+    lm = LineMatcher(["1", "1"])
+    with pytest.raises(pytest.fail.Exception) as excinfo:
+        lm.fnmatch_lines(["1"], complete=True)
+    assert str(excinfo.value).splitlines() == [
+        "exact match: '1'",
+        "output has unasserted lines: ['1']",
+    ]
+
 
 @pytest.mark.parametrize("function", ["no_fnmatch_line", "no_re_match_line"])
 def test_linematcher_no_matching(function: str) -> None:


### PR DESCRIPTION
Closes #6820

Adds a `complete` option to `LineMatcher.fnmatch_lines` and `LineMatcher.re_match_lines`. The assertion fails on unasserted output lines.

Prior art: https://github.com/blueyed/pytest/pull/257 explored this first. This converges on the per-call flag while reporting all unasserted lines at the end instead of failing at the first gap, so trailing leftovers are caught too.

- [ ] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.
- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.
- [X] If AI agents were used, they are credited in `Co-authored-by` commit trailers.
- [X] Create a new changelog file in the `changelog` directory, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.
- [ ] Add yourself to `AUTHORS` in alphabetical order.