### PR TITLE
ENH expose fixture definitions on Metafunc

### DIFF
--- a/changelog/14991.feature.rst
+++ b/changelog/14991.feature.rst
@@ -1,0 +1,1 @@
+﻿Added ``Metafunc.fixturedefs`` to expose the fixture definitions used by a test function, including transitive dependencies and fixture overrides. The returned tuple reflects fixture definitions after parametrization.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -447,6 +447,48 @@ def traverse_fixture_closure(
         yield from process_argname(argname)
 
 
+def traverse_fixturedef_closure(
+    initialnames: Iterable[str],
+    *,
+    getfixturedefs: Callable[[str], Sequence[FixtureDef[Any]] | None],
+) -> Iterator[FixtureDef[Any]]:
+    """Statically traverse the fixture definition closure in DFS order.
+
+    Each fixture definition is only yielded once.
+    """
+    current_indices: dict[str, int] = {}
+    yielded: set[FixtureDef[Any]] = set()
+
+    def process_argname(argname: str) -> Iterator[FixtureDef[Any]]:
+        index = current_indices.get(argname)
+
+        if index == -1:
+            return
+
+        fixturedefs = getfixturedefs(argname)
+        if not fixturedefs:
+            return
+
+        index = current_indices.get(argname, -1)
+        if -index > len(fixturedefs):
+            return
+
+        fixturedef = fixturedefs[index]
+        current_indices[argname] = index - 1
+
+        if fixturedef not in yielded:
+            yielded.add(fixturedef)
+            yield fixturedef
+
+        for dep in fixturedef.argnames:
+            yield from process_argname(dep)
+
+        current_indices[argname] = index
+
+    for argname in initialnames:
+        yield from process_argname(argname)
+
+
 @dataclasses.dataclass(frozen=True)
 class FuncFixtureInfo:
     """Fixture-related information for a fixture-requesting item (e.g. test

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1293,6 +1293,7 @@ class Metafunc:
 
         #: Set of fixture names required by the test function.
         self.fixturenames = fixtureinfo.names_closure
+        self._initialnames = fixtureinfo.initialnames
 
         #: Class object where the test function is defined in or ``None``.
         self.cls = cls
@@ -1303,6 +1304,16 @@ class Metafunc:
         self._calls: list[CallSpec] = []
 
         self._params_directness: dict[str, Literal["indirect", "direct"]] = {}
+
+    @property
+    def fixturedefs(self) -> tuple[fixtures.FixtureDef[Any], ...]:
+        """Fixture definitions used by the test function."""
+        return tuple(
+            fixtures.traverse_fixturedef_closure(
+                self._initialnames,
+                getfixturedefs=self._arg2fixturedefs.get,
+            )
+        )
 
     def parametrize(
         self,

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -67,6 +67,7 @@ class TestMetafunc:
             name2fixturedefs: dict[str, list[fixtures.FixtureDef[object]]] = {}
 
             def __init__(self, names):
+                self.initialnames = names
                 self.names_closure = names
 
         @dataclasses.dataclass
@@ -110,6 +111,187 @@ class TestMetafunc:
         assert "arg1" in metafunc.fixturenames
         assert metafunc.function is func
         assert metafunc.cls is None
+
+    def test_fixturedefs(self, pytester: Pytester) -> None:
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.fixture
+            def foo():
+                return 1
+
+            def pytest_generate_tests(metafunc):
+                assert len(metafunc.fixturedefs) == 1
+                assert metafunc.fixturedefs[0].argname == "foo"
+
+            def test_func(foo):
+                assert foo == 1
+            """
+        )
+        result = pytester.runpytest("-q")
+        result.assert_outcomes(passed=1)
+
+
+    def test_fixturedefs_with_transitive_dependency(self, pytester: Pytester) -> None:
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.fixture
+            def db():
+                return 1
+
+            @pytest.fixture
+            def app(db):
+                return db
+
+            def pytest_generate_tests(metafunc):
+                fixturedefs = metafunc.fixturedefs
+                assert [fixturedef.argname for fixturedef in fixturedefs] == ["app", "db"]
+
+            def test_func(app):
+                assert app == 1
+            """
+        )
+        result = pytester.runpytest("-q")
+        result.assert_outcomes(passed=1)
+
+
+    def test_fixturedefs_with_override(self, pytester: Pytester) -> None:
+        pytester.makeconftest(
+            """
+            import pytest
+
+            @pytest.fixture
+            def db():
+                return 1
+
+            @pytest.fixture
+            def app(db):
+                return db
+            """
+        )
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.fixture
+            def app(app):
+                return app
+
+            def pytest_generate_tests(metafunc):
+                fixturedefs = metafunc.fixturedefs
+                assert [fixturedef.func.__name__ for fixturedef in fixturedefs] == [
+                    "app",
+                    "app",
+                    "db",
+                ]
+
+            def test_func(app):
+                assert app == 1
+            """
+        )
+        result = pytester.runpytest("-q")
+        result.assert_outcomes(passed=1)
+
+
+    def test_fixturedefs_with_direct_parametrization(self, pytester: Pytester) -> None:
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.fixture
+            def foo():
+                return "fixture"
+
+            def pytest_generate_tests(metafunc):
+                assert metafunc.fixturedefs[0].func.__name__ == "foo"
+                metafunc.parametrize("foo", ["param"])
+                assert metafunc.fixturedefs[0].func.__name__ != "foo"
+
+            def test_func(foo):
+                assert foo == "param"
+            """
+        )
+        result = pytester.runpytest("-q")
+        result.assert_outcomes(passed=1)
+
+
+    def test_fixturedefs_with_unused_override(self, pytester: Pytester) -> None:
+        pytester.makeconftest(
+            """
+            import pytest
+
+            @pytest.fixture
+            def app():
+                return "parent"
+            """
+        )
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.fixture
+            def app():
+                return "local"
+
+            def pytest_generate_tests(metafunc):
+                fixturedefs = metafunc.fixturedefs
+                assert [fixturedef.func.__name__ for fixturedef in fixturedefs] == ["app"]
+
+            def test_func(app):
+                assert app == "local"
+            """
+        )
+        result = pytester.runpytest("-q")
+        result.assert_outcomes(passed=1)
+
+
+    def test_fixturedefs_with_circular_dependency(self, pytester: Pytester) -> None:
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.fixture
+            def a(b):
+                return b
+
+            @pytest.fixture
+            def b(a):
+                return a
+
+            def pytest_generate_tests(metafunc):
+                fixturedefs = metafunc.fixturedefs
+                assert [fixturedef.argname for fixturedef in fixturedefs] == ["a", "b"]
+
+            def test_func(a):
+                pass
+            """
+        )
+        result = pytester.runpytest("-q")
+        result.assert_outcomes(errors=1)
+
+
+    def test_fixturedefs_is_tuple(self, pytester: Pytester) -> None:
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.fixture
+            def foo():
+                return 1
+
+            def pytest_generate_tests(metafunc):
+                assert isinstance(metafunc.fixturedefs, tuple)
+
+            def test_func(foo):
+                assert foo == 1
+            """
+        )
+        result = pytester.runpytest("-q")
+        result.assert_outcomes(passed=1)
+
 
     def test_parametrize_single_arg_trailing_comma(self) -> None:
         """Test that trailing comma in string argnames behaves like tuple argnames.

--- a/testing/python/metafunc.py
+++ b/testing/python/metafunc.py
@@ -132,7 +132,6 @@ class TestMetafunc:
         result = pytester.runpytest("-q")
         result.assert_outcomes(passed=1)
 
-
     def test_fixturedefs_with_transitive_dependency(self, pytester: Pytester) -> None:
         pytester.makepyfile(
             """
