### PR TITLE
[rejected ai] fix: don't crash approx()'s diff formatter on non-numeric mapping values

### DIFF
--- a/src/_pytest/approx.py
+++ b/src/_pytest/approx.py
@@ -315,6 +315,9 @@ class ApproxMapping(Approx[Mapping[Any, Any]]):
                             )
                     except ZeroDivisionError:
                         pass
+                    # Ignore non-numbers for the diff calculations (#15009).
+                    except TypeError:
+                        pass
                 different_ids.append(approx_key)
 
         message_data = [

--- a/testing/python/approx.py
+++ b/testing/python/approx.py
@@ -1105,6 +1105,22 @@ class TestApprox:
         ):
             assert actual == approx(expected)
 
+    def test_approx_dicts_with_nonnumeric_mismatch(self) -> None:
+        """https://github.com/pytest-dev/pytest/issues/15009
+
+        Unlike ApproxSequenceLike, ApproxMapping's _repr_compare only
+        guarded against ZeroDivisionError, so a TypeError from diffing
+        non-numeric values (e.g. two unequal strings under the same key)
+        propagated out of the formatter instead of being ignored.
+        """
+        expected = {"item": "a"}
+        actual = {"item": "b"}
+
+        # this would raise TypeError instead of returning normally
+        result = approx(expected)._repr_compare(actual)
+
+        assert any("item" in line for line in result)
+
     def test_approx_on_unordered_mapping_with_mismatch(
         self, pytester: Pytester
     ) -> None:


### PR DESCRIPTION
## Summary
Fixes #15009.

`ApproxSequenceLike._repr_compare` already ignores `TypeError` when diffing non-numeric values (see #13012), but `ApproxMapping._repr_compare` only caught `ZeroDivisionError`. So comparing two mappings with unequal non-numeric values under the same key (e.g. two different strings) raised `TypeError` from inside the diff formatter, replacing the normal assertion failure with:

```
(pytest_assertion plugin: representation of details failed: ... TypeError: unsupported operand type(s) for -: 'str' and 'str' ...)
```

instead of a proper mismatch detail table.

## Fix
Added the same `TypeError` guard already used by `ApproxSequenceLike` to `ApproxMapping._repr_compare`, so non-numeric values are skipped in the diff-magnitude calculation instead of raising.

## Test plan
- [x] Added `test_approx_dicts_with_nonnumeric_mismatch`, calling `_repr_compare` directly on a mapping with an unequal string value and asserting it returns normally.
- [x] `pytest testing/python/approx.py` — 132 passed, 18 skipped (pre-existing, unrelated to this change)
- [x] `ruff check` clean; `black --check` reports two pre-existing formatting differences elsewhere in these files, unrelated to the lines this PR touches