### PR TITLE
docs: import sys in the captured output example

### DIFF
--- a/doc/en/how-to/capture-stdout-stderr.rst
+++ b/doc/en/how-to/capture-stdout-stderr.rst
@@ -121,6 +121,9 @@ Here is an example test function that performs some output related checks:
 
 .. code-block:: python
 
+    import sys
+
+
     def test_myoutput(capsys):  # or use "capfd" for fd-level
         print("hello")
         sys.stderr.write("world\n")


### PR DESCRIPTION
Add the missing `sys` import to the `capsys` example, which writes to `sys.stderr`.

Validation: copied the original snippet into a standalone test module and confirmed it fails with `NameError: name 'sys' is not defined`; the updated snippet passes using this checkout. The Sphinx HTML build passes with warnings treated as errors.
