### PR TITLE
[unattended ai] Fix monkeypatch.setattr/delattr binding descriptors with raising=False

### DIFF
--- a/changelog/10646.bugfix.rst
+++ b/changelog/10646.bugfix.rst
@@ -1,0 +1,4 @@
+``monkeypatch.setattr`` and ``monkeypatch.delattr`` called with
+``raising=False`` no longer bind descriptors when probing for the attribute's
+existence: the check now reads the attribute statically, so descriptor
+``__get__`` methods are no longer invoked with their side effects.

--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -251,9 +251,15 @@ class MonkeyPatch:
                     "import string"
                 )
 
-        oldval = getattr(target, name, NOTSET)
-        if raising and oldval is NOTSET:
-            raise AttributeError(f"{target!r} has no attribute {name!r}")
+        if raising:
+            oldval = getattr(target, name, NOTSET)
+            if oldval is NOTSET:
+                raise AttributeError(f"{target!r} has no attribute {name!r}")
+        else:
+            # When raising is disabled, probe the attribute statically so that
+            # descriptors are not bound (no ``__get__`` side effects) just to
+            # check for existence.
+            oldval = inspect.getattr_static(target, name, NOTSET)
 
         # avoid class descriptors like staticmethod/classmethod
         if inspect.isclass(target):
@@ -298,16 +304,22 @@ class MonkeyPatch:
                 )
             name, target = derive_importpath(target, raising)
 
-        if not hasattr(target, name):
-            if raising:
+        if raising:
+            if not hasattr(target, name):
                 raise AttributeError(name)
-        else:
             oldval = getattr(target, name, NOTSET)
-            # Avoid class descriptors like staticmethod/classmethod.
-            if inspect.isclass(target):
-                oldval = target.__dict__.get(name, NOTSET)
-            delattr(target, name)
-            self._setattr.append((target, name, oldval))
+        else:
+            # When raising is disabled, probe the attribute statically so that
+            # descriptors are not bound (no ``__get__`` side effects) just to
+            # check for existence.
+            oldval = inspect.getattr_static(target, name, NOTSET)
+            if oldval is NOTSET:
+                return
+        # Avoid class descriptors like staticmethod/classmethod.
+        if inspect.isclass(target):
+            oldval = target.__dict__.get(name, NOTSET)
+        delattr(target, name)
+        self._setattr.append((target, name, oldval))
 
     def setitem(self, dic: Mapping[K, V], name: K, value: V) -> None:
         """Set dictionary entry ``name`` to value."""

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -52,6 +52,55 @@ def test_setattr() -> None:
         monkeypatch.setattr(A, "y")  # type: ignore[call-overload]
 
 
+class RaisingDescriptor:
+    """A descriptor whose binding always fails, to detect unwanted ``__get__`` calls."""
+
+    def __get__(self, instance, owner=None):
+        raise AssertionError("descriptor was bound")
+
+
+def test_setattr_raising_does_not_bind_descriptors() -> None:
+    class A:
+        z = RaisingDescriptor()
+
+    # With raising=True the existence check binds descriptors on purpose.
+    monkeypatch = MonkeyPatch()
+    with pytest.raises(AssertionError, match="descriptor was bound"):
+        monkeypatch.setattr(A, "z", 2)
+    with pytest.raises(AssertionError, match="descriptor was bound"):
+        monkeypatch.setattr(A(), "z", 2)
+
+    # With raising=False the attribute must be probed statically, without
+    # binding descriptors (gh-10646).
+    monkeypatch = MonkeyPatch()
+    monkeypatch.setattr(A, "z", 2, raising=False)
+    assert A.z == 2
+    monkeypatch.undo()
+    assert isinstance(A.__dict__["z"], RaisingDescriptor)
+
+    monkeypatch = MonkeyPatch()
+    monkeypatch.setattr(A(), "z", 2, raising=False)
+    monkeypatch.undo()
+
+
+def test_delattr_raising_does_not_bind_descriptors() -> None:
+    class A:
+        z = RaisingDescriptor()
+
+    # With raising=True the existence check binds descriptors on purpose.
+    monkeypatch = MonkeyPatch()
+    with pytest.raises(AssertionError, match="descriptor was bound"):
+        monkeypatch.delattr(A, "z")
+
+    # With raising=False the attribute must be probed statically, without
+    # binding descriptors (gh-10646).
+    monkeypatch = MonkeyPatch()
+    monkeypatch.delattr(A, "z", raising=False)
+    assert "z" not in A.__dict__
+    monkeypatch.undo()
+    assert isinstance(A.__dict__["z"], RaisingDescriptor)
+
+
 class TestSetattrWithImportPath:
     def test_string_expression(self, monkeypatch: MonkeyPatch) -> None:
         with monkeypatch.context() as mp:


### PR DESCRIPTION
When `raising=False`, the attribute existence check now reads the attribute statically (`inspect.getattr_static`) instead of using `getattr`/`hasattr`, so descriptors are no longer bound during the check and their `__get__` side effects do not fire.

closes #10646

## Problem

`monkeypatch.setattr`/`delattr` with `raising=False` used `getattr`/`hasattr` to probe whether the attribute exists. That binds any descriptor on the target (invoking its `__get__`), triggering `__get__` side effects purely as a side effect of the existence check.

## Fix

When `raising=False`, probe the attribute statically with `inspect.getattr_static`, which reads the attribute without binding descriptors. `raising=True` keeps the previous behaviour (binding is intentional there).

## Tests

Adds regression tests in `testing/test_monkeypatch.py` using a `RaisingDescriptor` whose `__get__` raises, asserting the descriptor is bound with `raising=True` but not with `raising=False`, for both `setattr` and `delattr` (class and instance targets).
