### PR TITLE
approx: Decimal and numpy cleanup

### DIFF
--- a/changelog/15005.bugfix.rst
+++ b/changelog/15005.bugfix.rst
@@ -1,0 +1,1 @@
+:func:`pytest.approx` no longer treats finite :class:`~decimal.Decimal` values outside the :class:`float` range (such as ``Decimal("1e400")``) as infinite, which made in-tolerance comparisons fail.

--- a/changelog/15006.bugfix.1.rst
+++ b/changelog/15006.bugfix.1.rst
@@ -1,0 +1,1 @@
+The failure message for :func:`pytest.approx` comparisons of :class:`~decimal.Decimal` collections no longer reports ``Max absolute difference: -inf``, or crashes for mappings, when the :class:`decimal.FloatOperation` trap is set.

--- a/changelog/15006.bugfix.2.rst
+++ b/changelog/15006.bugfix.2.rst
@@ -1,0 +1,1 @@
+:func:`pytest.approx` no longer raises ``AttributeError`` when comparing :class:`numpy.ndarray` instances with ``object`` dtype, such as arrays of :class:`~decimal.Decimal`.

--- a/changelog/15006.bugfix.rst
+++ b/changelog/15006.bugfix.rst
@@ -1,0 +1,1 @@
+Restored the tolerance shown by :func:`pytest.approx` for :class:`~decimal.Decimal` values, which since 9.0 displayed ``???`` for the default tolerance and reported the raw ``rel`` ratio instead of the absolute tolerance actually compared against.

--- a/changelog/15006.improvement.rst
+++ b/changelog/15006.improvement.rst
@@ -1,0 +1,1 @@
+:func:`pytest.approx` now emits :class:`pytest.PytestApproxDecimalToleranceWarning` when a ``rel`` or ``abs`` tolerance is given as a :class:`float` that cannot be represented exactly for a :class:`~decimal.Decimal` comparison, since such a tolerance is widened to the float's exact binary value.

--- a/doc/en/reference/reference.rst
+++ b/doc/en/reference/reference.rst
@@ -1290,6 +1290,9 @@ Custom warnings generated in some situations such as improper usage or deprecate
 .. autoclass:: pytest.PytestWarning
    :show-inheritance:
 
+.. autoclass:: pytest.PytestApproxDecimalToleranceWarning
+   :show-inheritance:
+
 .. autoclass:: pytest.PytestAssertRewriteWarning
    :show-inheritance:
 

--- a/src/_pytest/approx.py
+++ b/src/_pytest/approx.py
@@ -12,6 +12,7 @@ from collections.abc import Sized
 from datetime import datetime
 from datetime import timedelta
 from decimal import Decimal
+from decimal import FloatOperation
 import math
 from numbers import Complex
 import pprint
@@ -28,6 +29,34 @@ if TYPE_CHECKING:
     from numpy import ndarray
 else:
     ndarray = object