@@ -156,7 +155,6 @@ class TestMetafunc:
         )
         result = pytester.runpytest("-q")
         result.assert_outcomes(passed=1)
-
 
     def test_fixturedefs_with_override(self, pytester: Pytester) -> None:
         pytester.makeconftest(
@@ -195,7 +193,6 @@ class TestMetafunc:
         result = pytester.runpytest("-q")
         result.assert_outcomes(passed=1)
 
-
     def test_fixturedefs_with_direct_parametrization(self, pytester: Pytester) -> None:
         pytester.makepyfile(
             """
@@ -216,7 +213,6 @@ class TestMetafunc:
         )
         result = pytester.runpytest("-q")
         result.assert_outcomes(passed=1)
-
 
     def test_fixturedefs_with_unused_override(self, pytester: Pytester) -> None:
         pytester.makeconftest(
@@ -247,7 +243,6 @@ class TestMetafunc:
         result = pytester.runpytest("-q")
         result.assert_outcomes(passed=1)
 
-
     def test_fixturedefs_with_circular_dependency(self, pytester: Pytester) -> None:
         pytester.makepyfile(
             """
@@ -272,7 +267,6 @@ class TestMetafunc:
         result = pytester.runpytest("-q")
         result.assert_outcomes(errors=1)
 
-
     def test_fixturedefs_is_tuple(self, pytester: Pytester) -> None:
         pytester.makepyfile(
             """
@@ -291,7 +285,6 @@ class TestMetafunc:
         )
         result = pytester.runpytest("-q")
         result.assert_outcomes(passed=1)
-
 
     def test_parametrize_single_arg_trailing_comma(self) -> None:
         """Test that trailing comma in string argnames behaves like tuple argnames.


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #14991

#### What does this implement/fix? Explain your changes?

Adds a public `Metafunc.fixturedefs` property that exposes the fixture definitions used by a test function.

The returned tuple includes transitive fixture dependencies and correctly follows fixture override resolution. It also reflects direct parametrization applied during `pytest_generate_tests`.

Tests cover direct fixtures, transitive dependencies, overrides, parametrization, circular dependencies, and the immutable tuple API.