+
+
+def _max_diff(current: Any, candidate: Any) -> Any:
+    """Track a running maximum without seeding it with a value of another type.
+
+    Seeding with ``-math.inf`` compares a float against whatever is being
+    accumulated. For Decimal that comparison is exact, but it signals
+    ``decimal.FloatOperation`` when that trap is set, and the sequence variant
+    used to swallow the signal (``decimal.FloatOperation`` is a ``TypeError``
+    subclass) and report ``-inf`` as the difference.
+    """
+    return candidate if current is None else max(current, candidate)
+
+
+def _vetted_diffs(
+    max_abs_diff: Any, max_rel_diff: Any, rel_diff_is_infinite: bool
+) -> tuple[Any, Any]:
+    """Turn the accumulators into the values shown in the failure message.
+
+    ``-math.inf`` means "no difference could be computed at all", which happens
+    when every mismatched element is a non-number (#13012).
+    """
+    if rel_diff_is_infinite:
+        max_rel_diff = math.inf
+    return (
+        -math.inf if max_abs_diff is None else max_abs_diff,
+        -math.inf if max_rel_diff is None else max_rel_diff,
+    )
 
 
 def _compare_approx(
@@ -153,7 +182,6 @@ class ApproxNumpy(Approx[ndarray]):
 
     def _repr_compare(self, other_side: ndarray | list[Any]) -> list[str]:
         import itertools
-        import math
 
         def get_value_from_nested_list(
             nested_list: list[Any], nd_index: tuple[Any, ...]
@@ -183,20 +211,25 @@ class ApproxNumpy(Approx[ndarray]):
             ]
 
         number_of_elements = self.expected.size
-        max_abs_diff = -math.inf
-        max_rel_diff = -math.inf
+        max_abs_diff: Any = None
+        max_rel_diff: Any = None
+        rel_diff_is_infinite = False
         different_ids = []
         for index in itertools.product(*(range(i) for i in np_array_shape)):
             approx_value = get_value_from_nested_list(approx_side_as_seq, index)
             other_value = get_value_from_nested_list(other_side_as_array, index)
             if approx_value != other_value:
                 abs_diff = abs(approx_value.expected - other_value)
-                max_abs_diff = max(max_abs_diff, abs_diff)
-                if other_value == 0.0:
-                    max_rel_diff = math.inf
+                max_abs_diff = _max_diff(max_abs_diff, abs_diff)
+                if other_value == 0:
+                    rel_diff_is_infinite = True
                 else:
-                    max_rel_diff = max(max_rel_diff, abs_diff / abs(other_value))
+                    max_rel_diff = _max_diff(max_rel_diff, abs_diff / abs(other_value))
                 different_ids.append(index)
+
+        max_abs_diff, max_rel_diff = _vetted_diffs(
+            max_abs_diff, max_rel_diff, rel_diff_is_infinite
+        )
 
         message_data = [
             (
@@ -270,7 +303,6 @@ class ApproxMapping(Approx[Mapping[Any, Any]]):
         return f"approx({ ({k: self._approx_scalar(v) for k, v in self.expected.items()})!r})"
 
     def _repr_compare(self, other_side: Mapping[object, float]) -> list[str]:
-        import math
 
         if len(self.expected) != len(other_side):
             return [
@@ -289,23 +321,24 @@ class ApproxMapping(Approx[Mapping[Any, Any]]):
         }
 
         number_of_elements = len(approx_side_as_map)
-        max_abs_diff = -math.inf
-        max_rel_diff = -math.inf
+        max_abs_diff: Any = None
+        max_rel_diff: Any = None
+        rel_diff_is_infinite = False
         different_ids = []
         for approx_key, approx_value in approx_side_as_map.items():
             other_value = other_side[approx_key]
             if approx_value != other_value:
                 if approx_value.expected is not None and other_value is not None:
                     try:
-                        max_abs_diff = max(
+                        max_abs_diff = _max_diff(
                             max_abs_diff,
                             # TODO: The type error here seems correct.
                             abs(approx_value.expected - other_value),  # type: ignore[operator]
                         )
-                        if approx_value.expected == 0.0:
-                            max_rel_diff = math.inf
+                        if approx_value.expected == 0:
+                            rel_diff_is_infinite = True
                         else:
-                            max_rel_diff = max(
+                            max_rel_diff = _max_diff(
                                 max_rel_diff,
                                 abs(
                                     # TODO: The type error here seems correct.
@@ -316,6 +349,10 @@ class ApproxMapping(Approx[Mapping[Any, Any]]):
                     except ZeroDivisionError:
                         pass
                 different_ids.append(approx_key)
+
+        max_abs_diff, max_rel_diff = _vetted_diffs(
+            max_abs_diff, max_rel_diff, rel_diff_is_infinite
+        )
 
         message_data = [
             (str(key), str(other_side[key]), str(approx_side_as_map[key]))
@@ -371,7 +408,6 @@ class ApproxSequenceLike(Approx[Sequence[Any]]):
         return f"approx({seq_type(self._approx_scalar(x) for x in self.expected)!r})"
 
     def _repr_compare(self, other_side: Sequence[float]) -> list[str]:
-        import math
 
         if len(self.expected) != len(other_side):
             return [
@@ -382,8 +418,9 @@ class ApproxSequenceLike(Approx[Sequence[Any]]):
         approx_side_as_map = _recursive_sequence_map(self._approx_scalar, self.expected)
 
         number_of_elements = len(approx_side_as_map)
-        max_abs_diff = -math.inf
-        max_rel_diff = -math.inf
+        max_abs_diff: Any = None
+        max_rel_diff: Any = None
+        rel_diff_is_infinite = False
         different_ids = []
         for i, (approx_value, other_value) in enumerate(
             zip(approx_side_as_map, other_side, strict=True)
@@ -391,16 +428,26 @@ class ApproxSequenceLike(Approx[Sequence[Any]]):
             if approx_value != other_value:
                 try:
                     abs_diff = abs(approx_value.expected - other_value)
-                    max_abs_diff = max(max_abs_diff, abs_diff)
+                    max_abs_diff = _max_diff(max_abs_diff, abs_diff)
+                # decimal.FloatOperation subclasses TypeError, so it would be
+                # caught below and reported as a missing difference.
+                except FloatOperation:
+                    raise
                 # Ignore non-numbers for the diff calculations (#13012).
                 except TypeError:
                     pass
                 else:
-                    if other_value == 0.0:
-                        max_rel_diff = math.inf
+                    if other_value == 0:
+                        rel_diff_is_infinite = True
                     else:
-                        max_rel_diff = max(max_rel_diff, abs_diff / abs(other_value))
+                        max_rel_diff = _max_diff(
+                            max_rel_diff, abs_diff / abs(other_value)
+                        )
                 different_ids.append(i)
+
+        max_abs_diff, max_rel_diff = _vetted_diffs(
+            max_abs_diff, max_rel_diff, rel_diff_is_infinite
+        )
         message_data = [
             (str(i), str(other_side[i]), str(approx_side_as_map[i]))
             for i in different_ids

--- a/src/_pytest/approx.py
+++ b/src/_pytest/approx.py
@@ -482,7 +482,14 @@ class ApproxScalar(Approx[ExpectedT]):
         # If a sensible tolerance can't be calculated, self.tolerance will
         # raise a ValueError.  In this case, display '???'.
         try:
-            if 1e-3 <= self.tolerance < 1e3:
+            if isinstance(self.tolerance, Decimal):
+                # Never let a Decimal meet a float literal: comparing against
+                # 1e-3/1e3 signals decimal.FloatOperation when that trap is set
+                # (#13530). Scientific notation is also the only readable choice
+                # here, because a tolerance derived from a float carries its
+                # full exact binary expansion (dozens of digits).
+                vetted_tolerance = f"{self.tolerance:.1e}"
+            elif 1e-3 <= self.tolerance < 1e3:
                 vetted_tolerance = f"{self.tolerance:n}"
             else:
                 vetted_tolerance = f"{self.tolerance:.1e}"
@@ -557,12 +564,12 @@ class ApproxScalar(Approx[ExpectedT]):
             self.abs if self.abs is not None else self.DEFAULT_ABSOLUTE_TOLERANCE
         )
 
+        if _is_nan(absolute_tolerance):
+            raise ValueError("absolute tolerance can't be NaN.")
         if absolute_tolerance < 0:
             raise ValueError(
                 f"absolute tolerance can't be negative: {absolute_tolerance}"
             )
-        if _is_nan(absolute_tolerance):
-            raise ValueError("absolute tolerance can't be NaN.")
 
         # If the user specified an absolute tolerance but not a relative one,
         # just return the absolute tolerance.
@@ -581,12 +588,12 @@ class ApproxScalar(Approx[ExpectedT]):
         abs_expected: ExpectedT = abs(self.expected)  # type: ignore[arg-type]
         relative_tolerance: float | Decimal = rel * abs_expected  # type: ignore[operator]
 
+        if _is_nan(relative_tolerance):
+            raise ValueError("relative tolerance can't be NaN.")
         if relative_tolerance < 0:
             raise ValueError(
                 f"relative tolerance can't be negative: {relative_tolerance}"
             )
-        if _is_nan(relative_tolerance):
-            raise ValueError("relative tolerance can't be NaN.")
 
         # Return the larger of the relative and absolute tolerances.
         return max(relative_tolerance, absolute_tolerance)
@@ -616,15 +623,6 @@ class ApproxDecimal(ApproxScalar[Decimal]):
         else:
             abs_ = abs
         super().__init__(expected, rel_, abs_, nan_ok)
-
-    def __repr__(self) -> str:
-        tol_str = "???"
-        if self.rel is not None and Decimal("1e-3") <= self.rel <= Decimal("1e3"):
-            tol_str = f"{self.rel:.1e}"
-        elif self.abs is not None:
-            tol_str = f"{self.abs:.1e}"
-
-        return f"{self.expected} ± {tol_str}"
 
 
 class ApproxTimedelta(Approx[datetime | timedelta]):

--- a/src/_pytest/approx.py
+++ b/src/_pytest/approx.py
@@ -273,10 +273,13 @@ class ApproxNumpy(Approx[ndarray]):
 
         if np.isscalar(actual):
             for i in np.ndindex(self.expected.shape):
-                yield actual, self.expected[i].item()
+                yield actual, _unbox_numpy_scalar(self.expected[i])
         else:
             for i in np.ndindex(self.expected.shape):
-                yield actual[i].item(), self.expected[i].item()
+                yield (
+                    _unbox_numpy_scalar(actual[i]),
+                    _unbox_numpy_scalar(self.expected[i]),
+                )
 
 
 class ApproxMapping(Approx[Mapping[Any, Any]]):
@@ -1050,6 +1053,16 @@ def _as_numpy_array(obj: object) -> ndarray | None:
         elif hasattr(obj, "__array__") or hasattr(obj, "__array_interface__"):
             return np.asarray(obj)
     return None
+
+
+def _unbox_numpy_scalar(value: Any) -> Any:
+    """Return the Python object behind a numpy scalar.
+
+    Indexing an object-dtype array yields the stored Python object, which has
+    no ``item()`` of its own -- only numpy's own scalar types need unboxing.
+    """
+    item = getattr(value, "item", None)
+    return value if item is None else item()
 
 
 def _is_bool(val: Any) -> bool:

--- a/src/_pytest/approx.py
+++ b/src/_pytest/approx.py
@@ -475,7 +475,7 @@ class ApproxScalar(Approx[ExpectedT]):
         if (
             _is_bool(self.expected)
             or (not isinstance(self.expected, Complex | Decimal))
-            or math.isinf(abs(self.expected))
+            or _is_inf(abs(self.expected))
         ):
             return str(self.expected)
 
@@ -490,7 +490,7 @@ class ApproxScalar(Approx[ExpectedT]):
             if (
                 isinstance(self.expected, Complex)
                 and self.expected.imag
-                and not math.isinf(self.tolerance)
+                and not _is_inf(self.tolerance)
             ):
                 vetted_tolerance += " ∠ ±180°"
         except ValueError:
@@ -526,8 +526,8 @@ class ApproxScalar(Approx[ExpectedT]):
         # Allow the user to control whether NaNs are considered equal to each
         # other or not.  The abs() calls are for compatibility with complex
         # numbers.
-        if math.isnan(abs(self.expected)):
-            return self.nan_ok and math.isnan(abs(actual))
+        if _is_nan(abs(self.expected)):
+            return self.nan_ok and _is_nan(abs(actual))
 
         # Infinity shouldn't be approximately equal to anything but itself, but
         # if there's a relative tolerance, it will be infinite and infinity
@@ -535,7 +535,7 @@ class ApproxScalar(Approx[ExpectedT]):
         # case would have been short circuited above, so here we can just
         # return false if the expected value is infinite.  The abs() call is
         # for compatibility with complex numbers.
-        if math.isinf(abs(self.expected)):
+        if _is_inf(abs(self.expected)):
             return False
 
         # Return true if the two numbers are within the tolerance.
@@ -561,7 +561,7 @@ class ApproxScalar(Approx[ExpectedT]):
             raise ValueError(
                 f"absolute tolerance can't be negative: {absolute_tolerance}"
             )
-        if math.isnan(absolute_tolerance):
+        if _is_nan(absolute_tolerance):
             raise ValueError("absolute tolerance can't be NaN.")
 
         # If the user specified an absolute tolerance but not a relative one,
@@ -585,7 +585,7 @@ class ApproxScalar(Approx[ExpectedT]):
             raise ValueError(
                 f"relative tolerance can't be negative: {relative_tolerance}"
             )
-        if math.isnan(relative_tolerance):
+        if _is_nan(relative_tolerance):
             raise ValueError("relative tolerance can't be NaN.")
 
         # Return the larger of the relative and absolute tolerances.
@@ -1014,3 +1014,17 @@ def _is_bool(val: Any) -> bool:
     if np := sys.modules.get("numpy"):
         return isinstance(val, np.bool_)
     return False
+
+
+def _is_nan(val: Any) -> bool:
+    # Decimal must not go through float(), which loses exactness and turns
+    # out-of-float-range values into infinities (see #15005).
+    if isinstance(val, Decimal):
+        return val.is_nan()
+    return math.isnan(val)
+
+
+def _is_inf(val: Any) -> bool:
+    if isinstance(val, Decimal):
+        return val.is_infinite()
+    return math.isinf(val)

--- a/src/_pytest/approx.py
+++ b/src/_pytest/approx.py
@@ -23,6 +23,9 @@ from typing import SupportsAbs
 from typing import TYPE_CHECKING
 from typing import TypeGuard
 from typing import TypeVar
+import warnings
+
+from _pytest.warning_types import PytestApproxDecimalToleranceWarning
 
 
 if TYPE_CHECKING:
@@ -1002,6 +1005,8 @@ def approx(
 
     __tracebackhide__ = True
 
+    _warn_on_inexact_decimal_tolerance(expected, rel, abs)
+
     if isinstance(expected, Decimal):
         return ApproxDecimal(expected, rel=rel, abs=abs, nan_ok=nan_ok)  # type: ignore[return-value]
     elif isinstance(expected, Mapping):
@@ -1017,6 +1022,55 @@ def approx(
         return ApproxTimedelta(expected, rel=rel, abs=abs, nan_ok=nan_ok)  # type: ignore[return-value]
     else:
         return ApproxScalar(expected, rel=rel, abs=abs, nan_ok=nan_ok)
+
+
+def _contains_decimal(expected: object) -> bool:
+    """Whether a comparison against ``expected`` will use Decimal arithmetic."""
+    if isinstance(expected, Decimal):
+        return True
+    if isinstance(expected, Mapping):
+        return any(isinstance(value, Decimal) for value in expected.values())
+    if _is_sequence_like(expected):
+        # ``.flat`` also makes a 0-d numpy array iterable, which it is not
+        # otherwise, despite being sized and subscriptable.
+        values = getattr(expected, "flat", expected)
+        return any(isinstance(value, Decimal) for value in values)
+    return False
+
+
+def _warn_on_inexact_decimal_tolerance(
+    expected: object,
+    rel: float | Decimal | timedelta | None,
+    abs: float | Decimal | timedelta | None,
+) -> None:
+    """Warn when a float tolerance is used for a Decimal comparison.
+
+    A float tolerance is converted with ``Decimal.from_float()``, which is
+    exact and therefore keeps the float's full binary expansion: ``rel=0.01``
+    really means a tolerance of ``0.010000000000000000208...``. That is wider
+    than the ``0.01`` that was written, which defeats the point of comparing
+    Decimals in the first place.
+
+    Only floats that cannot be represented exactly are worth warning about;
+    ``0.5`` and friends survive the conversion unchanged, as do ints.
+    """
+    inexact = [
+        (name, value)
+        for name, value in (("rel", rel), ("abs", abs))
+        if type(value) is float and Decimal.from_float(value) != Decimal(repr(value))
+    ]
+    if not inexact or not _contains_decimal(expected):
+        return
+    for name, value in inexact:
+        warnings.warn(
+            PytestApproxDecimalToleranceWarning(
+                f"{name}={value!r} cannot be represented exactly as a Decimal "
+                f"and was widened to {Decimal.from_float(value)}.\n"
+                f"Pass {name}=Decimal({str(value)!r}) to compare against the "
+                f"tolerance you wrote."
+            ),
+            stacklevel=3,
+        )
 
 
 def _is_sequence_like(expected: object) -> TypeGuard[Sequence[Any]]:

--- a/src/_pytest/warning_types.py
+++ b/src/_pytest/warning_types.py
@@ -135,6 +135,14 @@ class UnformattedWarning(Generic[_W]):
 
 
 @final
+class PytestApproxDecimalToleranceWarning(PytestWarning):
+    """Warning emitted when :func:`pytest.approx` is given a float tolerance
+    for a :class:`~decimal.Decimal` comparison."""
+
+    __module__ = "pytest"
+
+
+@final
 class PytestFDWarning(PytestWarning):
     """When the lsof plugin finds leaked fds."""
 

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -79,6 +79,7 @@ from _pytest.subtests import Subtests
 from _pytest.terminal import TerminalReporter
 from _pytest.terminal import TestShortLogReport
 from _pytest.tmpdir import TempPathFactory
+from _pytest.warning_types import PytestApproxDecimalToleranceWarning
 from _pytest.warning_types import PytestAssertRewriteWarning
 from _pytest.warning_types import PytestCacheWarning
 from _pytest.warning_types import PytestCollectionWarning
@@ -130,6 +131,7 @@ __all__ = [
     "OptionGroup",
     "Package",
     "Parser",
+    "PytestApproxDecimalToleranceWarning",
     "PytestAssertRewriteWarning",
     "PytestCacheWarning",
     "PytestCollectionWarning",

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -1099,14 +1099,73 @@ class TestApprox:
         assert repr(approx_obj) == "2.60 ± 2.6e-6"
 
     def test_decimal_approx_float_rel(self) -> None:
-        approx_obj = pytest.approx(decimal.Decimal("2.60"), rel=0.01)
+        with pytest.warns(pytest.PytestApproxDecimalToleranceWarning):
+            approx_obj = pytest.approx(decimal.Decimal("2.60"), rel=0.01)
         assert decimal.Decimal("2.600001") == approx_obj
         assert repr(approx_obj) == "2.60 ± 2.6e-2"
 
     def test_decimal_approx_float_abs(self) -> None:
-        approx_obj = pytest.approx(decimal.Decimal("2.60"), abs=0.01)
+        with pytest.warns(pytest.PytestApproxDecimalToleranceWarning):
+            approx_obj = pytest.approx(decimal.Decimal("2.60"), abs=0.01)
         assert decimal.Decimal("2.600001") == approx_obj
         assert repr(approx_obj) == "2.60 ± 1.0e-2"
+
+    @pytest.mark.parametrize(
+        ("expected", "kwargs"),
+        (
+            pytest.param(Decimal("2.60"), {"rel": 0.01}, id="scalar-rel"),
+            pytest.param(Decimal("2.60"), {"abs": 0.01}, id="scalar-abs"),
+            pytest.param([Decimal("2.60")], {"rel": 0.01}, id="sequence"),
+            pytest.param({"a": Decimal("2.60")}, {"rel": 0.01}, id="mapping"),
+        ),
+    )
+    def test_inexact_float_tolerance_warns(self, expected, kwargs) -> None:
+        """A float tolerance is widened to its exact binary value (#15006)."""
+        name = next(iter(kwargs))
+        with pytest.warns(
+            pytest.PytestApproxDecimalToleranceWarning,
+            match=rf"{name}=0\.01 cannot be represented exactly",
+        ):
+            approx(expected, **kwargs)
+
+    @pytest.mark.parametrize(
+        ("expected", "kwargs"),
+        (
+            pytest.param(2.60, {"rel": 0.01}, id="float-expected"),
+            pytest.param([1.0, 2.0], {"rel": 0.01}, id="float-sequence"),
+            pytest.param(Decimal("2.60"), {}, id="no-tolerance"),
+            pytest.param(Decimal("2.60"), {"rel": Decimal("0.01")}, id="decimal-rel"),
+            pytest.param(Decimal("2.60"), {"rel": 0.5}, id="exactly-representable"),
+            pytest.param(Decimal("2.60"), {"rel": 1}, id="int-rel"),
+        ),
+    )
+    def test_exact_tolerance_does_not_warn(self, expected, kwargs, recwarn) -> None:
+        approx(expected, **kwargs)
+        assert not [
+            w
+            for w in recwarn
+            if issubclass(w.category, pytest.PytestApproxDecimalToleranceWarning)
+        ]
+
+    def test_inexact_float_tolerance_warns_once_at_the_call_site(
+        self, pytester: Pytester
+    ) -> None:
+        """The warning must point at the user's line, not into approx itself."""
+        pytester.makepyfile(
+            """
+            from decimal import Decimal
+            import pytest
+
+            def test_seq():
+                values = [Decimal(i) for i in range(20)]
+                assert values == pytest.approx(values, rel=0.01)
+            """
+        )
+        result = pytester.runpytest("-Wdefault")
+        result.assert_outcomes(passed=1, warnings=1)
+        result.stdout.fnmatch_lines(
+            ["*:6: PytestApproxDecimalToleranceWarning: rel=0.01 *"]
+        )
 
     @pytest.mark.parametrize(
         ("kwargs", "expected_repr"),

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -1125,6 +1125,51 @@ class TestApprox:
         assert repr(approx(Decimal("NaN"))) == "NaN ± ???"
         assert repr(approx(nan)) == "nan ± ???"
 
+    @pytest.mark.parametrize(
+        ("other", "expected", "wanted"),
+        (
+            pytest.param(
+                [Decimal(1), Decimal(2)],
+                [Decimal(1), Decimal(9)],
+                ["Max absolute difference: 7", "Max relative difference: 3.5"],
+                id="sequence",
+            ),
+            pytest.param(
+                [Decimal(0)],
+                [Decimal(1)],
+                ["Max absolute difference: 1", "Max relative difference: inf"],
+                id="sequence-divide-by-zero",
+            ),
+            pytest.param(
+                {"a": Decimal(1)},
+                {"a": Decimal(9)},
+                [
+                    "Max absolute difference: 8",
+                    "Max relative difference: 0.8888888888888888888888888889",
+                ],
+                id="mapping",
+            ),
+            pytest.param(
+                {"a": Decimal(9)},
+                {"a": Decimal(0)},
+                ["Max absolute difference: 9", "Max relative difference: inf"],
+                id="mapping-divide-by-zero",
+            ),
+        ),
+    )
+    def test_decimal_repr_compare_is_float_free(
+        self, monkeypatch, other, expected, wanted
+    ) -> None:
+        """The failure message must not mix Decimals with float sentinels.
+
+        The sequence variant used to report ``-inf`` here, because
+        decimal.FloatOperation subclasses TypeError and was swallowed by the
+        handler meant for non-numbers.
+        """
+        monkeypatch.setitem(decimal.getcontext().traps, decimal.FloatOperation, True)
+        explanation = approx(expected)._repr_compare(other)
+        assert explanation[1:3] == wanted
+
     def test_decimal_nan_tolerance_raises_value_error(self) -> None:
         """A Decimal NaN tolerance must not escape as decimal.InvalidOperation."""
         nan_abs = approx(Decimal(1), abs=Decimal("NaN"))

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -858,6 +858,22 @@ class TestApprox:
         assert a12 != approx(a21)
         assert a21 != approx(a12)
 
+    @pytest.mark.parametrize(
+        ("values", "offset"),
+        (
+            pytest.param([Decimal("1.0"), Decimal("2.0")], Decimal(5), id="decimal"),
+            pytest.param([1.0, 2.0], 5.0, id="float"),
+            pytest.param([Fraction(1), Fraction(2)], Fraction(5), id="fraction"),
+        ),
+    )
+    def test_numpy_object_dtype(self, values, offset) -> None:
+        """Object arrays hold plain Python objects, which have no item()."""
+        np = pytest.importorskip("numpy")
+
+        expected = np.array(values, dtype=object)
+        assert expected == approx(expected)
+        assert np.array([v + offset for v in values], dtype=object) != approx(expected)
+
     def test_numpy_array_implicit_conversion(self):
         np = pytest.importorskip("numpy")
 

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -849,6 +849,13 @@ class TestApprox:
             assert op(a, approx(np.array(x)))
             assert op(np.array(a), approx(np.array(x)))
 
+    def test_numpy_actual_not_convertible(self):
+        np = pytest.importorskip("numpy")
+
+        with pytest.raises(TypeError, match=r"cannot compare .* to numpy\.ndarray"):
+            # A ragged nested sequence has no array representation.
+            [[1, 2], [3]] == approx(np.array([[1, 2], [3, 4]]))
+
     def test_numpy_array_wrong_shape(self):
         np = pytest.importorskip("numpy")
 
@@ -1244,6 +1251,37 @@ class TestApprox:
         monkeypatch.setitem(decimal.getcontext().traps, decimal.FloatOperation, True)
         explanation = approx(expected)._repr_compare(other)
         assert explanation[1:3] == wanted
+
+    def test_mapping_relative_diff_undefined(self) -> None:
+        """A zero expected value that does not compare equal to 0.
+
+        timedelta(0) != 0, so the divide-by-zero guard does not catch it and
+        the relative difference stays unknown.
+        """
+        explanation = approx({"a": datetime.timedelta(0)}, rel=0.01)._repr_compare(
+            {"a": datetime.timedelta(seconds=1)}
+        )
+        assert explanation[1:3] == [
+            "Max absolute difference: 0:00:01",
+            "Max relative difference: -inf",
+        ]
+
+    def test_mixed_decimal_and_float_sequence_does_not_hide_float_operation(
+        self, monkeypatch
+    ) -> None:
+        """Comparing the running maximum can still mix a Decimal with a float.
+
+        decimal.FloatOperation subclasses TypeError, so without the explicit
+        re-raise it would be swallowed as a non-number and the reported maximum
+        would silently be the smaller of the two differences.
+        """
+        expected = [Decimal(9), 9.0]
+        other = [Decimal(1), 2.0]
+        assert approx(expected)._repr_compare(other)[1] == "Max absolute difference: 8"
+
+        monkeypatch.setitem(decimal.getcontext().traps, decimal.FloatOperation, True)
+        with pytest.raises(decimal.FloatOperation):
+            approx(expected)._repr_compare(other)
 
     def test_decimal_nan_tolerance_raises_value_error(self) -> None:
         """A Decimal NaN tolerance must not escape as decimal.InvalidOperation."""

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -15,6 +15,7 @@ from operator import ne
 import re
 
 from _pytest.approx import _recursive_sequence_map
+from _pytest.approx import ApproxScalar
 from _pytest.pytester import Pytester
 import pytest
 from pytest import approx
@@ -1077,16 +1078,64 @@ class TestApprox:
         monkeypatch.setitem(decimal.getcontext().traps, decimal.FloatOperation, True)
         approx_obj = pytest.approx(decimal.Decimal("2.60"))
         assert decimal.Decimal("2.600001") == approx_obj
+        # Building the repr must not touch a float either (#13530); asserting
+        # only the comparison above is what let #15006 slip through.
+        assert repr(approx_obj) == "2.60 ± 2.6e-6"
 
     def test_decimal_approx_float_rel(self) -> None:
         approx_obj = pytest.approx(decimal.Decimal("2.60"), rel=0.01)
         assert decimal.Decimal("2.600001") == approx_obj
-        assert repr(approx_obj) == "2.60 ± 1.0e-2"
+        assert repr(approx_obj) == "2.60 ± 2.6e-2"
 
     def test_decimal_approx_float_abs(self) -> None:
         approx_obj = pytest.approx(decimal.Decimal("2.60"), abs=0.01)
         assert decimal.Decimal("2.600001") == approx_obj
         assert repr(approx_obj) == "2.60 ± 1.0e-2"
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected_repr"),
+        (
+            ({}, "2.60 ± 2.6e-6"),
+            ({"rel": Decimal("1e-6")}, "2.60 ± 2.6e-6"),
+            ({"rel": Decimal("0.01")}, "2.60 ± 2.6e-2"),
+            ({"abs": Decimal("0.01")}, "2.60 ± 1.0e-2"),
+            ({"rel": Decimal("0.01"), "abs": Decimal(1)}, "2.60 ± 1.0e+0"),
+        ),
+    )
+    def test_decimal_repr_shows_effective_tolerance(
+        self, kwargs, expected_repr
+    ) -> None:
+        """The ± value is the band actually compared against, not ``rel`` (#15006)."""
+        approx_obj = approx(Decimal("2.60"), **kwargs)
+        assert isinstance(approx_obj, ApproxScalar)
+        assert repr(approx_obj) == expected_repr
+        assert Decimal("2.60") + approx_obj.tolerance == approx_obj
+
+    def test_decimal_repr_outside_float_range(self) -> None:
+        """Reprs must not go through float() any more than comparisons do (#15005)."""
+        assert (
+            repr(approx(Decimal("1e400"), rel=Decimal("1e-6"))) == "1E+400 ± 1.0e+394"
+        )
+        assert repr(approx(Decimal("1e-400"))) == "1E-400 ± 1.0e-12"
+
+    def test_decimal_repr_nan_and_infinity(self) -> None:
+        # Infinity is not compared using a tolerance, so none is shown.
+        assert repr(approx(Decimal("Infinity"))) == "Infinity"
+        # A NaN expected value has no sensible tolerance, as for float("nan").
+        assert repr(approx(Decimal("NaN"))) == "NaN ± ???"
+        assert repr(approx(nan)) == "nan ± ???"
+
+    def test_decimal_nan_tolerance_raises_value_error(self) -> None:
+        """A Decimal NaN tolerance must not escape as decimal.InvalidOperation."""
+        nan_abs = approx(Decimal(1), abs=Decimal("NaN"))
+        assert isinstance(nan_abs, ApproxScalar)
+        with pytest.raises(ValueError, match="absolute tolerance can't be NaN"):
+            _ = nan_abs.tolerance
+
+        nan_rel = approx(Decimal(1), rel=Decimal("NaN"))
+        assert isinstance(nan_rel, ApproxScalar)
+        with pytest.raises(ValueError, match="relative tolerance can't be NaN"):
+            _ = nan_rel.tolerance
 
     def test_allow_ordered_sequences_only(self) -> None:
         """pytest.approx() should raise an error on unordered sequences (#9692)."""

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -620,6 +620,19 @@ class TestApprox:
             assert approx(x, rel=0, abs=Decimal("5e-3")) == a
             assert approx(x, rel=0, abs=Decimal("5e-7")) != a
 
+    def test_decimal_outside_float_range(self):
+        """Decimals beyond the float range must not be treated as infinite (#15005)."""
+        expected = Decimal("1e400")
+        actual = Decimal("1.0000001e400")
+        rel = Decimal("1e-6")
+        assert actual == approx(expected, rel=rel)
+        assert actual == approx(expected, abs=rel * expected)
+        assert Decimal("2e400") != approx(expected, rel=rel)
+        # Actual infinities keep behaving as before.
+        assert Decimal("Infinity") == approx(Decimal("Infinity"))
+        assert expected != approx(Decimal("Infinity"))
+        assert Decimal("Infinity") != approx(expected)
+
     def test_fraction(self):
         within_1e6 = [
             (1 + Fraction(1, 1000000), Fraction(1)),


### PR DESCRIPTION
This was explored and written by an AI agent (Claude Opus 5 via Claude Code) that I prompted. The diagnosis, the patches, the tests and this description are its work; I read it, reproduced it and am posting it.

Closes #15005.

A cleanup pass over `pytest.approx`, starting from #15005 and following the same mistake through the module. Five commits, each standalone with its own changelog fragment — reviewable and revertable one at a time.

`Decimal` and `float` meet in `_pytest/approx.py` in two ways, and only one is lossy:

* **`float(Decimal)` saturates.** `float(Decimal("1e400"))` is `inf` and `float(Decimal("1e-400"))` is `0.0`, silently. Every `math.*` call on a Decimal takes this route.
* **Comparing a `Decimal` to a `float` is exact.** CPython compares true values (`Decimal("0.1") < 0.1` is correctly `True`). Safe arithmetically; it only signals `decimal.FloatOperation` when that trap is set.

## 1. `nan`/`inf` checks — closes #15005

`math.isnan`/`math.isinf` take the lossy route, so `approx()` treated a finite `Decimal("1e400")` as infinite and short-circuited before the exact Decimal tolerance was used:

```pycon
>>> Decimal("1.0000001e400") == pytest.approx(Decimal("1e400"), rel=Decimal("1e-6"))
False   # difference 1E+393, tolerance 1E+394
```

Five sites, not just the infinity guard the issue names: the same guard in `__repr__`, the NaN checks in `__eq__` (which also raised `ValueError` on `Decimal("sNaN")`), and both NaN validations in `tolerance`. Fixed with `_is_nan`/`_is_inf` helpers using `Decimal.is_nan()`/`Decimal.is_infinite()`. No change for `float`/`complex`; `Decimal("Infinity")` still compares only to itself.

## 2. The displayed tolerance

#13543 fixed the `FloatOperation` crash of #13530 by overriding `__repr__` in `ApproxDecimal` so `self.tolerance` was never touched. The override copied `ApproxScalar`'s `1e-3 <= self.tolerance < 1e3` — where that bound only picks between `:n` and `:.1e` formatting — and reinterpreted it as a gate on whether to show `rel` **at all**. Its test asserted only that `==` stopped crashing, so no repr was pinned and the regression shipped.

| | 8.3.5 | 9.1.1 | here |
|---|---|---|---|
| `approx(Decimal("2.60"))` | `2.60 ± 2.6e-6` | `2.60 ± ???` | `2.60 ± 2.6e-6` |
| `rel=Decimal("1e-6")` | `2.60 ± 2.6e-6` | `2.60 ± ???` | `2.60 ± 2.6e-6` |
| `rel=Decimal("0.01")` | `2.60 ± 2.6e-2` | `2.60 ± 1.0e-2` | `2.60 ± 2.6e-2` |
| `approx(Decimal("Infinity"))` | `Infinity` | `Infinity ± ???` | `Infinity` |
| `approx(Decimal("NaN"))` | raises `InvalidOperation` | `NaN ± ???` | `NaN ± ???` |

The `± N` is the absolute band that decides pass/fail; `rel` is a dimensionless ratio. Printing `rel` there is a unit error — `2.60 ± 1.0e-2` reads as "within 0.01 of 2.60" when the band is 0.026.

The override is dropped and `ApproxScalar.__repr__` made type-correct: for a Decimal tolerance the float-literal bound is skipped and `:.1e` used unconditionally. That is also the only readable choice, since `ApproxDecimal.__init__` converts float tolerances with `Decimal.from_float` — exact, and so 55 digits for `abs=0.01`, which `:n` would print in full.

Removing the override re-exposed a bug it had masked: for a NaN Decimal the negativity check in `tolerance` runs before the NaN check and raises `decimal.InvalidOperation` instead of the `ValueError` that `__repr__` catches. NaN is now checked first, matching the float path — which is why the last row improves on 8.3.5 rather than merely restoring it.

## 3. Float sentinels in failure messages

All three `_repr_compare` implementations seeded their running maxima with `-math.inf` and tested `== 0.0`, so building a message for Decimal collections compared a float against a Decimal. Under the trap the two container variants diverged:

* **`ApproxSequenceLike` swallowed it.** `decimal.FloatOperation` **is a `TypeError` subclass**, so the `except TypeError` added for #13012 to skip non-numbers caught it, and the message reported `Max absolute difference: -inf`.
* **`ApproxMapping` did not**, so it escaped out of the assertion formatting as a bare `decimal.FloatOperation`.

Now accumulated from `None`, with `-math.inf` substituted only at the end where it still means "no difference could be computed" as #13012 needs. Divide-by-zero is a flag rather than a mid-loop `math.inf` assignment, which would reintroduce the mixing on the next element. The sequence variant re-raises `decimal.FloatOperation` explicitly, so a future leak fails loudly instead of reporting `-inf`.

## 4. numpy object dtype

```pycon
>>> np.array([1.0, 2.0], dtype=object) == pytest.approx(np.array([1.0, 2.0], dtype=object))
AttributeError: 'float' object has no attribute 'item'
```

`_yield_comparisons` calls `.item()` to unbox numpy scalars; indexing an object array yields the stored Python object, which has none. Not Decimal-specific — object arrays of `float` and `Fraction` fail identically — but Decimal is how you get there without asking, since `np.asarray([Decimal(1)])` picks object dtype on its own. It fires whenever the *expected* side is an object array.

Not a regression: `.item()` replaced `np.asscalar()` in `42bb0b390` when numpy 1.16 deprecated it, and `np.asscalar()` required an ndarray, so object dtype never worked. Unbox only when the element offers `item()`.

I could not find an existing issue for this (searched `asscalar`, `object dtype`, `dtype=object`, and the error text); the nearest is #12114, a different attribute in a different method.

## 5. Warning on inexact float tolerances

A float tolerance with a Decimal expected value is converted exactly, so it is *wider* than what was written, and that can change the result:

```pycon
>>> Decimal("1.10000000000000000001") == approx(Decimal("1"), rel=0.1)
True     # float band is 0.1000000000000000055511151231
>>> Decimal("1.10000000000000000001") == approx(Decimal("1"), rel=Decimal("0.1"))
False    # Decimal band is exactly 0.1
```

Of the tolerances anyone writes, only dyadic rationals (`0.5`, `0.25`) survive unchanged; `1e-6`, `1e-3`, `0.01`, `0.1`, `5e-6`, `1e-12` are all inexact. New `pytest.PytestApproxDecimalToleranceWarning` fires on those and stays quiet for exact floats, ints, Decimals, and non-Decimal comparisons.

The check lives in `approx()`, not `ApproxDecimal.__init__`. Containers build one `ApproxDecimal` per element from inside generator expressions — measured at 100 for a single `repr()` of a 100-element list — so warning there reports pytest's own source as the location, several times over. In `approx()` it warns once, at the line the user wrote, for scalars and containers alike.

This is also the tolerance half of what @RonnyPfannschmidt asked for on #8495 in 2021 (*"we should definitively warn when we approx compare floats vs Decimals"*) — the half that currently succeeds silently.

## Validation

Beyond the suite, the displayed tolerance was checked to be the actual pass/fail boundary across 65 combinations — magnitudes from `1e-400` to `1e100000`, spanning both float underflow and overflow, crossed with default/`rel`/`abs`/both/`rel=0` — with `decimal.FloatOperation` trapped throughout, so any remaining leak raises rather than passing quietly. The full approx suite also passes with that trap set globally.

## Test gaps closed

* `test_decimal_approx_repr` (the #13530 regression test) asserted only that `==` worked, never a repr — which is exactly how the repr regression shipped. It now pins the repr under the trap.
* `test_decimal_approx_float_rel` pinned the regressed string `1.0e-2`; it was added *after* the regression, so it encoded it.
* New coverage for: effective-tolerance reprs cross-checked against the real comparison boundary; reprs beyond the float range in both directions; `Infinity`/`NaN` reprs; NaN tolerance raising `ValueError` not `InvalidOperation`; Decimal failure messages under the trap for sequences, mappings and both divide-by-zero paths; numpy object arrays of Decimal, float and Fraction; and the warning firing once at the caller's line while staying silent for exact tolerances.

## 6. Coverage

`src/_pytest/approx.py` goes from 99% (4 missed statements and a partial branch) to **100% statement and branch coverage**. Two of the three gaps predate this branch, and all three turned out to be reachable rather than dead:

* a ragged nested sequence is what makes `np.asarray()` fail, reaching `cannot compare ... to numpy.ndarray`;
* `ApproxMapping` guards its relative difference with `expected == 0`, but `timedelta(0)` does not compare equal to `0`, so the division still raises `ZeroDivisionError`;
* the running maximum compares the current best against the next candidate, so a sequence mixing `Decimal` and `float` elements compares the two there — which is exactly the `decimal.FloatOperation` that commit 3 stops swallowing. Before that commit it reported `7` where the real maximum was `8`.

## Not addressed

#8495 (`float` vs `Decimal` values in `__eq__`) still fails identically on this branch — it needs the coercion decision from that thread, which is a larger question than this cleanup. #3247 was checked and no longer reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
